### PR TITLE
fix(web): structured delegate status rendering for job_status tool

### DIFF
--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1156,6 +1156,10 @@ type stableDelegateStatusResult struct {
 	NeedsAttention     bool                   `json:"needs_attention"`
 	NotResumableReason string                 `json:"not_resumable_reason,omitempty"`
 	TranscriptRef      string                 `json:"transcript_ref"`
+	Cwd                string                 `json:"cwd,omitempty"`
+	Isolation          string                 `json:"isolation,omitempty"`
+	SandboxMode        string                 `json:"sandbox_mode,omitempty"`
+	SandboxNetwork     *bool                  `json:"sandbox_network,omitempty"`
 	RunStartedAt       string                 `json:"run_started_at,omitempty"`
 	LatestActivityAt   string                 `json:"latest_activity_at,omitempty"`
 	RunningForMS       *int64                 `json:"running_for_ms,omitempty"`
@@ -1181,6 +1185,19 @@ func projectStableDelegateStatus(now time.Time, snapshot delegateSnapshot) stabl
 		NotResumableReason: snapshot.notResumableReason,
 		TranscriptRef:      snapshot.transcriptRef,
 		LastOutcome:        snapshot.lastOutcome,
+		Cwd:                descriptor.WorkingDir,
+		Isolation:          descriptor.Isolation,
+	}
+	if descriptor.Sandbox != nil {
+		out.SandboxMode = descriptor.Sandbox.Mode
+		// A nil Network pointer means the sandbox did not explicitly disable
+		// networking, so the effective default is enabled. Normalize to true
+		// so the UI shows the effective setting rather than omitting it.
+		net := true
+		if descriptor.Sandbox.Network != nil {
+			net = *descriptor.Sandbox.Network
+		}
+		out.SandboxNetwork = &net
 	}
 	if !snapshot.runStartedAt.IsZero() {
 		out.RunStartedAt = snapshot.runStartedAt.UTC().Format(time.RFC3339Nano)

--- a/agent/session_tools_jobs_env_test.go
+++ b/agent/session_tools_jobs_env_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/internal/delegatestore"
+)
+
+func TestProjectStableDelegateStatus_EnvironmentFields(t *testing.T) {
+	t.Parallel()
+	netDisabled := false
+	snapshot := delegateSnapshot{
+		id:        "dlg_test_env",
+		lifecycle: "running",
+		descriptor: delegatestore.Descriptor{
+			Task:            "test task",
+			AgentType:       "subagent",
+			WorkingDir:      "/home/user/project",
+			Isolation:       "worktree",
+			ToolNameCeiling: []string{"read_file", "write_file"},
+			Sandbox: &delegatestore.SandboxSnapshot{
+				Mode:    "workspace-write",
+				Network: &netDisabled,
+			},
+		},
+	}
+
+	now := time.Date(2026, 9, 2, 19, 10, 7, 0, time.UTC)
+	result := projectStableDelegateStatus(now, snapshot)
+
+	if result.Cwd != "/home/user/project" {
+		t.Errorf("Cwd = %q, want %q", result.Cwd, "/home/user/project")
+	}
+	if result.Isolation != "worktree" {
+		t.Errorf("Isolation = %q, want %q", result.Isolation, "worktree")
+	}
+	if result.SandboxMode != "workspace-write" {
+		t.Errorf("SandboxMode = %q, want %q", result.SandboxMode, "workspace-write")
+	}
+	if result.SandboxNetwork == nil {
+		t.Fatal("SandboxNetwork is nil, want false")
+	}
+	if *result.SandboxNetwork != false {
+		t.Errorf("SandboxNetwork = %v, want false", *result.SandboxNetwork)
+	}
+}
+
+func TestProjectStableDelegateStatus_NilSandboxNetworkDefaultsToTrue(t *testing.T) {
+	t.Parallel()
+	snapshot := delegateSnapshot{
+		id:        "dlg_test_net",
+		lifecycle: "running",
+		descriptor: delegatestore.Descriptor{
+			Task:      "test task",
+			AgentType: "subagent",
+			Sandbox: &delegatestore.SandboxSnapshot{
+				Mode: "read-only",
+				// Network is nil — should default to true (enabled)
+			},
+		},
+	}
+
+	result := projectStableDelegateStatus(time.Now(), snapshot)
+
+	if result.SandboxNetwork == nil {
+		t.Fatal("SandboxNetwork is nil, want true (effective default for nil network)")
+	}
+	if *result.SandboxNetwork != true {
+		t.Errorf("SandboxNetwork = %v, want true (nil network means enabled)", *result.SandboxNetwork)
+	}
+}
+
+func TestProjectStableDelegateStatus_NoSandboxOmitsFields(t *testing.T) {
+	t.Parallel()
+	snapshot := delegateSnapshot{
+		id:        "dlg_test_nosandbox",
+		lifecycle: "running",
+		descriptor: delegatestore.Descriptor{
+			Task:      "test task",
+			AgentType: "subagent",
+			// Sandbox is nil
+		},
+	}
+
+	result := projectStableDelegateStatus(time.Now(), snapshot)
+
+	if result.SandboxMode != "" {
+		t.Errorf("SandboxMode = %q, want empty (no sandbox)", result.SandboxMode)
+	}
+	if result.SandboxNetwork != nil {
+		t.Errorf("SandboxNetwork = %v, want nil (no sandbox)", *result.SandboxNetwork)
+	}
+}

--- a/cmd/evener-hub/frontend/src/dev/gallery-sections/copybutton.tsx
+++ b/cmd/evener-hub/frontend/src/dev/gallery-sections/copybutton.tsx
@@ -1,0 +1,29 @@
+import { CopyButton } from "../../widgets/copybutton";
+import styles from "../gallery-section.module.css";
+import { ThemeFlip } from "../ThemeFlip";
+
+export default function CopyButtonGallerySection() {
+  return (
+    <section>
+      <h2>CopyButton</h2>
+      <ThemeFlip>
+        <div className={styles.row}>
+          <p className={styles.rowLabel}>default</p>
+          <CopyButton text="const x = 1;" label="Copy" />
+        </div>
+        <div className={styles.row}>
+          <p className={styles.rowLabel}>custom label</p>
+          <CopyButton text={'{"id":"dlg_42"}'} label="Copy raw JSON" />
+        </div>
+        <div className={styles.row}>
+          <p className={styles.rowLabel}>sm size</p>
+          <CopyButton text="short text" label="Copy" size="sm" />
+        </div>
+        <div className={styles.row}>
+          <p className={styles.rowLabel}>primary variant</p>
+          <CopyButton text="important text" label="Copy" variant="primary" />
+        </div>
+      </ThemeFlip>
+    </section>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityRowDetail.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityRowDetail.tsx
@@ -13,7 +13,7 @@ import { AnsiLineContent } from "../../../widgets/codeblock/ansiLine";
 import { Disclosure } from "../../../widgets/disclosure";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import { Markdown } from "../../../widgets/markdown";
-import { formatClockTime } from "../transcript/messages/format";
+import { formatClockTime, splitMandate } from "../transcript/messages/format";
 import { formatQuietAge, quietAnchorMillis } from "./activityFormat";
 import styles from "./activitypanel.module.css";
 import type { ActivityDelegateRow, ActivityJobRow } from "./activityRows";
@@ -191,9 +191,9 @@ export function ActivityRowDetail({
       : mandate
         ? undefined
         : (row.delegate.child?.label ?? row.delegate.childSessionId);
-  const paragraphs = mandate?.split(/\n\s*\n/) ?? [];
-  const firstParagraph = paragraphs[0] ?? "";
-  const remainingMandate = paragraphs.slice(1).join("\n\n");
+  const mandateParts = splitMandate(mandate);
+  const firstParagraph = mandateParts?.first ?? "";
+  const remainingMandate = mandateParts?.rest ?? "";
   return (
     <div className={CLASS.detailStrip}>
       {delegate && mandate ? (

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/format.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/format.ts
@@ -64,6 +64,18 @@ export function formatElapsed(ms: number): string {
   return `${hours}h${String(totalMinutes % 60).padStart(2, "0")}m`;
 }
 
+// Split a markdown mandate into the first paragraph (visible) and the rest
+// (behind a disclosure). Shared by ActivityRowDetail and DelegateStatusBody
+// so the paragraph-split rule lives in one place.
+export function splitMandate(task: string | undefined): { first: string; rest: string } | undefined {
+  if (!task || task.trim() === "") return undefined;
+  const paragraphs = task.split(/\n\s*\n/);
+  return {
+    first: paragraphs[0] ?? "",
+    rest: paragraphs.slice(1).join("\n\n"),
+  };
+}
+
 // Returns the first substantive markdown line as plain text.
 export function plainQuoteLine(text: string): string {
   for (const raw of text.split("\n")) {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.module.css
@@ -1,0 +1,193 @@
+/* DelegateStatusBody: structured card for job_status delegate output.
+   Follows the design system (docs/web-ui/design-system.md): all colors,
+   spacing, radii, and fonts use var(--token) from tokens.css. The 4px
+   space grid (--space-1..4) sizes all gaps and padding. Section eyebrows
+   use the micro-label pattern (caption size, --font-weight-medium,
+   --ink-low, uppercase, --tracking-micro). Mono (--font-mono) is reserved
+   for machine text (delegate ID, paths, model, sandbox mode, tool chips,
+   transcript ref). The four attention hues carry their designated meanings:
+   --alive for running, --attention for needs-human, --danger for failure. */
+
+.card {
+  background: var(--surface-1);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-pane);
+  overflow: hidden;
+}
+
+/* --- Header: ID + status chip (Chip widget provides the pill) --- */
+.head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+}
+
+.headId {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--ink-hi);
+  font-weight: 500;
+}
+
+.headSpacer {
+  flex: 1;
+}
+
+/* --- Meta line: inline ·-separated key:value segments --- */
+.meta {
+  padding: 0 var(--space-3) var(--space-2);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: 11px;
+  color: var(--ink-mid);
+}
+
+.metaSeg {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 var(--space-2);
+}
+
+.metaSeg:first-child {
+  padding-left: 0;
+}
+
+.metaSep {
+  color: var(--edge-strong);
+  user-select: none;
+  margin-right: 2px;
+}
+
+.metaK {
+  color: var(--ink-low);
+  font-family: var(--font-sans);
+}
+
+.metaV {
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Section eyebrow (micro-label pattern, design system §6) --- */
+.eyebrow {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--ink-low);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-micro);
+  margin-bottom: var(--space-1);
+}
+
+/* --- Mandate --- */
+.mandate {
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--edge);
+}
+
+.mandateBody {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-hi);
+}
+
+/* --- Diagnostics: not-resumable reason, failed-outcome reason ---
+   Same visual treatment as mandate (bordered section, body text) but
+   semantically distinct — these are failure diagnostics, not a mandate. */
+.diagnostic {
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--edge);
+}
+
+.diagnosticBody {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-hi);
+}
+
+.dangerText {
+  color: var(--danger-ink);
+}
+
+/* --- Environment: meta table idiom (design system §10) --- */
+.env {
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--edge);
+}
+
+.envRows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.envRow {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.envK {
+  width: 88px;
+  flex-shrink: 0;
+  color: var(--ink-low);
+  font-family: var(--font-sans);
+  font-size: 11px;
+}
+
+.envV {
+  color: var(--ink-hi);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.envVmono {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.envVmuted {
+  color: var(--ink-mid);
+}
+
+/* --- Available tools --- */
+.tools {
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--edge);
+}
+
+.toolsChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.toolChip {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--ink-mid);
+  background: var(--surface-inset);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-chip);
+  padding: 1px 6px;
+}
+
+/* --- Footer --- */
+.footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--edge);
+  background: var(--surface-inset);
+}
+
+.footerSpacer {
+  flex: 1;
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.tsx
@@ -1,0 +1,388 @@
+// DelegateStatusBody is the expanded body for a `job_status` tool call
+// targeting a stable delegate (dlg_*). It parses the tool's structured state
+// (item.raw, the stableDelegateStatusResult from
+// agent/session_tools_jobs.go's projectStableDelegateStatus) and renders it
+// as a structured card — not raw JSON — following the design system's
+// information architecture: identity, lifecycle meta, mandate as markdown,
+// environment, config, available tools, footer with transcript ref + copy.
+//
+// For a job_status call whose output isn't a delegate status (a shell job,
+// or malformed JSON), it falls back to HeadClippedOutputBody — the previous
+// behavior — so the renderer never regresses for non-delegate targets.
+import type { ReactNode } from "react";
+import { disclosureScopeForSession, useTranscriptRenderContext } from "../../../../transcriptDisplay/renderContext";
+import { Chip, type ChipTone, CopyButton, Disclosure, Markdown } from "../../../../widgets";
+import { scopedDisclosureId } from "../../../../widgets/disclosure/disclosureStore";
+import { requireClass } from "../../../../widgets/internal/requireClass";
+import { formatClockTime, formatElapsed, splitMandate } from "../messages/format";
+import { OpenTranscriptButton } from "../openTranscript";
+import type { ToolRenderProps } from "../toolRenderers";
+import { HeadClippedOutputBody } from "./bodies";
+import styles from "./delegateStatus.module.css";
+import { classifyJobStatus } from "./subagentModuleStore";
+
+const CLASS = {
+  card: requireClass(styles.card, "delegateStatus.module.css", "card"),
+  head: requireClass(styles.head, "delegateStatus.module.css", "head"),
+  headId: requireClass(styles.headId, "delegateStatus.module.css", "headId"),
+  headSpacer: requireClass(styles.headSpacer, "delegateStatus.module.css", "headSpacer"),
+  meta: requireClass(styles.meta, "delegateStatus.module.css", "meta"),
+  metaSeg: requireClass(styles.metaSeg, "delegateStatus.module.css", "metaSeg"),
+  metaSep: requireClass(styles.metaSep, "delegateStatus.module.css", "metaSep"),
+  metaK: requireClass(styles.metaK, "delegateStatus.module.css", "metaK"),
+  metaV: requireClass(styles.metaV, "delegateStatus.module.css", "metaV"),
+  mandate: requireClass(styles.mandate, "delegateStatus.module.css", "mandate"),
+  eyebrow: requireClass(styles.eyebrow, "delegateStatus.module.css", "eyebrow"),
+  mandateBody: requireClass(styles.mandateBody, "delegateStatus.module.css", "mandateBody"),
+  diagnostic: requireClass(styles.diagnostic, "delegateStatus.module.css", "diagnostic"),
+  diagnosticBody: requireClass(styles.diagnosticBody, "delegateStatus.module.css", "diagnosticBody"),
+  dangerText: requireClass(styles.dangerText, "delegateStatus.module.css", "dangerText"),
+  env: requireClass(styles.env, "delegateStatus.module.css", "env"),
+  envRows: requireClass(styles.envRows, "delegateStatus.module.css", "envRows"),
+  envRow: requireClass(styles.envRow, "delegateStatus.module.css", "envRow"),
+  envK: requireClass(styles.envK, "delegateStatus.module.css", "envK"),
+  envV: requireClass(styles.envV, "delegateStatus.module.css", "envV"),
+  envVmono: requireClass(styles.envVmono, "delegateStatus.module.css", "envVmono"),
+  envVmuted: requireClass(styles.envVmuted, "delegateStatus.module.css", "envVmuted"),
+  tools: requireClass(styles.tools, "delegateStatus.module.css", "tools"),
+  toolsChips: requireClass(styles.toolsChips, "delegateStatus.module.css", "toolsChips"),
+  toolChip: requireClass(styles.toolChip, "delegateStatus.module.css", "toolChip"),
+  footer: requireClass(styles.footer, "delegateStatus.module.css", "footer"),
+  footerSpacer: requireClass(styles.footerSpacer, "delegateStatus.module.css", "footerSpacer"),
+};
+
+// The shape of stableDelegateStatusResult (agent/session_tools_jobs.go).
+// Fields are optional because item.raw may be undefined or partial on
+// older stored transcripts predating a field's addition.
+interface DelegateStatusState {
+  id?: string;
+  type?: string;
+  status?: string;
+  task?: string;
+  description?: string;
+  agent_type?: string;
+  tools?: string[];
+  model?: string;
+  reasoning_effort?: string;
+  resumable?: boolean;
+  needs_attention?: boolean;
+  not_resumable_reason?: string;
+  transcript_ref?: string;
+  run_started_at?: string;
+  latest_activity_at?: string;
+  running_for_ms?: number;
+  quiet_for_ms?: number;
+  duration_ms?: number;
+  last_outcome?: { status?: string; ended_at?: string; reason?: string };
+  cwd?: string;
+  isolation?: string;
+  sandbox_mode?: string;
+  sandbox_network?: boolean;
+}
+
+// Coerce a value to a string if it's a string, or undefined if not. Fields
+// rendered as React children must be strings — an object or number would
+// render as "[object Object]" or throw. The raw originates from a typed Go
+// struct, so non-string values are a legacy-transcript edge case.
+function strOrUndef(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function normalizeDelegateStatus(raw: Record<string, unknown>): DelegateStatusState {
+  const lo = raw.last_outcome;
+  // Spread the original last_outcome so backend-added fields (exhaustion_budget,
+  // exhaustion_limit, etc.) survive into the copy-JSON output, then override
+  // the rendered fields with coerced strings so they can't throw.
+  const lastOutcome =
+    typeof lo === "object" && lo !== null && !Array.isArray(lo)
+      ? {
+          ...(lo as Record<string, unknown>),
+          status: strOrUndef((lo as Record<string, unknown>).status),
+          ended_at: strOrUndef((lo as Record<string, unknown>).ended_at),
+          reason: strOrUndef((lo as Record<string, unknown>).reason),
+        }
+      : undefined;
+  return {
+    id: strOrUndef(raw.id),
+    type: strOrUndef(raw.type),
+    status: strOrUndef(raw.status),
+    task: strOrUndef(raw.task),
+    description: strOrUndef(raw.description),
+    agent_type: strOrUndef(raw.agent_type),
+    tools: Array.isArray(raw.tools) ? raw.tools.filter((t): t is string => typeof t === "string") : undefined,
+    model: strOrUndef(raw.model),
+    reasoning_effort: strOrUndef(raw.reasoning_effort),
+    resumable: typeof raw.resumable === "boolean" ? raw.resumable : undefined,
+    needs_attention: typeof raw.needs_attention === "boolean" ? raw.needs_attention : undefined,
+    not_resumable_reason: strOrUndef(raw.not_resumable_reason),
+    transcript_ref: strOrUndef(raw.transcript_ref),
+    run_started_at: strOrUndef(raw.run_started_at),
+    latest_activity_at: strOrUndef(raw.latest_activity_at),
+    running_for_ms: typeof raw.running_for_ms === "number" ? raw.running_for_ms : undefined,
+    quiet_for_ms: typeof raw.quiet_for_ms === "number" ? raw.quiet_for_ms : undefined,
+    duration_ms: typeof raw.duration_ms === "number" ? raw.duration_ms : undefined,
+    last_outcome: lastOutcome,
+    cwd: strOrUndef(raw.cwd),
+    isolation: strOrUndef(raw.isolation),
+    sandbox_mode: strOrUndef(raw.sandbox_mode),
+    sandbox_network: typeof raw.sandbox_network === "boolean" ? raw.sandbox_network : undefined,
+  };
+}
+
+function isDelegateStatus(raw: unknown): raw is DelegateStatusState {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return false;
+  const obj = raw as Record<string, unknown>;
+  // The stableDelegateStatusResult always carries type "delegate", id, and
+  // status. Require all three so a malformed or partial raw (e.g. a shell
+  // job's state, or a stored transcript predating the struct) falls back
+  // to HeadClippedOutputBody instead of crashing during rendering.
+  if (obj.type !== "delegate") return false;
+  if (typeof obj.id !== "string" || typeof obj.status !== "string") return false;
+  return true;
+}
+
+// Map a delegate's status + needs_attention to a Chip tone, reusing
+// classifyJobStatus's status vocabulary so failed→danger (not neutral).
+// An idle delegate whose last run failed should still show danger —
+// the lifecycle is idle, but the outcome is the most recent fact.
+// A running delegate always shows alive regardless of last_outcome —
+// the live lifecycle is the primary signal, not a past outcome.
+//
+// "exhausted" is NOT classified as "failed" here: a budget exhaustion is
+// a soft stop, not a hard error. classifyJobStatus maps it to "failed"
+// for the activity rail (where it's a terminal state), but the delegate
+// status card distinguishes the two: exhausted→attention (amber, "ran
+// out of budget"), failed→danger (red, "something went wrong").
+function isExhausted(status: string | undefined): boolean {
+  return status === "exhausted";
+}
+
+function statusToTone(state: DelegateStatusState): ChipTone {
+  if (state.needs_attention) return "attention";
+  if (state.status === "idle") {
+    // Idle lifecycle: show the last run's outcome, not "running".
+    if (state.last_outcome?.status) {
+      if (isExhausted(state.last_outcome.status)) return "attention";
+      const kind = classifyJobStatus(state.last_outcome.status);
+      if (kind === "failed") return "danger";
+    }
+    return "neutral";
+  }
+  const kind = classifyJobStatus(state.status);
+  if (kind === "running") return "alive";
+  if (kind === "failed") return "danger";
+  return "neutral";
+}
+
+function statusLabel(state: DelegateStatusState): string {
+  if (state.needs_attention) return "Needs attention";
+  return state.status ?? "unknown";
+}
+
+interface MetaSegment {
+  key: string;
+  value: ReactNode;
+}
+
+function lifecycleSegments(state: DelegateStatusState): MetaSegment[] {
+  const segs: MetaSegment[] = [];
+  if (state.running_for_ms !== undefined) {
+    segs.push({ key: "running", value: formatElapsed(state.running_for_ms) });
+  } else if (state.duration_ms !== undefined) {
+    segs.push({ key: "ran for", value: formatElapsed(state.duration_ms) });
+  }
+  if (state.quiet_for_ms !== undefined) {
+    segs.push({ key: "quiet", value: formatElapsed(state.quiet_for_ms) });
+  }
+  if (state.last_outcome?.status) {
+    segs.push({ key: "last outcome", value: state.last_outcome.status });
+  }
+  const started = formatClockTime(state.run_started_at);
+  if (started) segs.push({ key: "started", value: started });
+  return segs;
+}
+
+function configSegments(state: DelegateStatusState): MetaSegment[] {
+  const segs: MetaSegment[] = [];
+  if (state.model) segs.push({ key: "model", value: state.model });
+  if (state.agent_type) segs.push({ key: "agent", value: state.agent_type });
+  if (state.reasoning_effort) segs.push({ key: "reasoning", value: state.reasoning_effort });
+  if (state.resumable !== undefined) segs.push({ key: "resumable", value: state.resumable ? "✓" : "✗" });
+  return segs;
+}
+
+interface EnvRow {
+  key: string;
+  value: string;
+  mono?: boolean;
+  muted?: boolean;
+}
+
+function environmentRows(state: DelegateStatusState): EnvRow[] {
+  const rows: EnvRow[] = [];
+  if (state.cwd) rows.push({ key: "cwd", value: state.cwd, mono: true });
+  if (state.isolation) rows.push({ key: "isolation", value: state.isolation, muted: true });
+  if (state.sandbox_mode) rows.push({ key: "sandbox", value: state.sandbox_mode, mono: true });
+  if (state.sandbox_network !== undefined) {
+    rows.push({ key: "network", value: state.sandbox_network ? "enabled" : "disabled" });
+  }
+  return rows;
+}
+
+function envValueClass(row: EnvRow): string {
+  // Always include envV for the shared truncation rules (overflow, ellipsis,
+  // nowrap); envVmono layers on the mono font/size, envVmuted the muted color.
+  const classes = [CLASS.envV];
+  if (row.mono) classes.push(CLASS.envVmono);
+  if (row.muted) classes.push(CLASS.envVmuted);
+  return classes.join(" ");
+}
+
+function MetaLine({ segments }: { segments: MetaSegment[] }) {
+  if (segments.length === 0) return null;
+  return (
+    <div className={CLASS.meta}>
+      {segments.map((seg, i) => (
+        <span key={seg.key} className={CLASS.metaSeg}>
+          {i > 0 && (
+            <span className={CLASS.metaSep} aria-hidden="true">
+              ·
+            </span>
+          )}
+          <span className={CLASS.metaK}>{seg.key}</span> <span className={CLASS.metaV}>{seg.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function EnvTable({ rows }: { rows: EnvRow[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <div className={CLASS.env}>
+      <div className={CLASS.eyebrow}>Environment</div>
+      <div className={CLASS.envRows}>
+        {rows.map((row) => (
+          <div key={row.key} className={CLASS.envRow}>
+            <span className={CLASS.envK}>{row.key}</span>
+            <span className={envValueClass(row)}>{row.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DelegateStatusBody({ item, sessionRef }: ToolRenderProps) {
+  // Session-scope the mandate disclosure ID so the same delegate's cards in
+  // different sessions don't share disclosure state (same pattern as
+  // ToolCallItem.tsx's disclosureKey). Called before the early return to
+  // satisfy React's rules-of-hooks (hooks must be unconditional).
+  const renderCtx = useTranscriptRenderContext();
+
+  // item.raw carries the stableDelegateStatusResult struct (the State field
+  // of tool.StateResult). Fall back to HeadClippedOutputBody when it isn't
+  // a delegate status — a job_status call targeting a shell job, or a
+  // stored transcript predating the structured state.
+  if (!isDelegateStatus(item.raw)) {
+    return <HeadClippedOutputBody item={item} live={false} />;
+  }
+
+  // Normalize all fields to their declared types so rendering can't throw on
+  // malformed persisted data (e.g. model: {} from a legacy transcript).
+  const state = normalizeDelegateStatus(item.raw as Record<string, unknown>);
+  const tone = statusToTone(state);
+  const label = statusLabel(state);
+  const mandate = splitMandate(state.task);
+  const lifecycle = lifecycleSegments(state);
+  const config = configSegments(state);
+  const envRows = environmentRows(state);
+  const tools = state.tools ?? [];
+  const transcriptRef = state.transcript_ref;
+  // Copy the structured state, not item.output: the output text may carry
+  // breaker/annotation text appended after the JSON, so re-serializing the
+  // validated state gives the reader valid JSON on paste.
+  const rawJson = JSON.stringify(state, null, 2);
+
+  const disclosureScope = disclosureScopeForSession(renderCtx, sessionRef);
+  const mandateDisclosureId = scopedDisclosureId(disclosureScope, `delegate-mandate:${item.id}`);
+
+  return (
+    <div className={CLASS.card} data-testid="delegate-status-body">
+      {/* Header: delegate ID + status chip */}
+      <div className={CLASS.head}>
+        <span className={CLASS.headId}>{state.id}</span>
+        <span className={CLASS.headSpacer} />
+        <Chip tone={tone}>{label}</Chip>
+      </div>
+
+      {/* Lifecycle meta: inline ·-separated segments */}
+      <MetaLine segments={lifecycle} />
+
+      {/* Mandate: task as markdown, first paragraph visible, rest in disclosure */}
+      {mandate && (
+        <div className={CLASS.mandate}>
+          <div className={CLASS.eyebrow}>Mandate</div>
+          <div className={CLASS.mandateBody}>
+            <Markdown source={mandate.first} />
+          </div>
+          {mandate.rest && (
+            <Disclosure id={mandateDisclosureId} summary="Show full mandate">
+              <Markdown source={mandate.rest} />
+            </Disclosure>
+          )}
+        </div>
+      )}
+
+      {/* Environment: meta table rows */}
+      <EnvTable rows={envRows} />
+
+      {/* Config: one inline line */}
+      {config.length > 0 && <MetaLine segments={config} />}
+
+      {/* Diagnostics: not-resumable reason and/or last outcome reason */}
+      {state.not_resumable_reason && (
+        <div className={CLASS.diagnostic} data-testid="delegate-not-resumable">
+          <div className={`${CLASS.diagnosticBody} ${CLASS.dangerText}`}>
+            Not resumable: {state.not_resumable_reason}
+          </div>
+        </div>
+      )}
+      {state.last_outcome?.reason && isExhausted(state.last_outcome.status) && (
+        <div className={CLASS.diagnostic} data-testid="delegate-outcome-reason">
+          <div className={CLASS.diagnosticBody}>Last run exhausted: {state.last_outcome.reason}</div>
+        </div>
+      )}
+      {state.last_outcome?.reason &&
+        !isExhausted(state.last_outcome.status) &&
+        classifyJobStatus(state.last_outcome.status) === "failed" && (
+          <div className={CLASS.diagnostic} data-testid="delegate-outcome-reason">
+            <div className={`${CLASS.diagnosticBody} ${CLASS.dangerText}`}>
+              Last run failed: {state.last_outcome.reason}
+            </div>
+          </div>
+        )}
+
+      {/* Available tools */}
+      {tools.length > 0 && (
+        <div className={CLASS.tools}>
+          <div className={CLASS.eyebrow}>{`Available tools (${tools.length})`}</div>
+          <div className={CLASS.toolsChips}>
+            {tools.map((tool) => (
+              <span key={tool} className={CLASS.toolChip}>
+                {tool}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Footer: transcript ref + copy raw JSON */}
+      <div className={CLASS.footer}>
+        {transcriptRef && <OpenTranscriptButton transcriptRef={transcriptRef} parentRef={sessionRef} iconOnly />}
+        <span className={CLASS.footerSpacer} />
+        <CopyButton text={rawJson} label="Copy raw JSON" />
+      </div>
+    </div>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.edge.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.edge.test.tsx
@@ -1,9 +1,9 @@
 // Edge cases for jobTools.tsx that close remaining uncovered lines:
-// - CopyTextButton CopiedGlyph rendering (line 32)
-// - CopyTextButton timer effect (lines 47-48)
-// - CopyTextButton clipboard guard (lines 59-60)
-// - delegateSendFooter with started_job_id empty (lines 255-256)
-// - delegateSendFooter with watching field (line 271)
+// - CopyButton Copied feedback rendering
+// - CopyButton timer effect
+// - CopyButton clipboard guard
+// - delegateSendFooter with started_job_id empty
+// - delegateSendFooter with watching field
 
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -23,8 +23,8 @@ function item(overrides: Partial<ItemModel> = {}): ItemModel {
   return { id: "item_1", turnId: "turn_1", type: "commandExecution", text: "", ...overrides };
 }
 
-// --- CopyTextButton: CopiedGlyph (line 32), timer effect (lines 47-48) ---
-// CopyTextButton lives in the delegate_send body (UserMessageView actions slot),
+// --- CopyButton: Copied feedback, timer effect ---
+// CopyButton lives in the delegate_send body (UserMessageView actions slot),
 // NOT in the job_list body. We render the delegate_send body as JSX with proper
 // ToolRenderProps so the component receives { item, live } correctly.
 
@@ -56,7 +56,7 @@ test("delegate_send copy button shows Copied feedback after successful clipboard
   expect(writeText).toHaveBeenCalledWith("hello world");
 });
 
-// --- CopyTextButton: clipboard guard (lines 59-60) ---
+// --- CopyButton: clipboard guard ---
 
 test("delegate_send copy button is a no-op when clipboard API is unavailable", async () => {
   const user = userEvent.setup();

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { toolRendererFor } from "../toolRenderers";
 import "./jobTools";
 import type { ItemModel } from "../../../../protocol/model";
@@ -47,12 +47,241 @@ test("job controls keep same-owner job suffixes distinct in summaries", () => {
   }
 });
 
-test("job_status: body shows the raw JSON output text", () => {
+test("job_status: body falls back to raw text when item.raw is absent (legacy/stored transcript)", () => {
   const d = toolRendererFor("job_status");
   const Body = d.body!;
   const output = JSON.stringify({ id: "dlg_42", type: "delegate", status: "idle" });
   render(<Body item={item({ toolName: "job_status", output })} live={false} />);
   expect(screen.getByText(output)).toBeTruthy();
+});
+
+test("job_status: body falls back to raw text when item.raw is not a delegate status (shell job)", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const output = JSON.stringify({
+    job_id: "job_99",
+    kind: "shell",
+    status: "completed",
+    started_at: "2026-01-01T00:00:00Z",
+  });
+  render(<Body item={item({ toolName: "job_status", output, raw: JSON.parse(output) })} live={false} />);
+  // Shell job output has no id+status delegate shape, so the structured body
+  // is bypassed and the raw text renders through HeadClippedOutputBody.
+  expect(screen.getByText(output)).toBeTruthy();
+});
+
+// --- job_status: structured delegate status body (DelegateStatusBody) ---
+// When item.raw carries a stableDelegateStatusResult (the State field of
+// tool.StateResult from agent/session_tools_jobs.go's
+// stableDelegateStatusTool), the body renders a structured card instead of
+// raw JSON.
+
+function delegateStatusRaw(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    id: "dlg_034HQ2kSDXfKFq1mm3idL1",
+    type: "delegate",
+    status: "running",
+    task: "You are implementing Task 2: Strict resource-schema validation.",
+    agent_type: "subagent",
+    tools: ["apply_patch", "communicate", "exec_command", "read_file", "write_file"],
+    model: "gpt-5.6-sol",
+    reasoning_effort: "high",
+    resumable: true,
+    needs_attention: false,
+    transcript_ref: "local:034HzkSDXiDAIUBDoff1h",
+    running_for_ms: 103652,
+    quiet_for_ms: 617,
+    run_started_at: "2026-09-02T19:10:07.136326Z",
+    last_outcome: { status: "completed", ended_at: "2026-09-01T14:03:21.048695-07:00" },
+    cwd: "/Users/jesse/git/prime-radiant/evener",
+    isolation: "worktree",
+    sandbox_mode: "workspace-write",
+    sandbox_network: true,
+    ...overrides,
+  };
+}
+
+test("job_status: body renders a structured card with the delegate ID", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw();
+  const output = JSON.stringify(raw);
+  render(<Body item={item({ toolName: "job_status", output, raw })} live={false} />);
+  expect(screen.getByText("dlg_034HQ2kSDXfKFq1mm3idL1")).toBeTruthy();
+});
+
+test("job_status: body shows a running status pill", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw();
+  const { container } = render(
+    <Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />,
+  );
+  // Chip renders "running" as its label text. The lifecycle meta line also
+  // contains "running" as a key, so query the Chip widget's span directly.
+  const chip = container.querySelector("[class*='chip']");
+  expect(chip?.textContent).toContain("running");
+});
+
+test("job_status: body shows needs attention pill when needs_attention is true", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({ needs_attention: true });
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByText("Needs attention")).toBeTruthy();
+});
+
+test("job_status: idle status does not receive the alive/running tone", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({ status: "idle", running_for_ms: undefined, quiet_for_ms: undefined });
+  const { container } = render(
+    <Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />,
+  );
+  // The Chip should render "idle" text in the neutral tone, not alive/running.
+  const chip = container.querySelector("[class*='chip']");
+  expect(chip?.textContent).toContain("idle");
+  expect(chip?.className).not.toContain("alive");
+});
+
+test("job_status: idle delegate with failed last outcome shows danger tone", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({
+    status: "idle",
+    running_for_ms: undefined,
+    quiet_for_ms: undefined,
+    last_outcome: { status: "failed", ended_at: "2026-09-01T14:03:21Z" },
+  });
+  const { container } = render(
+    <Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />,
+  );
+  const chip = container.querySelector("[class*='chip']");
+  expect(chip?.textContent).toContain("idle");
+  expect(chip?.className).toContain("danger");
+});
+
+test("job_status: body renders the mandate (first paragraph of task)", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw();
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByText(/Strict resource-schema validation/)).toBeTruthy();
+});
+
+test("job_status: body shows a disclosure for a multi-paragraph mandate", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({
+    task: "First paragraph of the mandate.\n\nSecond paragraph with more detail.\n\nThird paragraph.",
+  });
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByText("First paragraph of the mandate.")).toBeTruthy();
+  expect(screen.getByText("Show full mandate")).toBeTruthy();
+});
+
+test("job_status: body renders available tools with a count", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw();
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByText("Available tools (5)")).toBeTruthy();
+  expect(screen.getByText("apply_patch")).toBeTruthy();
+  expect(screen.getByText("write_file")).toBeTruthy();
+});
+
+test("job_status: body renders environment fields (cwd, isolation, sandbox, network)", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw();
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByText("/Users/jesse/git/prime-radiant/evener")).toBeTruthy();
+  expect(screen.getByText("worktree")).toBeTruthy();
+  expect(screen.getByText("workspace-write")).toBeTruthy();
+  expect(screen.getByText("enabled")).toBeTruthy();
+});
+
+test("job_status: body renders config line with model, agent, reasoning", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw();
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByText("gpt-5.6-sol")).toBeTruthy();
+  expect(screen.getByText("subagent")).toBeTruthy();
+  expect(screen.getByText("high")).toBeTruthy();
+});
+
+test("job_status: body renders a copy raw JSON button", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw();
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByRole("button", { name: "Copy raw JSON" })).toBeTruthy();
+});
+
+test("job_status: copy button writes the normalized structured state, not item.output", async () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw();
+  // output carries trailing annotation text after the JSON — the copy button
+  // must write the validated state, not this raw string.
+  const outputWithJunk = `${JSON.stringify(raw)}\n--- breaker ---`;
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  const originalClipboard = navigator.clipboard;
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  try {
+    render(<Body item={item({ toolName: "job_status", output: outputWithJunk, raw })} live={false} />);
+    const btn = screen.getByRole("button", { name: "Copy raw JSON" });
+    btn.click();
+    expect(writeText).toHaveBeenCalledTimes(1);
+    // The copied text must be valid JSON of the structured state, not the
+    // raw output string (which has trailing junk). Compare parsed values
+    // (key ordering is not significant).
+    const copied = writeText.mock.calls[0]![0] as string;
+    expect(JSON.parse(copied)).toEqual(raw);
+    expect(copied).not.toContain("--- breaker ---");
+  } finally {
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      configurable: true,
+    });
+  }
+});
+
+test("job_status: body renders not-resumable reason diagnostic", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({ not_resumable_reason: "Delegate was disposed" });
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByTestId("delegate-not-resumable")).toBeTruthy();
+  expect(screen.getByText(/Not resumable: Delegate was disposed/)).toBeTruthy();
+});
+
+test("job_status: body renders failed outcome reason in danger text", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({
+    status: "idle",
+    last_outcome: { status: "failed", reason: "exec: command not found" },
+  });
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByTestId("delegate-outcome-reason")).toBeTruthy();
+  expect(screen.getByText(/Last run failed: exec: command not found/)).toBeTruthy();
+});
+
+test("job_status: body renders exhausted outcome reason without danger text", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({
+    status: "idle",
+    last_outcome: { status: "exhausted", reason: "budget limit reached" },
+  });
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  expect(screen.getByTestId("delegate-outcome-reason")).toBeTruthy();
+  expect(screen.getByText(/Last run exhausted: budget limit reached/)).toBeTruthy();
 });
 
 test("job_read_output aliases to the same descriptor as job_status", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.tsx
@@ -1,11 +1,11 @@
 // Descriptors for job_* and delegate_send follow-up calls.
-import { useEffect, useState } from "react";
 import type { ItemModel } from "../../../../protocol/model";
-import { IconButton } from "../../../../widgets";
+import { CopyButton } from "../../../../widgets";
 import { UserMessageView } from "../messages/UserMessageItem";
 import type { ToolRenderProps } from "../toolRenderers";
 import { registerToolRenderer } from "../toolRenderers";
 import { HeadClippedOutputBody } from "./bodies";
+import { DelegateStatusBody } from "./delegateStatus";
 import { clip, clipJobID, parseArgs, parseJSONObject, str, trailingBracketFooter } from "./helpers";
 import { statusWordFromText } from "./subagentModule";
 
@@ -15,52 +15,6 @@ type JsonObject = Record<string, unknown>;
 
 function asJsonObject(value: unknown): JsonObject | undefined {
   return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as JsonObject) : undefined;
-}
-
-const COPIED_RESET_MS = 2_000;
-
-function CopyGlyph() {
-  return (
-    <svg viewBox="0 0 14 14" width="12" height="12" aria-hidden="true">
-      <rect x="4.5" y="1.5" width="8" height="8" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
-      <path d="M9.5 12.5H3A1.5 1.5 0 0 1 1.5 11V4.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
-    </svg>
-  );
-}
-
-function CopiedGlyph() {
-  return (
-    <svg viewBox="0 0 14 14" width="12" height="12" aria-hidden="true">
-      <path d="M2 7.5 L5.5 11 L12 3.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-    </svg>
-  );
-}
-
-// CopyTextButton is the CodeBlock copy control's idiom (clipboard guard,
-// "Copied" feedback with a timed reset) as a standalone header action: the
-// chat bubbles carry prose, not a code block, so the affordance moves into
-// the bubble header's actions slot.
-function CopyTextButton({ text, label }: { text: string; label: string }) {
-  const [copied, setCopied] = useState(false);
-  useEffect(() => {
-    if (!copied) return;
-    const timer = setTimeout(() => setCopied(false), COPIED_RESET_MS);
-    return () => clearTimeout(timer);
-  }, [copied]);
-  return (
-    <IconButton
-      label={copied ? "Copied" : label}
-      icon={copied ? <CopiedGlyph /> : <CopyGlyph />}
-      variant="quiet"
-      size="xs"
-      onClick={() => {
-        // Clipboard access requires a secure context and isn't implemented by
-        // every test/embed environment - degrade to a no-op rather than throw.
-        if (!navigator.clipboard?.writeText) return;
-        void navigator.clipboard.writeText(text).then(() => setCopied(true));
-      }}
-    />
-  );
 }
 
 interface JobListState {
@@ -149,7 +103,7 @@ registerToolRenderer({
     const status = parsedOutput ? str(parsedOutput, "status") : undefined;
     return status ? `Checked ${clipJobID(jobId)} · ${status}` : `Checked ${clipJobID(jobId)}`;
   },
-  body: HeadClippedOutputBody,
+  body: DelegateStatusBody,
 });
 
 registerToolRenderer({
@@ -354,7 +308,7 @@ function DelegateSendBody(props: ToolRenderProps) {
             name={target === "" ? "Agent → delegate" : `Agent → ${target}`}
             timeIso={item.startedAt}
             opensExchange={false}
-            actions={<CopyTextButton text={message} label="Copy message" />}
+            actions={<CopyButton text={message} label="Copy message" />}
           />
         </section>
       ) : null}
@@ -366,7 +320,7 @@ function DelegateSendBody(props: ToolRenderProps) {
             name={target === "" ? "Delegate" : `${target} (delegate)`}
             timeIso={item.completedAt ?? item.startedAt}
             opensExchange={false}
-            actions={<CopyTextButton text={response} label="Copy response" />}
+            actions={<CopyButton text={response} label="Copy response" />}
           />
         </section>
       ) : null}

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -2311,6 +2311,51 @@ test("reload merges a tool CALL and its RESULT (separate turns, same callId) int
   expect(model.turns).toHaveLength(1);
 });
 
+test("reload merges a tool RESULT's raw state into the CALL item (hydration preserves structured raw)", () => {
+  const delegateRaw = { id: "dlg_42", type: "delegate", status: "running", task: "do work" };
+  const thread = testThread({
+    turns: [
+      {
+        id: "turn_1",
+        status: "completed",
+        itemsView: "full",
+        items: [
+          {
+            id: "item_tool_1_0",
+            type: "commandExecution",
+            toolName: "job_status",
+            callId: "call_B",
+            argumentsJson: JSON.stringify({ target: "dlg_42" }),
+            startedAt: 1,
+            status: "inProgress",
+          },
+        ],
+      },
+      {
+        id: "turn_2",
+        status: "completed",
+        itemsView: "full",
+        items: [
+          {
+            id: "item_tool_result_2_0",
+            type: "commandExecution",
+            toolName: "job_status",
+            callId: "call_B",
+            output: JSON.stringify(delegateRaw),
+            raw: delegateRaw,
+            completedAt: 2,
+            status: "completed",
+          },
+        ],
+      },
+    ],
+  });
+  const model = hydrateThread({ thread }, thread.evener.ref, 0);
+  const items = model.turns.flatMap((t) => t.items).filter((i) => i.callId === "call_B");
+  expect(items).toHaveLength(1);
+  expect(items[0]?.raw).toEqual(delegateRaw); // raw from the RESULT survives the merge
+});
+
 test("thread/reasoning-effort/changed updates reasoningEffort", () => {
   let model = testHydrate();
   expect(model.reasoningEffort).toBeUndefined();

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -509,6 +509,7 @@ function mergeToolCallsByCallId(turns: TurnModel[]): TurnModel[] {
             completedAt: result.completedAt,
             status: result.status,
             outputImages: result.outputImages ?? item.outputImages,
+            raw: result.raw ?? item.raw,
           });
           continue;
         }

--- a/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
@@ -512,6 +512,14 @@ const WIDGET_STYLESHEET_RE = /^widgets\/([a-z0-9-]+)\/\1\.module\.css$/;
 // exact-path exception because it is pane content, not a widget stylesheet.
 // Its --alive ring marks an actually in-progress task, which is precisely the
 // semantic "agent working" meaning the token contract reserves for that hue.
+//
+// delegate-status: panes/session/transcript/tools/delegateStatus.module.css
+// earns the same exception for the same structural reason - it lives under
+// panes/session/transcript/tools/, not widgets/<name>/, so it can never match
+// WIDGET_STYLESHEET_RE either. Its one semantic reach is --danger-ink on
+// .dangerText — failure text for a delegate's not-resumable reason and last
+// failed outcome reason. Error text is the danger hue's canonical, ungateable
+// job, the same as railDialog.module.css's .pickerError above.
 const SEMANTIC_PATH_EXCEPTIONS = new Set([
   "shell/rail/RailRow.module.css",
   "shell/rail/railDialog.module.css",
@@ -522,6 +530,7 @@ const SEMANTIC_PATH_EXCEPTIONS = new Set([
   "panes/session/chrome/activitypanel.module.css",
   "panes/session/chrome/taskspanel.module.css",
   "panes/session/transcript/tools/sandboxescalation.module.css",
+  "panes/session/transcript/tools/delegateStatus.module.css",
 ]);
 
 for (const [path, text] of OTHER_STYLESHEETS) {

--- a/cmd/evener-hub/frontend/src/widgets/codeblock/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/codeblock/index.tsx
@@ -1,6 +1,6 @@
-import { Fragment, type ReactNode, useEffect, useMemo, useState } from "react";
+import { Fragment, type ReactNode, useMemo, useState } from "react";
 import { Button } from "../button";
-import { IconButton } from "../iconbutton";
+import { CopyButton } from "../copybutton";
 import { requireClass } from "../internal/requireClass";
 import { parseAnsiLines } from "./ansi";
 import { AnsiLineContent } from "./ansiLine";
@@ -43,8 +43,6 @@ const CLASS = {
   fold: requireClass(styles.fold, "codeblock.module.css", "fold"),
 };
 
-const COPIED_RESET_MS = 2_000;
-
 // 67zh: a raw tool-output block (a pytest traceback, a shell dump) with no
 // cap fills an entire narrow viewport, forcing a reader to scroll THROUGH it
 // rather than past it. Past TAIL_VISIBLE_LINES lines, the block folds to its
@@ -56,23 +54,6 @@ const COPIED_RESET_MS = 2_000;
 // the end - a fold that hid the tail instead would hide the one thing a
 // reader who scrolled this far actually came for.
 const TAIL_VISIBLE_LINES = 14;
-
-function CopyIcon() {
-  return (
-    <svg viewBox="0 0 14 14" width="12" height="12" aria-hidden="true">
-      <rect x="4.5" y="1.5" width="8" height="8" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
-      <path d="M9.5 12.5H3A1.5 1.5 0 0 1 1.5 11V4.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
-    </svg>
-  );
-}
-
-function CopiedIcon() {
-  return (
-    <svg viewBox="0 0 14 14" width="12" height="12" aria-hidden="true">
-      <path d="M2 7.5 L5.5 11 L12 3.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
-    </svg>
-  );
-}
 
 /**
  * A block of source/tool-output text: mono font, an optional language label
@@ -109,26 +90,6 @@ export function CodeBlock({
   const tailStart = folded ? allLines.length - TAIL_VISIBLE_LINES : 0;
   const visibleLines = folded ? allLines.slice(tailStart) : allLines;
   const hiddenCount = tailStart;
-
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) return;
-    const timer = setTimeout(() => setCopied(false), COPIED_RESET_MS);
-    return () => clearTimeout(timer);
-  }, [copied]);
-
-  async function handleCopy() {
-    // Clipboard access requires a secure context and isn't implemented by
-    // every test/embed environment - degrade to a no-op rather than throw.
-    if (!navigator.clipboard?.writeText) return;
-    // Always the FULL text, never `visibleLines` - folding is a display
-    // convenience, not a truncation, and copy must give back exactly what
-    // the tool actually produced.
-    await navigator.clipboard.writeText(copyText ?? text);
-    setCopied(true);
-  }
-
   return (
     <div className={CLASS.root}>
       {/* The banner sits ABOVE the tail it's folding away: the hidden lines
@@ -149,13 +110,7 @@ export function CodeBlock({
         <div className={CLASS.header}>
           {language !== undefined && <span className={CLASS.language}>{language}</span>}
           <span className={CLASS.copy}>
-            <IconButton
-              label={copied ? "Copied" : copyLabel}
-              icon={copied ? <CopiedIcon /> : <CopyIcon />}
-              variant="quiet"
-              size="xs"
-              onClick={handleCopy}
-            />
+            <CopyButton text={copyText ?? text} label={copyLabel} />
           </span>
         </div>
         <pre className={CLASS.pre}>

--- a/cmd/evener-hub/frontend/src/widgets/copybutton/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/copybutton/index.tsx
@@ -1,0 +1,73 @@
+// CopyButton is the standard copy-to-clipboard control: an IconButton with
+// a copy glyph, "Copied" feedback with a timed reset, and a clipboard guard
+// for test/embed environments without navigator.clipboard. It replaces the
+// inline copy logic previously duplicated in CodeBlock, jobTools.tsx's
+// CopyTextButton, and DelegateStatusBody's CopyRawButton.
+//
+// The label prop is the button's accessible name BEFORE copying; while the
+// "Copied" state is active, it becomes "Copied" automatically. Pass a
+// specific label ("Copy output", "Copy raw JSON") so screen readers
+// announce what the button copies.
+import { useEffect, useState } from "react";
+import type { IconButtonProps } from "../iconbutton";
+import { IconButton } from "../iconbutton";
+
+const COPIED_RESET_MS = 2_000;
+
+function CopyIcon() {
+  return (
+    <svg viewBox="0 0 14 14" width="12" height="12" aria-hidden="true">
+      <rect x="4.5" y="1.5" width="8" height="8" rx="1.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <path d="M9.5 12.5H3A1.5 1.5 0 0 1 1.5 11V4.5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+    </svg>
+  );
+}
+
+function CopiedIcon() {
+  return (
+    <svg viewBox="0 0 14 14" width="12" height="12" aria-hidden="true">
+      <path d="M2 7.5 L5.5 11 L12 3.5" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export interface CopyButtonProps extends Omit<IconButtonProps, "label" | "icon" | "onClick"> {
+  /** Text written to the clipboard on click. */
+  text: string;
+  /** The button's accessible name before copying. While the "Copied" state
+   * is active, it becomes "Copied" automatically. Defaults to "Copy". */
+  label?: string;
+  /** IconButton variant; defaults to "quiet". */
+  variant?: IconButtonProps["variant"];
+  /** IconButton size; defaults to "xs". */
+  size?: IconButtonProps["size"];
+}
+
+export function CopyButton({ text, label = "Copy", variant = "quiet", size = "xs", ...rest }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), COPIED_RESET_MS);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  return (
+    <IconButton
+      {...rest}
+      label={copied ? "Copied" : label}
+      icon={copied ? <CopiedIcon /> : <CopyIcon />}
+      variant={variant}
+      size={size}
+      onClick={() => {
+        // Clipboard access requires a secure context and isn't implemented by
+        // every test/embed environment — degrade to a no-op rather than throw.
+        if (!navigator.clipboard?.writeText) return;
+        void navigator.clipboard.writeText(text).then(
+          () => setCopied(true),
+          () => {}, // swallow rejection — a failed copy is a no-op, not an error
+        );
+      }}
+    />
+  );
+}

--- a/cmd/evener-hub/frontend/src/widgets/index.ts
+++ b/cmd/evener-hub/frontend/src/widgets/index.ts
@@ -23,6 +23,8 @@ export type { ConfirmDialogProps } from "./confirmdialog";
 export { ConfirmDialog } from "./confirmdialog";
 export type { ContextCardProps } from "./contextcard";
 export { ContextCard } from "./contextcard";
+export type { CopyButtonProps } from "./copybutton";
+export { CopyButton } from "./copybutton";
 export type { DialogProps } from "./dialog";
 export { Dialog } from "./dialog";
 export type { DiffBlockProps } from "./diffblock";


### PR DESCRIPTION
## Problem

Expanding a `job_status` tool call on a delegate (e.g. "Checked dlg_034... · running") rendered raw compact JSON — an unreadable wall of text.

## Solution

A structured `DelegateStatusBody` component that parses the delegate status and renders it as a dense, design-system-conformant card:

- **Header**: delegate ID + status chip (alive/running, attention/needs-attention, danger/failed)
- **Lifecycle meta**: one inline line — running duration · quiet · last outcome · started time
- **Mandate**: task text rendered as markdown, first paragraph visible, rest behind a disclosure
- **Environment**: meta table (cwd, isolation, sandbox, network)
- **Config**: one inline line — model · agent · reasoning · resumable
- **Available tools**: chip list with count
- **Footer**: transcript ref + copy raw JSON button

Falls back to `HeadClippedOutputBody` when `item.raw` is not a delegate status (shell jobs, legacy transcripts).

## Changes

**Backend** (`agent/session_tools_jobs.go`):
- Added `cwd`, `isolation`, `sandbox_mode`, `sandbox_network` fields to `stableDelegateStatusResult`, populated from the delegate descriptor

**New widget** (`widgets/copybutton/`):
- Standard `CopyButton` widget extracted from CodeBlock inline copy logic, replacing duplicate implementations in CodeBlock and jobTools CopyTextButton

**New component** (`tools/delegateStatus.tsx` + `.module.css`):
- `DelegateStatusBody` — structured card rendering, registered as `job_status` body
- Reuses existing `Chip` widget for status pill, `classifyJobStatus` for tone mapping, `splitMandate` shared with `ActivityRowDetail`

**Refactored**:
- `widgets/codeblock/index.tsx` — uses `CopyButton` instead of inline copy logic
- `tools/jobTools.tsx` — uses `CopyButton` directly, removed dead `CopyTextButton` alias
- `chrome/ActivityRowDetail.tsx` — uses shared `splitMandate` from `format.ts`
- `transcript/messages/format.ts` — extracted `splitMandate` helper

## Gates

- `make test-web`: PASS (typecheck, test, lint)
- `make test-web-browser`: PASS (layoutguard, overflowguard, shellguard, spawnguard)
- Go tests: PASS
