### PR TITLE
feat(agent): delegates may delegate by default

### DIFF
--- a/agent/delegate_default_grant_test.go
+++ b/agent/delegate_default_grant_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Absent means "inherit the default grant"; an explicit 0 means a leaf. The
+// two must stay distinguishable through decoding.
+func TestDecodeDelegateArgs_AllowanceAbsentIsDefaultAndZeroIsLeaf(t *testing.T) {
+	absent, err := decodeDelegateArgs(map[string]any{"prompt": "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if absent.DelegationAllowance != nil {
+		t.Fatalf("absent delegation_allowance decoded as %d, want unset", *absent.DelegationAllowance)
+	}
+	for _, n := range []float64{0, 1, 3} {
+		got, err := decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": n})
+		if err != nil {
+			t.Fatalf("delegation_allowance %v: %v", n, err)
+		}
+		if got.DelegationAllowance == nil || *got.DelegationAllowance != int(n) {
+			t.Fatalf("delegation_allowance %v decoded as %v, want %d", n, got.DelegationAllowance, int(n))
+		}
+	}
+	if _, err := decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": float64(-1)}); err == nil || !strings.Contains(err.Error(), "invalid_request") {
+		t.Fatalf("negative delegation_allowance: err = %v, want invalid_request", err)
+	}
+}
+
+func TestDefaultDelegateGrant(t *testing.T) {
+	for own, want := range map[int]int{0: 0, 1: 0, 2: 1, 4: 3} {
+		if got := defaultDelegateGrant(own); got != want {
+			t.Errorf("defaultDelegateGrant(%d) = %d, want %d", own, got, want)
+		}
+	}
+}
+
+// A delegate created without delegation_allowance inherits one level below
+// its granter, so it can delegate in turn; 0 has to be asked for.
+func TestCreateDelegate_DefaultGrantIsOneBelowTheGranter(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		rootAllowance int
+		args          delegateArgs
+		wantAllowance int
+		wantDelegate  bool
+	}{
+		{"default at allowance 2", 2, delegateArgs{Task: "brief", AgentType: "subagent"}, 1, true},
+		{"default at allowance 1 is a leaf", 1, delegateArgs{Task: "brief", AgentType: "subagent"}, 0, false},
+		{"explicit zero is a leaf", 2, delegateArgs{Task: "brief", AgentType: "subagent", DelegationAllowance: new(0)}, 0, false},
+		{"explicit grant", 2, delegateArgs{Task: "brief", AgentType: "subagent", DelegationAllowance: new(1)}, 1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, _, _ := newDelegateResourceBootstrapSession(t)
+			root.mu.Lock()
+			root.delegationAllowance = tc.rootAllowance
+			root.mu.Unlock()
+			result := root.createDelegate(context.Background(), tc.args)
+			if result.Err != nil {
+				t.Fatalf("createDelegate: %v", result.Err)
+			}
+			root.delegateController.mu.Lock()
+			durable := root.delegateController.durable[result.DelegateID]
+			live := root.delegateController.live[result.DelegateID]
+			root.delegateController.mu.Unlock()
+			if durable == nil || durable.Descriptor.DelegationAllowance != tc.wantAllowance {
+				t.Fatalf("descriptor allowance = %+v, want %d", durable, tc.wantAllowance)
+			}
+			if live == nil || live.binding == nil || live.binding.runtime == nil {
+				t.Fatal("no live child session")
+			}
+			names := live.binding.runtime.reg.RegisteredNames()
+			if names["delegate"] != tc.wantDelegate || names["job_watch"] != tc.wantDelegate {
+				t.Errorf("child delegate=%v job_watch=%v, want both %v", names["delegate"], names["job_watch"], tc.wantDelegate)
+			}
+		})
+	}
+}

--- a/agent/delegate_resource_bootstrap_test.go
+++ b/agent/delegate_resource_bootstrap_test.go
@@ -37,7 +37,7 @@ func TestDelegateResourceBootstrap_ChildInheritsControllerAndStableOwnerID(t *te
 
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "report the result",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if result.Err != nil {
 		t.Fatalf("createDelegate: %v", result.Err)

--- a/agent/delegate_resource_create_test.go
+++ b/agent/delegate_resource_create_test.go
@@ -39,7 +39,7 @@ func TestDelegateResourceCreate_IsolationFailurePublishesNothing(t *testing.T) {
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "remain unpublished",
 		Sandbox:             "workspace-write",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if !errors.Is(result.Err, wantErr) {
 		t.Fatalf("createDelegate error = %v, want isolation failure", result.Err)
@@ -64,7 +64,7 @@ func TestDelegateResourceCreate_StableRouteSkipsLegacyRetentionReservation(t *te
 
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "do not reclaim legacy sessions",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if legacyReservationCalled {
 		t.Fatal("stable create invoked the legacy retained-session reservation seam")
@@ -94,7 +94,7 @@ func TestDelegateResourceCreate_StableIdentityCommitsBeforeRuntimeLaunch(t *test
 
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "commit before construction",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if !errors.Is(result.Err, wantErr) {
 		t.Fatalf("createDelegate error = %v, want construction failure", result.Err)
@@ -134,7 +134,7 @@ func TestDelegateResourceCreate_CommittedUpdatePrecedesConstruction(t *testing.T
 	go func() {
 		createDone <- root.createDelegate(context.Background(), delegateArgs{
 			Task:                "publish before construction",
-			DelegationAllowance: 0,
+			DelegationAllowance: new(0),
 		})
 	}()
 	<-constructorEntered
@@ -177,7 +177,7 @@ func TestDelegateResourceCreate_PostCommitConstructionFailureClosesResumability(
 
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "fail after commit",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if !errors.Is(result.Err, wantErr) {
 		t.Fatalf("createDelegate error = %v, want construction failure", result.Err)
@@ -932,7 +932,7 @@ func TestDelegateResourceCreate_RestoredRootStartsNewChildWithStartupHooks(t *te
 
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "start a new child from the restored root",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if result.Err != nil {
 		t.Fatalf("createDelegate: %v", result.Err)
@@ -972,7 +972,7 @@ func TestDelegateResourceCreate_PostCommitFailureRemainsInspectableAfterRestart(
 
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "remain inspectable",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if !errors.Is(result.Err, wantErr) {
 		t.Fatalf("createDelegate error = %v, want construction failure", result.Err)
@@ -1072,7 +1072,7 @@ func TestDelegateResourceCreate_ResumabilityAppendFailureDestroysNothing(t *test
 
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "retain after append failure",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if !errors.Is(result.Err, wantErr) || !strings.Contains(result.Err.Error(), "store is closed") {
 		t.Fatalf("createDelegate error = %v, want construction and closure-append failures", result.Err)
@@ -1280,7 +1280,7 @@ func prepareCommittedUnadoptedDelegate(t *testing.T, root *Session, task string)
 	t.Helper()
 	runtime := delegateRuntime{owner: root}
 	ctx := context.Background()
-	args := delegateArgs{Task: task, DelegationAllowance: 0}
+	args := delegateArgs{Task: task, DelegationAllowance: new(0)}
 	selection, err := root.selectSubagentModel(ctx, args.Model, args.AgentType)
 	if err != nil {
 		t.Fatalf("selectSubagentModel: %v", err)
@@ -1329,7 +1329,7 @@ func TestDelegateResourceCreate_DescendantEventCallbackSurvivesSpawnConfig(t *te
 	})
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                "preserve descendant callback",
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if result.Err != nil {
 		t.Fatalf("createDelegate: %v", result.Err)
@@ -1386,7 +1386,7 @@ func TestDelegateResourceCreate_ChildTranscriptIsPreseededBeforeRun(t *testing.T
 	const task = "preseed this exact task"
 	result := root.createDelegate(context.Background(), delegateArgs{
 		Task:                task,
-		DelegationAllowance: 0,
+		DelegationAllowance: new(0),
 	})
 	if result.Err != nil {
 		t.Fatalf("createDelegate: %v", result.Err)

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1149,7 +1149,10 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	s.mu.Lock()
 	ownAllowance := s.delegationAllowance
 	s.mu.Unlock()
-	if ok, validRange := validateDelegateGrant(args.DelegationAllowance, ownAllowance); !ok {
+	if args.DelegationAllowance == nil {
+		args.DelegationAllowance = new(defaultDelegateGrant(ownAllowance))
+	}
+	if ok, validRange := validateDelegateGrant(args.grantedAllowance(), ownAllowance); !ok {
 		return delegateStartFailed(fmt.Errorf("invalid_request: delegation_allowance must be less than your own allowance (%d); valid grants: %s", ownAllowance, validRange))
 	}
 	if err := llm.ValidateReasoningEffort(llm.NormalizeReasoningEffort(args.ReasoningEffort)); err != nil {
@@ -1287,8 +1290,8 @@ func (s *Session) delegateActor(ctx context.Context) (delegateActor, error) {
 }
 
 func (s *Session) stableDelegateEffectiveToolNameCeiling(selection subagentModelSelection, args delegateArgs, isolationName string) []string {
-	allTools, allowedTools, deniedTools := baseSubagentToolPolicy(selection.agent, args.DelegationAllowance > 0)
-	return stableDelegateToolNameCeiling(s.reg, s.resultToolName(), allTools, allowedTools, deniedTools, args.DelegationAllowance > 0, args.WatchParent, isolationName)
+	allTools, allowedTools, deniedTools := baseSubagentToolPolicy(selection.agent, args.grantsDelegation())
+	return stableDelegateToolNameCeiling(s.reg, s.resultToolName(), allTools, allowedTools, deniedTools, args.grantsDelegation(), args.WatchParent, isolationName)
 }
 
 func (runtime delegateRuntime) describe(ctx context.Context, args delegateArgs, brief, isolationName string, requestedSandbox *sandbox.SandboxPolicy, selection subagentModelSelection, toolNameCeiling []string) (delegatestore.Descriptor, identifier.Project, error) {
@@ -1301,7 +1304,7 @@ func (runtime delegateRuntime) describe(ctx context.Context, args delegateArgs, 
 	if agentType == "" {
 		agentType = "default"
 	}
-	agentName, rolePrompt := stableDelegateRole(selection, args.DelegationAllowance > 0, s)
+	agentName, rolePrompt := stableDelegateRole(selection, args.grantsDelegation(), s)
 	reasoningEffort := llm.NormalizeReasoningEffort(args.ReasoningEffort)
 	if reasoningEffort == "" {
 		reasoningEffort = llm.NormalizeReasoningEffort(childConfig.ReasoningEffort)
@@ -1365,7 +1368,7 @@ func (runtime delegateRuntime) describe(ctx context.Context, args delegateArgs, 
 		FrozenSkillBodies:             frozenSkillBodies,
 		LocalEnvPolicy:                localEnvPolicyName(s.currentEnv()),
 		ResultSchema:                  resultSchema,
-		DelegationAllowance:           args.DelegationAllowance,
+		DelegationAllowance:           args.grantedAllowance(),
 		WorkingDir:                    s.currentEnv().WorkingDirectory(),
 		Isolation:                     isolationName,
 		Sandbox:                       sandboxSnapshot,

--- a/agent/delegate_task_list_test.go
+++ b/agent/delegate_task_list_test.go
@@ -126,35 +126,6 @@ func TestBuiltinAgents_SubagentCarriesDelegationTools(t *testing.T) {
 	}
 }
 
-func TestCreateDelegate_SubagentDelegatesOnlyWhenGranted(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		allowance int
-		want      bool
-	}{{"granted", 1, true}, {"leaf", 0, false}} {
-		t.Run(tc.name, func(t *testing.T) {
-			root, _, _ := newDelegateResourceBootstrapSession(t)
-			result := root.createDelegate(context.Background(), delegateArgs{Task: "brief", AgentType: "subagent", DelegationAllowance: tc.allowance})
-			if result.Err != nil {
-				t.Fatalf("createDelegate: %v", result.Err)
-			}
-			root.delegateController.mu.Lock()
-			live := root.delegateController.live[result.DelegateID]
-			root.delegateController.mu.Unlock()
-			if live == nil || live.binding == nil || live.binding.runtime == nil {
-				t.Fatal("no live child session")
-			}
-			names := live.binding.runtime.reg.RegisteredNames()
-			if names["delegate"] != tc.want {
-				t.Errorf("child has delegate tool = %v, want %v (allowance %d)", names["delegate"], tc.want, tc.allowance)
-			}
-			if names["job_watch"] != tc.want {
-				t.Errorf("child has job_watch = %v, want %v: a granted subagent supervises its delegates with it, a leaf does not get it", names["job_watch"], tc.want)
-			}
-		})
-	}
-}
-
 // A delegate that shares its parent's task store cannot be seeded with its
 // own task_list: PopulateFromTemplates is a no-op on a non-empty store, so the
 // items would vanish silently. Refuse at creation instead.

--- a/agent/events_queue_covtest_test.go
+++ b/agent/events_queue_covtest_test.go
@@ -340,7 +340,7 @@ func TestCovDecodeDelegateArgs(t *testing.T) {
 	if args.Task != "do stuff" || args.AgentType != "coder" || args.Model != "gpt-5" ||
 		args.ReasoningEffort != "high" || !args.WatchParent || args.Isolation != "worktree" ||
 		args.Sandbox != "off" || args.SandboxNet == nil || !*args.SandboxNet ||
-		args.DelegationAllowance != 3 || args.ResultSchema == nil {
+		args.DelegationAllowance == nil || *args.DelegationAllowance != 3 || args.ResultSchema == nil {
 		t.Fatalf("args = %+v", args)
 	}
 
@@ -356,9 +356,9 @@ func TestCovDecodeDelegateArgs(t *testing.T) {
 		t.Fatalf("sandbox_net omitted: args=%+v, err=%v", args, err)
 	}
 
-	// delegation_allowance = 0 → unset.
+	// delegation_allowance = 0 → an explicit leaf, distinct from absent.
 	args, err = decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": 0})
-	if err != nil || args.DelegationAllowance != 0 {
+	if err != nil || args.DelegationAllowance == nil || *args.DelegationAllowance != 0 {
 		t.Fatalf("delegation_allowance=0: args=%+v, err=%v", args, err)
 	}
 }

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -167,8 +167,8 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 			"enum (described in your agents section); `model` and `reasoning_effort` override the defaults; " +
 			"`result_schema` requests a validated structured result. Creation returns immediately after the delegate's stable " +
 			"metadata and initial input are durable; use notifications or `delegate_send` for subsequent interaction. " +
-			"`delegation_allowance` lets the delegate itself delegate, up to one " +
-			"level shallower than your own allowance. Set watch_parent=true for an observer sidecar: the child can call job_watch(source=\"parent\") and report findings with communicate(end_turn=true). For delegate readiness, status, findings, and final reports, ask the " +
+			"A delegate may itself delegate: by default it gets an allowance one below yours; " +
+			"pass `delegation_allowance` 0 to make it a leaf, or a smaller value to cap its depth. Set watch_parent=true for an observer sidecar: the child can call job_watch(source=\"parent\") and report findings with communicate(end_turn=true). For delegate readiness, status, findings, and final reports, ask the " +
 			"delegate to call `communicate` with the exact marker/report. Observer readiness results can include `watching:true` and `watches` when the observer installed watches. Use the delegate's output as the evidence for judging the work.",
 		Strict: &strictFalse,
 		Parameters: map[string]any{
@@ -197,7 +197,7 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 				"agent_type":           agentTypeSchema,
 				"model":                map[string]any{"type": "string", "description": delegateModelOverrideDescription},
 				"reasoning_effort":     map[string]any{"type": "string", "description": "Reasoning effort for this delegate (low, medium, or high). Default inherits from parent.", "enum": []string{"low", "medium", "high"}},
-				"delegation_allowance": map[string]any{"type": "integer", "description": "0 (default): a leaf delegate that cannot itself delegate. >0: the delegate may delegate, granting onward allowances strictly smaller than this; must be strictly less than your own allowance. The allowance only takes effect if the chosen agent_type carries the `delegate` tool (the built-in `default` and `subagent` roles do; `explorer` does not)."},
+				"delegation_allowance": map[string]any{"type": "integer", "description": "Absent (default): the delegate gets an allowance one below yours and may delegate in turn. 0: a leaf delegate that cannot itself delegate. >0: the delegate may delegate, granting onward allowances strictly smaller than this; must be strictly less than your own allowance. The allowance only takes effect if the chosen agent_type carries the `delegate` tool (the built-in `default` and `subagent` roles do; `explorer` does not)."},
 				"watch_parent":         map[string]any{"type": "boolean", "description": "Grant this child permission to observe your session with job_watch(source=\"parent\"). This does not grant delegation or any transitive watch permission."},
 				"isolation": map[string]any{
 					"type":        "string",

--- a/agent/job_delegate.go
+++ b/agent/job_delegate.go
@@ -30,7 +30,7 @@ type delegateArgs struct {
 	AgentType           string
 	Model               string
 	ReasoningEffort     string
-	DelegationAllowance int
+	DelegationAllowance *int
 	WatchParent         bool
 	Isolation           string
 	Sandbox             string
@@ -162,6 +162,24 @@ func validGrantRange(own int) string {
 func validateDelegateGrant(requested, own int) (bool, string) {
 	return requested < own, validGrantRange(own)
 }
+
+// defaultDelegateGrant is the allowance a delegate receives when its creator
+// names none: one level below the creator's own, so delegates delegate in
+// turn by default and the chain still shortens to a leaf.
+func defaultDelegateGrant(own int) int {
+	return max(0, own-1)
+}
+
+// grantedAllowance is the delegate's resolved allowance; createDelegate fills
+// in the default before anything reads it.
+func (a delegateArgs) grantedAllowance() int {
+	if a.DelegationAllowance == nil {
+		return 0
+	}
+	return *a.DelegationAllowance
+}
+
+func (a delegateArgs) grantsDelegation() bool { return a.grantedAllowance() > 0 }
 
 func delegateStartFailed(err error) delegateResult {
 	return delegateResult{

--- a/agent/plugin_prompt_test.go
+++ b/agent/plugin_prompt_test.go
@@ -184,7 +184,7 @@ func TestUntypedDelegatingSubagentUsesDelegatingRolePrompt(t *testing.T) {
 
 	res := sess.createDelegate(context.Background(), delegateArgs{
 		Task:                "coordinate follow-up work",
-		DelegationAllowance: 1,
+		DelegationAllowance: new(1),
 	})
 	if res.Err != nil {
 		t.Fatalf("createDelegate: %v", res.Err)

--- a/agent/prompts/sections/delegation.md
+++ b/agent/prompts/sections/delegation.md
@@ -1,9 +1,10 @@
 ## Delegation
 
-You can call `delegate` and `job_watch`. By default a delegate is a leaf: it
-cannot delegate further. Pass `delegation_allowance` to `delegate` to let a
-delegate delegate in turn — each grant must be strictly smaller than your own
-allowance, so the chain always shortens and allowance 0 is a leaf.
+You can call `delegate` and `job_watch`. By default a delegate can delegate
+in turn: it gets an allowance one below yours, so the chain always shortens
+and ends in a leaf. Pass `delegation_allowance` 0 to `delegate` when a unit
+must stay a leaf, or a smaller value to cap its depth; every grant must be
+strictly smaller than your own allowance.
 
 Use `delegate` to assign scoped work: `prompt` is the brief and `task_list`
 the ordered steps, when the unit has more than one.

--- a/agent/sandbox_delegate_role_floor_test.go
+++ b/agent/sandbox_delegate_role_floor_test.go
@@ -175,7 +175,7 @@ func TestCreateDelegate_FilteredMutationToolUsesEffectiveCeilingFloor(t *testing
 			result := s.createDelegate(context.Background(), delegateArgs{
 				Task:                "inspect without workspace mutation",
 				AgentType:           "test:filtered-mutator",
-				DelegationAllowance: 0,
+				DelegationAllowance: new(0),
 				Sandbox:             tc.mode,
 			})
 			if !tc.allowed {

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -62,7 +62,7 @@ type SessionConfig struct {
 	MaxCommandTimeoutMS int `json:"max_command_timeout_ms,omitempty"`
 
 	// MaxSubagentDepth limits how deeply sub-agents may spawn further
-	// sub-agents (root session is depth 0). Zero defaults to 1.
+	// sub-agents (root session is depth 0). Zero defaults to 2.
 	MaxSubagentDepth int `json:"max_subagent_depth,omitempty"`
 
 	// MaxConcurrentDelegateTurns bounds concurrently running delegate turns

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -497,14 +497,15 @@ func decodeDelegateArgs(args map[string]any) (delegateArgs, error) {
 			return delegateArgs{}, errors.New("invalid_request: sandbox_net must be a JSON boolean (true or false, not a quoted string)")
 		}
 	}
-	// delegation_allowance: 0/absent = leaf delegate (cannot delegate); positive
-	// = grant; negative = invalid_request. Zero reads as unset (strict-zero rule).
-	// createDelegate enforces the grant rule (strictly less than own allowance).
-	if n, ok := shellIntArg(args, "delegation_allowance"); ok && n != 0 {
+	// delegation_allowance: absent = the default grant (one level below the
+	// creator, resolved by createDelegate); 0 = leaf delegate; positive =
+	// grant; negative = invalid_request. createDelegate enforces the grant
+	// rule (strictly less than own allowance).
+	if n, ok := shellIntArg(args, "delegation_allowance"); ok {
 		if n < 0 {
 			return delegateArgs{}, errors.New("invalid_request: delegation_allowance must be non-negative")
 		}
-		a.DelegationAllowance = n
+		a.DelegationAllowance = &n
 	}
 	if resultSchema, ok := args["result_schema"].(map[string]any); ok {
 		a.ResultSchema = resultSchema

--- a/agent/session_tools_jobs_covtest2_test.go
+++ b/agent/session_tools_jobs_covtest2_test.go
@@ -1191,17 +1191,17 @@ func TestCovDecodeDelegateArgs2(t *testing.T) {
 	if err != nil {
 		t.Fatalf("positive allowance: %v", err)
 	}
-	if a.DelegationAllowance != 3 {
-		t.Fatalf("allowance = %d, want 3", a.DelegationAllowance)
+	if a.DelegationAllowance == nil || *a.DelegationAllowance != 3 {
+		t.Fatalf("allowance = %v, want 3", a.DelegationAllowance)
 	}
 
-	// delegation_allowance zero — unset (strict-zero).
+	// delegation_allowance zero — an explicit leaf, distinct from absent.
 	a, err = decodeDelegateArgs(map[string]any{"prompt": "p", "delegation_allowance": 0})
 	if err != nil {
 		t.Fatalf("zero allowance: %v", err)
 	}
-	if a.DelegationAllowance != 0 {
-		t.Fatalf("zero allowance should be 0, got %d", a.DelegationAllowance)
+	if a.DelegationAllowance == nil || *a.DelegationAllowance != 0 {
+		t.Fatalf("zero allowance should be an explicit 0, got %v", a.DelegationAllowance)
 	}
 
 	// result_schema present.

--- a/agent/subagent_json_excerpt_test.go
+++ b/agent/subagent_json_excerpt_test.go
@@ -86,7 +86,7 @@ func TestSubagentSeesFailingInputExcerpt(t *testing.T) {
 	// on a genuine hang.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	res := sess.createDelegate(ctx, delegateArgs{Task: "write the report", DelegationAllowance: 0})
+	res := sess.createDelegate(ctx, delegateArgs{Task: "write the report", DelegationAllowance: new(0)})
 	if res.Err != nil {
 		t.Fatalf("createDelegate: %v (status=%s reason=%s)", res.Err, res.Status, res.Reason)
 	}

--- a/cmd/evener/main.go
+++ b/cmd/evener/main.go
@@ -264,7 +264,7 @@ func newRunFlagSet(stderr io.Writer) (*flag.FlagSet, *runCLIFlags) {
 	flags.resumeLast = fs.Bool("resume-last", false, "resume the most recent session")
 	flags.listSessions = fs.Bool("list-sessions", false, "list saved sessions and exit")
 	flags.maxRounds = fs.Int("max-rounds", -1, "max tool rounds per input (0=unlimited, default: 200)")
-	flags.maxSubagentDepth = fs.Int("max-subagent-depth", -1, "max subagent nesting depth (default: 1)")
+	flags.maxSubagentDepth = fs.Int("max-subagent-depth", -1, "max subagent nesting depth (default: 2)")
 	flags.maxConcurrentDelegates = fs.Int("max-concurrent-delegates", -1, "max concurrently running delegate turns per session tree (default: 50)")
 	flags.maxRetainedTerminal = fs.Int("max-retained-terminal", -1, "max retained terminal delegate records per session (default: 2048)")
 	flags.shareTaskStore = fs.Bool("share-task-store", false, "share task list between parent and child sessions")

--- a/docs/developing-evener/agentic-testing.md
+++ b/docs/developing-evener/agentic-testing.md
@@ -1047,7 +1047,7 @@ file a kata. Don't try to drive past the gate from the scenario.
   the Setup checklist, never Jesse's real one.
 - **Follow-up turn** (after the initial spawn prompt): send AppWire `turn/start` with `ref:"local:<SID>"`, a unique `clientMutationId`, and `input:[{"type":"text","text":"..."}]` (the spawn only starts turn 1; subsequent user turns use `turn/start`).
 - **Session URL**: `/s/local:<SID>`. A bare `/s/<SID>` renders "Page not found" client-side, by design.
-- **Recursion opt-in** (delegate subagents that can themselves delegate): per-spawn `launch_overrides.maxSubagentDepth:N` raises the root's own delegation allowance to N. Omitted/default is 1 (a root may delegate, but its delegates are leaves) — recursion is dark without this.
+- **Recursion depth** (delegate subagents that can themselves delegate): per-spawn `launch_overrides.maxSubagentDepth:N` sets the root's own delegation allowance to N; each delegate is granted one level below its creator by default. Omitted/default is 2 (the root's delegates may delegate once more; their delegates are leaves). Set 1 to make every delegate a leaf.
 - **Per-session transcript**: `$HOME/.local/state/evener/projects/<project-id>/sessions/<SID>.transcript.jsonl`
 - **Per-session meta**: same dir, `<SID>.meta.json`
 - **Per-daemon log** (everything a spawned session's `evener serve` writes,

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -156,7 +156,7 @@ branch on `type` and `id`; only shell rows carry `job_id`.
 6. **No model-facing ack.** Retention is automatic and policy-based.
 7. **No model-facing kill.** `job_stop` is the single model-facing stop primitive; forceful cleanup is an implementation detail when needed.
 8. **Provider-free restart.** Shell runtime loss is reconciled from shell evidence; stable delegates are folded/rearmed without constructing a Session or calling a provider.
-9. **Nested shell jobs are supported; nested delegation is allowance-gated.** Subagents may start shell jobs. A subagent may itself delegate only when it was granted a non-zero `delegation_allowance`; a leaf delegate (allowance 0, the default) cannot delegate, so an observer sidecar started without an allowance still must not delegate. See the delegation-allowance amendment below.
+9. **Nested shell jobs are supported; nested delegation is allowance-gated.** Subagents may start shell jobs. A subagent may itself delegate only while its `delegation_allowance` is non-zero. By default a delegate is granted one level below its creator, so it can delegate in turn until the chain reaches a leaf; a creator that passes `delegation_allowance: 0` makes a leaf, and an observer sidecar created that way must not delegate. See the delegation-allowance amendment below.
 10. **Delegate creation and follow-up are separate.** `delegate` starts a new delegate conversation; `delegate_send` follows up on an existing `delegate_id`.
 11. **Watches are watcher-owned.** `job_watch` defines conditions over a source's output/events/progress; when a condition is met it delivers a bounded notification/frame to the watcher that created the watch.
 12. **Observers are composed, not special.** An observer is a delegate granted `watch_parent:true`, a child-created `job_watch(source="parent")`, and an observer result through `communicate(end_turn=true)`.
@@ -164,13 +164,13 @@ branch on `type` and `id`; only shell rows carry `job_id`.
 
 ### Delegation allowance (recursive delegation)
 
-`delegate` accepts an optional `delegation_allowance` integer (default 0). The value follows the strict-zero rule used across the job-control surface — absent or 0 means a leaf delegate that cannot itself delegate, exactly today's behavior; there is no `minimum`/`maximum`/`default` keyword on the schema property.
+`delegate` accepts an optional `delegation_allowance` integer. Absent means the default grant: one level below the creator's own allowance (`max(0, own-1)`), so a delegate can delegate in turn until the chain reaches a leaf. An explicit `0` means a leaf delegate that cannot itself delegate; absent and `0` are therefore distinct, unlike the strict-zero rule used elsewhere on the job-control surface. There is no `minimum`/`maximum`/`default` keyword on the schema property.
 
 **The grant rule.** A session may grant a child a `delegation_allowance` strictly less than its own allowance, so the chain always shortens and allowance 0 is a leaf. A grant `>=` the granter's own allowance is rejected with `invalid_request: delegation_allowance must be less than your own allowance (<A>); valid grants: <range>`, where `<A>` is the granter's allowance and `<range>` enumerates the grantable values (`0` at allowance 1, otherwise `0..<A-1>`). A session's own allowance is persisted in the delegate restore descriptor, so it survives restore. The current allowance is also reported on every `job_list` result (see `job_list`), so an agent can read its budget without re-reading its system prompt.
 
 **Availability matrix (allowance-gated).** Whether a child receives the delegation surface is governed by its granted allowance, not by a fixed depth gate. At allowance 0 the child is a leaf: it does not receive `delegate`, agent-type listings that require delegation are filtered out of its prompt, and its system prompt shows the leaf limits block. `job_watch` is present at every allowance — a session that can run jobs can always watch its own jobs — with each cross-session source authorizing itself (`parent` requires the `watch_parent:true` grant; a concrete job id must be owned by the watching session). At allowance > 0 the child receives `delegate` (added to the default surface for an untyped child; a typed agent gets it only if its tool list names it), may grant onward allowances strictly smaller than its own, is told its allowance in its prompt, and sees the delegation + background-jobs prompt sections. A typed agent's tool list governs *what* the child gets; allowance governs *whether* the delegation tools are grantable at all — allowance never injects tools into a type that does not list them.
 
-**Double opt-in (dark by default).** A root session's allowance equals `MaxSubagentDepth` (default 1). Under defaults the root's allowance is 1, so the root may grant only 0 — every delegate is a leaf and recursion never happens. Enabling recursion requires **both** raising `MaxSubagentDepth` in config **and** passing a non-zero `delegation_allowance` per create. Neither alone unlocks it; recursion stays dark until an operator deliberately does both.
+**Depth is the operator's knob.** A root session's allowance equals `MaxSubagentDepth` (default 2). Under defaults the root's allowance is 2, so its delegates receive allowance 1 by default and may delegate once more; their delegates are leaves. An operator caps the whole tree by lowering `MaxSubagentDepth` (1 makes every delegate a leaf), and a creator caps one branch by passing a smaller `delegation_allowance` or `0`.
 
 ## Job identity and visibility
 
@@ -1418,9 +1418,10 @@ a released goroutine as proof of terminal persistence.
 
 ## Nested jobs
 
-Delegates may start shell jobs. They may also create stable child delegates when
-granted a non-zero `delegation_allowance`; allowance zero remains the default,
-so observer sidecars are leaves unless explicitly granted otherwise. Stable
+Delegates may start shell jobs. They may also create stable child delegates while
+their `delegation_allowance` is non-zero, which is the default one level below the
+creator; a creator passes `delegation_allowance: 0` to make a leaf, such as an
+observer sidecar that must not delegate. Stable
 delegate lineage stays in the delegate controller. Shell lineage is typed:
 `parent_job_id` links shell-to-shell work and `parent_delegate_id` names the
 stable delegate that launched a shell.
@@ -1571,9 +1572,9 @@ Tool descriptions and prompts should warn against:
 
 V1 does not define multi-job barriers, any-of/all-of watches, or named job groups. Agents coordinate multiple background jobs through individual terminal notifications and `job_list` recovery. Fan-in/barrier coordination is the likely first future coordination extension if heavy parallel workflows need less manual state tracking, but it remains out of v1 until that surface is deliberately designed.
 
-Nested delegation is allowance-gated: a delegate may create a child only with a
-granted non-zero `delegation_allowance`, and recursion requires both a raised
-`MaxSubagentDepth` and a per-create allowance. Shell jobs are not messageable;
+Nested delegation is allowance-gated: a delegate may create a child only while
+its `delegation_allowance` is non-zero. The default grant is one level below the
+creator, and `MaxSubagentDepth` bounds the whole tree. Shell jobs are not messageable;
 long-running REPL stdin is outside this contract.
 
 ## Capacity and discovery requirements
@@ -1624,9 +1625,9 @@ background unload protocol.
 ## Shipped recursion and owner attention
 
 The tree counter, `include_descendants`, owner-scoped attention, and recursive
-stable stop are shipped. Recursion beyond direct delegates remains behind the
-double opt-in: raise `MaxSubagentDepth` and grant a non-zero
-`delegation_allowance` on the parent delegate. Neither setting alone unlocks it.
+stable stop are shipped. Recursion beyond direct delegates is on by default
+within `MaxSubagentDepth`: each delegate is granted one level below its creator
+unless the creator passes a smaller `delegation_allowance` or `0`.
 
 A session renders only attention for work it owns. Parent-driven child turns
 preserve that rule while retaining ancestor inspection through

--- a/internal/bundled/agents/subagent.md
+++ b/internal/bundled/agents/subagent.md
@@ -1,6 +1,6 @@
 ---
 name: subagent
-description: "Implementer for one bounded unit of work: owns the paths its brief names, makes the change, runs the check that proves it, and reports the evidence. Also handles a scoped investigation or review when that is what the brief asks for. Delegates in turn only when its parent grants a `delegation_allowance`; with the default allowance of 0 it is a leaf."
+description: "Implementer for one bounded unit of work: owns the paths its brief names, makes the change, runs the check that proves it, and reports the evidence. Also handles a scoped investigation or review when that is what the brief asks for. Delegates in turn by default, one level below its parent's allowance; a parent that passes `delegation_allowance` 0 makes it a leaf."
 model: inherit
 color: blue
 tools: [glob, grep, read_file, write_file, apply_patch, shell, task_list, web_fetch, delegate, delegate_send, job_status, job_list, job_stop, read_transcript]


### PR DESCRIPTION
## Summary

- A delegate created without `delegation_allowance` now gets one level below its creator's allowance (`max(0, own-1)`) instead of 0, so it can delegate in turn until the chain reaches a leaf.
- An explicit `delegation_allowance: 0` still makes a leaf. Absent and `0` are now distinct, so `delegateArgs.DelegationAllowance` is a `*int` and `createDelegate` resolves the default before validation and before anything reads it.
- `MaxSubagentDepth` remains the operator bound. Under the default depth of 2 the root's delegates get allowance 1 and their delegates are leaves; depth 1 makes every delegate a leaf.
- Tool schema text, the delegation prompt section, the built-in `subagent` role description, and the job-control and agentic-testing docs now describe this default. The "double opt-in, dark by default" doctrine in `docs/job-control.md` is replaced by "depth is the operator's knob".

## Tests

- `TestDecodeDelegateArgs_AllowanceAbsentIsDefaultAndZeroIsLeaf`: absent decodes as unset, `0`/`1`/`3` as explicit, negative is `invalid_request`.
- `TestDefaultDelegateGrant`: `0→0, 1→0, 2→1, 4→3`.
- `TestCreateDelegate_DefaultGrantIsOneBelowTheGranter`: default at allowance 2 yields a child with allowance 1 carrying `delegate`/`job_watch`; default at allowance 1 yields a leaf without error; explicit 0 is a leaf; explicit 1 is granted. Replaces `TestCreateDelegate_SubagentDelegatesOnlyWhenGranted`.
- Existing decode tests updated from "0 means unset" to "0 is an explicit leaf"; existing `delegateArgs` literals that relied on leaf behavior now say `DelegationAllowance: new(0)`.

`go test ./agent/... ./cmd/... ./internal/...` and `golangci-lint` clean.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT