### PR TITLE
fix(web): render stopped/cancelled outcome reasons in delegate status diagnostics

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.tsx
@@ -340,7 +340,9 @@ export function DelegateStatusBody({ item, sessionRef }: ToolRenderProps) {
       {/* Config: one inline line */}
       {config.length > 0 && <MetaLine segments={config} />}
 
-      {/* Diagnostics: not-resumable reason and/or last outcome reason */}
+      {/* Diagnostics: not-resumable reason and/or last outcome reason.
+          All non-success terminal outcomes render their reason: failed→danger,
+          exhausted/cancelled/stopped→neutral (soft stops, not errors). */}
       {state.not_resumable_reason && (
         <div className={CLASS.diagnostic} data-testid="delegate-not-resumable">
           <div className={`${CLASS.diagnosticBody} ${CLASS.dangerText}`}>
@@ -362,6 +364,13 @@ export function DelegateStatusBody({ item, sessionRef }: ToolRenderProps) {
             </div>
           </div>
         )}
+      {state.last_outcome?.reason && classifyJobStatus(state.last_outcome.status) === "stopped" && (
+        <div className={CLASS.diagnostic} data-testid="delegate-outcome-reason">
+          <div className={CLASS.diagnosticBody}>
+            Last run {state.last_outcome.status === "cancelled" ? "cancelled" : "stopped"}: {state.last_outcome.reason}
+          </div>
+        </div>
+      )}
 
       {/* Available tools */}
       {tools.length > 0 && (

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.test.tsx
@@ -280,8 +280,39 @@ test("job_status: body renders exhausted outcome reason without danger text", ()
     last_outcome: { status: "exhausted", reason: "budget limit reached" },
   });
   render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
-  expect(screen.getByTestId("delegate-outcome-reason")).toBeTruthy();
+  const diag = screen.getByTestId("delegate-outcome-reason");
+  expect(diag).toBeTruthy();
   expect(screen.getByText(/Last run exhausted: budget limit reached/)).toBeTruthy();
+  // Soft stops are not errors — the diagnostic must not carry the danger class.
+  expect(diag.querySelector("[class]")?.className).not.toMatch(/dangerText/);
+});
+
+test("job_status: body renders stopped outcome reason without danger text", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({
+    status: "idle",
+    last_outcome: { status: "stopped", reason: "stopped_by_parent" },
+  });
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  const diag = screen.getByTestId("delegate-outcome-reason");
+  expect(diag).toBeTruthy();
+  expect(screen.getByText(/Last run stopped: stopped_by_parent/)).toBeTruthy();
+  expect(diag.querySelector("[class]")?.className).not.toMatch(/dangerText/);
+});
+
+test("job_status: body renders cancelled outcome with cancelled label", () => {
+  const d = toolRendererFor("job_status");
+  const Body = d.body!;
+  const raw = delegateStatusRaw({
+    status: "idle",
+    last_outcome: { status: "cancelled", reason: "user requested cancel" },
+  });
+  render(<Body item={item({ toolName: "job_status", output: JSON.stringify(raw), raw })} live={false} />);
+  const diag = screen.getByTestId("delegate-outcome-reason");
+  expect(diag).toBeTruthy();
+  expect(screen.getByText(/Last run cancelled: user requested cancel/)).toBeTruthy();
+  expect(diag.querySelector("[class]")?.className).not.toMatch(/dangerText/);
 });
 
 test("job_read_output aliases to the same descriptor as job_status", () => {


### PR DESCRIPTION
Roborev found that cancelled and stopped outcome reasons were omitted from the delegate status card — only exhausted and failed statuses rendered their reason. This adds a diagnostic block for stopped outcomes (cancelled maps to stopped via classifyJobStatus), and a test exercising the path.

Follow-up to #844 which was merged before this fix could be pushed.