### PR TITLE
fix(agent): heal default communicate envelopes

### DIFF
--- a/agent/cov_s3_communicate_test.go
+++ b/agent/cov_s3_communicate_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/agent/internal/tool"
 )
 
 func TestS3Cov_NormalizeNodeOutput(t *testing.T) {
@@ -138,31 +138,17 @@ func TestS3Cov_StringSetsEqual(t *testing.T) {
 func TestS3Cov_UsesDefaultCommunicateOutputEnvelope(t *testing.T) {
 	t.Parallel()
 
-	envelope := func(required any) llm.ToolDefinition {
-		return llm.ToolDefinition{Parameters: map[string]any{
-			"properties": map[string]any{
-				"output": map[string]any{
-					"properties": map[string]any{
-						"message":   map[string]any{},
-						"data":      map[string]any{},
-						"artifacts": map[string]any{},
-					},
-					"required": required,
-				},
-			},
-		}}
-	}
-
-	if !usesDefaultCommunicateOutputEnvelope(envelope([]any{"message", "data", "artifacts"})) {
+	if !usesDefaultCommunicateOutputEnvelope(tool.DefCommunicateNamed("communicate")) {
 		t.Fatal("full default envelope should be recognized")
 	}
-	// Missing a required name → not the default envelope.
-	if usesDefaultCommunicateOutputEnvelope(envelope([]any{"message"})) {
-		t.Fatal("partial required set is not the default envelope")
+	stricter := tool.DefCommunicateNamed("communicate")
+	params := tool.CloneSchemaMap(stricter.Parameters)
+	params["properties"].(map[string]any)["output"].(map[string]any)["properties"].(map[string]any)["message"] = map[string]any{
+		"type": "string", "enum": []string{"only"},
 	}
-	// No output props at all → false.
-	if usesDefaultCommunicateOutputEnvelope(llm.ToolDefinition{Parameters: map[string]any{}}) {
-		t.Fatal("missing output props should be false")
+	stricter.Parameters = params
+	if usesDefaultCommunicateOutputEnvelope(stricter) {
+		t.Fatal("same-key stricter output schema is not the default envelope")
 	}
 }
 

--- a/agent/cov_s3_communicate_test.go
+++ b/agent/cov_s3_communicate_test.go
@@ -152,6 +152,16 @@ func TestS3Cov_UsesDefaultCommunicateOutputEnvelope(t *testing.T) {
 	}
 }
 
+func BenchmarkUsesDefaultCommunicateOutputEnvelope(b *testing.B) {
+	def := tool.DefCommunicateNamed("communicate")
+	b.ReportAllocs()
+	for b.Loop() {
+		if !usesDefaultCommunicateOutputEnvelope(def) {
+			b.Fatal("canonical default envelope was not recognized")
+		}
+	}
+}
+
 func TestS3Cov_PredictionMessage(t *testing.T) {
 	t.Parallel()
 	pinnedLight := predictionMessage(false, lowPressurePredict-0.1)

--- a/agent/cov_s3_communicate_test.go
+++ b/agent/cov_s3_communicate_test.go
@@ -100,41 +100,6 @@ func TestS3Cov_HasMeaningfulRawOutput(t *testing.T) {
 	}
 }
 
-func TestS3Cov_CommunicateSchemaStringSlice(t *testing.T) {
-	t.Parallel()
-	if got := communicateSchemaStringSlice([]string{"a", "b"}); len(got) != 2 || got[0] != "a" {
-		t.Fatalf("[]string case: %v", got)
-	}
-	if got := communicateSchemaStringSlice([]any{"a", 1, "b"}); len(got) != 2 || got[1] != "b" {
-		t.Fatalf("[]any case: %v", got)
-	}
-	if got := communicateSchemaStringSlice(42); got != nil {
-		t.Fatalf("default case: %v", got)
-	}
-}
-
-func TestS3Cov_StringSetsEqual(t *testing.T) {
-	t.Parallel()
-	props := func(names ...string) map[string]any {
-		m := map[string]any{}
-		for _, n := range names {
-			m[n] = map[string]any{}
-		}
-		return m
-	}
-	if !stringSetsEqual(props("x", "y"), []string{"y", "x"}, "x", "y") {
-		t.Fatal("expected equal")
-	}
-	// Missing member.
-	if stringSetsEqual(props("x"), []string{"x", "y"}, "x", "y") {
-		t.Fatal("expected not equal: required missing y")
-	}
-	// Extra member.
-	if stringSetsEqual(props("x", "y", "z"), []string{"x", "y"}, "x", "y") {
-		t.Fatal("expected not equal: extra property z")
-	}
-}
-
 func TestS3Cov_UsesDefaultCommunicateOutputEnvelope(t *testing.T) {
 	t.Parallel()
 

--- a/agent/cov_stweb_fuzz_test.go
+++ b/agent/cov_stweb_fuzz_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"slices"
 	"strings"
 	"testing"
 
@@ -202,12 +201,6 @@ func stoolCommunicateRun(t *testing.T, data []byte) stoolCommunicateTrace {
 		if usesDefaultCommunicateOutputEnvelope(def) {
 			t.Fatalf("custom schema recognized as default: %#v", def)
 		}
-	}
-	if got := communicateSchemaStringSlice([]any{"message", 1, "data"}); len(got) != 2 || !slices.Contains(got, "data") {
-		t.Fatalf("schema string normalization = %#v", got)
-	}
-	if got := communicateSchemaStringSlice(42); got != nil {
-		t.Fatalf("unexpected schema strings = %#v", got)
 	}
 
 	return stoolCommunicateTrace{

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
 
@@ -37,8 +38,18 @@ const toolIntentDescription = "Describe what you expect to learn or accomplish f
 // keep the two values in sync by comment.)
 const MaxToolArgumentBytes = 2 * 1024 * 1024
 
-// Keep the unexported spelling for package-local callers and tests.
-const maxToolArgumentBytes = MaxToolArgumentBytes
+// ValidateRawArguments rejects raw tool argument bytes that must never reach a
+// lossy JSON decode or an allocation-heavy schema path. Callers return this
+// bounded diagnostic directly to keep all prevalidation paths consistent.
+func ValidateRawArguments(arguments []byte) error {
+	if len(arguments) > MaxToolArgumentBytes {
+		return fmt.Errorf("tool arguments too large: %d bytes exceeds the %d byte limit", len(arguments), MaxToolArgumentBytes)
+	}
+	if !utf8.Valid(arguments) {
+		return errors.New("invalid tool arguments JSON: input is not valid UTF-8")
+	}
+	return nil
+}
 
 // ctxIntentKey is the context key carrying a tool call's `intent` argument
 // past the registry's strip point (see ExecuteCall): handlers that want it —
@@ -656,9 +667,8 @@ func (r *Registry) ExecuteCall(ctx context.Context, env execenv.ExecutionEnviron
 		return truncateResult(name, callID, msg, true, defaultToolLimit(name))
 	}
 
-	if len(call.Arguments) > maxToolArgumentBytes {
-		msg := fmt.Sprintf("tool arguments too large: %d bytes exceeds the %d byte limit", len(call.Arguments), maxToolArgumentBytes)
-		return truncateResult(name, callID, msg, true, defaultToolLimit(name))
+	if err := ValidateRawArguments(call.Arguments); err != nil {
+		return truncateResult(name, callID, err.Error(), true, defaultToolLimit(name))
 	}
 
 	var args map[string]any

--- a/agent/internal/tool/registry.go
+++ b/agent/internal/tool/registry.go
@@ -25,7 +25,7 @@ import (
 
 const toolIntentDescription = "Describe what you expect to learn or accomplish from this tool call, using a verb-first gerund. Make the expected outcome clear to the user and your future self; e.g. \"Reading config to identify the active profile\" or \"Searching handlers to locate request routing.\""
 
-// maxToolArgumentBytes caps the size of a tool call's raw argument payload
+// MaxToolArgumentBytes caps the size of a tool call's raw argument payload
 // before it is parsed, so a runaway generation can't push a multi-hundred-KB
 // blob through JSON unmarshaling and schema validation for no useful reason.
 // This must stay above agent/jobs.go's maxPersistedStructuredResultJSONBytes
@@ -35,7 +35,10 @@ const toolIntentDescription = "Describe what you expect to learn or accomplish f
 // before it ever reached that graceful path. (Cross-package constant:
 // agent/internal/tool cannot import agent to derive this by reference, so
 // keep the two values in sync by comment.)
-const maxToolArgumentBytes = 2 * 1024 * 1024
+const MaxToolArgumentBytes = 2 * 1024 * 1024
+
+// Keep the unexported spelling for package-local callers and tests.
+const maxToolArgumentBytes = MaxToolArgumentBytes
 
 // ctxIntentKey is the context key carrying a tool call's `intent` argument
 // past the registry's strip point (see ExecuteCall): handlers that want it —

--- a/agent/internal/tool/registry_test.go
+++ b/agent/internal/tool/registry_test.go
@@ -343,7 +343,7 @@ func TestToolRegistry_OversizedArguments_IsReturnedToModel(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
-	arguments := json.RawMessage(strings.Repeat("a", maxToolArgumentBytes+1))
+	arguments := json.RawMessage(strings.Repeat("a", MaxToolArgumentBytes+1))
 	res := r.ExecuteCall(context.Background(), execenv.NewLocalExecutionEnvironment(t.TempDir()), llm.ToolCallData{
 		ID:        "c1",
 		Name:      "t",
@@ -352,7 +352,7 @@ func TestToolRegistry_OversizedArguments_IsReturnedToModel(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected error")
 	}
-	wantMsg := fmt.Sprintf("tool arguments too large: %d bytes exceeds the %d byte limit", len(arguments), maxToolArgumentBytes)
+	wantMsg := fmt.Sprintf("tool arguments too large: %d bytes exceeds the %d byte limit", len(arguments), MaxToolArgumentBytes)
 	if res.Output != wantMsg {
 		t.Fatalf("output = %q, want %q", res.Output, wantMsg)
 	}
@@ -374,7 +374,7 @@ func TestToolRegistry_ArgumentsAtSizeCapBoundary_NotRejectedByCap(t *testing.T) 
 	// Exactly at the cap: must not be rejected by the size gate. It's not
 	// valid JSON either, so it falls through to the existing "invalid tool
 	// arguments JSON" path - this test only confirms the size gate didn't fire.
-	arguments := json.RawMessage(strings.Repeat("a", maxToolArgumentBytes))
+	arguments := json.RawMessage(strings.Repeat("a", MaxToolArgumentBytes))
 	res := r.ExecuteCall(context.Background(), execenv.NewLocalExecutionEnvironment(t.TempDir()), llm.ToolCallData{
 		ID:        "c1",
 		Name:      "t",

--- a/agent/internal/tool/repair/repair.go
+++ b/agent/internal/tool/repair/repair.go
@@ -6,6 +6,7 @@ package repair
 
 import (
 	"maps"
+	"math"
 	"strconv"
 	"strings"
 )
@@ -131,7 +132,7 @@ func applyCoercions(params, args map[string]any) []Change {
 				continue
 			}
 			f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
-			if err != nil {
+			if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
 				continue
 			}
 			args[key] = f

--- a/agent/internal/tool/repair/repair.go
+++ b/agent/internal/tool/repair/repair.go
@@ -14,12 +14,15 @@ import (
 type ChangeKind string
 
 const (
-	ChangeAlias            ChangeKind = "alias"
-	ChangeCoerceType       ChangeKind = "coerce_type"
-	ChangeDropUnknown      ChangeKind = "drop_unknown"
-	ChangeUnicodeRepair    ChangeKind = "unicode_repair"
-	ChangeFillRequired     ChangeKind = "fill_required"
-	ChangeNormalizeDefault ChangeKind = "normalize_default"
+	ChangeAlias             ChangeKind = "alias"
+	ChangeCoerceType        ChangeKind = "coerce_type"
+	ChangeDropUnknown       ChangeKind = "drop_unknown"
+	ChangeUnicodeRepair     ChangeKind = "unicode_repair"
+	ChangeFillRequired      ChangeKind = "fill_required"
+	ChangeNormalizeDefault  ChangeKind = "normalize_default"
+	ChangeSynthesize        ChangeKind = "synthesize"
+	ChangeCopy              ChangeKind = "copy"
+	ChangePromoteJSONObject ChangeKind = "promote_json_object"
 )
 
 // Change records one repair for telemetry. Field is the affected key ("" for a

--- a/agent/internal/tool/repair/repair_test.go
+++ b/agent/internal/tool/repair/repair_test.go
@@ -158,6 +158,22 @@ func TestRepairArgs_Coerce_NonNumericStringUntouched(t *testing.T) {
 	}
 }
 
+func TestRepairArgs_Coerce_NonFiniteNumberStringsUntouched(t *testing.T) {
+	for _, value := range []string{"NaN", "+Inf", "-Inf"} {
+		t.Run(value, func(t *testing.T) {
+			out, changes := RepairArgs(coerceParams(), map[string]any{"count": value})
+			if out["count"] != value {
+				t.Fatalf("count = %#v, want original %q", out["count"], value)
+			}
+			for _, change := range changes {
+				if change.Field == "count" {
+					t.Fatalf("non-finite number was coerced: %+v", change)
+				}
+			}
+		})
+	}
+}
+
 func openParams() map[string]any {
 	return map[string]any{
 		"type":                 "object",

--- a/agent/session_communicate_issue831_test.go
+++ b/agent/session_communicate_issue831_test.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"sync"
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/agenttest"
+	"primeradiant.com/evener/agent/internal/hooks"
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/agent/internal/tool/repair"
+	"primeradiant.com/evener/agent/plugin"
 	"primeradiant.com/evener/llm"
 )
 
@@ -478,6 +482,135 @@ func TestSession_InvalidRawCommunicateArgumentsDoNotHealOrEmitTelemetryIssue831(
 			})
 		}
 	}
+}
+
+func TestSession_PreToolUseHookDoesNotDecodeOrMergeInvalidRawArgumentsIssue831(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args func() []byte
+		want func([]byte) string
+	}{
+		{
+			name: "over limit",
+			args: func() []byte {
+				base := `{"end_turn":true,"message":"top-level"}`
+				return []byte(base + strings.Repeat(" ", tool.MaxToolArgumentBytes+1-len(base)))
+			},
+			want: func(args []byte) string {
+				return fmt.Sprintf("tool arguments too large: %d bytes exceeds the %d byte limit", len(args), tool.MaxToolArgumentBytes)
+			},
+		},
+		{
+			name: "invalid UTF-8",
+			args: func() []byte {
+				args := append([]byte(`{"end_turn":true,"message":"`), 0xff)
+				return append(args, []byte(`"}`)...)
+			},
+			want: func([]byte) string { return "invalid tool arguments JSON: input is not valid UTF-8" },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sess := newSession(t, withoutGitSnapshot())
+			sess.stateDir = t.TempDir()
+			var mu sync.Mutex
+			var prompts []string
+			hookClient := llm.NewClient()
+			hookClient.Register(&agenttest.ScriptedAdapter{Provider: "openai", Responder: func(req llm.Request) llm.Response {
+				mu.Lock()
+				prompts = append(prompts, req.Messages[0].Text())
+				mu.Unlock()
+				return llm.Response{Message: llm.Assistant(`{"hookSpecificOutput":{"updatedInput":{"end_turn":true,"message":"hook replacement","output":{"message":"","data":{},"artifacts":[]}}}}`)}
+			}})
+			runner := hooks.NewRunner(hookClient, "gpt-5.2")
+			runner.Add(plugin.HookPreToolUse, plugin.RegisteredHook{Matcher: "*", Type: "prompt", Prompt: "input=$TOOL_INPUT"})
+			sess.hookRunner = runner
+
+			observed := make(chan struct {
+				repaired []events.ToolCallRepairedData
+				end      *events.ToolCallEndData
+			}, 1)
+			go func() {
+				var got struct {
+					repaired []events.ToolCallRepairedData
+					end      *events.ToolCallEndData
+				}
+				for event := range sess.Events() {
+					switch data := event.Data.(type) {
+					case events.ToolCallRepairedData:
+						got.repaired = append(got.repaired, data)
+					case events.ToolCallEndData:
+						if data.CallID == "issue831-hook-raw" {
+							data := data
+							got.end = &data
+						}
+					}
+				}
+				observed <- got
+			}()
+
+			args := tc.args()
+			res := sess.execTool(context.Background(), llm.ToolCallData{ID: "issue831-hook-raw", Name: "communicate", Arguments: args}, "")
+			if !res.IsError || !res.PrevalOnly || res.FullOutput != tc.want(args) {
+				t.Fatalf("result = %+v, want raw prevalidation error %q", res, tc.want(args))
+			}
+			if len(res.FullOutput) > 256 {
+				t.Fatalf("error was not bounded: %d bytes", len(res.FullOutput))
+			}
+
+			sess.Close()
+			got := <-observed
+			mu.Lock()
+			defer mu.Unlock()
+			if len(prompts) != 1 || prompts[0] != "input=null" {
+				t.Fatalf("hook prompts = %d/%q, want one bounded null input", len(prompts), boundedStringForIssue831(prompts))
+			}
+			if len(got.repaired) != 0 {
+				t.Fatalf("invalid raw hook call emitted repairs: %+v", got.repaired)
+			}
+			if got.end == nil || got.end.ArgumentsJSON != string(args) {
+				t.Fatalf("end = %+v, want original raw arguments", got.end)
+			}
+		})
+	}
+}
+
+func TestSession_PreToolUseHookStillReceivesValidSchemaInvalidArgumentsIssue831(t *testing.T) {
+	sess := newSession(t, withoutGitSnapshot())
+	sess.stateDir = t.TempDir()
+	var mu sync.Mutex
+	var prompts []string
+	hookClient := llm.NewClient()
+	hookClient.Register(&agenttest.ScriptedAdapter{Provider: "openai", Responder: func(req llm.Request) llm.Response {
+		mu.Lock()
+		prompts = append(prompts, req.Messages[0].Text())
+		mu.Unlock()
+		return llm.Response{Message: llm.Assistant(`{}`)}
+	}})
+	runner := hooks.NewRunner(hookClient, "gpt-5.2")
+	runner.Add(plugin.HookPreToolUse, plugin.RegisteredHook{Matcher: "*", Type: "prompt", Prompt: "input=$TOOL_INPUT"})
+	sess.hookRunner = runner
+
+	res := sess.execTool(context.Background(), llm.ToolCallData{ID: "issue831-hook-schema", Name: "communicate", Arguments: json.RawMessage(`{"end_turn":"not-a-bool","message":"top-level","output":{"message":"","data":{},"artifacts":[]}}`)}, "")
+	if !res.IsError || !res.PrevalOnly {
+		t.Fatalf("result = %+v, want schema prevalidation failure", res)
+	}
+	sess.Close()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(prompts) != 1 || prompts[0] == "input=null" || !strings.Contains(prompts[0], `"end_turn":"not-a-bool"`) {
+		t.Fatalf("valid schema-invalid input did not reach hook: %q", boundedStringForIssue831(prompts))
+	}
+}
+
+func boundedStringForIssue831(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	const outputLimit = 200
+	if len(values[0]) <= outputLimit {
+		return values[0]
+	}
+	return values[0][:outputLimit] + "…"
 }
 
 func TestPrepareToolCall_WhitespaceOutputMessageDoesNotBecomeTopLevelMessageIssue831(t *testing.T) {

--- a/agent/session_communicate_issue831_test.go
+++ b/agent/session_communicate_issue831_test.go
@@ -493,7 +493,7 @@ func TestSession_PreToolUseHookDoesNotDecodeOrMergeInvalidRawArgumentsIssue831(t
 		{
 			name: "over limit",
 			args: func() []byte {
-				base := `{"end_turn":true,"message":"top-level"}`
+				base := `{"end_turn":true,"intent":"must not become a start description","message":"top-level"}`
 				return []byte(base + strings.Repeat(" ", tool.MaxToolArgumentBytes+1-len(base)))
 			},
 			want: func(args []byte) string {
@@ -503,7 +503,7 @@ func TestSession_PreToolUseHookDoesNotDecodeOrMergeInvalidRawArgumentsIssue831(t
 		{
 			name: "invalid UTF-8",
 			args: func() []byte {
-				args := append([]byte(`{"end_turn":true,"message":"`), 0xff)
+				args := append([]byte(`{"end_turn":true,"intent":"must not become a start description","message":"`), 0xff)
 				return append(args, []byte(`"}`)...)
 			},
 			want: func([]byte) string { return "invalid tool arguments JSON: input is not valid UTF-8" },
@@ -527,17 +527,24 @@ func TestSession_PreToolUseHookDoesNotDecodeOrMergeInvalidRawArgumentsIssue831(t
 
 			observed := make(chan struct {
 				repaired []events.ToolCallRepairedData
+				start    *events.ToolCallStartData
 				end      *events.ToolCallEndData
 			}, 1)
 			go func() {
 				var got struct {
 					repaired []events.ToolCallRepairedData
+					start    *events.ToolCallStartData
 					end      *events.ToolCallEndData
 				}
 				for event := range sess.Events() {
 					switch data := event.Data.(type) {
 					case events.ToolCallRepairedData:
 						got.repaired = append(got.repaired, data)
+					case events.ToolCallStartData:
+						if data.CallID == "issue831-hook-raw" {
+							data := data
+							got.start = &data
+						}
 					case events.ToolCallEndData:
 						if data.CallID == "issue831-hook-raw" {
 							data := data
@@ -567,8 +574,109 @@ func TestSession_PreToolUseHookDoesNotDecodeOrMergeInvalidRawArgumentsIssue831(t
 			if len(got.repaired) != 0 {
 				t.Fatalf("invalid raw hook call emitted repairs: %+v", got.repaired)
 			}
+			if got.start == nil || got.start.Description != "" {
+				t.Fatalf("start = %+v, want no description derived from raw-invalid arguments", got.start)
+			}
 			if got.end == nil || got.end.ArgumentsJSON != string(args) {
 				t.Fatalf("end = %+v, want original raw arguments", got.end)
+			}
+		})
+	}
+}
+
+func TestSession_PreToolUseHookDenialCannotOverrideInvalidRawArgumentsIssue831(t *testing.T) {
+	sess := newSession(t, withoutGitSnapshot())
+	sess.stateDir = t.TempDir()
+	var mu sync.Mutex
+	var prompts []string
+	hookClient := llm.NewClient()
+	hookClient.Register(&agenttest.ScriptedAdapter{Provider: "openai", Responder: func(req llm.Request) llm.Response {
+		mu.Lock()
+		prompts = append(prompts, req.Messages[0].Text())
+		mu.Unlock()
+		return llm.Response{Message: llm.Assistant(`{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"hook denial"}}`)}
+	}})
+	runner := hooks.NewRunner(hookClient, "gpt-5.2")
+	runner.Add(plugin.HookPreToolUse, plugin.RegisteredHook{Matcher: "*", Type: "prompt", Prompt: "input=$TOOL_INPUT"})
+	sess.hookRunner = runner
+	args := []byte(`{"end_turn":true,"message":"top-level"}` + strings.Repeat(" ", tool.MaxToolArgumentBytes+1-len(`{"end_turn":true,"message":"top-level"}`)))
+
+	res := sess.execTool(context.Background(), llm.ToolCallData{ID: "issue831-hook-deny-raw", Name: "communicate", Arguments: args}, "")
+	if !res.IsError || !res.PrevalOnly || res.FullOutput != fmt.Sprintf("tool arguments too large: %d bytes exceeds the %d byte limit", len(args), tool.MaxToolArgumentBytes) {
+		t.Fatalf("result = %+v, want raw prevalidation error", res)
+	}
+	sess.Close()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(prompts) != 1 || prompts[0] != "input=null" {
+		t.Fatalf("hook prompts = %d/%q, want one bounded null input", len(prompts), boundedStringForIssue831(prompts))
+	}
+}
+
+func TestSession_PreToolUseHookCanDenyOrUpdateValidSchemaInvalidArgumentsIssue831(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		hookResponse string
+		wantError    bool
+		wantPreval   bool
+		wantOutput   string
+		wantUpdated  bool
+	}{
+		{
+			name:         "deny",
+			hookResponse: `{"hookSpecificOutput":{"permissionDecision":"deny","permissionDecisionReason":"hook denial"}}`,
+			wantError:    true,
+			wantOutput:   "hook denial",
+		},
+		{
+			name:         "update",
+			hookResponse: `{"hookSpecificOutput":{"permissionDecision":"allow","updatedInput":{"end_turn":true}}}`,
+			wantError:    true,
+			wantPreval:   true,
+			wantUpdated:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sess := newSession(t, withoutGitSnapshot())
+			sess.stateDir = t.TempDir()
+			var mu sync.Mutex
+			var prompts []string
+			hookClient := llm.NewClient()
+			hookClient.Register(&agenttest.ScriptedAdapter{Provider: "openai", Responder: func(req llm.Request) llm.Response {
+				mu.Lock()
+				prompts = append(prompts, req.Messages[0].Text())
+				mu.Unlock()
+				return llm.Response{Message: llm.Assistant(tc.hookResponse)}
+			}})
+			runner := hooks.NewRunner(hookClient, "gpt-5.2")
+			runner.Add(plugin.HookPreToolUse, plugin.RegisteredHook{Matcher: "*", Type: "prompt", Prompt: "input=$TOOL_INPUT"})
+			sess.hookRunner = runner
+			callID := "issue831-hook-schema-" + tc.name
+			observed := make(chan *events.ToolCallEndData, 1)
+			go func() {
+				var end *events.ToolCallEndData
+				for event := range sess.Events() {
+					if data, ok := event.Data.(events.ToolCallEndData); ok && data.CallID == callID {
+						data := data
+						end = &data
+					}
+				}
+				observed <- end
+			}()
+
+			res := sess.execTool(context.Background(), llm.ToolCallData{ID: callID, Name: "communicate", Arguments: json.RawMessage(`{"end_turn":"not-a-bool","message":"top-level","output":{"message":"","data":{},"artifacts":[]}}`)}, "")
+			if res.IsError != tc.wantError || res.PrevalOnly != tc.wantPreval || (tc.wantOutput != "" && res.FullOutput != tc.wantOutput) {
+				t.Fatalf("result = %+v, want error=%t preval=%t output=%q", res, tc.wantError, tc.wantPreval, tc.wantOutput)
+			}
+			sess.Close()
+			end := <-observed
+			mu.Lock()
+			defer mu.Unlock()
+			if len(prompts) != 1 || prompts[0] == "input=null" || !strings.Contains(prompts[0], `"end_turn":"not-a-bool"`) {
+				t.Fatalf("valid schema-invalid input did not reach hook: %q", boundedStringForIssue831(prompts))
+			}
+			if tc.wantUpdated && (end == nil || !strings.Contains(end.ArgumentsJSON, `"end_turn":true`)) {
+				t.Fatalf("updated raw-valid call end = %+v, want hook update applied", end)
 			}
 		})
 	}

--- a/agent/session_communicate_issue831_test.go
+++ b/agent/session_communicate_issue831_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/llm"
 )
@@ -241,6 +242,58 @@ func TestSession_DefaultCommunicateEnvelopeRepairsEmitBoundedTelemetryIssue831(t
 		if strings.Contains(change, "sensitive message") || !strings.Contains(change, "output") {
 			t.Fatalf("telemetry leaked a value or lacks path: %q", change)
 		}
+	}
+}
+
+func TestSession_FailedCommunicateOutputPromotionDoesNotEmitUnappliedJSONRepairIssue831(t *testing.T) {
+	sess := newSession(t, withoutGitSnapshot())
+	sess.stateDir = t.TempDir()
+	observed := make(chan struct {
+		repaired []events.ToolCallRepairedData
+		end      *events.ToolCallEndData
+	}, 1)
+	go func() {
+		var got struct {
+			repaired []events.ToolCallRepairedData
+			end      *events.ToolCallEndData
+		}
+		for event := range sess.Events() {
+			switch data := event.Data.(type) {
+			case events.ToolCallRepairedData:
+				if data.CallID == "issue831-unapplied" {
+					got.repaired = append(got.repaired, data)
+				}
+			case events.ToolCallEndData:
+				if data.CallID == "issue831-unapplied" {
+					data := data
+					got.end = &data
+				}
+			}
+		}
+		observed <- got
+	}()
+
+	// The broken outer escape is repairable, but the promoted nested output has
+	// trailing text and must be rejected. No repaired bytes reach dispatch.
+	arguments := json.RawMessage(`{"end_turn":true,"message":"\uX","output":"{\"message\":\"nested\",\"data\":{},\"artifacts\":[]} trailing"}`)
+	res := sess.execTool(context.Background(), llm.ToolCallData{ID: "issue831-unapplied", Name: "communicate", Arguments: arguments}, "")
+	if !res.IsError || !strings.Contains(res.FullOutput, "passed as an object") {
+		t.Fatalf("result = %+v, want nested output promotion failure", res)
+	}
+
+	sess.Close()
+	got := <-observed
+	if len(got.repaired) != 0 {
+		t.Fatalf("unapplied JSON repair emitted ToolCallRepaired: %+v", got.repaired)
+	}
+	if got.end == nil {
+		t.Fatal("missing ToolCallEnd event")
+	}
+	if !got.end.PrevalOnly || got.end.Error != res.FullOutput {
+		t.Fatalf("end = %+v, want prevalidation failure %q", got.end, res.FullOutput)
+	}
+	if got.end.ArgumentsJSON != string(arguments) {
+		t.Fatalf("end arguments = %q, want original unapplied bytes %q", got.end.ArgumentsJSON, arguments)
 	}
 }
 

--- a/agent/session_communicate_issue831_test.go
+++ b/agent/session_communicate_issue831_test.go
@@ -61,14 +61,14 @@ func TestPrepareToolCall_HealsDefaultCommunicateEnvelopeIssue831(t *testing.T) {
 		},
 		{
 			name:          "clean JSON object string",
-			arguments:     `{"end_turn":true,"output":` + strconvQuote(outputString) + `}`,
+			arguments:     `{"end_turn":true,"output":` + jsonQuote(outputString) + `}`,
 			wantMessage:   "output-only text",
 			wantOutputMsg: "output-only text",
 			wantChanges:   true,
 		},
 		{
 			name:          "observed double encoded shape",
-			arguments:     `{"end_turn":true,"message":"top-level","output":` + strconvQuote(observedDoubleEncoded) + `}`,
+			arguments:     `{"end_turn":true,"message":"top-level","output":` + jsonQuote(observedDoubleEncoded) + `}`,
 			wantMessage:   "top-level",
 			wantOutputMsg: "",
 			wantChanges:   true,
@@ -129,7 +129,7 @@ func TestPrepareToolCall_RejectsInvalidDefaultCommunicateOutputStringsIssue831(t
 		t.Run(tc.name, func(t *testing.T) {
 			arguments := tc.arguments
 			if arguments == nil {
-				arguments = []byte(`{"end_turn":true,"message":"top-level","output":` + strconvQuote(tc.output) + `}`)
+				arguments = []byte(`{"end_turn":true,"message":"top-level","output":` + jsonQuote(tc.output) + `}`)
 			}
 			res := prepareToolCall(llm.ToolCallData{ID: "issue831-invalid", Name: "communicate", Arguments: arguments}, rt, []string{"communicate"}, "communicate", "communicate", "")
 			if res.PrevalErr == "" {
@@ -140,6 +140,38 @@ func TestPrepareToolCall_RejectsInvalidDefaultCommunicateOutputStringsIssue831(t
 			}
 			if len(res.Changes) != 0 {
 				t.Fatalf("failed repair recorded changes %+v", res.Changes)
+			}
+		})
+	}
+}
+
+func TestPrepareToolCall_PromotedCommunicateOutputGuidanceOnlyNamesOutputFailuresIssue831(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+	const outputGuidance = "the decoded object did not satisfy the communicate output schema"
+
+	for _, tc := range []struct {
+		name         string
+		arguments    string
+		wantGuidance bool
+	}{
+		{
+			name:         "unrelated top-level schema failure",
+			arguments:    `{"end_turn":"not-a-bool","message":"top-level","output":"{\"message\":\"valid nested\",\"data\":{},\"artifacts\":[]}"}`,
+			wantGuidance: false,
+		},
+		{
+			name:         "output descendant schema failure",
+			arguments:    `{"end_turn":true,"message":"top-level","output":"{\"message\":\"nested\",\"data\":[],\"artifacts\":[]}"}`,
+			wantGuidance: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := prepareToolCall(llm.ToolCallData{ID: "issue831-guidance", Name: "communicate", Arguments: json.RawMessage(tc.arguments)}, rt, []string{"communicate"}, "communicate", "communicate", "")
+			if res.PrevalErr == "" {
+				t.Fatalf("invalid call was accepted: %s", tc.arguments)
+			}
+			if got := strings.Contains(res.PrevalErr, outputGuidance); got != tc.wantGuidance {
+				t.Fatalf("output guidance = %t, want %t: %q", got, tc.wantGuidance, res.PrevalErr)
 			}
 		})
 	}
@@ -212,7 +244,7 @@ func TestSession_DefaultCommunicateEnvelopeRepairsEmitBoundedTelemetryIssue831(t
 	}
 }
 
-func strconvQuote(s string) string {
+func jsonQuote(s string) string {
 	return string(mustMarshalIssue831JSON(s))
 }
 

--- a/agent/session_communicate_issue831_test.go
+++ b/agent/session_communicate_issue831_test.go
@@ -1,0 +1,225 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/llm"
+)
+
+func TestPrepareToolCall_HealsDefaultCommunicateEnvelopeIssue831(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+
+	outputString := `{"message":"output-only text","data":{"status":"ok"},"artifacts":["artifact:result"]}`
+	// Exact output string from session 034HvTCI5LrwbM2ZZpBMqN, where the
+	// provider encoded the object required at communicate.output as a string.
+	observedDoubleEncoded := `{"data":{"baseline_tests":"go test ./agent/ -run 'SessionName|SessionNamer|Rename' -count=1 — ok","files":["agent/session_namer.go","agent/internal/contextmgr/context_manager.go (read-only, root-cause evidence)","cmd/evener-tui/ (terminal title feature)"],"worktree":"session-auto-namer"}}`
+
+	for _, tc := range []struct {
+		name          string
+		arguments     string
+		wantMessage   string
+		wantOutputMsg string
+		wantChanges   bool
+	}{
+		{
+			name:          "complete object",
+			arguments:     `{"end_turn":true,"message":"top-level","output":{"message":"nested","data":{},"artifacts":[]}}`,
+			wantMessage:   "top-level",
+			wantOutputMsg: "nested",
+		},
+		{
+			name:          "object fills documented defaults",
+			arguments:     `{"end_turn":true,"message":"top-level","output":{}}`,
+			wantMessage:   "top-level",
+			wantOutputMsg: "",
+			wantChanges:   true,
+		},
+		{
+			name:          "absent output",
+			arguments:     `{"end_turn":true,"message":"top-level"}`,
+			wantMessage:   "top-level",
+			wantOutputMsg: "",
+			wantChanges:   true,
+		},
+		{
+			name:          "null output",
+			arguments:     `{"end_turn":true,"message":"top-level","output":null}`,
+			wantMessage:   "top-level",
+			wantOutputMsg: "",
+			wantChanges:   true,
+		},
+		{
+			name:          "output-only object text",
+			arguments:     `{"end_turn":true,"output":{"message":"output-only text","data":{},"artifacts":[]}}`,
+			wantMessage:   "output-only text",
+			wantOutputMsg: "output-only text",
+			wantChanges:   true,
+		},
+		{
+			name:          "clean JSON object string",
+			arguments:     `{"end_turn":true,"output":` + strconvQuote(outputString) + `}`,
+			wantMessage:   "output-only text",
+			wantOutputMsg: "output-only text",
+			wantChanges:   true,
+		},
+		{
+			name:          "observed double encoded shape",
+			arguments:     `{"end_turn":true,"message":"top-level","output":` + strconvQuote(observedDoubleEncoded) + `}`,
+			wantMessage:   "top-level",
+			wantOutputMsg: "",
+			wantChanges:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := prepareToolCall(llm.ToolCallData{ID: "issue831", Name: "communicate", Arguments: json.RawMessage(tc.arguments)}, rt, []string{"communicate"}, "communicate", "communicate", "")
+			if res.PrevalErr != "" {
+				t.Fatalf("prepareToolCall rejected healed default envelope: %s", res.PrevalErr)
+			}
+			if got := len(res.Changes) > 0; got != tc.wantChanges {
+				t.Fatalf("has changes = %t, want %t: %+v", got, tc.wantChanges, res.Changes)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(res.Call.Arguments, &got); err != nil {
+				t.Fatalf("unmarshal repaired call: %v", err)
+			}
+			if got["message"] != tc.wantMessage {
+				t.Fatalf("message = %#v, want %q", got["message"], tc.wantMessage)
+			}
+			output, ok := got["output"].(map[string]any)
+			if !ok {
+				t.Fatalf("output = %#v, want object", got["output"])
+			}
+			if output["message"] != tc.wantOutputMsg {
+				t.Fatalf("output.message = %#v, want %q", output["message"], tc.wantOutputMsg)
+			}
+			if _, ok := output["data"].(map[string]any); !ok {
+				t.Fatalf("output.data = %#v, want object", output["data"])
+			}
+			if _, ok := output["artifacts"].([]any); !ok {
+				t.Fatalf("output.artifacts = %#v, want array", output["artifacts"])
+			}
+		})
+	}
+}
+
+func TestPrepareToolCall_RejectsInvalidDefaultCommunicateOutputStringsIssue831(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+	const depthBeyondLimit = 65
+	tooDeep := strings.Repeat(`{"nested":`, depthBeyondLimit) + `{}` + strings.Repeat(`}`, depthBeyondLimit)
+
+	for _, tc := range []struct {
+		name      string
+		output    string
+		arguments []byte
+	}{
+		{name: "malformed", output: `{"message":`},
+		{name: "trailing", output: `{"message":"x","data":{},"artifacts":[]} trailing`},
+		{name: "scalar", output: `true`},
+		{name: "array", output: `[]`},
+		{name: "unknown nested field", output: `{"message":"x","data":{},"artifacts":[],"secret":"do not log"}`},
+		{name: "wrong nested type", output: `{"message":"x","data":[],"artifacts":[]}`},
+		{name: "oversized", output: strings.Repeat(" ", 2*1024*1024+1)},
+		{name: "over depth", output: tooDeep},
+		{name: "invalid UTF-8", arguments: []byte("{\"end_turn\":true,\"message\":\"top-level\",\"output\":\"{\xff}\"}")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			arguments := tc.arguments
+			if arguments == nil {
+				arguments = []byte(`{"end_turn":true,"message":"top-level","output":` + strconvQuote(tc.output) + `}`)
+			}
+			res := prepareToolCall(llm.ToolCallData{ID: "issue831-invalid", Name: "communicate", Arguments: arguments}, rt, []string{"communicate"}, "communicate", "communicate", "")
+			if res.PrevalErr == "" {
+				t.Fatalf("invalid output string was accepted: arguments %q changes %+v", arguments, res.Changes)
+			}
+			if !strings.Contains(res.PrevalErr, "passed as an object") {
+				t.Fatalf("error lacks JSON-string object guidance: %q", res.PrevalErr)
+			}
+			if len(res.Changes) != 0 {
+				t.Fatalf("failed repair recorded changes %+v", res.Changes)
+			}
+		})
+	}
+}
+
+func TestPrepareToolCall_DefaultCommunicateObjectStillRejectsInvalidNestedFieldsIssue831(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+	for _, arguments := range []string{
+		`{"end_turn":true,"message":"top-level","output":{"message":"nested","data":{},"artifacts":[],"unexpected":true}}`,
+		`{"end_turn":true,"message":"top-level","output":{"message":"nested","data":[],"artifacts":[]}}`,
+	} {
+		res := prepareToolCall(llm.ToolCallData{ID: "issue831-invalid-object", Name: "communicate", Arguments: json.RawMessage(arguments)}, rt, []string{"communicate"}, "communicate", "communicate", "")
+		if res.PrevalErr == "" {
+			t.Fatalf("invalid output object was accepted: %s", arguments)
+		}
+	}
+}
+
+func TestPrepareToolCall_SameKeysStricterCommunicateOutputSchemaIsNotHealedIssue831(t *testing.T) {
+	def := tool.DefCommunicateNamed("communicate")
+	params := tool.CloneSchemaMap(def.Parameters)
+	output := params["properties"].(map[string]any)["output"].(map[string]any)
+	output["properties"].(map[string]any)["message"] = map[string]any{"type": "string", "enum": []string{"allowed"}}
+
+	reg := tool.NewRegistry()
+	if err := reg.Register(regTool(llm.ToolDefinition{Name: "communicate", Parameters: params})); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	rt := reg.Get("communicate")
+	for _, arguments := range []string{
+		`{"end_turn":true,"message":"top-level","output":null}`,
+		`{"end_turn":true,"output":{"message":"allowed","data":{},"artifacts":[]}}`,
+		`{"end_turn":true,"output":"{\"message\":\"allowed\",\"data\":{},\"artifacts\":[]}"}`,
+	} {
+		res := prepareToolCall(llm.ToolCallData{ID: "issue831-strict", Name: "communicate", Arguments: json.RawMessage(arguments)}, rt, []string{"communicate"}, "communicate", "communicate", "")
+		if res.PrevalErr == "" {
+			t.Fatalf("same-keys stricter schema was healed: %s", arguments)
+		}
+		if len(res.Changes) != 0 {
+			t.Fatalf("same-keys stricter schema recorded repairs: %+v", res.Changes)
+		}
+	}
+}
+
+func TestSession_DefaultCommunicateEnvelopeRepairsEmitBoundedTelemetryIssue831(t *testing.T) {
+	sess := newSession(t, withoutGitSnapshot())
+	sess.stateDir = t.TempDir()
+	repairedCh := drainRepairedEvents(sess)
+
+	res := sess.execTool(context.Background(), llm.ToolCallData{
+		ID:        "issue831-telemetry",
+		Name:      "communicate",
+		Arguments: json.RawMessage(`{"end_turn":false,"output":"{\"message\":\"sensitive message\",\"data\":{},\"artifacts\":[]}"}`),
+	}, "")
+	if res.IsError {
+		t.Fatalf("communicate: %s", res.FullOutput)
+	}
+	sess.Close()
+	repaired := <-repairedCh
+	if len(repaired) != 1 {
+		t.Fatalf("repaired events = %+v, want one", repaired)
+	}
+	if repaired[0].ToolName != "communicate" || len(repaired[0].Changes) == 0 {
+		t.Fatalf("repair event = %+v, want communicate changes", repaired[0])
+	}
+	for _, change := range repaired[0].Changes {
+		if strings.Contains(change, "sensitive message") || !strings.Contains(change, "output") {
+			t.Fatalf("telemetry leaked a value or lacks path: %q", change)
+		}
+	}
+}
+
+func strconvQuote(s string) string {
+	return string(mustMarshalIssue831JSON(s))
+}
+
+func mustMarshalIssue831JSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/agent/session_communicate_issue831_test.go
+++ b/agent/session_communicate_issue831_test.go
@@ -3,11 +3,13 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/agent/internal/tool/repair"
 	"primeradiant.com/evener/llm"
 )
 
@@ -294,6 +296,79 @@ func TestSession_FailedCommunicateOutputPromotionDoesNotEmitUnappliedJSONRepairI
 	}
 	if got.end.ArgumentsJSON != string(arguments) {
 		t.Fatalf("end arguments = %q, want original unapplied bytes %q", got.end.ArgumentsJSON, arguments)
+	}
+}
+
+func TestPrepareToolCall_RepairsCommitArgumentsAndChangesAtomicallyIssue831(t *testing.T) {
+	def := issue831NumericRepairDefinition()
+	reg := tool.NewRegistry()
+	if err := reg.Register(regTool(def)); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	raw := json.RawMessage(`{"s":"\uX","n":"NaN"}`)
+	res := prepareToolCall(llm.ToolCallData{ID: "issue831-nan", Name: def.Name, Arguments: raw}, reg.Get(def.Name), []string{def.Name}, def.Name, "communicate", "")
+	if res.PrevalErr == "" {
+		t.Fatal("non-finite numeric repair was accepted")
+	}
+	if len(res.Changes) != 0 {
+		t.Fatalf("uncommitted repair changes = %+v", res.Changes)
+	}
+	if string(res.Call.Arguments) != string(raw) {
+		t.Fatalf("arguments = %q, want original raw bytes %q", res.Call.Arguments, raw)
+	}
+}
+
+func TestCommitPreparedRepairs_MarshalFailureDoesNotPartiallyCommitIssue831(t *testing.T) {
+	raw := json.RawMessage(`{"s":"raw"}`)
+	res := prepareResult{Call: llm.ToolCallData{Arguments: raw}}
+	changes := []repair.Change{{Kind: repair.ChangeCoerceType, Field: "n", Detail: `"NaN"→NaN`}}
+	if err := commitPreparedRepairs(&res, map[string]any{"n": math.NaN()}, changes); err == nil {
+		t.Fatal("non-finite arguments unexpectedly marshaled")
+	}
+	if len(res.Changes) != 0 {
+		t.Fatalf("marshal failure committed changes: %+v", res.Changes)
+	}
+	if string(res.Call.Arguments) != string(raw) {
+		t.Fatalf("marshal failure changed arguments to %q, want %q", res.Call.Arguments, raw)
+	}
+}
+
+func TestSession_NonFiniteNumericRepairDoesNotEmitUnappliedChangesIssue831(t *testing.T) {
+	sess := newSession(t, withoutGitSnapshot())
+	sess.stateDir = t.TempDir()
+	def := issue831NumericRepairDefinition()
+	if err := sess.reg.Register(regTool(def)); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	repairedCh := drainRepairedEvents(sess)
+
+	res := sess.execTool(context.Background(), llm.ToolCallData{
+		ID:        "issue831-nan-session",
+		Name:      def.Name,
+		Arguments: json.RawMessage(`{"s":"\uX","n":"NaN"}`),
+	}, "")
+	if !res.IsError || !res.PrevalOnly || !strings.Contains(res.FullOutput, `"n"`) {
+		t.Fatalf("result = %+v, want prevalidation type failure for n", res)
+	}
+
+	sess.Close()
+	if repaired := <-repairedCh; len(repaired) != 0 {
+		t.Fatalf("unapplied non-finite repair emitted ToolCallRepaired: %+v", repaired)
+	}
+}
+
+func issue831NumericRepairDefinition() llm.ToolDefinition {
+	return llm.ToolDefinition{
+		Name: "issue831_numeric_repair",
+		Parameters: map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"s": map[string]any{"type": "string"},
+				"n": map[string]any{"type": "number"},
+			},
+			"required": []string{"s", "n"},
+		},
 	}
 }
 

--- a/agent/session_communicate_issue831_test.go
+++ b/agent/session_communicate_issue831_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 	"strings"
 	"testing"
@@ -115,19 +116,20 @@ func TestPrepareToolCall_RejectsInvalidDefaultCommunicateOutputStringsIssue831(t
 	tooDeep := strings.Repeat(`{"nested":`, depthBeyondLimit) + `{}` + strings.Repeat(`}`, depthBeyondLimit)
 
 	for _, tc := range []struct {
-		name      string
-		output    string
-		arguments []byte
+		name          string
+		output        string
+		arguments     []byte
+		wantSubstring string
 	}{
-		{name: "malformed", output: `{"message":`},
-		{name: "trailing", output: `{"message":"x","data":{},"artifacts":[]} trailing`},
-		{name: "scalar", output: `true`},
-		{name: "array", output: `[]`},
-		{name: "unknown nested field", output: `{"message":"x","data":{},"artifacts":[],"secret":"do not log"}`},
-		{name: "wrong nested type", output: `{"message":"x","data":[],"artifacts":[]}`},
-		{name: "oversized", output: strings.Repeat(" ", 2*1024*1024+1)},
-		{name: "over depth", output: tooDeep},
-		{name: "invalid UTF-8", arguments: []byte("{\"end_turn\":true,\"message\":\"top-level\",\"output\":\"{\xff}\"}")},
+		{name: "malformed", output: `{"message":`, wantSubstring: "passed as an object"},
+		{name: "trailing", output: `{"message":"x","data":{},"artifacts":[]} trailing`, wantSubstring: "passed as an object"},
+		{name: "scalar", output: `true`, wantSubstring: "passed as an object"},
+		{name: "array", output: `[]`, wantSubstring: "passed as an object"},
+		{name: "unknown nested field", output: `{"message":"x","data":{},"artifacts":[],"secret":"do not log"}`, wantSubstring: "passed as an object"},
+		{name: "wrong nested type", output: `{"message":"x","data":[],"artifacts":[]}`, wantSubstring: "passed as an object"},
+		{name: "oversized", output: strings.Repeat(" ", 2*1024*1024+1), wantSubstring: "tool arguments too large"},
+		{name: "over depth", output: tooDeep, wantSubstring: "passed as an object"},
+		{name: "invalid UTF-8", arguments: []byte("{\"end_turn\":true,\"message\":\"top-level\",\"output\":\"{\xff}\"}"), wantSubstring: "not valid UTF-8"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			arguments := tc.arguments
@@ -138,8 +140,8 @@ func TestPrepareToolCall_RejectsInvalidDefaultCommunicateOutputStringsIssue831(t
 			if res.PrevalErr == "" {
 				t.Fatalf("invalid output string was accepted: arguments %q changes %+v", arguments, res.Changes)
 			}
-			if !strings.Contains(res.PrevalErr, "passed as an object") {
-				t.Fatalf("error lacks JSON-string object guidance: %q", res.PrevalErr)
+			if !strings.Contains(res.PrevalErr, tc.wantSubstring) {
+				t.Fatalf("error lacks %q guidance: %q", tc.wantSubstring, res.PrevalErr)
 			}
 			if len(res.Changes) != 0 {
 				t.Fatalf("failed repair recorded changes %+v", res.Changes)
@@ -354,6 +356,154 @@ func TestSession_NonFiniteNumericRepairDoesNotEmitUnappliedChangesIssue831(t *te
 	sess.Close()
 	if repaired := <-repairedCh; len(repaired) != 0 {
 		t.Fatalf("unapplied non-finite repair emitted ToolCallRepaired: %+v", repaired)
+	}
+}
+
+func TestPrepareToolCall_RejectsInvalidRawCommunicateArgumentsBeforeHealingIssue831(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+	for _, output := range []struct {
+		name string
+		tail string
+	}{
+		{name: "absent output", tail: `}`},
+		{name: "null output", tail: `,"output":null}`},
+	} {
+		for _, tc := range []struct {
+			name string
+			args func(string) []byte
+			want func([]byte) string
+		}{
+			{
+				name: "over limit",
+				args: func(tail string) []byte {
+					base := `{"end_turn":true,"message":"top-level"` + tail
+					return []byte(base + strings.Repeat(" ", tool.MaxToolArgumentBytes+1-len(base)))
+				},
+				want: func(args []byte) string {
+					return fmt.Sprintf("tool arguments too large: %d bytes exceeds the %d byte limit", len(args), tool.MaxToolArgumentBytes)
+				},
+			},
+			{
+				name: "invalid UTF-8",
+				args: func(tail string) []byte {
+					args := append([]byte(`{"end_turn":true,"message":"`), 0xff)
+					return append(args, []byte(`"`+tail)...)
+				},
+				want: func([]byte) string { return "invalid tool arguments JSON: input is not valid UTF-8" },
+			},
+		} {
+			t.Run(output.name+"/"+tc.name, func(t *testing.T) {
+				args := tc.args(output.tail)
+				res := prepareToolCall(llm.ToolCallData{ID: "issue831-raw", Name: "communicate", Arguments: args}, rt, []string{"communicate"}, "communicate", "communicate", "")
+				if res.PrevalErr != tc.want(args) {
+					t.Fatalf("prevalidation error = %q, want %q", res.PrevalErr, tc.want(args))
+				}
+				if len(res.Changes) != 0 {
+					t.Fatalf("invalid raw arguments recorded repairs: %+v", res.Changes)
+				}
+				if string(res.Call.Arguments) != string(args) {
+					t.Fatalf("arguments = %q, want original bytes %q", res.Call.Arguments, args)
+				}
+			})
+		}
+	}
+}
+
+func TestPrepareToolCall_ValidRawCommunicateArgumentsAtLimitAndUTF8StillHealIssue831(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+	base := `{"end_turn":true,"message":"top-level"}`
+	for _, args := range [][]byte{
+		[]byte(base + strings.Repeat(" ", tool.MaxToolArgumentBytes-len(base))),
+		[]byte(`{"end_turn":true,"message":"✓"}`),
+	} {
+		res := prepareToolCall(llm.ToolCallData{ID: "issue831-raw-valid", Name: "communicate", Arguments: args}, rt, []string{"communicate"}, "communicate", "communicate", "")
+		if res.PrevalErr != "" {
+			t.Fatalf("valid arguments rejected: %q", res.PrevalErr)
+		}
+		if len(res.Changes) == 0 {
+			t.Fatalf("valid default envelope was not healed: %q", args)
+		}
+	}
+}
+
+func TestSession_InvalidRawCommunicateArgumentsDoNotHealOrEmitTelemetryIssue831(t *testing.T) {
+	for _, output := range []struct {
+		name string
+		tail string
+	}{
+		{name: "absent output", tail: `}`},
+		{name: "null output", tail: `,"output":null}`},
+	} {
+		for _, tc := range []struct {
+			name string
+			args func(string) []byte
+			want func([]byte) string
+		}{
+			{
+				name: "over limit",
+				args: func(tail string) []byte {
+					base := `{"end_turn":true,"message":"top-level"` + tail
+					return []byte(base + strings.Repeat(" ", tool.MaxToolArgumentBytes+1-len(base)))
+				},
+				want: func(args []byte) string {
+					return fmt.Sprintf("tool arguments too large: %d bytes exceeds the %d byte limit", len(args), tool.MaxToolArgumentBytes)
+				},
+			},
+			{
+				name: "invalid UTF-8",
+				args: func(tail string) []byte {
+					args := append([]byte(`{"end_turn":true,"message":"`), 0xff)
+					return append(args, []byte(`"`+tail)...)
+				},
+				want: func([]byte) string { return "invalid tool arguments JSON: input is not valid UTF-8" },
+			},
+		} {
+			t.Run(output.name+"/"+tc.name, func(t *testing.T) {
+				sess := newSession(t, withoutGitSnapshot())
+				sess.stateDir = t.TempDir()
+				repairedCh := drainRepairedEvents(sess)
+				args := tc.args(output.tail)
+				res := sess.execTool(context.Background(), llm.ToolCallData{ID: "issue831-raw-session", Name: "communicate", Arguments: args}, "")
+				if !res.IsError || !res.PrevalOnly || res.FullOutput != tc.want(args) {
+					t.Fatalf("result = %+v, want bounded prevalidation error %q", res, tc.want(args))
+				}
+				if len(res.FullOutput) > 256 {
+					t.Fatalf("error was not bounded: %d bytes", len(res.FullOutput))
+				}
+
+				sess.Close()
+				if repaired := <-repairedCh; len(repaired) != 0 {
+					t.Fatalf("invalid raw arguments emitted repairs: %+v", repaired)
+				}
+			})
+		}
+	}
+}
+
+func TestPrepareToolCall_WhitespaceOutputMessageDoesNotBecomeTopLevelMessageIssue831(t *testing.T) {
+	_, rt := registerCommunicateForIssue627(t)
+	raw := json.RawMessage(`{"end_turn":true,"output":"{\"message\":\"   \",\"data\":{},\"artifacts\":[]}"}`)
+	res := prepareToolCall(llm.ToolCallData{ID: "issue831-whitespace", Name: "communicate", Arguments: raw}, rt, []string{"communicate"}, "communicate", "communicate", "")
+	if res.PrevalErr == "" || !strings.Contains(res.PrevalErr, `"message"`) {
+		t.Fatalf("result = %+v, want missing top-level message prevalidation error", res)
+	}
+	if len(res.Changes) != 0 || string(res.Call.Arguments) != string(raw) {
+		t.Fatalf("uncommitted whitespace repair = %+v, arguments = %q", res.Changes, res.Call.Arguments)
+	}
+}
+
+func TestSession_WhitespaceOutputMessageDoesNotEmitRepairIssue831(t *testing.T) {
+	sess := newSession(t, withoutGitSnapshot())
+	sess.stateDir = t.TempDir()
+	repairedCh := drainRepairedEvents(sess)
+	raw := json.RawMessage(`{"end_turn":true,"output":"{\"message\":\"   \",\"data\":{},\"artifacts\":[]}"}`)
+	res := sess.execTool(context.Background(), llm.ToolCallData{ID: "issue831-whitespace-session", Name: "communicate", Arguments: raw}, "")
+	if !res.IsError || !res.PrevalOnly || !strings.Contains(res.FullOutput, `"message"`) {
+		t.Fatalf("result = %+v, want missing top-level message prevalidation error", res)
+	}
+	sess.Close()
+	if repaired := <-repairedCh; len(repaired) != 0 {
+		t.Fatalf("uncommitted whitespace repair emitted telemetry: %+v", repaired)
 	}
 }
 

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -52,6 +52,7 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 	}
 
 	args := map[string]any{}
+	var pendingJSONChanges []repair.Change
 	if len(res.Call.Arguments) > 0 { // raw len, mirroring ExecuteCall (no TrimSpace)
 		if err := json.Unmarshal(res.Call.Arguments, &args); err != nil {
 			// A length-stopped turn cut the argument stream mid-JSON. Never
@@ -63,7 +64,6 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 				return res
 			}
 			repaired, c := repair.RepairJSON(res.Call.Arguments)
-			res.Changes = append(res.Changes, c...)
 			args = map[string]any{}
 			if err2 := json.Unmarshal(repaired, &args); err2 != nil {
 				// Show the model's own bytes and the original parse error
@@ -71,6 +71,10 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 				res.PrevalErr = repair.ExplainJSONError(requestedVisible, t.Definition.Parameters, err, res.Call.Arguments)
 				return res
 			}
+			// Keep repair changes pending until their repaired arguments are
+			// committed below. Every early return through preparation otherwise
+			// retains the model's raw bytes and must not claim a repair event.
+			pendingJSONChanges = c
 		}
 	}
 	if errText := unsupportedDelegateWaitOption(call.Name, args); errText != "" {
@@ -159,6 +163,10 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 			// remains invalid; failed generic repairs and envelope fills remain
 			// deliberately unrecorded.
 			if len(retainedReadChanges) > 0 {
+				// finalErrorArgs is committed for retained-read normalization even
+				// though another field failed. It includes any successful outer
+				// JSON repair, so record both applied repair sets together.
+				res.Changes = append(res.Changes, pendingJSONChanges...)
 				res.Changes = append(res.Changes, retainedReadChanges...)
 				if b, marshalErr := json.Marshal(finalErrorArgs); marshalErr == nil {
 					res.Call.Arguments = b
@@ -172,12 +180,16 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 			return res
 		}
 		args = healed
+		res.Changes = append(res.Changes, pendingJSONChanges...)
 		// The healed form carries the fill (it was validated above), so the
 		// fill's changes belong in the record alongside the healing changes.
 		res.Changes = append(res.Changes, fillChanges...)
 		res.Changes = append(res.Changes, c...)
-	} else if len(fillChanges) > 0 {
-		res.Changes = append(res.Changes, fillChanges...)
+	} else {
+		res.Changes = append(res.Changes, pendingJSONChanges...)
+		if len(fillChanges) > 0 {
+			res.Changes = append(res.Changes, fillChanges...)
+		}
 	}
 	res.Changes = append(res.Changes, retainedReadChanges...)
 

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -50,6 +50,10 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 		res.PrevalErr = repair.UnknownToolMessage(requestedVisible, visibleNames)
 		return res
 	}
+	if err := tool.ValidateRawArguments(res.Call.Arguments); err != nil {
+		res.PrevalErr = err.Error()
+		return res
+	}
 
 	args := map[string]any{}
 	var pendingJSONChanges []repair.Change
@@ -248,7 +252,7 @@ func repairDefaultCommunicateEnvelope(envelope, args map[string]any, rawArgument
 	changes = append(changes, fillCommunicateEnvelope(envelope, args)...)
 	if _, present := args["message"]; !present {
 		if output, ok := args["output"].(map[string]any); ok {
-			if message, ok := output["message"].(string); ok {
+			if message, ok := output["message"].(string); ok && strings.TrimSpace(message) != "" {
 				args["message"] = message
 				changes = append(changes, repair.Change{Kind: repair.ChangeCopy, Field: "message", Detail: "copied output.message"})
 			}
@@ -263,10 +267,13 @@ func repairDefaultCommunicateEnvelope(envelope, args map[string]any, rawArgument
 }
 
 func decodeDefaultCommunicateOutputString(encoded string, rawArguments []byte) (map[string]any, error) {
-	if len(rawArguments) > tool.MaxToolArgumentBytes || len(encoded) > tool.MaxToolArgumentBytes {
+	if err := tool.ValidateRawArguments(rawArguments); err != nil {
+		return nil, err
+	}
+	if len(encoded) > tool.MaxToolArgumentBytes {
 		return nil, fmt.Errorf("exceeds the %d byte argument limit", tool.MaxToolArgumentBytes)
 	}
-	if !utf8.Valid(rawArguments) || !utf8.ValidString(encoded) {
+	if !utf8.ValidString(encoded) {
 		return nil, errors.New("is not valid UTF-8")
 	}
 	if err := withinJSONDepth(encoded, maxCommunicateOutputJSONDepth); err != nil {

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -164,8 +164,9 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 					res.Call.Arguments = b
 				}
 			}
-			res.PrevalErr = repair.ExplainSchemaError(requestedVisible, t.Definition.Parameters, healed, offendingField(err2), offendingKeyword(err2))
-			if promotedOutputString {
+			offendingPath := offendingField(err2)
+			res.PrevalErr = repair.ExplainSchemaError(requestedVisible, t.Definition.Parameters, healed, offendingPath, offendingKeyword(err2))
+			if promotedOutputString && isCommunicateOutputSchemaPath(offendingPath) {
 				res.PrevalErr += "\n" + communicateOutputStringObjectError("the decoded object did not satisfy the communicate output schema")
 			}
 			return res
@@ -298,6 +299,10 @@ func withinJSONDepth(s string, maxDepth int) error {
 
 func communicateOutputStringObjectError(reason string) string {
 	return "communicate: output is a JSON-looking string and must be passed as an object, not a quoted string; " + reason
+}
+
+func isCommunicateOutputSchemaPath(path string) bool {
+	return path == "output" || strings.HasPrefix(path, "output/")
 }
 
 // normalizeRetainedReadArgs removes only the semantically empty retained-output

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -31,6 +31,10 @@ type prepareResult struct {
 	Changes   []repair.Change
 	PrevalErr string
 	Err       error
+	// RawArgumentsRejected keeps unvalidated bytes out of hook input and
+	// prevents a hook from replacing them. It is separate from PrevalErr so an
+	// unknown tool can retain its established unknown-tool diagnostic.
+	RawArgumentsRejected bool
 }
 
 // prepareToolCall heals a tool call before dispatch. t is the resolved tool
@@ -46,12 +50,15 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 	if strings.TrimSpace(res.Call.ID) == "" {
 		res.Call.ID = "call_" + shortHash(res.Call.Arguments)
 	}
+	if err := tool.ValidateRawArguments(res.Call.Arguments); err != nil {
+		res.RawArgumentsRejected = true
+		if t != nil {
+			res.PrevalErr = err.Error()
+			return res
+		}
+	}
 	if t == nil {
 		res.PrevalErr = repair.UnknownToolMessage(requestedVisible, visibleNames)
-		return res
-	}
-	if err := tool.ValidateRawArguments(res.Call.Arguments); err != nil {
-		res.PrevalErr = err.Error()
 		return res
 	}
 
@@ -124,7 +131,7 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 		filled := make(map[string]any, len(args))
 		maps.Copy(filled, args)
 		var err error
-		fillChanges, promotedOutputString, err = repairDefaultCommunicateEnvelope(envelope, filled, res.Call.Arguments)
+		fillChanges, promotedOutputString, err = repairDefaultCommunicateEnvelope(envelope, filled)
 		if err != nil {
 			res.PrevalErr = communicateOutputStringObjectError(err.Error())
 			return res
@@ -231,7 +238,7 @@ func repairCommitError() string {
 // communicateEnvelopeFor, but this function repeats the equality guard so no
 // future caller can accidentally apply a default-contract repair to a custom
 // result schema.
-func repairDefaultCommunicateEnvelope(envelope, args map[string]any, rawArguments []byte) ([]repair.Change, bool, error) {
+func repairDefaultCommunicateEnvelope(envelope, args map[string]any) ([]repair.Change, bool, error) {
 	if !isCanonicalDefaultCommunicateOutputEnvelope(envelope) {
 		return nil, false, nil
 	}
@@ -241,7 +248,7 @@ func repairDefaultCommunicateEnvelope(envelope, args map[string]any, rawArgument
 		args["output"] = map[string]any{}
 		changes = append(changes, repair.Change{Kind: repair.ChangeSynthesize, Field: "output", Detail: "synthesized default envelope"})
 	} else if encoded, ok := raw.(string); ok {
-		decoded, err := decodeDefaultCommunicateOutputString(encoded, rawArguments)
+		decoded, err := decodeDefaultCommunicateOutputString(encoded)
 		if err != nil {
 			return nil, false, err
 		}
@@ -266,10 +273,7 @@ func repairDefaultCommunicateEnvelope(envelope, args map[string]any, rawArgument
 	return changes, false, nil
 }
 
-func decodeDefaultCommunicateOutputString(encoded string, rawArguments []byte) (map[string]any, error) {
-	if err := tool.ValidateRawArguments(rawArguments); err != nil {
-		return nil, err
-	}
+func decodeDefaultCommunicateOutputString(encoded string) (map[string]any, error) {
 	if len(encoded) > tool.MaxToolArgumentBytes {
 		return nil, fmt.Errorf("exceeds the %d byte argument limit", tool.MaxToolArgumentBytes)
 	}

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v5"
 
@@ -14,6 +16,12 @@ import (
 	"primeradiant.com/evener/agent/internal/tool/repair"
 	"primeradiant.com/evener/llm"
 )
+
+// maxCommunicateOutputJSONDepth bounds the nested JSON value accepted when a
+// provider double-encodes the default communicate output object. The raw
+// argument cap bounds bytes; this separate structural bound keeps a compact
+// deeply nested value from consuming disproportionate parser resources.
+const maxCommunicateOutputJSONDepth = 64
 
 // prepareResult is the outcome of the pre-dispatch repair step. When PrevalErr
 // is non-empty, execTool returns it as the tool's error result WITHOUT calling
@@ -103,10 +111,16 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 	// call that still fails never emits a ToolCallRepaired event whose
 	// Arguments bytes were never applied.
 	var fillChanges []repair.Change
+	promotedOutputString := false
 	if envelope, ok := communicateEnvelopeFor(t, resultToolName); ok {
 		filled := make(map[string]any, len(args))
 		maps.Copy(filled, args)
-		fillChanges = fillCommunicateEnvelope(envelope, filled)
+		var err error
+		fillChanges, promotedOutputString, err = repairDefaultCommunicateEnvelope(envelope, filled, res.Call.Arguments)
+		if err != nil {
+			res.PrevalErr = communicateOutputStringObjectError(err.Error())
+			return res
+		}
 		args = filled
 	}
 
@@ -151,6 +165,9 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 				}
 			}
 			res.PrevalErr = repair.ExplainSchemaError(requestedVisible, t.Definition.Parameters, healed, offendingField(err2), offendingKeyword(err2))
+			if promotedOutputString {
+				res.PrevalErr += "\n" + communicateOutputStringObjectError("the decoded object did not satisfy the communicate output schema")
+			}
 			return res
 		}
 		args = healed
@@ -169,6 +186,118 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 		}
 	}
 	return res
+}
+
+// repairDefaultCommunicateEnvelope applies the documented defaults for the one
+// canonical communicate output contract. The caller obtains envelope only from
+// communicateEnvelopeFor, but this function repeats the equality guard so no
+// future caller can accidentally apply a default-contract repair to a custom
+// result schema.
+func repairDefaultCommunicateEnvelope(envelope, args map[string]any, rawArguments []byte) ([]repair.Change, bool, error) {
+	if !isCanonicalDefaultCommunicateOutputEnvelope(envelope) {
+		return nil, false, nil
+	}
+
+	var changes []repair.Change
+	if raw, present := args["output"]; !present || raw == nil {
+		args["output"] = map[string]any{}
+		changes = append(changes, repair.Change{Kind: repair.ChangeSynthesize, Field: "output", Detail: "synthesized default envelope"})
+	} else if encoded, ok := raw.(string); ok {
+		decoded, err := decodeDefaultCommunicateOutputString(encoded, rawArguments)
+		if err != nil {
+			return nil, false, err
+		}
+		args["output"] = decoded
+		changes = append(changes, repair.Change{Kind: repair.ChangePromoteJSONObject, Field: "output", Detail: "promoted JSON object string"})
+	}
+
+	changes = append(changes, fillCommunicateEnvelope(envelope, args)...)
+	if _, present := args["message"]; !present {
+		if output, ok := args["output"].(map[string]any); ok {
+			if message, ok := output["message"].(string); ok {
+				args["message"] = message
+				changes = append(changes, repair.Change{Kind: repair.ChangeCopy, Field: "message", Detail: "copied output.message"})
+			}
+		}
+	}
+	for _, change := range changes {
+		if change.Kind == repair.ChangePromoteJSONObject {
+			return changes, true, nil
+		}
+	}
+	return changes, false, nil
+}
+
+func decodeDefaultCommunicateOutputString(encoded string, rawArguments []byte) (map[string]any, error) {
+	if len(rawArguments) > tool.MaxToolArgumentBytes || len(encoded) > tool.MaxToolArgumentBytes {
+		return nil, fmt.Errorf("exceeds the %d byte argument limit", tool.MaxToolArgumentBytes)
+	}
+	if !utf8.Valid(rawArguments) || !utf8.ValidString(encoded) {
+		return nil, errors.New("is not valid UTF-8")
+	}
+	if err := withinJSONDepth(encoded, maxCommunicateOutputJSONDepth); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(strings.NewReader(encoded))
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, errors.New("is not valid JSON")
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, errors.New("contains trailing content")
+		}
+		return nil, errors.New("contains trailing invalid content")
+	}
+	output, ok := decoded.(map[string]any)
+	if !ok {
+		return nil, errors.New("does not decode to an object")
+	}
+	return output, nil
+}
+
+// withinJSONDepth counts object and array nesting without interpreting values.
+// json.Decoder remains the authority on JSON syntax; this pass only rejects an
+// otherwise bounded input that exceeds the named structural limit.
+func withinJSONDepth(s string, maxDepth int) error {
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			if inString {
+				escaped = !escaped
+			}
+			continue
+		case '"':
+			if !escaped {
+				inString = !inString
+			}
+			escaped = false
+			continue
+		default:
+			escaped = false
+		}
+		if inString {
+			continue
+		}
+		switch s[i] {
+		case '{', '[':
+			depth++
+			if depth > maxDepth {
+				return fmt.Errorf("exceeds the maximum JSON depth of %d", maxDepth)
+			}
+		case '}', ']':
+			depth--
+		}
+	}
+	return nil
+}
+
+func communicateOutputStringObjectError(reason string) string {
+	return "communicate: output is a JSON-looking string and must be passed as an object, not a quoted string; " + reason
 }
 
 // normalizeRetainedReadArgs removes only the semantically empty retained-output

--- a/agent/session_tool_repair.go
+++ b/agent/session_tool_repair.go
@@ -166,10 +166,11 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 				// finalErrorArgs is committed for retained-read normalization even
 				// though another field failed. It includes any successful outer
 				// JSON repair, so record both applied repair sets together.
-				res.Changes = append(res.Changes, pendingJSONChanges...)
-				res.Changes = append(res.Changes, retainedReadChanges...)
-				if b, marshalErr := json.Marshal(finalErrorArgs); marshalErr == nil {
-					res.Call.Arguments = b
+				committedChanges := append([]repair.Change(nil), pendingJSONChanges...)
+				committedChanges = append(committedChanges, retainedReadChanges...)
+				if err := commitPreparedRepairs(&res, finalErrorArgs, committedChanges); err != nil {
+					res.PrevalErr = repairCommitError()
+					return res
 				}
 			}
 			offendingPath := offendingField(err2)
@@ -180,25 +181,45 @@ func prepareToolCall(call llm.ToolCallData, t *tool.RegisteredTool, visibleNames
 			return res
 		}
 		args = healed
-		res.Changes = append(res.Changes, pendingJSONChanges...)
+		committedChanges := append([]repair.Change(nil), pendingJSONChanges...)
 		// The healed form carries the fill (it was validated above), so the
 		// fill's changes belong in the record alongside the healing changes.
-		res.Changes = append(res.Changes, fillChanges...)
-		res.Changes = append(res.Changes, c...)
-	} else {
-		res.Changes = append(res.Changes, pendingJSONChanges...)
-		if len(fillChanges) > 0 {
-			res.Changes = append(res.Changes, fillChanges...)
+		committedChanges = append(committedChanges, fillChanges...)
+		committedChanges = append(committedChanges, c...)
+		committedChanges = append(committedChanges, retainedReadChanges...)
+		if err := commitPreparedRepairs(&res, args, committedChanges); err != nil {
+			res.PrevalErr = repairCommitError()
+			return res
 		}
-	}
-	res.Changes = append(res.Changes, retainedReadChanges...)
-
-	if len(res.Changes) > 0 {
-		if b, err := json.Marshal(args); err == nil {
-			res.Call.Arguments = b
+	} else {
+		committedChanges := append([]repair.Change(nil), pendingJSONChanges...)
+		committedChanges = append(committedChanges, fillChanges...)
+		committedChanges = append(committedChanges, retainedReadChanges...)
+		if err := commitPreparedRepairs(&res, args, committedChanges); err != nil {
+			res.PrevalErr = repairCommitError()
+			return res
 		}
 	}
 	return res
+}
+
+// commitPreparedRepairs is the only repair commit point: changes and their
+// encoded arguments become observable together, or neither does.
+func commitPreparedRepairs(res *prepareResult, args map[string]any, changes []repair.Change) error {
+	if len(changes) == 0 {
+		return nil
+	}
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		return err
+	}
+	res.Call.Arguments = encoded
+	res.Changes = append([]repair.Change(nil), changes...)
+	return nil
+}
+
+func repairCommitError() string {
+	return "invalid_request: repaired tool arguments could not be encoded as JSON; the call was not applied."
 }
 
 // repairDefaultCommunicateEnvelope applies the documented defaults for the one

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -679,7 +679,7 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 		hi := s.hookInput(plugin.HookPreToolUse)
 		hi.ToolName = toolname.EvenerToClaude(call.Name)
 		hi.ToolUseID = call.ID
-		if len(call.Arguments) > 0 {
+		if !prep.RawArgumentsRejected && len(call.Arguments) > 0 {
 			_ = json.Unmarshal(call.Arguments, &hi.ToolInput)
 		}
 
@@ -703,7 +703,7 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 				IsError:    true,
 			}
 		}
-		if len(preResult.UpdatedInput) > 0 {
+		if !prep.RawArgumentsRejected && len(preResult.UpdatedInput) > 0 {
 			if err := applyUpdatedToolInput(&call, preResult.UpdatedInput); err != nil {
 				msg := "invalid hook updatedInput: " + err.Error()
 				return tool.ExecResult{

--- a/agent/session_tools.go
+++ b/agent/session_tools.go
@@ -690,7 +690,7 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 		for _, m := range preResult.UserMessages {
 			s.deliverHookUserMessage(m)
 		}
-		if preResult.Denied {
+		if !prep.RawArgumentsRejected && preResult.Denied {
 			denyMsg := "Tool call denied by hook"
 			if preResult.DenyMessage != "" {
 				denyMsg = preResult.DenyMessage
@@ -729,7 +729,7 @@ func (s *Session) execTool(ctx context.Context, call llm.ToolCallData, finishRea
 	}
 	// Promote intent to the top-level event field for observability.
 	var args map[string]any
-	if len(call.Arguments) > 0 {
+	if !prep.RawArgumentsRejected && len(call.Arguments) > 0 {
 		_ = json.Unmarshal(call.Arguments, &args)
 	}
 	if d := toolStartDescription(args); d != "" {

--- a/agent/session_tools_aux_exact_fuzz_test.go
+++ b/agent/session_tools_aux_exact_fuzz_test.go
@@ -154,9 +154,7 @@ func auxCommunicateExact(t *testing.T) {
 	}}}) {
 		t.Fatal("incomplete communicate requirements accepted")
 	}
-	if stringSetsEqual(map[string]any{"x": map[string]any{}}, []string{"y"}, defaultEnvelopeKeys...) {
-		t.Fatal("schema contains absent value")
-	}
+
 	if got := canonicalNodeOutputTextWithMarshal(nil, func(any) ([]byte, error) { return nil, errors.New("marshal") }); got != "{}" {
 		t.Fatalf("unmarshalable canonical output = %q", got)
 	}

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"slices"
 	"strings"
 
 	"primeradiant.com/evener/agent/events"
@@ -263,7 +262,6 @@ func hasMeaningfulNodeOutput(out nodeOutput) bool {
 
 // defaultEnvelopeKeys are the output-envelope keys the default communicate
 // schema declares — and the only keys the documented-defaults fill may add.
-// Kept as one constant so the shape predicate and the fill cannot drift apart.
 var defaultEnvelopeKeys = []string{"message", "data", "artifacts"}
 
 // canonicalDefaultCommunicateOutputSchema is constructed once because every
@@ -313,40 +311,6 @@ func usesDefaultCommunicateOutputEnvelope(def llm.ToolDefinition) bool {
 
 func isCanonicalDefaultCommunicateOutputEnvelope(output map[string]any) bool {
 	return reflect.DeepEqual(output, canonicalDefaultCommunicateOutputSchema)
-}
-
-// stringSetsEqual reports whether the schema's property names and required
-// names are each exactly the wanted set (as sets: same members, same count).
-func stringSetsEqual(props map[string]any, required []string, want ...string) bool {
-	if len(props) != len(want) || len(required) != len(want) {
-		return false
-	}
-	for _, name := range want {
-		if _, ok := props[name]; !ok {
-			return false
-		}
-		if !slices.Contains(required, name) {
-			return false
-		}
-	}
-	return true
-}
-
-func communicateSchemaStringSlice(v any) []string {
-	switch x := v.(type) {
-	case []string:
-		return append([]string(nil), x...)
-	case []any:
-		out := make([]string, 0, len(x))
-		for _, item := range x {
-			if s, ok := item.(string); ok {
-				out = append(out, s)
-			}
-		}
-		return out
-	default:
-		return nil
-	}
 }
 
 // fillCommunicateEnvelope fills a present default-envelope `output` object's

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -266,6 +266,16 @@ func hasMeaningfulNodeOutput(out nodeOutput) bool {
 // Kept as one constant so the shape predicate and the fill cannot drift apart.
 var defaultEnvelopeKeys = []string{"message", "data", "artifacts"}
 
+// canonicalDefaultCommunicateOutputSchema is constructed once because every
+// communicate repair checks it, sometimes multiple times. It is private and
+// only read by reflect.DeepEqual; callers never receive this mutable map.
+var canonicalDefaultCommunicateOutputSchema = func() map[string]any {
+	parameters := tool.DefCommunicateNamed("communicate").Parameters
+	properties, _ := parameters["properties"].(map[string]any)
+	output, _ := properties["output"].(map[string]any)
+	return output
+}()
+
 // communicateEnvelopeFor reports whether t is the session's result tool with
 // the exact canonical default output envelope, returning that envelope schema
 // when it is.
@@ -302,9 +312,7 @@ func usesDefaultCommunicateOutputEnvelope(def llm.ToolDefinition) bool {
 }
 
 func isCanonicalDefaultCommunicateOutputEnvelope(output map[string]any) bool {
-	canonicalProps, _ := tool.DefCommunicateNamed("communicate").Parameters["properties"].(map[string]any)
-	canonicalOutput, _ := canonicalProps["output"].(map[string]any)
-	return reflect.DeepEqual(output, canonicalOutput)
+	return reflect.DeepEqual(output, canonicalDefaultCommunicateOutputSchema)
 }
 
 // stringSetsEqual reports whether the schema's property names and required
@@ -345,12 +353,10 @@ func communicateSchemaStringSlice(v any) []string {
 // missing message/data/artifacts keys with their documented empty defaults
 // ("" / {} / []). It mutates args in place on the working copy the caller
 // owns, and never overwrites an existing key. Only communicateEnvelopeFor's
-// envelope — the default one — may be passed here; a custom output schema
-// must keep failing loudly on keys the model was required to choose.
+// envelope — the default one — may be passed here; repairDefaultCommunicateEnvelope
+// owns that canonical-schema gate before calling this helper. A custom output
+// schema must keep failing loudly on keys the model was required to choose.
 func fillCommunicateEnvelope(envelope, args map[string]any) []repair.Change {
-	if !isCanonicalDefaultCommunicateOutputEnvelope(envelope) {
-		return nil
-	}
 	raw, isMap := args["output"].(map[string]any)
 	if !isMap {
 		return nil

--- a/agent/session_tools_communicate.go
+++ b/agent/session_tools_communicate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -266,15 +267,15 @@ func hasMeaningfulNodeOutput(out nodeOutput) bool {
 var defaultEnvelopeKeys = []string{"message", "data", "artifacts"}
 
 // communicateEnvelopeFor reports whether t is the session's result tool with
-// its default output envelope, returning that envelope schema when it is.
+// the exact canonical default output envelope, returning that envelope schema
+// when it is.
 // This is the single owner of the fill's two gates (issue #627):
 //   - identity: only the result tool gets the fill. A same-shaped schema on
 //     any other registered tool (an MCP or plugin tool) must keep failing
 //     loudly on keys the model was required to choose.
-//   - exact shape: properties and required must each be precisely
-//     defaultEnvelopeKeys — a custom output schema (a delegate result_schema
-//     installed via WithCommunicateOutputSchema, or a WithAllowedDecisions
-//     superset) keeps failing loudly.
+//   - exact schema: equality with DefCommunicateNamed's canonical output
+//     schema. Same-key schemas can carry stricter types, enums, descriptions,
+//     or other constraints, so key-name comparison is not sufficient.
 //
 // Returning the envelope it validated (rather than a bool the caller
 // re-derives) is what keeps the check and the fill from diverging.
@@ -284,32 +285,26 @@ func communicateEnvelopeFor(t *tool.RegisteredTool, resultToolName string) (map[
 	}
 	props, _ := t.Definition.Parameters["properties"].(map[string]any)
 	envelope, _ := props["output"].(map[string]any)
-	outProps, _ := envelope["properties"].(map[string]any)
-	if outProps == nil {
-		return nil, false
-	}
-	required := communicateSchemaStringSlice(envelope["required"])
-	if !stringSetsEqual(outProps, required, defaultEnvelopeKeys...) {
+	if !isCanonicalDefaultCommunicateOutputEnvelope(envelope) {
 		return nil, false
 	}
 	return envelope, true
 }
 
 // usesDefaultCommunicateOutputEnvelope reports whether def's `output` property
-// is exactly the default envelope DefCommunicateNamed builds: properties and
-// required are each precisely {message, data, artifacts} — no more, no fewer.
-// A superset (WithAllowedDecisions adds an enum-constrained `decision`) or a
-// differently-shaped schema is a custom envelope, whose required keys the
-// model was expected to choose.
+// equals the complete canonical output schema DefCommunicateNamed builds. A
+// superset, a same-key schema with a stricter enum, or any other variation is a
+// custom envelope whose fields must remain exact.
 func usesDefaultCommunicateOutputEnvelope(def llm.ToolDefinition) bool {
 	props, _ := def.Parameters["properties"].(map[string]any)
 	output, _ := props["output"].(map[string]any)
-	outProps, _ := output["properties"].(map[string]any)
-	if outProps == nil {
-		return false
-	}
-	required := communicateSchemaStringSlice(output["required"])
-	return stringSetsEqual(outProps, required, defaultEnvelopeKeys...)
+	return isCanonicalDefaultCommunicateOutputEnvelope(output)
+}
+
+func isCanonicalDefaultCommunicateOutputEnvelope(output map[string]any) bool {
+	canonicalProps, _ := tool.DefCommunicateNamed("communicate").Parameters["properties"].(map[string]any)
+	canonicalOutput, _ := canonicalProps["output"].(map[string]any)
+	return reflect.DeepEqual(output, canonicalOutput)
 }
 
 // stringSetsEqual reports whether the schema's property names and required
@@ -353,6 +348,9 @@ func communicateSchemaStringSlice(v any) []string {
 // envelope — the default one — may be passed here; a custom output schema
 // must keep failing loudly on keys the model was required to choose.
 func fillCommunicateEnvelope(envelope, args map[string]any) []repair.Change {
+	if !isCanonicalDefaultCommunicateOutputEnvelope(envelope) {
+		return nil
+	}
 	raw, isMap := args["output"].(map[string]any)
 	if !isMap {
 		return nil
@@ -372,7 +370,7 @@ func fillCommunicateEnvelope(envelope, args map[string]any) []repair.Change {
 			continue
 		}
 		raw[key] = v
-		changes = append(changes, repair.Change{Kind: repair.ChangeFillRequired, Field: "output", Detail: "filled " + key})
+		changes = append(changes, repair.Change{Kind: repair.ChangeFillRequired, Field: "output." + key, Detail: "filled default"})
 	}
 	return changes
 }

--- a/agent/session_tools_transcript.go
+++ b/agent/session_tools_transcript.go
@@ -172,6 +172,14 @@ func apiLogResultTranscriptPlaceholder(call llm.ToolCallData, result tool.ExecRe
 	if call.Name != "read_session_transcript" && result.ToolName != "read_session_transcript" {
 		return "", false
 	}
+	// A prevalidation-only result may carry rejected raw arguments (including
+	// unknown tool calls). Do not derive API-log identity from those bytes: the
+	// raw validator is the presentation-free boundary that tells projection
+	// whether decoding them is safe. Valid canceled API-log calls are not
+	// prevalidation-only and retain the usual private-evidence placeholder.
+	if result.PrevalOnly && tool.ValidateRawArguments(call.Arguments) != nil {
+		return "", false
+	}
 
 	var resultIdentity apiLogTranscriptResultIdentity
 	resultIsAPILog := json.Unmarshal([]byte(result.Output), &resultIdentity) == nil && resultIdentity.Source == apiLogSource

--- a/agent/session_tools_transcript.go
+++ b/agent/session_tools_transcript.go
@@ -184,8 +184,10 @@ func apiLogResultTranscriptPlaceholder(call llm.ToolCallData, result tool.ExecRe
 	var resultIdentity apiLogTranscriptResultIdentity
 	resultIsAPILog := json.Unmarshal([]byte(result.Output), &resultIdentity) == nil && resultIdentity.Source == apiLogSource
 	var args map[string]any
-	_ = json.Unmarshal(call.Arguments, &args)
-	callIsAPILog := stringArg(args, "source") == apiLogSource || strings.TrimSpace(stringArg(args, "attempt_id")) != ""
+	callIsAPILog := false
+	if json.Unmarshal(call.Arguments, &args) == nil {
+		callIsAPILog = stringArg(args, "source") == apiLogSource || strings.TrimSpace(stringArg(args, "attempt_id")) != ""
+	}
 	if !resultIsAPILog && !callIsAPILog {
 		return "", false
 	}

--- a/agent/session_tools_transcript_branches_test.go
+++ b/agent/session_tools_transcript_branches_test.go
@@ -1138,6 +1138,41 @@ func TestProjectToolResultsForTranscriptWithProjection(t *testing.T) {
 	}
 }
 
+func TestProjectToolResultsForTranscriptRawRejectedUnknownCallPreservesDiagnostic(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args func() []byte
+	}{
+		{
+			name: "invalid UTF-8",
+			args: func() []byte {
+				args := append([]byte(`{"source":"api_log","hint":"`), 0xff)
+				return append(args, []byte(`"}`)...)
+			},
+		},
+		{
+			name: "over limit",
+			args: func() []byte {
+				base := `{"source":"api_log"}`
+				return []byte(base + strings.Repeat(" ", tool.MaxToolArgumentBytes+1-len(base)))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const diagnostic = "invalid_request: unknown tool read_session_transcript"
+			calls := []llm.ToolCallData{{Name: "read_session_transcript", Arguments: tc.args()}}
+			results := []tool.ExecResult{{ToolName: "read_session_transcript", Output: diagnostic, FullOutput: diagnostic, IsError: true, PrevalOnly: true}}
+			parts := []llm.ContentPart{{ToolResult: &llm.ToolResultData{Content: diagnostic}}}
+
+			out := projectToolResultsForTranscript(calls, results, parts)
+			content, ok := out[0].ToolResult.Content.(string)
+			if !ok || content != diagnostic {
+				t.Fatalf("projected raw-rejected diagnostic = %#v, want exact %q", out[0].ToolResult.Content, diagnostic)
+			}
+		})
+	}
+}
+
 func TestProjectToolResultsForTranscriptNilToolResult(t *testing.T) {
 	calls := []llm.ToolCallData{{Name: "read_session_transcript", Arguments: json.RawMessage(`{"source":"api_log"}`)}}
 	results := []tool.ExecResult{{ToolName: "read_session_transcript", Output: `{"source":"api_log"}`}}

--- a/agent/session_tools_transcript_branches_test.go
+++ b/agent/session_tools_transcript_branches_test.go
@@ -1138,7 +1138,7 @@ func TestProjectToolResultsForTranscriptWithProjection(t *testing.T) {
 	}
 }
 
-func TestProjectToolResultsForTranscriptRawRejectedUnknownCallPreservesDiagnostic(t *testing.T) {
+func TestProjectToolResultsForTranscriptInvalidUnknownCallPreservesDiagnostic(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		args func() []byte
@@ -1157,6 +1157,12 @@ func TestProjectToolResultsForTranscriptRawRejectedUnknownCallPreservesDiagnosti
 				return []byte(base + strings.Repeat(" ", tool.MaxToolArgumentBytes+1-len(base)))
 			},
 		},
+		{
+			name: "numeric overflow",
+			args: func() []byte {
+				return []byte(`{"source":"api_log","overflow":1e1000}`)
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			const diagnostic = "invalid_request: unknown tool read_session_transcript"
@@ -1170,6 +1176,19 @@ func TestProjectToolResultsForTranscriptRawRejectedUnknownCallPreservesDiagnosti
 				t.Fatalf("projected raw-rejected diagnostic = %#v, want exact %q", out[0].ToolResult.Content, diagnostic)
 			}
 		})
+	}
+}
+
+func TestProjectToolResultsForTranscriptResultIdentitySurvivesCallDecodeError(t *testing.T) {
+	const resultJSON = `{"source":"api_log","transcript_ref":"local:abc","attempt":{"attempt_id":"att_1"}}`
+	calls := []llm.ToolCallData{{Name: "read_session_transcript", Arguments: json.RawMessage(`{"source":"api_log","overflow":1e1000}`)}}
+	results := []tool.ExecResult{{ToolName: "read_session_transcript", Output: resultJSON, PrevalOnly: true}}
+	parts := []llm.ContentPart{{ToolResult: &llm.ToolResultData{Content: "original"}}}
+
+	out := projectToolResultsForTranscript(calls, results, parts)
+	content, ok := out[0].ToolResult.Content.(string)
+	if !ok || content == "original" || !strings.Contains(content, `"att_1"`) {
+		t.Fatalf("independently identified API-log result = %#v, want projected result placeholder", out[0].ToolResult.Content)
 	}
 }
 

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -1752,12 +1752,23 @@ func repairChangePhrase(raw string) string {
 			return fmt.Sprintf("filled the required %q key", key)
 		}
 		return fmt.Sprintf("filled a required key in the %q field", field)
-	default:
-		if field == "" {
-			return "adjusted the arguments"
+	case "synthesize":
+		if field == "output" && fieldDetail(parts) == "synthesized default envelope" {
+			return "created the required output object"
 		}
-		return fmt.Sprintf("adjusted the %q field", field)
+	case "copy":
+		if field == "message" && fieldDetail(parts) == "copied output.message" {
+			return "copied nested output.message to the required message"
+		}
+	case "promote_json_object":
+		if field == "output" && fieldDetail(parts) == "promoted JSON object string" {
+			return "converted the output JSON string to an object"
+		}
 	}
+	if field == "" {
+		return "adjusted the arguments"
+	}
+	return fmt.Sprintf("adjusted the %q field", field)
 }
 
 // fieldDetail returns the third ("detail") segment of a split "kind:field:detail"

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -1745,6 +1745,9 @@ func repairChangePhrase(raw string) string {
 	case "unicode_repair":
 		return "fixed an invalid character in the arguments"
 	case "fill_required":
+		if fieldKey, ok := strings.CutPrefix(field, "output."); ok && fieldDetail(parts) == "filled default" && fieldKey != "" {
+			return fmt.Sprintf("filled the required %q key", fieldKey)
+		}
 		if key, ok := strings.CutPrefix(fieldDetail(parts), "filled "); ok && key != "" {
 			return fmt.Sprintf("filled the required %q key", key)
 		}

--- a/internal/appprojector/appwire_projection_gaps2_test.go
+++ b/internal/appprojector/appwire_projection_gaps2_test.go
@@ -146,6 +146,32 @@ func TestRepairChangePhraseAliasWithDetail(t *testing.T) {
 	}
 }
 
+func TestRepairChangePhraseDefaultCommunicateEnvelopeRepairs(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want string
+	}{
+		{
+			raw:  "synthesize:output:synthesized default envelope",
+			want: "created the required output object",
+		},
+		{
+			raw:  "copy:message:copied output.message",
+			want: "copied nested output.message to the required message",
+		},
+		{
+			raw:  "promote_json_object:output:promoted JSON object string",
+			want: "converted the output JSON string to an object",
+		},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			if got := repairChangePhrase(tc.raw); got != tc.want {
+				t.Fatalf("repairChangePhrase(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestFieldDetailShortParts covers the len < 3 return of "".
 func TestFieldDetailShortParts(t *testing.T) {
 	if got := fieldDetail([]string{"a", "b"}); got != "" {

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -1871,6 +1871,25 @@ func TestAppEventProjectorProjectsAgentOnlyEventsAsSystemAnnouncements(t *testin
 			},
 		},
 		{
+			name: "tool call repaired: nested fill_required three keys",
+			event: events.SessionEvent{Kind: events.EventToolCallRepaired, SessionID: "th_1", Data: events.ToolCallRepairedData{
+				ToolName: "communicate",
+				CallID:   "c1",
+				Changes: []string{
+					"fill_required:output.message:filled default",
+					"fill_required:output.data:filled default",
+					"fill_required:output.artifacts:filled default",
+				},
+			}},
+			description: "Tool call repaired",
+			contains: []string{
+				`filled the required "message" key`,
+				`filled the required "data" key`,
+				`filled the required "artifacts" key`,
+			},
+			notContains: []string{"fill_required:output.message:filled default", `"default"`},
+		},
+		{
 			name: "tool call repaired: multiple changes",
 			event: events.SessionEvent{Kind: events.EventToolCallRepaired, SessionID: "th_1", Data: events.ToolCallRepairedData{
 				ToolName: "communicate",


### PR DESCRIPTION
## Summary
- heal absent, null, incomplete, and double-encoded `communicate.output` only for the exact canonical default schema
- copy `output.message` into a missing top-level message and emit bounded repair telemetry
- reject malformed, non-object, oversized, overly deep, and custom-schema output strings without broadening custom contracts

## Validation
- `go test ./agent -run 'Issue831|Communicate(Output|.*Envelope|.*Schema|.*Filled|.*Default)' -count=1`
- `go test ./agent/internal/tool ./agent/internal/tool/repair -count=1`
- `go test -p 1 ./agent -count=1`
- `go vet ./agent ./agent/internal/tool ./agent/internal/tool/repair`
- `make lint-gofmt`
- `GOLANGCI_LINT_CACHE="$EVENER_SCRATCH_DIR/golangci-lint-cache" make lint-golangci`

Closes #831