### PR TITLE
test: wait on the real completion in two hub and drain barriers

### DIFF
--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -164,6 +164,30 @@ func (jm *jobManager) hasRunningDrainJob() bool {
 	return false
 }
 
+// ManagedJobsFinalizedForTest reports whether none of this session's own
+// managed jobs is still inside finalization: the running map is clear of them,
+// which — because armFinalizedJob (jobs.go) appends the durable
+// EventJobNotificationPending BEFORE it deletes the running entry — means every
+// completion this drain owes the model is already recorded as a pending owner
+// notification.
+//
+// Test-only seam. cmd/evener's drain tests hold the drain until the shell they
+// launched has completed, and a completion that is merely RECORDED terminal is
+// not that state: until armFinalizedJob deletes the running entry, the job is
+// still in the running map, backgroundDrainState reads the background set off
+// that map alone, and so a drain starting in the window counts a finished shell
+// as a live undisposed background job — arming the announcement ladder on work
+// that was already committed. The residue after the delete needs no barrier:
+// the NotifyPending record written before it is what both the sole-reason test
+// and subtreeHasLiveTerminalDrainWork count, so a drain that starts there waits
+// for the notification instead of announcing.
+func (s *Session) ManagedJobsFinalizedForTest() bool {
+	if s == nil || s.jobManager == nil {
+		return false
+	}
+	return !s.jobManager.hasRunningDrainJob()
+}
+
 // treeHasOutstandingWork reports whether this session or any live descendant in
 // its managed-job subtree still owes drain work: an outstanding managed job, a
 // pending job notification, a pending caller-targeted watch send, a pending

--- a/cmd/evener-tui/hub_read_cut_test.go
+++ b/cmd/evener-tui/hub_read_cut_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/internal/appserver"
@@ -33,15 +34,41 @@ func captureReadServer(app *appserver.Server, reads *[]appwire.ThreadReadParams)
 	})
 }
 
-// barrierAfterBroadcast proves the client has already processed every frame the
-// server sent before this call. One appwire read loop drains the connection in
-// wire order, so a response to a request issued after a broadcast cannot
-// overtake it.
-func barrierAfterBroadcast(t *testing.T, client *appwire.Client) {
+// awaitPostCutFrame waits until the feed has actually observed the broadcast
+// and filed it above the open read's cut. That is the condition the test needs,
+// and a request round trip does not establish it: while a subscription is still
+// buffering after a subscribed read, Subscriptions.Route holds a concurrent
+// broadcast in the subscription buffer, and the buffer is flushed by
+// Server.releaseHydration from the finalizer that runs AFTER the read response
+// is already queued. A later request can be answered out of that window, so its
+// response says nothing about where the broadcast is.
+func awaitPostCutFrame(t *testing.T, feed *hubFrameFeed, text string) {
 	t.Helper()
-	if _, err := client.HarnessList(context.Background(), appwire.HarnessListParams{}); err != nil {
-		t.Fatalf("barrier request: %v", err)
+	// TRIPWIRE: the broadcast is one loopback hop away and normally lands in
+	// microseconds; this bound only fires when it is never coming at all.
+	deadline := time.Now().Add(30 * time.Second)
+	for !feedHoldsPostCutFrame(feed, text) {
+		if time.Now().After(deadline) {
+			t.Fatalf("broadcast %q never reached the read capture's post-cut side", text)
+		}
+		time.Sleep(time.Millisecond)
 	}
+}
+
+// feedHoldsPostCutFrame reports whether the open capture is already holding a
+// frame carrying text on the far side of its cut.
+func feedHoldsPostCutFrame(feed *hubFrameFeed, text string) bool {
+	feed.mu.Lock()
+	defer feed.mu.Unlock()
+	if feed.capture == nil {
+		return false
+	}
+	for _, notification := range feed.capture.after {
+		if strings.Contains(string(notification.Params), text) {
+			return true
+		}
+	}
+	return false
 }
 
 // pendingHubNotifications reports every notification the model's feed is
@@ -103,7 +130,7 @@ func TestHubModelReReadHoldsPostCutFrameUntilSnapshotApplied(t *testing.T) {
 			Status: "completed",
 		},
 	})
-	barrierAfterBroadcast(t, client)
+	awaitPostCutFrame(t, frames, "rollback finished")
 
 	// Fold whatever the feed offers BEFORE the snapshot. Nothing forbids that
 	// order: bubbletea takes the two goroutines' messages in whichever order

--- a/cmd/evener/run_drain_test.go
+++ b/cmd/evener/run_drain_test.go
@@ -139,9 +139,10 @@ func (e *shellExecutorEnvironment) StreamCommand(ctx context.Context, command, w
 // running makes the session yield so the completion is delivered as a
 // notification turn (session_lifecycle.go post-tool seam), which would fold the
 // notification into the tool-result request and race these scripted steps
-// against a fast local process. waitForCompletion, when supplied, is the
-// executor's completion event, not a timing assumption about when finalization
-// will happen.
+// against a fast local process. waitForCompletion, when supplied, blocks until
+// the job manager has finalized the shell (its terminal record is durable and
+// it has left the running map), not merely until the executor reported
+// completion, so the drain never starts mid-finalization.
 func releaseOnDrainStart(t *testing.T, release func(), waitForCompletion func(*agent.Session)) {
 	t.Helper()
 	oldDrainJobTree := runDrainJobTree

--- a/cmd/evener/run_drain_test.go
+++ b/cmd/evener/run_drain_test.go
@@ -12,10 +12,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/provider"
+	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/llm"
 )
 
@@ -140,13 +142,13 @@ func (e *shellExecutorEnvironment) StreamCommand(ctx context.Context, command, w
 // against a fast local process. waitForCompletion, when supplied, is the
 // executor's completion event, not a timing assumption about when finalization
 // will happen.
-func releaseOnDrainStart(t *testing.T, release func(), waitForCompletion func()) {
+func releaseOnDrainStart(t *testing.T, release func(), waitForCompletion func(*agent.Session)) {
 	t.Helper()
 	oldDrainJobTree := runDrainJobTree
 	runDrainJobTree = func(sess *agent.Session, ctx context.Context) (string, error) {
 		release()
 		if waitForCompletion != nil {
-			waitForCompletion()
+			waitForCompletion(sess)
 		}
 		return oldDrainJobTree(sess, ctx)
 	}
@@ -163,7 +165,63 @@ func installHeldRunShell(t *testing.T, executor *heldShellExecutor) {
 		return oldNewSession(client, profile, &shellExecutorEnvironment{ExecutionEnvironment: env, executor: executor}, cfg)
 	}
 	t.Cleanup(func() { runNewSession = oldNewSession })
-	releaseOnDrainStart(t, executor.releaseShell, func() { <-executor.waitReturned })
+	releaseOnDrainStart(t, executor.releaseShell, func(sess *agent.Session) {
+		<-executor.waitReturned
+		awaitDurableJobCompletion(t, sess)
+	})
+}
+
+// awaitDurableJobCompletion waits until every managed job the session started
+// has committed a terminal record. That is the state the drain has to start
+// from, and the executor's own completion event does not establish it: runShell
+// calls SignalName from the wait goroutine BEFORE it hands the result to
+// finalizeShellWhenDone (agent/job_shell.go), so waitReturned closes while the
+// terminal record is still uncommitted and no owner notification exists yet.
+//
+// A drain that starts inside that window sees a job that is merely running. It
+// parks, arms the undisposed-background-job ladder on the pass that found it,
+// and on the next recheck tick announces to the model instead of delivering the
+// completion — and an announcement turn's reply is housekeeping the drain
+// discards, so the drain returns "" and the run prints its pre-drain answer.
+func awaitDurableJobCompletion(t *testing.T, sess *agent.Session) {
+	t.Helper()
+	// TRIPWIRE: finalization is one goroutine hop and one store append past a
+	// process that has already exited, so this bound only fires when the
+	// terminal record is never going to be committed at all.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		done, err := managedJobsTerminal(sess)
+		if err != nil {
+			t.Fatalf("read job activity tree: %v", err)
+		}
+		if done {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("managed job never committed a terminal record before the drain started")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// managedJobsTerminal reports whether the session has at least one managed job
+// and every one of them is terminal.
+func managedJobsTerminal(sess *agent.Session) (bool, error) {
+	tree, err := sess.JobActivityTree(appwire.JobsListParams{})
+	if err != nil {
+		return false, err
+	}
+	seen := false
+	for _, entry := range tree.Root.Entries {
+		if entry.Job == nil {
+			continue
+		}
+		seen = true
+		if !entry.Job.Terminal {
+			return false, nil
+		}
+	}
+	return seen, nil
 }
 
 // TestRunDrainsDelegatedJobTreeBeforeExit is the PRI-2441 B1 regression: a

--- a/cmd/evener/run_drain_test.go
+++ b/cmd/evener/run_drain_test.go
@@ -172,17 +172,24 @@ func installHeldRunShell(t *testing.T, executor *heldShellExecutor) {
 }
 
 // awaitDurableJobCompletion waits until every managed job the session started
-// has committed a terminal record. That is the state the drain has to start
-// from, and the executor's own completion event does not establish it: runShell
-// calls SignalName from the wait goroutine BEFORE it hands the result to
-// finalizeShellWhenDone (agent/job_shell.go), so waitReturned closes while the
-// terminal record is still uncommitted and no owner notification exists yet.
+// has committed a terminal record AND been released by the job manager. That is
+// the state the drain has to start from, and the executor's own completion event
+// does not establish it: runShell calls SignalName from the wait goroutine
+// BEFORE it hands the result to finalizeShellWhenDone (agent/job_shell.go), so
+// waitReturned closes while the terminal record is still uncommitted and no
+// owner notification exists yet.
 //
 // A drain that starts inside that window sees a job that is merely running. It
 // parks, arms the undisposed-background-job ladder on the pass that found it,
 // and on the next recheck tick announces to the model instead of delivering the
 // completion — and an announcement turn's reply is housekeeping the drain
 // discards, so the drain returns "" and the run prints its pre-drain answer.
+//
+// The terminal record alone does not close that window: it is committed before
+// armFinalizedJob runs, and the job stays in the job manager's running map
+// through the whole of it, so the drain still sees a live background shell.
+// ManagedJobsFinalizedForTest is the other half — the running entry is deleted
+// only after the durable owner notification has been appended.
 func awaitDurableJobCompletion(t *testing.T, sess *agent.Session) {
 	t.Helper()
 	// TRIPWIRE: finalization is one goroutine hop and one store append past a
@@ -194,11 +201,11 @@ func awaitDurableJobCompletion(t *testing.T, sess *agent.Session) {
 		if err != nil {
 			t.Fatalf("read job activity tree: %v", err)
 		}
-		if done {
+		if done && sess.ManagedJobsFinalizedForTest() {
 			return
 		}
 		if time.Now().After(deadline) {
-			t.Fatal("managed job never committed a terminal record before the drain started")
+			t.Fatal("managed job never finished finalizing before the drain started")
 		}
 		time.Sleep(time.Millisecond)
 	}

--- a/internal/plugins/git_signal_unix_test.go
+++ b/internal/plugins/git_signal_unix_test.go
@@ -10,17 +10,36 @@ import (
 	"time"
 )
 
-// waitForFile polls until path exists or the deadline passes.
-func waitForFile(t *testing.T, path string) {
+// gitCancelTripwire bounds the waits in this file. TRIPWIRE: each one is a
+// hang guard, never the synchronisation mechanism — the readiness file and
+// git()'s own return are the real conditions. It sits far above the expected
+// time because getting the fake git to its readiness file costs two process
+// creations on a machine that may be running the rest of the suite beside it;
+// that latency was measured at 10s on a loaded 18-core runner, which is what
+// made the old 5s ceiling fail while doing the real work.
+const gitCancelTripwire = 90 * time.Second
+
+// waitForFakeGitStart waits until the fake git has recorded that it is running
+// with its TERM trap installed. run is git()'s own result channel: a fake that
+// never execs will never write the file, and polling out the tripwire would
+// report "never appeared" instead of naming the error git() already has.
+func waitForFakeGitStart(t *testing.T, path string, run <-chan error) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	deadline := time.Now().Add(gitCancelTripwire)
+	for {
 		if _, err := os.Stat(path); err == nil {
 			return
 		}
+		select {
+		case err := <-run:
+			t.Fatalf("git() returned before the fake git started: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("fake git never wrote %s within %s", path, gitCancelTripwire)
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("file %s never appeared", path)
 }
 
 // TestGit_CancellationSendsSIGTERM pins the graceful-cancellation contract of
@@ -36,10 +55,19 @@ func TestGit_CancellationSendsSIGTERM(t *testing.T) {
 	script := "#!/bin/sh\n" +
 		"trap 'touch " + termed + "; exit 143' TERM\n" +
 		"touch " + started + "\n" +
-		// Background + wait keeps the shell interruptible (the trap fires
-		// during wait); the redirect keeps the orphaned sleep from holding
-		// git()'s output pipe open past the shell's exit.
-		"sleep 30 >/dev/null 2>&1 & wait $!\n"
+		// Park in short foreground sleeps. `sleep 30 & wait $!` reads as the
+		// same thing but loses the race this test creates: cancellation fires
+		// the moment the readiness file lands, which is before the shell is
+		// parked, and the shell's `wait` does not notice a trapped signal that
+		// was already pending when it started blocking. The trap would then
+		// run when the 30s sleep ended, long after git()'s WaitDelay had
+		// SIGKILLed the shell, so the TERM record never arrived at all. A
+		// pending trap always runs at the next command boundary, so whichever
+		// side of the race the signal lands on, the record is written within
+		// one sleep interval. The count bounds the fake's own lifetime, so an
+		// orphan still exits on its own.
+		"n=0\n" +
+		"while [ $n -lt 300 ]; do sleep 0.1; n=$((n + 1)); done\n"
 	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -52,15 +80,21 @@ func TestGit_CancellationSendsSIGTERM(t *testing.T) {
 		_, err := git(ctx, "", "fetch")
 		errCh <- err
 	}()
-	waitForFile(t, started)
+	waitForFakeGitStart(t, started, errCh)
 	cancel()
+	var gitErr error
 	select {
-	case err := <-errCh:
-		if err == nil {
+	case gitErr = <-errCh:
+		if gitErr == nil {
 			t.Fatal("git() returned nil after cancellation; want error")
 		}
-	case <-time.After(10 * time.Second):
+	case <-time.After(gitCancelTripwire):
 		t.Fatal("git() did not return after cancellation")
 	}
-	waitForFile(t, termed)
+	// git() returns only once the child has been reaped, and the trap writes
+	// its record before the shell exits, so the record is on disk already or
+	// it is never coming: there is nothing left to wait for here.
+	if _, err := os.Stat(termed); err != nil {
+		t.Fatalf("fake git exited without recording SIGTERM (%v); git() error: %v", err, gitErr)
+	}
 }


### PR DESCRIPTION
Three flaky tests that waited on something other than the condition they actually needed: two completion barriers that stopped one goroutine hop short, and a process fixture that could not take the signal it was waiting for.

**cmd/evener-tui `TestHubModelReReadHoldsPostCutFrameUntilSnapshotApplied`.** `barrierAfterBroadcast` assumed one HarnessList round trip ordered a broadcast issued before it, but while a subscription is still buffering after a subscribed read, `Subscriptions.Route` parks the broadcast in the subscription buffer and only `Server.releaseHydration` — running from the response finalizer, after the read response is already queued — flushes it. A request issued inside that window is answered while the broadcast is still parked, so both non-blocking drains saw nothing and the post-cut frame never reached the model. The barrier now polls until the feed's own open capture is holding the frame above its cut.

**cmd/evener `TestRunDrainsManagedShellWhenSystemPromptNamesTheJobFrame`.** `installHeldRunShell` waited on the fake executor's `SignalName` hook, which `runShell` calls from the wait goroutine before it hands the result to `finalizeShellWhenDone`, so the barrier cleared while the terminal record was still uncommitted and no owner notification existed. The real `DrainJobTree` then started mid-finalization, saw a job that was merely running, armed the undisposed-background-job ladder and announced on the next 250ms recheck tick instead of delivering; an announcement turn's reply is housekeeping the drain discards, so the drain returned `""` and the run printed its pre-drain answer. The barrier now polls the session's job activity tree until every managed job it started is terminal.

**internal/plugins `TestGit_CancellationSendsSIGTERM`.** Two load-dependent modes, both test-side; `git()`'s cancellation path is correct. First, the readiness poll's 5s ceiling was doing the real work: reaching the fake git's readiness file costs two process creations (exec of `/bin/sh`, then of `touch`), measured at up to 10.0s on a host also running the rest of the suite, against a p50 of 0.21s over 690 loaded samples. That ceiling is now a named 90s tripwire, and the poll watches `git()`'s own result channel, so a fake that never execs names that error instead of "file never appeared". Second, the fake parked in `sleep 30 >/dev/null 2>&1 & wait $!`, and the test cancels the moment the readiness file lands — before the shell is parked. A TERM delivered in that window is already pending when the shell's `wait` starts blocking, and `wait` does not notice an already-pending trapped signal, so the trap would have run when the 30s sleep ended, long after `git()`'s 5s `WaitDelay` had SIGKILLed the shell: `git fetch: signal: killed` at 5.002s with the TERM record absent. The fake now parks in bounded foreground sleeps, where a pending trap always runs at the next command boundary, and the TERM record is no longer polled at all — `git()` returns only once the child has been reaped and the trap writes its record before the shell exits, so the record is on disk already or it is never coming.

## Forced-interleaving proof

Each hole was confirmed by widening its window before the fix, and each fix was re-run with the same sleep still in place.

- Hub: a 200ms sleep in `Connection.enqueueResponse` between queuing the response and `finalizer.commit()` reproduced the CI failure verbatim (`transcript=[check the deploy deploy looks healthy]`) on 3/3 runs; with the new barrier the same sleep passed 20/20. Sleep removed.
- Drain: a sleep in the fake executor's `SignalName`, after `waitReturned` closes and before `runShell`'s `waitCh` send, reproduced both failure modes. At 250ms it reproduced the CI failure verbatim (`stdout = "waiting for shell\n"`); at 500ms it tripped the announcement assertion instead. With the new barrier both sleeps passed 6/6 across the managed-shell drain tests. Sleep removed.
- Plugins: this one has no in-repo seam to widen — the window is inside the shell's `wait` builtin — so it was reproduced by load instead, under a repeating `go test ./internal/... -count=1 -p 8` on an 18-core host. The old test failed 1 round of 5 (`termed never appeared`, 10.45s); instrumented runs pinned both modes (10.0s readiness spawns; `signal: killed` at 5.002s in 2 of ~690 runs, plus 1 lost TERM in ~1150 iterations of the same script driven straight from a shell with no Go involved). The fixed test is 930/930 clean across 31 rounds of `-count=30` under that load, and the new park lost 0 of ~950 shell-level iterations.

Test-only changes; no production code.

## Gates

`gofmt -l cmd/`, `go vet ./cmd/evener-tui/ ./cmd/evener/`, `golangci-lint run ./cmd/...` (0 issues), `go test ./cmd/evener-tui/ -run TestHubModelReReadHoldsPostCutFrameUntilSnapshotApplied -count=50`, `go test -race ./cmd/evener/ -run TestRunDrainsManagedShellWhenSystemPromptNamesTheJobFrame -count=20`, `go test ./cmd/evener-tui/ ./cmd/evener/ -count=1`, and `TestNoBareWallClockDeadlineInAgentTests` — all pass. For the plugins fix: `gofmt -l internal/plugins/`, `go vet ./internal/plugins/`, `golangci-lint run ./internal/plugins/...` (0 issues), `go test ./internal/plugins/ -run TestGit_CancellationSendsSIGTERM -count=30` looped under the load above, and `go test ./internal/plugins/ -count=1` — all pass.

## Follow-ups

- `TestRunDrainContinuesWhenNotificationTurnStartsAnotherShell` has no completion barrier by design (shell A is released at drain start) and rests on finalization beating the 250 ms recheck; the same forced delay that reproduced the drain flake fails it too.
- `internal/devtool/procgroup/procgroup_test.go` has the same bare 10 s readiness ceiling for child spawns that the git fixture had.
- `agent/execenv` `TestCleanupRetainsOwnedTmpAfterChildGrace` failed once under full-suite load on 2026-09-03 and passed on re-run and 3/3 in isolation; not diagnosed.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT


