### PR TITLE
fix(llm): clamp effort-derived thinking budget under the output ceiling

### DIFF
--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -684,6 +684,11 @@ above). On the anthropic protocol, a row whose `ThinkingShape` is `adaptive`
 (e.g. Opus 4.6, Sonnet 4.6, and later) sends `output_config.effort`; a row
 whose shape is `budget` or `budget+effort` (e.g. Opus 4.5, `kimi-for-coding`)
 maps the effort to `thinking.budget_tokens`.
+That derived budget is clamped to leave the one token of headroom the
+protocol's `max_tokens > budget_tokens` contract requires, so an effort whose
+table budget meets the row's output cap (max and xhigh map to 131072 —
+`kimi-for-coding` k3's cap) still yields a sendable request instead of a
+pre-dispatch `max_output_tokens` budget error.
 
 **Setting it.** Launch: `--reasoning-effort`, `EVENER_REASONING_EFFORT`,
 `reasoning_effort` in `launch.toml`, or the spawn-form effort chip

--- a/llm/providers/anthropic/protocol_request.go
+++ b/llm/providers/anthropic/protocol_request.go
@@ -99,11 +99,8 @@ func buildProtocolBodyForOperation(req llm.Request, res registry.Resolved, enfor
 // always-on adaptive rows included: no Claude row lists an off effort level,
 // so there is no value that says "off" here, and keeping the always-on body
 // would switch thinking on against the user's stated intent. An unset shape
-// sends nothing. A budget the output ceiling cannot fit is reduced to fit —
-// the completion contract requires max_tokens to strictly exceed
-// budget_tokens, so a budget equal to the ceiling (ReasoningBudget maps
-// max/xhigh onto exactly the 131072-token cap of rows like kimi-for-coding
-// k3) is a request this adapter could never send.
+// sends nothing. A budget the output ceiling cannot fit is reduced to fit
+// (fitThinkingBudgetToOutputCeiling).
 func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps) {
 	if req.ReasoningEffort != nil && *req.ReasoningEffort == "none" {
 		return
@@ -140,30 +137,24 @@ func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps
 	}
 }
 
-// minimumThinkingBudgetTokens is the smallest thinking.budget_tokens
-// Anthropic documents accepting; llm.ReasoningBudget's minimal row encodes
-// the same floor (#714).
-const minimumThinkingBudgetTokens = 1024
-
 // fitThinkingBudgetToOutputCeiling reduces an effort-derived thinking budget
 // so the completion contract — max_tokens must strictly exceed budget_tokens
 // — can hold for a request this adapter itself derived. The ceiling is the
 // smallest positive output bound the request carries: the max_tokens already
 // on the body (caller allocation or the fallback) and the row's
 // max_output_tokens, the same inputs ReconcileOutputField min's into the
-// final max_tokens. A budget that would have to drop below Anthropic's
-// documented thinking minimum to fit is returned unchanged, so the
-// completion contract reports the unsatisfiable request instead of sending a
-// wire-rejectable budget.
+// final max_tokens. ReasoningBudget's table maps max/xhigh onto exactly the
+// 131072-token cap of rows like kimi-for-coding k3, so without this clamp the
+// max effort tier could never produce a sendable request. A budget that
+// would have to drop below Anthropic's documented thinking minimum to fit is
+// returned unchanged, so the completion contract reports the unsatisfiable
+// request instead of sending a wire-rejectable budget.
 func fitThinkingBudgetToOutputCeiling(budget int, maxTokens any, outputCap *int) int {
 	ceiling := requestutil.MinPositiveInt(
 		requestutil.PositiveInt(maxTokens),
 		requestutil.PositivePointerInt(outputCap),
 	)
-	if ceiling <= 0 || budget < ceiling {
-		return budget
-	}
-	if fitted := ceiling - 1; fitted >= minimumThinkingBudgetTokens {
+	if fitted := ceiling - 1; budget >= ceiling && fitted >= llm.MinimumThinkingBudgetTokens {
 		return fitted
 	}
 	return budget

--- a/llm/providers/anthropic/protocol_request.go
+++ b/llm/providers/anthropic/protocol_request.go
@@ -73,7 +73,7 @@ func buildProtocolBodyForOperation(req llm.Request, res registry.Resolved, enfor
 	if tools, ok := body["tools"].([]map[string]any); ok && len(tools) > 0 && ttl != "" {
 		tools[len(tools)-1]["cache_control"] = cacheMarker(ttl)
 	}
-	applyThinkingShape(body, req, caps)
+	applyThinkingShape(body, req, caps, enforceCompletionContract)
 	if ov, ok := req.ProviderOptions[registry.ProtocolAnthropic].(map[string]any); ok {
 		for k, v := range ov {
 			if k == "beta_headers" {
@@ -99,9 +99,11 @@ func buildProtocolBodyForOperation(req llm.Request, res registry.Resolved, enfor
 // always-on adaptive rows included: no Claude row lists an off effort level,
 // so there is no value that says "off" here, and keeping the always-on body
 // would switch thinking on against the user's stated intent. An unset shape
-// sends nothing. A budget the output ceiling cannot fit is reduced to fit
-// (fitThinkingBudgetToOutputCeiling).
-func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps) {
+// sends nothing. On the completion path a budget the output ceiling cannot
+// fit is reduced to fit (fitThinkingBudgetToOutputCeiling); a token-count
+// body keeps the effort-derived budget, since that path enforces no
+// completion contract and strips max_tokens as an output-side field.
+func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps, enforceCompletionContract bool) {
 	if req.ReasoningEffort != nil && *req.ReasoningEffort == "none" {
 		return
 	}
@@ -127,8 +129,10 @@ func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps
 			return
 		}
 		budget := llm.ReasoningBudget(effort)
-		if budget > 0 {
+		if budget > 0 && enforceCompletionContract {
 			budget = fitThinkingBudgetToOutputCeiling(budget, body["max_tokens"], caps.MaxOutputTokens)
+		}
+		if budget > 0 {
 			body["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
 		}
 		if registry.StringValue(caps.ThinkingShape) == "budget+effort" {

--- a/llm/providers/anthropic/protocol_request.go
+++ b/llm/providers/anthropic/protocol_request.go
@@ -73,7 +73,7 @@ func buildProtocolBodyForOperation(req llm.Request, res registry.Resolved, enfor
 	if tools, ok := body["tools"].([]map[string]any); ok && len(tools) > 0 && ttl != "" {
 		tools[len(tools)-1]["cache_control"] = cacheMarker(ttl)
 	}
-	applyThinkingShape(body, req, caps, enforceCompletionContract)
+	applyThinkingShape(body, req, res, enforceCompletionContract)
 	if ov, ok := req.ProviderOptions[registry.ProtocolAnthropic].(map[string]any); ok {
 		for k, v := range ov {
 			if k == "beta_headers" {
@@ -103,7 +103,8 @@ func buildProtocolBodyForOperation(req llm.Request, res registry.Resolved, enfor
 // fit is reduced to fit (fitThinkingBudgetToOutputCeiling); a token-count
 // body keeps the effort-derived budget, since that path enforces no
 // completion contract and strips max_tokens as an output-side field.
-func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps, enforceCompletionContract bool) {
+func applyThinkingShape(body map[string]any, req llm.Request, res registry.Resolved, enforceCompletionContract bool) {
+	caps := res.Caps
 	if req.ReasoningEffort != nil && *req.ReasoningEffort == "none" {
 		return
 	}
@@ -130,7 +131,7 @@ func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps
 		}
 		budget := llm.ReasoningBudget(effort)
 		if budget > 0 && enforceCompletionContract {
-			budget = fitThinkingBudgetToOutputCeiling(budget, body["max_tokens"], providerOptionMaxTokens(req), caps.MaxOutputTokens)
+			budget = fitThinkingBudgetToOutputCeiling(budget, body["max_tokens"], providerOptionMaxTokens(req), transportBodyMaxTokens(res), caps.MaxOutputTokens)
 		}
 		if budget > 0 {
 			body["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
@@ -147,18 +148,21 @@ func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps
 // smallest positive output bound the request carries: the max_tokens already
 // on the body (caller allocation or the fallback), the anthropic.max_tokens
 // override the ProviderOptions overlay will write (the overlay runs after
-// this fit), and the row's max_output_tokens — the same bounds
-// ReconcileOutputField min's into the final max_tokens. ReasoningBudget's
+// this fit), the max_tokens constant the transport's body constants will
+// write (they run after this fit too and override both), and the row's
+// max_output_tokens — the same bounds ReconcileOutputField min's into the
+// final max_tokens. ReasoningBudget's
 // table maps max/xhigh onto exactly the
 // 131072-token cap of rows like kimi-for-coding k3, so without this clamp the
 // max effort tier could never produce a sendable request. A budget that
 // would have to drop below Anthropic's documented thinking minimum to fit is
 // returned unchanged, so the completion contract reports the unsatisfiable
 // request instead of sending a wire-rejectable budget.
-func fitThinkingBudgetToOutputCeiling(budget int, maxTokens, overlayMaxTokens any, outputCap *int) int {
+func fitThinkingBudgetToOutputCeiling(budget int, maxTokens, overlayMaxTokens, transportConstantMaxTokens any, outputCap *int) int {
 	ceiling := requestutil.MinPositiveInt(
 		requestutil.PositiveInt(maxTokens),
 		requestutil.PositiveInt(overlayMaxTokens),
+		requestutil.PositiveInt(transportConstantMaxTokens),
 		requestutil.PositivePointerInt(outputCap),
 	)
 	if fitted := ceiling - 1; budget >= ceiling && fitted >= llm.MinimumThinkingBudgetTokens {
@@ -177,4 +181,13 @@ func providerOptionMaxTokens(req llm.Request) any {
 		return nil
 	}
 	return ov["max_tokens"]
+}
+
+// transportBodyMaxTokens returns the max_tokens constant the transport's
+// body constants will write, or nil when the row sets none. Those constants
+// run after the body builder and the ProviderOptions overlay and override
+// whatever max_tokens either left there, so the row's constant bounds the
+// effort-derived budget the same way.
+func transportBodyMaxTokens(res registry.Resolved) any {
+	return res.Transport.Body["max_tokens"]
 }

--- a/llm/providers/anthropic/protocol_request.go
+++ b/llm/providers/anthropic/protocol_request.go
@@ -5,6 +5,7 @@ import (
 
 	"primeradiant.com/evener/llm"
 	"primeradiant.com/evener/llm/providers/internal/protocolhttp"
+	"primeradiant.com/evener/llm/providers/internal/requestutil"
 	"primeradiant.com/evener/llm/registry"
 )
 
@@ -98,7 +99,11 @@ func buildProtocolBodyForOperation(req llm.Request, res registry.Resolved, enfor
 // always-on adaptive rows included: no Claude row lists an off effort level,
 // so there is no value that says "off" here, and keeping the always-on body
 // would switch thinking on against the user's stated intent. An unset shape
-// sends nothing.
+// sends nothing. A budget the output ceiling cannot fit is reduced to fit —
+// the completion contract requires max_tokens to strictly exceed
+// budget_tokens, so a budget equal to the ceiling (ReasoningBudget maps
+// max/xhigh onto exactly the 131072-token cap of rows like kimi-for-coding
+// k3) is a request this adapter could never send.
 func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps) {
 	if req.ReasoningEffort != nil && *req.ReasoningEffort == "none" {
 		return
@@ -126,10 +131,40 @@ func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps
 		}
 		budget := llm.ReasoningBudget(effort)
 		if budget > 0 {
+			budget = fitThinkingBudgetToOutputCeiling(budget, body["max_tokens"], caps.MaxOutputTokens)
 			body["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
 		}
 		if registry.StringValue(caps.ThinkingShape) == "budget+effort" {
 			body["output_config"] = map[string]any{"effort": effort}
 		}
 	}
+}
+
+// minimumThinkingBudgetTokens is the smallest thinking.budget_tokens
+// Anthropic documents accepting; llm.ReasoningBudget's minimal row encodes
+// the same floor (#714).
+const minimumThinkingBudgetTokens = 1024
+
+// fitThinkingBudgetToOutputCeiling reduces an effort-derived thinking budget
+// so the completion contract — max_tokens must strictly exceed budget_tokens
+// — can hold for a request this adapter itself derived. The ceiling is the
+// smallest positive output bound the request carries: the max_tokens already
+// on the body (caller allocation or the fallback) and the row's
+// max_output_tokens, the same inputs ReconcileOutputField min's into the
+// final max_tokens. A budget that would have to drop below Anthropic's
+// documented thinking minimum to fit is returned unchanged, so the
+// completion contract reports the unsatisfiable request instead of sending a
+// wire-rejectable budget.
+func fitThinkingBudgetToOutputCeiling(budget int, maxTokens any, outputCap *int) int {
+	ceiling := requestutil.MinPositiveInt(
+		requestutil.PositiveInt(maxTokens),
+		requestutil.PositivePointerInt(outputCap),
+	)
+	if ceiling <= 0 || budget < ceiling {
+		return budget
+	}
+	if fitted := ceiling - 1; fitted >= minimumThinkingBudgetTokens {
+		return fitted
+	}
+	return budget
 }

--- a/llm/providers/anthropic/protocol_request.go
+++ b/llm/providers/anthropic/protocol_request.go
@@ -130,7 +130,7 @@ func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps
 		}
 		budget := llm.ReasoningBudget(effort)
 		if budget > 0 && enforceCompletionContract {
-			budget = fitThinkingBudgetToOutputCeiling(budget, body["max_tokens"], caps.MaxOutputTokens)
+			budget = fitThinkingBudgetToOutputCeiling(budget, body["max_tokens"], providerOptionMaxTokens(req), caps.MaxOutputTokens)
 		}
 		if budget > 0 {
 			body["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
@@ -145,21 +145,36 @@ func applyThinkingShape(body map[string]any, req llm.Request, caps registry.Caps
 // so the completion contract — max_tokens must strictly exceed budget_tokens
 // — can hold for a request this adapter itself derived. The ceiling is the
 // smallest positive output bound the request carries: the max_tokens already
-// on the body (caller allocation or the fallback) and the row's
-// max_output_tokens, the same inputs ReconcileOutputField min's into the
-// final max_tokens. ReasoningBudget's table maps max/xhigh onto exactly the
+// on the body (caller allocation or the fallback), the anthropic.max_tokens
+// override the ProviderOptions overlay will write (the overlay runs after
+// this fit), and the row's max_output_tokens — the same bounds
+// ReconcileOutputField min's into the final max_tokens. ReasoningBudget's
+// table maps max/xhigh onto exactly the
 // 131072-token cap of rows like kimi-for-coding k3, so without this clamp the
 // max effort tier could never produce a sendable request. A budget that
 // would have to drop below Anthropic's documented thinking minimum to fit is
 // returned unchanged, so the completion contract reports the unsatisfiable
 // request instead of sending a wire-rejectable budget.
-func fitThinkingBudgetToOutputCeiling(budget int, maxTokens any, outputCap *int) int {
+func fitThinkingBudgetToOutputCeiling(budget int, maxTokens, overlayMaxTokens any, outputCap *int) int {
 	ceiling := requestutil.MinPositiveInt(
 		requestutil.PositiveInt(maxTokens),
+		requestutil.PositiveInt(overlayMaxTokens),
 		requestutil.PositivePointerInt(outputCap),
 	)
 	if fitted := ceiling - 1; budget >= ceiling && fitted >= llm.MinimumThinkingBudgetTokens {
 		return fitted
 	}
 	return budget
+}
+
+// providerOptionMaxTokens returns the anthropic.max_tokens value the
+// ProviderOptions overlay will write, or nil when the caller set none. The
+// effort-budget clamp fits under it because the overlay runs after the clamp
+// while the completion contract still binds the final max_tokens.
+func providerOptionMaxTokens(req llm.Request) any {
+	ov, ok := req.ProviderOptions[registry.ProtocolAnthropic].(map[string]any)
+	if !ok {
+		return nil
+	}
+	return ov["max_tokens"]
 }

--- a/llm/providers/anthropic/protocol_test.go
+++ b/llm/providers/anthropic/protocol_test.go
@@ -186,21 +186,33 @@ func TestProtocolBuildBody_CapsAndRequestFields(t *testing.T) {
 	}
 }
 
-func TestProtocolBuildBody_HighThinkingRejectsUnknownOutputCap(t *testing.T) {
+// TestProtocolBuildBody_HighThinkingClampsUnderUnknownOutputCapFallback
+// updates the #824 guard's unknown-cap case. That guard exists to stop body
+// construction from RAISING max_tokens above its ceiling to fit a thinking
+// budget (docs/superpowers/plans/2026-09-01-provider-safe-token-budget.md,
+// step 1), and it still does — for caller-provided budgets (the ProviderOnly
+// test below) and for ceilings too small to fit Anthropic's 1024-token
+// thinking minimum. But an effort-derived budget must not wedge the request:
+// with no row cap the body's fallback max_tokens is the ceiling, and the
+// budget clamps under it instead of failing every call — the same
+// liberal-then-loud-400 philosophy fallbackMaxTokens documents for itself.
+// Failing closed here stranded sessions with no recourse: an effort-derived
+// budget that meets or exceeds the effective ceiling is the adapter's own
+// arithmetic, not caller input to validate.
+func TestProtocolBuildBody_HighThinkingClampsUnderUnknownOutputCapFallback(t *testing.T) {
 	res := protoRes(func(c *registry.Caps) {
 		c.MaxOutputTokens = nil
 		c.ThinkingShape = new("budget")
 	})
 	body, err := (&Protocol{}).BuildBody(llm.ShapeRequest(protoReq("high"), res), res)
-	if body != nil {
-		t.Fatalf("body = %v, want no unsafe request", body)
+	if err != nil {
+		t.Fatalf("BuildBody: %v", err)
 	}
-	var budgetErr *llm.ContextBudgetError
-	if !errors.As(err, &budgetErr) {
-		t.Fatalf("error = %v, want *llm.ContextBudgetError", err)
+	if got := intFromAny(body["thinking"].(map[string]any)["budget_tokens"]); got != fallbackMaxTokens-1 {
+		t.Fatalf("budget_tokens = %d, want %d under the fallback max_tokens", got, fallbackMaxTokens-1)
 	}
-	if budgetErr.Limit != "max_output_tokens" || budgetErr.Maximum != fallbackMaxTokens || budgetErr.OutputTokens != llm.ReasoningBudget("high")+1 {
-		t.Fatalf("ContextBudgetError = %+v, want fail-closed unknown-cap high effort", budgetErr)
+	if got := intFromAny(body["max_tokens"]); got != fallbackMaxTokens {
+		t.Fatalf("max_tokens = %d, want the fallback %d", got, fallbackMaxTokens)
 	}
 }
 
@@ -254,6 +266,71 @@ func TestProtocolBuildBody_MixedCaseProviderThinkingBudgetFailsWithinAdmittedMax
 	_, err := (&Protocol{}).BuildBody(llm.ShapeRequest(req, protoRes(nil)), protoRes(nil))
 	if _, ok := errors.AsType[*llm.ContextBudgetError](err); !ok {
 		t.Fatalf("error = %v, want *llm.ContextBudgetError", err)
+	}
+}
+
+// TestProtocolBuildBody_BudgetEffortClampedToOutputCeiling pins the fix for a
+// session-wedging defect: ReasoningBudget maps max/xhigh to 131072 tokens, and
+// a budget-shaped row whose max_output_tokens is also 131072 (kimi-for-coding
+// k3) can never satisfy the Anthropic contract that max_tokens strictly
+// exceeds budget_tokens — once a session selected max effort, every model call
+// was rejected before provider dispatch with a non-retryable
+// ContextBudgetError. An effort-derived budget must shrink under the output
+// ceiling the request already carries so a request this adapter derived is
+// always sendable. A caller-provided ProviderOptions budget that does not fit
+// keeps the explicit pre-dispatch error instead (pinned by the ProviderOnly
+// test above), and a ceiling too small to fit Anthropic's documented
+// 1024-token thinking minimum keeps it too: silently sending a sub-minimum
+// budget would only move the failure to the provider's 400.
+func TestProtocolBuildBody_BudgetEffortClampedToOutputCeiling(t *testing.T) {
+	// kimi-for-coding k3's shape: budget+effort thinking, a 131072-token
+	// output cap, and the admitted allocation ApplyTokenBudget produces for
+	// effort max (the full cap).
+	res := protoRes(func(c *registry.Caps) {
+		c.ThinkingShape = new("budget+effort")
+		c.MaxOutputTokens = new(131072)
+	})
+	req := protoReq("max")
+	req.MaxTokens = new(131072)
+	body := protoBuild(t, req, res)
+	thinking, ok := body["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("thinking = %#v, want a budget object", body["thinking"])
+	}
+	if got := intFromAny(thinking["budget_tokens"]); got != 131071 {
+		t.Fatalf("budget_tokens = %d, want 131071 (output ceiling minus the one token max_tokens must exceed the budget by)", got)
+	}
+	if got := intFromAny(body["max_tokens"]); got != 131072 {
+		t.Fatalf("max_tokens = %d, want the admitted 131072", got)
+	}
+	effortCfg, ok := body["output_config"].(map[string]any)
+	if !ok || effortCfg["effort"] != "max" {
+		t.Fatalf("output_config.effort = %#v, want the requested tier preserved", body["output_config"])
+	}
+
+	// A smaller admitted allocation is the ceiling: the budget clamps under it
+	// the same way instead of failing the request.
+	req.MaxTokens = new(32768)
+	body = protoBuild(t, req, res)
+	if got := intFromAny(body["thinking"].(map[string]any)["budget_tokens"]); got != 32767 {
+		t.Fatalf("budget_tokens = %d, want 32767 under the admitted 32768", got)
+	}
+	if got := intFromAny(body["max_tokens"]); got != 32768 {
+		t.Fatalf("max_tokens = %d, want the admitted 32768", got)
+	}
+
+	// A ceiling that cannot fit the 1024-token thinking minimum keeps the
+	// explicit pre-dispatch error rather than sending a wire-rejectable
+	// budget.
+	res = protoRes(func(c *registry.Caps) {
+		c.ThinkingShape = new("budget")
+		c.MaxOutputTokens = new(1024)
+	})
+	req = protoReq("high")
+	req.MaxTokens = new(1024)
+	_, err := (&Protocol{}).BuildBody(llm.ShapeRequest(req, res), res)
+	if _, ok := errors.AsType[*llm.ContextBudgetError](err); !ok {
+		t.Fatalf("error = %v, want *llm.ContextBudgetError for a ceiling below the thinking minimum", err)
 	}
 }
 

--- a/llm/providers/anthropic/protocol_test.go
+++ b/llm/providers/anthropic/protocol_test.go
@@ -334,6 +334,38 @@ func TestProtocolBuildBody_BudgetEffortClampedToOutputCeiling(t *testing.T) {
 	}
 }
 
+// TestProtocolBuildBody_BudgetEffortClampedUnderProviderOptionMaxTokens pins
+// the overlay interaction roborev flagged on d96adbe: the effort-derived
+// budget is fitted before the ProviderOptions overlay runs, and the overlay
+// can lower max_tokens afterwards, so a caller's explicit
+// anthropic.max_tokens override must be part of the ceiling the budget fits
+// under — the completion contract still requires max_tokens to strictly
+// exceed budget_tokens. An override too small to fit the thinking minimum
+// keeps the explicit error rather than silently sending a sub-minimum
+// budget.
+func TestProtocolBuildBody_BudgetEffortClampedUnderProviderOptionMaxTokens(t *testing.T) {
+	res := protoRes(func(c *registry.Caps) {
+		c.ThinkingShape = new("budget+effort")
+		c.MaxOutputTokens = new(131072)
+	})
+	req := protoReq("max")
+	req.MaxTokens = new(131072)
+	req.ProviderOptions = map[string]any{registry.ProtocolAnthropic: map[string]any{"max_tokens": 8192}}
+	body := protoBuild(t, req, res)
+	if got := intFromAny(body["thinking"].(map[string]any)["budget_tokens"]); got != 8191 {
+		t.Fatalf("budget_tokens = %d, want 8191 under the caller's 8192 override", got)
+	}
+	if got := intFromAny(body["max_tokens"]); got != 8192 {
+		t.Fatalf("max_tokens = %d, want the caller's 8192 override", got)
+	}
+
+	req.ProviderOptions = map[string]any{registry.ProtocolAnthropic: map[string]any{"max_tokens": 800}}
+	_, err := (&Protocol{}).BuildBody(llm.ShapeRequest(req, res), res)
+	if _, ok := errors.AsType[*llm.ContextBudgetError](err); !ok {
+		t.Fatalf("error = %v, want *llm.ContextBudgetError for an override below the thinking minimum", err)
+	}
+}
+
 func TestProtocolBuildBody_FinalThinkingOverlayStateControlsReconciliation(t *testing.T) {
 	for _, tc := range []struct {
 		name           string

--- a/llm/providers/anthropic/protocol_transport_test.go
+++ b/llm/providers/anthropic/protocol_transport_test.go
@@ -184,6 +184,57 @@ func TestProtocolCompletionFinalizerDoesNotRestoreDisabledOutputField(t *testing
 	}
 }
 
+// TestProtocolCompletionClampsEffortBudgetUnderTransportMaxTokensConstant
+// pins the transport-overlay interaction roborev flagged on 312ce22: the
+// transport's body constants run after the body builder and override the
+// max_tokens it left there, and the completion finalizer then enforces
+// max_tokens > budget_tokens against the overlaid value — so a row-level
+// max_tokens constant must bound the effort-derived thinking budget too.
+func TestProtocolCompletionClampsEffortBudgetUnderTransportMaxTokensConstant(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		run  func(*Protocol, llm.Request, registry.Resolved) error
+	}{
+		{"complete", messagesJSON, func(p *Protocol, req llm.Request, res registry.Resolved) error {
+			_, err := p.Complete(context.Background(), req, res)
+			return err
+		}},
+		{"stream", messagesSSE, func(p *Protocol, req llm.Request, res registry.Resolved) error {
+			stream, err := p.Stream(context.Background(), req, res)
+			if err != nil {
+				return err
+			}
+			for event := range stream.Events() {
+				if event.Type == llm.StreamEventError {
+					return event.Err
+				}
+			}
+			return nil
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, got := protoServer(t, func(*http.Request) (int, string) { return http.StatusOK, tc.body })
+			res := protoLive(srv)
+			res.Caps.ThinkingShape = new("budget+effort")
+			res.Caps.MaxOutputTokens = new(131072)
+			res.Transport.Body = map[string]any{"max_tokens": 8192}
+			req := protoReq("high") // a 32768-token table budget over the 8192 constant
+			req.MaxTokens = new(131072)
+			if err := tc.run(&Protocol{Client: srv.Client()}, req, res); err != nil {
+				t.Fatal(err)
+			}
+			thinking, _ := got.body["thinking"].(map[string]any)
+			if budget := intFromAny(thinking["budget_tokens"]); budget != 8191 {
+				t.Fatalf("wire budget_tokens = %d, want 8191 under the transport's 8192 constant: %v", budget, got.body)
+			}
+			if mt := intFromAny(got.body["max_tokens"]); mt != 8192 {
+				t.Fatalf("wire max_tokens = %d, want the 8192 transport constant: %v", mt, got.body)
+			}
+		})
+	}
+}
+
 func TestProtocolListModelsPaginatesAndCountTokensStrips(t *testing.T) {
 	srv, got := protoServer(t, func(r *http.Request) (int, string) {
 		switch {

--- a/llm/providers/anthropic/protocol_transport_test.go
+++ b/llm/providers/anthropic/protocol_transport_test.go
@@ -249,6 +249,26 @@ func TestProtocolCountTokensDoesNotEnforceCompletionThinkingBudget(t *testing.T)
 	}
 }
 
+// TestProtocolCountTokensKeepsEffortBudgetUnclamped pins the count-tokens
+// counterpart of the completion clamp: the clamp exists to satisfy the
+// completion contract that max_tokens strictly exceeds budget_tokens, which
+// as ReasoningBudget produced it.
+func TestProtocolCountTokensKeepsEffortBudgetUnclamped(t *testing.T) {
+	srv, got := protoServer(t, func(*http.Request) (int, string) { return http.StatusOK, `{"input_tokens":21}` })
+	res := protoLive(srv)
+	res.Caps.ThinkingShape = new("budget")
+	req := protoReq("high") // a 32768-token table budget over the 8192 admitted
+	req.MaxTokens = new(8192)
+	n, err := (&Protocol{Client: srv.Client()}).CountTokens(context.Background(), req, res)
+	if err != nil || n != 21 {
+		t.Fatalf("CountTokens = %d, %v; want 21, nil", n, err)
+	}
+	thinking, _ := got.body["thinking"].(map[string]any)
+	if budget := intFromAny(thinking["budget_tokens"]); budget != llm.ReasoningBudget("high") {
+		t.Fatalf("count body budget_tokens = %d, want the unclamped effort budget %d", budget, llm.ReasoningBudget("high"))
+	}
+}
+
 // TestProtocolEndpointFamilies pins the api-log endpoint_family of each
 // operation; count_tokens and models must not inherit anthropic_messages.
 func TestProtocolEndpointFamilies(t *testing.T) {

--- a/llm/types.go
+++ b/llm/types.go
@@ -599,16 +599,17 @@ func (req Request) Validate() error {
 	return nil
 }
 
+// MinimumThinkingBudgetTokens is the smallest thinking budget Anthropic
+// documents accepting; a lower value is wire-rejectable on budget-shaped
+// rows (#714).
+const MinimumThinkingBudgetTokens = 1024
+
 // ReasoningBudget converts a reasoning effort level to a token budget.
 // Returns 0 for unrecognized values.
 func ReasoningBudget(effort string) int {
 	switch strings.ToLower(strings.TrimSpace(effort)) {
-	case "minimal":
-		// Anthropic documents 1024 as the minimum for thinking.budget_tokens;
-		// a lower value is wire-rejectable on budget-shaped rows (#714).
-		return 1024
-	case "low":
-		return 1024
+	case "minimal", "low":
+		return MinimumThinkingBudgetTokens
 	case "medium":
 		return 8192
 	case "high":


### PR DESCRIPTION
## Summary

- Clamps the effort-derived anthropic `thinking.budget_tokens` under the request's output ceiling, so the protocol's `max_tokens > budget_tokens` contract always holds for a request the adapter itself derived.

## Why

Production incident (session `034IY3Zk6JSKI7i9eVhTRc`, 2026-09-03): `llm.ReasoningBudget` maps `max`/`xhigh` to 131072 tokens — exactly `kimi-for-coding` k3's `max_output_tokens` — so once the session selected effort `max`, **every** model call was rejected before provider dispatch with a non-retryable error:

```
Evener blocked kimi-code/k3 before provider dispatch: token budget exceeds max_output_tokens (input=0 output=131073 maximum=131072)
```

The API log showed the failed turns as zero-attempt `transport_failure` groups (no HTTP attempt was ever made), the transcript had no assistant turn after the user's messages, and there was no retry or recovery short of lowering the effort — the session looked dead while still accepting user input. The same wedge is reachable via loop-detector escalation to "high" on budget-shaped rows that have no catalog output cap (the 32000 fallback becomes the ceiling).

## What changed

- `applyThinkingShape` clamps the effort-derived budget via `fitThinkingBudgetToOutputCeiling`, floored at Anthropic's documented 1024-token thinking minimum (now shared as `llm.MinimumThinkingBudgetTokens`, hoisted beside the table whose minimal row already encoded it).
- Deliberately unchanged: #824's guard still errors for caller-provided `ProviderOptions` budgets that don't fit, and for ceilings too small to fit the thinking minimum. The clamp never *raises* `max_tokens` — the thing that guard exists to prevent (per the [plan](docs/superpowers/plans/2026-09-01-provider-safe-token-budget.md), step 1).
- `TestProtocolBuildBody_HighThinkingRejectsUnknownOutputCap` → `...ClampsUnderUnknownOutputCapFallback`: it pinned the over-generalized fail-closed that produced this wedge. Commit 58196ab16 carries the full reasoning.
- The second commit (7cbbfc3fa) is a behavior-neutral simplify pass over the fix.

## Verification

- TDD: the new regression test reproduced the exact incident error text before the fix.
- End-to-end against the real registry row: `kimi-code/k3` at effort `max` now builds `max_tokens=131072, budget_tokens=131071, output_config.effort=max`.
- `make merge-approval-gate`: **PASS** (exit 0) — lint, build, `ROOT_FULL=1 make test` (root 95s, llm, agent, auth, envvars, invariant, identifier, web 92s) all green on this branch.