### PR TITLE
fix(web): redesign subagent activity view with relative timestamps

### DIFF
--- a/cmd/evener-hub/frontend/src/dev/gallery-sections/timestamp.tsx
+++ b/cmd/evener-hub/frontend/src/dev/gallery-sections/timestamp.tsx
@@ -1,0 +1,33 @@
+import { Timestamp } from "../../widgets/timestamp";
+import styles from "../gallery-section.module.css";
+import { ThemeFlip } from "../ThemeFlip";
+
+// A fixed anchor instant, not Date.now() (same reasoning as cadence.tsx's and
+// loader.tsx's own gallery sections): Timestamp is a pure render of its props,
+// so its sample data — including the frozen relative readout — should not
+// look different on every reload.
+const NOW = 1_700_000_000_000;
+
+const SAMPLES: { label: string; value: number }[] = [
+  { label: "just now", value: NOW - 4_000 },
+  { label: "seconds", value: NOW - 30_000 },
+  { label: "minutes", value: NOW - 5 * 60_000 },
+  { label: "hours", value: NOW - 3 * 3_600_000 },
+  { label: "days (other-day → date+time on hover)", value: NOW - 2 * 86_400_000 },
+];
+
+export default function TimestampGallerySection() {
+  return (
+    <section>
+      <h2>Timestamp</h2>
+      <ThemeFlip>
+        {SAMPLES.map(({ label, value }) => (
+          <div className={styles.row} key={label}>
+            <p className={styles.rowLabel}>{label}</p>
+            <Timestamp value={value} now={NOW} />
+          </div>
+        ))}
+      </ThemeFlip>
+    </section>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.test.tsx
@@ -479,8 +479,22 @@ test("expanding a card lists recent quotes - intents plain, messages italic - ea
     argumentsJSON: JSON.stringify({ prompt: "audit the reducer" }),
     output: JSON.stringify({ delegate_id: "job_qs", status: "running", transcript_ref: "ref_quotes_child" }),
   });
+  // A fixed reference instant 70s after the stamped step (same calendar day),
+  // so the relative time is deterministic and the absolute stays time-only.
+  const stepStart = new Date(2026, 7, 20, 9, 41, 2);
+  const fixedNow = new Date(2026, 7, 20, 9, 42, 12).getTime();
+  const absStart = new Intl.DateTimeFormat("en", {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).format(stepStart);
   const user = userEvent.setup();
-  render(<Body item={running} live={false} />);
+  render(
+    <SessionNowContext.Provider value={fixedNow}>
+      <Body item={running} live={false} />
+    </SessionNowContext.Provider>,
+  );
 
   const row = screen.getByTestId("subagent-row");
   await user.click(within(row).getByRole("button", { name: /show recent activity/i }));
@@ -489,18 +503,23 @@ test("expanding a card lists recent quotes - intents plain, messages italic - ea
   // Two real steps plus the final message; the whitespace-only description
   // contributed no quote (the same statedIntentOf rule the old feed used).
   expect(items).toHaveLength(3);
-  expect(items.map((li) => li.value)).toEqual([1, 2, 3]);
+  // The activity feed is a sequence, not an enumeration: no <li> carries an
+  // ordinal value attribute, so the "72. 73. …" numbering is gone.
+  expect(items.every((li) => li.getAttribute("value") === null)).toBe(true);
 
-  // Runtime + timestamp ride each stamped quote: "6s · HH:MM:SS" local. The
-  // expected stamp is computed through the same Date parsing the formatter
-  // uses, so the suite stays timezone-independent.
-  const parsed = new Date(2026, 7, 20, 9, 41, 2);
-  const stamp = `${String(parsed.getHours()).padStart(2, "0")}:${String(parsed.getMinutes()).padStart(2, "0")}:${String(parsed.getSeconds()).padStart(2, "0")}`;
+  // Each stamped quote shows its per-step runtime and a relative start time
+  // (the absolute instant is the <time title> hover), never a wall-clock
+  // string in the visible text. absStart mirrors the widget's own formatter,
+  // so the assertion is timezone-independent.
+  const time0 = items[0]!.querySelector("time");
+  expect(time0).not.toBeNull();
+  expect(time0!.getAttribute("title")).toBe(absStart);
   expect(items[0]!.textContent).toContain("step one");
   expect(items[0]!.textContent).toContain("6s");
-  expect(items[0]!.textContent).toContain(stamp);
-  // Unstamped quotes render no runtime segment rather than a guess.
+  expect(items[0]!.textContent).toContain("1m ago");
+  // Unstamped quotes render no runtime or timestamp segment rather than a guess.
   expect(items[1]!.textContent).toBe("step two");
+  expect(items[1]!.querySelector("time")).toBeNull();
 
   // Expanded activity retains source-specific treatment.
   expect(items[2]!.querySelector("em")?.textContent).toBe("all done");
@@ -650,7 +669,8 @@ test("the Activity feed elides round_timings items and ordinals count only real 
   // round_timings items never entered the count, so ordinals run 2..6, not
   // 4..8.
   expect(items.map((li) => li.textContent)).toEqual(["step 2", "step 3", "step 4", "step 5", "step 6"]);
-  expect(items.map((li) => li.value)).toEqual([2, 3, 4, 5, 6]);
+  // No ordinals: the feed is unnumbered, so no <li> carries a value attribute.
+  expect(items.every((li) => li.getAttribute("value") === null)).toBe(true);
 });
 
 test("dr7e: no Job detail section renders when neither resumable nor exhaustion fields are set", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.tsx
@@ -6,12 +6,12 @@ import { useEffect } from "react";
 import { type ItemModel, SYSTEM_PRELUDE_TURN_ID } from "../../../../protocol/model";
 import type { EvenerDelegateInfo } from "../../../../protocol/types.gen";
 import { threadsStore, useThreadsStore } from "../../../../stores/threads";
-import { Chevron, IconButton } from "../../../../widgets";
+import { Chevron, IconButton, Timestamp } from "../../../../widgets";
 import { isDisclosureOpen, toggleDisclosure } from "../../../../widgets/disclosure/disclosureStore";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { formatUsagePair } from "../../chrome/activityFormat";
 import { cadenceStateForStatus, useSessionNow } from "../../liveness";
-import { formatClockTimeSeconds, formatElapsed, plainQuoteLine } from "../messages/format";
+import { formatElapsed, plainQuoteLine } from "../messages/format";
 import { statedIntentOf } from "../ToolRow";
 import type { ToolRenderProps } from "../toolRenderers";
 import { registerToolRenderer } from "../toolRenderers";
@@ -38,6 +38,7 @@ const CLASS = {
   statusGlyph: requireClass(styles.statusGlyph, "subagentmodule.module.css", "statusGlyph"),
   srOnly: requireClass(styles.srOnly, "subagentmodule.module.css", "srOnly"),
   quote: requireClass(styles.quote, "subagentmodule.module.css", "quote"),
+  quoteText: requireClass(styles.quoteText, "subagentmodule.module.css", "quoteText"),
   stats: requireClass(styles.stats, "subagentmodule.module.css", "stats"),
   statsSep: requireClass(styles.statsSep, "subagentmodule.module.css", "statsSep"),
   statsSpring: requireClass(styles.statsSpring, "subagentmodule.module.css", "statsSpring"),
@@ -301,16 +302,22 @@ function SubagentCard({
                     : live && q.startedAt !== undefined
                       ? "…"
                       : undefined;
-                const stamp = formatClockTimeSeconds(q.startedAt);
-                const meta = [runtime, stamp].filter((s) => s !== undefined).join(" · ");
+                // Relative start time (absolute on hover) replaces the
+                // always-visible wall clock; an unparseable start omits it.
+                const startMs = q.startedAt !== undefined ? Date.parse(q.startedAt) : Number.NaN;
+                const hasStart = !Number.isNaN(startMs);
                 return (
-                  <li
-                    key={q.id}
-                    value={q.ordinal}
-                    className={live ? `${CLASS.quoteItem} ${CLASS.quoteLive}` : CLASS.quoteItem}
-                  >
-                    {q.msg ? <em className={CLASS.quoteMsg}>{q.text}</em> : <span>{q.text}</span>}
-                    {meta && <span className={CLASS.quoteMeta}>{meta}</span>}
+                  <li key={q.id} className={live ? `${CLASS.quoteItem} ${CLASS.quoteLive}` : CLASS.quoteItem}>
+                    <span className={CLASS.quoteText}>
+                      {q.msg ? <em className={CLASS.quoteMsg}>{q.text}</em> : q.text}
+                    </span>
+                    {(runtime !== undefined || hasStart) && (
+                      <span className={CLASS.quoteMeta}>
+                        {runtime !== undefined && <span>{runtime}</span>}
+                        {runtime !== undefined && hasStart && <span className={CLASS.statsSep}>·</span>}
+                        {hasStart && <Timestamp value={startMs} now={nowMs} />}
+                      </span>
+                    )}
                   </li>
                 );
               })}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentmodule.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentmodule.module.css
@@ -49,7 +49,6 @@
   flex-wrap: wrap;
   align-items: center;
   gap: var(--space-1);
-  font-family: var(--font-mono);
   font-size: var(--font-size-caption);
   color: var(--ink-low);
 }
@@ -83,21 +82,23 @@
 .quotesList {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: var(--space-1);
   margin: 0;
-  padding-left: var(--space-5);
-  list-style: decimal;
+  padding: 0;
+  list-style: none;
 }
 .quoteItem {
+  display: flex;
+  gap: var(--space-2);
+  align-items: baseline;
   min-width: 0;
   font-size: var(--font-size-ui);
   color: var(--ink-mid);
   overflow-wrap: anywhere;
 }
-.quoteItem::marker {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-caption);
-  color: var(--ink-low);
+.quoteText {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .quoteLive {
   color: var(--ink-hi);
@@ -108,10 +109,12 @@
   color: var(--ink-hi);
 }
 .quoteMeta {
-  font-family: var(--font-mono);
+  display: flex;
+  flex: none;
+  align-items: baseline;
+  gap: var(--space-1);
   font-size: var(--font-size-caption);
   color: var(--ink-low);
-  margin-left: var(--space-2);
   white-space: nowrap;
 }
 .quotesEmpty {
@@ -136,7 +139,6 @@
   font-family: var(--font-sans);
   font-size: var(--font-size-ui);
   color: var(--ink-hi);
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/index.ts
+++ b/cmd/evener-hub/frontend/src/widgets/index.ts
@@ -104,6 +104,8 @@ export type { TableColumn, TableFilter, TableProps, TableSortDir } from "./table
 export { Table } from "./table";
 export type { TextareaProps } from "./textarea";
 export { Textarea } from "./textarea";
+export type { TimestampProps } from "./timestamp";
+export { Timestamp } from "./timestamp";
 export type { ToastKind } from "./toast";
 export { Toast, useToasts } from "./toast";
 export type { ToolIconKind, ToolIconProps } from "./toolicon";

--- a/cmd/evener-hub/frontend/src/widgets/timestamp/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/timestamp/index.tsx
@@ -1,0 +1,92 @@
+// A relative-time label whose absolute instant is one hover away.
+//
+// Built on the platform's own Intl formatters (RelativeTimeFormat for the
+// visible relative text, DateTimeFormat for the absolute hover) — no third-
+// party date dependency, matching the project's "prefer standard defaults"
+// stance. The locale is pinned to "en" so output is deterministic across
+// environments (CI and dev alike); the existing transcript formatters
+// (messages/format.ts) are likewise en-style by construction.
+//
+// Pure render, no internal clock — mirrors Cadence and Loader: the caller
+// owns "now" (the session's shared 3s tick via useSessionNow, or a fixed
+// value in tests), so a component with no timer cannot fake or drift liveness
+// between renders.
+import { requireClass } from "../internal/requireClass";
+import styles from "./timestamp.module.css";
+
+export interface TimestampProps {
+  /** Epoch-ms instant the event occurred. */
+  value: number;
+  /** Epoch-ms "current" instant the relative time is measured against.
+   * Prop-driven, never Date.now() internally — same pure-render rule as
+   * Cadence (src/widgets/cadence/index.tsx) and Loader. */
+  now: number;
+}
+
+const CLASS = {
+  time: requireClass(styles.time, "timestamp.module.css", "time"),
+};
+
+// One formatter per shape, module-singleton — Intl construction is not cheap,
+// and the relative formatter is called on every render of every visible
+// timestamp. Pinned locale keeps the snapshot deterministic.
+const RELATIVE = new Intl.RelativeTimeFormat("en", { style: "narrow", numeric: "always" });
+
+const ABS_SAME_DAY = new Intl.DateTimeFormat("en", {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+const ABS_OTHER_DAY = new Intl.DateTimeFormat("en", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+// Pick the largest unit whose magnitude is >= 1, rounding to that unit so
+// "90s" reads "2m ago" rather than "90s ago" (a 90-second-old step is a minute
+// and a half, not ninety seconds — the same rounding every "time ago" UI does).
+// Below 10s the step is effectively current, so it collapses to "now" rather
+// than "0s ago"/"9s ago" noise. Future (clock-skew) values also collapse to
+// "now": a timestamp slightly ahead of the clock is not "in 4 seconds", it is
+// just now.
+function relativeLabel(diffMs: number): string {
+  if (diffMs < 10_000) return "now";
+  const sec = Math.round(diffMs / 1000);
+  if (sec < 60) return RELATIVE.format(-sec, "second");
+  const min = Math.round(sec / 60);
+  if (min < 60) return RELATIVE.format(-min, "minute");
+  const hr = Math.round(min / 60);
+  if (hr < 24) return RELATIVE.format(-hr, "hour");
+  const day = Math.round(hr / 24);
+  if (day < 7) return RELATIVE.format(-day, "day");
+  const wk = Math.round(day / 7);
+  return RELATIVE.format(-wk, "week");
+}
+
+// Adaptive absolute: time-only when the event shares the reference day,
+// date+time once it crosses a calendar boundary. `toDateString` is the
+// cheapest same-calendar-day test and is timezone-correct for both operands.
+function absoluteLabel(value: number, now: number): string {
+  const sameDay = new Date(value).toDateString() === new Date(now).toDateString();
+  return (sameDay ? ABS_SAME_DAY : ABS_OTHER_DAY).format(value);
+}
+
+/** A relative time (e.g. "5m ago") whose absolute instant ("13:53:45", or
+ * "Aug 20, 09:41:02" once it crosses a day boundary) is the native
+ * `<time title>` hover tooltip. The `dateTime` attribute carries the ISO
+ * instant for assistive tech and copy/paste. Pure render of `value`/`now` —
+ * no timers, no Date.now(). */
+export function Timestamp({ value, now }: TimestampProps) {
+  if (Number.isNaN(value) || Number.isNaN(now)) return null;
+  const diff = now - value;
+  return (
+    <time className={CLASS.time} dateTime={new Date(value).toISOString()} title={absoluteLabel(value, now)}>
+      {relativeLabel(diff)}
+    </time>
+  );
+}

--- a/cmd/evener-hub/frontend/src/widgets/timestamp/timestamp.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/timestamp/timestamp.module.css
@@ -1,0 +1,24 @@
+/* A relative-time label with the absolute instant on hover (native <time
+ * title>). Not a control: no focus ring, no tab stop — the visible relative
+ * text plus the machine-readable dateTime attribute is the full accessible
+ * contract, and the absolute-on-hover is a mouse convenience. The dotted
+ * underline appears only on hover to signal "hover for the exact time"
+ * (the <abbr>/help-cursor idiom), never at rest, so it never reads as a link. */
+
+.time {
+  flex: none;
+  font-family: var(--font-sans);
+  font-size: var(--font-size-caption);
+  color: var(--ink-low);
+  white-space: nowrap;
+  cursor: help;
+  border-bottom: 1px dotted transparent;
+  transition:
+    color var(--motion-duration-hover) var(--motion-easing-standard),
+    border-color var(--motion-duration-hover) var(--motion-easing-standard);
+}
+
+.time:hover {
+  color: var(--ink-mid);
+  border-bottom-color: var(--edge-strong);
+}

--- a/cmd/evener-hub/frontend/src/widgets/timestamp/timestamp.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/timestamp/timestamp.test.tsx
@@ -1,0 +1,107 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import { Timestamp } from "./index";
+
+afterEach(() => cleanup());
+
+// Expected absolutes are computed through the SAME Intl formatters the
+// widget uses, on the SAME epoch values — so the suite is timezone-
+// independent by construction (the widget pins "en"; the test mirrors it).
+
+const NOW = 1_700_000_000_000;
+const SAME_DAY_OPTS = { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false } as const;
+const OTHER_DAY_OPTS = {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+} as const;
+
+function absSameDay(value: number): string {
+  return new Intl.DateTimeFormat("en", SAME_DAY_OPTS).format(value);
+}
+function absOtherDay(value: number): string {
+  return new Intl.DateTimeFormat("en", OTHER_DAY_OPTS).format(value);
+}
+
+test("renders a <time> element with a dateTime ISO attribute", () => {
+  render(<Timestamp value={NOW} now={NOW} />);
+  const t = screen.getByText("now");
+  expect(t.tagName).toBe("TIME");
+  expect(t.getAttribute("dateTime")).toBe(new Date(NOW).toISOString());
+});
+
+test("'now' for an instant within 10s of the reference", () => {
+  render(<Timestamp value={NOW - 9_000} now={NOW} />);
+  expect(screen.getByText("now")).toBeTruthy();
+});
+
+test("future / clock-skew values collapse to 'now', not 'in N seconds'", () => {
+  render(<Timestamp value={NOW + 4_000} now={NOW} />);
+  expect(screen.getByText("now")).toBeTruthy();
+});
+
+test("seconds: 30s ago", () => {
+  render(<Timestamp value={NOW - 30_000} now={NOW} />);
+  expect(screen.getByText("30s ago")).toBeTruthy();
+});
+
+test("minutes round up: 90s reads '2m ago', not '90s ago'", () => {
+  render(<Timestamp value={NOW - 90_000} now={NOW} />);
+  expect(screen.getByText("2m ago")).toBeTruthy();
+});
+
+test("hours: 3h ago", () => {
+  render(<Timestamp value={NOW - 3 * 3_600_000} now={NOW} />);
+  expect(screen.getByText("3h ago")).toBeTruthy();
+});
+
+test("days: 2d ago", () => {
+  render(<Timestamp value={NOW - 2 * 86_400_000} now={NOW} />);
+  expect(screen.getByText("2d ago")).toBeTruthy();
+});
+
+test("weeks: 14d ago reads '2w ago' at the week threshold", () => {
+  render(<Timestamp value={NOW - 14 * 86_400_000} now={NOW} />);
+  expect(screen.getByText("2w ago")).toBeTruthy();
+});
+
+test("same-day absolute is time-only and on the title (hover), not the visible text", () => {
+  const value = NOW - 30_000;
+  render(<Timestamp value={value} now={NOW} />);
+  const t = screen.getByText("30s ago");
+  expect(t.getAttribute("title")).toBe(absSameDay(value));
+  expect(t.textContent).toBe("30s ago");
+});
+
+test("other-day absolute carries the date (adaptive format) on the title", () => {
+  const value = NOW - 2 * 86_400_000; // two days earlier → different calendar day
+  render(<Timestamp value={value} now={NOW} />);
+  const t = screen.getByText("2d ago");
+  expect(t.getAttribute("title")).toBe(absOtherDay(value));
+  // The other-day format begins with a month abbreviation, proving it is not
+  // the time-only same-day shape.
+  expect(t.getAttribute("title")).toMatch(/^[A-Z][a-z]{2} \d/);
+});
+
+test("a NaN value renders nothing", () => {
+  const { container } = render(<Timestamp value={Number.NaN} now={NOW} />);
+  expect(container.querySelector("time")).toBeNull();
+});
+
+test("a NaN now renders nothing", () => {
+  const { container } = render(<Timestamp value={NOW} now={Number.NaN} />);
+  expect(container.querySelector("time")).toBeNull();
+});
+
+test("never re-renders on its own - no internal timers (now is fully prop-driven)", () => {
+  vi.useFakeTimers();
+  render(<Timestamp value={NOW - 30_000} now={NOW} />);
+  const before = screen.getByText("30s ago").textContent;
+  vi.advanceTimersByTime(120_000); // 2 minutes of virtual time; nothing scheduled
+  const after = screen.getByText("30s ago").textContent;
+  expect(after).toEqual(before);
+  vi.useRealTimers();
+});


### PR DESCRIPTION
## Summary

The expanded "recent activity" region of a running subagent card was off-system: item ordinals (`72. 73. …`), always-visible absolute wall-clock times in monospace, and pre-wrapped mandate text. This redesign brings it in line with the design system's copy and type rules.

**Before / after mockup** used the real dark-theme tokens; the three open judgment calls were confirmed with the design review:
- Stats strip → sans throughout (no preformatted text except code)
- Per-step runtime → kept beside the relative time
- Absolute hover format → adaptive (time-only same day, date+time other days)

## Changes

- **Drop the item ids** — the activity list is no longer a numbered `<ol>`. Removed `value={q.ordinal}`, `list-style: decimal`, and the `::marker` rule. Activity is a sequence of steps, not an enumeration.
- **Relative timestamps, absolute on hover** — each step's wall-clock time is replaced by a new reusable `<Timestamp>` widget: visible relative text (`5m ago`, `1h ago`, …) with the absolute instant as the native `<time title>` hover tooltip. Built on the platform `Intl.RelativeTimeFormat` + `Intl.DateTimeFormat` (the web standard library — no new npm dependency), pinned to `"en"` for deterministic output. Adaptive hover format: time-only same day, date+time other days. Prop-driven `now` (from the existing `useSessionNow()` 3s tick), no internal timers — same pure-render rule as Cadence/Loader.
- **No preformatted text except code** — the stats strip, per-line meta, and mandate moved off `--font-mono` / `pre-wrap` to `--font-sans` / normal wrapping.

## New artifact

`<Timestamp>` joins the widget library under `widgets/timestamp/` (component + CSS module + 13 tests), with a gallery section so the `WidgetGallery` completeness test passes, exported from `widgets/index.ts`.

## Files

- `widgets/timestamp/{index.tsx, timestamp.module.css, timestamp.test.tsx}` — new
- `dev/gallery-sections/timestamp.tsx` — new
- `widgets/index.ts` — export added
- `panes/session/transcript/tools/subagentModule.tsx` + `.module.css` — restyled
- `panes/session/transcript/tools/subagentModule.test.tsx` — updated for the new layout (no assertions weakened)

## Verification

\`\`\`
make test-web
PASS  web-typecheck
PASS  web-test
PASS  web-lint
MAKE_TEST_WEB_EXIT=0
\`\`\`

Full vitest suite: 7530 tests pass; token-contract test covers the new CSS module.