### PR TITLE
feat(web): keybinding dispatcher core + migration of global chords (Phase 2a)

### DIFF
--- a/cmd/evener-hub/frontend/package-lock.json
+++ b/cmd/evener-hub/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router": "^8.3.0",
+        "tinykeys": "^4.0.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -2412,6 +2413,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinykeys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tinykeys/-/tinykeys-4.0.0.tgz",
+      "integrity": "sha512-z5bQRQHL1PSx3lGOZEAMM2oKp0EBtn5T5f7HJnaKPOzk6vEH0wUPvdHLeQ7F4tmkek8AgoTQISUFmn/5SNF2xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/tinyrainbow": {

--- a/cmd/evener-hub/frontend/package.json
+++ b/cmd/evener-hub/frontend/package.json
@@ -32,6 +32,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router": "^8.3.0",
+    "tinykeys": "^4.0.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/cmd/evener-hub/frontend/src/keybindings/actions.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/actions.ts
@@ -1,0 +1,15 @@
+// Canonical shell action ids. Where a palette command already owns the
+// behavior, the action id IS the palette command id (see
+// shell/palette/commands.ts: "next-needs-you"); the rest are shell action ids.
+// Task 2 registers each id's real run function against the registry.
+
+export const ACTIONS = {
+  paletteOpen: "palette.open",
+  railToggle: "rail.toggle",
+  composerFocus: "composer.focus",
+  nextNeedsYou: "next-needs-you",
+  selectionQuote: "selection.quote",
+  settingsClose: "settings.close",
+} as const;
+
+export type ActionId = (typeof ACTIONS)[keyof typeof ACTIONS];

--- a/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+import { type Chord, formatChord, formatSequence, parseChord, serializeChord } from "./chord";
+
+function singleChord(input: string): Chord {
+  const sequence = parseChord(input);
+  if (sequence.length !== 1) throw new Error(`expected exactly one press in "${input}"`);
+  return sequence[0]!;
+}
+
+// jsdom's navigator.platform is "" on every host, so tinykeys resolves the
+// "$mod" alias to "Control" here regardless of the machine running the suite.
+// Tests that want the Meta spelling parse "Meta+..." explicitly.
+describe("parseChord", () => {
+  test("parses a single press with a modifier", () => {
+    expect(parseChord("$mod+K")).toEqual([{ modifiers: ["Control"], optionalModifiers: [], key: "K" }]);
+  });
+
+  test("parses a bare key with no modifiers", () => {
+    expect(parseChord("Escape")).toEqual([{ modifiers: [], optionalModifiers: [], key: "Escape" }]);
+  });
+
+  test("parses a sequence of presses", () => {
+    expect(parseChord("Shift+A b")).toEqual([
+      { modifiers: ["Shift"], optionalModifiers: [], key: "A" },
+      { modifiers: [], optionalModifiers: [], key: "b" },
+    ]);
+  });
+
+  test("parses optional modifiers", () => {
+    expect(parseChord("$mod+[Alt]+K")).toEqual([{ modifiers: ["Control"], optionalModifiers: ["Alt"], key: "K" }]);
+  });
+
+  test("canonicalizes modifier order", () => {
+    expect(parseChord("Shift+Control+K")).toEqual([
+      { modifiers: ["Control", "Shift"], optionalModifiers: [], key: "K" },
+    ]);
+  });
+
+  test("parses a regex key", () => {
+    const chord = singleChord("(a|b)");
+    expect(chord.modifiers).toEqual([]);
+    expect(chord.key).toBeInstanceOf(RegExp);
+  });
+
+  test("rejects a blank keybinding string", () => {
+    expect(() => parseChord("")).toThrow();
+    expect(() => parseChord("   ")).toThrow();
+  });
+});
+
+describe("serializeChord round-trips", () => {
+  const CASES = ["$mod+K", "$mod+B", "$mod+'", "Escape", "Shift+A b", "$mod+[Alt]+K", "Control+Shift+Home"];
+
+  test.each(CASES)("parse -> serialize -> parse is stable: %s", (input) => {
+    const ast = parseChord(input);
+    expect(parseChord(serializeChord(ast))).toEqual(ast);
+  });
+
+  test.each(CASES)("serialization is idempotent: %s", (input) => {
+    const once = serializeChord(parseChord(input));
+    expect(serializeChord(parseChord(once))).toBe(once);
+  });
+
+  test("serializes modifiers in canonical order", () => {
+    expect(serializeChord(parseChord("Shift+Control+K"))).toBe("Control+Shift+K");
+  });
+
+  test("serializes optional modifiers with bracket syntax", () => {
+    expect(serializeChord(parseChord("$mod+[Alt]+K"))).toBe("Control+[Alt]+K");
+  });
+
+  test("serializes a sequence as space-separated presses", () => {
+    expect(serializeChord(parseChord("Shift+A b"))).toBe("Shift+A b");
+  });
+});
+
+describe("formatChord", () => {
+  // The Mod platform-split concept from widgets/keyhint: the primary modifier
+  // reads "Ctrl" off Apple platforms and "⌘" on them. tinykeys has already
+  // resolved "$mod" by parse time, so formatting maps the resolved modifier.
+  test("formats Control with the Ctrl label", () => {
+    expect(formatChord(singleChord("Control+K"))).toBe("Ctrl+K");
+  });
+
+  test("formats Meta with the Apple command glyph", () => {
+    expect(formatChord(singleChord("Meta+K"))).toBe("⌘+K");
+  });
+
+  test("leaves non-split keys verbatim", () => {
+    expect(formatChord(singleChord("Shift+Enter"))).toBe("Shift+Enter");
+  });
+
+  test("formats a bare key", () => {
+    expect(formatChord(singleChord("Escape"))).toBe("Escape");
+  });
+});
+
+describe("formatSequence", () => {
+  test("joins presses with a space", () => {
+    expect(formatSequence(parseChord("Shift+A b"))).toBe("Shift+A b");
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -40,6 +40,17 @@ export function parseChord(input: string): KeySequence {
   }));
 }
 
+/** Returns a copy of the sequence with `modifier` added as an OPTIONAL
+ * modifier on every press that neither requires nor already optionally
+ * lists it, preserving canonical modifier order. Used by the default map to
+ * express the legacy "either or both of Meta/Ctrl" chords. */
+export function withOptionalModifier(sequence: KeySequence, modifier: string): KeySequence {
+  return sequence.map((press) => {
+    if (press.modifiers.includes(modifier) || press.optionalModifiers.includes(modifier)) return press;
+    return { ...press, optionalModifiers: [...press.optionalModifiers, modifier].sort(byCanonicalOrder) };
+  });
+}
+
 /** Serializes the AST back to a tinykeys keybinding string: parseChord(serializeChord(ast)) deep-equals ast. */
 export function serializeChord(sequence: KeySequence): string {
   return sequence.map(serializePress).join(" ");

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -1,0 +1,81 @@
+// Canonical chord AST for the keybinding module: a Chord is one key press
+// (required modifiers + optional modifiers + key), a KeySequence is a list of
+// presses (tinykeys' space-separated multi-press bindings). Parsing delegates
+// to tinykeys' parseKeybinding, which also resolves the "$mod" alias to "Meta"
+// on Apple platforms and "Control" everywhere else at parse time - so an AST
+// captured at runtime is already platform-resolved.
+//
+// This module is deliberately React-free: the Mod ⌘/Ctrl platform-split
+// CONCEPT comes from widgets/keyhint (see keyhint/index.tsx:24-37), but no
+// widget code is imported here.
+
+import { parseKeybinding } from "tinykeys";
+
+export interface Chord {
+  /** Required modifiers, canonical KeyboardEvent modifier names, in canonical order. */
+  modifiers: string[];
+  /** Optional modifiers (tinykeys' [Alt] bracket syntax): match with or without. */
+  optionalModifiers: string[];
+  /** KeyboardEvent.key (matched case-insensitively by tinykeys) or a regex against key/code. */
+  key: string | RegExp;
+}
+
+export type KeySequence = Chord[];
+
+// Fixed display/serialization order for modifiers, so a chord's canonical
+// form never depends on the order its source string happened to list them in.
+const MODIFIER_ORDER = ["Control", "Alt", "Shift", "Meta"];
+
+function byCanonicalOrder(a: string, b: string): number {
+  return MODIFIER_ORDER.indexOf(a) - MODIFIER_ORDER.indexOf(b);
+}
+
+/** Parses a tinykeys keybinding string ("$mod+K", "Shift+A b") into the canonical AST. */
+export function parseChord(input: string): KeySequence {
+  if (input.trim() === "") throw new Error("cannot parse an empty keybinding");
+  return parseKeybinding(input).map(([required, optional, key]) => ({
+    modifiers: [...required].sort(byCanonicalOrder),
+    optionalModifiers: [...optional].sort(byCanonicalOrder),
+    key,
+  }));
+}
+
+/** Serializes the AST back to a tinykeys keybinding string: parseChord(serializeChord(ast)) deep-equals ast. */
+export function serializeChord(sequence: KeySequence): string {
+  return sequence.map(serializePress).join(" ");
+}
+
+function serializePress(chord: Chord): string {
+  const mods = [...chord.modifiers, ...chord.optionalModifiers.map((m) => `[${m}]`)];
+  return [...mods, serializeKey(chord.key)].join("+");
+}
+
+function serializeKey(key: string | RegExp): string {
+  if (!(key instanceof RegExp)) return key;
+  // parseKeybinding wraps a (regex) key as /^(?:regex)$/iv; unwrap that exact
+  // anchor so a parsed regex serializes back to its source form and the
+  // round-trip stays stable instead of nesting anchors on every pass.
+  const anchored = key.source.match(/^\^\(\?:(.*)\)\$$/);
+  return `(${anchored?.[1] ?? key.source})`;
+}
+
+// Display labels, reusing keyhint's platform-split concept: "$mod" has already
+// been resolved by parse time, so Meta reads as the Apple command glyph and
+// Control as the cross-platform "Ctrl". Every other name renders verbatim,
+// exactly as keyhint treats non-Mod keys.
+const MODIFIER_DISPLAY: Record<string, string> = {
+  Control: "Ctrl",
+  Meta: "⌘",
+};
+
+/** One press as speakable words: "⌘+K" on Apple platforms, "Ctrl+K" elsewhere. */
+export function formatChord(chord: Chord): string {
+  const mods = chord.modifiers.map((m) => MODIFIER_DISPLAY[m] ?? m);
+  const key = chord.key instanceof RegExp ? chord.key.source : chord.key;
+  return [...mods, key].join("+");
+}
+
+/** A whole sequence as words, presses space-separated: "Shift+A b". */
+export function formatSequence(sequence: KeySequence): string {
+  return sequence.map(formatChord).join(" ");
+}

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { ACTIONS } from "./actions";
-import { parseChord, serializeChord } from "./chord";
+import { formatSequence, parseChord, serializeChord } from "./chord";
 import { DEFAULT_BINDINGS, registerDefaultBindings, SETTINGS_SCOPE } from "./defaults";
 import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
 import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
@@ -23,13 +23,17 @@ describe("default binding map", () => {
 
   // Chords are compared through parse+serialize so the assertion is
   // platform-independent ("$mod" resolves per host platform at parse time).
+  // The optional modifiers are the legacy-faithful semantics: the AppShell
+  // K/I/J listener had no shift/alt guard, SelectionQuote guarded only
+  // AltGr (alt), rail.toggle guarded both, and the Settings Escape listener
+  // had no modifier guard at all.
   test.each([
-    [ACTIONS.paletteOpen, "$mod+K"],
+    [ACTIONS.paletteOpen, "$mod+[Shift]+[Alt]+K"],
     [ACTIONS.railToggle, "$mod+B"],
-    [ACTIONS.composerFocus, "$mod+I"],
-    [ACTIONS.nextNeedsYou, "$mod+J"],
-    [ACTIONS.selectionQuote, "$mod+'"],
-    [ACTIONS.settingsClose, "Escape"],
+    [ACTIONS.composerFocus, "$mod+[Shift]+[Alt]+I"],
+    [ACTIONS.nextNeedsYou, "$mod+[Shift]+[Alt]+J"],
+    [ACTIONS.selectionQuote, "$mod+[Shift]+'"],
+    [ACTIONS.settingsClose, "[Control]+[Alt]+[Shift]+[Meta]+Escape"],
   ])("%s is bound to %s", (actionId, chord) => {
     const binding = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
     expect(binding).toBeDefined();
@@ -50,6 +54,13 @@ describe("default binding map", () => {
     expect(binding?.scope).toBe(SETTINGS_SCOPE);
     for (const other of DEFAULT_BINDINGS.filter((b) => b.actionId !== ACTIONS.settingsClose)) {
       expect(other.scope ?? GLOBAL_SCOPE).toBe(GLOBAL_SCOPE);
+    }
+  });
+
+  test("display formatting renders every default chord (optional modifiers are dropped from display - parked L22 minor, but it must not crash)", () => {
+    for (const binding of DEFAULT_BINDINGS) {
+      const rendered = formatSequence(parseChord(String(binding.chord)));
+      expect(rendered.length).toBeGreaterThan(0);
     }
   });
 
@@ -135,9 +146,54 @@ describe("default bindings through the dispatcher", () => {
     expect(calls).toEqual([ACTIONS.paletteOpen]);
   });
 
-  test("Mod+chords with an extra Shift do not match today's plain-chord bindings", () => {
+  // Extra-modifier variants: the legacy AppShell ⌘K/⌘I/⌘J listener checked
+  // only metaKey||ctrlKey + key (NO shift/alt guard), and the legacy
+  // Settings Escape listener checked only key === "Escape" - so these all
+  // fired legacy and must still fire.
+  test("⌘⇧K and ⌘⌥K fire palette.open (legacy had no shift/alt guard)", () => {
     setup();
-    window.dispatchEvent(keydown({ key: "k", code: "KeyK", ctrlKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, altKey: true }));
+    expect(calls).toEqual([ACTIONS.paletteOpen, ACTIONS.paletteOpen]);
+  });
+
+  test("Meta+Ctrl+K fires palette.open (legacy accepted either or both modifiers)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.paletteOpen]);
+  });
+
+  test("⌘⇧I fires composer.focus", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true, shiftKey: true }));
+    expect(calls).toEqual([ACTIONS.composerFocus]);
+  });
+
+  test("Ctrl+Shift+J fires next-needs-you", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true, shiftKey: true }));
+    expect(calls).toEqual([ACTIONS.nextNeedsYou]);
+  });
+
+  test("Shift+Escape closes settings while the settings scope is pushed (legacy had no modifier guard)", () => {
+    setup();
+    registry.getState().pushScope(SETTINGS_SCOPE);
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape", shiftKey: true }));
+    expect(calls).toEqual([ACTIONS.settingsClose]);
+  });
+
+  test("⌘⇧' fires selection.quote but ⌘⌥' does NOT (the legacy AltGr guard)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true, shiftKey: true }));
+    expect(calls).toEqual([ACTIONS.selectionQuote]);
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true, altKey: true }));
+    expect(calls).toEqual([ACTIONS.selectionQuote]);
+  });
+
+  test("⌘⇧B and ⌘⌥B do NOT fire rail.toggle (the legacy listener guarded both)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", metaKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", metaKey: true, altKey: true }));
     expect(calls).toEqual([]);
   });
 

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -59,6 +59,20 @@ describe("default binding map", () => {
       expect(binding.ignoreIfDefaultPrevented ?? true).toBe(expected);
     }
   });
+
+  test("modal policy matches today's per-site modal guards", () => {
+    // palette.open (AppShell's deliberate ⌘K exemption), rail.toggle and
+    // selection.quote (their listeners have no modal check at all) are exempt;
+    // composer.focus / next-needs-you (AppShell's blockedByOpenModal) and
+    // settings.close keep the default suppression.
+    const policy = new Map(DEFAULT_BINDINGS.map((b) => [b.actionId, b.allowInModal ?? false]));
+    expect(policy.get(ACTIONS.paletteOpen)).toBe(true);
+    expect(policy.get(ACTIONS.railToggle)).toBe(true);
+    expect(policy.get(ACTIONS.selectionQuote)).toBe(true);
+    expect(policy.get(ACTIONS.composerFocus)).toBe(false);
+    expect(policy.get(ACTIONS.nextNeedsYou)).toBe(false);
+    expect(policy.get(ACTIONS.settingsClose)).toBe(false);
+  });
 });
 
 describe("default bindings through the dispatcher", () => {
@@ -125,5 +139,25 @@ describe("default bindings through the dispatcher", () => {
     setup();
     window.dispatchEvent(keydown({ key: "k", code: "KeyK", ctrlKey: true, shiftKey: true }));
     expect(calls).toEqual([]);
+  });
+
+  test("every $mod chord also fires under Meta (today's listeners accept metaKey||ctrlKey)", () => {
+    // jsdom resolves tinykeys' $mod to Control, but the shell's pre-dispatcher
+    // listeners (and Mac users hitting Ctrl+K) accept either modifier on every
+    // platform, so registerDefaultBindings registers the cross-platform twin
+    // of each $mod chord as well.
+    setup();
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true }));
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", metaKey: true }));
+    window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true }));
+    window.dispatchEvent(keydown({ key: "j", code: "KeyJ", metaKey: true }));
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true }));
+    expect(calls).toEqual([
+      ACTIONS.paletteOpen,
+      ACTIONS.railToggle,
+      ACTIONS.composerFocus,
+      ACTIONS.nextNeedsYou,
+      ACTIONS.selectionQuote,
+    ]);
   });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -163,6 +163,18 @@ describe("default bindings through the dispatcher", () => {
     expect(calls).toEqual([ACTIONS.paletteOpen]);
   });
 
+  test("Meta+Ctrl+B fires rail.toggle (legacy accepted either or both; only Alt/Shift stay strict)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", metaKey: true, ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.railToggle]);
+  });
+
+  test("Meta+Ctrl+' fires selection.quote (legacy accepted either or both; only Alt stays strict)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true, ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.selectionQuote]);
+  });
+
   test("⌘⇧I fires composer.focus", () => {
     setup();
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true, shiftKey: true }));

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { ACTIONS } from "./actions";
+import { parseChord, serializeChord } from "./chord";
+import { DEFAULT_BINDINGS, registerDefaultBindings, SETTINGS_SCOPE } from "./defaults";
+import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
+import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+describe("default binding map", () => {
+  test("is exactly the six shell chords", () => {
+    expect(DEFAULT_BINDINGS.map((b) => b.actionId)).toEqual([
+      ACTIONS.paletteOpen,
+      ACTIONS.railToggle,
+      ACTIONS.composerFocus,
+      ACTIONS.nextNeedsYou,
+      ACTIONS.selectionQuote,
+      ACTIONS.settingsClose,
+    ]);
+  });
+
+  // Chords are compared through parse+serialize so the assertion is
+  // platform-independent ("$mod" resolves per host platform at parse time).
+  test.each([
+    [ACTIONS.paletteOpen, "$mod+K"],
+    [ACTIONS.railToggle, "$mod+B"],
+    [ACTIONS.composerFocus, "$mod+I"],
+    [ACTIONS.nextNeedsYou, "$mod+J"],
+    [ACTIONS.selectionQuote, "$mod+'"],
+    [ACTIONS.settingsClose, "Escape"],
+  ])("%s is bound to %s", (actionId, chord) => {
+    const binding = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
+    expect(binding).toBeDefined();
+    expect(serializeChord(parseChord(String(binding?.chord)))).toBe(serializeChord(parseChord(chord)));
+  });
+
+  test("editable-target policy matches today's per-chord behavior", () => {
+    const policy = new Map(DEFAULT_BINDINGS.map((b) => [b.actionId, b.allowInEditable ?? false]));
+    expect(policy.get(ACTIONS.paletteOpen)).toBe(true);
+    expect(policy.get(ACTIONS.composerFocus)).toBe(true);
+    expect(policy.get(ACTIONS.nextNeedsYou)).toBe(true);
+    expect(policy.get(ACTIONS.selectionQuote)).toBe(true);
+    expect(policy.get(ACTIONS.railToggle)).toBe(false);
+  });
+
+  test("settings.close is scope-gated, not global", () => {
+    const binding = DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.settingsClose);
+    expect(binding?.scope).toBe(SETTINGS_SCOPE);
+    for (const other of DEFAULT_BINDINGS.filter((b) => b.actionId !== ACTIONS.settingsClose)) {
+      expect(other.scope ?? GLOBAL_SCOPE).toBe(GLOBAL_SCOPE);
+    }
+  });
+});
+
+describe("default bindings through the dispatcher", () => {
+  let registry: KeybindingsRegistry;
+  let dispatcher: KeybindingDispatcher;
+  let detach: () => void;
+  let calls: string[];
+
+  afterEach(() => {
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+
+  function setup() {
+    registry = createKeybindingsRegistry();
+    calls = [];
+    for (const actionId of Object.values(ACTIONS)) {
+      registry.getState().registerAction(actionId, () => {
+        calls.push(actionId);
+      });
+    }
+    registerDefaultBindings(registry);
+    dispatcher = createKeybindingDispatcher({ registry });
+    detach = dispatcher.attach(window);
+  }
+
+  test("each chord runs its own action", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "i", code: "KeyI", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", ctrlKey: true }));
+    expect(calls).toEqual([
+      ACTIONS.paletteOpen,
+      ACTIONS.railToggle,
+      ACTIONS.composerFocus,
+      ACTIONS.nextNeedsYou,
+      ACTIONS.selectionQuote,
+    ]);
+  });
+
+  test("Escape only closes settings while the settings scope is pushed", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
+    expect(calls).toEqual([]);
+    registry.getState().pushScope(SETTINGS_SCOPE);
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
+    expect(calls).toEqual([ACTIONS.settingsClose]);
+  });
+
+  test("Mod+B is suppressed in an editable target while Mod+K still fires", () => {
+    setup();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(keydown({ key: "b", code: "KeyB", ctrlKey: true }));
+    expect(calls).toEqual([]);
+    input.dispatchEvent(keydown({ key: "k", code: "KeyK", ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.paletteOpen]);
+  });
+
+  test("Mod+chords with an extra Shift do not match today's plain-chord bindings", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", ctrlKey: true, shiftKey: true }));
+    expect(calls).toEqual([]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -52,6 +52,13 @@ describe("default binding map", () => {
       expect(other.scope ?? GLOBAL_SCOPE).toBe(GLOBAL_SCOPE);
     }
   });
+
+  test("only rail.toggle opts out of the defaultPrevented gate (RailHost.tsx:59-66 has no such check)", () => {
+    for (const binding of DEFAULT_BINDINGS) {
+      const expected = binding.actionId !== ACTIONS.railToggle;
+      expect(binding.ignoreIfDefaultPrevented ?? true).toBe(expected);
+    }
+  });
 });
 
 describe("default bindings through the dispatcher", () => {

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -20,7 +20,16 @@ export const SETTINGS_SCOPE = "settings";
 
 export const DEFAULT_BINDINGS: readonly BindingInput[] = [
   { id: ACTIONS.paletteOpen, actionId: ACTIONS.paletteOpen, chord: "$mod+K", allowInEditable: true },
-  { id: ACTIONS.railToggle, actionId: ACTIONS.railToggle, chord: "$mod+B", allowInEditable: false },
+  // ignoreIfDefaultPrevented: false - RailHost's ⌘B listener (RailHost.tsx:59-66)
+  // guards only the editable target; it has no defaultPrevented check and
+  // toggles the rail even when an inner handler already claimed the keydown.
+  {
+    id: ACTIONS.railToggle,
+    actionId: ACTIONS.railToggle,
+    chord: "$mod+B",
+    allowInEditable: false,
+    ignoreIfDefaultPrevented: false,
+  },
   { id: ACTIONS.composerFocus, actionId: ACTIONS.composerFocus, chord: "$mod+I", allowInEditable: true },
   { id: ACTIONS.nextNeedsYou, actionId: ACTIONS.nextNeedsYou, chord: "$mod+J", allowInEditable: true },
   { id: ACTIONS.selectionQuote, actionId: ACTIONS.selectionQuote, chord: "$mod+'", allowInEditable: true },

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -1,6 +1,6 @@
 // The default binding map: exactly the six shell chords that today live in six
 // independent keydown listeners (AppShell, RailHost, SelectionQuote,
-// Settings). Editable-target policy per chord matches today's behavior:
+// Settings). Per-binding policy per chord matches today's behavior:
 //
 //   - ⌘K / ⌘I / ⌘J / ⌘' fire from editable targets (allowInEditable: true):
 //     none of today's listeners for these chords guards on the target.
@@ -9,30 +9,53 @@
 //     native text fields.
 //   - settings.close fires from editable targets too: today's Settings Escape
 //     listener is document-level with no editable guard.
+//   - ⌘K, ⌘B and ⌘' fire while a modal is open (allowInModal: true):
+//     AppShell deliberately exempts ⌘K from its blockedByOpenModal guard
+//     ("opening the palette while it's already open is a harmless no-op
+//     reset"), and RailHost's ⌘B / SelectionQuote's ⌘' listeners have no
+//     modal check at all. ⌘I / ⌘J keep the default suppression (AppShell's
+//     blockedByOpenModal covered exactly them), and so does settings.close -
+//     today a modal dialog claims Escape first via its FocusScope/OverlayPanel
+//     handler, which the dispatcher's per-binding defaultPrevented gate
+//     reproduces.
 //
 // settings.close is scope-gated: it lives in the settings scope, NOT global.
-// Task 2 pushes that scope while the Settings pane is open.
+// The Settings pane pushes that scope while it is open.
 
 import { ACTIONS } from "./actions";
+import { parseChord, serializeChord } from "./chord";
 import type { Binding, BindingInput, KeybindingsRegistry } from "./registry";
 
 export const SETTINGS_SCOPE = "settings";
 
 export const DEFAULT_BINDINGS: readonly BindingInput[] = [
-  { id: ACTIONS.paletteOpen, actionId: ACTIONS.paletteOpen, chord: "$mod+K", allowInEditable: true },
-  // ignoreIfDefaultPrevented: false - RailHost's ⌘B listener (RailHost.tsx:59-66)
-  // guards only the editable target; it has no defaultPrevented check and
-  // toggles the rail even when an inner handler already claimed the keydown.
+  {
+    id: ACTIONS.paletteOpen,
+    actionId: ACTIONS.paletteOpen,
+    chord: "$mod+K",
+    allowInEditable: true,
+    allowInModal: true,
+  },
+  // ignoreIfDefaultPrevented: false - RailHost's ⌘B listener guards only the
+  // editable target; it has no defaultPrevented check and toggles the rail
+  // even when an inner handler already claimed the keydown.
   {
     id: ACTIONS.railToggle,
     actionId: ACTIONS.railToggle,
     chord: "$mod+B",
     allowInEditable: false,
+    allowInModal: true,
     ignoreIfDefaultPrevented: false,
   },
   { id: ACTIONS.composerFocus, actionId: ACTIONS.composerFocus, chord: "$mod+I", allowInEditable: true },
   { id: ACTIONS.nextNeedsYou, actionId: ACTIONS.nextNeedsYou, chord: "$mod+J", allowInEditable: true },
-  { id: ACTIONS.selectionQuote, actionId: ACTIONS.selectionQuote, chord: "$mod+'", allowInEditable: true },
+  {
+    id: ACTIONS.selectionQuote,
+    actionId: ACTIONS.selectionQuote,
+    chord: "$mod+'",
+    allowInEditable: true,
+    allowInModal: true,
+  },
   {
     id: ACTIONS.settingsClose,
     actionId: ACTIONS.settingsClose,
@@ -42,7 +65,33 @@ export const DEFAULT_BINDINGS: readonly BindingInput[] = [
   },
 ];
 
-/** Registers the full default map; returns the registered entries. */
+// tinykeys resolves "$mod" to Meta on Apple platforms and Control everywhere
+// else AT PARSE TIME, but every pre-dispatcher listener these bindings replace
+// accepted `event.metaKey || event.ctrlKey` on EVERY platform (a Mac user's
+// Ctrl+K opened the palette exactly like ⌘K). Registering the cross-platform
+// twin of each $mod chord preserves that. It also keeps the shell's jsdom
+// suites - where $mod resolves to Control but userEvent/fireEvent press Meta
+// chords - exercising the same code path production does.
+function modTwin(input: BindingInput): BindingInput | null {
+  if (typeof input.chord !== "string" || !input.chord.includes("$mod")) return null;
+  const resolved = serializeChord(parseChord(input.chord));
+  for (const mod of ["Meta", "Control"] as const) {
+    const candidate = input.chord.replaceAll("$mod", mod);
+    if (serializeChord(parseChord(candidate)) !== resolved) {
+      return { ...input, id: `${input.id}#mod-twin`, chord: candidate };
+    }
+  }
+  return null;
+}
+
+/** Registers the full default map (plus each $mod chord's cross-platform
+ * twin); returns the registered entries. */
 export function registerDefaultBindings(registry: KeybindingsRegistry): Binding[] {
-  return DEFAULT_BINDINGS.map((input) => registry.getState().registerBinding(input));
+  const registered: Binding[] = [];
+  for (const input of DEFAULT_BINDINGS) {
+    registered.push(registry.getState().registerBinding(input));
+    const twin = modTwin(input);
+    if (twin !== null) registered.push(registry.getState().registerBinding(twin));
+  }
+  return registered;
 }

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -19,22 +19,53 @@
 //     handler, which the dispatcher's per-binding defaultPrevented gate
 //     reproduces.
 //
+// Extra-modifier semantics are equally legacy-faithful (tinykeys matches
+// strictly, so each chord lists as OPTIONAL exactly the modifiers the legacy
+// listener ignored):
+//
+//   - ⌘K / ⌘I / ⌘J: the legacy AppShell listener checked only
+//     metaKey||ctrlKey + key - NO shift/alt guard - so ⌘⇧K, ⌘⌥I,
+//     Ctrl+Shift+J etc. all fired, on either OR BOTH of Meta/Ctrl. Chords
+//     are $mod+[Shift]+[Alt]+… plus legacyEitherMod (the other of
+//     Meta/Ctrl also optional on the entry and its twin). RATIONALE: this
+//     permissiveness means these chords keep hijacking the browser's
+//     DevTools shortcuts (⌘⌥I, Ctrl+Shift+J) exactly like the legacy
+//     listeners did - deliberately revisiting THAT is Phase 3 policy, not
+//     this PR.
+//   - ⌘': extra Shift allowed ([Shift] - the legacy listener had no shift
+//     guard), extra Alt NOT (the legacy !event.altKey AltGr guard).
+//   - ⌘B: strict - the legacy listener guarded !event.altKey &&
+//     !event.shiftKey.
+//   - Escape (settings.close): every modifier optional - the legacy
+//     listener checked only event.key === "Escape".
+//
 // settings.close is scope-gated: it lives in the settings scope, NOT global.
 // The Settings pane pushes that scope while it is open.
 
 import { ACTIONS } from "./actions";
-import { parseChord, serializeChord } from "./chord";
+import { type KeySequence, parseChord, serializeChord, withOptionalModifier } from "./chord";
 import type { Binding, BindingInput, KeybindingsRegistry } from "./registry";
 
 export const SETTINGS_SCOPE = "settings";
 
-export const DEFAULT_BINDINGS: readonly BindingInput[] = [
+/** A default-map entry: a BindingInput plus the module-internal
+ * legacyEitherMod marker (stripped before registerBinding - see modPair). */
+interface DefaultBindingInput extends BindingInput {
+  /** Legacy "either or both of Meta/Ctrl" permissiveness: the AppShell
+   * ⌘K/⌘I/⌘J listener checked metaKey||ctrlKey with no regard for the OTHER
+   * modifier's state, so Meta+Ctrl+K fired. The complement of $mod is added
+   * as an OPTIONAL modifier on both this entry and its twin. */
+  legacyEitherMod?: boolean;
+}
+
+export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.paletteOpen,
     actionId: ACTIONS.paletteOpen,
-    chord: "$mod+K",
+    chord: "$mod+[Shift]+[Alt]+K",
     allowInEditable: true,
     allowInModal: true,
+    legacyEitherMod: true,
   },
   // ignoreIfDefaultPrevented: false - RailHost's ⌘B listener guards only the
   // editable target; it has no defaultPrevented check and toggles the rail
@@ -47,19 +78,34 @@ export const DEFAULT_BINDINGS: readonly BindingInput[] = [
     allowInModal: true,
     ignoreIfDefaultPrevented: false,
   },
-  { id: ACTIONS.composerFocus, actionId: ACTIONS.composerFocus, chord: "$mod+I", allowInEditable: true },
-  { id: ACTIONS.nextNeedsYou, actionId: ACTIONS.nextNeedsYou, chord: "$mod+J", allowInEditable: true },
+  {
+    id: ACTIONS.composerFocus,
+    actionId: ACTIONS.composerFocus,
+    chord: "$mod+[Shift]+[Alt]+I",
+    allowInEditable: true,
+    legacyEitherMod: true,
+  },
+  {
+    id: ACTIONS.nextNeedsYou,
+    actionId: ACTIONS.nextNeedsYou,
+    chord: "$mod+[Shift]+[Alt]+J",
+    allowInEditable: true,
+    legacyEitherMod: true,
+  },
+  // The dispatcher preventDefaults when a handler accepts this chord; the
+  // legacy ⌘' listener never preventDefault'd. That superset is deliberate
+  // and harmless: nothing meaningful defaults on Ctrl/⌘+'.
   {
     id: ACTIONS.selectionQuote,
     actionId: ACTIONS.selectionQuote,
-    chord: "$mod+'",
+    chord: "$mod+[Shift]+'",
     allowInEditable: true,
     allowInModal: true,
   },
   {
     id: ACTIONS.settingsClose,
     actionId: ACTIONS.settingsClose,
-    chord: "Escape",
+    chord: "[Control]+[Alt]+[Shift]+[Meta]+Escape",
     scope: SETTINGS_SCOPE,
     allowInEditable: true,
   },
@@ -72,16 +118,40 @@ export const DEFAULT_BINDINGS: readonly BindingInput[] = [
 // twin of each $mod chord preserves that. It also keeps the shell's jsdom
 // suites - where $mod resolves to Control but userEvent/fireEvent press Meta
 // chords - exercising the same code path production does.
-function modTwin(input: BindingInput): BindingInput | null {
+//
+// Returns the two entries to register for a $mod-sourced binding (platform
+// base + twin), or null when the chord has no $mod. With legacyEitherMod the
+// complement of $mod is added as an OPTIONAL modifier on both entries, so
+// pressing Meta and Ctrl together also fires - legacy accepted either or
+// both regardless of the other modifier's state.
+function modPair(input: DefaultBindingInput): [BindingInput, BindingInput] | null {
   if (typeof input.chord !== "string" || !input.chord.includes("$mod")) return null;
   const resolved = serializeChord(parseChord(input.chord));
+  let twinString: string | null = null;
   for (const mod of ["Meta", "Control"] as const) {
     const candidate = input.chord.replaceAll("$mod", mod);
-    if (serializeChord(parseChord(candidate)) !== resolved) {
-      return { ...input, id: `${input.id}#mod-twin`, chord: candidate };
-    }
+    if (serializeChord(parseChord(candidate)) !== resolved) twinString = candidate;
   }
-  return null;
+  if (twinString === null) return null;
+  const { legacyEitherMod: _legacyEitherMod, ...base } = input;
+  const twin: BindingInput = { ...base, id: `${base.id}#mod-twin`, chord: twinString };
+  if (!input.legacyEitherMod) return [base, twin];
+  return [
+    { ...base, chord: withComplementOptional(parseChord(input.chord as string)) },
+    { ...twin, chord: withComplementOptional(parseChord(twinString)) },
+  ];
+}
+
+// Adds the OTHER of Meta/Ctrl as an optional modifier to every press that
+// requires one of them.
+function withComplementOptional(sequence: KeySequence): KeySequence {
+  let complement: string | null = null;
+  for (const press of sequence) {
+    if (press.modifiers.includes("Meta")) complement = "Control";
+    else if (press.modifiers.includes("Control")) complement = "Meta";
+  }
+  if (complement === null) return sequence;
+  return withOptionalModifier(sequence, complement);
 }
 
 /** Registers the full default map (plus each $mod chord's cross-platform
@@ -89,9 +159,10 @@ function modTwin(input: BindingInput): BindingInput | null {
 export function registerDefaultBindings(registry: KeybindingsRegistry): Binding[] {
   const registered: Binding[] = [];
   for (const input of DEFAULT_BINDINGS) {
-    registered.push(registry.getState().registerBinding(input));
-    const twin = modTwin(input);
-    if (twin !== null) registered.push(registry.getState().registerBinding(twin));
+    const pair = modPair(input);
+    for (const entry of pair ?? [input]) {
+      registered.push(registry.getState().registerBinding(entry));
+    }
   }
   return registered;
 }

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -52,9 +52,11 @@ export const SETTINGS_SCOPE = "settings";
  * legacyEitherMod marker (stripped before registerBinding - see modPair). */
 interface DefaultBindingInput extends BindingInput {
   /** Legacy "either or both of Meta/Ctrl" permissiveness: the AppShell
-   * ⌘K/⌘I/⌘J listener checked metaKey||ctrlKey with no regard for the OTHER
-   * modifier's state, so Meta+Ctrl+K fired. The complement of $mod is added
-   * as an OPTIONAL modifier on both this entry and its twin. */
+   * ⌘K/⌘I/⌘J, RailHost ⌘B and SelectionQuote ⌘' listeners all checked
+   * metaKey||ctrlKey with no regard for the OTHER modifier's state (their
+   * guards rejected only Alt/Shift), so Meta+Ctrl+<key> fired. The
+   * complement of $mod is added as an OPTIONAL modifier on both this entry
+   * and its twin. Alt/Shift strictness is unaffected. */
   legacyEitherMod?: boolean;
 }
 
@@ -77,6 +79,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     allowInEditable: false,
     allowInModal: true,
     ignoreIfDefaultPrevented: false,
+    legacyEitherMod: true,
   },
   {
     id: ACTIONS.composerFocus,
@@ -101,6 +104,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     chord: "$mod+[Shift]+'",
     allowInEditable: true,
     allowInModal: true,
+    legacyEitherMod: true,
   },
   {
     id: ACTIONS.settingsClose,

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -1,0 +1,39 @@
+// The default binding map: exactly the six shell chords that today live in six
+// independent keydown listeners (AppShell, RailHost, SelectionQuote,
+// Settings). Editable-target policy per chord matches today's behavior:
+//
+//   - ⌘K / ⌘I / ⌘J / ⌘' fire from editable targets (allowInEditable: true):
+//     none of today's listeners for these chords guards on the target.
+//   - ⌘B suppresses in editable targets (allowInEditable: false):
+//     RailHost guards so Ctrl+B keeps its emacs "cursor back" meaning in
+//     native text fields.
+//   - settings.close fires from editable targets too: today's Settings Escape
+//     listener is document-level with no editable guard.
+//
+// settings.close is scope-gated: it lives in the settings scope, NOT global.
+// Task 2 pushes that scope while the Settings pane is open.
+
+import { ACTIONS } from "./actions";
+import type { Binding, BindingInput, KeybindingsRegistry } from "./registry";
+
+export const SETTINGS_SCOPE = "settings";
+
+export const DEFAULT_BINDINGS: readonly BindingInput[] = [
+  { id: ACTIONS.paletteOpen, actionId: ACTIONS.paletteOpen, chord: "$mod+K", allowInEditable: true },
+  { id: ACTIONS.railToggle, actionId: ACTIONS.railToggle, chord: "$mod+B", allowInEditable: false },
+  { id: ACTIONS.composerFocus, actionId: ACTIONS.composerFocus, chord: "$mod+I", allowInEditable: true },
+  { id: ACTIONS.nextNeedsYou, actionId: ACTIONS.nextNeedsYou, chord: "$mod+J", allowInEditable: true },
+  { id: ACTIONS.selectionQuote, actionId: ACTIONS.selectionQuote, chord: "$mod+'", allowInEditable: true },
+  {
+    id: ACTIONS.settingsClose,
+    actionId: ACTIONS.settingsClose,
+    chord: "Escape",
+    scope: SETTINGS_SCOPE,
+    allowInEditable: true,
+  },
+];
+
+/** Registers the full default map; returns the registered entries. */
+export function registerDefaultBindings(registry: KeybindingsRegistry): Binding[] {
+  return DEFAULT_BINDINGS.map((input) => registry.getState().registerBinding(input));
+}

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
@@ -295,4 +295,34 @@ describe("default editable-target detection", () => {
     dispatcher.dispose();
     document.body.innerHTML = "";
   });
+
+  test("an element inside a contenteditable=false island inside an editor is NOT editable", () => {
+    // The nearest contenteditable ancestor's VALUE decides: an explicitly
+    // non-editable control nested in an editor must not suppress bindings
+    // (e.g. Ctrl+B inside a toolbar embedded in a rich-text editor).
+    const registry = createKeybindingsRegistry();
+    const dispatcher = createKeybindingDispatcher({ registry });
+    const detach = dispatcher.attach(window);
+    const run = vi.fn();
+    registry.getState().registerAction("a", run);
+    registry.getState().registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "true");
+    const island = document.createElement("div");
+    island.setAttribute("contenteditable", "false");
+    const button = document.createElement("button");
+    editor.appendChild(island);
+    island.appendChild(button);
+    document.body.appendChild(editor);
+    pressOn(button, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+    // ...while a plain descendant of the same editor still suppresses.
+    const plain = document.createElement("span");
+    editor.appendChild(plain);
+    pressOn(plain, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
+import { createKeybindingsRegistry, type KeybindingsRegistry } from "./registry";
+
+// jsdom resolves tinykeys' "$mod" to "Control" on every host, so every Mod
+// chord in this file is pressed with ctrlKey and the tests stay
+// platform-deterministic.
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+function pressOn(target: Window | Element, init: KeyboardEventInit): KeyboardEvent {
+  const event = keydown(init);
+  target.dispatchEvent(event);
+  return event;
+}
+
+const MOD_K: KeyboardEventInit = { key: "k", code: "KeyK", ctrlKey: true };
+
+describe("dispatcher", () => {
+  let registry: KeybindingsRegistry;
+  let dispatcher: KeybindingDispatcher;
+  let detach: () => void;
+
+  afterEach(() => {
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+
+  function setup(options: { isModalOpen?: (event: KeyboardEvent) => boolean } = {}) {
+    registry = createKeybindingsRegistry();
+    dispatcher = createKeybindingDispatcher({ registry, ...options });
+    detach = dispatcher.attach(window);
+    return registry.getState();
+  }
+
+  test("runs the action bound to a matching chord and preventDefaults", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("palette.open", run);
+    state.registerBinding({ id: "b1", actionId: "palette.open", chord: "$mod+K" });
+    const event = pressOn(window, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("ignores IME composition keydowns (isComposing / keyCode 229)", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    pressOn(window, { ...MOD_K, isComposing: true });
+    pressOn(window, { ...MOD_K, keyCode: 229 });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  test("yields to a keydown another handler already claimed", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const inner = document.createElement("div");
+    inner.addEventListener("keydown", (event) => event.preventDefault());
+    document.body.appendChild(inner);
+    pressOn(inner, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  test("suppresses bindings in editable targets by default", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    const event = pressOn(input, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("allowInEditable bindings fire from editable targets", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K", allowInEditable: true });
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    pressOn(input, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("the modal predicate suppresses every binding", () => {
+    const state = setup({ isModalOpen: () => true });
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K", allowInEditable: true });
+    const event = pressOn(window, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("the default modal check sees an [aria-modal] ancestor of the target", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const modal = document.createElement("div");
+    modal.setAttribute("aria-modal", "true");
+    const inner = document.createElement("button");
+    modal.appendChild(inner);
+    document.body.appendChild(modal);
+    pressOn(inner, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    pressOn(window, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("scope stack top-down shadows the global scope for the same chord", () => {
+    const state = setup();
+    const globalRun = vi.fn();
+    const scopedRun = vi.fn();
+    state.registerAction("global.action", globalRun);
+    state.registerAction("scoped.action", scopedRun);
+    state.registerBinding({ id: "b1", actionId: "global.action", chord: "$mod+K" });
+    state.registerBinding({ id: "b2", actionId: "scoped.action", chord: "$mod+K", scope: "settings" });
+    pressOn(window, MOD_K);
+    expect(globalRun).toHaveBeenCalledTimes(1);
+    expect(scopedRun).not.toHaveBeenCalled();
+    state.pushScope("settings");
+    pressOn(window, MOD_K);
+    expect(scopedRun).toHaveBeenCalledTimes(1);
+    expect(globalRun).toHaveBeenCalledTimes(1);
+    state.popScope("settings");
+    pressOn(window, MOD_K);
+    expect(globalRun).toHaveBeenCalledTimes(2);
+  });
+
+  test("a scope without a matching binding falls through to global", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    state.pushScope("settings");
+    pressOn(window, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("a binding whose action is not registered does not fire or preventDefault", () => {
+    const state = setup();
+    state.registerBinding({ id: "b1", actionId: "missing", chord: "$mod+K" });
+    const event = pressOn(window, MOD_K);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("matches a multi-press sequence", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "x y" });
+    pressOn(window, { key: "x", code: "KeyX" });
+    expect(run).not.toHaveBeenCalled();
+    const event = pressOn(window, { key: "y", code: "KeyY" });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("a binding stops matching once unregistered", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    state.unregisterBinding("b1");
+    pressOn(window, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  test("detach removes the listener", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    detach();
+    pressOn(window, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    detach = () => undefined;
+  });
+});
+
+describe("default editable-target detection", () => {
+  test.each(["input", "textarea", "select"])("treats <%s> as editable", (tagName) => {
+    const registry = createKeybindingsRegistry();
+    const dispatcher = createKeybindingDispatcher({ registry });
+    const detach = dispatcher.attach(window);
+    const run = vi.fn();
+    registry.getState().registerAction("a", run);
+    registry.getState().registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const element = document.createElement(tagName);
+    document.body.appendChild(element);
+    pressOn(element, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+
+  test("treats a contenteditable element as editable", () => {
+    const registry = createKeybindingsRegistry();
+    const dispatcher = createKeybindingDispatcher({ registry });
+    const detach = dispatcher.attach(window);
+    const run = vi.fn();
+    registry.getState().registerAction("a", run);
+    registry.getState().registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    // jsdom does not implement the contentEditable/isContentEditable IDL
+    // properties, so the test sets the content attribute the dispatcher's
+    // [contenteditable] check (and tinykeys' own default ignore) matches.
+    const element = document.createElement("div");
+    element.setAttribute("contenteditable", "true");
+    document.body.appendChild(element);
+    pressOn(element, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
@@ -68,6 +68,21 @@ describe("dispatcher", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  test("ignoreIfDefaultPrevented: false fires on a keydown another handler claimed", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    // RailHost's ⌘B listener has no defaultPrevented check (RailHost.tsx:59-66)
+    // and toggles even when an inner handler claimed the keydown; the flag
+    // exists so the module can express exactly that.
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+B", ignoreIfDefaultPrevented: false });
+    const inner = document.createElement("div");
+    inner.addEventListener("keydown", (event) => event.preventDefault());
+    document.body.appendChild(inner);
+    pressOn(inner, { key: "b", code: "KeyB", ctrlKey: true });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
   test("suppresses bindings in editable targets by default", () => {
     const state = setup();
     const run = vi.fn();

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
@@ -116,6 +116,18 @@ describe("dispatcher", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  test("allowInModal: true fires while the modal predicate reports open", () => {
+    // Today's ⌘K handler deliberately exempts palette.open from the modal
+    // guard (and RailHost's ⌘B / SelectionQuote's ⌘' listeners have no modal
+    // check at all), so the modal layer is per-binding, not blanket.
+    const state = setup({ isModalOpen: () => true });
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K", allowInModal: true });
+    pressOn(window, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
   test("the default modal check sees an [aria-modal] ancestor of the target", () => {
     const state = setup();
     const run = vi.fn();
@@ -167,6 +179,22 @@ describe("dispatcher", () => {
     state.registerBinding({ id: "b1", actionId: "missing", chord: "$mod+K" });
     const event = pressOn(window, MOD_K);
     expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("matches a synthetic keydown with no code (fireEvent-style), running the real event", () => {
+    // The pre-dispatcher listeners never looked at event.code, and the app's
+    // existing suites (and any app code dispatching a bare KeyboardEvent)
+    // construct codeless events that tinykeys' isKeyboardEvent gate would
+    // otherwise drop.
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const event = pressOn(window, { key: "k", ctrlKey: true });
+    expect(event.code).toBe("");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith(event);
+    expect(event.defaultPrevented).toBe(true);
   });
 
   test("matches a multi-press sequence", () => {

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
@@ -181,6 +181,34 @@ describe("dispatcher", () => {
     expect(event.defaultPrevented).toBe(false);
   });
 
+  test("action handlers run in registration order until one handles the event", () => {
+    const state = setup();
+    const calls: string[] = [];
+    state.registerAction("a", () => {
+      calls.push("first");
+      return false; // declines: try the next handler
+    });
+    state.registerAction("a", () => {
+      calls.push("second");
+    });
+    state.registerAction("a", () => {
+      calls.push("third");
+    });
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const event = pressOn(window, MOD_K);
+    expect(calls).toEqual(["first", "second"]);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("an event every handler declines is not preventDefault'd", () => {
+    const state = setup();
+    state.registerAction("a", () => false);
+    state.registerAction("a", () => false);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const event = pressOn(window, MOD_K);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   test("matches a synthetic keydown with no code (fireEvent-style), running the real event", () => {
     // The pre-dispatcher listeners never looked at event.code, and the app's
     // existing suites (and any app code dispatching a bare KeyboardEvent)

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
@@ -106,7 +106,7 @@ describe("dispatcher", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
-  test("the modal predicate suppresses every binding", () => {
+  test("the modal predicate suppresses bindings by default", () => {
     const state = setup({ isModalOpen: () => true });
     const run = vi.fn();
     state.registerAction("a", run);

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
@@ -1,0 +1,121 @@
+// The single window-level keydown dispatcher. Matching is tinykeys
+// (createKeybindingsHandler over the active scope set); precedence, in order:
+//
+//   1. IME composition keydowns (event.isComposing / keyCode 229) are ignored.
+//   2. Per-binding editable-target policy (allowInEditable, default false).
+//   3. An open modal suppresses every binding: [aria-modal="true"] ancestor of
+//      the event target by default, plus whatever store check the caller's
+//      injected predicate adds (Task 2 wires paletteStore.open there).
+//   4. The scope stack, top-down.
+//   5. The global scope.
+//
+// The first (highest-precedence) binding for a chord claims it outright: a
+// firing binding preventDefaults and stops evaluation, and a shadowed or
+// policy-blocked binding never falls through to a lower-precedence twin.
+//
+// An event another handler already claimed (event.defaultPrevented) is ignored
+// before any of the above, matching every listener site this module replaces.
+
+import { createKeybindingsHandler, type KeybindingsMap } from "tinykeys";
+import { serializeChord } from "./chord";
+import { GLOBAL_SCOPE, type KeybindingsRegistry, type KeybindingsState, keybindingsRegistry } from "./registry";
+
+export type ModalOpenPredicate = (event: KeyboardEvent) => boolean;
+export type EditableTargetPredicate = (target: EventTarget | null) => boolean;
+
+/** shell/rail/RailHost.tsx's isEditableTarget, plus the [contenteditable]
+ * attribute check: isContentEditable alone already covers descendants of an
+ * editable ancestor in a real browser, but jsdom does not implement the
+ * property at all (it is undefined there), and the attribute form is what
+ * tinykeys' own default ignore uses. Everything else doesn't count. */
+export const isEditableTarget: EditableTargetPredicate = (target) => {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.isContentEditable ||
+    target.closest("[contenteditable]") !== null ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT"
+  );
+};
+
+/** The DOM half of AppShell.tsx's blockedByOpenModal. The palette is not an
+ * [aria-modal] element, so callers should compose this with a
+ * paletteStore.open-style store check (Task 2 injects that predicate). */
+export const isModalOpenTarget: ModalOpenPredicate = (event) => {
+  const target = event.target;
+  return target instanceof Element && target.closest('[aria-modal="true"]') !== null;
+};
+
+export interface DispatcherOptions {
+  /** Defaults to the app-wide registry singleton. */
+  registry?: KeybindingsRegistry;
+  isModalOpen?: ModalOpenPredicate;
+  isEditableTarget?: EditableTargetPredicate;
+}
+
+export interface KeybindingDispatcher {
+  handleKeyDown(event: KeyboardEvent): void;
+  /** Adds the keydown listener; returns the detach function. */
+  attach(target: Window): () => void;
+  /** Stops tracking the registry. Always pair with the attach disposer. */
+  dispose(): void;
+}
+
+export function createKeybindingDispatcher(options: DispatcherOptions = {}): KeybindingDispatcher {
+  const registry = options.registry ?? keybindingsRegistry;
+  const isModalOpen = options.isModalOpen ?? isModalOpenTarget;
+  const isEditable = options.isEditableTarget ?? isEditableTarget;
+
+  function buildHandler(state: KeybindingsState): EventListener {
+    const map: KeybindingsMap = {};
+    const claimed = new Set<string>();
+    const scopes = [...state.scopeStack].reverse();
+    scopes.push(GLOBAL_SCOPE);
+    for (const scope of scopes) {
+      for (const binding of state.bindings) {
+        if (binding.scope !== scope) continue;
+        const chordKey = serializeChord(binding.chord);
+        if (claimed.has(chordKey)) continue;
+        claimed.add(chordKey);
+        map[chordKey] = (event) => {
+          if (!binding.allowInEditable && isEditable(event.target)) return;
+          const run = registry.getState().actions.get(binding.actionId);
+          if (!run) return;
+          event.preventDefault();
+          run(event);
+        };
+      }
+    }
+    // ignore: () => false - the precedence layers above replace tinykeys'
+    // default ignore wholesale; the default would suppress EVERY binding from
+    // an editable target, which several shell chords explicitly allow.
+    return createKeybindingsHandler(map, { ignore: () => false });
+  }
+
+  let current = buildHandler(registry.getState());
+  const unsubscribe = registry.subscribe((state) => {
+    current = buildHandler(state);
+  });
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (event.defaultPrevented) return;
+    if (event.isComposing || event.keyCode === 229) return;
+    if (isModalOpen(event)) return;
+    current(event);
+  }
+
+  return {
+    handleKeyDown,
+    attach(target) {
+      const listener = (event: Event) => {
+        if (event instanceof KeyboardEvent) handleKeyDown(event);
+      };
+      target.addEventListener("keydown", listener);
+      return () => target.removeEventListener("keydown", listener);
+    },
+    dispose() {
+      unsubscribe();
+    },
+  };
+}

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
@@ -93,10 +93,19 @@ export function createKeybindingDispatcher(options: DispatcherOptions = {}): Key
           if (binding.ignoreIfDefaultPrevented && real.defaultPrevented) return;
           if (!binding.allowInModal && isModalOpen(real)) return;
           if (!binding.allowInEditable && isEditable(real.target)) return;
-          const run = registry.getState().actions.get(binding.actionId);
-          if (!run) return;
-          real.preventDefault();
-          run(real);
+          const handlers = registry.getState().actions.get(binding.actionId);
+          if (!handlers || handlers.length === 0) return;
+          // Registration order, until one handler accepts (returns
+          // true/undefined); a handler returning false declines and the next
+          // is tried - the multi-instance equivalent of the per-component
+          // listeners this module replaced (one SelectionQuote per session
+          // pane; only the instance holding a selection acts). An event
+          // every handler declines is not preventDefault'd.
+          for (const run of handlers) {
+            if (run(real) === false) continue;
+            real.preventDefault();
+            return;
+          }
         };
       }
     }

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
@@ -33,16 +33,30 @@ import { GLOBAL_SCOPE, type KeybindingsRegistry, type KeybindingsState, keybindi
 export type ModalOpenPredicate = (event: KeyboardEvent) => boolean;
 export type EditableTargetPredicate = (target: EventTarget | null) => boolean;
 
-/** shell/rail/RailHost.tsx's isEditableTarget, plus the [contenteditable]
- * attribute check: isContentEditable alone already covers descendants of an
- * editable ancestor in a real browser, but jsdom does not implement the
- * property at all (it is undefined there), and the attribute form is what
- * tinykeys' own default ignore uses. Everything else doesn't count. */
+/** Walks up from the target; the FIRST element bearing a contenteditable
+ * attribute decides - editable unless its value is "false" (empty string,
+ * "true" and "plaintext-only" are all editable), which is how the
+ * contentEditable IDL property inherits in a real browser. A
+ * contenteditable="false" island inside an editor (a toolbar, an embedded
+ * control) is therefore NOT editable. */
+function hasEditableContentEditableAncestor(target: HTMLElement): boolean {
+  for (let element: HTMLElement | null = target; element !== null; element = element.parentElement) {
+    const value = element.getAttribute("contenteditable");
+    if (value !== null) return value.toLowerCase() !== "false";
+  }
+  return false;
+}
+
+/** shell/rail/RailHost.tsx's isEditableTarget, plus the contenteditable
+ * attribute walk above: isContentEditable alone already covers descendants
+ * of an editable ancestor in a real browser, but jsdom does not implement
+ * the property at all (it is undefined there), so the attribute walk stands
+ * in for it. Everything else doesn't count. */
 export const isEditableTarget: EditableTargetPredicate = (target) => {
   if (!(target instanceof HTMLElement)) return false;
   return (
     target.isContentEditable ||
-    target.closest("[contenteditable]") !== null ||
+    hasEditableContentEditableAncestor(target) ||
     target.tagName === "INPUT" ||
     target.tagName === "TEXTAREA" ||
     target.tagName === "SELECT"

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
@@ -2,12 +2,18 @@
 // (createKeybindingsHandler over the active scope set); precedence, in order:
 //
 //   1. IME composition keydowns (event.isComposing / keyCode 229) are ignored.
-//   2. Per-binding editable-target policy (allowInEditable, default false).
-//   3. An open modal suppresses every binding: [aria-modal="true"] ancestor of
-//      the event target by default, plus whatever store check the caller's
-//      injected predicate adds (Task 2 wires paletteStore.open there).
-//   4. The scope stack, top-down.
-//   5. The global scope.
+//   2. The scope stack, top-down, then the global scope, decide WHICH binding
+//      a chord resolves to (the first/highest-precedence binding claims it).
+//   3. Per-binding policy on the matched binding, each flag reproducing one
+//      of the pre-dispatcher listeners' own guards:
+//      - ignoreIfDefaultPrevented (default true): an already-claimed keydown
+//        is ignored.
+//      - allowInModal (default false): an open modal suppresses the binding -
+//        [aria-modal="true"] ancestor of the event target by default, plus
+//        whatever store check the caller's injected predicate adds (the app
+//        wiring adds paletteStore.open there).
+//      - allowInEditable (default false): an editable event target suppresses
+//        the binding.
 //
 // The first (highest-precedence) binding for a chord claims it outright: a
 // firing binding preventDefaults and stops evaluation, and a shadowed or
@@ -15,10 +21,10 @@
 //
 // An event another handler already claimed (event.defaultPrevented) is
 // ignored per binding: ignoreIfDefaultPrevented defaults to true, matching
-// AppShell (AppShell.tsx:392), Settings (Settings.tsx:188), and
-// SelectionQuote (SelectionQuote.tsx:148) - but NOT RailHost's ⌘B listener
-// (RailHost.tsx:59-66), which has no defaultPrevented check and so binds with
-// ignoreIfDefaultPrevented: false in defaults.ts.
+// the pre-dispatcher AppShell ⌘K/⌘I/⌘J, Settings Escape, and SelectionQuote
+// ⌘' listeners - but NOT RailHost's ⌘B listener, which had no
+// defaultPrevented check and so binds with ignoreIfDefaultPrevented: false
+// in defaults.ts.
 
 import { createKeybindingsHandler, type KeybindingsMap } from "tinykeys";
 import { serializeChord } from "./chord";
@@ -43,9 +49,9 @@ export const isEditableTarget: EditableTargetPredicate = (target) => {
   );
 };
 
-/** The DOM half of AppShell.tsx's blockedByOpenModal. The palette is not an
- * [aria-modal] element, so callers should compose this with a
- * paletteStore.open-style store check (Task 2 injects that predicate). */
+/** The DOM half of the shell's old blockedByOpenModal check. The palette is
+ * not an [aria-modal] element, so the app wiring (shell/installKeybindings.ts)
+ * composes this with a paletteStore.open store check. */
 export const isModalOpenTarget: ModalOpenPredicate = (event) => {
   const target = event.target;
   return target instanceof Element && target.closest('[aria-modal="true"]') !== null;
@@ -83,12 +89,14 @@ export function createKeybindingDispatcher(options: DispatcherOptions = {}): Key
         if (claimed.has(chordKey)) continue;
         claimed.add(chordKey);
         map[chordKey] = (event) => {
-          if (binding.ignoreIfDefaultPrevented && event.defaultPrevented) return;
-          if (!binding.allowInEditable && isEditable(event.target)) return;
+          const real = realEvent ?? event;
+          if (binding.ignoreIfDefaultPrevented && real.defaultPrevented) return;
+          if (!binding.allowInModal && isModalOpen(real)) return;
+          if (!binding.allowInEditable && isEditable(real.target)) return;
           const run = registry.getState().actions.get(binding.actionId);
           if (!run) return;
-          event.preventDefault();
-          run(event);
+          real.preventDefault();
+          run(real);
         };
       }
     }
@@ -103,10 +111,41 @@ export function createKeybindingDispatcher(options: DispatcherOptions = {}): Key
     current = buildHandler(state);
   });
 
+  // The binding handler tinykeys invokes receives whatever event object the
+  // handler was called with; when matching ran against a code-fallback view
+  // (see handleKeyDown), the REAL event is what's run through the binding.
+  // Single-threaded dispatch makes the stash safe: current() runs
+  // synchronously to completion inside the try.
+  let realEvent: KeyboardEvent | null = null;
+
   function handleKeyDown(event: KeyboardEvent): void {
     if (event.isComposing || event.keyCode === 229) return;
-    if (isModalOpen(event)) return;
-    current(event);
+    // tinykeys' isKeyboardEvent gate drops any event with an empty `code`.
+    // Real browsers always set one, but synthetic keydowns (fireEvent-style
+    // tests, and any app code dispatching a bare KeyboardEvent) routinely
+    // omit it - and the pre-dispatcher listeners this module replaced never
+    // looked at `code`. Match against a view whose code falls back to the
+    // key: matching consults code only as a fallback for string keys
+    // (already case-insensitively matched on `key`) and as a second target
+    // for regex keys (where code===key can never add a match the key itself
+    // didn't already produce), so the fallback is semantically invisible.
+    const view =
+      event.code === "" && event.key !== ""
+        ? new KeyboardEvent("keydown", {
+            key: event.key,
+            code: event.key,
+            ctrlKey: event.ctrlKey,
+            altKey: event.altKey,
+            shiftKey: event.shiftKey,
+            metaKey: event.metaKey,
+          })
+        : event;
+    realEvent = event;
+    try {
+      current(view);
+    } finally {
+      realEvent = null;
+    }
   }
 
   return {

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
@@ -13,8 +13,12 @@
 // firing binding preventDefaults and stops evaluation, and a shadowed or
 // policy-blocked binding never falls through to a lower-precedence twin.
 //
-// An event another handler already claimed (event.defaultPrevented) is ignored
-// before any of the above, matching every listener site this module replaces.
+// An event another handler already claimed (event.defaultPrevented) is
+// ignored per binding: ignoreIfDefaultPrevented defaults to true, matching
+// AppShell (AppShell.tsx:392), Settings (Settings.tsx:188), and
+// SelectionQuote (SelectionQuote.tsx:148) - but NOT RailHost's ⌘B listener
+// (RailHost.tsx:59-66), which has no defaultPrevented check and so binds with
+// ignoreIfDefaultPrevented: false in defaults.ts.
 
 import { createKeybindingsHandler, type KeybindingsMap } from "tinykeys";
 import { serializeChord } from "./chord";
@@ -79,6 +83,7 @@ export function createKeybindingDispatcher(options: DispatcherOptions = {}): Key
         if (claimed.has(chordKey)) continue;
         claimed.add(chordKey);
         map[chordKey] = (event) => {
+          if (binding.ignoreIfDefaultPrevented && event.defaultPrevented) return;
           if (!binding.allowInEditable && isEditable(event.target)) return;
           const run = registry.getState().actions.get(binding.actionId);
           if (!run) return;
@@ -99,7 +104,6 @@ export function createKeybindingDispatcher(options: DispatcherOptions = {}): Key
   });
 
   function handleKeyDown(event: KeyboardEvent): void {
-    if (event.defaultPrevented) return;
     if (event.isComposing || event.keyCode === 229) return;
     if (isModalOpen(event)) return;
     current(event);

--- a/cmd/evener-hub/frontend/src/keybindings/registry.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.test.ts
@@ -6,9 +6,34 @@ describe("action registration", () => {
     const registry = createKeybindingsRegistry();
     const run = vi.fn();
     const unregister = registry.getState().registerAction("palette.open", run);
-    expect(registry.getState().actions.get("palette.open")).toBe(run);
+    expect(registry.getState().actions.get("palette.open")).toEqual([run]);
     unregister();
     expect(registry.getState().actions.has("palette.open")).toBe(false);
+  });
+
+  test("multiple handlers coexist per action id; a disposer removes only its own registration", () => {
+    // SelectionQuote mounts one instance per session pane, each registering
+    // selection.quote - the multi-instance equivalent of the old per-instance
+    // document listeners. Overwriting or clobbering across instances breaks
+    // ⌘' in multi-pane workspaces.
+    const registry = createKeybindingsRegistry();
+    const first = vi.fn();
+    const second = vi.fn();
+    registry.getState().registerAction("a", first);
+    const unregisterSecond = registry.getState().registerAction("a", second);
+    unregisterSecond();
+    expect(registry.getState().actions.get("a")).toEqual([first]);
+  });
+
+  test("a stale disposer cannot remove a later registration of the same id", () => {
+    const registry = createKeybindingsRegistry();
+    const first = vi.fn();
+    const second = vi.fn();
+    const unregisterFirst = registry.getState().registerAction("a", first);
+    unregisterFirst();
+    registry.getState().registerAction("a", second);
+    unregisterFirst(); // stale: must not clobber the second registration
+    expect(registry.getState().actions.get("a")).toEqual([second]);
   });
 });
 

--- a/cmd/evener-hub/frontend/src/keybindings/registry.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.test.ts
@@ -21,6 +21,16 @@ describe("binding registration", () => {
     expect(registry.getState().bindings).toHaveLength(1);
   });
 
+  test("allowInModal defaults to false and is stored verbatim when set", () => {
+    const registry = createKeybindingsRegistry();
+    const plain = registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(plain.allowInModal).toBe(false);
+    const exempt = registry
+      .getState()
+      .registerBinding({ id: "b2", actionId: "a1", chord: "$mod+J", allowInModal: true });
+    expect(exempt.allowInModal).toBe(true);
+  });
+
   test("accepts a pre-parsed chord sequence", () => {
     const registry = createKeybindingsRegistry();
     const parsed = registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });

--- a/cmd/evener-hub/frontend/src/keybindings/registry.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test, vi } from "vitest";
+import { createKeybindingsRegistry, GLOBAL_SCOPE } from "./registry";
+
+describe("action registration", () => {
+  test("registers and unregisters an action", () => {
+    const registry = createKeybindingsRegistry();
+    const run = vi.fn();
+    const unregister = registry.getState().registerAction("palette.open", run);
+    expect(registry.getState().actions.get("palette.open")).toBe(run);
+    unregister();
+    expect(registry.getState().actions.has("palette.open")).toBe(false);
+  });
+});
+
+describe("binding registration", () => {
+  test("applies defaults: global scope, editable targets suppressed", () => {
+    const registry = createKeybindingsRegistry();
+    const binding = registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(binding.scope).toBe(GLOBAL_SCOPE);
+    expect(binding.allowInEditable).toBe(false);
+    expect(registry.getState().bindings).toHaveLength(1);
+  });
+
+  test("accepts a pre-parsed chord sequence", () => {
+    const registry = createKeybindingsRegistry();
+    const parsed = registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    const fromAst = registry.getState().registerBinding({ id: "b2", actionId: "a1", chord: parsed.chord, scope: "s" });
+    expect(fromAst.chord).toEqual(parsed.chord);
+  });
+
+  test("rejects the same chord twice in the same scope", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(() => registry.getState().registerBinding({ id: "b2", actionId: "a2", chord: "$mod+K" })).toThrow(
+      /conflict/i,
+    );
+    expect(registry.getState().bindings).toHaveLength(1);
+  });
+
+  test("allows the same chord in different scopes (stack order shadows)", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "Escape" });
+    expect(() =>
+      registry.getState().registerBinding({ id: "b2", actionId: "a2", chord: "Escape", scope: "settings" }),
+    ).not.toThrow();
+  });
+
+  test("rejects a duplicate binding id even across scopes", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(() =>
+      registry.getState().registerBinding({ id: "b1", actionId: "a2", chord: "$mod+J", scope: "settings" }),
+    ).toThrow(/b1/);
+  });
+
+  test("unregisterBinding removes the entry", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(registry.getState().unregisterBinding("b1")).toBe(true);
+    expect(registry.getState().bindings).toHaveLength(0);
+    expect(registry.getState().unregisterBinding("b1")).toBe(false);
+  });
+
+  test("carries an optional structured when clause without evaluating it", () => {
+    const registry = createKeybindingsRegistry();
+    const binding = registry
+      .getState()
+      .registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K", when: { pane: "settings" } });
+    expect(binding.when).toEqual({ pane: "settings" });
+  });
+});
+
+describe("scope stack", () => {
+  test("push appends, pop removes the topmost matching scope", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().pushScope("a");
+    registry.getState().pushScope("b");
+    registry.getState().pushScope("a");
+    expect(registry.getState().scopeStack).toEqual(["a", "b", "a"]);
+    expect(registry.getState().popScope("a")).toBe(true);
+    expect(registry.getState().scopeStack).toEqual(["a", "b"]);
+    expect(registry.getState().popScope("missing")).toBe(false);
+    expect(registry.getState().scopeStack).toEqual(["a", "b"]);
+  });
+
+  test("the pushScope disposer removes its own entry and is idempotent", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().pushScope("a");
+    const dispose = registry.getState().pushScope("b");
+    dispose();
+    expect(registry.getState().scopeStack).toEqual(["a"]);
+    dispose();
+    expect(registry.getState().scopeStack).toEqual(["a"]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/registry.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.ts
@@ -23,6 +23,10 @@ export interface Binding {
   scope: string;
   when?: WhenClause;
   allowInEditable: boolean;
+  /** When true (the default), a keydown another handler already claimed
+   * (event.defaultPrevented) suppresses this binding. RailHost's ⌘B listener
+   * has no such check, so rail.toggle sets this to false. */
+  ignoreIfDefaultPrevented: boolean;
 }
 
 export interface BindingInput {
@@ -35,6 +39,8 @@ export interface BindingInput {
   when?: WhenClause;
   /** Defaults to false: bindings are suppressed while an editable target has focus. */
   allowInEditable?: boolean;
+  /** Defaults to true. */
+  ignoreIfDefaultPrevented?: boolean;
 }
 
 export interface KeybindingsState {
@@ -89,6 +95,7 @@ export function createKeybindingsRegistry(): KeybindingsRegistry {
         scope: input.scope ?? GLOBAL_SCOPE,
         ...(input.when === undefined ? {} : { when: input.when }),
         allowInEditable: input.allowInEditable ?? false,
+        ignoreIfDefaultPrevented: input.ignoreIfDefaultPrevented ?? true,
       };
       const serialized = serializeChord(chord);
       for (const existing of get().bindings) {

--- a/cmd/evener-hub/frontend/src/keybindings/registry.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.ts
@@ -23,6 +23,11 @@ export interface Binding {
   scope: string;
   when?: WhenClause;
   allowInEditable: boolean;
+  /** When true, an open modal does NOT suppress this binding. Default false.
+   * Three of the shell's pre-dispatcher listeners had no modal guard at all
+   * (AppShell's deliberate ⌘K exemption, RailHost's ⌘B, SelectionQuote's ⌘'),
+   * so modal suppression is per-binding rather than a blanket layer. */
+  allowInModal: boolean;
   /** When true (the default), a keydown another handler already claimed
    * (event.defaultPrevented) suppresses this binding. RailHost's ⌘B listener
    * has no such check, so rail.toggle sets this to false. */
@@ -39,6 +44,8 @@ export interface BindingInput {
   when?: WhenClause;
   /** Defaults to false: bindings are suppressed while an editable target has focus. */
   allowInEditable?: boolean;
+  /** Defaults to false: bindings are suppressed while a modal is open. */
+  allowInModal?: boolean;
   /** Defaults to true. */
   ignoreIfDefaultPrevented?: boolean;
 }
@@ -95,6 +102,7 @@ export function createKeybindingsRegistry(): KeybindingsRegistry {
         scope: input.scope ?? GLOBAL_SCOPE,
         ...(input.when === undefined ? {} : { when: input.when }),
         allowInEditable: input.allowInEditable ?? false,
+        allowInModal: input.allowInModal ?? false,
         ignoreIfDefaultPrevented: input.ignoreIfDefaultPrevented ?? true,
       };
       const serialized = serializeChord(chord);

--- a/cmd/evener-hub/frontend/src/keybindings/registry.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.ts
@@ -1,0 +1,136 @@
+// The keybinding registry: a vanilla zustand store (same pattern as
+// shell/palette/paletteController.ts) holding the action registry (action id
+// -> run function), the binding entries, and the scope stack the dispatcher
+// evaluates top-down. Pure logic - no DOM, no React.
+
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { type KeySequence, parseChord, serializeChord } from "./chord";
+
+/** The implicit bottom of every scope stack: bindings with no `scope` land here. */
+export const GLOBAL_SCOPE = "global";
+
+/** Structured when-clause, carried for Phase 2b. Task 1 stores it verbatim and
+ * never evaluates it: scope-stack membership is the only gating the dispatcher
+ * applies. */
+export type WhenClause = Readonly<Record<string, string | boolean>>;
+
+export type ActionRunner = (event: KeyboardEvent) => void;
+
+export interface Binding {
+  id: string;
+  actionId: string;
+  chord: KeySequence;
+  scope: string;
+  when?: WhenClause;
+  allowInEditable: boolean;
+}
+
+export interface BindingInput {
+  id: string;
+  actionId: string;
+  /** A tinykeys keybinding string ("$mod+K") or an already-parsed sequence. */
+  chord: string | KeySequence;
+  /** Defaults to the global scope. */
+  scope?: string;
+  when?: WhenClause;
+  /** Defaults to false: bindings are suppressed while an editable target has focus. */
+  allowInEditable?: boolean;
+}
+
+export interface KeybindingsState {
+  actions: ReadonlyMap<string, ActionRunner>;
+  bindings: readonly Binding[];
+  /** Bottom-to-top; the dispatcher evaluates it top-down before the global scope. */
+  scopeStack: readonly string[];
+  /** Returns an unregister disposer. */
+  registerAction(id: string, run: ActionRunner): () => void;
+  /**
+   * Throws on a duplicate binding id, or on a chord conflict: the same chord
+   * already bound in the SAME scope. The same chord in a DIFFERENT scope is
+   * not a conflict - scope-stack order shadows it deterministically.
+   */
+  registerBinding(input: BindingInput): Binding;
+  unregisterBinding(id: string): boolean;
+  /** Returns an idempotent disposer that pops this entry. */
+  pushScope(scope: string): () => void;
+  /** Removes the topmost matching scope; false when the scope is not on the stack. */
+  popScope(scope: string): boolean;
+}
+
+export type KeybindingsRegistry = StoreApi<KeybindingsState>;
+
+export function createKeybindingsRegistry(): KeybindingsRegistry {
+  return createStore<KeybindingsState>()((set, get) => ({
+    actions: new Map(),
+    bindings: [],
+    scopeStack: [],
+
+    registerAction(id, run) {
+      set((s) => {
+        const actions = new Map(s.actions);
+        actions.set(id, run);
+        return { actions };
+      });
+      return () => {
+        set((s) => {
+          const actions = new Map(s.actions);
+          actions.delete(id);
+          return { actions };
+        });
+      };
+    },
+
+    registerBinding(input) {
+      const chord = typeof input.chord === "string" ? parseChord(input.chord) : input.chord;
+      const binding: Binding = {
+        id: input.id,
+        actionId: input.actionId,
+        chord,
+        scope: input.scope ?? GLOBAL_SCOPE,
+        ...(input.when === undefined ? {} : { when: input.when }),
+        allowInEditable: input.allowInEditable ?? false,
+      };
+      const serialized = serializeChord(chord);
+      for (const existing of get().bindings) {
+        if (existing.id === binding.id) {
+          throw new Error(`keybinding id "${binding.id}" is already registered`);
+        }
+        if (existing.scope === binding.scope && serializeChord(existing.chord) === serialized) {
+          throw new Error(
+            `keybinding conflict: "${serialized}" in scope "${binding.scope}" is already bound by "${existing.id}"`,
+          );
+        }
+      }
+      set((s) => ({ bindings: [...s.bindings, binding] }));
+      return binding;
+    },
+
+    unregisterBinding(id) {
+      const found = get().bindings.some((b) => b.id === id);
+      if (found) set((s) => ({ bindings: s.bindings.filter((b) => b.id !== id) }));
+      return found;
+    },
+
+    pushScope(scope) {
+      set((s) => ({ scopeStack: [...s.scopeStack, scope] }));
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        get().popScope(scope);
+      };
+    },
+
+    popScope(scope) {
+      const stack = get().scopeStack;
+      const index = stack.lastIndexOf(scope);
+      if (index === -1) return false;
+      set({ scopeStack: [...stack.slice(0, index), ...stack.slice(index + 1)] });
+      return true;
+    },
+  }));
+}
+
+/** The app-wide registry. Task 2 wires it to AppShell; tests build their own
+ * with createKeybindingsRegistry(). */
+export const keybindingsRegistry = createKeybindingsRegistry();

--- a/cmd/evener-hub/frontend/src/keybindings/registry.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.ts
@@ -14,7 +14,13 @@ export const GLOBAL_SCOPE = "global";
  * applies. */
 export type WhenClause = Readonly<Record<string, string | boolean>>;
 
-export type ActionRunner = (event: KeyboardEvent) => void;
+/** An action handler. Returning false DECLINES the event - the dispatcher
+ * tries the action's next handler (multi-instance components like
+ * SelectionQuote register one handler per mounted instance, and only the
+ * instance holding state that can act accepts). Returning true or undefined
+ * reports the event handled and stops iteration. */
+// biome-ignore lint/suspicious/noConfusingVoidType: "false declines, anything else (including a void fall-through) accepts" IS the contract; boolean|undefined would reject the existing void-bodied handlers
+export type ActionRunner = (event: KeyboardEvent) => boolean | void;
 
 export interface Binding {
   id: string;
@@ -51,11 +57,14 @@ export interface BindingInput {
 }
 
 export interface KeybindingsState {
-  actions: ReadonlyMap<string, ActionRunner>;
+  /** Action id -> its handlers, in registration order. */
+  actions: ReadonlyMap<string, readonly ActionRunner[]>;
   bindings: readonly Binding[];
   /** Bottom-to-top; the dispatcher evaluates it top-down before the global scope. */
   scopeStack: readonly string[];
-  /** Returns an unregister disposer. */
+  /** Appends a handler for the action; the returned disposer removes ONLY
+   * this registration (by identity), never another instance's handler for
+   * the same action, and is idempotent. */
   registerAction(id: string, run: ActionRunner): () => void;
   /**
    * Throws on a duplicate binding id, or on a chord conflict: the same chord
@@ -81,13 +90,22 @@ export function createKeybindingsRegistry(): KeybindingsRegistry {
     registerAction(id, run) {
       set((s) => {
         const actions = new Map(s.actions);
-        actions.set(id, run);
+        actions.set(id, [...(actions.get(id) ?? []), run]);
         return { actions };
       });
+      let active = true;
       return () => {
+        if (!active) return;
+        active = false;
         set((s) => {
+          const list = s.actions.get(id);
+          if (!list) return {};
+          const index = list.indexOf(run);
+          if (index === -1) return {};
           const actions = new Map(s.actions);
-          actions.delete(id);
+          const next = [...list.slice(0, index), ...list.slice(index + 1)];
+          if (next.length === 0) actions.delete(id);
+          else actions.set(id, next);
           return { actions };
         });
       };

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.test.tsx
@@ -279,3 +279,58 @@ test("mousedown on the bar is prevented, so clicking its action never collapses 
   const event = fireEvent.mouseDown(screen.getByRole("toolbar", { name: "Selection actions" }));
   expect(event).toBe(false); // fireEvent returns false when preventDefault() was called
 });
+
+// Multi-pane workspaces mount one SelectionQuote per session pane
+// (Session.tsx), and each instance registers the selection.quote action.
+// These two tests pin the multi-instance contract against the two ways a
+// shared registry can break it: the LAST-registered instance clobbering the
+// one holding the selection, and an instance's unmount deadening the chord
+// for every remaining instance.
+function renderInstance(label: string, onInvoke: (text: string) => void) {
+  const containerRef = createRef<HTMLDivElement>();
+  const rendered = render(
+    <div ref={containerRef} data-testid={`${label}-container`}>
+      <div data-view-anchor-message="true" data-testid={`${label}-message`}>
+        selectable message prose
+      </div>
+      <SelectionQuote containerRef={containerRef} actions={[{ label: "Quote in reply", onInvoke }]} />
+    </div>,
+  );
+  return {
+    containerRef,
+    unmount: rendered.unmount,
+    messageNode: screen.getByTestId(`${label}-message`).firstChild as Text,
+  };
+}
+
+test("two mounted instances: the one holding the selection handles Mod+', not the last-registered", () => {
+  const onInvokeA = vi.fn();
+  const onInvokeB = vi.fn();
+  const a = renderInstance("a", onInvokeA);
+  renderInstance("b", onInvokeB);
+  installFakeSelection({ text: "quoted prose", anchorNode: a.messageNode });
+  act(() => {
+    a.containerRef.current?.dispatchEvent(new Event("pointerup", { bubbles: true }));
+  });
+
+  fireEvent.keyDown(document, { key: "'", metaKey: true });
+
+  expect(onInvokeA).toHaveBeenCalledExactlyOnceWith("quoted prose");
+  expect(onInvokeB).not.toHaveBeenCalled();
+});
+
+test("unmounting the last-registered instance does not deaden Mod+' for the remaining ones", () => {
+  const onInvokeA = vi.fn();
+  const onInvokeB = vi.fn();
+  const a = renderInstance("a", onInvokeA);
+  const b = renderInstance("b", onInvokeB);
+  b.unmount();
+  installFakeSelection({ text: "quoted prose", anchorNode: a.messageNode });
+  act(() => {
+    a.containerRef.current?.dispatchEvent(new Event("pointerup", { bubbles: true }));
+  });
+
+  fireEvent.keyDown(document, { key: "'", metaKey: true });
+
+  expect(onInvokeA).toHaveBeenCalledExactlyOnceWith("quoted prose");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.tsx
@@ -109,12 +109,21 @@ export function SelectionQuote({ containerRef, actions }: SelectionQuoteProps) {
   // keeps the updater the pure `() => null` it always should have been.
   useEffect(() => {
     installKeybindings();
+    // One SelectionQuote mounts per session pane (Session.tsx), so several
+    // instances register selection.quote at once. The registry invokes an
+    // action's handlers in registration order until one ACCEPTS; returning
+    // false when THIS instance holds no captured selection passes the chord
+    // to the instance that does - exactly the old per-instance document
+    // listeners' semantics (every instance saw the keydown; only the one
+    // holding the selection acted). The disposer removes only this
+    // instance's registration, so unmounting one pane never deadens ⌘' for
+    // the rest.
     return keybindingsRegistry.getState().registerAction(ACTIONS.selectionQuote, () => {
       const current = selectionRef.current;
-      if (current) {
-        actionsRef.current[0]?.onInvoke(current.text);
-        setSelection(null);
-      }
+      if (!current) return false;
+      actionsRef.current[0]?.onInvoke(current.text);
+      setSelection(null);
+      return true;
     });
   }, []);
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.tsx
@@ -32,6 +32,9 @@
 // scroller, anywhere) rather than leaving it floating over content it no
 // longer points at.
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { ACTIONS } from "../../../keybindings/actions";
+import { keybindingsRegistry } from "../../../keybindings/registry";
+import { installKeybindings } from "../../../shell/installKeybindings";
 import { Button } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import { clampToBounds, messageContentElement } from "./selectionQuoteLogic";
@@ -71,19 +74,49 @@ export function SelectionQuote({ containerRef, actions }: SelectionQuoteProps) {
   const [selection, setSelection] = useState<CapturedSelection | null>(null);
   const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
   const barRef = useRef<HTMLDivElement>(null);
-  // Read by the Mod+' handler inside the effect below without making
-  // `actions` an effect dependency - every caller (Session.tsx included)
-  // passes a fresh array literal each render, and re-subscribing the whole
-  // listener set on every render for that reason alone would be wasteful
-  // (same idiom as Composer.tsx's own textRef, kept live without being a
-  // dependency).
+  // Read by the selection.quote action below without making `actions` an
+  // effect dependency - every caller (Session.tsx included) passes a fresh
+  // array literal each render, and re-registering the action on every render
+  // for that reason alone would be wasteful (same idiom as Composer.tsx's
+  // own textRef, kept live without being a dependency).
   const actionsRef = useRef(actions);
   actionsRef.current = actions;
-  // Mirrors `selection` state, read (never written) by the Mod+' handler -
-  // see that handler's own comment for why it reads this ref instead of
-  // the setSelection updater's own current-value argument.
+  // Mirrors `selection` state, read (never written) by the selection.quote
+  // action - see that registration's own comment for why it reads this ref
+  // instead of the setSelection updater's own current-value argument.
   const selectionRef = useRef(selection);
   selectionRef.current = selection;
+
+  // Mod+' invokes the bar's first (and today, only) action directly against
+  // the currently captured selection - the same code path a click on the
+  // bar's own button takes (actions[0].onInvoke below), just reachable
+  // without a pointer. A no-op with nothing captured. The chord is the
+  // keybindings dispatcher's; its binding (keybindings/defaults.ts's
+  // selection.quote) carries this listener's old policy: strict modifiers
+  // (AltGr, reported as ctrlKey+altKey, does not misfire the chord - see
+  // MDN's own note on AltGr), no editable-target or modal guard (the old
+  // listener had neither), and still yields to a keydown another handler
+  // already claimed (defaultPrevented - see OverlayPanel.tsx's own Escape
+  // precedent).
+  //
+  // BLOCKER fix (preserved): onInvoke must NOT run inside a setSelection
+  // updater. A setState updater must be a pure function - React calls it
+  // twice under StrictMode (see shell/rail/Rail.tsx:323-325's own comment on
+  // this exact rule) - so a real double-invoke there ran onInvoke (and so
+  // requestQuoteInsert) twice per keypress, silently double-inserting the
+  // quote. Reading the current selection from selectionRef (written every
+  // render, never inside a state updater) and invoking OUTSIDE setSelection
+  // keeps the updater the pure `() => null` it always should have been.
+  useEffect(() => {
+    installKeybindings();
+    return keybindingsRegistry.getState().registerAction(ACTIONS.selectionQuote, () => {
+      const current = selectionRef.current;
+      if (current) {
+        actionsRef.current[0]?.onInvoke(current.text);
+        setSelection(null);
+      }
+    });
+  }, []);
 
   const evaluate = useCallback(() => {
     const container = containerRef.current;
@@ -121,36 +154,6 @@ export function SelectionQuote({ containerRef, actions }: SelectionQuoteProps) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setSelection(null);
-        return;
-      }
-      // Mod+' invokes the bar's first (and today, only) action directly
-      // against the currently captured selection - the same code path a
-      // click on the bar's own button takes (actions[0].onInvoke below),
-      // just reachable without a pointer. A no-op with nothing captured.
-      //
-      // !event.altKey: AltGr (used to type "'" directly on some non-US
-      // keyboard layouts) is reported as ctrlKey+altKey by browsers - see
-      // MDN's own note on AltGr - so without this guard, typing a literal
-      // "'" via AltGr on those layouts would misfire this chord.
-      // !event.defaultPrevented: some other handler (e.g. an ancestor
-      // overlay) already claimed this keydown - see OverlayPanel.tsx's own
-      // Escape precedent for the same idea.
-      //
-      // BLOCKER fix: onInvoke used to run INSIDE the setSelection updater
-      // function. A setState updater must be a pure function - React calls
-      // it twice under StrictMode (see shell/rail/Rail.tsx:323-325's own
-      // comment on this exact rule) - so a real double-invoke there ran
-      // onInvoke (and so requestQuoteInsert) twice per keypress, silently
-      // double-inserting the quote. Reading the current selection from
-      // selectionRef (written every render, never inside a state updater)
-      // and invoking OUTSIDE setSelection fixes that: the updater itself is
-      // now the pure `() => null` it always should have been.
-      if (event.key === "'" && (event.metaKey || event.ctrlKey) && !event.altKey && !event.defaultPrevented) {
-        const current = selectionRef.current;
-        if (current) {
-          actionsRef.current[0]?.onInvoke(current.text);
-          setSelection(null);
-        }
       }
     };
     const handleScroll = () => setSelection(null);

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
@@ -1,6 +1,10 @@
 import type { ComponentType } from "react";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import { ACTIONS } from "../../keybindings/actions";
+import { SETTINGS_SCOPE } from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
 import { chromeStore } from "../../shell/chromeStore";
+import { installKeybindings } from "../../shell/installKeybindings";
 import type { PaneProps } from "../../shell/paneRegistry";
 import { navigate, paneToURL } from "../../shell/routing";
 import { useIsMobile } from "../../shell/useIsMobile";
@@ -168,29 +172,34 @@ export default function Settings({ params, paneId }: PaneProps<SettingsPaneParam
   // in a real browser: Escape/close did nothing). Routing through
   // paneToURL/navigate keeps the URL and the workspace in agreement, so
   // there is nothing left for reconciliation to "fix".
-  function handleClose() {
+  const handleClose = useCallback(() => {
     const url = paneToURL("welcome", {});
     if (url !== null) navigate(url);
     workspaceStore.getState().closePane(paneId);
-  }
+  }, [paneId]);
 
-  // Escape closes the pane. A React onKeyDown on the pane's own div only
-  // fires when focus is INSIDE it — and the common open path (clicking the
-  // rail's gear) leaves focus on the gear button, so in a real browser the
-  // pane-scoped handler never saw the key (live-verified regression). A
-  // document-level bubble-phase listener sees Escape regardless of where
-  // focus sits, and still yields to anything inside settings that claimed
-  // the key first: a Dialog/Menu preventDefaults its own Escape (see
-  // OverlayPanel/Menu), which this checks before closing.
+  // Escape closes the pane, via the keybindings dispatcher: the pane pushes
+  // the settings scope while it is open and registers the settings.close
+  // action (Escape, scope-gated - keybindings/defaults.ts), so the chord is
+  // live exactly while this pane exists. A React onKeyDown on the pane's own
+  // div only fires when focus is INSIDE it — and the common open path
+  // (clicking the rail's gear) leaves focus on the gear button, so in a real
+  // browser the pane-scoped handler never saw the key (live-verified
+  // regression). The dispatcher's window-level listener sees Escape
+  // regardless of where focus sits, and still yields to anything inside
+  // settings that claimed the key first: a Dialog/Menu preventDefaults its
+  // own Escape (see OverlayPanel/Menu), which the binding's
+  // ignoreIfDefaultPrevented gate (default true) checks before closing.
   useEffect(() => {
-    function onDocumentKeyDown(event: globalThis.KeyboardEvent) {
-      if (event.key !== "Escape") return;
-      if (event.defaultPrevented) return;
-      handleClose();
-    }
-    document.addEventListener("keydown", onDocumentKeyDown);
-    return () => document.removeEventListener("keydown", onDocumentKeyDown);
-  });
+    installKeybindings();
+    const registry = keybindingsRegistry.getState();
+    const popScope = registry.pushScope(SETTINGS_SCOPE);
+    const unregister = registry.registerAction(ACTIONS.settingsClose, () => handleClose());
+    return () => {
+      unregister();
+      popScope();
+    };
+  }, [handleClose]);
 
   return (
     <PaneScaffold

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -3,6 +3,8 @@
 // workspace - DockHost (dockview) on desktop; renders NotFound in its
 // place for a path urlToPane() can't resolve at all.
 import { useEffect, useReducer, useRef, useState } from "react";
+import { ACTIONS } from "../keybindings/actions";
+import { keybindingsRegistry } from "../keybindings/registry";
 import { initNotifications } from "../notifications";
 import { requestComposerFocus } from "../panes/session/composer/composerFocus";
 import { AppwireClient } from "../protocol/client";
@@ -23,6 +25,7 @@ import { ConnectionBanner } from "./ConnectionBanner";
 import { ToastRegion } from "./chrome/ToastRegion";
 import { ClientProvider } from "./clientContext";
 import { DockRegion } from "./DockRegion";
+import { installKeybindings } from "./installKeybindings";
 import { StackHost } from "./mobile/StackHost";
 import { NotFound } from "./NotFound";
 import { CommandPalette } from "./palette/CommandPalette";
@@ -299,36 +302,34 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
     return () => owned?.close();
   }, [client, owned]);
 
-  // Global command-palette entry points (floor §2.1): ⌘K / Ctrl-K from
-  // anywhere in the app, and a click on any [data-search-trigger] element.
-  // Both open the palette through the one openPalette() the whole app shares
-  // (Composer's leading-"/"-on-empty hook is the third). ⌘B (sidebar cycle,
-  // T5) is a separate, disjoint listener and is never added here (PIN-D).
+  // Global chord wiring (floor §2.1 + the UX-fix chords), now driven by the
+  // keybindings dispatcher (src/keybindings/, installed app-wide by
+  // installKeybindings): this effect registers the three actions AppShell
+  // owns - palette.open (⌘K / Ctrl-K from anywhere, through the one
+  // openPalette() the whole app shares; Composer's leading-"/"-on-empty hook
+  // and the [data-search-trigger] click listener below are the other entry
+  // points), composer.focus (⌘I: focuses the focused session pane's composer
+  // via composerFocus.ts's per-ref seam - a no-op when the focused pane isn't
+  // a session), and next-needs-you (⌘J: cycles the needs-you sessions, tree
+  // order, wrapping from whichever session is currently focused, opening a
+  // hit through the same top-level/nested seams the rail itself uses -
+  // needsYouCycle.ts). ⌘B (sidebar cycle) is RailHost's action, never
+  // registered here (PIN-D).
   //
-  // ⌘I / Ctrl-I (UX fix) focuses the focused session pane's composer
-  // (composerFocus.ts's per-ref seam) - a no-op when the focused pane isn't a
-  // session. ⌘J / Ctrl-J (UX fix) cycles the needs-you sessions (tree order,
-  // wrapping from whichever session is currently focused), opening a hit
-  // through the same top-level/nested seams the rail itself uses
-  // (needsYouCycle.ts). Both are Mod-chords, like ⌘K, so they fire
-  // everywhere - including while typing in an input/textarea - matching how
-  // ⌘K already behaves; only event.defaultPrevented (another handler already
-  // claimed this keystroke) suppresses them.
-  //
-  // BLOCKER fix: I/J used to fire straight through an open modal (the
-  // command palette itself, or a Dialog/Sheet like Settings' credential
-  // editors) - ⌘I stealing focus into a session composer, or ⌘J navigating
-  // the tree, out from under a modal the user is still looking at. Guarded
-  // two ways: paletteStore's own `open` flag (the palette isn't a
-  // [role=dialog] - it's CommandPalette's own overlay, so the DOM check
-  // below wouldn't catch it) and event.target sitting inside any
-  // [aria-modal="true"] element (every OverlayPanel-based Dialog/Sheet sets
-  // this - see widgets/dialog/OverlayPanel.tsx - and it needs no per-modal
-  // wiring here to keep catching new ones). ⌘K is deliberately exempt:
-  // opening the palette while it's already open is a harmless no-op reset,
-  // not a focus hijack, and ⌘K from inside a Dialog is the same "open the
-  // palette" intent as anywhere else.
+  // The chords' shared guards live on the bindings (keybindings/defaults.ts),
+  // not in these runners: all three fire from editable targets
+  // (allowInEditable) and yield to a keydown another handler already claimed
+  // (defaultPrevented). The modal guard (the old blockedByOpenModal:
+  // paletteStore.open, plus the event target sitting inside any
+  // [aria-modal="true"] element - every OverlayPanel Dialog/Sheet) is the
+  // dispatcher's injected isModalOpen predicate; it suppresses ⌘I/⌘J (the
+  // BLOCKER fix: ⌘I stealing composer focus, or ⌘J navigating the tree, out
+  // from under a modal the user is still looking at) while ⌘K stays
+  // deliberately exempt via its binding's allowInModal - opening the palette
+  // while it's already open is a harmless no-op reset, and ⌘K from inside a
+  // Dialog is the same "open the palette" intent as anywhere else.
   useEffect(() => {
+    installKeybindings();
     const requestedPages = new Set<string>();
     let generation = navigationStore.getState().clientGenerationID;
     let mounted = true;
@@ -383,30 +384,14 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
         })
         .catch(() => undefined);
     };
-    function blockedByOpenModal(event: KeyboardEvent): boolean {
-      if (paletteStore.getState().open) return true;
-      const target = event.target;
-      return target instanceof Element && target.closest('[aria-modal="true"]') !== null;
-    }
-    function onKeyDown(event: KeyboardEvent): void {
-      if (event.defaultPrevented) return;
-      if (!(event.metaKey || event.ctrlKey)) return;
-      const key = event.key.toLowerCase();
-      if (key === "k") {
-        event.preventDefault();
-        openPalette();
-        return;
-      }
-      if (key === "i") {
-        if (blockedByOpenModal(event)) return;
-        event.preventDefault();
+    const registry = keybindingsRegistry.getState();
+    const unregisterActions = [
+      registry.registerAction(ACTIONS.paletteOpen, () => openPalette()),
+      registry.registerAction(ACTIONS.composerFocus, () => {
         const ref = focusedSessionRef();
         if (ref !== null) requestComposerFocus(ref);
-        return;
-      }
-      if (key === "j") {
-        if (blockedByOpenModal(event)) return;
-        event.preventDefault();
+      }),
+      registry.registerAction(ACTIONS.nextNeedsYou, () => {
         const state = navigationStore.getState();
         if (state.clientGenerationID !== generation) {
           generation = state.clientGenerationID;
@@ -449,8 +434,8 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
         }
         const next = nextNeedsYouRef(refs, current);
         if (next !== null) openNeedsYouSession(next);
-      }
-    }
+      }),
+    ];
     function onClick(event: MouseEvent): void {
       const target = event.target as Element | null;
       if (target?.closest("[data-search-trigger]")) {
@@ -458,12 +443,11 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
         openPalette();
       }
     }
-    window.addEventListener("keydown", onKeyDown);
     document.addEventListener("click", onClick);
     return () => {
       mounted = false;
       intent++;
-      window.removeEventListener("keydown", onKeyDown);
+      for (const unregister of unregisterActions) unregister();
       document.removeEventListener("click", onClick);
     };
   }, []);

--- a/cmd/evener-hub/frontend/src/shell/installKeybindings.ts
+++ b/cmd/evener-hub/frontend/src/shell/installKeybindings.ts
@@ -1,0 +1,37 @@
+// The one app-startup wiring point between the React-free keybindings module
+// (src/keybindings/) and the live app: registers the default binding map and
+// attaches the single window-level dispatcher, with the modal predicate
+// composed from the real stores - paletteStore.open (the palette is
+// CommandPalette's own overlay, not an [aria-modal] element, so the DOM check
+// alone can't see it) OR an [aria-modal="true"] ancestor of the event target
+// (every OverlayPanel-based Dialog/Sheet). This is exactly the old AppShell
+// blockedByOpenModal check, kept blanket - with per-binding allowInModal
+// exemptions living on the bindings themselves (keybindings/defaults.ts),
+// the predicate never sniffs which chord was pressed.
+//
+// Idempotent per window: AppShell installs it at mount, and every component
+// that registers a chord action (RailHost, Settings, SelectionQuote) calls it
+// too so the chord also works when the component is mounted WITHOUT the shell
+// - those components' own unit tests render them standalone, and a chord that
+// silently did nothing there would be worse than this belt-and-braces call.
+// Per-window lifetime by design: the dispatcher and the (actionless on their
+// own) default bindings stay attached until the page unloads; actions and
+// scopes come and go with their components. Vitest file isolation gives each
+// test file a fresh module registry, so the singleton never crosses files.
+
+import { registerDefaultBindings } from "../keybindings/defaults";
+import { createKeybindingDispatcher, isModalOpenTarget } from "../keybindings/dispatcher";
+import { keybindingsRegistry } from "../keybindings/registry";
+import { paletteStore } from "./palette/paletteController";
+
+let installed = false;
+
+export function installKeybindings(): void {
+  if (installed) return;
+  installed = true;
+  registerDefaultBindings(keybindingsRegistry);
+  const dispatcher = createKeybindingDispatcher({
+    isModalOpen: (event) => paletteStore.getState().open || isModalOpenTarget(event),
+  });
+  dispatcher.attach(window);
+}

--- a/cmd/evener-hub/frontend/src/shell/keybindingsMigration.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/keybindingsMigration.test.tsx
@@ -1,0 +1,411 @@
+// Migration tests for the keybindings dispatcher wiring (Task 2 of the
+// webui-keybindings-p2a plan): the six shell chords moved from six ad-hoc
+// keydown listeners (AppShell, RailHost, Settings, SelectionQuote) onto the
+// single window-level dispatcher (src/keybindings/, installed by
+// shell/installKeybindings.ts). These tests pin the chord-policy contract
+// that the pre-existing suites do NOT already cover: firing-or-not from
+// editable targets, from open modals (per-binding allowInModal), while the
+// palette itself is open, on IME composition keydowns, and against a keydown
+// another handler already claimed - plus the one deliberate non-migration
+// (FocusScope's Tab trap is untouched).
+//
+// The AppShell render/warm-up/store-reset scaffolding below mirrors
+// AppShell.test.tsx's own (helpers duplicated, not shared - this project has
+// no cross-test-file test-utils module; see that file's and
+// stores/threads.test.ts's own notes on the convention).
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { initNotifications, resetNotificationsForTests } from "../notifications";
+import * as composerFocus from "../panes/session/composer/composerFocus";
+import { FakeClient } from "../protocol/testing/fakeClient";
+import type { NavigationReadParams, NavigationReadResponse, NavigationSessionLocation } from "../protocol/types.gen";
+import { connectionStore } from "../stores/connection";
+import { navigationStore, resetNavigationStoreForTests } from "../stores/navigation/store";
+import { keyID } from "../stores/navigation/types";
+import { prefsStore, resetPrefsStoreForTests } from "../stores/prefs";
+import { resetSettingsOverviewStoreForTests } from "../stores/settingsOverview";
+import { FocusScope } from "../widgets/focusscope";
+import { AppShell } from "./AppShell";
+import { closePalette, paletteStore } from "./palette/paletteController";
+import { resetWorkspaceStoreForTests, workspaceStore } from "./workspace";
+
+// See AppShell.test.tsx for why both stubs are needed (jsdom has no
+// ResizeObserver; Node 26 shadows jsdom's localStorage accessor).
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const TREE_SESSION = {
+  row_id: "project:proj1:local:s1",
+  ref: "local:s1",
+  host_id: "local",
+  session_id: "s1",
+  title: "Session one",
+  project: "prime-radiant",
+  state: "idle",
+  kind: "session",
+  live: true,
+  children: [],
+};
+
+function navigationRead(params: NavigationReadParams): NavigationReadResponse {
+  const envelope = (data: unknown): NavigationReadResponse => ({
+    status: "ok",
+    generationId: "generation_test",
+    revision: 1,
+    etag: '"test"',
+    data,
+  });
+  if (params.resource === "location") {
+    return envelope({
+      generation_id: "generation_test",
+      revision: 1,
+      ref: params.ref,
+      top_level_ref: params.ref,
+      top_level: true,
+      session: { ...TREE_SESSION, ref: params.ref, session_id: params.ref },
+    });
+  }
+  throw new Error(`unsupported navigation resource: ${params.resource}`);
+}
+
+// A FakeClient whose connect() advertises v1 navigation - see AppShell.
+// test.tsx's own navClient comment for why a bare FakeClient("ready") leaves
+// the navigation store in "error" mode instead.
+function navClient(): FakeClient {
+  const client = new FakeClient("ready");
+  client.on("evener/navigation/read", navigationRead);
+  client.scriptConnect(() => ({
+    serverInfo: { name: "fake", version: "1" },
+    protocolVersion: "evener-appwire-v3",
+    sourceId: "fake",
+    features: {} as never,
+    navigation: { version: 1, generationId: "generation_test", sequence: 0 },
+  }));
+  return client;
+}
+
+function installLocationForRoute(ref: string): void {
+  const location: NavigationSessionLocation = {
+    generation_id: "generation_test",
+    revision: 1,
+    ref,
+    top_level_ref: ref,
+    top_level: true,
+    session: {
+      ref,
+      host_id: "local",
+      session_id: ref,
+      title: ref,
+      project: "test-project",
+      state: "idle",
+      kind: "session",
+      live: false,
+      children: [],
+    },
+  };
+  const key = { kind: "location", ref } as const;
+  const resources = new Map(navigationStore.getState().resources);
+  resources.set(keyID(key), {
+    key,
+    data: location,
+    loadedRevision: location.revision,
+    targetRevision: null,
+    forceToken: 0,
+    etag: '"test"',
+    loading: false,
+    stale: false,
+    error: null,
+    generationID: location.generation_id,
+  });
+  navigationStore.setState({ mode: "v1", clientGenerationID: location.generation_id, resources });
+}
+
+function installNeedsYouRows(): void {
+  const key = { kind: "section", section: "needs_you", offset: 0, limit: 50 } as const;
+  const rows = [
+    { ...TREE_SESSION, ref: "local:ny1", session_id: "ny1", title: "Needs you one", state: "awaiting" },
+    { ...TREE_SESSION, ref: "local:ny2", session_id: "ny2", title: "Needs you two", state: "awaiting" },
+  ];
+  const resources = new Map(navigationStore.getState().resources);
+  resources.set(keyID(key), {
+    key,
+    data: { generation_id: "generation_test", revision: 1, sessions: rows, remaining: 0, truncated: false },
+    loadedRevision: 1,
+    targetRevision: null,
+    forceToken: 0,
+    etag: '"test"',
+    loading: false,
+    stale: false,
+    error: null,
+    generationID: "generation_test",
+  });
+  navigationStore.setState({ mode: "v1", resources });
+}
+
+// A focused plain <input> appended beside the shell: the editable target the
+// editable-policy tests fire their chords from. Returns a cleanup.
+function focusedInput(): { input: HTMLInputElement; remove: () => void } {
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  return { input, remove: () => input.remove() };
+}
+
+// An [aria-modal="true"] stand-in for an OverlayPanel Dialog/Sheet, with a
+// focusable element inside so chords can be fired from within it.
+function openFakeModal(): { modal: HTMLElement; inside: HTMLButtonElement; close: () => void } {
+  const modal = document.createElement("div");
+  modal.setAttribute("aria-modal", "true");
+  const inside = document.createElement("button");
+  modal.appendChild(inside);
+  document.body.appendChild(modal);
+  inside.focus();
+  return { modal, inside, close: () => modal.remove() };
+}
+
+beforeAll(async () => {
+  globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver;
+  // @ts-expect-error MemoryStorage deliberately implements only the Storage
+  // methods the stores actually call - see AppShell.test.tsx's own stub.
+  globalThis.localStorage = new MemoryStorage();
+  // Await the lazy pane/dock modules once up front, then pay react-dom's
+  // per-boundary fallback throttle in one warm render per route shape - see
+  // AppShell.test.tsx's warmRoute for the full reasoning (the cost is real
+  // and awaitable here; inside a test it would eat the assertion window).
+  await import("../panes/welcome/Welcome");
+  await import("../panes/session/Session");
+  await import("../panes/settings/Settings");
+  await import("./DockHost");
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+  window.history.pushState({}, "", "/settings");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByRole("navigation", { name: "Settings sections" }, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+  resetSettingsOverviewStoreForTests();
+  window.history.pushState({}, "", "/s/local:warm");
+  installLocationForRoute("local:warm");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText(/loading transcript/i, undefined, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+  window.history.pushState({}, "", "/");
+});
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetWorkspaceStoreForTests();
+  resetNavigationStoreForTests();
+  navigationStore.setState({ mode: "v1" });
+  resetPrefsStoreForTests();
+  // @ts-expect-error see the beforeAll stub.
+  globalThis.localStorage = new MemoryStorage();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  window.history.pushState({}, "", "/");
+  paletteStore.setState({ open: false, query: "" });
+  resetSettingsOverviewStoreForTests();
+  // Same module-singleton reasoning as AppShell.test.tsx's afterEach: the
+  // notifications engine's reconnect detector must not carry one test's
+  // ready-client into the next.
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetNavigationStoreForTests();
+  resetNotificationsForTests();
+  initNotifications();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// --- editable targets -------------------------------------------------------
+
+test("Mod+K fires while an input is focused", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { input, remove } = focusedInput();
+
+  fireEvent.keyDown(input, { key: "k", metaKey: true });
+
+  expect(await screen.findByRole("dialog", { name: "Command palette" })).toBeTruthy();
+  remove();
+});
+
+test("Mod+I fires while an input is focused", async () => {
+  const focusSpy = vi.spyOn(composerFocus, "requestComposerFocus");
+  window.history.pushState({}, "", "/s/local:ref_abc123");
+  installLocationForRoute("local:ref_abc123");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText(/loading transcript/i);
+  const { input, remove } = focusedInput();
+
+  fireEvent.keyDown(input, { key: "i", metaKey: true });
+
+  expect(focusSpy).toHaveBeenCalledWith("local:ref_abc123");
+  remove();
+});
+
+test("Mod+J fires while an input is focused", async () => {
+  installNeedsYouRows();
+  render(<AppShell client={navClient()} />);
+  await screen.findByText("No session open");
+  const { input, remove } = focusedInput();
+
+  fireEvent.keyDown(input, { key: "j", metaKey: true });
+
+  await waitFor(() => expect(workspaceStore.getState().mainPane()?.params).toMatchObject({ ref: "local:ny1" }));
+  remove();
+});
+
+test("Mod+B is suppressed from editable targets (Ctrl+B keeps its emacs meaning)", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { input, remove } = focusedInput();
+
+  const metaEvent = new KeyboardEvent("keydown", { key: "b", metaKey: true, bubbles: true, cancelable: true });
+  act(() => {
+    input.dispatchEvent(metaEvent);
+  });
+  const ctrlEvent = new KeyboardEvent("keydown", { key: "b", ctrlKey: true, bubbles: true, cancelable: true });
+  act(() => {
+    input.dispatchEvent(ctrlEvent);
+  });
+
+  expect(prefsStore.getState().sidebarHidden).toBe(false);
+  // A suppressed binding claims nothing: the text field's own Ctrl+B behavior
+  // (cursor back) must not be preventDefault'd either.
+  expect(metaEvent.defaultPrevented).toBe(false);
+  expect(ctrlEvent.defaultPrevented).toBe(false);
+  remove();
+});
+
+// --- open modals (per-binding allowInModal) ---------------------------------
+
+test("Mod+K fired while the palette is already open re-opens it (the deliberate exemption)", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  await user.keyboard("{Meta>}k{/Meta}");
+  await screen.findByRole("dialog", { name: "Command palette" });
+  const openSeq = paletteStore.getState().openSeq;
+
+  await user.keyboard("{Meta>}k{/Meta}");
+
+  // Every openPalette() call bumps openSeq - the remount-on-open contract the
+  // exemption exists to preserve (paletteController.ts's own comment).
+  expect(paletteStore.getState().openSeq).toBe(openSeq + 1);
+  expect(screen.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
+});
+
+test("Mod+K and Mod+B still fire while an [aria-modal] dialog is open", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { inside, close } = openFakeModal();
+
+  fireEvent.keyDown(inside, { key: "k", metaKey: true });
+  expect(await screen.findByRole("dialog", { name: "Command palette" })).toBeTruthy();
+
+  act(() => closePalette());
+  inside.focus();
+  fireEvent.keyDown(inside, { key: "b", metaKey: true });
+  expect(prefsStore.getState().sidebarHidden).toBe(true);
+  close();
+});
+
+test("Mod+I and Mod+J are suppressed while an [aria-modal] dialog is open", async () => {
+  const focusSpy = vi.spyOn(composerFocus, "requestComposerFocus");
+  installNeedsYouRows();
+  window.history.pushState({}, "", "/s/local:ref_abc123");
+  installLocationForRoute("local:ref_abc123");
+  render(<AppShell client={navClient()} />);
+  await screen.findByText(/loading transcript/i);
+  const { inside, close } = openFakeModal();
+
+  fireEvent.keyDown(inside, { key: "i", metaKey: true });
+  fireEvent.keyDown(inside, { key: "j", metaKey: true });
+
+  expect(focusSpy).not.toHaveBeenCalled();
+  expect(workspaceStore.getState().mainPane()?.params).toMatchObject({ ref: "local:ref_abc123" });
+  close();
+});
+
+// --- claimed events / IME composition ----------------------------------------
+
+test("an isComposing keydown is ignored (IME input never triggers a chord)", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  fireEvent.keyDown(window, { key: "k", metaKey: true, isComposing: true });
+
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(paletteStore.getState().open).toBe(false);
+});
+
+test("Escape claimed by an earlier handler (defaultPrevented) does not close Settings", async () => {
+  window.history.pushState({}, "", "/settings");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByRole("navigation", { name: "Settings sections" });
+  const claimEscape = (event: globalThis.KeyboardEvent) => {
+    if (event.key === "Escape") event.preventDefault();
+  };
+  document.addEventListener("keydown", claimEscape, true);
+
+  try {
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(workspaceStore.getState().mainPane()?.type).toBe("settings");
+  } finally {
+    document.removeEventListener("keydown", claimEscape, true);
+  }
+
+  // Mechanism check: with the claiming handler gone, the same Escape DOES
+  // close the pane - the suppression above was the gate, not a dead chord.
+  fireEvent.keyDown(document.body, { key: "Escape" });
+  await screen.findByText("No session open");
+  expect(workspaceStore.getState().mainPane()?.type).not.toBe("settings");
+});
+
+// --- deliberately not migrated ----------------------------------------------
+
+test("FocusScope Tab cycling from a text field is unaffected by the dispatcher", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  render(
+    <FocusScope trap>
+      <input aria-label="Field" />
+      <button type="button">After</button>
+    </FocusScope>,
+  );
+
+  const field = screen.getByRole("textbox", { name: "Field" });
+  field.focus();
+  await user.tab();
+  expect(document.activeElement).toBe(screen.getByRole("button", { name: "After" }));
+  // Trapped: Tabbing past the last tabbable loops back to the first.
+  await user.tab();
+  expect(document.activeElement).toBe(field);
+});

--- a/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
@@ -14,11 +14,14 @@
 // (railController) hands it a session ref; if the rail is hidden, revealing
 // docks it first so there's a mounted Rail to expand + scroll.
 import { type JSX, useCallback, useEffect, useState } from "react";
+import { ACTIONS } from "../../keybindings/actions";
+import { keybindingsRegistry } from "../../keybindings/registry";
 import { selectNeedsYouCount } from "../../stores/navigation/selectors";
 import { useNavigationStore } from "../../stores/navigation/store";
 import { prefsStore, usePrefsStore } from "../../stores/prefs";
 import { Badge } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
+import { installKeybindings } from "../installKeybindings";
 import { useIsMobile } from "../useIsMobile";
 import { Rail } from "./Rail";
 import styles from "./RailHost.module.css";
@@ -28,20 +31,6 @@ const CLASS = {
   chipBar: requireClass(styles.chipBar, "RailHost.module.css", "chipBar"),
   chip: requireClass(styles.chip, "RailHost.module.css", "chip"),
 };
-
-// Ctrl+B is the macOS emacs-style "move cursor back one character" binding
-// native text fields honor while focused; without this guard, the ⌘B
-// listener below would hijack it mid-typing (it accepts ctrl as well as
-// meta for the cross-platform chord).
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  return (
-    target.isContentEditable ||
-    target.tagName === "INPUT" ||
-    target.tagName === "TEXTAREA" ||
-    target.tagName === "SELECT"
-  );
-}
 
 export function RailHost(_props: { railSlot?: never } = {}): JSX.Element {
   const isMobile = useIsMobile();
@@ -53,19 +42,20 @@ export function RailHost(_props: { railSlot?: never } = {}): JSX.Element {
   const clearReveal = useCallback(() => setRevealTarget(null), []);
 
   // ⌘B toggles the sidebar (desktop only — mobile's drawer is its own
-  // show/hide). PIN-D: ⌘B is the rail's; ⌘K (palette) is AppShell's.
+  // show/hide, and with no action registered the binding is inert there).
+  // PIN-D: ⌘B is the rail's; ⌘K (palette) is AppShell's. The chord itself is
+  // the keybindings dispatcher's (keybindings/defaults.ts's rail.toggle
+  // binding carries this listener's old policy verbatim: suppressed from
+  // editable targets so Ctrl+B keeps its emacs "cursor back" meaning in
+  // native text fields, and NO defaultPrevented check -
+  // ignoreIfDefaultPrevented: false).
   useEffect(() => {
     if (isMobile) return undefined;
-    function onKeyDown(event: KeyboardEvent): void {
-      if (isEditableTarget(event.target)) return;
-      if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "b") {
-        event.preventDefault();
-        const prefs = prefsStore.getState();
-        prefs.setSidebarHidden(!prefs.sidebarHidden);
-      }
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    installKeybindings();
+    return keybindingsRegistry.getState().registerAction(ACTIONS.railToggle, () => {
+      const prefs = prefsStore.getState();
+      prefs.setSidebarHidden(!prefs.sidebarHidden);
+    });
   }, [isMobile]);
 
   // Reveal seam (railController /project, PIN-A). Reveal-first when hidden:

--- a/docs/web-ui/README.md
+++ b/docs/web-ui/README.md
@@ -14,6 +14,9 @@ Design documentation for the web hub (`cmd/evener-hub`). Started 2026-06-16.
 - **[ux-plan-2026-07.md](ux-plan-2026-07.md)** — the five-participant study of
   the SPA against the old server-rendered build, and the plan that came out of
   it. Cited from live source comments.
+- **[keybindings.md](keybindings.md)** — the keybindings dispatcher: registry,
+  scope stack, precedence layers, per-binding policy flags, and how to
+  register an action or a chord.
 - **[parity/](parity/)** — the behaviour-parity checklists the React rewrite was
   graded against, mined from the legacy hub before it was deleted. The code they
   cite is gone, so their `path:line` citations no longer resolve; they survive

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -16,10 +16,10 @@ Four pieces, all in `src/keybindings/` and all React-free:
   round-trips an AST to a tinykeys string; `formatChord`/`formatSequence`
   render one for humans.
 - **registry.ts** — a vanilla zustand store holding three things: the
-  **action registry** (action id → run function), the **bindings** (chord →
-  action id, plus scope and policy flags), and the **scope stack**. The
-  app-wide singleton is `keybindingsRegistry`; tests build their own with
-  `createKeybindingsRegistry()`.
+  **action registry** (action id → its handlers, in registration order), the
+  **bindings** (chord → action id, plus scope and policy flags), and the
+  **scope stack**. The app-wide singleton is `keybindingsRegistry`; tests
+  build their own with `createKeybindingsRegistry()`.
 - **dispatcher.ts** — the single window-level `keydown` listener. On every
   registry change it rebuilds a tinykeys `createKeybindingsHandler` over the
   active scope set: the scope stack top-down, then the `global` scope.
@@ -67,8 +67,14 @@ When a `keydown` arrives, in order:
      fire from editable targets, as they always have.
 
 A binding whose action is not (yet) registered does not fire and does not
-preventDefault. A firing binding preventDefaults, then runs the action with
-the original event.
+preventDefault. When an action has handlers, they run in registration order
+until one accepts the event: a handler returns `false` to decline (the next
+handler is tried) and `true`/`undefined` to accept (iteration stops and the
+binding preventDefaults). An event every handler declines is not
+preventDefault'd. Multi-instance components rely on this: one SelectionQuote
+mounts per session pane, each registering `selection.quote`, and only the
+instance holding a captured selection accepts — the multi-instance
+equivalent of the per-component listeners the dispatcher replaced.
 
 ## Registering an action and a binding
 

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,0 +1,135 @@
+# Web UI keybindings
+
+Status: **current** (Phase 2a). The web hub's global keyboard chords are
+owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
+window-level dispatcher, instead of each component installing its own
+`keydown` listener.
+
+## Architecture
+
+Four pieces, all in `src/keybindings/` and all React-free:
+
+- **chord.ts** — the chord AST (`Chord` = required modifiers + optional
+  modifiers + key; `KeySequence` = a list of presses). `parseChord` wraps
+  tinykeys' `parseKeybinding`, so `$mod` resolves to `Meta` on Apple
+  platforms and `Control` elsewhere at parse time. `serializeChord`
+  round-trips an AST to a tinykeys string; `formatChord`/`formatSequence`
+  render one for humans.
+- **registry.ts** — a vanilla zustand store holding three things: the
+  **action registry** (action id → run function), the **bindings** (chord →
+  action id, plus scope and policy flags), and the **scope stack**. The
+  app-wide singleton is `keybindingsRegistry`; tests build their own with
+  `createKeybindingsRegistry()`.
+- **dispatcher.ts** — the single window-level `keydown` listener. On every
+  registry change it rebuilds a tinykeys `createKeybindingsHandler` over the
+  active scope set: the scope stack top-down, then the `global` scope.
+- **defaults.ts** — the built-in binding map (the six shell chords) and
+  `registerDefaultBindings`, which also registers each `$mod` chord's
+  cross-platform Meta/Control twin (the pre-dispatcher listeners accepted
+  `metaKey || ctrlKey` on every platform, so both work everywhere).
+
+The one wiring point that touches React and the app's stores is
+`src/shell/installKeybindings.ts`: an idempotent per-window installer that
+registers the default bindings and attaches the dispatcher with the real
+predicates injected. AppShell calls it at mount; every component that
+registers a chord action (RailHost, Settings, SelectionQuote) calls it too,
+so those components' chords also work when they are mounted without the
+shell — their unit tests render them standalone.
+
+## Precedence
+
+When a `keydown` arrives, in order:
+
+1. **IME composition** (`event.isComposing` / `keyCode === 229`) is ignored,
+   blanket.
+2. **Scope resolution**: the scope stack, top-down, then `global`. The first
+   (highest-precedence) binding for the chord claims it outright — a
+   shadowed or policy-blocked binding never falls through to a
+   lower-precedence twin, and a codeless synthetic event is matched against
+   a code-synthesized view (`fireEvent`-style events carry no `code`, and
+   tinykeys' `isKeyboardEvent` gate would otherwise drop them).
+3. **Per-binding policy** on the matched binding, in this order:
+   - `ignoreIfDefaultPrevented` (default **true**): a keydown another
+     handler already claimed is ignored. This is how Settings' Escape
+     coexists with a Dialog's own Escape-to-close (OverlayPanel
+     preventDefaults; the binding then skips).
+   - `allowInModal` (default **false**): an open modal suppresses the
+     binding. The injected predicate is
+     `paletteStore.getState().open || target.closest('[aria-modal="true"]')`
+     — the palette is not an `[aria-modal]` element, so the store half is
+     required. `palette.open`, `rail.toggle` and `selection.quote` are
+     exempt (`allowInModal: true`) because their pre-dispatcher listeners
+     had no modal guard.
+   - `allowInEditable` (default **false**): an editable event target
+     (`input`/`textarea`/`select`/contenteditable) suppresses the binding.
+     `rail.toggle` keeps this suppression so Ctrl+B keeps its emacs
+     "cursor back" meaning in native text fields; the other Mod chords
+     fire from editable targets, as they always have.
+
+A binding whose action is not (yet) registered does not fire and does not
+preventDefault. A firing binding preventDefaults, then runs the action with
+the original event.
+
+## Registering an action and a binding
+
+```ts
+import { ACTIONS } from "../keybindings/actions";
+import { keybindingsRegistry } from "../keybindings/registry";
+import { installKeybindings } from "./installKeybindings";
+
+// In a component effect; the disposer runs on unmount.
+useEffect(() => {
+  installKeybindings();
+  return keybindingsRegistry.getState().registerAction(ACTIONS.myAction, (event) => {
+    // ...
+  });
+}, []);
+```
+
+A new chord is a `registerBinding` call (or, for a built-in, a new entry in
+`DEFAULT_BINDINGS`):
+
+```ts
+keybindingsRegistry.getState().registerBinding({
+  id: "my-feature.my-chord",      // unique; duplicates throw
+  actionId: ACTIONS.myAction,
+  chord: "$mod+Shift+P",          // tinykeys syntax; [Alt] = optional modifier
+  scope: "my-pane",               // optional; defaults to "global"
+});
+```
+
+Registering the same chord twice in the SAME scope throws; the same chord in
+a DIFFERENT scope is allowed and shadowed deterministically by scope-stack
+order. A pane that owns a scope pushes it while open and pops it on unmount
+(`pushScope` returns an idempotent disposer) — Settings.tsx is the template:
+it pushes `SETTINGS_SCOPE` and registers `settings.close` in one effect.
+
+## Testing conventions
+
+- Module tests (`src/keybindings/*.test.ts`) use a private
+  `createKeybindingsRegistry()` and attach a dispatcher to `window`
+  directly. jsdom resolves `$mod` to `Control` on every host, so module
+  tests press Mod chords with `ctrlKey`.
+- App-level tests press chords the way the existing suites do
+  (`user.keyboard("{Meta>}k{/Meta}")`, `fireEvent.keyDown(...)`) — the
+  Meta/Control twin registration makes those exercise the same path
+  production does. Include `code` or don't; both match.
+- Migration/behavior tests for the shell chords live in
+  `src/shell/keybindingsMigration.test.tsx`. Assert observable effects (the
+  palette opened, `requestComposerFocus` was called, the pane closed), not
+  dispatcher internals.
+- Determinism: no timers, no network, no localStorage in the module itself.
+  A component's action registration/scope push must be undone by its effect
+  cleanup so the next test in the file starts clean.
+
+## Deliberately not here yet
+
+Phase 2a is a behavior-preserving migration only. Later phases of the
+webui-keybindings plan add, and this module already leaves room for:
+
+- **Server persistence / user remapping** (Phase 2b) — `Binding.when` is
+  stored verbatim and never evaluated yet; bindings are the compiled-in
+  defaults only.
+- **A shortcuts overlay / cheatsheet UI** (Phase 3).
+- **Hold-modifier chord hints** (Phase 4) — `formatChord`/`formatSequence`
+  exist for exactly this consumer.


### PR DESCRIPTION
## Summary

Phase 2a of the webui keybinding project (survey: #853): the keybinding **infrastructure**, landed with **no user-visible behavior change**.

- New `src/keybindings/` module (React-free): chord parser/serializer built on **tinykeys 4** (new dependency, ~1 KB gz), zustand **registry** with scope stack + conflict detection, single window-level **dispatcher** with per-binding policy flags (`allowInEditable`, `allowInModal`, `ignoreIfDefaultPrevented`), and the default six-chord map.
- All six global chords migrated off their per-component listeners onto the dispatcher: ⌘K (palette), ⌘B (rail), ⌘I (composer focus), ⌘J (needs-you cycle), ⌘' (selection quote), Settings Escape (now scope-gated). Every legacy guard is preserved exactly — including ⌘K's modal exemption, ⌘B's missing `defaultPrevented` check, the AltGr guard on ⌘', extra-modifier permissiveness on K/I/J and Settings Escape, and multi-pane SelectionQuote semantics (multi-handler action registration).
- `src/shell/installKeybindings.ts` — the single (idempotent) wiring point where the module meets the app's stores.
- Dev doc: `docs/web-ui/keybindings.md` — architecture, precedence policy, how to register actions/bindings, testing conventions, and what is deliberately deferred (persistence → Phase 2b, overlay/hints → Phase 4).

Not here yet: server-persisted user remapping (Phase 2b), new navigation bindings (Phase 3), cheatsheet overlay and hold-modifier hints (Phase 4).

## Test plan

- `make test-web` green (typecheck + unit + biome), run on the final tree.
- All pre-existing frontend tests pass unmodified; new migration suite (`keybindingsMigration.test.tsx`) pins the legacy guard contract (chords from inputs, modal interplay, IME suppression, claimed-event handling, FocusScope Tab).
- Module suites: 87/87; two fix rounds reviewed and re-reviewed (per-binding `defaultPrevented` opt-out; multi-instance action registration), plus a final whole-branch review with one ruled fix wave (extra-modifier preservation).

🤖 Generated via subagent-driven development with per-task and whole-branch review.