### PR TITLE
feat(hub,web): server-persisted keybinding overrides (Phase 2b)

### DIFF
--- a/appwire/keybindings.go
+++ b/appwire/keybindings.go
@@ -1,0 +1,177 @@
+package appwire
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	MethodEvenerSettingsKeybindingsGet   = "evener/settings/keybindings/get"
+	MethodEvenerSettingsKeybindingsPatch = "evener/settings/keybindings/patch"
+
+	NotifyEvenerSettingsKeybindingsChanged = "evener/settings/keybindings/changed"
+)
+
+// KeybindingsRule is one user override: a non-nil Chord rebinds the action, a
+// nil Chord (JSON null) unbinds it. The server stores rules verbatim; last
+// rule wins on conflict, resolved by the frontend.
+type KeybindingsRule struct {
+	Action string  `json:"action"`
+	Chord  *string `json:"chord"`
+}
+
+// KeybindingsConfig is the user-controlled part of the keybindings overrides:
+// the payload contract minus the store-owned revision.
+type KeybindingsConfig struct {
+	Version int               `json:"version"`
+	Rules   []KeybindingsRule `json:"rules"`
+}
+
+// KeybindingsOverrides is the canonical payload returned by the get method and
+// broadcast on change: {version, revision, rules}.
+type KeybindingsOverrides struct {
+	Version  int               `json:"version"`
+	Revision uint64            `json:"revision"`
+	Rules    []KeybindingsRule `json:"rules"`
+}
+
+// KeybindingsGetResponse is kept as an operation-oriented name for callers;
+// the wire result's underlying named type is KeybindingsOverrides.
+type KeybindingsGetResponse = KeybindingsOverrides
+
+type KeybindingsPatchParams struct {
+	ExpectedRevision uint64            `json:"expectedRevision"`
+	Config           KeybindingsConfig `json:"config"`
+}
+
+type KeybindingsPatchResponse = KeybindingsOverrides
+
+type KeybindingsChangedParams = KeybindingsOverrides
+
+type KeybindingsChangedNotification = KeybindingsOverrides
+
+type KeybindingsConflictData struct {
+	EvenerErrorInfo ErrorInfo            `json:"evenerErrorInfo"`
+	Current         KeybindingsOverrides `json:"current"`
+}
+
+const keybindingsConfigVersion = 1
+
+// KeybindingsShippedDefaults is the payload when nothing is persisted: empty
+// overrides (all default bindings) at revision 0.
+func KeybindingsShippedDefaults() KeybindingsOverrides {
+	return KeybindingsOverrides{Version: keybindingsConfigVersion, Rules: []KeybindingsRule{}}
+}
+
+// ValidateKeybindingsConfig checks the structural contract only: the version
+// and rule-field sanity. Semantic validation (action ids, reserved chords,
+// conflicts) is the frontend's job; the server does not know the action
+// registry.
+func ValidateKeybindingsConfig(config KeybindingsConfig) error {
+	if config.Version != keybindingsConfigVersion {
+		return fmt.Errorf("unsupported keybindings config version %d", config.Version)
+	}
+	for i, rule := range config.Rules {
+		if strings.TrimSpace(rule.Action) == "" {
+			return fmt.Errorf("rule %d: action must be a non-empty string", i)
+		}
+		if rule.Chord != nil && strings.TrimSpace(*rule.Chord) == "" {
+			return fmt.Errorf("rule %d (%s): chord must be null or a non-empty string", i, rule.Action)
+		}
+	}
+	return nil
+}
+
+func DecodeKeybindingsPatchParams(raw json.RawMessage) (KeybindingsPatchParams, error) {
+	var params KeybindingsPatchParams
+	if err := decodeKeybindingsStrictJSON(raw, &params); err != nil {
+		return KeybindingsPatchParams{}, err
+	}
+
+	top, err := keybindingsObjectFields(raw)
+	if err != nil {
+		return KeybindingsPatchParams{}, err
+	}
+	if err := requireKeybindingsFields(top, "expectedRevision", "config"); err != nil {
+		return KeybindingsPatchParams{}, err
+	}
+	if string(bytes.TrimSpace(top["expectedRevision"])) == "null" {
+		return KeybindingsPatchParams{}, errors.New("expectedRevision must be an unsigned integer")
+	}
+
+	configFields, err := keybindingsObjectFields(top["config"])
+	if err != nil {
+		return KeybindingsPatchParams{}, fmt.Errorf("config: %w", err)
+	}
+	if err := requireKeybindingsFields(configFields, "version", "rules"); err != nil {
+		return KeybindingsPatchParams{}, fmt.Errorf("config: %w", err)
+	}
+	if string(bytes.TrimSpace(configFields["version"])) == "null" {
+		return KeybindingsPatchParams{}, errors.New("config: version must be an integer")
+	}
+	if string(bytes.TrimSpace(configFields["rules"])) == "null" {
+		return KeybindingsPatchParams{}, errors.New("config: rules must be an array")
+	}
+
+	var rules []json.RawMessage
+	if err := json.Unmarshal(configFields["rules"], &rules); err != nil {
+		return KeybindingsPatchParams{}, fmt.Errorf("config: rules: %w", err)
+	}
+	for i, rawRule := range rules {
+		ruleFields, err := keybindingsObjectFields(rawRule)
+		if err != nil {
+			return KeybindingsPatchParams{}, fmt.Errorf("rule %d: %w", i, err)
+		}
+		if err := requireKeybindingsFields(ruleFields, "action", "chord"); err != nil {
+			return KeybindingsPatchParams{}, fmt.Errorf("rule %d: %w", i, err)
+		}
+		if string(bytes.TrimSpace(ruleFields["action"])) == "null" {
+			return KeybindingsPatchParams{}, fmt.Errorf("rule %d: action must be a string", i)
+		}
+	}
+
+	if err := ValidateKeybindingsConfig(params.Config); err != nil {
+		return KeybindingsPatchParams{}, err
+	}
+	return params, nil
+}
+
+func decodeKeybindingsStrictJSON(raw []byte, dst any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return fmt.Errorf("invalid keybindings patch: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return errors.New("invalid keybindings patch: trailing JSON value")
+		}
+		return fmt.Errorf("invalid keybindings patch: trailing JSON: %w", err)
+	}
+	return nil
+}
+
+func keybindingsObjectFields(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	if fields == nil {
+		return nil, errors.New("expected JSON object")
+	}
+	return fields, nil
+}
+
+func requireKeybindingsFields(fields map[string]json.RawMessage, names ...string) error {
+	for _, name := range names {
+		if _, ok := fields[name]; !ok {
+			return fmt.Errorf("missing required field %q", name)
+		}
+	}
+	return nil
+}

--- a/appwire/keybindings_test.go
+++ b/appwire/keybindings_test.go
@@ -1,0 +1,150 @@
+package appwire
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestKeybindingsShippedDefaults(t *testing.T) {
+	got := KeybindingsShippedDefaults()
+	if got.Version != 1 {
+		t.Errorf("defaults version = %d, want 1", got.Version)
+	}
+	if got.Revision != 0 {
+		t.Errorf("defaults revision = %d, want 0", got.Revision)
+	}
+	if got.Rules == nil || len(got.Rules) != 0 {
+		t.Errorf("defaults rules = %#v, want empty non-nil slice", got.Rules)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `{"version":1,"revision":0,"rules":[]}`; string(encoded) != want {
+		t.Fatalf("defaults JSON = %s, want %s", encoded, want)
+	}
+}
+
+func TestDecodeKeybindingsPatchAcceptsRebindAndUnbind(t *testing.T) {
+	raw := json.RawMessage(`{"expectedRevision":3,"config":{"version":1,"rules":[{"action":"thread.new","chord":"ctrl+n"},{"action":"thread.close","chord":null}]}}`)
+	got, err := DecodeKeybindingsPatchParams(raw)
+	if err != nil {
+		t.Fatalf("valid patch rejected: %v", err)
+	}
+	if got.ExpectedRevision != 3 || got.Config.Version != 1 || len(got.Config.Rules) != 2 {
+		t.Fatalf("decoded = %#v", got)
+	}
+	rebind := got.Config.Rules[0]
+	if rebind.Action != "thread.new" || rebind.Chord == nil || *rebind.Chord != "ctrl+n" {
+		t.Fatalf("rebind rule = %#v", rebind)
+	}
+	unbind := got.Config.Rules[1]
+	if unbind.Action != "thread.close" || unbind.Chord != nil {
+		t.Fatalf("unbind rule = %#v", unbind)
+	}
+}
+
+func TestDecodeKeybindingsPatchAcceptsEmptyRules(t *testing.T) {
+	raw := json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[]}}`)
+	got, err := DecodeKeybindingsPatchParams(raw)
+	if err != nil {
+		t.Fatalf("empty rules rejected: %v", err)
+	}
+	if got.Config.Rules == nil || len(got.Config.Rules) != 0 {
+		t.Fatalf("decoded rules = %#v, want empty non-nil slice", got.Config.Rules)
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsUnknownFields(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"top level": json.RawMessage(`{"expectedRevision":0,"unexpected":true,"config":{"version":1,"rules":[]}}`),
+		"config":    json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[],"unexpected":true}}`),
+		"rule":      json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"thread.new","chord":"ctrl+n","unexpected":true}]}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+				t.Fatal("unknown field accepted")
+			}
+		})
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsMissingFields(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"expectedRevision": json.RawMessage(`{"config":{"version":1,"rules":[]}}`),
+		"config":           json.RawMessage(`{"expectedRevision":0}`),
+		"version":          json.RawMessage(`{"expectedRevision":0,"config":{"rules":[]}}`),
+		"rules":            json.RawMessage(`{"expectedRevision":0,"config":{"version":1}}`),
+		"rule action":      json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"chord":"ctrl+n"}]}}`),
+		"rule chord":       json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"thread.new"}]}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+				t.Fatal("missing field accepted")
+			}
+		})
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsNullScalars(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"expectedRevision": json.RawMessage(`{"expectedRevision":null,"config":{"version":1,"rules":[]}}`),
+		"version":          json.RawMessage(`{"expectedRevision":0,"config":{"version":null,"rules":[]}}`),
+		"rules":            json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":null}}`),
+		"rule action":      json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":null,"chord":"ctrl+n"}]}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+				t.Fatal("null scalar accepted")
+			}
+		})
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsTrailingJSON(t *testing.T) {
+	raw := json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[]}} {}`)
+	if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+		t.Fatal("trailing JSON accepted")
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsInvalidValues(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"version":           json.RawMessage(`{"expectedRevision":0,"config":{"version":2,"rules":[]}}`),
+		"empty action":      json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"","chord":"ctrl+n"}]}}`),
+		"whitespace action": json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"  ","chord":"ctrl+n"}]}}`),
+		"empty chord":       json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"thread.new","chord":""}]}}`),
+		"whitespace chord":  json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"thread.new","chord":" \t "}]}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+				t.Fatal("invalid value accepted")
+			}
+		})
+	}
+}
+
+func TestValidateKeybindingsConfigRejectsInvalidShapes(t *testing.T) {
+	chord := "ctrl+n"
+	empty := ""
+	tests := []struct {
+		name   string
+		config KeybindingsConfig
+	}{
+		{name: "version", config: KeybindingsConfig{Version: 2, Rules: []KeybindingsRule{}}},
+		{name: "empty action", config: KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: "", Chord: &chord}}}},
+		{name: "whitespace action", config: KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: " ", Chord: &chord}}}},
+		{name: "empty chord", config: KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: "thread.new", Chord: &empty}}}},
+		{name: "whitespace chord", config: KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: "thread.new", Chord: &[]string{"\n"}[0]}}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateKeybindingsConfig(tc.config); err == nil {
+				t.Fatal("invalid config accepted")
+			}
+		})
+	}
+	if err := ValidateKeybindingsConfig(KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: "thread.new", Chord: &chord}, {Action: "thread.close"}}}); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+}

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -197,6 +197,8 @@ var Methods = []MethodSpec{
 	{MethodEvenerSettingsOverview, EmptyParams{}, SettingsOverviewResponse{}, ScopeHub, "Returns the settings overview field bag: hub/runtime, storage, agent roster, codex launch configs, and probed MCP servers — the six template-only settings sections' data."},
 	{MethodEvenerSettingsTranscriptDisplayGet, EmptyParams{}, TranscriptDisplayDefaults{}, ScopeHub, "Reads the canonical Desktop and Mobile transcript-display defaults."},
 	{MethodEvenerSettingsTranscriptDisplayPatch, TranscriptDisplayDefaultsPatchParams{}, TranscriptDisplayPatchResponse{}, ScopeHub, "Updates one transcript-display default using an expected revision and returns the canonical value."},
+	{MethodEvenerSettingsKeybindingsGet, EmptyParams{}, KeybindingsOverrides{}, ScopeHub, "Reads the canonical user keybinding overrides (version, revision, rules)."},
+	{MethodEvenerSettingsKeybindingsPatch, KeybindingsPatchParams{}, KeybindingsOverrides{}, ScopeHub, "Replaces the user keybinding overrides using an expected revision and returns the canonical value."},
 	{MethodEvenerSandboxEscalationResolve, SandboxEscalationResolveParams{}, EmptyResponse{}, ScopeBoth, "Delivers a human's approve/deny decision for a pending sandbox-exemption escalation (M7); the daemon unblocks the waiting tool-exec goroutine, the hub relays."},
 }
 
@@ -289,4 +291,5 @@ var Notifications = []NotificationSpec{
 	{NotifyEvenerSandboxEscalationRequested, SandboxEscalationRequested{}, "A harness-raised, human-gated sandbox-exemption approval card (M7); the tool-exec goroutine blocks until answered via evener/sandbox/escalation/resolve."},
 	{NotifyEvenerSandboxEscalationResolved, SandboxEscalationResolved{}, "A previously-raised sandbox escalation left the pending set — resolved, turn-interrupted, or cleared by session close (M7); every OTHER subscribed client clears its now-stale copy of the card."},
 	{NotifyEvenerSettingsTranscriptDisplayChanged, TranscriptDisplayChangedParams{}, "Broadcast after a transcript-display default changes; carries the layout, revision, and canonical configuration."},
+	{NotifyEvenerSettingsKeybindingsChanged, KeybindingsOverrides{}, "Broadcast after the user keybinding overrides change; carries the revision and canonical rules."},
 }

--- a/appwire/protocol_test.go
+++ b/appwire/protocol_test.go
@@ -246,6 +246,63 @@ func TestTranscriptDisplayCatalog(t *testing.T) {
 	}
 }
 
+func TestKeybindingsCatalog(t *testing.T) {
+	methods := map[string]MethodSpec{}
+	for _, method := range Methods {
+		methods[method.Name] = method
+	}
+	for _, name := range []string{
+		MethodEvenerSettingsKeybindingsGet,
+		MethodEvenerSettingsKeybindingsPatch,
+	} {
+		method, ok := methods[name]
+		if !ok {
+			t.Fatalf("method catalog missing %s", name)
+		}
+		if method.Scope != ScopeHub {
+			t.Errorf("method %s scope = %q, want %q", name, method.Scope, ScopeHub)
+		}
+	}
+	var changed *NotificationSpec
+	for i := range Notifications {
+		if Notifications[i].Name == NotifyEvenerSettingsKeybindingsChanged {
+			changed = &Notifications[i]
+			break
+		}
+	}
+	if changed == nil {
+		t.Fatalf("notification catalog missing %s", NotifyEvenerSettingsKeybindingsChanged)
+	}
+	if reflect.TypeOf(changed.Payload) != reflect.TypeFor[KeybindingsOverrides]() {
+		t.Fatalf("changed payload type = %T, want %T", changed.Payload, KeybindingsOverrides{})
+	}
+}
+
+func TestFeatureSetKeybindingsJSONField(t *testing.T) {
+	encoded, err := json.Marshal(FeatureSet{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(`"keybindingsSettings"`)) {
+		t.Fatalf("false feature must be omitted: %s", encoded)
+	}
+	encoded, err = json.Marshal(FeatureSet{KeybindingsSettings: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(encoded, []byte(`"keybindingsSettings":true`)) {
+		t.Fatalf("true feature missing from JSON: %s", encoded)
+	}
+
+	generated, err := os.ReadFile("../cmd/evener-hub/frontend/src/protocol/types.gen.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(generated, []byte("keybindingsSettings?: boolean;")) {
+		t.Fatal("generated TypeScript feature field is not optional")
+	}
+}
+
 func TestFeatureSetTranscriptDisplayJSONField(t *testing.T) {
 	encoded, err := json.Marshal(FeatureSet{})
 	if err != nil {
@@ -397,6 +454,7 @@ func TestThreadNotificationsRequireAuthoritativeRoutingIdentity(t *testing.T) {
 		NotifyEvenerPluginUpdated:                    true,
 		NotifyEvenerNavigationInvalidated:            true,
 		NotifyEvenerSettingsTranscriptDisplayChanged: true,
+		NotifyEvenerSettingsKeybindingsChanged:       true,
 	}
 	for _, notification := range Notifications {
 		if global[notification.Name] {

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -469,6 +469,7 @@ type FeatureSet struct {
 	DirectoryComplete         bool `json:"directoryComplete"`
 	Auth                      bool `json:"auth"`
 	TranscriptDisplaySettings bool `json:"transcriptDisplaySettings,omitempty"`
+	KeybindingsSettings       bool `json:"keybindingsSettings,omitempty"`
 }
 
 type Thread struct {

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -176,6 +176,7 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 			DirectoryComplete:         true,
 			Auth:                      true,
 			TranscriptDisplaySettings: true,
+			KeybindingsSettings:       true,
 		},
 	})
 	hubStateRoot := cfg.HubStateRoot
@@ -220,6 +221,7 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 	registerMiscHandlers(server, cfg, sources)
 	registerPluginAutoUpgradeHandlers(server, plugins.NewManager(cfg.PluginRoot))
 	registerTranscriptDisplayHandlers(server, cfg.TranscriptDisplayStore)
+	registerKeybindingsHandlers(server, cfg.KeybindingsStore)
 	return server
 }
 

--- a/cmd/evener-hub/app_rpc_keybindings.go
+++ b/cmd/evener-hub/app_rpc_keybindings.go
@@ -1,0 +1,32 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/appserver"
+)
+
+func registerKeybindingsHandlers(server *appserver.Server, store *hubcore.KeybindingsStore) {
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsKeybindingsGet,
+		func(context.Context, appwire.EmptyParams) (appwire.KeybindingsOverrides, error) {
+			return store.Snapshot(), nil
+		})
+	server.Router().Handle(appwire.MethodEvenerSettingsKeybindingsPatch,
+		func(_ context.Context, raw json.RawMessage) (any, error) {
+			params, err := appwire.DecodeKeybindingsPatchParams(raw)
+			if err != nil {
+				return nil, appwire.InvalidParams(err.Error())
+			}
+			result, err := store.Patch(params)
+			if err != nil {
+				return nil, err
+			}
+			if result.Revision != params.ExpectedRevision {
+				server.BroadcastAll(appwire.NotifyEvenerSettingsKeybindingsChanged, result)
+			}
+			return result, nil
+		})
+}

--- a/cmd/evener-hub/app_rpc_keybindings_test.go
+++ b/cmd/evener-hub/app_rpc_keybindings_test.go
@@ -1,0 +1,372 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestHubRPCKeybindingsGetReturnsCanonicalShippedDefaults(t *testing.T) {
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: t.TempDir()})
+	defer hub.Close()
+
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	init, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion})
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if !init.Features.KeybindingsSettings {
+		t.Fatalf("keybindings capability is false: %+v", init.Features)
+	}
+
+	var got appwire.KeybindingsOverrides
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if want := appwire.KeybindingsShippedDefaults(); !equalKeybindingsOverrides(got, want) {
+		t.Fatalf("GET defaults = %#v, want %#v", got, want)
+	}
+}
+
+func TestHubRPCKeybindingsPatchBroadcastsCanonicalValue(t *testing.T) {
+	store, err := hubcore.NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{KeybindingsStore: store})
+	defer hub.Close()
+
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChordPtr("ctrl+n")},
+		{Action: "thread.close", Chord: nil},
+	}}
+	var result appwire.KeybindingsPatchResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 0,
+			Config:           config,
+		}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Revision != 1 || result.Version != 1 || !equalKeybindingsRules(result.Rules, config.Rules) {
+		t.Fatalf("PATCH result = %#v, want revision 1 and canonical rules", result)
+	}
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		notification := receiveKeybindingsChanged(t, client)
+		if notification.Revision != result.Revision || notification.Version != result.Version || !equalKeybindingsRules(notification.Rules, result.Rules) {
+			t.Fatalf("notification = %#v, result = %#v", notification, result)
+		}
+	}
+}
+
+func TestHubRPCKeybindingsPatchRawUnknownFieldRejectedWithoutNotification(t *testing.T) {
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: t.TempDir()})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := json.Marshal(map[string]any{
+		"expectedRevision": 0,
+		"config": map[string]any{
+			"version": 1,
+			"rules":   []any{},
+		},
+		"unknown": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result appwire.KeybindingsPatchResponse
+	err = client.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch, json.RawMessage(raw), &result)
+	assertKeybindingsWireCode(t, err, appwire.CodeInvalidParams)
+	assertNoKeybindingsNotification(t, client)
+}
+
+func TestHubRPCKeybindingsPatchFailuresDoNotNotify(t *testing.T) {
+	root := t.TempDir()
+	store, err := hubcore.NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{KeybindingsStore: store})
+	defer hub.Close()
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	defaults := appwire.KeybindingsShippedDefaults()
+	var noOp appwire.KeybindingsPatchResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 0,
+			Config:           appwire.KeybindingsConfig{Version: defaults.Version, Rules: defaults.Rules},
+		}, &noOp); err != nil {
+		t.Fatalf("no-op PATCH: %v", err)
+	}
+	if noOp.Revision != 0 {
+		t.Fatalf("no-op revision = %d, want 0", noOp.Revision)
+	}
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+
+	invalidRaw, err := json.Marshal(map[string]any{
+		"expectedRevision": 0,
+		"config": map[string]any{
+			"version": 99,
+			"rules":   []any{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var invalidResult appwire.KeybindingsPatchResponse
+	err = clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch, json.RawMessage(invalidRaw), &invalidResult)
+	assertKeybindingsWireCode(t, err, appwire.CodeInvalidParams)
+	if !containsKeybindingsError(err, "unsupported keybindings config version") {
+		t.Fatalf("structural validation error = %v, want unsupported-version diagnostic", err)
+	}
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+
+	changed := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChordPtr("ctrl+n")},
+	}}
+	var first appwire.KeybindingsPatchResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 0,
+			Config:           changed,
+		}, &first); err != nil {
+		t.Fatalf("first PATCH: %v", err)
+	}
+	_ = receiveKeybindingsChanged(t, clientA)
+	_ = receiveKeybindingsChanged(t, clientB)
+
+	var staleResult appwire.KeybindingsPatchResponse
+	err = clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 0,
+			Config:           appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{}},
+		}, &staleResult)
+	var conflict appwire.WireError
+	if !errors.As(err, &conflict) || conflict.Code != appwire.CodeConflict {
+		t.Fatalf("stale PATCH error = %T %v, want conflict", err, err)
+	}
+	var conflictData appwire.KeybindingsConflictData
+	conflictJSON, err := json.Marshal(conflict.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(conflictJSON, &conflictData); err != nil {
+		t.Fatalf("decode conflict data: %v", err)
+	}
+	if conflictData.EvenerErrorInfo != appwire.ErrorConflict || conflictData.Current.Revision != 1 || !equalKeybindingsRules(conflictData.Current.Rules, changed.Rules) {
+		t.Fatalf("conflict data = %#v, want current revision 1 with canonical rules", conflictData)
+	}
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+
+	if err := os.RemoveAll(filepath.Join(root, "keybindings")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "keybindings"), []byte("blocked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	failedConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChordPtr("ctrl+alt+n")},
+	}}
+	var failedResult appwire.KeybindingsPatchResponse
+	err = clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 1,
+			Config:           failedConfig,
+		}, &failedResult)
+	assertKeybindingsWireCode(t, err, appwire.CodeInternalError)
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+}
+
+func TestHubRPCKeybindingsPatchPersistsAcrossRestart(t *testing.T) {
+	root := t.TempDir()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: root})
+	client := dialHubRPC(t, hub)
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChordPtr("ctrl+n")},
+		{Action: "thread.close", Chord: nil},
+	}}
+	var result appwire.KeybindingsPatchResponse
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{Config: config}, &result); err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	_ = receiveKeybindingsChanged(t, client)
+	client.Close()
+	hub.Close()
+
+	hub = newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: root})
+	defer hub.Close()
+	client = dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	var got appwire.KeybindingsOverrides
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("GET after restart: %v", err)
+	}
+	if got.Revision != 1 || got.Version != 1 || !equalKeybindingsRules(got.Rules, config.Rules) {
+		t.Fatalf("GET after restart = %#v, want revision 1 and canonical rules", got)
+	}
+}
+
+func TestHubRPCKeybindingsMalformedStateUsesFallbackAndRemainsReadOnly(t *testing.T) {
+	root := t.TempDir()
+	statePath := filepath.Join(root, "keybindings", "state.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	malformed := []byte(`{"version":1,"revision":`)
+	if err := os.WriteFile(statePath, malformed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	hub, web := newHubRPCTestServerWithWeb(t, hubcore.WebConfig{HubStateRoot: root})
+	defer hub.Close()
+	if web.cfg.KeybindingsStore == nil || web.keybindingsStoreErr == nil {
+		t.Fatalf("malformed startup store=%p loadErr=%v, want non-nil fallback and diagnostic", web.cfg.KeybindingsStore, web.keybindingsStoreErr)
+	}
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var got appwire.KeybindingsOverrides
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("GET malformed state: %v", err)
+	}
+	if want := appwire.KeybindingsShippedDefaults(); !equalKeybindingsOverrides(got, want) {
+		t.Fatalf("GET malformed state = %#v, want fallback %#v", got, want)
+	}
+	var result appwire.KeybindingsPatchResponse
+	err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{Config: appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+			{Action: "thread.new", Chord: keybindingsChordPtr("ctrl+n")},
+		}}}, &result)
+	assertKeybindingsWireCode(t, err, appwire.CodeInternalError)
+	if !containsKeybindingsError(err, "decode keybindings state") {
+		t.Fatalf("malformed-state PATCH error = %v, want load diagnostic", err)
+	}
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+	unchanged, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(unchanged, malformed) {
+		t.Fatalf("malformed state was overwritten: %q", unchanged)
+	}
+}
+
+func receiveKeybindingsChanged(t *testing.T, client *appwire.Client) appwire.KeybindingsChangedParams {
+	t.Helper()
+	select {
+	case notification := <-client.Notifications():
+		if notification.Method != appwire.NotifyEvenerSettingsKeybindingsChanged {
+			t.Fatalf("notification method = %q, want %q", notification.Method, appwire.NotifyEvenerSettingsKeybindingsChanged)
+		}
+		var params appwire.KeybindingsChangedParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode notification: %v", err)
+		}
+		return params
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for keybindings notification")
+		return appwire.KeybindingsChangedParams{}
+	}
+}
+
+func assertNoKeybindingsNotification(t *testing.T, client *appwire.Client) {
+	t.Helper()
+	select {
+	case notification := <-client.Notifications():
+		t.Fatalf("unexpected notification %q", notification.Method)
+	default:
+	}
+}
+
+func assertKeybindingsWireCode(t *testing.T, err error, code int) {
+	t.Helper()
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != code {
+		t.Fatalf("error = %T %v, want wire code %d", err, err, code)
+	}
+}
+
+func containsKeybindingsError(err error, want string) bool {
+	return err != nil && strings.Contains(err.Error(), want)
+}
+
+func equalKeybindingsOverrides(a, b appwire.KeybindingsOverrides) bool {
+	return a.Version == b.Version && a.Revision == b.Revision && equalKeybindingsRules(a.Rules, b.Rules)
+}
+
+func equalKeybindingsRules(a, b []appwire.KeybindingsRule) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	for i := range a {
+		if a[i].Action != b[i].Action {
+			return false
+		}
+		if (a[i].Chord == nil) != (b[i].Chord == nil) {
+			return false
+		}
+		if a[i].Chord != nil && *a[i].Chord != *b[i].Chord {
+			return false
+		}
+	}
+	return true
+}
+
+func keybindingsChordPtr(chord string) *string {
+	return &chord
+}

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11132,6 +11132,8 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodEvenerSettingsOverview,
 		appwire.MethodEvenerSettingsTranscriptDisplayGet,
 		appwire.MethodEvenerSettingsTranscriptDisplayPatch,
+		appwire.MethodEvenerSettingsKeybindingsGet,
+		appwire.MethodEvenerSettingsKeybindingsPatch,
 		appwire.MethodEvenerMarketplaceList,
 		appwire.MethodEvenerMarketplaceAdd,
 		appwire.MethodEvenerMarketplaceRemove,

--- a/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { type Chord, formatChord, formatSequence, parseChord, serializeChord } from "./chord";
+import { type Chord, chordsOverlap, formatChord, formatSequence, parseChord, serializeChord } from "./chord";
 
 function singleChord(input: string): Chord {
   const sequence = parseChord(input);
@@ -98,5 +98,42 @@ describe("formatChord", () => {
 describe("formatSequence", () => {
   test("joins presses with a space", () => {
     expect(formatSequence(parseChord("Shift+A b"))).toBe("Shift+A b");
+  });
+});
+
+describe("chordsOverlap", () => {
+  test("identical single-press chords overlap", () => {
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+K"))).toBe(true);
+  });
+
+  test("keys match case-insensitively", () => {
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+k"))).toBe(true);
+  });
+
+  test("an exact-required chord overlaps a chord that lists the rest as OPTIONAL", () => {
+    // The dispatch-time shadowing the whole-branch review flagged: Control+K
+    // matches palette.open's Control+[Meta]+[Shift]+[Alt]+K default.
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+[Meta]+[Shift]+[Alt]+K"))).toBe(true);
+    // Symmetrically, the fully-loaded press also overlaps the plain one.
+    expect(chordsOverlap(parseChord("Control+[Meta]+[Shift]+[Alt]+K"), parseChord("Control+K"))).toBe(true);
+  });
+
+  test("an extra REQUIRED modifier escapes the overlap when the other side does not allow it", () => {
+    expect(chordsOverlap(parseChord("Control+Alt+B"), parseChord("Control+B"))).toBe(false);
+    expect(chordsOverlap(parseChord("Control+B"), parseChord("Control+Alt+B"))).toBe(false);
+  });
+
+  test("an extra required modifier still overlaps when the other side lists it as optional", () => {
+    expect(chordsOverlap(parseChord("Control+Alt+K"), parseChord("Control+[Alt]+K"))).toBe(true);
+  });
+
+  test("different keys never overlap", () => {
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+J"))).toBe(false);
+  });
+
+  test("multi-press sequences fall back to serialization equality", () => {
+    expect(chordsOverlap(parseChord("Control+K Control+W"), parseChord("Control+K Control+W"))).toBe(true);
+    expect(chordsOverlap(parseChord("Control+K Control+W"), parseChord("Control+K Control+V"))).toBe(false);
+    expect(chordsOverlap(parseChord("Control+K Control+W"), parseChord("Control+K"))).toBe(false);
   });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -56,6 +56,35 @@ export function serializeChord(sequence: KeySequence): string {
   return sequence.map(serializePress).join(" ");
 }
 
+/** Do two chords share a matching key event? Two SINGLE-press chords overlap
+ * when their keys match case-insensitively AND each side's required-modifier
+ * set is a subset of the other side's required ∪ optional set - the exact
+ * condition for one KeyboardEvent's modifier state to satisfy both. This is
+ * the conflict predicate for validation and rebind: serialization equality
+ * alone misses e.g. Control+K vs a default's Control+[Meta]+[Shift]+[Alt]+K,
+ * which the same event matches (the earlier-registered binding shadows the
+ * later one at dispatch).
+ *
+ * Multi-press sequences keep the old serialization-equality check: a
+ * per-press overlap extension is out of scope (user multi-press overrides
+ * are rare, and a false non-conflict there has the same shadowing symptom,
+ * just far less likely). Regex keys (tinykeys' "(...)" syntax) compare by
+ * source text, so only identical regexes overlap. */
+export function chordsOverlap(a: KeySequence, b: KeySequence): boolean {
+  if (a.length !== 1 || b.length !== 1) return serializeChord(a) === serializeChord(b);
+  const pressA = a[0];
+  const pressB = b[0];
+  if (pressA === undefined || pressB === undefined) return false;
+  if (keyIdentity(pressA) !== keyIdentity(pressB)) return false;
+  const allowedA = [...pressA.modifiers, ...pressA.optionalModifiers];
+  const allowedB = [...pressB.modifiers, ...pressB.optionalModifiers];
+  return pressA.modifiers.every((m) => allowedB.includes(m)) && pressB.modifiers.every((m) => allowedA.includes(m));
+}
+
+function keyIdentity(chord: Chord): string {
+  return chord.key instanceof RegExp ? chord.key.source : chord.key.toLowerCase();
+}
+
 function serializePress(chord: Chord): string {
   const mods = [...chord.modifiers, ...chord.optionalModifiers.map((m) => `[${m}]`)];
   return [...mods, serializeKey(chord.key)].join("+");

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -79,11 +79,18 @@ const MODIFIER_DISPLAY: Record<string, string> = {
   Meta: "⌘",
 };
 
+/** One press as display tokens, in KeyHint's `keys` shape: ["⌘","K"] on Apple
+ * platforms (the AST was `$mod`-resolved at parse time), ["Ctrl","K"]
+ * elsewhere. Optional modifiers are NOT included - they describe match
+ * permissiveness, not the key the user presses. */
+export function chordDisplayKeys(chord: Chord): string[] {
+  const key = chord.key instanceof RegExp ? chord.key.source : chord.key;
+  return [...chord.modifiers.map((m) => MODIFIER_DISPLAY[m] ?? m), key];
+}
+
 /** One press as speakable words: "⌘+K" on Apple platforms, "Ctrl+K" elsewhere. */
 export function formatChord(chord: Chord): string {
-  const mods = chord.modifiers.map((m) => MODIFIER_DISPLAY[m] ?? m);
-  const key = chord.key instanceof RegExp ? chord.key.source : chord.key;
-  return [...mods, key].join("+");
+  return chordDisplayKeys(chord).join("+");
 }
 
 /** A whole sequence as words, presses space-separated: "Shift+A b". */

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -44,7 +44,7 @@
 
 import { ACTIONS } from "./actions";
 import { type KeySequence, parseChord, serializeChord, withOptionalModifier } from "./chord";
-import type { Binding, BindingInput, KeybindingsRegistry } from "./registry";
+import { type Binding, type BindingInput, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
 export const SETTINGS_SCOPE = "settings";
 
@@ -181,4 +181,29 @@ export function registerDefaultBindingsForAction(registry: KeybindingsRegistry, 
     }
   }
   return registered;
+}
+
+export interface DefaultChordInfo {
+  scope: string;
+  serialized: string;
+}
+
+/** The (scope, serialized chord) pairs registerDefaultBindingsForAction would
+ * register for the action, WITHOUT registering them: the validation layer
+ * simulates dropped-override restorations against these. Throws on an
+ * unknown action id. */
+export function defaultBindingChordsForAction(actionId: string): DefaultChordInfo[] {
+  const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
+  if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
+  const chords: DefaultChordInfo[] = [];
+  for (const input of inputs) {
+    const pair = modPair(input);
+    for (const entry of pair ?? [input]) {
+      chords.push({
+        scope: entry.scope ?? GLOBAL_SCOPE,
+        serialized: serializeChord(typeof entry.chord === "string" ? parseChord(entry.chord) : entry.chord),
+      });
+    }
+  }
+  return chords;
 }

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -51,6 +51,12 @@ export const SETTINGS_SCOPE = "settings";
 /** A default-map entry: a BindingInput plus the module-internal
  * legacyEitherMod marker (stripped before registerBinding - see modPair). */
 interface DefaultBindingInput extends BindingInput {
+  /** The action's user-facing title, shown by the Settings keybindings
+   * section. Kept on the default-map entry itself so the section's action
+   * list is sourced live from this map - a new action appears there
+   * automatically, and no second hand-maintained list can go stale (the
+   * survey's stale-HELP_ROWS lesson). */
+  title: string;
   /** Legacy "either or both of Meta/Ctrl" permissiveness: the AppShell
    * ⌘K/⌘I/⌘J listener checked metaKey||ctrlKey with no regard for the OTHER
    * modifier's state, so Meta+Ctrl+K fired. The complement of $mod is added
@@ -62,6 +68,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.paletteOpen,
     actionId: ACTIONS.paletteOpen,
+    title: "Open the command palette",
     chord: "$mod+[Shift]+[Alt]+K",
     allowInEditable: true,
     allowInModal: true,
@@ -73,6 +80,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.railToggle,
     actionId: ACTIONS.railToggle,
+    title: "Toggle the sidebar",
     chord: "$mod+B",
     allowInEditable: false,
     allowInModal: true,
@@ -81,6 +89,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.composerFocus,
     actionId: ACTIONS.composerFocus,
+    title: "Focus the composer",
     chord: "$mod+[Shift]+[Alt]+I",
     allowInEditable: true,
     legacyEitherMod: true,
@@ -88,6 +97,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.nextNeedsYou,
     actionId: ACTIONS.nextNeedsYou,
+    title: "Go to the next session needing you",
     chord: "$mod+[Shift]+[Alt]+J",
     allowInEditable: true,
     legacyEitherMod: true,
@@ -98,6 +108,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.selectionQuote,
     actionId: ACTIONS.selectionQuote,
+    title: "Quote the selection into the composer",
     chord: "$mod+[Shift]+'",
     allowInEditable: true,
     allowInModal: true,
@@ -105,6 +116,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.settingsClose,
     actionId: ACTIONS.settingsClose,
+    title: "Close settings",
     chord: "[Control]+[Alt]+[Shift]+[Meta]+Escape",
     scope: SETTINGS_SCOPE,
     allowInEditable: true,
@@ -133,7 +145,7 @@ function modPair(input: DefaultBindingInput): [BindingInput, BindingInput] | nul
     if (serializeChord(parseChord(candidate)) !== resolved) twinString = candidate;
   }
   if (twinString === null) return null;
-  const { legacyEitherMod: _legacyEitherMod, ...base } = input;
+  const { legacyEitherMod: _legacyEitherMod, title: _title, ...base } = input;
   const twin: BindingInput = { ...base, id: `${base.id}#mod-twin`, chord: twinString };
   if (!input.legacyEitherMod) return [base, twin];
   return [

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -199,27 +199,42 @@ export function registerDefaultBindingsForAction(registry: KeybindingsRegistry, 
   return registered;
 }
 
+export interface DefaultBindingShape {
+  scope: string;
+  sequence: KeySequence;
+}
+
+/** The (scope, parsed chord) pairs registerDefaultBindingsForAction would
+ * register for the action, WITHOUT registering them: the validation layer
+ * simulates dropped-override restorations against these. Throws on an
+ * unknown action id. */
+export function defaultBindingShapesForAction(actionId: string): DefaultBindingShape[] {
+  const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
+  if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
+  const shapes: DefaultBindingShape[] = [];
+  for (const input of inputs) {
+    const pair = modPair(input);
+    for (const entry of pair ?? [input]) {
+      shapes.push({
+        scope: entry.scope ?? GLOBAL_SCOPE,
+        sequence: typeof entry.chord === "string" ? parseChord(entry.chord) : entry.chord,
+      });
+    }
+  }
+  return shapes;
+}
+
 export interface DefaultChordInfo {
   scope: string;
   serialized: string;
 }
 
-/** The (scope, serialized chord) pairs registerDefaultBindingsForAction would
- * register for the action, WITHOUT registering them: the validation layer
- * simulates dropped-override restorations against these. Throws on an
- * unknown action id. */
+/** The display-oriented (scope, serialized chord) form of
+ * defaultBindingShapesForAction, for the read-only settings section's
+ * customized-marker comparison. */
 export function defaultBindingChordsForAction(actionId: string): DefaultChordInfo[] {
-  const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
-  if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
-  const chords: DefaultChordInfo[] = [];
-  for (const input of inputs) {
-    const pair = modPair(input);
-    for (const entry of pair ?? [input]) {
-      chords.push({
-        scope: entry.scope ?? GLOBAL_SCOPE,
-        serialized: serializeChord(typeof entry.chord === "string" ? parseChord(entry.chord) : entry.chord),
-      });
-    }
-  }
-  return chords;
+  return defaultBindingShapesForAction(actionId).map((shape) => ({
+    scope: shape.scope,
+    serialized: serializeChord(shape.sequence),
+  }));
 }

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -166,3 +166,19 @@ export function registerDefaultBindings(registry: KeybindingsRegistry): Binding[
   }
   return registered;
 }
+
+/** Registers only the given action's default entries (plus the $mod twin),
+ * the per-action equivalent of registerDefaultBindings the overrides store
+ * uses to restore one action's defaults. Throws on an unknown action id. */
+export function registerDefaultBindingsForAction(registry: KeybindingsRegistry, actionId: string): Binding[] {
+  const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
+  if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
+  const registered: Binding[] = [];
+  for (const input of inputs) {
+    const pair = modPair(input);
+    for (const entry of pair ?? [input]) {
+      registered.push(registry.getState().registerBinding(entry));
+    }
+  }
+  return registered;
+}

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
@@ -148,3 +148,21 @@ describe("restoreDefaultBinding", () => {
     expect(() => restoreDefaultBinding(registry, "no.such.action")).toThrow(/unknown/);
   });
 });
+
+describe("rebindAction overlap conflicts", () => {
+  test("throws when the chord only overlaps another action's OPTIONAL modifiers, atomically", () => {
+    // Control+K matches palette.open's Control+[Meta]+[Shift]+[Alt]+K at
+    // dispatch time; the earlier-registered default would shadow the override.
+    const registry = withDefaults();
+    const before = registry.getState().bindings;
+    expect(() => rebindAction(registry, ACTIONS.composerFocus, "Control+K")).toThrow(/conflict/);
+    expect(registry.getState().bindings).toEqual(before);
+  });
+
+  test("accepts a genuinely non-overlapping chord (extra required modifier nothing allows)", () => {
+    const registry = withDefaults();
+    expect(() => rebindAction(registry, ACTIONS.composerFocus, "Control+Alt+B")).not.toThrow();
+    const override = bindingsFor(registry, ACTIONS.composerFocus)[0];
+    expect(serializeChord(override?.chord ?? [])).toBe("Control+Alt+B");
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "vitest";
+import { ACTIONS } from "./actions";
+import { serializeChord } from "./chord";
+import { registerDefaultBindings } from "./defaults";
+import { rebindAction, restoreDefaultBinding } from "./overrides";
+import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
+
+function withDefaults(): KeybindingsRegistry {
+  const registry = createKeybindingsRegistry();
+  registerDefaultBindings(registry);
+  return registry;
+}
+
+function bindingsFor(registry: KeybindingsRegistry, actionId: string) {
+  return registry.getState().bindings.filter((b) => b.actionId === actionId);
+}
+
+describe("rebindAction", () => {
+  test("replaces the default binding AND its mod-twin with a single override entry", () => {
+    const registry = withDefaults();
+    expect(bindingsFor(registry, ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+
+    const bindings = bindingsFor(registry, ACTIONS.paletteOpen);
+    expect(bindings).toHaveLength(1);
+    const override = bindings[0];
+    expect(override?.id).toBe(`${ACTIONS.paletteOpen}#override`);
+    expect(serializeChord(override?.chord ?? [])).toBe("Control+P");
+  });
+
+  test("keeps the default's scope and policy flags - a rebind changes the chord, not the guards", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.railToggle, "Control+Alt+B");
+    const override = bindingsFor(registry, ACTIONS.railToggle)[0];
+    expect(override?.scope).toBe(GLOBAL_SCOPE);
+    expect(override?.allowInEditable).toBe(false);
+    expect(override?.allowInModal).toBe(true);
+    expect(override?.ignoreIfDefaultPrevented).toBe(false);
+  });
+
+  test("keeps a non-global default's scope (settings.close stays in the settings scope)", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.settingsClose, "Control+Shift+Escape");
+    const override = bindingsFor(registry, ACTIONS.settingsClose)[0];
+    expect(override?.scope).toBe("settings");
+    expect(override?.allowInEditable).toBe(true);
+  });
+
+  test("does not twin-expand the override chord: the user chord binds exactly what was written", () => {
+    const registry = withDefaults();
+    // "$mod" resolves to Control under jsdom; a twin would add a Meta entry.
+    rebindAction(registry, ACTIONS.paletteOpen, "$mod+P");
+    expect(bindingsFor(registry, ACTIONS.paletteOpen)).toHaveLength(1);
+  });
+
+  test("a null chord unbinds the action entirely", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, null);
+    expect(bindingsFor(registry, ACTIONS.paletteOpen)).toHaveLength(0);
+    // Other actions are untouched.
+    expect(bindingsFor(registry, ACTIONS.railToggle)).toHaveLength(2);
+  });
+
+  test("re-applying the same override is idempotent", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+    const first = bindingsFor(registry, ACTIONS.paletteOpen);
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+    const second = bindingsFor(registry, ACTIONS.paletteOpen);
+    expect(second).toHaveLength(1);
+    expect(serializeChord(second[0]?.chord ?? [])).toBe(serializeChord(first[0]?.chord ?? []));
+  });
+
+  test("a later override replaces an earlier one (last rule wins)", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+U");
+    const bindings = bindingsFor(registry, ACTIONS.paletteOpen);
+    expect(bindings).toHaveLength(1);
+    expect(serializeChord(bindings[0]?.chord ?? [])).toBe("Control+U");
+  });
+
+  test("throws on an unknown action id and leaves the registry unchanged", () => {
+    const registry = withDefaults();
+    const before = registry.getState().bindings;
+    expect(() => rebindAction(registry, "no.such.action", "Control+P")).toThrow(/unknown/);
+    expect(registry.getState().bindings).toEqual(before);
+  });
+
+  test("throws on an unparseable chord and leaves the registry unchanged", () => {
+    const registry = withDefaults();
+    const before = registry.getState().bindings;
+    expect(() => rebindAction(registry, ACTIONS.paletteOpen, "")).toThrow();
+    expect(registry.getState().bindings).toEqual(before);
+  });
+
+  test("throws on a conflict with another action's effective binding, atomically", () => {
+    const registry = withDefaults();
+    registry.getState().registerBinding({ id: "other", actionId: "other.action", chord: "Control+X" });
+    const before = registry.getState().bindings;
+    expect(() => rebindAction(registry, ACTIONS.paletteOpen, "Control+X")).toThrow(/conflict/);
+    // The failure is atomic: palette.open's default + twin survive intact.
+    expect(registry.getState().bindings).toEqual(before);
+  });
+
+  test("no conflict when the same chord lives in a different scope", () => {
+    const registry = withDefaults();
+    registry
+      .getState()
+      .registerBinding({ id: "other", actionId: "other.action", chord: "Control+X", scope: "settings" });
+    expect(() => rebindAction(registry, ACTIONS.paletteOpen, "Control+X")).not.toThrow();
+  });
+});
+
+describe("restoreDefaultBinding", () => {
+  test("restores the default and its mod-twin after an override", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+    restoreDefaultBinding(registry, ACTIONS.paletteOpen);
+    expect(bindingsFor(registry, ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("restores the default after an unbind", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, null);
+    restoreDefaultBinding(registry, ACTIONS.paletteOpen);
+    expect(bindingsFor(registry, ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  test("is a no-op equivalent on an action that was never overridden", () => {
+    const registry = withDefaults();
+    restoreDefaultBinding(registry, ACTIONS.paletteOpen);
+    expect(bindingsFor(registry, ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("throws on an unknown action id", () => {
+    const registry = withDefaults();
+    expect(() => restoreDefaultBinding(registry, "no.such.action")).toThrow(/unknown/);
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.ts
@@ -15,7 +15,7 @@
 // bad rules with warnings, so these throws should never reach startup; they
 // exist so a direct caller cannot corrupt the registry either.
 
-import { parseChord, serializeChord } from "./chord";
+import { chordsOverlap, parseChord, serializeChord } from "./chord";
 import { DEFAULT_BINDINGS, registerDefaultBindingsForAction } from "./defaults";
 import { type BindingInput, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
@@ -50,7 +50,7 @@ export function rebindAction(registry: KeybindingsRegistry, actionId: string, ch
   const scope = defaultInput.scope ?? GLOBAL_SCOPE;
   for (const existing of registry.getState().bindings) {
     if (existing.actionId === actionId) continue;
-    if (existing.scope === scope && serializeChord(existing.chord) === serialized) {
+    if (existing.scope === scope && chordsOverlap(existing.chord, sequence)) {
       throw new Error(`keybinding conflict: "${serialized}" in scope "${scope}" is already bound by "${existing.id}"`);
     }
   }

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.ts
@@ -1,0 +1,76 @@
+// User override application for the keybinding registry: rebindAction is the
+// one primitive the overrides store (src/stores/keybindings.ts) applies each
+// validated rule through. A rebind replaces the action's CURRENT binding(s) -
+// the default entry and its cross-platform `#mod-twin`, or an earlier
+// `#override` - with a single binding that keeps the default's scope and
+// policy flags (allowInEditable/allowInModal/ignoreIfDefaultPrevented): a
+// rebind changes the chord, never the action's guards. The override chord
+// binds exactly what the user wrote - no twin expansion, because user chords
+// are platform-explicit (a `$mod` spelling resolves at parse time).
+//
+// Every throwing path (unknown action, unparseable chord, conflict with
+// another action's effective binding) throws BEFORE mutating the registry, so
+// a failed rebind never leaves the action half-unbound. The store's semantic
+// validation layer (validation.ts) pre-checks the same conditions and skips
+// bad rules with warnings, so these throws should never reach startup; they
+// exist so a direct caller cannot corrupt the registry either.
+
+import { parseChord, serializeChord } from "./chord";
+import { DEFAULT_BINDINGS, registerDefaultBindingsForAction } from "./defaults";
+import { type BindingInput, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
+
+function defaultInputFor(actionId: string): BindingInput {
+  const input = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
+  if (input === undefined) throw new Error(`unknown keybinding action "${actionId}"`);
+  return input;
+}
+
+/** Removes every binding the action currently has (default, `#mod-twin`,
+ * `#override`); the registry-equivalent of an unbound action. */
+export function removeActionBindings(registry: KeybindingsRegistry, actionId: string): void {
+  const state = registry.getState();
+  for (const binding of state.bindings) {
+    if (binding.actionId === actionId) state.unregisterBinding(binding.id);
+  }
+}
+
+/** Applies one override rule: `chord` rebinds the action, null unbinds it.
+ * Re-applying the same override is idempotent; a later override replaces an
+ * earlier one (last rule wins, matching the wire payload). Throws - without
+ * mutating the registry - on an unknown action id, an unparseable chord, or a
+ * conflict with another action's effective binding in the same scope. */
+export function rebindAction(registry: KeybindingsRegistry, actionId: string, chord: string | null): void {
+  const defaultInput = defaultInputFor(actionId);
+  if (chord === null) {
+    removeActionBindings(registry, actionId);
+    return;
+  }
+  const sequence = parseChord(chord);
+  const serialized = serializeChord(sequence);
+  const scope = defaultInput.scope ?? GLOBAL_SCOPE;
+  for (const existing of registry.getState().bindings) {
+    if (existing.actionId === actionId) continue;
+    if (existing.scope === scope && serializeChord(existing.chord) === serialized) {
+      throw new Error(`keybinding conflict: "${serialized}" in scope "${scope}" is already bound by "${existing.id}"`);
+    }
+  }
+  removeActionBindings(registry, actionId);
+  registry.getState().registerBinding({
+    id: `${defaultInput.id}#override`,
+    actionId,
+    chord: sequence,
+    ...(defaultInput.scope === undefined ? {} : { scope: defaultInput.scope }),
+    allowInEditable: defaultInput.allowInEditable,
+    allowInModal: defaultInput.allowInModal,
+    ignoreIfDefaultPrevented: defaultInput.ignoreIfDefaultPrevented,
+  });
+}
+
+/** Restores the action's default binding(s) (plus the `$mod` twin), removing
+ * any override or unbind. Idempotent on an action that was never overridden.
+ * Throws on an unknown action id. */
+export function restoreDefaultBinding(registry: KeybindingsRegistry, actionId: string): void {
+  defaultInputFor(actionId);
+  removeActionBindings(registry, actionId);
+  registerDefaultBindingsForAction(registry, actionId);
+}

--- a/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "vitest";
+import { ACTIONS } from "./actions";
+import { serializeChord } from "./chord";
+import { registerDefaultBindings } from "./defaults";
+import { createKeybindingsRegistry, type KeybindingsRegistry } from "./registry";
+import { validateOverrideRules } from "./validation";
+
+function withDefaults(): KeybindingsRegistry {
+  const registry = createKeybindingsRegistry();
+  registerDefaultBindings(registry);
+  return registry;
+}
+
+function defaultChord(registry: KeybindingsRegistry, bindingId: string): string {
+  const binding = registry.getState().bindings.find((b) => b.id === bindingId);
+  if (binding === undefined) throw new Error(`test setup: no binding ${bindingId}`);
+  return serializeChord(binding.chord);
+}
+
+describe("validateOverrideRules", () => {
+  test("accepts a well-formed rebind and unbind", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+        { action: ACTIONS.railToggle, chord: null },
+      ],
+      registry,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(2);
+    expect(result.rules[0]?.action).toBe(ACTIONS.paletteOpen);
+    expect(serializeChord(result.rules[0]?.chord ?? [])).toBe("Control+P");
+    expect(result.rules[1]?.chord).toBeNull();
+  });
+
+  test("collects a warning and skips an unknown action without throwing", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+      ],
+      registry,
+    );
+    expect(result.rules).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("unknown-action");
+    expect(result.warnings[0]?.rule.action).toBe("no.such.action");
+  });
+
+  test("collects a warning and skips an unparseable chord", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "" }], registry);
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings[0]?.reason).toBe("unparseable-chord");
+  });
+
+  test("last rule wins for repeated rules on the same action", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        { action: ACTIONS.paletteOpen, chord: "Control+U" },
+      ],
+      registry,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+    expect(serializeChord(result.rules[0]?.chord ?? [])).toBe("Control+U");
+  });
+
+  test("flags a chord two rules in the same payload try to claim", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+        { action: ACTIONS.railToggle, chord: "Control+P" },
+      ],
+      registry,
+    );
+    expect(result.rules).toHaveLength(1);
+    expect(result.rules[0]?.action).toBe(ACTIONS.paletteOpen);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("conflict");
+    expect(result.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+  });
+
+  test("flags a rule that lands on another action's current effective binding", () => {
+    const registry = withDefaults();
+    const taken = defaultChord(registry, ACTIONS.paletteOpen);
+    const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: taken }], registry);
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings[0]?.reason).toBe("conflict");
+    expect(result.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+  });
+
+  test("a chord freed by the same payload can be claimed by a later rule", () => {
+    const registry = withDefaults();
+    const freed = defaultChord(registry, ACTIONS.paletteOpen);
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        { action: ACTIONS.railToggle, chord: freed },
+      ],
+      registry,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(2);
+  });
+
+  test("an unbind frees the action's chord for a later rule", () => {
+    const registry = withDefaults();
+    const freed = defaultChord(registry, ACTIONS.paletteOpen);
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: null },
+        { action: ACTIONS.railToggle, chord: freed },
+      ],
+      registry,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(2);
+  });
+
+  test("a chord taken in a different scope does not conflict", () => {
+    const registry = withDefaults();
+    // settings.close lives in the settings scope; a global-scope rule may
+    // reuse its chord (stack order shadows deterministically).
+    const settingsChord = defaultChord(registry, ACTIONS.settingsClose);
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: settingsChord }], registry);
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+});
+
+describe("validateOverrideRules reserved chords", () => {
+  test("Control+W/N/T/Tab, Ctrl+digits, F11 are reserved on non-Apple platforms", () => {
+    const registry = withDefaults();
+    for (const chord of ["Control+W", "Control+N", "Control+T", "Control+Tab", "Control+5", "F11"]) {
+      const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord }], registry, "other");
+      expect(result.rules, chord).toHaveLength(0);
+      expect(result.warnings[0]?.reason, chord).toBe("reserved-chord");
+    }
+  });
+
+  test("Meta+W is NOT reserved on non-Apple platforms", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Meta+W" }], registry, "other");
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test("the macOS family (Cmd+W/N/T/Q, Cmd+digits, Cmd+Shift+N/T) is reserved on Apple platforms", () => {
+    const registry = withDefaults();
+    for (const chord of ["Meta+W", "Meta+N", "Meta+T", "Meta+Q", "Meta+5", "Meta+Shift+N", "Meta+Shift+T"]) {
+      const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord }], registry, "apple");
+      expect(result.rules, chord).toHaveLength(0);
+      expect(result.warnings[0]?.reason, chord).toBe("reserved-chord");
+    }
+  });
+
+  test("the Control family stays reserved on Apple platforms too (the survey lists it unqualified)", () => {
+    const registry = withDefaults();
+    for (const chord of ["Control+W", "Control+Tab", "Control+5"]) {
+      const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord }], registry, "apple");
+      expect(result.rules, chord).toHaveLength(0);
+      expect(result.warnings[0]?.reason, chord).toBe("reserved-chord");
+    }
+  });
+
+  test("Alt+F4 is reserved on non-Apple platforms but not on Apple", () => {
+    const registry = withDefaults();
+    const other = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Alt+F4" }], registry, "other");
+    expect(other.warnings[0]?.reason).toBe("reserved-chord");
+    const apple = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Alt+F4" }], registry, "apple");
+    expect(apple.warnings).toEqual([]);
+  });
+
+  test("Ctrl+Shift+P is NOT reserved: the survey's caveat is Firefox-private-window specific", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [{ action: ACTIONS.paletteOpen, chord: "Control+Shift+P" }],
+      registry,
+      "other",
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test("an optional extra modifier does not rescue a reserved chord (the no-modifier case is undeliverable)", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [{ action: ACTIONS.paletteOpen, chord: "[Shift]+Control+W" }],
+      registry,
+      "other",
+    );
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings[0]?.reason).toBe("reserved-chord");
+  });
+
+  test("extra REQUIRED modifiers escape the reserved list (Cmd+Shift+W is not the survey's Cmd+W)", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Meta+Shift+W" }], registry, "apple");
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test("multi-press sequences are never reserved", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [{ action: ACTIONS.paletteOpen, chord: "Control+K Control+W" }],
+      registry,
+      "other",
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
@@ -253,3 +253,36 @@ describe("validateOverrideRules dropped-override restorations", () => {
     expect(result.warnings).toEqual([]);
   });
 });
+
+describe("validateOverrideRules overlap conflicts", () => {
+  test("flags an override whose exact chord overlaps a default's OPTIONAL modifiers (dispatch would shadow it)", () => {
+    // palette.open's default is Control+[Meta]+[Shift]+[Alt]+K: a plain
+    // Control+K matches it at dispatch time, and the earlier-registered
+    // default would win - so this is a conflict, not a valid remap.
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: "Control+K" }], registry);
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("conflict");
+    expect(result.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+    expect(result.warnings[0]?.message).toContain('scope "global"');
+  });
+
+  test("a genuinely non-overlapping chord (extra required modifier nothing allows) still validates", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: "Control+Alt+B" }], registry);
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test("the reserved-chord check runs before conflict detection: a reserved chord reports only reserved-chord", () => {
+    const registry = withDefaults();
+    // A foreign live binding holds Control+W, so the chord is BOTH reserved
+    // and conflicting; check order must surface only the reserved warning.
+    registry.getState().registerBinding({ id: "foreign", actionId: "foreign.action", chord: "Control+W" });
+    const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: "Control+W" }], registry, "other");
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("reserved-chord");
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import { ACTIONS } from "./actions";
 import { serializeChord } from "./chord";
 import { registerDefaultBindings } from "./defaults";
+import { rebindAction } from "./overrides";
 import { createKeybindingsRegistry, type KeybindingsRegistry } from "./registry";
 import { validateOverrideRules } from "./validation";
 
@@ -215,5 +216,40 @@ describe("validateOverrideRules reserved chords", () => {
     );
     expect(result.warnings).toEqual([]);
     expect(result.rules).toHaveLength(1);
+  });
+});
+
+describe("validateOverrideRules dropped-override restorations", () => {
+  test("a rule claiming a chord a dropped override's restored default needs is skipped with a warning", () => {
+    const registry = withDefaults();
+    const reclaimed = defaultChord(registry, ACTIONS.paletteOpen);
+    // The live state the reviewer's payload 1 produces: palette.open moved
+    // away, rail.toggle claimed its freed default chord.
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+Y");
+    rebindAction(registry, ACTIONS.railToggle, reclaimed);
+
+    // Payload 2 drops palette.open (its defaults must be restored) and keeps
+    // rail.toggle's claim on the chord the restore needs. The restore wins:
+    // the rule is skipped with a conflict warning so every action stays bound.
+    const result = validateOverrideRules(
+      [{ action: ACTIONS.railToggle, chord: reclaimed }],
+      registry,
+      "other",
+      new Set([ACTIONS.paletteOpen, ACTIONS.railToggle]),
+    );
+
+    expect(result.rules).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("conflict");
+    expect(result.warnings[0]?.rule).toEqual({ action: ACTIONS.railToggle, chord: reclaimed });
+    expect(result.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+  });
+
+  test("a dropped override restores cleanly when its default chord was not reclaimed", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+Y");
+    const result = validateOverrideRules([], registry, "other", new Set([ACTIONS.paletteOpen]));
+    expect(result.rules).toEqual([]);
+    expect(result.warnings).toEqual([]);
   });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -1,0 +1,220 @@
+// Semantic validation for user keybinding overrides. The server validates
+// STRUCTURE only (it does not know the frontend action registry); everything
+// that requires knowing the live bindings happens here, at load and at patch:
+//
+//   - action ids against the default map (unknown or stale rules are skipped),
+//   - chord parseability,
+//   - the survey's per-platform never-use list (docs/web-ui/specs/
+//     2026-09-03-keybinding-system-survey.md "Reserved-chord landscape") -
+//     chords the browser will never deliver to the page,
+//   - conflicts against the effective map the payload would produce.
+//
+// Validation NEVER throws into startup: every problem becomes a warning and
+// the offending rule is skipped, so persisted data can degrade to defaults
+// but can never crash the shell.
+
+import { type KeySequence, parseChord, serializeChord } from "./chord";
+import { DEFAULT_BINDINGS } from "./defaults";
+import { GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
+
+export type KeybindingsPlatform = "apple" | "other";
+
+/** Same platform split tinykeys applies for `$mod` (and keyhint for display):
+ * navigator.platform's Apple tokens. jsdom reports "", so tests default to
+ * "other" regardless of the host running them. */
+export function currentKeybindingsPlatform(): KeybindingsPlatform {
+  if (typeof window === "undefined") return "other";
+  return /Mac|iPhone|iPad|iPod/.test(window.navigator.platform) ? "apple" : "other";
+}
+
+// The survey's verified never-use list ("not interceptable by pages"),
+// platform-split. The Control family is listed unqualified in the survey, so
+// it is reserved on every platform. Two survey entries are deliberately NOT
+// encoded: "Escape in fullscreen" is context-dependent (Escape is
+// settings.close's own default chord), and "Ctrl+Shift+P in Firefox" is a
+// private-window-only caveat in one browser, not a platform rule.
+const COMMON_RESERVED = [
+  "Control+W",
+  "Control+N",
+  "Control+T",
+  "Control+Tab",
+  "Control+Shift+Tab",
+  "Control+1",
+  "Control+2",
+  "Control+3",
+  "Control+4",
+  "Control+5",
+  "Control+6",
+  "Control+7",
+  "Control+8",
+  "Control+9",
+  "F11",
+];
+const APPLE_RESERVED = [
+  "Meta+W",
+  "Meta+N",
+  "Meta+T",
+  "Meta+Q",
+  "Meta+Shift+N",
+  "Meta+Shift+T",
+  "Meta+1",
+  "Meta+2",
+  "Meta+3",
+  "Meta+4",
+  "Meta+5",
+  "Meta+6",
+  "Meta+7",
+  "Meta+8",
+  "Meta+9",
+];
+const OTHER_RESERVED = ["Alt+F4", "Control+Alt+Delete"];
+
+// A reserved match compares REQUIRED modifiers + key only (case-insensitive
+// on the key): a user chord that lists extra OPTIONAL modifiers still has a
+// no-modifier match the browser will never deliver, so it stays reserved.
+// Extra REQUIRED modifiers escape the list (Meta+Shift+W is not the survey's
+// Meta+W), and multi-press sequences are never reserved - the browser
+// delivers every press after the first to the page.
+function canonicalPress(sequence: KeySequence): string | null {
+  if (sequence.length !== 1) return null;
+  const press = sequence[0];
+  if (press === undefined) return null;
+  const key = press.key instanceof RegExp ? press.key.source : press.key;
+  return `${press.modifiers.join("+")}+${key.toLowerCase()}`;
+}
+
+const RESERVED_BY_PLATFORM: Record<KeybindingsPlatform, ReadonlySet<string>> = {
+  apple: new Set(
+    [...COMMON_RESERVED, ...APPLE_RESERVED].map((chord) => {
+      const canonical = canonicalPress(parseChord(chord));
+      if (canonical === null) throw new Error(`bad reserved chord "${chord}"`);
+      return canonical;
+    }),
+  ),
+  other: new Set(
+    [...COMMON_RESERVED, ...OTHER_RESERVED].map((chord) => {
+      const canonical = canonicalPress(parseChord(chord));
+      if (canonical === null) throw new Error(`bad reserved chord "${chord}"`);
+      return canonical;
+    }),
+  ),
+};
+
+export interface OverrideRule {
+  action: string;
+  chord: string | null;
+}
+
+export type ValidationWarningReason = "unknown-action" | "unparseable-chord" | "reserved-chord" | "conflict";
+
+export interface ValidationWarning {
+  rule: OverrideRule;
+  reason: ValidationWarningReason;
+  message: string;
+  /** For "conflict": the other action holding the chord. */
+  conflictWith?: string;
+}
+
+export interface ValidatedRule {
+  action: string;
+  chord: KeySequence | null;
+}
+
+export interface ValidatedOverrides {
+  /** The payload's effective rules: valid, deduped last-rule-wins, in order. */
+  rules: ValidatedRule[];
+  warnings: ValidationWarning[];
+}
+
+interface EffectiveBinding {
+  scope: string;
+  serialized: string;
+}
+
+/** Validates a rules payload against the live registry. Conflict detection
+ * simulates the effective map the payload would produce: each accepted rule
+ * replaces its action's bindings in the simulation, so a chord freed by an
+ * earlier rule (rebind-away or unbind) can be claimed by a later one, and a
+ * later rule landing on an earlier rule's new chord is the conflict. */
+export function validateOverrideRules(
+  rules: readonly OverrideRule[],
+  registry: KeybindingsRegistry,
+  platform: KeybindingsPlatform = currentKeybindingsPlatform(),
+): ValidatedOverrides {
+  const warnings: ValidationWarning[] = [];
+  const validated: ValidatedRule[] = [];
+  const effective = new Map<string, EffectiveBinding[]>();
+  for (const binding of registry.getState().bindings) {
+    const list = effective.get(binding.actionId) ?? [];
+    list.push({ scope: binding.scope, serialized: serializeChord(binding.chord) });
+    effective.set(binding.actionId, list);
+  }
+  const reserved = RESERVED_BY_PLATFORM[platform];
+
+  // The payload resolves same-action repeats last-rule-wins; the validated
+  // list keeps only the winning rule.
+  const pushRule = (rule: ValidatedRule): void => {
+    const prior = validated.findIndex((r) => r.action === rule.action);
+    if (prior !== -1) validated.splice(prior, 1);
+    validated.push(rule);
+  };
+
+  for (const rule of rules) {
+    const defaultInput = DEFAULT_BINDINGS.find((b) => b.actionId === rule.action);
+    if (defaultInput === undefined) {
+      warnings.push({
+        rule,
+        reason: "unknown-action",
+        message: `unknown keybinding action "${rule.action}"`,
+      });
+      continue;
+    }
+    if (rule.chord === null) {
+      pushRule({ action: rule.action, chord: null });
+      effective.set(rule.action, []);
+      continue;
+    }
+    let sequence: KeySequence;
+    try {
+      sequence = parseChord(rule.chord);
+    } catch (error) {
+      warnings.push({
+        rule,
+        reason: "unparseable-chord",
+        message: `cannot parse chord "${rule.chord}": ${error instanceof Error ? error.message : String(error)}`,
+      });
+      continue;
+    }
+    const canonical = canonicalPress(sequence);
+    if (canonical !== null && reserved.has(canonical)) {
+      warnings.push({
+        rule,
+        reason: "reserved-chord",
+        message: `chord "${rule.chord}" is reserved by the browser/OS on this platform and would never reach the page`,
+      });
+      continue;
+    }
+    const scope = defaultInput.scope ?? GLOBAL_SCOPE;
+    const serialized = serializeChord(sequence);
+    let conflictWith: string | undefined;
+    for (const [otherAction, bindings] of effective) {
+      if (otherAction === rule.action) continue;
+      if (bindings.some((b) => b.scope === scope && b.serialized === serialized)) {
+        conflictWith = otherAction;
+        break;
+      }
+    }
+    if (conflictWith !== undefined) {
+      warnings.push({
+        rule,
+        reason: "conflict",
+        conflictWith,
+        message: `chord "${rule.chord}" in scope "${scope}" is already bound by "${conflictWith}"`,
+      });
+      continue;
+    }
+    pushRule({ action: rule.action, chord: sequence });
+    effective.set(rule.action, [{ scope, serialized }]);
+  }
+  return { rules: validated, warnings };
+}

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -14,7 +14,7 @@
 // but can never crash the shell.
 
 import { type KeySequence, parseChord, serializeChord } from "./chord";
-import { DEFAULT_BINDINGS } from "./defaults";
+import { DEFAULT_BINDINGS, defaultBindingChordsForAction } from "./defaults";
 import { GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
 export type KeybindingsPlatform = "apple" | "other";
@@ -131,32 +131,55 @@ interface EffectiveBinding {
   serialized: string;
 }
 
+/** The actions currently carrying an override, derived from the live registry
+ * when the caller (the store) doesn't pass its authoritative set: an action
+ * with an `#override` binding, or with NO bindings at all (an unbind
+ * override). Only actions present in the default map are considered. */
+function deriveOverriddenActions(registry: KeybindingsRegistry): Set<string> {
+  const overridden = new Set<string>();
+  for (const input of DEFAULT_BINDINGS) {
+    const bindings = registry.getState().bindings.filter((b) => b.actionId === input.actionId);
+    if (bindings.length === 0 || bindings.some((b) => b.id === `${input.id}#override`)) {
+      overridden.add(input.actionId);
+    }
+  }
+  return overridden;
+}
+
 /** Validates a rules payload against the live registry. Conflict detection
- * simulates the effective map the payload would produce: each accepted rule
- * replaces its action's bindings in the simulation, so a chord freed by an
- * earlier rule (rebind-away or unbind) can be claimed by a later one, and a
- * later rule landing on an earlier rule's new chord is the conflict. */
+ * simulates the FINAL effective map the payload would produce: untouched
+ * actions keep their live bindings, every currently-overridden action the
+ * payload does not (validly) name gets its defaults restored, and each
+ * candidate rule claims its new chord. A chord freed by an earlier rule
+ * (rebind-away or unbind) can therefore be claimed by a later one.
+ *
+ * When a restored default and a rule claim collide, THE RESTORE WINS: the
+ * rule is skipped with a conflict warning and its action falls back to its
+ * own defaults. This is the choice that leaves every action bound - the
+ * alternative (deferring the restore) would strand the dropped action on an
+ * override the hub payload no longer contains, diverging the registry from
+ * the payload indefinitely. Defaults never conflict with each other, so a
+ * conflict always has a rule claim to blame. */
 export function validateOverrideRules(
   rules: readonly OverrideRule[],
   registry: KeybindingsRegistry,
   platform: KeybindingsPlatform = currentKeybindingsPlatform(),
+  appliedActionIds?: ReadonlySet<string>,
 ): ValidatedOverrides {
   const warnings: ValidationWarning[] = [];
-  const validated: ValidatedRule[] = [];
-  const effective = new Map<string, EffectiveBinding[]>();
-  for (const binding of registry.getState().bindings) {
-    const list = effective.get(binding.actionId) ?? [];
-    list.push({ scope: binding.scope, serialized: serializeChord(binding.chord) });
-    effective.set(binding.actionId, list);
-  }
   const reserved = RESERVED_BY_PLATFORM[platform];
 
-  // The payload resolves same-action repeats last-rule-wins; the validated
+  interface Candidate {
+    rule: OverrideRule;
+    chord: KeySequence | null;
+  }
+  const candidates: Candidate[] = [];
+  // The payload resolves same-action repeats last-rule-wins; the candidate
   // list keeps only the winning rule.
-  const pushRule = (rule: ValidatedRule): void => {
-    const prior = validated.findIndex((r) => r.action === rule.action);
-    if (prior !== -1) validated.splice(prior, 1);
-    validated.push(rule);
+  const pushCandidate = (candidate: Candidate): void => {
+    const prior = candidates.findIndex((c) => c.rule.action === candidate.rule.action);
+    if (prior !== -1) candidates.splice(prior, 1);
+    candidates.push(candidate);
   };
 
   for (const rule of rules) {
@@ -170,8 +193,7 @@ export function validateOverrideRules(
       continue;
     }
     if (rule.chord === null) {
-      pushRule({ action: rule.action, chord: null });
-      effective.set(rule.action, []);
+      pushCandidate({ rule, chord: null });
       continue;
     }
     let sequence: KeySequence;
@@ -194,27 +216,89 @@ export function validateOverrideRules(
       });
       continue;
     }
-    const scope = defaultInput.scope ?? GLOBAL_SCOPE;
-    const serialized = serializeChord(sequence);
-    let conflictWith: string | undefined;
-    for (const [otherAction, bindings] of effective) {
-      if (otherAction === rule.action) continue;
-      if (bindings.some((b) => b.scope === scope && b.serialized === serialized)) {
-        conflictWith = otherAction;
-        break;
+    pushCandidate({ rule, chord: sequence });
+  }
+
+  const live = new Map<string, EffectiveBinding[]>();
+  for (const binding of registry.getState().bindings) {
+    const list = live.get(binding.actionId) ?? [];
+    list.push({ scope: binding.scope, serialized: serializeChord(binding.chord) });
+    live.set(binding.actionId, list);
+  }
+  const overridden = appliedActionIds ?? deriveOverriddenActions(registry);
+  const dropped = new Set<string>();
+  for (const action of overridden) {
+    if (!candidates.some((c) => c.rule.action === action)) dropped.add(action);
+  }
+
+  // Conflict resolution on the final simulated map, iterated to a fixpoint:
+  // skipping a rule converts its action to a dropped restore (when it was
+  // overridden), which can surface a further conflict. Each pass skips at
+  // least one rule, so the loop is bounded by the candidate count; the guard
+  // break covers the production-unreachable restore-vs-foreign-binding
+  // collision, which reconcile's rollback + notification containment handle.
+  let guard = candidates.length + 1;
+  for (;;) {
+    const final = new Map<string, EffectiveBinding[]>();
+    for (const [action, bindings] of live) final.set(action, [...bindings]);
+    for (const action of dropped) final.set(action, defaultBindingChordsForAction(action));
+    for (const candidate of candidates) {
+      const defaultInput = DEFAULT_BINDINGS.find((b) => b.actionId === candidate.rule.action);
+      if (defaultInput === undefined) continue;
+      final.set(
+        candidate.rule.action,
+        candidate.chord === null
+          ? []
+          : [{ scope: defaultInput.scope ?? GLOBAL_SCOPE, serialized: serializeChord(candidate.chord) }],
+      );
+    }
+    // Each (scope, chord) pair's first claimant; later claimants conflict
+    // with it, so conflict pairs always name the earliest claimant first.
+    const claimant = new Map<string, string>();
+    const conflicts: [string, string][] = [];
+    for (const [action, bindings] of final) {
+      for (const binding of bindings) {
+        const key = `${binding.scope}\0${binding.serialized}`;
+        const other = claimant.get(key);
+        if (other === undefined) claimant.set(key, action);
+        else if (other !== action) conflicts.push([other, action]);
       }
     }
-    if (conflictWith !== undefined) {
+    if (conflicts.length === 0 || guard-- <= 0) break;
+    let skipped = false;
+    for (const [first, second] of conflicts) {
+      const indexFirst = candidates.findIndex((c) => c.rule.action === first);
+      const indexSecond = candidates.findIndex((c) => c.rule.action === second);
+      let skip = -1;
+      let conflictWith = "";
+      if (indexFirst !== -1 && indexSecond !== -1) {
+        // Both rules claim the chord: the later rule loses.
+        skip = Math.max(indexFirst, indexSecond);
+        conflictWith = skip === indexFirst ? second : first;
+      } else if (indexFirst !== -1) {
+        skip = indexFirst;
+        conflictWith = second;
+      } else if (indexSecond !== -1) {
+        skip = indexSecond;
+        conflictWith = first;
+      }
+      if (skip === -1) continue;
+      const removed = candidates.splice(skip, 1)[0];
+      if (removed === undefined) continue;
       warnings.push({
-        rule,
+        rule: removed.rule,
         reason: "conflict",
         conflictWith,
-        message: `chord "${rule.chord}" in scope "${scope}" is already bound by "${conflictWith}"`,
+        message: `chord "${removed.rule.chord ?? ""}" is already bound by "${conflictWith}"`,
       });
-      continue;
+      if (overridden.has(removed.rule.action)) dropped.add(removed.rule.action);
+      skipped = true;
     }
-    pushRule({ action: rule.action, chord: sequence });
-    effective.set(rule.action, [{ scope, serialized }]);
+    if (!skipped) break;
   }
-  return { rules: validated, warnings };
+
+  return {
+    rules: candidates.map((candidate) => ({ action: candidate.rule.action, chord: candidate.chord })),
+    warnings,
+  };
 }

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -13,8 +13,8 @@
 // the offending rule is skipped, so persisted data can degrade to defaults
 // but can never crash the shell.
 
-import { type KeySequence, parseChord, serializeChord } from "./chord";
-import { DEFAULT_BINDINGS, defaultBindingChordsForAction } from "./defaults";
+import { chordsOverlap, type KeySequence, parseChord } from "./chord";
+import { DEFAULT_BINDINGS, defaultBindingShapesForAction } from "./defaults";
 import { GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
 export type KeybindingsPlatform = "apple" | "other";
@@ -128,22 +128,7 @@ export interface ValidatedOverrides {
 
 interface EffectiveBinding {
   scope: string;
-  serialized: string;
-}
-
-/** The actions currently carrying an override, derived from the live registry
- * when the caller (the store) doesn't pass its authoritative set: an action
- * with an `#override` binding, or with NO bindings at all (an unbind
- * override). Only actions present in the default map are considered. */
-function deriveOverriddenActions(registry: KeybindingsRegistry): Set<string> {
-  const overridden = new Set<string>();
-  for (const input of DEFAULT_BINDINGS) {
-    const bindings = registry.getState().bindings.filter((b) => b.actionId === input.actionId);
-    if (bindings.length === 0 || bindings.some((b) => b.id === `${input.id}#override`)) {
-      overridden.add(input.actionId);
-    }
-  }
-  return overridden;
+  sequence: KeySequence;
 }
 
 /** Validates a rules payload against the live registry. Conflict detection
@@ -152,6 +137,9 @@ function deriveOverriddenActions(registry: KeybindingsRegistry): Set<string> {
  * payload does not (validly) name gets its defaults restored, and each
  * candidate rule claims its new chord. A chord freed by an earlier rule
  * (rebind-away or unbind) can therefore be claimed by a later one.
+ * Conflicts are OVERLAPS (chordsOverlap), not serialization equality: an
+ * override whose exact chord overlaps a default's optional modifiers would
+ * be shadowed by the earlier-registered default at dispatch time.
  *
  * When a restored default and a rule claim collide, THE RESTORE WINS: the
  * rule is skipped with a conflict warning and its action falls back to its
@@ -164,7 +152,7 @@ export function validateOverrideRules(
   rules: readonly OverrideRule[],
   registry: KeybindingsRegistry,
   platform: KeybindingsPlatform = currentKeybindingsPlatform(),
-  appliedActionIds?: ReadonlySet<string>,
+  appliedActionIds: ReadonlySet<string> = new Set(),
 ): ValidatedOverrides {
   const warnings: ValidationWarning[] = [];
   const reserved = RESERVED_BY_PLATFORM[platform];
@@ -222,12 +210,11 @@ export function validateOverrideRules(
   const live = new Map<string, EffectiveBinding[]>();
   for (const binding of registry.getState().bindings) {
     const list = live.get(binding.actionId) ?? [];
-    list.push({ scope: binding.scope, serialized: serializeChord(binding.chord) });
+    list.push({ scope: binding.scope, sequence: binding.chord });
     live.set(binding.actionId, list);
   }
-  const overridden = appliedActionIds ?? deriveOverriddenActions(registry);
   const dropped = new Set<string>();
-  for (const action of overridden) {
+  for (const action of appliedActionIds) {
     if (!candidates.some((c) => c.rule.action === action)) dropped.add(action);
   }
 
@@ -241,27 +228,34 @@ export function validateOverrideRules(
   for (;;) {
     const final = new Map<string, EffectiveBinding[]>();
     for (const [action, bindings] of live) final.set(action, [...bindings]);
-    for (const action of dropped) final.set(action, defaultBindingChordsForAction(action));
+    for (const action of dropped) {
+      final.set(
+        action,
+        defaultBindingShapesForAction(action).map((shape) => ({ scope: shape.scope, sequence: shape.sequence })),
+      );
+    }
     for (const candidate of candidates) {
       const defaultInput = DEFAULT_BINDINGS.find((b) => b.actionId === candidate.rule.action);
       if (defaultInput === undefined) continue;
       final.set(
         candidate.rule.action,
-        candidate.chord === null
-          ? []
-          : [{ scope: defaultInput.scope ?? GLOBAL_SCOPE, serialized: serializeChord(candidate.chord) }],
+        candidate.chord === null ? [] : [{ scope: defaultInput.scope ?? GLOBAL_SCOPE, sequence: candidate.chord }],
       );
     }
-    // Each (scope, chord) pair's first claimant; later claimants conflict
-    // with it, so conflict pairs always name the earliest claimant first.
-    const claimant = new Map<string, string>();
+    // Each binding's first overlapping claimant in final-map order, so
+    // conflict pairs always name the earliest claimant first.
+    const claimants: { action: string; binding: EffectiveBinding }[] = [];
     const conflicts: [string, string][] = [];
     for (const [action, bindings] of final) {
       for (const binding of bindings) {
-        const key = `${binding.scope}\0${binding.serialized}`;
-        const other = claimant.get(key);
-        if (other === undefined) claimant.set(key, action);
-        else if (other !== action) conflicts.push([other, action]);
+        const overlapping = claimants.find(
+          (c) =>
+            c.action !== action &&
+            c.binding.scope === binding.scope &&
+            chordsOverlap(c.binding.sequence, binding.sequence),
+        );
+        if (overlapping === undefined) claimants.push({ action, binding });
+        else conflicts.push([overlapping.action, action]);
       }
     }
     if (conflicts.length === 0 || guard-- <= 0) break;
@@ -285,13 +279,15 @@ export function validateOverrideRules(
       if (skip === -1) continue;
       const removed = candidates.splice(skip, 1)[0];
       if (removed === undefined) continue;
+      const removedDefault = DEFAULT_BINDINGS.find((b) => b.actionId === removed.rule.action);
+      const scope = removedDefault?.scope ?? GLOBAL_SCOPE;
       warnings.push({
         rule: removed.rule,
         reason: "conflict",
         conflictWith,
-        message: `chord "${removed.rule.chord ?? ""}" is already bound by "${conflictWith}"`,
+        message: `chord "${removed.rule.chord ?? ""}" in scope "${scope}" is already bound by "${conflictWith}"`,
       });
-      if (overridden.has(removed.rule.action)) dropped.add(removed.rule.action);
+      if (appliedActionIds.has(removed.rule.action)) dropped.add(removed.rule.action);
       skipped = true;
     }
     if (!skipped) break;

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
@@ -22,6 +22,7 @@ import { DisplaySection } from "./sections/display";
 import { GeneralSection } from "./sections/general";
 import { HubSection } from "./sections/hub";
 import { InRepoSection } from "./sections/inrepo";
+import { KeybindingsSection } from "./sections/keybindings";
 import { CodexLaunchSection } from "./sections/launchCodex";
 import { LaunchServerSection } from "./sections/launchServer";
 import { MarketplacesPluginsSection } from "./sections/marketplacesPlugins";
@@ -81,6 +82,7 @@ const SECTION_COMPONENTS: Record<string, ComponentType<{ sectionId: string }>> =
   transcript: TranscriptSection,
   display: DisplaySection,
   notifications: NotificationsSection,
+  keybindings: KeybindingsSection,
   hub: HubSection,
   mobile: MobileSection,
   storage: StorageSection,

--- a/cmd/evener-hub/frontend/src/panes/settings/sections.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections.test.ts
@@ -13,8 +13,8 @@ import {
 // two sections with no legacy counterpart, "about" and "mobile" (see
 // sections.ts's own doc comment).
 
-test("has exactly 18 sections", () => {
-  expect(SETTINGS_SECTIONS).toHaveLength(18);
+test("has exactly 19 sections", () => {
+  expect(SETTINGS_SECTIONS).toHaveLength(19);
 });
 
 test("every section id is unique", () => {
@@ -22,10 +22,17 @@ test("every section id is unique", () => {
   expect(new Set(ids).size).toBe(ids.length);
 });
 
-test("the 5 ungrouped sections are General/Theme/Transcript display/Display/Notifications, in this order, first", () => {
+test("the 6 ungrouped sections are General/Theme/Transcript display/Display/Notifications/Keybindings, in this order, first", () => {
   const ungrouped = SETTINGS_SECTIONS.filter((s) => s.cluster === undefined);
-  expect(ungrouped.map((s) => s.label)).toEqual(["General", "Theme", "Transcript display", "Display", "Notifications"]);
-  expect(SETTINGS_SECTIONS.slice(0, 5)).toEqual(ungrouped);
+  expect(ungrouped.map((s) => s.label)).toEqual([
+    "General",
+    "Theme",
+    "Transcript display",
+    "Display",
+    "Notifications",
+    "Keybindings",
+  ]);
+  expect(SETTINGS_SECTIONS.slice(0, 6)).toEqual(ungrouped);
 });
 
 test('the "Agents & models" cluster has exactly these 5 sections, in order, right after the ungrouped ones', () => {
@@ -37,19 +44,19 @@ test('the "Agents & models" cluster has exactly these 5 sections, in order, righ
     "Codex launch",
     "In-repo config",
   ]);
-  expect(SETTINGS_SECTIONS.slice(5, 10)).toEqual(cluster);
+  expect(SETTINGS_SECTIONS.slice(6, 11)).toEqual(cluster);
 });
 
 test('the "Extensions" cluster has exactly these 4 sections, in order, right after "Agents & models"', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "extensions");
   expect(cluster.map((s) => s.label)).toEqual(["Marketplaces & Plugins", "Plugins", "Skills", "MCP servers"]);
-  expect(SETTINGS_SECTIONS.slice(10, 14)).toEqual(cluster);
+  expect(SETTINGS_SECTIONS.slice(11, 15)).toEqual(cluster);
 });
 
 test('the "Daemon" cluster has exactly these 4 sections, in order, last', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "daemon");
   expect(cluster.map((s) => s.label)).toEqual(["Hub", "Mobile app", "Storage", "About"]);
-  expect(SETTINGS_SECTIONS.slice(14, 18)).toEqual(cluster);
+  expect(SETTINGS_SECTIONS.slice(15, 19)).toEqual(cluster);
 });
 
 test('"About" is the very last section overall', () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections.ts
@@ -2,9 +2,11 @@
 // SettingsNav's link list/grouping, the pane's own title() (paneRegistry),
 // and (via DEFAULT_SECTION_ID) what a bare /settings resolves to. Verified
 // against templates/partials/settings.html:13-31 (16 exact - "16 nav
-// sections" per the wave-7 plan's own Goal line) PLUS one section with no
-// legacy counterpart: "about" (design-language credits) and "mobile"
-// (browser-only dedicated-app pairing), added after that
+// sections" per the wave-7 plan's own Goal line) PLUS three sections with no
+// legacy counterpart: "keybindings" (the Phase 2b read-only effective-
+// shortcuts list, appended to the ungrouped top links), "about"
+// (design-language credits) and "mobile"
+// (browser-only dedicated-app pairing), the latter two added after that
 // baseline and deliberately placed last, in the Daemon cluster. The 16
 // legacy-parity sections are 5 ungrouped top links (General/Theme/
 // Transcript display/Display/Notifications) plus 3 labeled clusters ("Agents &
@@ -42,6 +44,7 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
   { id: "transcript", label: "Transcript display" },
   { id: "display", label: "Display" },
   { id: "notifications", label: "Notifications" },
+  { id: "keybindings", label: "Keybindings" },
   // --- Agents & models -----------------------------------------------
   { id: "credentials", label: "Providers & credentials", cluster: "agents-models" },
   { id: "agents", label: "Agents", cluster: "agents-models" },

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
@@ -1,0 +1,84 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+.intro {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+  line-height: var(--line-height-body);
+}
+
+.status {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+.status p {
+  margin: 0;
+}
+
+.warningList {
+  margin: var(--space-1) 0 0;
+  padding-left: var(--space-4);
+}
+
+.error {
+  margin: 0;
+  background: var(--surface-inset);
+  padding: var(--space-2) var(--space-3);
+  color: var(--ink-hi);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+  line-height: var(--line-height-body);
+}
+
+.marker {
+  background: var(--surface-inset);
+  border-radius: var(--radius-chip);
+  padding: 0 var(--space-2);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+.unbound {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+.chord {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { ACTIONS } from "../../../keybindings/actions";
+import { DEFAULT_BINDINGS, registerDefaultBindings } from "../../../keybindings/defaults";
+import { keybindingsRegistry } from "../../../keybindings/registry";
+import { FakeClient } from "../../../protocol/testing/fakeClient";
+import type { KeybindingsOverrides, KeybindingsRule } from "../../../protocol/types.gen";
+import { connectionStore } from "../../../stores/connection";
+import { keybindingsStore, resetKeybindingsStoreForTests } from "../../../stores/keybindings";
+import { KeybindingsSection } from "./keybindings";
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+function overridesPayload(revision: number, rules: KeybindingsRule[]): KeybindingsOverrides {
+  return { version: 1, revision, rules };
+}
+
+async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  });
+  await keybindingsStore.getState().refreshOverrides();
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+});
+
+afterEach(() => {
+  cleanup();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+});
+
+function rowFor(title: string): HTMLElement {
+  const label = screen.getByText(title);
+  const row = label.closest("li");
+  if (row === null) throw new Error(`no row for "${title}"`);
+  return row;
+}
+
+test("lists every default action with its title and effective chord, none customized", () => {
+  render(<KeybindingsSection />);
+
+  // The row list is sourced live from the keybindings module's default map,
+  // never a hand-maintained copy: one row per action, in default-map order.
+  const rows = screen.getAllByRole("listitem");
+  expect(rows).toHaveLength(DEFAULT_BINDINGS.length);
+  expect(rows.map((row) => row.textContent)).toEqual([
+    expect.stringContaining("Open the command palette"),
+    expect.stringContaining("Toggle the sidebar"),
+    expect.stringContaining("Focus the composer"),
+    expect.stringContaining("Go to the next session needing you"),
+    expect.stringContaining("Quote the selection into the composer"),
+    expect.stringContaining("Close settings"),
+  ]);
+  expect(screen.queryByText("Customized")).toBeNull();
+
+  // jsdom resolves $mod to Control, so palette.open's effective chord renders
+  // as the Ctrl + K kbd pair via the KeyHint widget.
+  const paletteRow = rowFor("Open the command palette");
+  expect(within(paletteRow).getByText("Ctrl")).toBeTruthy();
+  expect(within(paletteRow).getByText("K")).toBeTruthy();
+  // settings.close's default chord lists every modifier as optional, so only
+  // the Escape key renders.
+  const settingsRow = rowFor("Close settings");
+  expect(within(settingsRow).getByText("Escape")).toBeTruthy();
+});
+
+test("with no hub connection the section waits quietly and still shows the defaults", () => {
+  render(<KeybindingsSection />);
+  expect(screen.getByRole("status").textContent).toContain("Waiting for the hub");
+  expect(rowFor("Open the command palette").textContent).toContain("K");
+});
+
+test("an applied override marks the action customized and shows the override chord", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  const paletteRow = rowFor("Open the command palette");
+  expect(within(paletteRow).getByText("Customized")).toBeTruthy();
+  expect(within(paletteRow).getByText("P")).toBeTruthy();
+  expect(within(paletteRow).queryByText("K")).toBeNull();
+  // Untouched actions keep their default chords and no marker.
+  const railRow = rowFor("Toggle the sidebar");
+  expect(within(railRow).queryByText("Customized")).toBeNull();
+  expect(within(railRow).getByText("B")).toBeTruthy();
+});
+
+test("an unbound action renders Unbound and counts as customized", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: null }]),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  const paletteRow = rowFor("Open the command palette");
+  expect(within(paletteRow).getByText("Unbound")).toBeTruthy();
+  expect(within(paletteRow).getByText("Customized")).toBeTruthy();
+});
+
+test("a hub that predates the feature shows a quiet unsupported status and the defaults", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+  await wireClient(client, false);
+  render(<KeybindingsSection />);
+
+  expect(screen.getByRole("status").textContent).toContain("does not support synced keybinding overrides");
+  expect(screen.queryByRole("alert")).toBeNull();
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
+test("a hub load failure surfaces the error honestly and keeps the defaults visible", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => {
+    throw new Error("socket went away");
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  expect(screen.getByRole("alert").textContent).toContain("socket went away");
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
+test("validation warnings from the applied payload are listed quietly", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(2, [
+      { action: "no.such.action", chord: "Control+P" },
+      { action: ACTIONS.railToggle, chord: "Control+W" }, // reserved on every platform
+    ]),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  const status = screen.getByRole("status");
+  expect(status.textContent).toContain('unknown keybinding action "no.such.action"');
+  expect(status.textContent).toContain('chord "Control+W" is reserved');
+  // Both bad rules were skipped: every action stays on its default.
+  expect(screen.queryByText("Customized")).toBeNull();
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -1,0 +1,137 @@
+// Settings -> Keybindings: a READ-ONLY listing of the effective bindings.
+// The action list is sourced live from the keybindings module's default map
+// (DEFAULT_BINDINGS is also the validator's action universe), never a
+// hand-maintained copy - the survey's stale-HELP_ROWS lesson. The chords come
+// from the live registry, so hub overrides applied by the keybindings store
+// show up the moment they reconcile. Editing affordances are deliberately
+// absent; the shortcuts editor is a later phase.
+
+import { useStore } from "zustand";
+import { chordDisplayKeys, serializeChord } from "../../../keybindings/chord";
+import { DEFAULT_BINDINGS, defaultBindingChordsForAction } from "../../../keybindings/defaults";
+import { type Binding, keybindingsRegistry } from "../../../keybindings/registry";
+import { useKeybindingsStore } from "../../../stores/keybindings";
+import { KeyHint } from "../../../widgets";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import styles from "./keybindings.module.css";
+
+const CLASS = {
+  root: requireClass(styles.root, "keybindings.module.css", "root"),
+  intro: requireClass(styles.intro, "keybindings.module.css", "intro"),
+  status: requireClass(styles.status, "keybindings.module.css", "status"),
+  warningList: requireClass(styles.warningList, "keybindings.module.css", "warningList"),
+  error: requireClass(styles.error, "keybindings.module.css", "error"),
+  list: requireClass(styles.list, "keybindings.module.css", "list"),
+  row: requireClass(styles.row, "keybindings.module.css", "row"),
+  label: requireClass(styles.label, "keybindings.module.css", "label"),
+  marker: requireClass(styles.marker, "keybindings.module.css", "marker"),
+  unbound: requireClass(styles.unbound, "keybindings.module.css", "unbound"),
+  chord: requireClass(styles.chord, "keybindings.module.css", "chord"),
+};
+
+interface ActionRow {
+  actionId: string;
+  title: string;
+}
+
+// One row per action, in default-map order. Module-level because it derives
+// entirely from the compiled-in default map; the effective chord each row
+// shows is read from the live registry at render.
+const ACTION_ROWS: readonly ActionRow[] = (() => {
+  const seen = new Set<string>();
+  const rows: ActionRow[] = [];
+  for (const input of DEFAULT_BINDINGS) {
+    if (seen.has(input.actionId)) continue;
+    seen.add(input.actionId);
+    rows.push({ actionId: input.actionId, title: input.title });
+  }
+  return rows;
+})();
+
+/** The binding to display for an action: the override when present, else the
+ * platform base entry (its `#mod-twin` shows the same chord on this
+ * platform), else whatever binding the action has left. */
+function displayBindingFor(bindings: readonly Binding[], actionId: string): Binding | undefined {
+  const owned = bindings.filter((b) => b.actionId === actionId);
+  return owned.find((b) => b.id === `${actionId}#override`) ?? owned.find((b) => b.id === actionId) ?? owned[0];
+}
+
+/** Whether the action's effective bindings differ from its default map
+ * entries - including the unbound (override `chord: null`) case, where the
+ * effective set is empty. */
+function isCustomized(bindings: readonly Binding[], actionId: string): boolean {
+  const effective = bindings
+    .filter((b) => b.actionId === actionId)
+    .map((b) => `${b.scope} ${serializeChord(b.chord)}`)
+    .sort();
+  const defaults = defaultBindingChordsForAction(actionId)
+    .map((d) => `${d.scope} ${d.serialized}`)
+    .sort();
+  return effective.length !== defaults.length || effective.some((entry, i) => entry !== defaults[i]);
+}
+
+export function KeybindingsSection() {
+  const hubSupport = useKeybindingsStore((s) => s.hubSupport);
+  const hubError = useKeybindingsStore((s) => s.hubError);
+  const warnings = useKeybindingsStore((s) => s.warnings);
+  const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
+
+  let status: string | undefined;
+  if (hubSupport === "unknown") {
+    status = "Waiting for the hub connection to report keybindings support.";
+  } else if (hubSupport === "unsupported") {
+    status = "This hub does not support synced keybinding overrides. The built-in defaults are in effect.";
+  }
+
+  return (
+    <div className={CLASS.root}>
+      <p className={CLASS.intro}>
+        The keyboard shortcuts currently in effect. Bindings marked Customized come from this hub's synced overrides.
+      </p>
+
+      {status !== undefined && (
+        <p className={CLASS.status} role="status">
+          {status}
+        </p>
+      )}
+      {hubError !== null && (
+        <p className={CLASS.error} role="alert">
+          Could not load keybinding overrides: {hubError}
+        </p>
+      )}
+      {warnings.length > 0 && (
+        <div className={CLASS.status} role="status">
+          <p>Some saved overrides were skipped:</p>
+          <ul className={CLASS.warningList}>
+            {warnings.map((warning) => (
+              <li key={warning.message}>{warning.message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <ul className={CLASS.list}>
+        {ACTION_ROWS.map((row) => {
+          const binding = displayBindingFor(bindings, row.actionId);
+          return (
+            <li className={CLASS.row} key={row.actionId}>
+              <span className={CLASS.label}>
+                {row.title}
+                {isCustomized(bindings, row.actionId) && <span className={CLASS.marker}>Customized</span>}
+              </span>
+              {binding === undefined ? (
+                <span className={CLASS.unbound}>Unbound</span>
+              ) : (
+                <span className={CLASS.chord}>
+                  {binding.chord.map((press) => (
+                    <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
+                  ))}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -427,6 +427,7 @@ export interface FeatureSet {
   directoryComplete: boolean;
   auth: boolean;
   transcriptDisplaySettings?: boolean;
+  keybindingsSettings?: boolean;
 }
 
 export interface GitHeadParams {
@@ -714,6 +715,27 @@ export interface JobsTreeUpdatedParams {
   threadId: string;
   ref: string;
   revision: number;
+}
+
+export interface KeybindingsConfig {
+  version: number;
+  rules: KeybindingsRule[];
+}
+
+export interface KeybindingsOverrides {
+  version: number;
+  revision: number;
+  rules: KeybindingsRule[];
+}
+
+export interface KeybindingsPatchParams {
+  expectedRevision: number;
+  config: KeybindingsConfig;
+}
+
+export interface KeybindingsRule {
+  action: string;
+  chord: string | null;
 }
 
 export interface LaunchConfigDiagnostic {
@@ -2118,6 +2140,8 @@ export const METHOD_NAMES = [
   "evener/settings/overview",
   "evener/settings/transcriptDisplay/get",
   "evener/settings/transcriptDisplay/patch",
+  "evener/settings/keybindings/get",
+  "evener/settings/keybindings/patch",
   "evener/sandbox/escalation/resolve",
 ] as const;
 
@@ -2159,6 +2183,7 @@ export const NOTIFICATION_NAMES = [
   "evener/sandbox/escalation/requested",
   "evener/sandbox/escalation/resolved",
   "evener/settings/transcriptDisplay/changed",
+  "evener/settings/keybindings/changed",
 ] as const;
 
 export type NotificationName = (typeof NOTIFICATION_NAMES)[number];
@@ -2295,6 +2320,8 @@ export interface MethodTypes {
   "evener/settings/overview": { params: EmptyParams; result: SettingsOverviewResponse };
   "evener/settings/transcriptDisplay/get": { params: EmptyParams; result: TranscriptDisplayDefaults };
   "evener/settings/transcriptDisplay/patch": { params: TranscriptDisplayDefaultsPatchParams; result: TranscriptDisplayPatchResponse };
+  "evener/settings/keybindings/get": { params: EmptyParams; result: KeybindingsOverrides };
+  "evener/settings/keybindings/patch": { params: KeybindingsPatchParams; result: KeybindingsOverrides };
   "evener/sandbox/escalation/resolve": { params: SandboxEscalationResolveParams; result: EmptyResponse };
 }
 
@@ -2334,6 +2361,7 @@ export interface NotificationTypes {
   "evener/sandbox/escalation/requested": SandboxEscalationRequested;
   "evener/sandbox/escalation/resolved": SandboxEscalationResolved;
   "evener/settings/transcriptDisplay/changed": TranscriptDisplayChangedParams;
+  "evener/settings/keybindings/changed": KeybindingsOverrides;
 }
 
 export type AnyNotification = { [K in NotificationName]: { method: K; params: NotificationTypes[K] } }[NotificationName];

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -24,6 +24,12 @@ function overridesPayload(revision: number, rules: KeybindingsRule[]): Keybindin
   return { version: 1, revision, rules };
 }
 
+function defaultChordOf(bindingId: string): string {
+  const binding = keybindingsRegistry.getState().bindings.find((b) => b.id === bindingId);
+  if (binding === undefined) throw new Error(`test setup: no binding ${bindingId}`);
+  return serializeChord(binding.chord);
+}
+
 async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
   connectionStore.getState().connect(client);
   connectionStore.setState({
@@ -268,5 +274,113 @@ describe("keybindings store: patch", () => {
       keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
     ).rejects.toThrow(/unavailable/);
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+});
+
+describe("keybindings store: reconcile resilience", () => {
+  test("dropping an override whose default chord was reclaimed degrades to a warning and restores every action", async () => {
+    // The reviewer's reproduction. Payload 1 is legal via freed-chord
+    // reclaim: palette.open moves away, rail.toggle claims its default chord.
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        { action: ACTIONS.railToggle, chord: paletteDefault },
+      ]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+
+    // Payload 2 drops palette.open's override: restoring its default needs
+    // the chord rail.toggle is holding. The reconcile must not throw.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, [{ action: ACTIONS.railToggle, chord: paletteDefault }]),
+    });
+
+    const state = keybindingsStore.getState();
+    expect(state.hubError).toBeNull();
+    expect(state.revision).toBe(2);
+    // The restore wins: the rule claiming the restored default's chord is
+    // skipped with a conflict warning, so BOTH actions fall back to their
+    // defaults and every action stays bound.
+    expect(state.warnings).toHaveLength(1);
+    expect(state.warnings[0]?.reason).toBe("conflict");
+    expect(state.warnings[0]?.rule).toEqual({ action: ACTIONS.railToggle, chord: paletteDefault });
+    expect(state.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+    expect(state.overrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([
+      ACTIONS.railToggle,
+      `${ACTIONS.railToggle}#mod-twin`,
+    ]);
+  });
+
+  test("a reconcile failure on the changed path sets hubError, keeps the revision retryable, and rolls back", async () => {
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().revision).toBe(1);
+
+    // Out-of-band wedge: a foreign binding squats palette.open's default
+    // chord, so restoring it (when the override is dropped) conflicts with a
+    // binding no rule can be reassigned to.
+    keybindingsRegistry
+      .getState()
+      .registerBinding({ id: "foreign", actionId: "foreign.action", chord: paletteDefault });
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, []),
+    });
+
+    const failed = keybindingsStore.getState();
+    // Nothing escaped the notification dispatch; the failure is surfaced.
+    expect(failed.hubError).not.toBeNull();
+    // The revision did NOT advance past a failed apply...
+    expect(failed.revision).toBe(1);
+    // ...and the registry rolled back to its last good state.
+    const paletteBindings = bindingsFor(ACTIONS.paletteOpen);
+    expect(paletteBindings.map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(serializeChord(paletteBindings[0]?.chord ?? [])).toBe("Control+P");
+
+    // Removing the wedge makes the SAME revision retryable (the stale guard
+    // did not eat it).
+    keybindingsRegistry.getState().unregisterBinding("foreign");
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, []),
+    });
+    const retried = keybindingsStore.getState();
+    expect(retried.hubError).toBeNull();
+    expect(retried.revision).toBe(2);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("resetKeybindingsStoreForTests is safe after a wedging attempt", async () => {
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    keybindingsRegistry
+      .getState()
+      .registerBinding({ id: "foreign", actionId: "foreign.action", chord: paletteDefault });
+
+    expect(() => resetKeybindingsStoreForTests()).not.toThrow();
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().overrides).toEqual([]);
   });
 });

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ACTIONS } from "../keybindings/actions";
+import { serializeChord } from "../keybindings/chord";
+import { registerDefaultBindings } from "../keybindings/defaults";
+import { type Binding, keybindingsRegistry } from "../keybindings/registry";
+import { WireError } from "../protocol/errors";
+import { FakeClient } from "../protocol/testing/fakeClient";
+import type { KeybindingsOverrides, KeybindingsRule } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+import { keybindingsStore, resetKeybindingsStoreForTests } from "./keybindings";
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+function bindingsFor(actionId: string): Binding[] {
+  return keybindingsRegistry.getState().bindings.filter((b) => b.actionId === actionId);
+}
+
+function overridesPayload(revision: number, rules: KeybindingsRule[]): KeybindingsOverrides {
+  return { version: 1, revision, rules };
+}
+
+async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  });
+  await keybindingsStore.getState().refreshOverrides();
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+});
+
+afterEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+  vi.restoreAllMocks();
+});
+
+describe("keybindings store: startup", () => {
+  test("applies the hub overrides to the registry on connect", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+
+    const bindings = bindingsFor(ACTIONS.paletteOpen);
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0]?.id).toBe(`${ACTIONS.paletteOpen}#override`);
+    expect(serializeChord(bindings[0]?.chord ?? [])).toBe("Control+P");
+
+    const state = keybindingsStore.getState();
+    expect(state.hubSupport).toBe("supported");
+    expect(state.revision).toBe(3);
+    expect(state.overrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(state.warnings).toEqual([]);
+    expect(state.hubError).toBeNull();
+  });
+
+  test("defaults only when the server predates the feature: no request, unsupported state, no crash", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    await wireClient(client, false);
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/get")).toHaveLength(0);
+    expect(keybindingsStore.getState().hubSupport).toBe("unsupported");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("an unreachable hub surfaces hubError and leaves defaults in place", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => {
+      throw new Error("socket went away");
+    });
+    await wireClient(client, true);
+
+    expect(keybindingsStore.getState().hubError).toBe("socket went away");
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  test("malformed get payloads surface hubError and leave defaults in place", async () => {
+    const client = new FakeClient("ready");
+    client.on(
+      "evener/settings/keybindings/get",
+      () => ({ version: 2, revision: "three", rules: "nope" }) as unknown as KeybindingsOverrides,
+    );
+    await wireClient(client, true);
+
+    expect(keybindingsStore.getState().hubError).not.toBeNull();
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  test("semantically invalid rules are skipped with warnings; valid rules still apply", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(2, [
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.railToggle, chord: "Control+W" }, // reserved on this platform
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]),
+    );
+    await wireClient(client, true);
+
+    const state = keybindingsStore.getState();
+    expect(state.warnings.map((w) => w.reason)).toEqual(["unknown-action", "reserved-chord"]);
+    expect(state.overrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+    expect(bindingsFor(ACTIONS.railToggle)).toHaveLength(2);
+  });
+});
+
+describe("keybindings store: changed reconciliation", () => {
+  test("a changed notification rebinds the delta and leaves other bindings untouched (same object identity)", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    const untouched = bindingsFor(ACTIONS.railToggle);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+U" }]),
+    });
+
+    const bindings = bindingsFor(ACTIONS.paletteOpen);
+    expect(bindings).toHaveLength(1);
+    expect(serializeChord(bindings[0]?.chord ?? [])).toBe("Control+U");
+    // The delta discipline: rail.toggle's binding objects were never torn down.
+    expect(bindingsFor(ACTIONS.railToggle)).toEqual(untouched);
+    expect(bindingsFor(ACTIONS.railToggle)[0]).toBe(untouched[0]);
+    expect(keybindingsStore.getState().revision).toBe(4);
+  });
+
+  test("a changed notification that drops an override restores the action's defaults", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(1);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, []),
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    expect(keybindingsStore.getState().overrides).toEqual([]);
+    expect(keybindingsStore.getState().revision).toBe(4);
+  });
+
+  test("a changed notification can unbind an action (chord null)", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    await wireClient(client, true);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: null }]),
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(0);
+    expect(keybindingsStore.getState().overrides).toEqual([{ action: ACTIONS.paletteOpen, chord: null }]);
+  });
+
+  test("a stale changed notification (older revision) is ignored", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(5, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, []),
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(keybindingsStore.getState().revision).toBe(5);
+  });
+});
+
+describe("keybindings store: patch", () => {
+  test("sends expectedRevision and applies the canonical response", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    const requested: KeybindingsRule[] = [{ action: ACTIONS.composerFocus, chord: "Control+M" }];
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, requested));
+    await wireClient(client, true);
+
+    const result = await keybindingsStore.getState().patchOverrides(requested);
+
+    expect(result.revision).toBe(4);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 3,
+      config: { version: 1, rules: requested },
+    });
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+    expect(keybindingsStore.getState().revision).toBe(4);
+    expect(keybindingsStore.getState().conflict).toBeNull();
+  });
+
+  test("a revision conflict refreshes to the server's current state and surfaces the conflict", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => {
+      throw new WireError("revision conflict", -32013, {
+        evenerErrorInfo: "conflict",
+        current: overridesPayload(6, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+      });
+    });
+    await wireClient(client, true);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow("revision conflict");
+
+    const state = keybindingsStore.getState();
+    expect(state.revision).toBe(6);
+    expect(state.conflict).toBe("revision conflict");
+    expect(state.hubError).toBe("revision conflict");
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+  });
+
+  test("a non-conflict patch failure surfaces hubError and changes nothing", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => {
+      throw new WireError("state unavailable", -32014);
+    });
+    await wireClient(client, true);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow("state unavailable");
+
+    expect(keybindingsStore.getState().hubError).toBe("state unavailable");
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+  });
+
+  test("patch against an unsupported server throws without a request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, false);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow(/unavailable/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -1,0 +1,352 @@
+// The keybindings overrides store: mirrors stores/transcriptDisplay.ts's hub
+// posture (feature gating, hubSupport, ready-generation wiring, conflict
+// refresh) for user keybinding overrides. The hub layer is the ONLY layer -
+// unlike transcript display there is no localStorage layer: an unsupported
+// or unreachable hub means defaults only, never a local fallback copy.
+//
+// Applied overrides live in the keybindings registry (src/keybindings/), not
+// in this store's state: startup `get` and every `changed` notification are
+// validated semantically (keybindings/validation.ts) and reconciled into the
+// registry as a DELTA - only actions whose effective chord changed are
+// rebound, and actions whose overrides vanished get their defaults restored -
+// so in-flight dispatcher state for untouched actions is never torn down.
+// Validation failures degrade to warnings + skipped rules; nothing here can
+// crash startup on malformed persisted data.
+
+import { useStore } from "zustand";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { serializeChord } from "../keybindings/chord";
+import { rebindAction, removeActionBindings, restoreDefaultBinding } from "../keybindings/overrides";
+import { keybindingsRegistry } from "../keybindings/registry";
+import { type OverrideRule, type ValidationWarning, validateOverrideRules } from "../keybindings/validation";
+import { WireError } from "../protocol/errors";
+import type { AppwireClientLike } from "../protocol/testing/fakeClient";
+import type { AnyNotification, KeybindingsOverrides } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+
+export interface KeybindingsStoreState {
+  hubSupport: "unknown" | "supported" | "unsupported";
+  hubLoading: boolean;
+  hubError: string | null;
+  /** Revision of the last confirmed hub payload (0 = shipped defaults). */
+  revision: number;
+  /** The validated rules currently applied to the registry. */
+  overrides: readonly OverrideRule[];
+  /** Semantic-validation warnings from the last applied payload. */
+  warnings: readonly ValidationWarning[];
+  /** Set when a patch lost the revision race; the store has already refreshed
+   * to the server's current state when this is non-null. */
+  conflict: string | null;
+  refreshOverrides(): Promise<void>;
+  patchOverrides(rules: readonly OverrideRule[]): Promise<KeybindingsOverrides>;
+}
+
+function initialState(): Omit<KeybindingsStoreState, "refreshOverrides" | "patchOverrides"> {
+  return {
+    hubSupport: "unknown",
+    hubLoading: false,
+    hubError: null,
+    revision: 0,
+    overrides: [],
+    warnings: [],
+    conflict: null,
+  };
+}
+
+let wiredClient: AppwireClientLike | null = null;
+let unwireNotification: (() => void) | null = null;
+let unwireReady: (() => void) | null = null;
+let clientEpoch = 0;
+let activeReadyClient: AppwireClientLike | null = null;
+let activeReadyEpoch = -1;
+let refreshSerial = 0;
+let patchSerial = 0;
+
+/** The action -> effective override (serialized chord, or null for an unbind)
+ * currently applied to the registry. Module-level like the template's wiring
+ * state: it describes the registry singleton, not store state. */
+const appliedOverrides = new Map<string, string | null>();
+
+/** Structural check for a wire payload (get result, changed params, patch
+ * response, conflict `current`). The server's own validation already ran; this
+ * is the trust-boundary re-check so a malformed payload degrades to an error
+ * state instead of a crash. */
+function fromWireOverrides(value: unknown): KeybindingsOverrides | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.version !== 1) return undefined;
+  if (typeof candidate.revision !== "number" || !Number.isSafeInteger(candidate.revision) || candidate.revision < 0)
+    return undefined;
+  if (!Array.isArray(candidate.rules)) return undefined;
+  for (const rule of candidate.rules) {
+    if (typeof rule !== "object" || rule === null || Array.isArray(rule)) return undefined;
+    const entry = rule as Record<string, unknown>;
+    if (typeof entry.action !== "string" || !(entry.chord === null || typeof entry.chord === "string"))
+      return undefined;
+  }
+  return value as KeybindingsOverrides;
+}
+
+/** Reconciles the registry to the payload's effective overrides: validates,
+ * strips the bindings of every action whose effective chord changed, then
+ * re-establishes each (override or restored default). Two-phase so a payload
+ * that moves a chord between actions never trips a transient conflict. */
+function applyOverrideRules(rules: readonly OverrideRule[]): void {
+  const validated = validateOverrideRules(rules, keybindingsRegistry);
+  const next = new Map<string, string | null>();
+  for (const rule of validated.rules) {
+    next.set(rule.action, rule.chord === null ? null : serializeChord(rule.chord));
+  }
+  const changedActions = new Set<string>();
+  for (const [action, chord] of next) {
+    if (!appliedOverrides.has(action) || appliedOverrides.get(action) !== chord) changedActions.add(action);
+  }
+  for (const action of appliedOverrides.keys()) {
+    if (!next.has(action)) changedActions.add(action);
+  }
+  if (changedActions.size > 0) {
+    for (const action of changedActions) removeActionBindings(keybindingsRegistry, action);
+    for (const action of changedActions) {
+      if (next.has(action)) {
+        rebindAction(keybindingsRegistry, action, next.get(action) ?? null);
+      } else {
+        restoreDefaultBinding(keybindingsRegistry, action);
+      }
+    }
+  }
+  appliedOverrides.clear();
+  for (const [action, chord] of next) appliedOverrides.set(action, chord);
+  keybindingsStore.setState({
+    overrides: validated.rules.map((rule) => ({
+      action: rule.action,
+      chord: rule.chord === null ? null : serializeChord(rule.chord),
+    })),
+    warnings: validated.warnings,
+  });
+}
+
+/** Applies a confirmed hub payload (get result, changed params, patch
+ * response): stale revisions are ignored, the rest reconcile the registry. */
+function applyHubOverrides(payload: KeybindingsOverrides): void {
+  const state = keybindingsStore.getState();
+  if (payload.revision < state.revision) return;
+  keybindingsStore.setState({ revision: payload.revision });
+  applyOverrideRules(payload.rules);
+}
+
+function currentSupport(): "unknown" | "supported" | "unsupported" {
+  const features = connectionStore.getState().features;
+  if (features === undefined) return "unknown";
+  return features.keybindingsSettings === true ? "supported" : "unsupported";
+}
+
+function currentClient(): AppwireClientLike | null {
+  return connectionStore.getState().client;
+}
+
+function isCurrentReady(client: AppwireClientLike, epoch: number): boolean {
+  return (
+    wiredClient === client &&
+    activeReadyClient === client &&
+    activeReadyEpoch === epoch &&
+    clientEpoch === epoch &&
+    connectionStore.getState().client === client &&
+    client.state === "ready"
+  );
+}
+
+function invalidateReadyGeneration(): void {
+  activeReadyClient = null;
+  activeReadyEpoch = -1;
+  clientEpoch += 1;
+  unwireNotification?.();
+  unwireNotification = null;
+}
+
+function beginReadyGeneration(client: AppwireClientLike): number {
+  activeReadyClient = client;
+  activeReadyEpoch = ++clientEpoch;
+  const epoch = activeReadyEpoch;
+  unwireNotification?.();
+  unwireNotification = client.onNotification((notification) => {
+    if (!isCurrentReady(client, epoch)) return;
+    onNotification(notification);
+  });
+  return epoch;
+}
+
+function setSupportFromConnection(): void {
+  const support = currentSupport();
+  const state = keybindingsStore.getState();
+  if (support === "supported") {
+    if (state.hubSupport !== support) keybindingsStore.setState({ hubSupport: support });
+    return;
+  }
+  if (state.hubSupport !== support || state.hubLoading || state.hubError !== null)
+    keybindingsStore.setState({ hubSupport: support, hubLoading: false, hubError: null });
+}
+
+function onNotification(notification: AnyNotification): void {
+  if (notification.method !== "evener/settings/keybindings/changed") return;
+  const payload = fromWireOverrides(notification.params);
+  if (payload === undefined) return;
+  applyHubOverrides(payload);
+}
+
+async function refreshFor(client: AppwireClientLike, epoch: number): Promise<void> {
+  if (!isCurrentReady(client, epoch) || currentSupport() !== "supported") return;
+  const serial = ++refreshSerial;
+  keybindingsStore.setState({ hubLoading: true, hubError: null });
+  try {
+    const result = await client.request("evener/settings/keybindings/get", {});
+    if (!isCurrentReady(client, epoch) || serial !== refreshSerial || currentSupport() !== "supported") return;
+    const payload = fromWireOverrides(result);
+    if (payload === undefined) throw new Error("Hub returned malformed keybindings overrides");
+    applyHubOverrides(payload);
+  } catch (error) {
+    if (isCurrentReady(client, epoch) && serial === refreshSerial) {
+      keybindingsStore.setState({ hubError: error instanceof Error ? error.message : String(error) });
+    }
+  } finally {
+    if (isCurrentReady(client, epoch) && serial === refreshSerial) keybindingsStore.setState({ hubLoading: false });
+  }
+}
+
+function rewireClient(client: AppwireClientLike): void {
+  if (client === wiredClient) return;
+  invalidateReadyGeneration();
+  unwireReady?.();
+  unwireReady = null;
+  wiredClient = client;
+  unwireReady = client.onReady(() => {
+    const epoch = beginReadyGeneration(client);
+    void refreshFor(client, epoch);
+  });
+  if (client.state === "ready") {
+    const epoch = beginReadyGeneration(client);
+    void refreshFor(client, epoch);
+  }
+}
+
+function onConnectionChange(
+  state: ReturnType<typeof connectionStore.getState>,
+  previous: ReturnType<typeof connectionStore.getState>,
+): void {
+  if (state.client !== wiredClient && state.client !== null) rewireClient(state.client);
+  if (
+    state.client === wiredClient &&
+    previous.client === state.client &&
+    previous.state === "ready" &&
+    state.state !== "ready"
+  ) {
+    invalidateReadyGeneration();
+  }
+  if (state.client === null && wiredClient !== null) {
+    invalidateReadyGeneration();
+    unwireReady?.();
+    unwireReady = null;
+    wiredClient = null;
+  }
+  setSupportFromConnection();
+  if (
+    state.client === wiredClient &&
+    state.features?.keybindingsSettings === true &&
+    previous.features?.keybindingsSettings !== true &&
+    state.client?.state === "ready"
+  ) {
+    if (activeReadyClient === state.client) void refreshFor(state.client, activeReadyEpoch);
+  }
+}
+
+/** Extracts the server's current payload from a revision-conflict rejection
+ * (appwire CodeConflict -32013 with data.evenerErrorInfo "conflict"). */
+function conflictCurrent(error: unknown): KeybindingsOverrides | undefined {
+  if (!(error instanceof WireError) || error.code !== -32013 || typeof error.data !== "object" || error.data === null)
+    return undefined;
+  const data = error.data as Record<string, unknown>;
+  if (data.evenerErrorInfo !== "conflict") return undefined;
+  return fromWireOverrides(data.current);
+}
+
+export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<KeybindingsStoreState>(() => ({
+  ...initialState(),
+  refreshOverrides: async () => {
+    const client = currentClient();
+    if (client === null || client !== wiredClient || activeReadyClient !== client) return;
+    await refreshFor(client, activeReadyEpoch);
+  },
+  patchOverrides: async (rules): Promise<KeybindingsOverrides> => {
+    const state = keybindingsStore.getState();
+    const client = currentClient();
+    const generation = client === activeReadyClient ? activeReadyEpoch : -1;
+    if (
+      state.hubSupport !== "supported" ||
+      currentSupport() !== "supported" ||
+      client === null ||
+      client !== wiredClient ||
+      generation < 0 ||
+      client.state !== "ready"
+    ) {
+      const error = "Hub keybindings settings are unavailable.";
+      keybindingsStore.setState({ hubError: error });
+      throw new Error(error);
+    }
+    const token = ++patchSerial;
+    try {
+      const result = await client.request("evener/settings/keybindings/patch", {
+        expectedRevision: state.revision,
+        config: { version: 1, rules: rules.map((rule) => ({ action: rule.action, chord: rule.chord })) },
+      });
+      if (token !== patchSerial || !isCurrentReady(client, generation)) {
+        const current = keybindingsStore.getState();
+        return { version: 1, revision: current.revision, rules: [...current.overrides] };
+      }
+      const payload = fromWireOverrides(result);
+      if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");
+      applyHubOverrides(payload);
+      keybindingsStore.setState({ hubError: null, conflict: null });
+      return payload;
+    } catch (error) {
+      if (token === patchSerial && isCurrentReady(client, generation)) {
+        const current = conflictCurrent(error);
+        if (current !== undefined) applyHubOverrides(current);
+        const message = error instanceof Error ? error.message : String(error);
+        keybindingsStore.setState({
+          hubError: message,
+          ...(current === undefined ? {} : { conflict: message }),
+        });
+      }
+      throw error;
+    }
+  },
+}));
+
+connectionStore.subscribe(onConnectionChange);
+const initialClient = connectionStore.getState().client;
+if (initialClient !== null) rewireClient(initialClient);
+
+export function resetKeybindingsStoreForTests(): void {
+  invalidateReadyGeneration();
+  unwireReady?.();
+  unwireReady = null;
+  wiredClient = null;
+  refreshSerial += 1;
+  patchSerial += 1;
+  // Restore defaults for every applied override so the registry singleton
+  // cannot leak overrides into the next test.
+  for (const action of appliedOverrides.keys()) {
+    restoreDefaultBinding(keybindingsRegistry, action);
+  }
+  appliedOverrides.clear();
+  keybindingsStore.setState({ ...initialState() });
+  setSupportFromConnection();
+}
+
+export function useKeybindingsStore(): KeybindingsStoreState;
+export function useKeybindingsStore<T>(selector: (state: KeybindingsStoreState) => T): T;
+export function useKeybindingsStore<T>(selector?: (state: KeybindingsStoreState) => T): T | KeybindingsStoreState {
+  // Same Zustand hook in both arms; the overload only avoids exposing an
+  // optional selector to useStore's stricter TypeScript signature.
+  // biome-ignore lint/correctness/useHookAtTopLevel: both arms call the same hook
+  return selector ? useStore(keybindingsStore, selector) : useStore(keybindingsStore);
+}

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -17,7 +17,7 @@ import { useStore } from "zustand";
 import { createStore, type StoreApi } from "zustand/vanilla";
 import { serializeChord } from "../keybindings/chord";
 import { rebindAction, removeActionBindings, restoreDefaultBinding } from "../keybindings/overrides";
-import { keybindingsRegistry } from "../keybindings/registry";
+import { type Binding, keybindingsRegistry } from "../keybindings/registry";
 import { type OverrideRule, type ValidationWarning, validateOverrideRules } from "../keybindings/validation";
 import { WireError } from "../protocol/errors";
 import type { AppwireClientLike } from "../protocol/testing/fakeClient";
@@ -87,12 +87,36 @@ function fromWireOverrides(value: unknown): KeybindingsOverrides | undefined {
   return value as KeybindingsOverrides;
 }
 
+/** Restores a bindings snapshot taken before a failed reconcile: unwinds
+ * every current binding and re-registers the snapshot in order, returning
+ * the registry to its last good state. Re-registering a previously-valid
+ * set cannot conflict. */
+function rollbackBindings(snapshot: readonly Binding[]): void {
+  const state = keybindingsRegistry.getState();
+  for (const binding of state.bindings) state.unregisterBinding(binding.id);
+  for (const binding of snapshot) {
+    state.registerBinding({
+      id: binding.id,
+      actionId: binding.actionId,
+      chord: binding.chord,
+      scope: binding.scope,
+      ...(binding.when === undefined ? {} : { when: binding.when }),
+      allowInEditable: binding.allowInEditable,
+      allowInModal: binding.allowInModal,
+      ignoreIfDefaultPrevented: binding.ignoreIfDefaultPrevented,
+    });
+  }
+}
+
 /** Reconciles the registry to the payload's effective overrides: validates,
  * strips the bindings of every action whose effective chord changed, then
  * re-establishes each (override or restored default). Two-phase so a payload
- * that moves a chord between actions never trips a transient conflict. */
+ * that moves a chord between actions never trips a transient conflict. The
+ * mutation is atomic: a throw rolls the registry back to its pre-reconcile
+ * state before propagating, so callers surface the failure with the last
+ * good bindings intact. */
 function applyOverrideRules(rules: readonly OverrideRule[]): void {
-  const validated = validateOverrideRules(rules, keybindingsRegistry);
+  const validated = validateOverrideRules(rules, keybindingsRegistry, undefined, new Set(appliedOverrides.keys()));
   const next = new Map<string, string | null>();
   for (const rule of validated.rules) {
     next.set(rule.action, rule.chord === null ? null : serializeChord(rule.chord));
@@ -105,13 +129,19 @@ function applyOverrideRules(rules: readonly OverrideRule[]): void {
     if (!next.has(action)) changedActions.add(action);
   }
   if (changedActions.size > 0) {
-    for (const action of changedActions) removeActionBindings(keybindingsRegistry, action);
-    for (const action of changedActions) {
-      if (next.has(action)) {
-        rebindAction(keybindingsRegistry, action, next.get(action) ?? null);
-      } else {
-        restoreDefaultBinding(keybindingsRegistry, action);
+    const snapshot = keybindingsRegistry.getState().bindings;
+    try {
+      for (const action of changedActions) removeActionBindings(keybindingsRegistry, action);
+      for (const action of changedActions) {
+        if (next.has(action)) {
+          rebindAction(keybindingsRegistry, action, next.get(action) ?? null);
+        } else {
+          restoreDefaultBinding(keybindingsRegistry, action);
+        }
       }
+    } catch (error) {
+      rollbackBindings(snapshot);
+      throw error;
     }
   }
   appliedOverrides.clear();
@@ -126,12 +156,16 @@ function applyOverrideRules(rules: readonly OverrideRule[]): void {
 }
 
 /** Applies a confirmed hub payload (get result, changed params, patch
- * response): stale revisions are ignored, the rest reconcile the registry. */
+ * response): stale revisions are ignored, the rest reconcile the registry.
+ * The revision advances ONLY after a successful reconcile: a failed apply
+ * leaves the previous revision in place so the payload stays retryable and
+ * a later `changed` with the same revision is not eaten by the stale guard. */
 function applyHubOverrides(payload: KeybindingsOverrides): void {
   const state = keybindingsStore.getState();
   if (payload.revision < state.revision) return;
-  keybindingsStore.setState({ revision: payload.revision });
   applyOverrideRules(payload.rules);
+  // A successful apply also supersedes any earlier apply failure's hubError.
+  keybindingsStore.setState({ revision: payload.revision, hubError: null });
 }
 
 function currentSupport(): "unknown" | "supported" | "unsupported" {
@@ -190,7 +224,14 @@ function onNotification(notification: AnyNotification): void {
   if (notification.method !== "evener/settings/keybindings/changed") return;
   const payload = fromWireOverrides(notification.params);
   if (payload === undefined) return;
-  applyHubOverrides(payload);
+  try {
+    applyHubOverrides(payload);
+  } catch (error) {
+    // Same posture as refreshFor: a reconcile failure surfaces as hubError
+    // (the registry has already rolled back to its last good state), never
+    // as an exception escaping the client's notification dispatch.
+    keybindingsStore.setState({ hubError: error instanceof Error ? error.message : String(error) });
+  }
 }
 
 async function refreshFor(client: AppwireClientLike, epoch: number): Promise<void> {
@@ -333,9 +374,15 @@ export function resetKeybindingsStoreForTests(): void {
   refreshSerial += 1;
   patchSerial += 1;
   // Restore defaults for every applied override so the registry singleton
-  // cannot leak overrides into the next test.
+  // cannot leak overrides into the next test. A wedged registry (a foreign
+  // binding squatting a default chord) must not make reset itself throw.
   for (const action of appliedOverrides.keys()) {
-    restoreDefaultBinding(keybindingsRegistry, action);
+    try {
+      restoreDefaultBinding(keybindingsRegistry, action);
+    } catch {
+      // The next test rebuilds the registry from scratch; a failed restore
+      // here leaves the override binding in place, which that rebuild removes.
+    }
   }
   appliedOverrides.clear();
   keybindingsStore.setState({ ...initialState() });

--- a/cmd/evener-hub/internal/hubcore/config.go
+++ b/cmd/evener-hub/internal/hubcore/config.go
@@ -41,6 +41,8 @@ type WebConfig struct {
 	LaunchConfigRoot          string                  // root of the layered launch config (launch.toml, projects/<id>/{launch.toml,meta.toml}); user-editable, so distinct from HubStateRoot — defaults to cmdutil.DefaultConfigRoot() when empty
 	TranscriptDisplayStore    *TranscriptDisplayStore // hub-authoritative Desktop/Mobile transcript-display defaults; nil → load from HubStateRoot
 	TranscriptDisplayStoreErr error                   // diagnostic returned while loading the injected store; retained for startup diagnostics
+	KeybindingsStore          *KeybindingsStore       // hub-authoritative user keybinding overrides; nil → load from HubStateRoot
+	KeybindingsStoreErr       error                   // diagnostic returned while loading the injected store; retained for startup diagnostics
 	RunDir                    string                  // run directory where rendezvous files live
 	PastIndexPath             string                  // path to the SQLite past-index DB, for display in settings
 	Roster                    *Roster

--- a/cmd/evener-hub/internal/hubcore/keybindings_store.go
+++ b/cmd/evener-hub/internal/hubcore/keybindings_store.go
@@ -1,0 +1,342 @@
+package hubcore
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/evener/appwire"
+)
+
+const (
+	keybindingsSnapshotVersion uint64 = 1
+	keybindingsStateSubdir            = "keybindings"
+	keybindingsStateFilename          = "state.json"
+)
+
+type keybindingsSnapshot struct {
+	Version  uint64                    `json:"version"`
+	Revision uint64                    `json:"revision"`
+	Config   appwire.KeybindingsConfig `json:"config"`
+}
+
+type keybindingsStoreFaults struct {
+	BeforeRename func() error
+	AfterRename  func() error
+}
+
+// KeybindingsStore is the hub-authoritative store for user keybinding
+// overrides. One mutex serializes each durable update.
+type KeybindingsStore struct {
+	mu      sync.Mutex
+	fs      afero.Fs
+	root    string
+	state   keybindingsSnapshot
+	loadErr error
+	faults  keybindingsStoreFaults
+}
+
+// NewKeybindingsStore opens the keybindings state below stateRoot. A malformed
+// snapshot returns a usable shipped-default fallback together with the load
+// diagnostic; callers must retain both values and report the error.
+func NewKeybindingsStore(stateRoot string) (*KeybindingsStore, error) {
+	return newKeybindingsStoreFS(afero.NewOsFs(), stateRoot, keybindingsStoreFaults{})
+}
+
+func newKeybindingsStoreFS(fs afero.Fs, stateRoot string, faults keybindingsStoreFaults) (*KeybindingsStore, error) {
+	state, err := loadKeybindingsSnapshotFS(fs, stateRoot)
+	if err != nil {
+		state = keybindingsShippedSnapshot()
+	}
+	return &KeybindingsStore{
+		fs:      fs,
+		root:    stateRoot,
+		state:   state,
+		loadErr: err,
+		faults:  faults,
+	}, err
+}
+
+// Snapshot returns a deep value copy of the canonical overrides. The returned
+// rules slice is never shared with the store.
+func (s *KeybindingsStore) Snapshot() appwire.KeybindingsOverrides {
+	if s == nil {
+		return appwire.KeybindingsShippedDefaults()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return keybindingsSnapshotOverrides(s.state)
+}
+
+// Patch validates and durably replaces the overrides using optimistic
+// revision checking. A durable error before rename leaves the old state
+// published; an error after rename publishes the new canonical state in
+// memory.
+func (s *KeybindingsStore) Patch(params appwire.KeybindingsPatchParams) (appwire.KeybindingsOverrides, error) {
+	if s == nil {
+		return appwire.KeybindingsOverrides{}, errors.New("keybindings store is not configured")
+	}
+	if err := appwire.ValidateKeybindingsConfig(params.Config); err != nil {
+		return appwire.KeybindingsOverrides{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.loadErr != nil {
+		return appwire.KeybindingsOverrides{}, fmt.Errorf("keybindings state is unavailable: %w", s.loadErr)
+	}
+
+	if s.state.Revision != params.ExpectedRevision {
+		return appwire.KeybindingsOverrides{}, keybindingsConflict(s.state, params.ExpectedRevision)
+	}
+	if reflect.DeepEqual(s.state.Config, params.Config) {
+		return keybindingsSnapshotOverrides(s.state), nil
+	}
+	if s.state.Revision == math.MaxUint64 {
+		return appwire.KeybindingsOverrides{}, errors.New("keybindings revision overflow")
+	}
+
+	next := keybindingsSnapshot{
+		Version:  s.state.Version,
+		Revision: s.state.Revision + 1,
+		Config:   cloneKeybindingsConfig(params.Config),
+	}
+	renamed, err := saveKeybindingsSnapshotFS(s.fs, s.root, next, s.faults)
+	if renamed {
+		s.state = next
+	}
+	if err != nil {
+		return appwire.KeybindingsOverrides{}, err
+	}
+	return keybindingsSnapshotOverrides(s.state), nil
+}
+
+func keybindingsConflict(state keybindingsSnapshot, expected uint64) appwire.WireError {
+	return appwire.WireError{
+		Code:    appwire.CodeConflict,
+		Message: fmt.Sprintf("keybindings revision conflict: expected %d, current %d", expected, state.Revision),
+		Data: appwire.KeybindingsConflictData{
+			EvenerErrorInfo: appwire.ErrorConflict,
+			Current:         keybindingsSnapshotOverrides(state),
+		},
+	}
+}
+
+func keybindingsStatePath(stateRoot string) string {
+	return filepath.Join(stateRoot, keybindingsStateSubdir, keybindingsStateFilename)
+}
+
+func loadKeybindingsSnapshotFS(fs afero.Fs, stateRoot string) (keybindingsSnapshot, error) {
+	empty := keybindingsShippedSnapshot()
+	if stateRoot == "" {
+		return empty, nil
+	}
+	data, err := afero.ReadFile(fs, keybindingsStatePath(stateRoot))
+	if os.IsNotExist(err) {
+		return empty, nil
+	}
+	if err != nil {
+		return empty, fmt.Errorf("read keybindings state: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return empty, nil
+	}
+
+	var state keybindingsSnapshot
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&state); err != nil {
+		return empty, fmt.Errorf("decode keybindings state: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return empty, errors.New("decode keybindings state: trailing JSON value")
+		}
+		return empty, fmt.Errorf("decode keybindings state trailing data: %w", err)
+	}
+	if err := validateKeybindingsSnapshotShape(data); err != nil {
+		return empty, fmt.Errorf("validate keybindings state shape: %w", err)
+	}
+	if err := validateKeybindingsSnapshot(state); err != nil {
+		return empty, fmt.Errorf("validate keybindings state: %w", err)
+	}
+	return state, nil
+}
+
+func saveKeybindingsSnapshotFS(fs afero.Fs, stateRoot string, state keybindingsSnapshot, faults keybindingsStoreFaults) (renamed bool, err error) {
+	if err := validateKeybindingsSnapshot(state); err != nil {
+		return false, err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return false, fmt.Errorf("marshal keybindings state: %w", err)
+	}
+	if stateRoot == "" {
+		return true, nil
+	}
+
+	path := keybindingsStatePath(stateRoot)
+	dir := filepath.Dir(path)
+	if err := fs.MkdirAll(dir, 0o700); err != nil {
+		return false, fmt.Errorf("create keybindings state directory: %w", err)
+	}
+	temp, err := afero.TempFile(fs, dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return false, fmt.Errorf("create temp keybindings state: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() {
+		if temp != nil {
+			_ = temp.Close()
+		}
+		if !renamed {
+			_ = fs.Remove(tempPath)
+		}
+	}()
+	if _, err := temp.Write(data); err != nil {
+		return false, fmt.Errorf("write temp keybindings state: %w", err)
+	}
+	if err := temp.Sync(); err != nil && !deletionSyncUnsupported(err) {
+		return false, fmt.Errorf("sync temp keybindings state: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return false, fmt.Errorf("close temp keybindings state: %w", err)
+	}
+	temp = nil
+	if faults.BeforeRename != nil {
+		if err := faults.BeforeRename(); err != nil {
+			return false, err
+		}
+	}
+	if err := fs.Rename(tempPath, path); err != nil {
+		return false, fmt.Errorf("rename keybindings state: %w", err)
+	}
+	renamed = true
+	directory, err := fs.Open(dir)
+	if err != nil {
+		return true, fmt.Errorf("open keybindings state directory: %w", err)
+	}
+	if err := directory.Sync(); err != nil && !deletionSyncUnsupported(err) {
+		_ = directory.Close()
+		return true, fmt.Errorf("sync keybindings state directory: %w", err)
+	}
+	if err := directory.Close(); err != nil {
+		return true, fmt.Errorf("close keybindings state directory: %w", err)
+	}
+	if faults.AfterRename != nil {
+		if err := faults.AfterRename(); err != nil {
+			return true, err
+		}
+	}
+	return true, nil
+}
+
+func validateKeybindingsSnapshot(state keybindingsSnapshot) error {
+	if state.Version != keybindingsSnapshotVersion {
+		return fmt.Errorf("unsupported keybindings state version %d", state.Version)
+	}
+	return appwire.ValidateKeybindingsConfig(state.Config)
+}
+
+func validateKeybindingsSnapshotShape(raw []byte) error {
+	top, err := keybindingsSnapshotObjectFields(raw)
+	if err != nil {
+		return err
+	}
+	if err := requireKeybindingsSnapshotFields(top, "version", "revision", "config"); err != nil {
+		return err
+	}
+	if bytes.Equal(bytes.TrimSpace(top["revision"]), []byte("null")) {
+		return errors.New("revision must be an unsigned integer")
+	}
+	configFields, err := keybindingsSnapshotObjectFields(top["config"])
+	if err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	if err := requireKeybindingsSnapshotFields(configFields, "version", "rules"); err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	if bytes.Equal(bytes.TrimSpace(configFields["rules"]), []byte("null")) {
+		return errors.New("config: rules must be an array")
+	}
+	var rules []json.RawMessage
+	if err := json.Unmarshal(configFields["rules"], &rules); err != nil {
+		return fmt.Errorf("config: rules: %w", err)
+	}
+	for i, rawRule := range rules {
+		ruleFields, err := keybindingsSnapshotObjectFields(rawRule)
+		if err != nil {
+			return fmt.Errorf("rule %d: %w", i, err)
+		}
+		if err := requireKeybindingsSnapshotFields(ruleFields, "action", "chord"); err != nil {
+			return fmt.Errorf("rule %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func keybindingsSnapshotObjectFields(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	if fields == nil {
+		return nil, errors.New("expected JSON object")
+	}
+	return fields, nil
+}
+
+func requireKeybindingsSnapshotFields(fields map[string]json.RawMessage, names ...string) error {
+	for _, name := range names {
+		if _, ok := fields[name]; !ok {
+			return fmt.Errorf("missing required field %q", name)
+		}
+	}
+	return nil
+}
+
+func keybindingsShippedSnapshot() keybindingsSnapshot {
+	defaults := appwire.KeybindingsShippedDefaults()
+	return keybindingsSnapshot{
+		Version:  keybindingsSnapshotVersion,
+		Revision: defaults.Revision,
+		Config:   appwire.KeybindingsConfig{Version: defaults.Version, Rules: cloneKeybindingsRules(defaults.Rules)},
+	}
+}
+
+func keybindingsSnapshotOverrides(state keybindingsSnapshot) appwire.KeybindingsOverrides {
+	return appwire.KeybindingsOverrides{
+		Version:  state.Config.Version,
+		Revision: state.Revision,
+		Rules:    cloneKeybindingsRules(state.Config.Rules),
+	}
+}
+
+func cloneKeybindingsConfig(config appwire.KeybindingsConfig) appwire.KeybindingsConfig {
+	return appwire.KeybindingsConfig{Version: config.Version, Rules: cloneKeybindingsRules(config.Rules)}
+}
+
+func cloneKeybindingsRules(rules []appwire.KeybindingsRule) []appwire.KeybindingsRule {
+	if rules == nil {
+		return nil
+	}
+	cloned := make([]appwire.KeybindingsRule, len(rules))
+	for i, rule := range rules {
+		cloned[i] = rule
+		if rule.Chord != nil {
+			chord := *rule.Chord
+			cloned[i].Chord = &chord
+		}
+	}
+	return cloned
+}

--- a/cmd/evener-hub/internal/hubcore/keybindings_store_test.go
+++ b/cmd/evener-hub/internal/hubcore/keybindings_store_test.go
@@ -1,0 +1,345 @@
+package hubcore
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"math"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/evener/appwire"
+)
+
+func TestKeybindingsStoreMissingRootUsesShippedDefaults(t *testing.T) {
+	store, err := NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store == nil {
+		t.Fatal("NewKeybindingsStore returned nil store")
+	}
+	if got, want := store.Snapshot(), appwire.KeybindingsShippedDefaults(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Snapshot = %#v, want %#v", got, want)
+	}
+}
+
+func TestKeybindingsStorePatchIncrementsRevision(t *testing.T) {
+	store, err := NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+		{Action: "thread.close", Chord: nil},
+	}}
+	got, err := store.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: 0, Config: config})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Revision != 1 || !reflect.DeepEqual(got.Rules, config.Rules) || got.Version != 1 {
+		t.Fatalf("patch result=%#v", got)
+	}
+	if snapshot := store.Snapshot(); !reflect.DeepEqual(snapshot, got) {
+		t.Fatalf("snapshot=%#v, want patch result %#v", snapshot, got)
+	}
+}
+
+func TestKeybindingsStorePersistsAndReloads(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+shift+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := reloaded.Snapshot()
+	if got.Revision != 1 || !reflect.DeepEqual(got.Rules, config.Rules) {
+		t.Fatalf("reloaded snapshot=%#v, want revision 1/rules %#v", got, config.Rules)
+	}
+}
+
+func TestKeybindingsStoreNoOpDoesNotIncrementRevision(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := afero.ReadFile(afero.NewOsFs(), keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: 1, Config: config})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Revision != 1 || !reflect.DeepEqual(got.Rules, config.Rules) {
+		t.Fatalf("no-op result=%#v", got)
+	}
+	after, err := afero.ReadFile(afero.NewOsFs(), keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("no-op rewrote durable state: before=%q after=%q", before, after)
+	}
+}
+
+func TestKeybindingsStoreStaleRevisionReturnsCanonicalConflict(t *testing.T) {
+	store, err := NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: first}); err != nil {
+		t.Fatal(err)
+	}
+	stale := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+alt+n")},
+	}}
+	_, err = store.Patch(appwire.KeybindingsPatchParams{Config: stale})
+	if err == nil {
+		t.Fatal("stale patch unexpectedly succeeded")
+	}
+	var wireErr appwire.WireError
+	if !errors.As(err, &wireErr) {
+		t.Fatalf("stale error=%T %v, want appwire.WireError", err, err)
+	}
+	if wireErr.Code != appwire.CodeConflict {
+		t.Fatalf("stale code=%d, want %d", wireErr.Code, appwire.CodeConflict)
+	}
+	data, ok := wireErr.Data.(appwire.KeybindingsConflictData)
+	if !ok {
+		t.Fatalf("stale data=%T, want appwire.KeybindingsConflictData", wireErr.Data)
+	}
+	if data.EvenerErrorInfo != appwire.ErrorConflict || data.Current.Revision != 1 || !reflect.DeepEqual(data.Current.Rules, first.Rules) {
+		t.Fatalf("conflict data=%#v", data)
+	}
+}
+
+func TestKeybindingsStoreConcurrentPatchesSerialize(t *testing.T) {
+	store, err := NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+	}}
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			_, err := store.Patch(appwire.KeybindingsPatchParams{Config: config})
+			results <- err
+		})
+	}
+	wg.Wait()
+	close(results)
+	var success, conflicts int
+	for err := range results {
+		if err == nil {
+			success++
+			continue
+		}
+		var wireErr appwire.WireError
+		if errors.As(err, &wireErr) && wireErr.Code == appwire.CodeConflict {
+			conflicts++
+			continue
+		}
+		t.Fatalf("concurrent patch error=%T %v", err, err)
+	}
+	if success != 1 || conflicts != 1 || store.Snapshot().Revision != 1 {
+		t.Fatalf("success=%d conflicts=%d snapshot=%#v", success, conflicts, store.Snapshot())
+	}
+}
+
+func TestKeybindingsStoreMalformedSnapshotFallsBackAndBlocksPatches(t *testing.T) {
+	root := t.TempDir()
+	path := keybindingsStatePath(root)
+	if err := writeKeybindingsStateFile(afero.NewOsFs(), root, []byte(`{"version":1,"revision":0,"config":{}} trailing`)); err != nil {
+		t.Fatal(err)
+	}
+	before, err := afero.ReadFile(afero.NewOsFs(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, loadErr := NewKeybindingsStore(root)
+	if store == nil || loadErr == nil {
+		t.Fatalf("store=%#v loadErr=%v, want usable fallback and diagnostic", store, loadErr)
+	}
+	if got, want := store.Snapshot(), appwire.KeybindingsShippedDefaults(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback snapshot=%#v, want %#v", got, want)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); err == nil {
+		t.Fatal("patch against malformed snapshot unexpectedly succeeded")
+	}
+	after, err := afero.ReadFile(afero.NewOsFs(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("malformed evidence changed: before=%q after=%q", before, after)
+	}
+}
+
+func TestKeybindingsStoreEmptySnapshotUsesShippedDefaults(t *testing.T) {
+	root := t.TempDir()
+	if err := writeKeybindingsStateFile(afero.NewOsFs(), root, nil); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := store.Snapshot(), appwire.KeybindingsShippedDefaults(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("empty snapshot=%#v, want %#v", got, want)
+	}
+}
+
+func TestKeybindingsStoreRevisionOverflowIsRejected(t *testing.T) {
+	root := t.TempDir()
+	state := keybindingsSnapshot{
+		Version:  keybindingsSnapshotVersion,
+		Revision: math.MaxUint64,
+		Config:   appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{}},
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeKeybindingsStateFile(afero.NewOsFs(), root, data); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: math.MaxUint64, Config: config}); err == nil || !strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("overflow patch error=%v", err)
+	}
+	if got := store.Snapshot().Revision; got != math.MaxUint64 {
+		t.Fatalf("overflow changed revision=%d", got)
+	}
+}
+
+func TestKeybindingsStoreStrictSnapshotDecoding(t *testing.T) {
+	valid := keybindingsSnapshot{
+		Version: keybindingsSnapshotVersion,
+		Config:  appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{}},
+	}
+	encoded, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		data string
+	}{
+		{name: "unknown field", data: strings.TrimSuffix(string(encoded), "}") + `,"unknown":true}`},
+		{name: "trailing value", data: string(encoded) + ` {}`},
+		{name: "invalid config", data: `{"version":1,"revision":0,"config":{"version":99,"rules":[]}}`},
+		{name: "empty rule action", data: `{"version":1,"revision":0,"config":{"version":1,"rules":[{"action":"","chord":"ctrl+n"}]}}`},
+		{name: "empty rule chord", data: `{"version":1,"revision":0,"config":{"version":1,"rules":[{"action":"thread.new","chord":""}]}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := writeKeybindingsStateFile(afero.NewOsFs(), root, []byte(tc.data)); err != nil {
+				t.Fatal(err)
+			}
+			store, loadErr := NewKeybindingsStore(root)
+			if store == nil || loadErr == nil {
+				t.Fatalf("store=%#v loadErr=%v, want fallback and diagnostic", store, loadErr)
+			}
+			if got := store.Snapshot(); !reflect.DeepEqual(got, appwire.KeybindingsShippedDefaults()) {
+				t.Fatalf("fallback=%#v", got)
+			}
+		})
+	}
+}
+
+func TestKeybindingsStoreStrictSnapshotRequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+	}{
+		{name: "missing revision", data: `{"version":1,"config":{"version":1,"rules":[]}}`},
+		{name: "missing config", data: `{"version":1,"revision":0}`},
+		{name: "missing config version", data: `{"version":1,"revision":0,"config":{"rules":[]}}`},
+		{name: "missing rules", data: `{"version":1,"revision":0,"config":{"version":1}}`},
+		{name: "null rules", data: `{"version":1,"revision":0,"config":{"version":1,"rules":null}}`},
+		{name: "missing rule action", data: `{"version":1,"revision":0,"config":{"version":1,"rules":[{"chord":"ctrl+n"}]}}`},
+		{name: "missing rule chord", data: `{"version":1,"revision":0,"config":{"version":1,"rules":[{"action":"thread.new"}]}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := writeKeybindingsStateFile(afero.NewOsFs(), root, []byte(tc.data)); err != nil {
+				t.Fatal(err)
+			}
+			before, err := afero.ReadFile(afero.NewOsFs(), keybindingsStatePath(root))
+			if err != nil {
+				t.Fatal(err)
+			}
+			store, loadErr := NewKeybindingsStore(root)
+			if store == nil || loadErr == nil {
+				t.Fatalf("store=%#v loadErr=%v, want fallback and diagnostic", store, loadErr)
+			}
+			if got := store.Snapshot(); !reflect.DeepEqual(got, appwire.KeybindingsShippedDefaults()) {
+				t.Fatalf("fallback=%#v", got)
+			}
+			config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+				{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+			}}
+			if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); err == nil {
+				t.Fatal("patch against malformed snapshot unexpectedly succeeded")
+			}
+			after, err := afero.ReadFile(afero.NewOsFs(), keybindingsStatePath(root))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("malformed evidence changed: before=%q after=%q", before, after)
+			}
+		})
+	}
+}
+
+func writeKeybindingsStateFile(fs afero.Fs, root string, data []byte) error {
+	path := keybindingsStatePath(root)
+	if err := fs.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return afero.WriteFile(fs, path, data, 0o600)
+}
+
+func keybindingsChord(chord string) *string {
+	return &chord
+}

--- a/cmd/evener-hub/internal/hubcore/keybindings_store_write_test.go
+++ b/cmd/evener-hub/internal/hubcore/keybindings_store_write_test.go
@@ -1,0 +1,175 @@
+package hubcore
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/evener/appwire"
+)
+
+type keybindingsReadFaultFs struct {
+	afero.Fs
+	path string
+	err  error
+}
+
+func (f *keybindingsReadFaultFs) Open(name string) (afero.File, error) {
+	if filepath.Clean(name) == filepath.Clean(f.path) {
+		return nil, f.err
+	}
+	return f.Fs.Open(name)
+}
+
+func TestKeybindingsStorePreRenameFailurePreservesOldState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	store, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: oldConfig}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := afero.ReadFile(fs, keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantFailure := errors.New("before rename failed")
+	failing, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{
+		BeforeRename: func() error { return wantFailure },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+alt+n")},
+	}}
+	if _, err := failing.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: 1, Config: newConfig}); !errors.Is(err, wantFailure) {
+		t.Fatalf("pre-rename error=%v, want %v", err, wantFailure)
+	}
+	if got := failing.Snapshot(); got.Revision != 1 || !reflect.DeepEqual(got.Rules, oldConfig.Rules) {
+		t.Fatalf("pre-rename memory=%#v, want revision 1/rules %#v", got, oldConfig.Rules)
+	}
+	after, err := afero.ReadFile(fs, keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("pre-rename disk changed: before=%q after=%q", before, after)
+	}
+}
+
+func TestKeybindingsStorePostRenameFailurePublishesNewState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	store, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: oldConfig}); err != nil {
+		t.Fatal(err)
+	}
+
+	wantFailure := errors.New("after rename failed")
+	failing, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{
+		AfterRename: func() error { return wantFailure },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+alt+n")},
+	}}
+	if _, err := failing.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: 1, Config: newConfig}); !errors.Is(err, wantFailure) {
+		t.Fatalf("post-rename error=%v, want %v", err, wantFailure)
+	}
+	if got := failing.Snapshot(); got.Revision != 2 || !reflect.DeepEqual(got.Rules, newConfig.Rules) {
+		t.Fatalf("post-rename memory=%#v, want revision 2/rules %#v", got, newConfig.Rules)
+	}
+	reloaded, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reloaded.Snapshot(); got.Revision != 2 || !reflect.DeepEqual(got.Rules, newConfig.Rules) {
+		t.Fatalf("post-rename reload=%#v, want revision 2/rules %#v", got, newConfig.Rules)
+	}
+}
+
+func TestKeybindingsStoreWriteValidatesBeforeCreatingState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	invalid := keybindingsSnapshot{Version: keybindingsSnapshotVersion}
+	if renamed, err := saveKeybindingsSnapshotFS(fs, root, invalid, keybindingsStoreFaults{}); renamed || err == nil {
+		t.Fatalf("invalid save renamed=%v err=%v, want no publication and error", renamed, err)
+	}
+	if _, err := fs.Stat(filepath.Join(root, keybindingsStateSubdir)); !errors.Is(err, afero.ErrFileNotFound) {
+		t.Fatalf("invalid save state directory error=%v, want absent", err)
+	}
+}
+
+func TestKeybindingsStoreWriteCleansTempAfterPreRenameFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	state := keybindingsSnapshot{
+		Version: keybindingsSnapshotVersion,
+		Config:  appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{}},
+	}
+	wantFailure := errors.New("before rename failed")
+	if renamed, err := saveKeybindingsSnapshotFS(fs, root, state, keybindingsStoreFaults{BeforeRename: func() error { return wantFailure }}); renamed || !errors.Is(err, wantFailure) {
+		t.Fatalf("pre-rename save renamed=%v err=%v", renamed, err)
+	}
+	entries, err := afero.ReadDir(fs, filepath.Join(root, keybindingsStateSubdir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("pre-rename temp residue=%v", entries)
+	}
+}
+
+func TestKeybindingsStoreReadFailureFallsBackAndBlocksPatches(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	evidence := []byte("durable evidence that must not be overwritten")
+	if err := writeKeybindingsStateFile(fs, root, evidence); err != nil {
+		t.Fatal(err)
+	}
+	wantFailure := errors.New("state read failed")
+	faultFS := &keybindingsReadFaultFs{
+		Fs:   fs,
+		path: keybindingsStatePath(root),
+		err:  wantFailure,
+	}
+	store, loadErr := newKeybindingsStoreFS(faultFS, root, keybindingsStoreFaults{})
+	if store == nil || !errors.Is(loadErr, wantFailure) {
+		t.Fatalf("store=%#v loadErr=%v, want fallback and %v", store, loadErr, wantFailure)
+	}
+	if got := store.Snapshot(); !reflect.DeepEqual(got, appwire.KeybindingsShippedDefaults()) {
+		t.Fatalf("read-fault fallback=%#v", got)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: keybindingsChord("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); !errors.Is(err, wantFailure) {
+		t.Fatalf("read-fault patch error=%v, want %v", err, wantFailure)
+	}
+	after, err := afero.ReadFile(fs, keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, evidence) {
+		t.Fatalf("read-fault evidence changed: before=%q after=%q", evidence, after)
+	}
+}

--- a/cmd/evener-hub/main.go
+++ b/cmd/evener-hub/main.go
@@ -359,6 +359,10 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 	if transcriptDisplayStoreErr != nil {
 		_, _ = fmt.Fprintf(stderr, "[hub] transcript display state: %v\n", transcriptDisplayStoreErr)
 	}
+	keybindingsStore, keybindingsStoreErr := hubcore.NewKeybindingsStore(hubStateRoot)
+	if keybindingsStoreErr != nil {
+		_, _ = fmt.Fprintf(stderr, "[hub] keybindings state: %v\n", keybindingsStoreErr)
+	}
 
 	// Resolve the registry root once for this hub process. Launch configuration
 	// may override XDG_CONFIG_HOME for a child, so the child must receive this
@@ -375,6 +379,8 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 		PluginRoot:                pluginRoot,
 		TranscriptDisplayStore:    transcriptDisplayStore,
 		TranscriptDisplayStoreErr: transcriptDisplayStoreErr,
+		KeybindingsStore:          keybindingsStore,
+		KeybindingsStoreErr:       keybindingsStoreErr,
 		RunDir:                    runDir,
 		PastIndexPath:             pastIndexDB,
 		Roster:                    roster,

--- a/cmd/evener-hub/web.go
+++ b/cmd/evener-hub/web.go
@@ -49,6 +49,7 @@ type WebServer struct {
 	frontendHash              string
 	deletionStoreErr          error
 	transcriptDisplayStoreErr error
+	keybindingsStoreErr       error
 }
 
 var manifestMarshal = json.Marshal
@@ -66,6 +67,10 @@ func newWebServer(cfg hubcore.WebConfig, appwireTrace *appserver.WebSocketTrace)
 	transcriptDisplayStoreErr := cfg.TranscriptDisplayStoreErr
 	if cfg.TranscriptDisplayStore == nil {
 		cfg.TranscriptDisplayStore, transcriptDisplayStoreErr = hubcore.NewTranscriptDisplayStore(cfg.HubStateRoot)
+	}
+	keybindingsStoreErr := cfg.KeybindingsStoreErr
+	if cfg.KeybindingsStore == nil {
+		cfg.KeybindingsStore, keybindingsStoreErr = hubcore.NewKeybindingsStore(cfg.HubStateRoot)
 	}
 	sources := newHubSourceRegistry(cfg)
 	if cfg.CodexLauncher == nil && len(cfg.CodexLaunches) > 0 {
@@ -89,6 +94,7 @@ func newWebServer(cfg hubcore.WebConfig, appwireTrace *appserver.WebSocketTrace)
 		frontendHash:              fHash,
 		deletionStoreErr:          deletionStoreErr,
 		transcriptDisplayStoreErr: transcriptDisplayStoreErr,
+		keybindingsStoreErr:       keybindingsStoreErr,
 	}
 	if web.cfg.LiveModels == nil {
 		web.cfg.LiveModels = web.fetchLiveModels

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -172,6 +172,8 @@ no router (reserved).
 | `evener/settings/overview` | hub | `EmptyParams` | `SettingsOverviewResponse` | Returns the settings overview field bag: hub/runtime, storage, agent roster, codex launch configs, and probed MCP servers — the six template-only settings sections' data. |
 | `evener/settings/transcriptDisplay/get` | hub | `EmptyParams` | `TranscriptDisplayDefaults` | Reads the canonical Desktop and Mobile transcript-display defaults. |
 | `evener/settings/transcriptDisplay/patch` | hub | `TranscriptDisplayDefaultsPatchParams` | `TranscriptDisplayPatchResponse` | Updates one transcript-display default using an expected revision and returns the canonical value. |
+| `evener/settings/keybindings/get` | hub | `EmptyParams` | `KeybindingsOverrides` | Reads the canonical user keybinding overrides (version, revision, rules). |
+| `evener/settings/keybindings/patch` | hub | `KeybindingsPatchParams` | `KeybindingsOverrides` | Replaces the user keybinding overrides using an expected revision and returns the canonical value. |
 | `evener/sandbox/escalation/resolve` | both | `SandboxEscalationResolveParams` | `EmptyResponse` | Delivers a human's approve/deny decision for a pending sandbox-exemption escalation (M7); the daemon unblocks the waiting tool-exec goroutine, the hub relays. |
 
 ## Notifications (server → client)
@@ -216,6 +218,7 @@ Pushed to subscribed connections; no `id`. The web client maps these in
 | `evener/sandbox/escalation/requested` | `SandboxEscalationRequested` | A harness-raised, human-gated sandbox-exemption approval card (M7); the tool-exec goroutine blocks until answered via evener/sandbox/escalation/resolve. |
 | `evener/sandbox/escalation/resolved` | `SandboxEscalationResolved` | A previously-raised sandbox escalation left the pending set — resolved, turn-interrupted, or cleared by session close (M7); every OTHER subscribed client clears its now-stale copy of the card. |
 | `evener/settings/transcriptDisplay/changed` | `TranscriptDisplayChangedParams` | Broadcast after a transcript-display default changes; carries the layout, revision, and canonical configuration. |
+| `evener/settings/keybindings/changed` | `KeybindingsOverrides` | Broadcast after the user keybinding overrides change; carries the revision and canonical rules. |
 
 ## Type reference
 
@@ -926,6 +929,23 @@ _(no fields)_
 | `threadId` | `string` |  |  |
 | `ref` | `string` |  |  |
 | `revision` | `uint64` |  |  |
+
+
+### `KeybindingsOverrides`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `version` | `int` |  |  |
+| `revision` | `uint64` |  |  |
+| `rules` | `[]appwire.KeybindingsRule` |  |  |
+
+
+### `KeybindingsPatchParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `expectedRevision` | `uint64` |  |  |
+| `config` | `appwire.KeybindingsConfig` |  |  |
 
 
 ### `LaunchConfigGetLayerParams`

--- a/docs/web-ui/README.md
+++ b/docs/web-ui/README.md
@@ -16,7 +16,8 @@ Design documentation for the web hub (`cmd/evener-hub`). Started 2026-06-16.
   it. Cited from live source comments.
 - **[keybindings.md](keybindings.md)** — the keybindings dispatcher: registry,
   scope stack, precedence layers, per-binding policy flags, and how to
-  register an action or a chord.
+  register an action or a chord, plus the hub-persisted override sync
+  (payload contract, validation split, failure posture).
 - **[parity/](parity/)** — the behaviour-parity checklists the React rewrite was
   graded against, mined from the legacy hub before it was deleted. The code they
   cite is gone, so their `path:line` citations no longer resolve; they survive

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,9 +1,10 @@
 # Web UI keybindings
 
-Status: **current** (Phase 2a). The web hub's global keyboard chords are
+Status: **current** (Phase 2b). The web hub's global keyboard chords are
 owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
 window-level dispatcher, instead of each component installing its own
-`keydown` listener.
+`keydown` listener. User overrides persist on the hub and sync to every
+paired browser.
 
 ## Architecture
 
@@ -27,6 +28,21 @@ Four pieces, all in `src/keybindings/` and all React-free:
   `registerDefaultBindings`, which also registers each `$mod` chord's
   cross-platform Meta/Control twin (the pre-dispatcher listeners accepted
   `metaKey || ctrlKey` on every platform, so both work everywhere).
+  `DEFAULT_BINDINGS` is also the canonical action universe: each entry
+  carries the action's user-facing `title`, and the Settings keybindings
+  section enumerates it live. `registerDefaultBindingsForAction` and
+  `defaultBindingChordsForAction` are the per-action variants the overrides
+  layer uses to restore and to simulate restorations.
+- **overrides.ts** — `rebindAction(registry, actionId, chord | null)`
+  replaces an action's current bindings (default + `#mod-twin` + any earlier
+  `#override`) with a single `#override` binding that keeps the default's
+  scope and policy flags, or unbinds it on `null`. No twin expansion for user
+  chords. Every throwing path throws before mutating.
+  `restoreDefaultBinding` re-registers the action's defaults.
+- **validation.ts** — `validateOverrideRules(rules, registry, platform?)`
+  never throws: unknown actions, unparseable chords, reserved
+  (browser/OS-claimed) chords, and conflicts each become a typed
+  `ValidationWarning` and the rule is skipped.
 
 The one wiring point that touches React and the app's stores is
 `src/shell/installKeybindings.ts`: an idempotent per-window installer that
@@ -128,14 +144,117 @@ it pushes `SETTINGS_SCOPE` and registers `settings.close` in one effect.
   A component's action registration/scope push must be undone by its effect
   cleanup so the next test in the file starts clean.
 
+## Persistence (Phase 2b)
+
+Overrides are stored **on the hub**, not in the browser. There is no
+localStorage layer: an unsupported or unreachable hub means built-in
+defaults only, never a local fallback copy.
+
+### Server side
+
+`cmd/evener-hub/internal/hubcore/keybindings_store.go` keeps one snapshot
+`{version, revision, config}` at `<HubStateRoot>/keybindings/state.json`,
+written temp-file + rename + fsync. Three appwire methods
+(`appwire/keybindings.go`, handlers in `cmd/evener-hub/app_rpc_keybindings.go`):
+
+- `evener/settings/keybindings/get` → the canonical payload.
+- `evener/settings/keybindings/patch` — optimistic concurrency: params are
+  `{expectedRevision, config}`; a stale `expectedRevision` is rejected with
+  appwire `CodeConflict` (-32013) whose `data` carries
+  `evenerErrorInfo: "conflict"` and `current`, the server's present payload.
+  A no-op patch returns current without touching disk.
+- `evener/settings/keybindings/changed` — broadcast to all clients, only
+  when the revision actually changed.
+
+The feature is advertised as `features.keybindingsSettings`; an older hub
+simply omits it.
+
+### Payload contract
+
+```json
+{ "version": 1, "revision": 3, "rules": [ { "action": "palette.open", "chord": "Control+P" } ] }
+```
+
+`rules` is the whole override set, not a delta: `chord` (a tinykeys string)
+rebinds the action, `chord: null` unbinds it, and an action absent from
+`rules` is on its defaults. Revision 0 with empty rules is the shipped
+default.
+
+### Validation split
+
+- **Server — structure only.** It does not know the frontend action
+  registry, so it enforces the shape: strict decode (unknown fields and
+  trailing JSON rejected), `version == 1`, required per-rule `action`/`chord`
+  keys, non-empty/non-whitespace action and chord strings, revision
+  optimism. A state file that fails the raw-shape re-check on load falls
+  back to shipped defaults and the store goes read-only (patches are
+  rejected) until the file is fixed.
+- **Frontend — semantics** (`src/keybindings/validation.ts`): action ids
+  against the default map, chord parseability, the survey's platform-split
+  never-use list (chords the browser will never deliver to the page), and
+  conflicts against a simulation of the FINAL effective map the payload
+  would produce. The simulation includes the implied default-restoration of
+  every currently-overridden action the payload drops, iterated to a
+  fixpoint; when a rule's chord collides with a restoration, **the restore
+  wins** — the rule is skipped with a `conflict` warning and its action
+  falls back to its own defaults, so every action stays bound. A chord freed
+  earlier in the same payload (rebind-away or unbind) can be claimed by a
+  later rule.
+
+### Apply flow
+
+`src/stores/keybindings.ts` owns sync. Applied state lives in the registry,
+not the store; the store carries `hubSupport`, `revision`, the validated
+`overrides`, `warnings`, `hubError`, and `conflict`.
+
+- **Startup**: once the connection is ready and the feature is advertised,
+  `get` → structural re-check of the wire payload (`fromWireOverrides`:
+  version 1, safe-integer revision ≥ 0, well-formed rules) → semantic
+  validation → reconcile.
+- **Changed**: the same payload path; revisions older than the store's are
+  ignored.
+- **Reconcile** is a delta: only actions whose effective chord changed are
+  rebound, two-phase (strip every changed action's bindings, then
+  re-establish each via `rebindAction` or `restoreDefaultBinding`) so a
+  payload moving a chord between actions never trips a transient conflict.
+  Untouched actions keep their exact binding objects — in-flight dispatcher
+  state is never torn down. The mutation is atomic: a throw rolls the
+  registry back to a pre-reconcile snapshot, and the store's `revision`
+  advances only after a successful apply, so a failed payload stays
+  retryable (a later `changed` with the same revision is not eaten by the
+  stale guard).
+- **Patch** (used by the future editor): sends `expectedRevision` +
+  `{version: 1, rules}`; on success the canonical response is applied; on a
+  conflict rejection the store refreshes to `data.current`, sets `conflict`
+  and `hubError`, and rethrows.
+
+### Failure posture
+
+Nothing here can crash startup on persisted data. Malformed payloads,
+validation failures, unreachable hubs, and reconcile throws all degrade to
+warnings or a surfaced `hubError` with the last good (or default) bindings
+in place; the `changed`-notification path catches so a reconcile failure
+never escapes the client's notification dispatch.
+
+### Settings section
+
+Settings → Keybindings is a **read-only** listing of the effective
+bindings: one row per action from `DEFAULT_BINDINGS` (never a
+hand-maintained copy), the chord rendered with the `KeyHint` widget from
+the live registry, and a "Customized" marker on actions whose effective
+bindings differ from the default map (including unbound actions). The
+store's `hubSupport`/`hubError`/validation warnings surface as quiet status
+or alert text. Editing arrives with the Phase 4 editor.
+
 ## Deliberately not here yet
 
-Phase 2a is a behavior-preserving migration only. Later phases of the
-webui-keybindings plan add, and this module already leaves room for:
+Later phases of the webui-keybindings plan add, and this module already
+leaves room for:
 
-- **Server persistence / user remapping** (Phase 2b) — `Binding.when` is
-  stored verbatim and never evaluated yet; bindings are the compiled-in
-  defaults only.
+- **A keybinding editor** (Phase 4) — the store's `patchOverrides` is the
+  write path it will use; the Settings section stays read-only until then.
 - **A shortcuts overlay / cheatsheet UI** (Phase 3).
 - **Hold-modifier chord hints** (Phase 4) — `formatChord`/`formatSequence`
   exist for exactly this consumer.
+- `Binding.when` is still stored verbatim and never evaluated; scope-stack
+  membership is the only gating the dispatcher applies.


### PR DESCRIPTION
## Summary

Phase 2b of the webui keybinding project (survey #853, dispatcher #860 — **stacked on #860's branch**, retargets to main after it merges): user keybinding overrides persisted on the hub, cloned from the proven transcriptDisplay settings pattern.

- **Server (Go):** `evener/settings/keybindings/{get,patch,changed}` wire methods + catalog + `keybindingsSettings` feature flag; `hubcore.KeybindingsStore` (`<stateroot>/keybindings/state.json`, revisioned optimistic concurrency with CodeConflict, temp+rename+fsync durability, load-failure blocks patches without destroying evidence); revision-gated `changed` broadcast; regenerated `types.gen.ts` + `docs/appwire-protocol.md`.
- **Payload contract:** `{version: 1, revision, rules: [{action, chord | null}]}` — chord rebinds, null unbinds, last rule wins.
- **Validation split:** server validates structure only (strict decode, unknown-field rejection); frontend validates semantics (live action registry, per-platform reserved chords, **overlap-aware** conflict detection via `chordsOverlap`).
- **Frontend:** `stores/keybindings.ts` (feature-gated, startup apply, `changed`-reconcile with revision-after-success ordering and notification containment, CodeConflict refresh), `keybindings/overrides.ts` (atomic rebind/restore), read-only Settings section listing effective bindings live from the registry.
- **Docs:** `docs/web-ui/keybindings.md` gains the persistence architecture, payload contract, validation split, and failure posture.

Hub-shared scoping is deliberate: the hub has a single shared auth token and no per-user identity, so overrides sync across the hub's browsers (matches the approved design).

## Test plan

- Server: store/durability/fault-injection suites (t.TempDir, afero), two-client broadcast RPC tests, strict-decode rejection matrix; `go test ./appwire/... ./cmd/evener-hub/...` green, `make vet` clean, `go generate ./appwire` no drift.
- Frontend: 766 tests green incl. FakeClient store tests (startup apply, reconcile-removal, unsupported-server fallback, conflict retry); `make test-web` green.
- Review loop: per-task reviews + final whole-branch review; a reconcile-wedge Critical and an optional-modifier conflict-shadowing Important were caught, fixed, and re-reviewed.

🤖 Generated via subagent-driven development with per-task and whole-branch review.