### PR TITLE
feat(web): navigation key bindings — session cycling, transcript scroll, AskDock keyboard completion (Phase 3)

### DIFF
--- a/cmd/evener-hub/frontend/src/keybindings/actions.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/actions.ts
@@ -9,6 +9,17 @@ export const ACTIONS = {
   composerFocus: "composer.focus",
   nextNeedsYou: "next-needs-you",
   selectionQuote: "selection.quote",
+  sessionNext: "session.next",
+  sessionPrevious: "session.previous",
+  transcriptLineUp: "transcript.lineUp",
+  transcriptLineDown: "transcript.lineDown",
+  transcriptPageUp: "transcript.pageUp",
+  transcriptPageDown: "transcript.pageDown",
+  // No DEFAULT_BINDINGS entries for these two: their handlers exist (the
+  // session transcript registers them per pane) but the Phase 4 keymap
+  // decides whether they get a chord at all.
+  transcriptScrollTop: "transcript.scrollTop",
+  transcriptScrollBottom: "transcript.scrollBottom",
   settingsClose: "settings.close",
 } as const;
 

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -10,15 +10,29 @@ function keydown(init: KeyboardEventInit): KeyboardEvent {
 }
 
 describe("default binding map", () => {
-  test("is exactly the six shell chords", () => {
+  test("is exactly the shell chords", () => {
     expect(DEFAULT_BINDINGS.map((b) => b.actionId)).toEqual([
       ACTIONS.paletteOpen,
       ACTIONS.railToggle,
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.sessionNext,
+      ACTIONS.sessionPrevious,
+      ACTIONS.transcriptLineUp,
+      ACTIONS.transcriptLineDown,
+      ACTIONS.transcriptPageUp,
+      ACTIONS.transcriptPageDown,
       ACTIONS.settingsClose,
     ]);
+  });
+
+  // Phase 3 registers the scrollTop/scrollBottom ACTIONS (their handlers are
+  // the session transcript's) but deliberately ships no default chord for
+  // them - the Phase 4 keymap decides whether they get one.
+  test("transcript.scrollTop/scrollBottom ship with no default chord", () => {
+    expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollTop)).toBe(false);
+    expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollBottom)).toBe(false);
   });
 
   // Chords are compared through parse+serialize so the assertion is
@@ -34,6 +48,12 @@ describe("default binding map", () => {
     [ACTIONS.nextNeedsYou, "$mod+[Shift]+[Alt]+J"],
     [ACTIONS.selectionQuote, "$mod+[Shift]+'"],
     [ACTIONS.settingsClose, "[Control]+[Alt]+[Shift]+[Meta]+Escape"],
+    [ACTIONS.sessionNext, "Alt+ArrowRight"],
+    [ACTIONS.sessionPrevious, "Alt+ArrowLeft"],
+    [ACTIONS.transcriptLineUp, "Alt+ArrowUp"],
+    [ACTIONS.transcriptLineDown, "Alt+ArrowDown"],
+    [ACTIONS.transcriptPageUp, "Alt+Shift+ArrowUp"],
+    [ACTIONS.transcriptPageDown, "Alt+Shift+ArrowDown"],
   ])("%s is bound to %s", (actionId, chord) => {
     const binding = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
     expect(binding).toBeDefined();
@@ -47,6 +67,15 @@ describe("default binding map", () => {
     expect(policy.get(ACTIONS.nextNeedsYou)).toBe(true);
     expect(policy.get(ACTIONS.selectionQuote)).toBe(true);
     expect(policy.get(ACTIONS.railToggle)).toBe(false);
+    // The Phase 3 navigation chords all suppress in editable targets: plain
+    // Alt+Arrow and Alt+Shift+Arrow keep their native text-editing meanings
+    // (word/selection movement) inside inputs and the composer.
+    expect(policy.get(ACTIONS.sessionNext)).toBe(false);
+    expect(policy.get(ACTIONS.sessionPrevious)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptLineUp)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptLineDown)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptPageUp)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptPageDown)).toBe(false);
   });
 
   test("settings.close is scope-gated, not global", () => {
@@ -118,13 +147,35 @@ describe("default bindings through the dispatcher", () => {
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "'", code: "Quote", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowRight", code: "ArrowRight", altKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowLeft", code: "ArrowLeft", altKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
     expect(calls).toEqual([
       ACTIONS.paletteOpen,
       ACTIONS.railToggle,
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.sessionNext,
+      ACTIONS.sessionPrevious,
+      ACTIONS.transcriptLineUp,
+      ACTIONS.transcriptLineDown,
+      ACTIONS.transcriptPageUp,
+      ACTIONS.transcriptPageDown,
     ]);
+  });
+
+  test("the Alt+Arrow chords are suppressed in an editable target", () => {
+    setup();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(keydown({ key: "ArrowRight", code: "ArrowRight", altKey: true }));
+    input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+    input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+    expect(calls).toEqual([]);
   });
 
   test("Escape only closes settings while the settings scope is pushed", () => {

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -1,6 +1,8 @@
-// The default binding map: exactly the six shell chords that today live in six
+// The default binding map: the six legacy shell chords that lived in six
 // independent keydown listeners (AppShell, RailHost, SelectionQuote,
-// Settings). Per-binding policy per chord matches today's behavior:
+// Settings), plus the Phase 3 navigation chords (session-pane cycling and
+// transcript scroll). For the legacy six, per-binding policy per chord
+// matches the pre-dispatcher behavior:
 //
 //   - ⌘K / ⌘I / ⌘J / ⌘' fire from editable targets (allowInEditable: true):
 //     none of today's listeners for these chords guards on the target.
@@ -116,6 +118,56 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     allowInEditable: true,
     allowInModal: true,
     legacyEitherMod: true,
+  },
+  // Phase 3 navigation chords (the webui-keybindings-p3 approved map). All
+  // six are strict single-modifier-family Alt chords with NO optional
+  // modifiers: Alt+ArrowUp and Alt+Shift+ArrowUp must stay distinct bindings
+  // (line vs page scroll), which forbids a [Shift] on the plain chord. All
+  // keep the default allowInEditable: false - plain Alt+Arrow keeps its
+  // native text-editing meaning inside inputs and the composer - and the
+  // default allowInModal/ignoreIfDefaultPrevented policy. None is a $mod
+  // chord, so modPair registers no cross-platform twin.
+  //
+  // The session-cycling pair acts even when the focused pane is NOT a
+  // session (focusing the first/last open session then); the transcript
+  // scroll actions are per-pane multi-instance registrations whose handlers
+  // decline unless their pane is the focused one - see
+  // panes/session/transcript/flow/useTranscriptScrollKeys.ts.
+  {
+    id: ACTIONS.sessionNext,
+    actionId: ACTIONS.sessionNext,
+    title: "Focus the next session pane",
+    chord: "Alt+ArrowRight",
+  },
+  {
+    id: ACTIONS.sessionPrevious,
+    actionId: ACTIONS.sessionPrevious,
+    title: "Focus the previous session pane",
+    chord: "Alt+ArrowLeft",
+  },
+  {
+    id: ACTIONS.transcriptLineUp,
+    actionId: ACTIONS.transcriptLineUp,
+    title: "Scroll the transcript up one line",
+    chord: "Alt+ArrowUp",
+  },
+  {
+    id: ACTIONS.transcriptLineDown,
+    actionId: ACTIONS.transcriptLineDown,
+    title: "Scroll the transcript down one line",
+    chord: "Alt+ArrowDown",
+  },
+  {
+    id: ACTIONS.transcriptPageUp,
+    actionId: ACTIONS.transcriptPageUp,
+    title: "Scroll the transcript up one page",
+    chord: "Alt+Shift+ArrowUp",
+  },
+  {
+    id: ACTIONS.transcriptPageDown,
+    actionId: ACTIONS.transcriptPageDown,
+    title: "Scroll the transcript down one page",
+    chord: "Alt+Shift+ArrowDown",
   },
   {
     id: ACTIONS.settingsClose,

--- a/cmd/evener-hub/frontend/src/panes/session/Session.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.tsx
@@ -46,6 +46,7 @@ import { LoadOlderRow } from "./transcript/flow/LoadOlderRow";
 import { NewContentPill } from "./transcript/flow/NewContentPill";
 import { useSeenDivider } from "./transcript/flow/useSeenDivider";
 import { useTranscriptScroll } from "./transcript/flow/useTranscriptScroll";
+import { useTranscriptScrollKeys } from "./transcript/flow/useTranscriptScrollKeys";
 import { SelectionQuote } from "./transcript/SelectionQuote";
 import { formatQuoteBlock } from "./transcript/selectionQuoteLogic";
 import {
@@ -210,6 +211,10 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
     renderedRowCount: renderRows.length,
     sourceTurnRowIndexes,
   });
+  // The transcript's keyboard scroll (Alt+Arrow/Alt+Shift+Arrow, Phase 3):
+  // per-pane handlers against the shared registry that decline unless THIS
+  // pane is the workspace's focused one. Nothing registers on mobile.
+  useTranscriptScrollKeys({ paneId, listRef: virtualListRef, jumpToBottom: flow.jumpToBottom });
   const showColdStartSkeleton = useColdStartSkeleton(ref, model);
   // kata g2ez: names the one turn (if any) that starts what's arrived since
   // this pane was last open, so a reopened session shows where to pick up.

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
@@ -15,6 +15,7 @@ import {
   subscribeMutationPersistence,
   threadsStore,
 } from "../../../../stores/threads";
+import { resetComposerFocusStoreForTests, useComposerFocusRequest } from "../composerFocus";
 import { AskDock } from "./AskDock";
 import { askDockStore, resetAskDockStoreForTests } from "./askDockStore";
 
@@ -147,6 +148,7 @@ beforeEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   resetThreadsStoreForTests();
   resetAskDockStoreForTests();
+  resetComposerFocusStoreForTests();
 });
 
 test("renders nothing when there is no pending ask for this ref", async () => {
@@ -268,6 +270,12 @@ test("clicking Send composes and submits through the plain send() path, then the
   expect(screen.queryByText("Deploy?")).toBeNull();
 });
 
+// Escape is a documented NO-OP on the ask dock, not a missing feature:
+// parity-m5-composer.md:120 ("the dock is the one canonical response surface
+// and there is no alternate 'collapse' state to escape to") and
+// contracts-composer-queue-pending.md's test-ask-card.js row both record it
+// as deliberate. AskDock installs no Escape handler at all - this test and
+// the one at the end of this file pin the no-op so it stays deliberate.
 test("Escape does not dismiss the dock or clear any in-progress selection", async () => {
   const user = userEvent.setup();
   const fake = connectFakeClient();
@@ -705,4 +713,186 @@ test("Mod+Enter is ignored while an IME composition is in progress", async () =>
 
   await new Promise((resolve) => setTimeout(resolve, 0));
   expect(fake.calls.some((c) => c.method === "turn/start")).toBe(false);
+});
+
+// --- Phase 3 keyboard operation -------------------------------------------
+//
+// Three pins on top of the walk/submit keys above:
+//
+// - Escape STAYS a no-op (parity-m5-composer.md:120 documents the no-dismiss
+//   behavior as deliberate) - and pressing it inside the dock must not leak
+//   into anything else either (no send, no cleared answer/note). The only
+//   window-level Escape consumers are SelectionQuote's selection clear (which
+//   reads no dock state) and the settings scope's close (pushed only while
+//   Settings is open); the composer has no Escape-to-clear at all.
+// - Alt+PageDown/Alt+PageUp jump focus between question BATCHES directly
+//   (the tab strip's ArrowLeft/Right walk only moves within one batch).
+//   Alt+Page* is chosen over Alt+Arrow* because the Phase 3 transcript
+//   scroll bindings own Alt+ArrowUp/Down with allowInEditable: false - and
+//   the dispatcher's editable test only covers INPUT/TEXTAREA/SELECT, so
+//   from the dock's tab/send BUTTONS those chords would scroll the
+//   transcript. Bare PageUp/PageDown keep their native meaning (the dock is
+//   its own overflow-y scroller). No registered chord or native text-editing
+//   meaning uses Alt+PageUp/Down.
+// - A send that empties the dock requests composer focus through
+//   composerFocus.ts's requestComposerFocus seam (the same one ⌘I drives);
+//   a send with batches still pending moves focus to the next batch's entry
+//   control instead, because the composer input row is still hidden/inert.
+
+const SECOND_ASK = [{ header: "Later", question: "q_later", options: [{ label: "later-opt", detail: "d" }] }];
+
+// renderTwoBatches drives the REAL two-batch route (reconcileBatches.ts: a
+// batch mid-send is frozen, so the late ask_user call mints a sibling batch
+// instead of joining the open one). Determinism lives in the ordering, not
+// in any timing: the click and the ack run in ONE synchronous block (act's
+// callback executes synchronously), and send() can only resolve after its
+// durable outbox write - an IndexedDB round trip that cannot complete inside
+// a synchronous block - so the ack is guaranteed to land while batch 1 is
+// still sending. turn/start stays parked so nothing else settles the batch.
+async function renderTwoBatches(
+  fake: FakeClient,
+  secondQuestions: Array<Record<string, unknown>> = SECOND_ASK,
+): Promise<void> {
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(<AskDock ref="ref_a" />);
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /send answers/i }));
+    ackAskUserCall(fake, "ref_a", "turn_1", "item_2", "call_2", secondQuestions);
+  });
+  expect(askDockStore.getState().byRef.get("ref_a")?.batches.length).toBe(2);
+}
+
+test("Escape inside the dock sends nothing and preserves both the answer and a typed note", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(<AskDock ref="ref_a" />);
+
+  await user.click(screen.getByRole("radio", { name: "Yes" }));
+  const note = screen.getByPlaceholderText(/note \(optional\)/i);
+  await user.type(note, "keep me");
+  await user.keyboard("{Escape}");
+
+  expect(screen.getByText("Deploy?")).toBeTruthy();
+  expect(screen.getByRole("radio", { name: "Yes" })).toHaveProperty("checked", true);
+  expect((note as HTMLInputElement).value).toBe("keep me");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(fake.calls.some((c) => c.method === "turn/start")).toBe(false);
+});
+
+test("Alt+PageDown/Alt+PageUp jump focus between batches, wrapping at both ends", async () => {
+  const fake = connectFakeClient();
+  await renderTwoBatches(fake);
+
+  const batch1Radio = screen.getByRole("radio", { name: "Yes" });
+  batch1Radio.focus();
+  fireEvent.keyDown(batch1Radio, { key: "PageDown", altKey: true });
+  const batch2Radio = screen.getByRole("radio", { name: "later-opt" });
+  expect(document.activeElement).toBe(batch2Radio);
+
+  // Past the last batch: wrap to the first.
+  fireEvent.keyDown(batch2Radio, { key: "PageDown", altKey: true });
+  expect(document.activeElement).toBe(batch1Radio);
+
+  // Before the first batch: wrap to the last.
+  fireEvent.keyDown(batch1Radio, { key: "PageUp", altKey: true });
+  expect(document.activeElement).toBe(batch2Radio);
+});
+
+test("batch jump lands on the target batch's selected tab when it has a tab strip", async () => {
+  const fake = connectFakeClient();
+  await renderTwoBatches(fake, [
+    { header: "Alpha", question: "q_alpha", options: [{ label: "alpha-opt", detail: "" }] },
+    { header: "Beta", question: "q_beta", options: [{ label: "beta-opt", detail: "" }] },
+  ]);
+
+  const batch1Radio = screen.getByRole("radio", { name: "Yes" });
+  batch1Radio.focus();
+  fireEvent.keyDown(batch1Radio, { key: "PageDown", altKey: true });
+
+  const selectedTab = screen.getByRole("tab", { name: /1\. Alpha/ });
+  expect(selectedTab.getAttribute("aria-selected")).toBe("true");
+  expect(document.activeElement).toBe(selectedTab);
+});
+
+test("plain PageUp/PageDown keep their native meaning - no batch jump without Alt", async () => {
+  const fake = connectFakeClient();
+  await renderTwoBatches(fake);
+
+  const batch1Radio = screen.getByRole("radio", { name: "Yes" });
+  batch1Radio.focus();
+  fireEvent.keyDown(batch1Radio, { key: "PageDown" });
+  expect(document.activeElement).toBe(batch1Radio);
+  fireEvent.keyDown(batch1Radio, { key: "PageUp" });
+  expect(document.activeElement).toBe(batch1Radio);
+});
+
+test("a send that empties the dock requests composer focus", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", (params) => ({
+    receipt: {
+      clientMutationId: params.clientMutationId,
+      disposition: "applied",
+      threadId: "thread_a",
+      projectionState: "reflected",
+    },
+    turn: { id: "turn_2", status: "inProgress", itemsView: "" },
+  }));
+  // The composerFocus store's only read seam is its hook (composerFocus.ts),
+  // so the assertion renders a probe over it rather than reaching into the
+  // module's private store.
+  function Probe() {
+    return <span>{useComposerFocusRequest("ref_a") ? "requested" : "none"}</span>;
+  }
+  render(
+    <>
+      <AskDock ref="ref_a" />
+      <Probe />
+    </>,
+  );
+
+  const persisted = nextMutationPersistence("ref_a");
+  await user.click(screen.getByRole("button", { name: /send answers/i }));
+  await persisted;
+
+  await waitFor(() => expect(screen.getByText("requested")).toBeTruthy());
+});
+
+test("a send with another batch still pending moves focus to the remaining batch, not the composer", async () => {
+  const fake = connectFakeClient();
+  function Probe() {
+    return <span>{useComposerFocusRequest("ref_a") ? "requested" : "none"}</span>;
+  }
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(
+    <>
+      <AskDock ref="ref_a" />
+      <Probe />
+    </>,
+  );
+  // Focus lives in batch 1; its send starts (parked turn/start) and the
+  // late ask mints batch 2 while batch 1 is genuinely mid-send - one
+  // synchronous block, so the send cannot settle first (renderTwoBatches's
+  // own comment has the determinism argument).
+  screen.getByRole("radio", { name: "Yes" }).focus();
+  const persisted = nextMutationPersistence("ref_a");
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /send answers/i }));
+    ackAskUserCall(fake, "ref_a", "turn_1", "item_2", "call_2", SECOND_ASK);
+  });
+  expect(askDockStore.getState().byRef.get("ref_a")?.batches.length).toBe(2);
+
+  await persisted;
+  await waitFor(() => expect(askDockStore.getState().byRef.get("ref_a")?.batches.length).toBe(1));
+
+  // Batch 1 unmounted with the focus in it; focus lands on the remaining
+  // batch's first answer control, and the still-hidden composer is NOT
+  // asked for focus.
+  await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("radio", { name: "later-opt" })));
+  expect(screen.getByText("none")).toBeTruthy();
 });

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.tsx
@@ -45,9 +45,28 @@
 //   - Failure feedback for a local durable-enqueue error is a toast (the
 //     wave's decided convention, T1's loadOlder reference implementation);
 //     network outcomes are rendered by recovery state, not an inline banner.
+//
+// Phase 3 keyboard operation (webui-keybindings-p3): on top of the per-batch
+// keys above, Alt+PageDown/Alt+PageUp jump focus between BATCHES directly,
+// wrapping at both ends (landing on the target batch's selected tab when it
+// has a tab strip, else its first answer control). Alt+Page* rather than
+// Alt+Arrow* because the Phase 3 transcript-scroll bindings own
+// Alt+ArrowUp/Down with allowInEditable: false - and the dispatcher's
+// editable test only covers INPUT/TEXTAREA/SELECT, so from the dock's tab
+// and send BUTTONS those chords would still scroll the transcript - and
+// rather than bare PageUp/PageDown, which keep their native meaning (the
+// dock is its own overflow-y scroller). Escape stays a deliberate NO-OP:
+// parity-m5-composer.md:120 documents that the dock is the one canonical
+// response surface with no collapse state to escape to, so this component
+// installs no Escape handler at all (AskDock.test.tsx pins both halves). A
+// send returns focus: to the composer via composerFocus.ts's
+// requestComposerFocus seam when the dock just emptied, or to the next
+// still-pending batch's entry control when it has not (the composer input
+// row is hidden/inert until the last batch resolves - Composer.tsx).
 import { useEffect, useId, useRef } from "react";
 import { Button, useToasts } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
+import { requestComposerFocus } from "../composerFocus";
 import { AskQuestionCard } from "./AskQuestionCard";
 import type { AskResolution } from "./askCompose";
 import { type AskAnswerState, askDockStore, nextUnansweredKey, useAskDockStore } from "./askDockStore";
@@ -73,6 +92,25 @@ export interface AskDockProps {
 const NO_BATCHES: AskBatch[] = [];
 const NO_ANSWERS: Record<string, AskAnswerState> = {};
 const UNTOUCHED_ANSWER: AskAnswerState = { resolution: null, note: "" };
+
+// FIRST_CONTROL_SELECTOR names a batch's first answer control. Two callers:
+// the activation auto-focus effect (scoped to [data-ask-question] so a
+// multi-question batch's TAB BUTTONS - which sit before the card in DOM
+// order, kata 99yf - never win over the first actual answer control) and
+// focusBatchEntry's no-tab-strip fallback below.
+const FIRST_CONTROL_SELECTOR =
+  '[data-ask-question] input[type="radio"], [data-ask-question] input[type="checkbox"], [data-ask-question] input[type="text"], [data-ask-question] button';
+
+// focusBatchEntry moves focus into a batch at its orientation point: the
+// selected tab when the batch has a tab strip (the tab announces where in
+// the walk the reader is - "2. Second, tab, selected"), else the first
+// answer control, matching the dock-activation auto-focus below.
+function focusBatchEntry(batchEl: HTMLElement): void {
+  const entry =
+    batchEl.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]') ??
+    batchEl.querySelector<HTMLElement>(FIRST_CONTROL_SELECTOR);
+  entry?.focus();
+}
 
 // useAskDockPending is the seam T2 (or any other composer-surface owner)
 // reads to decide whether to hide/inert the plain composer for `ref` -
@@ -203,8 +241,11 @@ function AskBatchCard({ sessionRef, batch, answers, onSend }: AskBatchCardProps)
   }
 
   return (
+    // data-ask-batch lets the dock-level batch jump (Alt+PageUp/Down) and the
+    // post-send focus move locate each batch's card without depending on the
+    // CSS-module class name.
     // biome-ignore lint/a11y/noStaticElementInteractions: catches Mod+Enter/Enter bubbling up from the batch's own controls (radios, the free-text input) - the div is a layout container, not itself interactive, same precedent as Settings.tsx's own Escape-catching wrapper
-    <div className={CLASS.batch} onKeyDown={handleBatchKeyDown}>
+    <div className={CLASS.batch} onKeyDown={handleBatchKeyDown} data-ask-batch={batch.id}>
       {total > 1 && (
         // key="tabs"/key="panel" on both siblings: when a late ask_user call
         // grows a single-question batch past one question, the tab strip
@@ -312,9 +353,7 @@ export function AskDock({ ref: sessionRef }: AskDockProps) {
     const wasEmpty = wasEmptyRef.current;
     wasEmptyRef.current = isEmpty;
     if (!wasEmpty || isEmpty) return;
-    const first = dockRef.current?.querySelector<HTMLElement>(
-      '[data-ask-question] input[type="radio"], [data-ask-question] input[type="checkbox"], [data-ask-question] input[type="text"], [data-ask-question] button',
-    );
+    const first = dockRef.current?.querySelector<HTMLElement>(FIRST_CONTROL_SELECTOR);
     first?.focus();
   }, [batches.length]);
 
@@ -327,14 +366,59 @@ export function AskDock({ ref: sessionRef }: AskDockProps) {
       // that can still tell a failed send from the failed session resume
       // behind it (askDockStore's SendBatchOutcome).
       toasts.push("error", outcome.message);
+      return;
     }
-    // "sent"/"stale": nothing further to do here - a successful send's own
-    // batch removal, and a stale click's own no-op, are both already
-    // reflected by askDockStore's reactive state.
+    // "stale": nothing further to do here - the dock re-checked and found
+    // nothing left to send, and that no-op is already reflected by
+    // askDockStore's reactive state.
+    if (outcome.outcome !== "sent") return;
+    // Focus return (Phase 3): the sent batch's card - including whichever
+    // control had focus - unmounts with it, and without an explicit move
+    // keyboard focus drops to <body>. removeBatch has already run inside
+    // sendBatch, so the store (not the not-yet-flushed DOM) says what
+    // remains. Dock empty: ask the composer to take focus back through the
+    // composerFocus.ts seam (the request survives until the input row's
+    // hidden/inert lifts - exactly the transition this send just caused).
+    // Batches remain: the composer input row is still hidden/inert, so move
+    // focus to the next pending batch's entry control instead. That
+    // batch's DOM element still exists pre-flush and survives it (keyed),
+    // so the query is safe at either flush ordering.
+    const remaining = askDockStore.getState().byRef.get(sessionRef)?.batches ?? [];
+    const nextBatch = remaining[0];
+    if (nextBatch === undefined) {
+      requestComposerFocus(sessionRef);
+      return;
+    }
+    const nextEl = dockRef.current?.querySelector<HTMLElement>(`[data-ask-batch="${nextBatch.id}"]`);
+    if (nextEl) focusBatchEntry(nextEl);
+  }
+
+  // Batch jump (Phase 3): Alt+PageDown/Alt+PageUp move focus between batch
+  // cards directly, wrapping at both ends - the tab strip's ArrowLeft/Right
+  // walk only moves within ONE batch. Strict Alt-only chord (an extra
+  // modifier or an IME composition lets the key keep whatever other meaning
+  // it has). Fewer than two batches: nothing to jump to, and the event is
+  // left alone rather than claimed.
+  function handleDockKeyDown(event: React.KeyboardEvent) {
+    if (event.nativeEvent.isComposing) return;
+    if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+    const delta = event.key === "PageDown" ? 1 : event.key === "PageUp" ? -1 : 0;
+    if (delta === 0) return;
+    const root = dockRef.current;
+    if (!root) return;
+    const batchEls = Array.from(root.querySelectorAll<HTMLElement>("[data-ask-batch]"));
+    if (batchEls.length < 2) return;
+    event.preventDefault();
+    const current = batchEls.findIndex((el) => event.target instanceof Node && el.contains(event.target));
+    const next =
+      current === -1 ? (delta === 1 ? 0 : batchEls.length - 1) : (current + delta + batchEls.length) % batchEls.length;
+    const target = batchEls[next];
+    if (target) focusBatchEntry(target);
   }
 
   return (
-    <div className={CLASS.dock} ref={dockRef} data-ask-response-dock>
+    // biome-ignore lint/a11y/noStaticElementInteractions: catches Alt+PageUp/Down bubbling up from any control inside any batch - the div is a layout container, not itself interactive, same precedent as the batch-level Enter handler above
+    <div className={CLASS.dock} ref={dockRef} data-ask-response-dock onKeyDown={handleDockKeyDown}>
       <div className={CLASS.anchor} role="status" aria-live="polite">
         Answer the agent’s questions.
       </div>

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.test.tsx
@@ -1,0 +1,203 @@
+// Tests for useTranscriptScrollKeys (webui-keybindings-p3 Task 1): the
+// session transcript's keyboard scroll seam. Each mounted Session pane
+// registers its own transcript.* handlers against the shared keybindings
+// registry; the multi-instance rule (a handler returns false when its pane
+// is not workspaceStore.focusedPaneId) is the SelectionQuote clobber class
+// from Phase 2a, pinned here with a two-pane test. Chord dispatch goes
+// through the REAL dispatcher/defaults (installKeybindings) so these tests
+// also pin the Alt+Arrow chords themselves, the editable-target suppression,
+// and mobile inertness (rail.toggle's no-registration pattern).
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { ACTIONS } from "../../../../keybindings/actions";
+import { DEFAULT_BINDINGS } from "../../../../keybindings/defaults";
+import { keybindingsRegistry } from "../../../../keybindings/registry";
+import { installKeybindings } from "../../../../shell/installKeybindings";
+import { resetMobileViewportForTests } from "../../../../shell/useIsMobile";
+import { resetWorkspaceStoreForTests, workspaceStore } from "../../../../shell/workspace";
+import type { VirtualListHandle } from "../../../../widgets/virtuallist";
+import { TRANSCRIPT_LINE_SCROLL_PX, useTranscriptScrollKeys } from "./useTranscriptScrollKeys";
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+// A VirtualListHandle double whose scroll element is a real (layout-free)
+// jsdom div: scrollTop assignment sticks in jsdom, and clientHeight is
+// defined explicitly (500px) so the page-scroll step has geometry to read.
+function renderPaneKeys(paneId: string, { mounted = true }: { mounted?: boolean } = {}) {
+  const el = document.createElement("div");
+  Object.defineProperty(el, "clientHeight", { value: 500, configurable: true });
+  document.body.appendChild(el);
+  const scrollToIndex = vi.fn();
+  const listRef = {
+    current: {
+      scrollToIndex,
+      getScrollElement: () => (mounted ? el : null),
+      getVisibleRange: () => null,
+    } as VirtualListHandle,
+  };
+  const jumpToBottom = vi.fn();
+  const hook = renderHook(() => useTranscriptScrollKeys({ paneId, listRef, jumpToBottom }));
+  return { el, scrollToIndex, jumpToBottom, unmount: hook.unmount };
+}
+
+beforeEach(() => {
+  resetWorkspaceStoreForTests();
+  installKeybindings();
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+  resetMobileViewportForTests();
+});
+
+test("Alt+ArrowDown scrolls only the focused pane's transcript (two-pane multi-instance pin)", () => {
+  const a = renderPaneKeys("pane_a");
+  const b = renderPaneKeys("pane_b");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+  expect(b.el.scrollTop).toBe(0);
+
+  workspaceStore.setState({ focusedPaneId: "pane_b" });
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+  expect(b.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+});
+
+test("Alt+ArrowUp scrolls the focused transcript up one line step", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  a.el.scrollTop = 100;
+
+  window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true }));
+  expect(a.el.scrollTop).toBe(100 - TRANSCRIPT_LINE_SCROLL_PX);
+});
+
+test("Alt+Shift+ArrowDown/Up page the focused transcript by ~0.9 of the viewport", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+  expect(a.el.scrollTop).toBe(450);
+
+  window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true, shiftKey: true }));
+  expect(a.el.scrollTop).toBe(0);
+});
+
+test("the Alt+Shift page chords do NOT also fire the plain line-scroll bindings", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+  // Exactly the page step, not page+line (the line binding requires Shift to
+  // be absent).
+  expect(a.el.scrollTop).toBe(450);
+});
+
+test("Alt+Arrow scroll chords are suppressed from editable targets", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+
+  input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(0);
+
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+});
+
+test("a keydown no pane accepts is not preventDefaulted (unfocused panes decline, unmounted lists decline)", () => {
+  const a = renderPaneKeys("pane_a");
+  // pane_b registers handlers too, but its VirtualList has no scroll element.
+  renderPaneKeys("pane_b", { mounted: false });
+  // Nobody focused: both handlers decline.
+  const unfocused = keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+  window.dispatchEvent(unfocused);
+  expect(unfocused.defaultPrevented).toBe(false);
+  expect(a.el.scrollTop).toBe(0);
+
+  // Focused but the transcript's VirtualList has not mounted a scroll
+  // element yet (a dormant session renders EmptyTranscript, no list).
+  workspaceStore.setState({ focusedPaneId: "pane_b" });
+  const unmounted = keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+  window.dispatchEvent(unmounted);
+  expect(unmounted.defaultPrevented).toBe(false);
+});
+
+test("unmounting a pane unregisters only that pane's handlers", () => {
+  const a = renderPaneKeys("pane_a");
+  const b = renderPaneKeys("pane_b");
+  workspaceStore.setState({ focusedPaneId: "pane_b" });
+  b.unmount();
+
+  const event = keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+  window.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(false);
+  expect(a.el.scrollTop).toBe(0);
+
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+});
+
+test("transcript.scrollTop/scrollBottom ship with NO default chord (Phase 4's map decides)", () => {
+  expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollTop)).toBe(false);
+  expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollBottom)).toBe(false);
+});
+
+test("scrollTop/scrollBottom drive the focused pane's virtualizer (bound to test chords here)", () => {
+  const a = renderPaneKeys("pane_a");
+  const b = renderPaneKeys("pane_b");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  const registry = keybindingsRegistry.getState();
+  registry.registerBinding({ id: "test.transcript.scrollTop", actionId: ACTIONS.transcriptScrollTop, chord: "F8" });
+  registry.registerBinding({
+    id: "test.transcript.scrollBottom",
+    actionId: ACTIONS.transcriptScrollBottom,
+    chord: "F9",
+  });
+  try {
+    window.dispatchEvent(keydown({ key: "F8", code: "F8" }));
+    expect(a.scrollToIndex).toHaveBeenCalledWith(0, { align: "start" });
+    expect(b.scrollToIndex).not.toHaveBeenCalled();
+
+    window.dispatchEvent(keydown({ key: "F9", code: "F9" }));
+    expect(a.jumpToBottom).toHaveBeenCalledOnce();
+    expect(b.jumpToBottom).not.toHaveBeenCalled();
+  } finally {
+    registry.unregisterBinding("test.transcript.scrollTop");
+    registry.unregisterBinding("test.transcript.scrollBottom");
+  }
+});
+
+// jsdom has no matchMedia at all (useIsMobile.test.ts's header documents the
+// probe); a matching stub puts every useIsMobile consumer on mobile.
+function installMobileViewport(): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      media,
+      matches: media === "(max-width: 899px)",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })),
+  );
+}
+
+test("mobile: no transcript scroll handlers register at all (the rail.toggle inertness pattern)", () => {
+  installMobileViewport();
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+
+  expect(keybindingsRegistry.getState().actions.get(ACTIONS.transcriptLineDown)).toBeUndefined();
+  const event = keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+  window.dispatchEvent(event);
+  expect(a.el.scrollTop).toBe(0);
+  expect(event.defaultPrevented).toBe(false);
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.ts
@@ -1,0 +1,105 @@
+// useTranscriptScrollKeys: the session transcript's keyboard scroll seam
+// (webui-keybindings-p3 Task 1). Every mounted Session pane registers its own
+// handlers for the transcript.* actions against the shared keybindings
+// registry, using the registry's multi-instance support (registry.ts's
+// ActionRunner contract): a handler returns false - DECLINES - when its pane
+// is not workspaceStore.focusedPaneId, so only the focused pane's transcript
+// scrolls. This is the SelectionQuote clobber class from Phase 2a, pinned by
+// this hook's own two-pane test.
+//
+// The scroll mechanisms are the ones the transcript's own flow stack already
+// exposes - no new scroll math:
+//   - line/page steps write the scroll element's scrollTop directly, the
+//     same adjustment useTranscriptScroll's own anchor-restore paths use
+//     (el.scrollTop += delta). The native scroll listener that hook attaches
+//     keeps wasAtBottom/the new-content pill in step afterward.
+//   - scrollTop uses the virtualizer's scrollToIndex(0, { align: "start" }).
+//   - scrollBottom is the hook's own jumpToBottom (error-anchor aware, pill
+//     clearing) - the exact action NewContentPill's click target runs.
+//
+// Mobile: nothing registers at all (rail.toggle's no-registration pattern);
+// with no handler the bindings are inert there.
+
+import { type RefObject, useEffect, useRef } from "react";
+import { ACTIONS } from "../../../../keybindings/actions";
+import { keybindingsRegistry } from "../../../../keybindings/registry";
+import { installKeybindings } from "../../../../shell/installKeybindings";
+import { useIsMobile } from "../../../../shell/useIsMobile";
+import { workspaceStore } from "../../../../shell/workspace";
+import type { VirtualListHandle } from "../../../../widgets/virtuallist";
+
+/** One line-scroll step in pixels (≈ one transcript row's text line). */
+export const TRANSCRIPT_LINE_SCROLL_PX = 40;
+
+/** One page-scroll step as a fraction of the scroll viewport's height. */
+export const TRANSCRIPT_PAGE_SCROLL_RATIO = 0.9;
+
+export interface UseTranscriptScrollKeysOptions {
+  /** The workspace pane this Session instance is mounted as. */
+  paneId: string;
+  listRef: RefObject<VirtualListHandle | null>;
+  /** useTranscriptScroll's jumpToBottom (error-anchor aware, pill clearing). */
+  jumpToBottom: () => void;
+}
+
+export function useTranscriptScrollKeys({ paneId, listRef, jumpToBottom }: UseTranscriptScrollKeysOptions): void {
+  const isMobile = useIsMobile();
+  // jumpToBottom's identity tracks useTranscriptScroll's renders; the ref
+  // keeps the registered handler stable across them (SelectionQuote's
+  // actionsRef idiom).
+  const jumpToBottomRef = useRef(jumpToBottom);
+  jumpToBottomRef.current = jumpToBottom;
+
+  useEffect(() => {
+    if (isMobile) return undefined;
+    installKeybindings();
+    const registry = keybindingsRegistry.getState();
+    const focused = () => workspaceStore.getState().focusedPaneId === paneId;
+    const scrollElement = () => listRef.current?.getScrollElement() ?? null;
+    const unregister = [
+      registry.registerAction(ACTIONS.transcriptLineUp, () => {
+        if (!focused()) return false;
+        const el = scrollElement();
+        if (!el) return false;
+        el.scrollTop -= TRANSCRIPT_LINE_SCROLL_PX;
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptLineDown, () => {
+        if (!focused()) return false;
+        const el = scrollElement();
+        if (!el) return false;
+        el.scrollTop += TRANSCRIPT_LINE_SCROLL_PX;
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptPageUp, () => {
+        if (!focused()) return false;
+        const el = scrollElement();
+        if (!el) return false;
+        el.scrollTop -= el.clientHeight * TRANSCRIPT_PAGE_SCROLL_RATIO;
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptPageDown, () => {
+        if (!focused()) return false;
+        const el = scrollElement();
+        if (!el) return false;
+        el.scrollTop += el.clientHeight * TRANSCRIPT_PAGE_SCROLL_RATIO;
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptScrollTop, () => {
+        if (!focused()) return false;
+        const list = listRef.current;
+        if (!list) return false;
+        list.scrollToIndex(0, { align: "start" });
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptScrollBottom, () => {
+        if (!focused()) return false;
+        jumpToBottomRef.current();
+        return true;
+      }),
+    ];
+    return () => {
+      for (const dispose of unregister) dispose();
+    };
+  }, [isMobile, paneId, listRef]);
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -61,6 +61,12 @@ test("lists every default action with its title and effective chord, none custom
     expect.stringContaining("Focus the composer"),
     expect.stringContaining("Go to the next session needing you"),
     expect.stringContaining("Quote the selection into the composer"),
+    expect.stringContaining("Focus the next session pane"),
+    expect.stringContaining("Focus the previous session pane"),
+    expect.stringContaining("Scroll the transcript up one line"),
+    expect.stringContaining("Scroll the transcript down one line"),
+    expect.stringContaining("Scroll the transcript up one page"),
+    expect.stringContaining("Scroll the transcript down one page"),
     expect.stringContaining("Close settings"),
   ]);
   expect(screen.queryByText("Customized")).toBeNull();

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -2297,3 +2297,96 @@ test("Escape in Settings exits to welcome and the URL stays there, not reinstate
   });
   expect(screen.queryByRole("navigation", { name: "Settings sections" })).toBeNull();
 });
+
+// --- Alt+ArrowLeft/Right session-pane cycling (webui-keybindings-p3 Task 1)
+//
+// AppShell registers session.next/session.previous against the keybindings
+// registry (desktop only - the rail.toggle inertness pattern); the actions
+// drive workspaceStore.focusPane through shell/sessionCycle.ts. These tests
+// pin the WIRING (real dispatcher, real defaults, real shell); the cycling
+// order/wrap/no-op semantics themselves are sessionCycle.test.ts's.
+
+test("Alt+ArrowRight/Left cycle the open session panes through the shell, wrapping", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  let a = "";
+  let b = "";
+  act(() => {
+    a = workspaceStore.getState().openPane("session", { ref: "local:cycle-a" });
+    b = workspaceStore.getState().openPane("session", { ref: "local:cycle-b" });
+    workspaceStore.getState().focusPane(a);
+  });
+  await waitFor(() => expect(workspaceStore.getState().panes).toHaveLength(2));
+
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+
+  // Wrap: the last session pane's next is the first.
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+
+  await user.keyboard("{Alt>}{ArrowLeft}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+});
+
+test("Alt+Arrow cycling is a no-op with a single session pane open", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  let only = "";
+  act(() => {
+    only = workspaceStore.getState().openPane("session", { ref: "local:cycle-only" });
+  });
+  await waitFor(() => expect(workspaceStore.getState().panes).toHaveLength(1));
+
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(only);
+  await user.keyboard("{Alt>}{ArrowLeft}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(only);
+});
+
+test("Alt+Arrow cycling is suppressed from an editable target", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  let a = "";
+  act(() => {
+    a = workspaceStore.getState().openPane("session", { ref: "local:cycle-a" });
+    workspaceStore.getState().openPane("session", { ref: "local:cycle-b" });
+    workspaceStore.getState().focusPane(a);
+  });
+  await waitFor(() => expect(workspaceStore.getState().panes).toHaveLength(2));
+
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  try {
+    await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+    expect(workspaceStore.getState().focusedPaneId).toBe(a);
+  } finally {
+    input.remove();
+  }
+});
+
+test("mobile: Alt+Arrow cycling registers nothing and is inert", async () => {
+  installMobileViewport();
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  let a = "";
+  act(() => {
+    a = workspaceStore.getState().openPane("session", { ref: "local:cycle-a" });
+    workspaceStore.getState().openPane("session", { ref: "local:cycle-b" });
+    workspaceStore.getState().focusPane(a);
+  });
+  await waitFor(() => expect(workspaceStore.getState().panes).toHaveLength(2));
+
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+  vi.unstubAllGlobals();
+});

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -33,6 +33,7 @@ import { openPalette, paletteStore } from "./palette/paletteController";
 import { RailHost } from "./rail";
 import { needsYouRefs, nextNeedsYouRef, openNeedsYouSession } from "./rail/needsYouCycle";
 import { urlToPane } from "./routing";
+import { cycleSessionPane } from "./sessionCycle";
 import { openNestedSessionWithOwner, openTopLevelSession } from "./sessionPlacement";
 import { isSinglePaneRoute } from "./singlePane";
 import { useIsMobile } from "./useIsMobile";
@@ -475,6 +476,25 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
       .catch(() => undefined);
   }, [locationFailed, locationRef, locationResource]);
   const isMobile = useIsMobile();
+  // Alt+ArrowLeft/Right cycle focus through the open session panes (Phase 3;
+  // cycling semantics live in sessionCycle.ts). Desktop only, following
+  // RailHost's rail.toggle pattern: with no action registered on mobile the
+  // bindings are inert there. The handlers CLAIM their chord even when
+  // cycling no-ops (fewer than two session panes): Alt+ArrowLeft is the
+  // browser's Back shortcut, and declining would navigate the SPA's history
+  // underneath a user who has one session open.
+  useEffect(() => {
+    if (isMobile) return undefined;
+    installKeybindings();
+    const registry = keybindingsRegistry.getState();
+    const unregister = [
+      registry.registerAction(ACTIONS.sessionNext, () => cycleSessionPane("next")),
+      registry.registerAction(ACTIONS.sessionPrevious, () => cycleSessionPane("previous")),
+    ];
+    return () => {
+      for (const dispose of unregister) dispose();
+    };
+  }, [isMobile]);
   // Keeps --keyboard-inset current for the mobile .shell rule; see
   // useKeyboardInset.ts's header for the why.
   useKeyboardInset();

--- a/cmd/evener-hub/frontend/src/shell/sessionCycle.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/sessionCycle.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+
+// Unit tests for sessionCycle.ts (webui-keybindings-p3 Task 1): the
+// session.next/session.previous actions cycle the workspace's SESSION panes
+// in workspace (workspaceStore.panes) order, wrapping at both ends, skipping
+// every non-session pane, and no-op with fewer than two session panes open.
+// Pane-registration scaffolding mirrors workspace.test.ts's own (fixture
+// descriptors over the shared paneRegistry singleton).
+import { lazy } from "react";
+import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
+import { type PaneDescriptor, type PaneProps, registerPaneForTests } from "./paneRegistry";
+import { cycleSessionPane } from "./sessionCycle";
+import { resetWorkspaceStoreForTests, workspaceStore } from "./workspace";
+
+function fixtureDescriptor<P>(
+  id: PaneDescriptor<P>["id"],
+  overrides: Partial<PaneDescriptor<P>> = {},
+): PaneDescriptor<P> {
+  return {
+    id,
+    title: () => `title for ${id}`,
+    component: lazy(() => new Promise<{ default: React.ComponentType<PaneProps<P>> }>(() => {})),
+    ...overrides,
+  };
+}
+
+const restorePaneFixtures: Array<() => void> = [];
+
+beforeAll(() => {
+  restorePaneFixtures.push(registerPaneForTests(fixtureDescriptor("session")));
+  restorePaneFixtures.push(registerPaneForTests(fixtureDescriptor("settings", { singleton: true })));
+  restorePaneFixtures.push(registerPaneForTests(fixtureDescriptor("doc")));
+});
+
+afterAll(() => {
+  for (const restore of restorePaneFixtures) restore();
+});
+
+beforeEach(() => {
+  resetWorkspaceStoreForTests();
+});
+
+function openSessions(...refs: string[]): string[] {
+  return refs.map((ref) => workspaceStore.getState().openPane("session", { ref }));
+}
+
+test("next cycles through the session panes in workspace order", () => {
+  // The tuple casts: noUncheckedIndexedAccess types destructured elements string|undefined.
+  const [a, b, c] = openSessions("local:a", "local:b", "local:c") as [string, string, string];
+  workspaceStore.getState().focusPane(a);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(c);
+});
+
+test("next wraps from the last session pane back to the first", () => {
+  const [a, , c] = openSessions("local:a", "local:b", "local:c") as [string, string, string];
+  workspaceStore.getState().focusPane(c);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+});
+
+test("previous cycles backward and wraps from the first to the last", () => {
+  // The tuple casts: noUncheckedIndexedAccess types destructured elements string|undefined.
+  const [a, b, c] = openSessions("local:a", "local:b", "local:c") as [string, string, string];
+  workspaceStore.getState().focusPane(a);
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(c);
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+});
+
+test("non-session panes in the workspace are skipped", () => {
+  const a = workspaceStore.getState().openPane("session", { ref: "local:a" });
+  workspaceStore.getState().openPane("settings", {});
+  workspaceStore.getState().openPane("doc", { session: "local:a", path: "README.md" });
+  const b = workspaceStore.getState().openPane("session", { ref: "local:b" });
+  workspaceStore.getState().focusPane(a);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+});
+
+test("no-op when no session pane is open", () => {
+  const settings = workspaceStore.getState().openPane("settings", {});
+  workspaceStore.getState().focusPane(settings);
+  cycleSessionPane("next");
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(settings);
+});
+
+test("no-op when only one session pane is open", () => {
+  const [only] = openSessions("local:only") as [string];
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(only);
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(only);
+});
+
+test("with focus on a non-session pane, next focuses the first session and previous the last", () => {
+  const [a, , c] = openSessions("local:a", "local:b", "local:c") as [string, string, string];
+  const settings = workspaceStore.getState().openPane("settings", {});
+  workspaceStore.getState().focusPane(settings);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+  workspaceStore.getState().focusPane(settings);
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(c);
+});
+
+test("no focused pane at all still lands on a session pane rather than throwing", () => {
+  const [a] = openSessions("local:a", "local:b") as [string];
+  workspaceStore.setState({ focusedPaneId: null });
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+});

--- a/cmd/evener-hub/frontend/src/shell/sessionCycle.ts
+++ b/cmd/evener-hub/frontend/src/shell/sessionCycle.ts
@@ -1,0 +1,33 @@
+// Session-pane cycling for the session.next/session.previous keybinding
+// actions (webui-keybindings-p3 Task 1): Alt+ArrowRight/Left move focus
+// through the workspace's SESSION panes in workspaceStore.panes order,
+// wrapping at both ends. The action handlers (AppShell) call
+// cycleSessionPane; the semantics live here, against the store, so the
+// handler is one line and the policy is unit-testable without the shell.
+//
+// Only panes of type "session" participate - the transcript/doc/tasks/etc.
+// panels beside a session are not cycling targets. Fewer than two session
+// panes open is a no-op (cycling one pane onto itself would be motion
+// without movement). When the focused pane is not a session (settings, a
+// doc, nothing focused at all), next lands on the FIRST session pane and
+// previous on the LAST - needsYouCycle.ts's nextNeedsYouRef precedent for
+// "current not in the cycle list".
+
+import { workspaceStore } from "./workspace";
+
+export type SessionCycleDirection = "next" | "previous";
+
+export function cycleSessionPane(direction: SessionCycleDirection): void {
+  const state = workspaceStore.getState();
+  const sessions = state.panes.filter((pane) => pane.type === "session");
+  if (sessions.length < 2) return;
+  const index = sessions.findIndex((pane) => pane.id === state.focusedPaneId);
+  let target: (typeof sessions)[number] | undefined;
+  if (index < 0) {
+    target = direction === "next" ? sessions[0] : sessions[sessions.length - 1];
+  } else {
+    const step = direction === "next" ? 1 : -1;
+    target = sessions[(index + step + sessions.length) % sessions.length];
+  }
+  if (target) state.focusPane(target.id);
+}

--- a/docs/web-ui/README.md
+++ b/docs/web-ui/README.md
@@ -16,8 +16,10 @@ Design documentation for the web hub (`cmd/evener-hub`). Started 2026-06-16.
   it. Cited from live source comments.
 - **[keybindings.md](keybindings.md)** — the keybindings dispatcher: registry,
   scope stack, precedence layers, per-binding policy flags, and how to
-  register an action or a chord, plus the hub-persisted override sync
-  (payload contract, validation split, failure posture).
+  register an action or a chord, the shipped default binding map (including
+  the Phase 3 navigation chords and the AskDock keyboard contract), plus the
+  hub-persisted override sync (payload contract, validation split, failure
+  posture).
 - **[parity/](parity/)** — the behaviour-parity checklists the React rewrite was
   graded against, mined from the legacy hub before it was deleted. The code they
   cite is gone, so their `path:line` citations no longer resolve; they survive

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,10 +1,12 @@
 # Web UI keybindings
 
-Status: **current** (Phase 2b). The web hub's global keyboard chords are
+Status: **current** (Phase 3). The web hub's global keyboard chords are
 owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
 window-level dispatcher, instead of each component installing its own
 `keydown` listener. User overrides persist on the hub and sync to every
-paired browser.
+paired browser. Phase 3 added the first navigation bindings (session-pane
+cycling, transcript scroll) on that infrastructure, plus full keyboard
+operation of the AskDock ask-user surface.
 
 ## Architecture
 
@@ -24,7 +26,8 @@ Four pieces, all in `src/keybindings/` and all React-free:
 - **dispatcher.ts** — the single window-level `keydown` listener. On every
   registry change it rebuilds a tinykeys `createKeybindingsHandler` over the
   active scope set: the scope stack top-down, then the `global` scope.
-- **defaults.ts** — the built-in binding map (the six shell chords) and
+- **defaults.ts** — the built-in binding map (the six legacy shell chords
+  plus the six Phase 3 navigation chords) and
   `registerDefaultBindings`, which also registers each `$mod` chord's
   cross-platform Meta/Control twin (the pre-dispatcher listeners accepted
   `metaKey || ctrlKey` on every platform, so both work everywhere).
@@ -48,9 +51,10 @@ The one wiring point that touches React and the app's stores is
 `src/shell/installKeybindings.ts`: an idempotent per-window installer that
 registers the default bindings and attaches the dispatcher with the real
 predicates injected. AppShell calls it at mount; every component that
-registers a chord action (RailHost, Settings, SelectionQuote) calls it too,
-so those components' chords also work when they are mounted without the
-shell — their unit tests render them standalone.
+registers a chord action (RailHost, Settings, SelectionQuote, and every
+Session pane via its transcript-scroll hook) calls it too, so those
+components' chords also work when they are mounted without the shell —
+their unit tests render them standalone.
 
 ## Precedence
 
@@ -91,6 +95,168 @@ preventDefault'd. Multi-instance components rely on this: one SelectionQuote
 mounts per session pane, each registering `selection.quote`, and only the
 instance holding a captured selection accepts — the multi-instance
 equivalent of the per-component listeners the dispatcher replaced.
+Phase 3's transcript scroll uses the same contract, keyed on the focused
+pane instead of a captured selection (see below).
+
+## Default binding map (as shipped after Phase 3)
+
+Every entry of `DEFAULT_BINDINGS` (`src/keybindings/defaults.ts`), in map
+order. Chords are rendered the way `KeyHint`/`formatChord` render them:
+`$mod` reads as ⌘ on Apple platforms and Ctrl elsewhere, every other key
+name is verbatim. "Policy" lists only the flags that differ from the
+defaults (`allowInEditable: false`, `allowInModal: false`,
+`ignoreIfDefaultPrevented: true`).
+
+| Chord | Action | Scope | Non-default policy | What it does |
+|---|---|---|---|---|
+| ⌘K / Ctrl+K | `palette.open` | global | `allowInEditable`, `allowInModal` | Open the command palette |
+| ⌘B / Ctrl+B | `rail.toggle` | global | `allowInModal`, `ignoreIfDefaultPrevented: false` | Toggle the sidebar |
+| ⌘I / Ctrl+I | `composer.focus` | global | `allowInEditable` | Focus the composer |
+| ⌘J / Ctrl+J | `next-needs-you` | global | `allowInEditable` | Go to the next session needing you |
+| ⌘' / Ctrl+' | `selection.quote` | global | `allowInEditable`, `allowInModal` | Quote the selection into the composer |
+| Alt+ArrowRight | `session.next` | global | — | Focus the next session pane |
+| Alt+ArrowLeft | `session.previous` | global | — | Focus the previous session pane |
+| Alt+ArrowUp | `transcript.lineUp` | global | — | Scroll the focused pane's transcript up one line |
+| Alt+ArrowDown | `transcript.lineDown` | global | — | Scroll the focused pane's transcript down one line |
+| Alt+Shift+ArrowUp | `transcript.pageUp` | global | — | Scroll the focused pane's transcript up one page |
+| Alt+Shift+ArrowDown | `transcript.pageDown` | global | — | Scroll the focused pane's transcript down one page |
+| Escape | `settings.close` | settings | `allowInEditable` | Close settings |
+
+Match permissiveness, per chord (all of it exact preservation of the
+pre-dispatcher listeners — Phase 2a's ruling was no behavior change):
+
+- Every `$mod` chord also registers its cross-platform Meta/Control twin,
+  so e.g. Ctrl+K fires on macOS exactly like ⌘K. On top of that, the five
+  legacy `$mod` chords carry `legacyEitherMod`: the other of Meta/Ctrl is
+  an *optional* modifier on both the entry and its twin, so Meta+Ctrl+K
+  fires too.
+- ⌘K / ⌘I / ⌘J list `[Shift]+[Alt]` as optional modifiers (the legacy
+  AppShell listener had no shift/alt guard), so ⌘⇧K, ⌘⌥I, Ctrl+Shift+J
+  etc. all fire. This means `composer.focus` and `next-needs-you` keep
+  hijacking the browser's DevTools chords (⌘⌥I, Ctrl+Shift+J) exactly as
+  the legacy listeners did — see the provisional-status note below.
+- ⌘' allows an extra Shift but never Alt (the legacy `!event.altKey`
+  AltGr guard); ⌘B is strict — no extra modifiers at all.
+- `settings.close`'s Escape lists every modifier optional (the legacy
+  listener checked only `event.key === "Escape"`).
+- The six Phase 3 Alt chords are strict single-family chords with no
+  optional modifiers — Alt+ArrowUp and Alt+Shift+ArrowUp must stay
+  distinct bindings (line vs page scroll), which forbids a `[Shift]` on
+  the plain chord — and no `$mod` twin. All keep the default
+  `allowInEditable: false`, so plain Alt+Arrow keeps its native
+  word-move/selection meaning inside inputs and the composer.
+
+Two registered actions have **no default chord**: `transcript.scrollTop`
+and `transcript.scrollBottom`. Their handlers exist (each Session pane
+registers them), but the Phase 4 keymap decides whether they get a chord
+at all. Because `DEFAULT_BINDINGS` is the Settings section's row source
+and the override validator's action universe, chord-less actions appear in
+neither — an override payload naming one is skipped with an unknown-action
+warning.
+
+### Provisional status
+
+The six Phase 3 chords are provisional: Phase 4 owns the comprehensive
+keymap and may re-cut any of them (they are registry defaults, remappable
+via the Phase 2b overrides store from day one). The ledger records two
+known Phase 4 candidates:
+
+1. **Removing the legacy DevTools-chord hijack permissiveness.** ⌘⌥I and
+   Ctrl+Shift+J fire `composer.focus` and `next-needs-you` today because
+   Phase 2a preserved the legacy listeners' missing shift/alt guards
+   exactly. Revisiting that was deferred policy then and is still open.
+2. **Deciding chords for `transcript.scrollTop`/`scrollBottom`** — and, if
+   they stay chord-less, giving the validator/Settings story for actions
+   that exist outside `DEFAULT_BINDINGS`.
+
+## Phase 3: session-pane cycling
+
+`session.next` / `session.previous` (Alt+ArrowRight / Alt+ArrowLeft) cycle
+focus through the workspace's **session** panes — panes of
+`type === "session"` only; transcript/doc/tasks panels are not cycling
+targets. The semantics live in `src/shell/sessionCycle.ts`
+(`cycleSessionPane`), against the store; AppShell's handlers are one line
+each:
+
+- Order is `workspaceStore.panes` order, wrapping at both ends.
+- Fewer than two session panes open is a no-op (cycling one pane onto
+  itself would be motion without movement).
+- When the focused pane is not a session (settings, a doc, nothing
+  focused), `next` lands on the FIRST session pane and `previous` on the
+  LAST — the `nextNeedsYouRef` precedent for "current not in the list".
+- The handlers always **claim** the chord (they never decline), even when
+  cycling no-ops: Alt+ArrowLeft is the browser's Back shortcut, and
+  declining it would navigate the SPA's history underneath a user with a
+  single session open.
+- Desktop only: AppShell registers nothing on mobile (RailHost's
+  `rail.toggle` no-registration pattern), so the bindings are inert there.
+
+## Phase 3: transcript scroll
+
+`transcript.lineUp/lineDown` (Alt+ArrowUp/Down) and
+`transcript.pageUp/pageDown` (Alt+Shift+ArrowUp/Down) scroll the focused
+session pane's transcript; `transcript.scrollTop`/`scrollBottom` jump to
+the ends (chord-less for now). The seam is
+`src/panes/session/transcript/flow/useTranscriptScrollKeys.ts`, mounted
+once per Session pane:
+
+- **Per-pane multi-instance registration.** Every mounted Session pane
+  registers its own handlers for all six `transcript.*` actions on the
+  shared registry. Arbitration is the registry's multi-instance contract:
+  a handler returns `false` (declines) unless
+  `workspaceStore.focusedPaneId` is its own pane, so only the focused
+  pane's transcript scrolls. Unmount disposes only that pane's handlers.
+- **No new scroll math** — the mechanisms are the transcript flow stack's
+  own. Line steps write the virtualizer scroll element's `scrollTop`
+  directly by `TRANSCRIPT_LINE_SCROLL_PX` (40px), the same adjustment
+  `useTranscriptScroll`'s anchor-restore paths use; page steps use
+  `± 0.9 * clientHeight` (`TRANSCRIPT_PAGE_SCROLL_RATIO`). `scrollTop` is
+  the virtualizer's `scrollToIndex(0, { align: "start" })`; `scrollBottom`
+  is the hook's own `jumpToBottom` (error-anchor aware, pill clearing) —
+  the exact action the NewContentPill click target runs.
+- A pane whose VirtualList hasn't mounted (a dormant session renders
+  EmptyTranscript — no scroll element) declines, so such a keydown is not
+  preventDefault'd.
+- Mobile registers nothing; with no handler the bindings are inert there.
+
+## Phase 3: AskDock keyboard contract
+
+The AskDock ask-user answering surface
+(`src/panes/session/composer/askDock/AskDock.tsx`) is fully
+keyboard-operable. Its keys are **component-internal** `keydown` handlers,
+not registry bindings, so they are not remappable via the Phase 2b
+overrides store:
+
+- Every rendered control is a native element: radios (single-option
+  questions, arrows move+select inside the group), checkboxes
+  (multi-option), the free-text and note inputs, and the footer's primary
+  `<button>`. A multi-question batch's tab strip is ARIA tabs with a
+  roving tabindex and automatic activation (Arrow keys move and select;
+  Home/End jump the ends).
+- **Mod+Enter anywhere in a batch** invokes the footer primary action
+  (Send, or advance in the question walk). Bare Enter does the same only
+  from the free-text answer input. Both are IME-guarded
+  (`isComposing`).
+- **Alt+PageDown / Alt+PageUp** jump focus between batches directly,
+  wrapping at both ends, landing on the target batch's selected tab when
+  it has a tab strip, else its first answer control. The chord is strict
+  Alt-only (an extra modifier or an IME composition lets the key keep its
+  other meaning); with fewer than two batches the event is left alone, not
+  claimed. Alt+Arrow* was rejected for this because the transcript-scroll
+  bindings own it, and bare PageUp/PageDown keep their native meaning (the
+  dock is its own `overflow-y: auto` scroller).
+- **Escape is a deliberate no-op** — the component installs no Escape
+  handler at all. `docs/web-ui/parity/parity-m5-composer.md:120` documents
+  the legacy behavior: the dock is the one canonical response surface and
+  there is no alternate "collapse" state to escape to. AskDock.test.tsx
+  pins the no-op.
+- **Focus return after send**: when a send empties the dock, focus returns
+  to the composer through `composerFocus.ts`'s `requestComposerFocus` seam
+  (the request survives until the composer input row's hidden/inert lifts,
+  which this send just caused). When batches remain, the composer input
+  row is still hidden/inert, so focus moves to the first remaining batch's
+  entry control instead. A failed send keeps focus in the intact dock; a
+  stale outcome is a no-op.
 
 ## Registering an action and a binding
 
@@ -253,7 +419,9 @@ leaves room for:
 
 - **A keybinding editor** (Phase 4) — the store's `patchOverrides` is the
   write path it will use; the Settings section stays read-only until then.
-- **A shortcuts overlay / cheatsheet UI** (Phase 3).
+- **A shortcuts overlay / cheatsheet UI** — planned for Phase 3, not landed;
+  Phase 3 as executed shipped the navigation bindings, the AskDock keyboard
+  contract, and this map instead.
 - **Hold-modifier chord hints** (Phase 4) — `formatChord`/`formatSequence`
   exist for exactly this consumer.
 - `Binding.when` is still stored verbatim and never evaluated; scope-stack


### PR DESCRIPTION
## Summary

Phase 3 of the webui keybinding project (survey #853, dispatcher #860, persistence #861 — **stacked on #861's branch**; retargets as the stack merges). The first NEW bindings on the dispatcher infrastructure, driving existing mechanisms (no parallel navigation system):

- **Session cycling** — `Alt+←/→` cycles open session panes in workspace order (wrapping; no-op with <2; lands on first/last when focus is outside sessions) via `workspaceStore.focusPane`. `Alt+←` is claimed even on no-op to guard the browser Back shortcut.
- **Transcript scroll** — `Alt+↑/↓` line scroll, `Alt+Shift+↑/↓` page scroll on the focused session pane's transcript, via the transcript stack's own scroll API (virtualizer scrollToIndex / scrollTop / jumpToBottom). Per-pane multi-instance handlers with focused-pane arbitration; dormant panes decline. `scrollTop`/`scrollBottom` actions exist chord-less (Phase 4 assigns).
- **AskDock keyboard completion** — batch jump (`Alt+PageUp/Down`, wrapping, landing on the selected tab), focus return to the composer after send, and the Escape no-op **pinned as deliberate** per `docs/web-ui/parity/parity-m5-composer.md:120` (the dock is the one canonical response surface). A reachability audit confirmed no mouse-only control remains in the rendered set.

All new chords are registry defaults — remappable via the 2b persistence from day one — and provisional: Phase 4 owns the comprehensive map. Chords are inert on mobile.

Dev docs: `docs/web-ui/keybindings.md` gains the full binding-map table (generated from `defaults.ts`), the Phase 3 mechanisms, and the provisional-status note.

## Test plan

- New suites: sessionCycle (order/wrap/no-op/mobile), useTranscriptScrollKeys (focused-pane arbitration incl. two-pane, editable suppression), AskDock (batch jump, focus return, Escape no-op pin). Focused final gate: 57/57 green.
- `make test-web` green at the head; existing suites pass unmodified.
- Per-task reviews + final whole-branch review: Approved, 0 Critical/Important.

🤖 Generated via subagent-driven development with per-task and whole-branch review.