### PR TITLE
fix(drain): keep the answer when a completion rides the announcement turn

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -481,6 +481,12 @@ type Session struct {
 	// one second (captureTerminalNotificationCut).
 	pendingJobNotifsMu sync.Mutex
 	pendingJobNotifs   []jobNotification
+	// jobNotifsDelivered counts the job notifications acceptNotificationInput
+	// has delivered to the model over the session's lifetime. The one-shot
+	// drain reads it across an undisposed-job announcement turn: growth means a
+	// completion rode that request, so the reply is an answer, not
+	// housekeeping. Guarded by pendingJobNotifsMu.
+	jobNotifsDelivered uint64
 	// nextJobNotifSeq gives every queue entry a process-lifetime identity. The
 	// terminal acceptance cut snapshots this watermark while jm.mu prevents a
 	// finalizer from crossing its durable-pending/running-map boundary.
@@ -924,6 +930,25 @@ func (s *Session) peekNotifications() int {
 	s.pendingJobNotifsMu.Lock()
 	defer s.pendingJobNotifsMu.Unlock()
 	return len(s.pendingJobNotifs)
+}
+
+// countJobNotificationsDelivered records n job notifications delivered to the
+// model by the turn that just accepted them.
+func (s *Session) countJobNotificationsDelivered(n int) {
+	if n <= 0 {
+		return
+	}
+	s.pendingJobNotifsMu.Lock()
+	defer s.pendingJobNotifsMu.Unlock()
+	s.jobNotifsDelivered += uint64(n)
+}
+
+// jobNotificationsDelivered reports the lifetime count of job notifications
+// delivered to the model.
+func (s *Session) jobNotificationsDelivered() uint64 {
+	s.pendingJobNotifsMu.Lock()
+	defer s.pendingJobNotifsMu.Unlock()
+	return s.jobNotifsDelivered
 }
 
 // SetNotifyFunc registers the callback the server uses to wake an idle session

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -1049,12 +1049,21 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 		// set still undisposed. Announce; announce again naming the
 		// consequence; then stop waiting so Close()'s kill path can run.
 		//
-		// The announcement turns are housekeeping, so their replies never fold
+		// The announcement turns are housekeeping, so their replies do not fold
 		// into lastResult (a run's printed answer must not become "I stopped
 		// job_2"), and their errors never fail the drain — a provider error on
 		// a housekeeping turn must not convert a successful run into a failed
 		// one. A failed turn still advances the escalation: the alternative is
 		// retrying a broken provider forever with the process held open.
+		//
+		// One exception, decided per turn: a job that finishes between this
+		// pass's queue gate above and the turn's own queue drain
+		// (acceptNotificationInput) has its completion queued in time to ride
+		// the announcement request. The model then answers the completion, and
+		// that reply is the run's answer exactly as a notification turn's is —
+		// discarding it printed the pre-drain answer and lost the real one.
+		// The delivered-notification count tells the two apart: the reply is
+		// kept only when the count grew during the turn.
 		//
 		// Under serve the session outlives the turn, background jobs genuinely
 		// report later, and none of this fires (TurnEndsProcess is the gate).
@@ -1117,9 +1126,15 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 					// before any model call — which is exactly how an earlier
 					// attempt at this shipped inert.
 					s.SteerKind(text, events.SteeringKindNotification)
-					if _, perr := process(ctx, "", nil, EntryNotification); perr != nil {
+					deliveredBefore := s.jobNotificationsDelivered()
+					res, perr := process(ctx, "", nil, EntryNotification)
+					if perr != nil {
 						s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf(
 							"undisposed-background-job announcement turn failed: %v", perr)})
+					} else if res != "" && s.jobNotificationsDelivered() != deliveredBefore {
+						// A completion rode this request: the model answered it,
+						// so this reply is the run's answer (see above).
+						lastResult = res
 					}
 					stallStart = time.Time{}
 					continue

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -126,7 +126,10 @@ func (jm *jobManager) outstandingDrainJobIDsByBackground() (all, background []st
 		if isOwnedDrainJob(run.rec, jm.sessionID) {
 			counted[id] = true
 			ids = append(ids, id)
-			if run.rec.Background && run.stopStatus == "" {
+			// A job whose terminal record exists is finalizing (armFinalizedJob
+			// is between its EventJobFinished and its running-map delete): one
+			// wake from delivery, never an undisposed job to announce.
+			if run.rec.Background && run.stopStatus == "" && run.terminal == nil {
 				background = append(background, id)
 			}
 		}
@@ -172,15 +175,17 @@ func (jm *jobManager) hasRunningDrainJob() bool {
 // notification.
 //
 // Test-only seam. cmd/evener's drain tests hold the drain until the shell they
-// launched has completed, and a completion that is merely RECORDED terminal is
-// not that state: until armFinalizedJob deletes the running entry, the job is
-// still in the running map, backgroundDrainState reads the background set off
-// that map alone, and so a drain starting in the window counts a finished shell
-// as a live undisposed background job — arming the announcement ladder on work
-// that was already committed. The residue after the delete needs no barrier:
-// the NotifyPending record written before it is what both the sole-reason test
-// and subtreeHasLiveTerminalDrainWork count, so a drain that starts there waits
-// for the notification instead of announcing.
+// launched has left the running map, so their scripted provider steps start
+// from the state a real run reaches after the completion wake: the owner
+// notification durable and on its way to the queue. A drain that starts
+// earlier does not announce a finished shell — a job still in the running map
+// with its terminal record written is excluded from the background set
+// (outstandingDrainJobIDsByBackground), and after the delete the NotifyPending
+// record is deliverable work both the sole-reason test and
+// subtreeHasLiveTerminalDrainWork count. What the barrier buys the scripts is
+// a fixed step order, the completion as the next turn, instead of a race
+// between the drain's first pass and an executor exit the manager cannot see
+// until Wait returns.
 func (s *Session) ManagedJobsFinalizedForTest() bool {
 	if s == nil || s.jobManager == nil {
 		return false
@@ -1111,6 +1116,13 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 			} else {
 				switch bgAnnounced[setKey] {
 				case 0, 1:
+					// The verdict above was assembled across sequential reads. A
+					// wake raised since this pass took its edge means a completion
+					// finalized meanwhile and is deliverable now: re-run the pass
+					// so it is delivered instead of announced.
+					if takeDrainWake(wake) {
+						continue
+					}
 					canDetach := s.detachedShellAvailable()
 					var text string
 					if bgAnnounced[setKey] == 0 {

--- a/agent/session_jobtree_drain_undisposed_test.go
+++ b/agent/session_jobtree_drain_undisposed_test.go
@@ -646,6 +646,8 @@ func TestOneShotDrainKeepsAnswerWhenCompletionRidesAnnouncement(t *testing.T) {
 		// between the pass's queue gate and the turn's own drain.
 		completedOnAnnounce.Do(func() {
 			releaseShell()
+			// TRIPWIRE: the enqueue is one goroutine hop and a few store appends
+			// away; 30s only fires if finalization never lands.
 			waitForCondition(t, 30*time.Second, "completion queued on the rail", func() bool {
 				return sess.peekNotifications() > 0
 			})
@@ -675,5 +677,72 @@ func TestOneShotDrainKeepsAnswerWhenCompletionRidesAnnouncement(t *testing.T) {
 	}
 	if d.res != answer {
 		t.Fatalf("drain result = %q, want %q: the reply to a request that delivered the completion is the run's answer", d.res, answer)
+	}
+}
+
+// TestOneShotDrainDeliversInsteadOfAnnouncingAFinalizingJob: a job whose
+// terminal record is durable but which is still in the running map (armFinalizedJob
+// has appended NotifyPending and not yet deleted the entry) is finishing, not
+// undisposed. A recheck that meets it there must wait for its notification
+// instead of announcing a job that has already finished.
+func TestOneShotDrainDeliversInsteadOfAnnouncingAFinalizingJob(t *testing.T) {
+	t.Parallel()
+	const answer = "FINAL-ANSWER: the build passed"
+	adapter := &fakeAdapter{name: "openai", steps: []func(llm.Request) llm.Response{
+		func(llm.Request) llm.Response { return finalResponse(answer) },
+	}}
+	sess := newSession(t, withAdapter(adapter), withConfig(SessionConfig{
+		NoProjectPrompts: true,
+		TurnEndsProcess:  true,
+	}))
+	jobID, releaseShell := startControlledBackgroundShell(t, sess)
+
+	// TRIPWIRE: every step is scripted or fed; 30s only fires on a hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	recheck := make(chan time.Time)
+	sess.jobManager.testOnlyAfterNotifyPendingAppend = func(string) {
+		// The terminal record and NotifyPending are durable; the running entry
+		// is still present. Hand the parked drain its recheck tick, then hold
+		// the delete and enqueue until the drain parks again — until that pass
+		// has decided what a finalizing job is. An unbuffered send completes
+		// only while the drain is in waitDrainWake, so no timing is assumed.
+		for range 2 {
+			select {
+			case recheck <- time.Time{}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+	done := make(chan drainResult, 1)
+	go func() {
+		res, err := sess.drainJobTreeWith(ctx, recheck, sess.kickDriveTree, sess.ProcessInputKind)
+		done <- drainResult{res, err}
+	}()
+	// The drain's first pass arms on the running job and parks; the release
+	// starts finalization, whose hook above then drives the passes.
+	releaseShell()
+	var d drainResult
+	select {
+	case d = <-done:
+	case <-ctx.Done():
+		t.Fatal("drain did not return")
+	}
+	if d.err != nil {
+		t.Fatalf("drain error: %v", d.err)
+	}
+	reqs := adapter.Requests()
+	if requestsContain(reqs, "cannot finish") {
+		t.Fatalf("a finalizing job was announced as undisposed (result %q, %d model calls)", d.res, len(reqs))
+	}
+	if !requestsContain(reqs, jobID, "<job-notification") {
+		t.Fatalf("the completion was never delivered: %d model calls", len(reqs))
+	}
+	if d.res != answer {
+		t.Fatalf("drain result = %q, want %q", d.res, answer)
+	}
+	if warnings := collectStallWarnings(sess); len(warnings) != 0 {
+		t.Fatalf("no job was killed, want no warning, got %+v", warnings)
 	}
 }

--- a/agent/session_jobtree_drain_undisposed_test.go
+++ b/agent/session_jobtree_drain_undisposed_test.go
@@ -168,27 +168,8 @@ func TestOneShotDrainAnnouncementStopResolves(t *testing.T) {
 		NoProjectPrompts: true,
 		TurnEndsProcess:  true,
 	}))
-	se := newDelayedExitStreamingExecutor()
-	started := runShell(context.Background(), sess.jobManager, se, shellArgs{
-		Command:    "controlled stop",
-		Mode:       shellModeBackground,
-		Background: true,
-	})
-	if started.JobID == "" || !started.RunningInBackground {
-		t.Fatalf("controlled shell start = %+v, want a live background job", started)
-	}
-	jobID = started.JobID
-	releaseShell := func() {
-		select {
-		case <-se.release:
-		default:
-			close(se.release)
-		}
-	}
-	t.Cleanup(func() {
-		releaseShell()
-		waitForShellDone(t, sess.jobManager, jobID)
-	})
+	var releaseShell func()
+	jobID, releaseShell = startControlledBackgroundShell(t, sess, "controlled stop")
 	if ids, sole, err := sess.undisposedBackgroundDrainJobs(); err != nil || !sole || len(ids) != 1 || ids[0] != jobID {
 		t.Fatalf("controlled shell drain candidate = (%v, %v, %v), want (%v, true, nil)", ids, sole, err, jobID)
 	}
@@ -242,8 +223,9 @@ func TestOneShotDrainAnnouncementStopResolves(t *testing.T) {
 	if finalWarningSeen.Load() {
 		t.Fatal("drain escalated to a final warning while stopStatus was pending")
 	}
-	// The stop's cancelled notification is the only post-stop model turn. What
-	// must NEVER happen is the announcement turn's reply becoming the answer.
+	// The stop's cancelled notification is the only post-stop model turn. A
+	// pure announcement reply is never the answer; only a reply to a request
+	// that also carried a notification is, and no announcement here carries one.
 	if d.res != "all wrapped up" && d.res != "" {
 		t.Fatalf("drain result = %q: an announcement-turn reply leaked into the run's answer", d.res)
 	}
@@ -592,11 +574,11 @@ func TestUndisposedBackgroundJobsFinalWarningUsesAvailableRemedy(t *testing.T) {
 // startControlledBackgroundShell launches a background shell whose exit the
 // test controls: the returned release finishes the process, and cleanup
 // finishes it if the test never did.
-func startControlledBackgroundShell(t *testing.T, sess *Session) (jobID string, release func()) {
+func startControlledBackgroundShell(t *testing.T, sess *Session, command string) (jobID string, release func()) {
 	t.Helper()
 	se := newDelayedExitStreamingExecutor()
 	started := runShell(context.Background(), sess.jobManager, se, shellArgs{
-		Command:    "controlled build",
+		Command:    command,
 		Mode:       shellModeBackground,
 		Background: true,
 	})
@@ -633,7 +615,7 @@ func TestOneShotDrainKeepsAnswerWhenCompletionRidesAnnouncement(t *testing.T) {
 		NoProjectPrompts: true,
 		TurnEndsProcess:  true,
 	}))
-	jobID, releaseShell := startControlledBackgroundShell(t, sess)
+	jobID, releaseShell := startControlledBackgroundShell(t, sess, "controlled build")
 
 	// TRIPWIRE: every step is scripted or fed; 30s only fires on a hang.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -646,11 +628,20 @@ func TestOneShotDrainKeepsAnswerWhenCompletionRidesAnnouncement(t *testing.T) {
 		// between the pass's queue gate and the turn's own drain.
 		completedOnAnnounce.Do(func() {
 			releaseShell()
+			// This runs on the drain goroutine, so a miss is reported with
+			// t.Error and a return, never t.Fatal; the result assertions on the
+			// test goroutine then fail the test.
+			//
 			// TRIPWIRE: the enqueue is one goroutine hop and a few store appends
 			// away; 30s only fires if finalization never lands.
-			waitForCondition(t, 30*time.Second, "completion queued on the rail", func() bool {
-				return sess.peekNotifications() > 0
-			})
+			deadline := time.Now().Add(30 * time.Second)
+			for sess.peekNotifications() == 0 {
+				if time.Now().After(deadline) {
+					t.Error("completion never queued on the rail before the announcement turn opened")
+					return
+				}
+				time.Sleep(2 * time.Millisecond)
+			}
 		})
 		return sess.ProcessInputKind(ctx, input, images, kind)
 	}
@@ -695,7 +686,7 @@ func TestOneShotDrainDeliversInsteadOfAnnouncingAFinalizingJob(t *testing.T) {
 		NoProjectPrompts: true,
 		TurnEndsProcess:  true,
 	}))
-	jobID, releaseShell := startControlledBackgroundShell(t, sess)
+	jobID, releaseShell := startControlledBackgroundShell(t, sess, "controlled build")
 
 	// TRIPWIRE: every step is scripted or fed; 30s only fires on a hang.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/agent/session_jobtree_drain_undisposed_test.go
+++ b/agent/session_jobtree_drain_undisposed_test.go
@@ -588,3 +588,92 @@ func TestUndisposedBackgroundJobsFinalWarningUsesAvailableRemedy(t *testing.T) {
 		t.Fatalf("sandbox announcement advertised detached mode or omitted stop-and-report: %q", sandbox)
 	}
 }
+
+// startControlledBackgroundShell launches a background shell whose exit the
+// test controls: the returned release finishes the process, and cleanup
+// finishes it if the test never did.
+func startControlledBackgroundShell(t *testing.T, sess *Session) (jobID string, release func()) {
+	t.Helper()
+	se := newDelayedExitStreamingExecutor()
+	started := runShell(context.Background(), sess.jobManager, se, shellArgs{
+		Command:    "controlled build",
+		Mode:       shellModeBackground,
+		Background: true,
+	})
+	if started.JobID == "" || !started.RunningInBackground {
+		t.Fatalf("controlled shell start = %+v, want a live background job", started)
+	}
+	release = func() {
+		select {
+		case <-se.release:
+		default:
+			close(se.release)
+		}
+	}
+	t.Cleanup(func() {
+		release()
+		waitForShellDone(t, sess.jobManager, started.JobID)
+	})
+	return started.JobID, release
+}
+
+// TestOneShotDrainKeepsAnswerWhenCompletionRidesAnnouncement: the job
+// finishes after the drain has committed to the undisposed-job announcement
+// (its steering is queued) and before that turn drains the notification queue,
+// so the completion rides the announcement request. The model answers the
+// completion — that reply is the run's answer, not housekeeping, and the drain
+// must return it.
+func TestOneShotDrainKeepsAnswerWhenCompletionRidesAnnouncement(t *testing.T) {
+	t.Parallel()
+	const answer = "FINAL-ANSWER: the build passed"
+	adapter := &fakeAdapter{name: "openai", steps: []func(llm.Request) llm.Response{
+		func(llm.Request) llm.Response { return finalResponse(answer) },
+	}}
+	sess := newSession(t, withAdapter(adapter), withConfig(SessionConfig{
+		NoProjectPrompts: true,
+		TurnEndsProcess:  true,
+	}))
+	jobID, releaseShell := startControlledBackgroundShell(t, sess)
+
+	// TRIPWIRE: every step is scripted or fed; 30s only fires on a hang.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	var completedOnAnnounce sync.Once
+	process := func(ctx context.Context, input string, images []ImageAttachment, kind EntryKind) (string, error) {
+		// The drain has queued the announcement and not yet opened the turn.
+		// Finish the job here so its notification is queued before
+		// acceptNotificationInput drains the queue: the gap production leaves
+		// between the pass's queue gate and the turn's own drain.
+		completedOnAnnounce.Do(func() {
+			releaseShell()
+			waitForCondition(t, 30*time.Second, "completion queued on the rail", func() bool {
+				return sess.peekNotifications() > 0
+			})
+		})
+		return sess.ProcessInputKind(ctx, input, images, kind)
+	}
+	done := make(chan drainResult, 1)
+	go func() {
+		res, err := sess.drainJobTreeWith(ctx, feedRechecks(ctx), sess.kickDriveTree, process)
+		done <- drainResult{res, err}
+	}()
+	var d drainResult
+	select {
+	case d = <-done:
+	case <-ctx.Done():
+		t.Fatal("drain did not return")
+	}
+	if d.err != nil {
+		t.Fatalf("drain error: %v", d.err)
+	}
+	reqs := adapter.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("model calls = %d, want exactly 1: the announcement carrying the completion", len(reqs))
+	}
+	if !requestsContain(reqs, jobID, "cannot finish") || !requestsContain(reqs, jobID, "<job-notification") {
+		t.Fatalf("the one request must carry both the announcement and the completion, got: %v", reqs[0].Messages[1:])
+	}
+	if d.res != answer {
+		t.Fatalf("drain result = %q, want %q: the reply to a request that delivered the completion is the run's answer", d.res, answer)
+	}
+}

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -1882,6 +1882,7 @@ func (s *Session) acceptNotificationInput(ctx context.Context, turnID string) (p
 	if len(deliveredFailures) == 0 {
 		s.resetJobNotificationRetry()
 	}
+	s.countJobNotificationsDelivered(len(jobNotifs) - len(deliveredFailures))
 	// Settle caller-targeted watch sends only after the durable reminder turn
 	// persisted (above): the durable pending survives an appendSteeringTurnDurably
 	// failure for re-token (at-least-once contract, spec §4.3).

--- a/cmd/evener/run_drain_test.go
+++ b/cmd/evener/run_drain_test.go
@@ -183,14 +183,15 @@ func installHeldRunShell(t *testing.T, executor *heldShellExecutor) {
 // A drain that starts inside that window sees a job that is merely running. It
 // parks, arms the undisposed-background-job ladder on the pass that found it,
 // and on the next recheck tick announces to the model instead of delivering the
-// completion — and an announcement turn's reply is housekeeping the drain
-// discards, so the drain returns "" and the run prints its pre-drain answer.
+// completion — a different turn from the one these scripts answer.
 //
-// The terminal record alone does not close that window: it is committed before
-// armFinalizedJob runs, and the job stays in the job manager's running map
-// through the whole of it, so the drain still sees a live background shell.
-// ManagedJobsFinalizedForTest is the other half — the running entry is deleted
-// only after the durable owner notification has been appended.
+// The terminal record alone would keep the drain from announcing — a job with
+// its terminal record written is no longer a background candidate even while
+// it remains in the running map — but the barrier still waits for the running
+// entry to go, so the drain starts with the completion on its way to the queue
+// rather than mid-finalization. ManagedJobsFinalizedForTest is that half: the
+// running entry is deleted only after the durable owner notification has been
+// appended.
 func awaitDurableJobCompletion(t *testing.T, sess *agent.Session) {
 	t.Helper()
 	// TRIPWIRE: finalization is one goroutine hop and one store append past a


### PR DESCRIPTION
## The window

In a one-shot run, `DrainJobTree` announces an undisposed background job on the recheck that finds it still in the running map, and that decision (`backgroundDrainState` → `outstandingDrainJobIDsByBackground`) reads only the running map and the queue gate, never `run.terminal`. A job that finishes between the pass's queue gate (`peekNotifications() == 0`) and the announcement turn's own queue drain (`acceptNotificationInput` → `drainJobNotifications`) has its completion queued in time to ride the announcement request, and a job whose terminal record was written but whose running entry `armFinalizedJob` had not yet deleted still counted as a live undisposed shell. The drain then discarded the announcement turn's reply as housekeeping, so the model's real answer to the completion was lost and `run` printed its pre-drain answer.

## Reproduction

`TestOneShotDrainKeepsAnswerWhenCompletionRidesAnnouncement` (agent package) runs the real drain loop and the real `ProcessInputKind` against a background shell on a held fake executor; the process wrapper finishes the job after the drain has queued the announcement and waits for the completion to be queued before opening the turn. Against `main` it produced one model request carrying both the `<job-notification>` reminder and the announcement, the scripted reply `FINAL-ANSWER: the build passed`, and a drain result of `""` (durable record `delivered`, block in history). `TestOneShotDrainDeliversInsteadOfAnnouncingAFinalizingJob` uses the production `testOnlyAfterNotifyPendingAppend` hook to hand the drain its recheck while the job is terminal-in-manager but still in the running map; against `main` the drain announced twice and returned `""`.

## What each change closes

- **Ride-along detection** (`4b001153a`): the session counts job notifications as `acceptNotificationInput` delivers them; the drain snapshots the count around the announcement `process` call and keeps the reply as its result when the count grew during the turn, exactly as a notification turn's reply is kept. A reply to a request that carried no completion is still dropped.
- **Narrowing** (`81297ccc2`): a job with a terminal record is excluded from the background set, so a recheck that meets a finalizing job waits for its notification instead of announcing a finished job; and the drain re-checks its wake edge before committing to an announcement, so a completion that finalized while the pass looked is delivered instead. The wake re-check has no deterministic test: the span it guards has no production seam a test can hold.

Not in this PR: a completion that finalizes during an announcement turn whose reply is the session's first terminal communicate is consumed by the #329 cut and never shown to the model. Separate finding, separate PR.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
