### PR TITLE
fix(plugins): validate the store root where paths are derived and where the lock is taken

### DIFF
--- a/internal/plugins/autoupgrade.go
+++ b/internal/plugins/autoupgrade.go
@@ -57,7 +57,7 @@ func (m *Manager) upgradeAuto(ctx context.Context, plugin, marketplace string) (
 // Failures are collected but do not stop the others (failure-isolated),
 // matching UpdateAll.
 func (m *Manager) UpdateAutoUpgrade(ctx context.Context) ([]UpgradedPlugin, error) {
-	reg, err := m.registryForSweep()
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/autoupgrade.go
+++ b/internal/plugins/autoupgrade.go
@@ -57,7 +57,7 @@ func (m *Manager) upgradeAuto(ctx context.Context, plugin, marketplace string) (
 // Failures are collected but do not stop the others (failure-isolated),
 // matching UpdateAll.
 func (m *Manager) UpdateAutoUpgrade(ctx context.Context) ([]UpgradedPlugin, error) {
-	reg, err := installLoadRegistry(m.registryPath())
+	reg, err := m.registryForSweep()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/autoupgrade.go
+++ b/internal/plugins/autoupgrade.go
@@ -23,7 +23,7 @@ type UpgradedPlugin struct {
 // the change-detection both happen fresh, under this same lock acquisition,
 // rather than against a snapshot taken before the lock was acquired.
 func (m *Manager) upgradeAuto(ctx context.Context, plugin, marketplace string) (entry InstallEntry, changed, skipped bool, err error) {
-	release, err := installAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, installAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return InstallEntry{}, false, false, err
 	}

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -129,7 +129,7 @@ func catalogPluginName(raw json.RawMessage) string {
 // Browse returns the parsed catalog of a registered marketplace, lazily
 // cloning it first if it was only seeded as an unfetched pointer.
 func (m *Manager) Browse(ctx context.Context, name string) (Catalog, error) {
-	release, err := acquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, acquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return Catalog{}, err
 	}

--- a/internal/plugins/doctor.go
+++ b/internal/plugins/doctor.go
@@ -66,7 +66,7 @@ type DoctorFinding struct {
 // returned as an error; it becomes a FAIL finding instead, so the rest of the
 // report is still useful.
 func (m *Manager) Doctor() ([]DoctorFinding, error) {
-	reg, err := LoadRegistry(m.registryPath())
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/doctor.go
+++ b/internal/plugins/doctor.go
@@ -64,8 +64,24 @@ type DoctorFinding struct {
 // or known_marketplaces.json) failed to parse — the same failure every other
 // Manager verb would hit. A per-plugin or per-marketplace problem is never
 // returned as an error; it becomes a FAIL finding instead, so the rest of the
-// report is still useful.
+// report is still useful. A store root that cannot be used is a finding too,
+// and the only one: there is nothing under such a root to report on.
 func (m *Manager) Doctor() ([]DoctorFinding, error) {
+	// A root that cannot be used is an environment problem, and Doctor reports
+	// those as findings — this is the one it exists to report, since it
+	// explains every other check that cannot run. There is nothing to check
+	// under such a root either: the registry and the marketplaces file would
+	// be read from, and the writability probe written into, whatever directory
+	// the process happens to be in.
+	if err := m.storeRootError(); err != nil {
+		return []DoctorFinding{{
+			Level:       LevelFail,
+			Category:    catEnvironment,
+			Message:     fmt.Sprintf("plugin store is unusable: %v", err),
+			Remediation: "point the store at an absolute path: set XDG_CONFIG_HOME or HOME, or pass --plugin-root",
+		}}, nil
+	}
+
 	reg, err := m.loadRegistry()
 	if err != nil {
 		return nil, err
@@ -331,7 +347,16 @@ func (m *Manager) doctorEnvironment() []DoctorFinding {
 // exist, it is probed with a throwaway temp file, without disturbing any real
 // state.
 func (m *Manager) checkStoreWritable() (exists bool, err error) {
-	info, statErr := doctorStat(m.Root)
+	// Deriving the root is what refuses an unresolved one, before the probe
+	// creates its temp file. Under a relative root that file landed in the
+	// working directory, which is a write from the one verb that promises to
+	// make none. Doctor turns the root away before it gets here; this keeps
+	// the promise for any caller that does not.
+	root, err := m.storePath()
+	if err != nil {
+		return false, err
+	}
+	info, statErr := doctorStat(root)
 	if statErr != nil {
 		if errors.Is(statErr, fs.ErrNotExist) {
 			return false, nil
@@ -339,10 +364,10 @@ func (m *Manager) checkStoreWritable() (exists bool, err error) {
 		return false, statErr
 	}
 	if !info.IsDir() {
-		return true, fmt.Errorf("%s is not a directory", m.Root)
+		return true, fmt.Errorf("%s is not a directory", root)
 	}
 
-	f, err := doctorCreateTemp(m.Root, ".doctor-write-test-*")
+	f, err := doctorCreateTemp(root, ".doctor-write-test-*")
 	if err != nil {
 		return true, err
 	}

--- a/internal/plugins/doctor.go
+++ b/internal/plugins/doctor.go
@@ -81,7 +81,7 @@ func (m *Manager) Doctor() ([]DoctorFinding, error) {
 			Level:       LevelFail,
 			Category:    catEnvironment,
 			Message:     fmt.Sprintf("plugin store is unusable: %v", err),
-			Remediation: "point the store at an absolute path: set XDG_CONFIG_HOME or HOME, or pass --plugin-root",
+			Remediation: "point the store at an absolute path: set XDG_CONFIG_HOME or HOME to an absolute directory, or pass an absolute --store-root to evener-doctor (--plugin-root to evener serve)",
 		}}, nil
 	}
 

--- a/internal/plugins/doctor.go
+++ b/internal/plugins/doctor.go
@@ -65,16 +65,19 @@ type DoctorFinding struct {
 // Manager verb would hit. A per-plugin or per-marketplace problem is never
 // returned as an error; it becomes a FAIL finding instead, so the rest of the
 // report is still useful. A store root that cannot be used is a finding too,
-// and the only one: there is nothing under such a root to report on.
+// and the report is then that finding and the git check, which is the only
+// other one that does not need the store.
 func (m *Manager) Doctor() ([]DoctorFinding, error) {
 	// A root that cannot be used is an environment problem, and Doctor reports
 	// those as findings — this is the one it exists to report, since it
-	// explains every other check that cannot run. There is nothing to check
-	// under such a root either: the registry and the marketplaces file would
-	// be read from, and the writability probe written into, whatever directory
-	// the process happens to be in.
+	// explains every other check that cannot run. There is nothing under such
+	// a root to check either: the registry and the marketplaces file would be
+	// read from, and the writability probe written into, whatever directory
+	// the process happens to be in. git is the exception, because it is on
+	// PATH rather than in the store, and a report that dropped it would hide a
+	// second thing the user has to fix.
 	if err := m.storeRootError(); err != nil {
-		return []DoctorFinding{{
+		return []DoctorFinding{doctorGitFinding(), {
 			Level:       LevelFail,
 			Category:    catEnvironment,
 			Message:     fmt.Sprintf("plugin store is unusable: %v", err),
@@ -308,19 +311,24 @@ func (m *Manager) doctorMarketplace(name string, ref MarketplaceRef) DoctorFindi
 	return DoctorFinding{Level: LevelOK, Category: catMarketplace, Message: name + ": healthy"}
 }
 
+// doctorGitFinding reports whether git is on PATH. It is the one check that
+// does not look at the store, so it is also the one Doctor can still make when
+// the store root is unusable.
+func doctorGitFinding() DoctorFinding {
+	if doctorGitAvailable() {
+		return DoctorFinding{Level: LevelOK, Category: catEnvironment, Message: "git is available on PATH"}
+	}
+	return DoctorFinding{
+		Level: LevelWarn, Category: catEnvironment,
+		Message:     "git not found on PATH",
+		Remediation: "install git; marketplace/plugin fetch, clone, and upgrade all shell out to it",
+	}
+}
+
 // doctorEnvironment checks the two preconditions every other operation
 // depends on: git for fetch/clone/pull, and a writable store root.
 func (m *Manager) doctorEnvironment() []DoctorFinding {
-	var findings []DoctorFinding
-	if doctorGitAvailable() {
-		findings = append(findings, DoctorFinding{Level: LevelOK, Category: catEnvironment, Message: "git is available on PATH"})
-	} else {
-		findings = append(findings, DoctorFinding{
-			Level: LevelWarn, Category: catEnvironment,
-			Message:     "git not found on PATH",
-			Remediation: "install git; marketplace/plugin fetch, clone, and upgrade all shell out to it",
-		})
-	}
+	findings := []DoctorFinding{doctorGitFinding()}
 
 	switch exists, err := m.checkStoreWritable(); {
 	case err != nil:

--- a/internal/plugins/doctor_test.go
+++ b/internal/plugins/doctor_test.go
@@ -625,15 +625,26 @@ func TestDoctor_ReportsARootThatIsNotResolvedWithoutWriting(t *testing.T) {
 				return origCreateTemp(dir, pattern)
 			}
 
+			// git does not live under the store root, so its availability is
+			// still worth reporting — and is still really checked, which a
+			// stub that disagrees with this machine is what proves.
+			origGitAvailable := doctorGitAvailable
+			t.Cleanup(func() { doctorGitAvailable = origGitAvailable })
+			doctorGitAvailable = func() bool { return false }
+
 			m := &Manager{Root: test.root, Stderr: io.Discard}
 			findings, err := m.Doctor()
 			if err != nil {
 				t.Fatalf("Doctor error = %v, want the root reported as a finding", err)
 			}
-			if len(findings) != 1 {
-				t.Fatalf("findings = %+v, want exactly the unusable-root finding", findings)
+			if len(findings) != 2 {
+				t.Fatalf("findings = %+v, want the git finding and the unusable-root finding", findings)
 			}
-			got := findings[0]
+			git := findings[0]
+			if git.Level != LevelWarn || git.Category != catEnvironment || !strings.Contains(git.Message, "git not found on PATH") {
+				t.Errorf("first finding = %+v, want git availability reported despite the root", git)
+			}
+			got := findings[1]
 			if got.Level != LevelFail || got.Category != catEnvironment {
 				t.Errorf("finding = %+v, want a FAIL under %q", got, catEnvironment)
 			}

--- a/internal/plugins/doctor_test.go
+++ b/internal/plugins/doctor_test.go
@@ -3,9 +3,11 @@ package plugins
 import (
 	"context"
 	"errors"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -589,4 +591,85 @@ func TestDoctor_CleanStoreHasNoFailOrWarn(t *testing.T) {
 			t.Errorf("clean store produced a non-OK finding: %+v", f)
 		}
 	}
+}
+
+// Doctor is the read-only report, and an unusable store root is the
+// environment problem that explains every other check failing. It is reported
+// the way Doctor reports the rest of the environment — a FAIL finding, not an
+// error — and reported without touching the working directory: the writability
+// probe used to create its temp file under a relative root such as ".", which
+// is a write from the one verb that promises not to make any.
+func TestDoctor_ReportsARootThatIsNotResolvedWithoutWriting(t *testing.T) {
+	tests := []struct {
+		name    string
+		root    string
+		wantErr string
+	}{
+		{"no root could be resolved", "", "no plugin store root is configured"},
+		{"the root is the working directory", ".", "not an absolute path"},
+		{"the root names a relative directory", "store", "not an absolute path"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cwd := t.TempDir()
+			t.Chdir(cwd)
+			plantAmbientStore(t, cwd)
+			before := dirNames(t, cwd)
+			// The probe removes its temp file, so the directory listing alone
+			// would not notice it. Watch the seam instead.
+			origCreateTemp := doctorCreateTemp
+			t.Cleanup(func() { doctorCreateTemp = origCreateTemp })
+			probed := ""
+			doctorCreateTemp = func(dir, pattern string) (doctorTempFile, error) {
+				probed = dir
+				return origCreateTemp(dir, pattern)
+			}
+
+			m := &Manager{Root: test.root, Stderr: io.Discard}
+			findings, err := m.Doctor()
+			if err != nil {
+				t.Fatalf("Doctor error = %v, want the root reported as a finding", err)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("findings = %+v, want exactly the unusable-root finding", findings)
+			}
+			got := findings[0]
+			if got.Level != LevelFail || got.Category != catEnvironment {
+				t.Errorf("finding = %+v, want a FAIL under %q", got, catEnvironment)
+			}
+			if !strings.Contains(got.Message, test.wantErr) {
+				t.Errorf("finding message = %q, want it to contain %q", got.Message, test.wantErr)
+			}
+			if got.Remediation == "" {
+				t.Error("finding has no remediation")
+			}
+			// The probe refuses on its own too, so a caller that reaches it
+			// directly cannot write into the working directory either.
+			if exists, probeErr := m.checkStoreWritable(); probeErr == nil || exists {
+				t.Errorf("checkStoreWritable = %v, %v; want a refusal that probes nothing", exists, probeErr)
+			}
+			if probed != "" {
+				t.Errorf("the writability probe created a file under %q", probed)
+			}
+			if after := dirNames(t, cwd); !slices.Equal(before, after) {
+				t.Errorf("working directory went from %v to %v; Doctor wrote to it", before, after)
+			}
+		})
+	}
+}
+
+// dirNames is the sorted contents of dir, for asserting that a call left it
+// exactly as it found it.
+func dirNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	slices.Sort(names)
+	return names
 }

--- a/internal/plugins/gc.go
+++ b/internal/plugins/gc.go
@@ -31,7 +31,7 @@ var (
 // when the user is idle. Gc itself does not enforce that; it runs under the
 // same flock as every other mutation, so it never races an install/upgrade.
 func (m *Manager) Gc(ctx context.Context) ([]string, error) {
-	release, err := gcAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, gcAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/gc.go
+++ b/internal/plugins/gc.go
@@ -37,7 +37,7 @@ func (m *Manager) Gc(ctx context.Context) ([]string, error) {
 	}
 	defer release()
 
-	reg, err := LoadRegistry(m.registryPath())
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -375,11 +375,26 @@ func (m *Manager) List() ([]ListItem, error) {
 	return out, nil
 }
 
+// registryForSweep reads the registry that names which plugins a sweep is
+// going to visit. UpdateAll and UpdateAutoUpgrade lock once per plugin rather
+// than once for the pass, so a registry that names nothing is a sweep that
+// never takes a lock and never reaches acquireStoreLock's refusal: against an
+// unresolved root they would read whatever installed_plugins.json the working
+// directory happens to hold, or none at all, and report a clean sweep of
+// somebody's project. This is where a sweep first reads the store, so this is
+// where it asks whether there is one.
+func (m *Manager) registryForSweep() (Registry, error) {
+	if err := m.storeRootError(); err != nil {
+		return Registry{}, err
+	}
+	return installLoadRegistry(m.registryPath())
+}
+
 // UpdateAll upgrades every installed, git-backed plugin (directory/relative
 // sources are inherently current and skipped). Failures are collected but do
 // not stop the others.
 func (m *Manager) UpdateAll(ctx context.Context) ([]InstallEntry, error) {
-	reg, err := installLoadRegistry(m.registryPath())
+	reg, err := m.registryForSweep()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -95,7 +95,7 @@ func (m *Manager) commitStaged(marketplace, plugin, staging, sha string) (string
 
 // Install installs plugin from marketplace, enabled.
 func (m *Manager) Install(ctx context.Context, plugin, marketplace string) (InstallEntry, error) {
-	release, err := installAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, installAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return InstallEntry{}, err
 	}
@@ -171,7 +171,7 @@ func (m *Manager) Install(ctx context.Context, plugin, marketplace string) (Inst
 // The auto-upgrade daemon uses upgradeAuto instead, which re-checks the flag
 // under the same lock immediately before acting — see upgradeLocked.
 func (m *Manager) Upgrade(ctx context.Context, plugin, marketplace string) (InstallEntry, error) {
-	release, err := installAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, installAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return InstallEntry{}, err
 	}
@@ -263,7 +263,7 @@ func (m *Manager) upgradeLocked(ctx context.Context, plugin, marketplace string,
 }
 
 func (m *Manager) mutateEntry(ctx context.Context, plugin, marketplace string, fn func(*InstallEntry)) error {
-	release, err := installAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, installAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return err
 	}
@@ -294,7 +294,7 @@ func (m *Manager) SetAutoUpgrade(ctx context.Context, plugin, marketplace string
 // Remove deletes the registry entry and its cache dir. A plugin referenced in
 // place (directory-source marketplace) leaves the source untouched.
 func (m *Manager) Remove(ctx context.Context, plugin, marketplace string) error {
-	release, err := installAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, installAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return err
 	}

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -29,6 +29,27 @@ var (
 
 func registryKey(plugin, marketplace string) string { return plugin + "@" + marketplace }
 
+// loadRegistry and saveRegistry are the only ways this package reaches
+// installed_plugins.json. Both derive the path through storePath, so a caller
+// that never takes the store lock — List, and the update sweeps, which
+// enumerate the registry before they lock anything — is refused an unresolved
+// root by construction rather than by remembering to ask.
+func (m *Manager) loadRegistry() (Registry, error) {
+	path, err := m.storePath(registryFileName)
+	if err != nil {
+		return Registry{}, err
+	}
+	return installLoadRegistry(path)
+}
+
+func (m *Manager) saveRegistry(reg Registry) error {
+	path, err := m.storePath(registryFileName)
+	if err != nil {
+		return err
+	}
+	return installSaveRegistry(path, reg)
+}
+
 // catalogPlugin finds a named plugin's entry + its marketplace ref, lazily
 // fetching a seeded-but-unfetched marketplace first. Callers (Install/Upgrade)
 // already hold m.lockPath(), which ensureFetched requires.
@@ -149,12 +170,12 @@ func (m *Manager) Install(ctx context.Context, plugin, marketplace string) (Inst
 		Source:       cp.Source,
 		Note:         note,
 	}
-	reg, err := installLoadRegistry(m.registryPath())
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return InstallEntry{}, err
 	}
 	reg.Plugins[registryKey(plugin, marketplace)] = []InstallEntry{entry}
-	if err := installSaveRegistry(m.registryPath(), reg); err != nil {
+	if err := m.saveRegistry(reg); err != nil {
 		return InstallEntry{}, err
 	}
 	return entry, nil
@@ -206,7 +227,7 @@ func (m *Manager) upgradeLocked(ctx context.Context, plugin, marketplace string,
 	}
 
 	key := registryKey(plugin, marketplace)
-	reg, err := installLoadRegistry(m.registryPath())
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return InstallEntry{}, false, false, err
 	}
@@ -256,7 +277,7 @@ func (m *Manager) upgradeLocked(ctx context.Context, plugin, marketplace string,
 	prev.Source = cp.Source
 	prev.Note = note
 	reg.Plugins[key] = []InstallEntry{prev}
-	if err := installSaveRegistry(m.registryPath(), reg); err != nil {
+	if err := m.saveRegistry(reg); err != nil {
 		return InstallEntry{}, false, false, err
 	}
 	return prev, true, false, nil
@@ -269,7 +290,7 @@ func (m *Manager) mutateEntry(ctx context.Context, plugin, marketplace string, f
 	}
 	defer release()
 	key := registryKey(plugin, marketplace)
-	reg, err := installLoadRegistry(m.registryPath())
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return err
 	}
@@ -280,7 +301,7 @@ func (m *Manager) mutateEntry(ctx context.Context, plugin, marketplace string, f
 	e := entries[0]
 	fn(&e)
 	reg.Plugins[key] = []InstallEntry{e}
-	return installSaveRegistry(m.registryPath(), reg)
+	return m.saveRegistry(reg)
 }
 
 func (m *Manager) SetEnabled(ctx context.Context, plugin, marketplace string, enabled bool) error {
@@ -300,7 +321,7 @@ func (m *Manager) Remove(ctx context.Context, plugin, marketplace string) error 
 	}
 	defer release()
 	key := registryKey(plugin, marketplace)
-	reg, err := installLoadRegistry(m.registryPath())
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return err
 	}
@@ -315,7 +336,7 @@ func (m *Manager) Remove(ctx context.Context, plugin, marketplace string) error 
 		}
 	}
 	delete(reg.Plugins, key)
-	return installSaveRegistry(m.registryPath(), reg)
+	return m.saveRegistry(reg)
 }
 
 type ListItem struct {
@@ -339,7 +360,7 @@ func splitKey(key string) (plugin, marketplace string) {
 }
 
 func (m *Manager) List() ([]ListItem, error) {
-	reg, err := installLoadRegistry(m.registryPath())
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return nil, err
 	}
@@ -375,26 +396,11 @@ func (m *Manager) List() ([]ListItem, error) {
 	return out, nil
 }
 
-// registryForSweep reads the registry that names which plugins a sweep is
-// going to visit. UpdateAll and UpdateAutoUpgrade lock once per plugin rather
-// than once for the pass, so a registry that names nothing is a sweep that
-// never takes a lock and never reaches acquireStoreLock's refusal: against an
-// unresolved root they would read whatever installed_plugins.json the working
-// directory happens to hold, or none at all, and report a clean sweep of
-// somebody's project. This is where a sweep first reads the store, so this is
-// where it asks whether there is one.
-func (m *Manager) registryForSweep() (Registry, error) {
-	if err := m.storeRootError(); err != nil {
-		return Registry{}, err
-	}
-	return installLoadRegistry(m.registryPath())
-}
-
 // UpdateAll upgrades every installed, git-backed plugin (directory/relative
 // sources are inherently current and skipped). Failures are collected but do
 // not stop the others.
 func (m *Manager) UpdateAll(ctx context.Context) ([]InstallEntry, error) {
-	reg, err := m.registryForSweep()
+	reg, err := m.loadRegistry()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/plugins/locks.go
+++ b/internal/plugins/locks.go
@@ -41,12 +41,11 @@ type lockAcquirer func(context.Context, string, time.Duration) (func(), error)
 // forget the check without also forgetting the lock.
 //
 // Locking is not the whole of it. A caller that reads or creates something
-// before it locks needs its own check and keeps one: resolveForLaunch never
-// locks at all, prepareBundledStore creates the store directories first,
-// SeedDefaultMarketplaces stats an ambient marketplaces file that would answer
-// "already seeded", and the two update sweeps (registryForSweep) enumerate the
-// registry first — on a broken root they wrote nothing, they just reported a
-// clean sweep of a store that was not there.
+// before it locks — resolveForLaunch, which never locks at all; the update
+// sweeps, which enumerate the registry first and on a broken root wrote
+// nothing but reported a clean sweep of a store that was not there; List and
+// ListMarketplaces, which only read — is refused by storePath instead, where
+// the path it would have used is derived.
 func (m *Manager) acquireStoreLock(ctx context.Context, acquire lockAcquirer, lockPath string, timeout time.Duration) (func(), error) {
 	if err := m.storeRootError(); err != nil {
 		return nil, err

--- a/internal/plugins/locks.go
+++ b/internal/plugins/locks.go
@@ -33,12 +33,20 @@ type lockAcquirer func(context.Context, string, time.Duration) (func(), error)
 // is the mutation's first write, so this is the one place that turns away a
 // root which resolves against whatever directory the process happens to be in
 // — an empty root (none could be resolved) or a relative one. Calling
-// storeRootError used to be each writer's own job, and not one of the eleven
-// that mutate the store did it, so every one of them planted a store in
-// somebody's project. Here a writer cannot forget the check without also
-// forgetting the lock. Paths that read or create something before they lock
-// still need their own check: see resolveForLaunch, prepareBundledStore,
-// SeedDefaultMarketplaces and registryForSweep.
+// storeRootError used to be each caller's own job: the nine writers that take
+// the lock and then write (install, upgrade, remove, the two flag setters, gc,
+// and the three marketplace mutations) skipped it and planted a store in
+// somebody's project, and Browse, which clones a marketplace lazily, skipped
+// it too. Seeding checked for itself and still does. Here a writer cannot
+// forget the check without also forgetting the lock.
+//
+// Locking is not the whole of it. A caller that reads or creates something
+// before it locks needs its own check and keeps one: resolveForLaunch never
+// locks at all, prepareBundledStore creates the store directories first,
+// SeedDefaultMarketplaces stats an ambient marketplaces file that would answer
+// "already seeded", and the two update sweeps (registryForSweep) enumerate the
+// registry first — on a broken root they wrote nothing, they just reported a
+// clean sweep of a store that was not there.
 func (m *Manager) acquireStoreLock(ctx context.Context, acquire lockAcquirer, lockPath string, timeout time.Duration) (func(), error) {
 	if err := m.storeRootError(); err != nil {
 		return nil, err

--- a/internal/plugins/locks.go
+++ b/internal/plugins/locks.go
@@ -29,23 +29,23 @@ type lockAcquirer func(context.Context, string, time.Duration) (func(), error)
 // acquireStoreLock refuses a store root that cannot be used, then takes the
 // store lock at lockPath through acquire.
 //
-// Every mutation of the store passes through here, and creating the lock file
-// is the mutation's first write, so this is the one place that turns away a
-// root which resolves against whatever directory the process happens to be in
-// — an empty root (none could be resolved) or a relative one. Calling
-// storeRootError used to be each caller's own job: the nine writers that take
-// the lock and then write (install, upgrade, remove, the two flag setters, gc,
-// and the three marketplace mutations) skipped it and planted a store in
-// somebody's project, and Browse, which clones a marketplace lazily, skipped
-// it too. Seeding checked for itself and still does. Here a writer cannot
-// forget the check without also forgetting the lock.
+// storePath refuses the same roots wherever a store path is derived, which
+// covers everything a writer goes on to touch. It cannot cover the lock file:
+// the lock is taken before any of those paths is derived, and its own path is
+// the plain join m.lockPath(). So this is the second guard, on the first write
+// every mutation makes. Calling storeRootError used to be each caller's own
+// job: the nine writers that take the lock and then write (install, upgrade,
+// remove, the two flag setters, gc, and the three marketplace mutations)
+// skipped it and planted a store in somebody's project, and Browse, which
+// clones a marketplace lazily, skipped it too. Here a writer cannot forget the
+// check without also forgetting the lock.
 //
-// Locking is not the whole of it. A caller that reads or creates something
-// before it locks — resolveForLaunch, which never locks at all; the update
-// sweeps, which enumerate the registry first and on a broken root wrote
-// nothing but reported a clean sweep of a store that was not there; List and
-// ListMarketplaces, which only read — is refused by storePath instead, where
-// the path it would have used is derived.
+// Three checks are written out on top of storePath, and these are all of them.
+// This one, because the lock file is created before any store path is derived.
+// resolveForLaunch, because a launch continues without plugins rather than
+// failing, so it needs the unusable store as a diagnostic and not an error.
+// Doctor, because reporting the environment is what Doctor is for, so it needs
+// a FAIL finding and not an error. Everywhere else derives through storePath.
 func (m *Manager) acquireStoreLock(ctx context.Context, acquire lockAcquirer, lockPath string, timeout time.Duration) (func(), error) {
 	if err := m.storeRootError(); err != nil {
 		return nil, err

--- a/internal/plugins/locks.go
+++ b/internal/plugins/locks.go
@@ -22,13 +22,35 @@ var (
 	lockSleep = time.Sleep
 )
 
+// lockAcquirer is acquireLock's signature, which the per-area test seams
+// (installAcquireLock and its siblings) stand in for.
+type lockAcquirer func(context.Context, string, time.Duration) (func(), error)
+
+// acquireStoreLock refuses a store root that cannot be used, then takes the
+// store lock at lockPath through acquire.
+//
+// Every mutation of the store passes through here, and creating the lock file
+// is the mutation's first write, so this is the one place that turns away a
+// root which resolves against whatever directory the process happens to be in
+// — an empty root (none could be resolved) or a relative one. A writer cannot
+// forget the check without also forgetting the lock, which is what the eleven
+// writers that predate this did: each was expected to call storeRootError for
+// itself and all but three did not, and a store appeared in somebody's
+// project. Read paths that act before any lock still need their own check;
+// see resolveForLaunch, prepareBundledStore and SeedDefaultMarketplaces.
+func (m *Manager) acquireStoreLock(ctx context.Context, acquire lockAcquirer, lockPath string, timeout time.Duration) (func(), error) {
+	if err := m.storeRootError(); err != nil {
+		return nil, err
+	}
+	return acquire(ctx, lockPath, timeout)
+}
+
 // acquireBundledLock takes the bundled cache's lock for one mutation of
 // <Root>/bundled. Every bundled-cache mutation acquires here and nowhere else,
-// so whatever the acquirer the store lock goes through grows — the store-root
-// check Manager.acquireStoreLock centralizes — has one place to land for this
-// lock too. Callers reaching here have already been through storeRootError.
+// and it goes through acquireStoreLock so the store-root check lands on this
+// lock the same way it lands on the store lock.
 func (m *Manager) acquireBundledLock(ctx context.Context, timeout time.Duration) (func(), error) {
-	return acquireLock(ctx, m.bundledLockPath(), timeout)
+	return m.acquireStoreLock(ctx, acquireLock, m.bundledLockPath(), timeout)
 }
 
 // acquireLock takes an exclusive flock on lockPath, retrying with capped

--- a/internal/plugins/locks.go
+++ b/internal/plugins/locks.go
@@ -32,12 +32,13 @@ type lockAcquirer func(context.Context, string, time.Duration) (func(), error)
 // Every mutation of the store passes through here, and creating the lock file
 // is the mutation's first write, so this is the one place that turns away a
 // root which resolves against whatever directory the process happens to be in
-// — an empty root (none could be resolved) or a relative one. A writer cannot
-// forget the check without also forgetting the lock, which is what the eleven
-// writers that predate this did: each was expected to call storeRootError for
-// itself and all but three did not, and a store appeared in somebody's
-// project. Read paths that act before any lock still need their own check;
-// see resolveForLaunch, prepareBundledStore and SeedDefaultMarketplaces.
+// — an empty root (none could be resolved) or a relative one. Calling
+// storeRootError used to be each writer's own job, and not one of the eleven
+// that mutate the store did it, so every one of them planted a store in
+// somebody's project. Here a writer cannot forget the check without also
+// forgetting the lock. Paths that read or create something before they lock
+// still need their own check: see resolveForLaunch, prepareBundledStore,
+// SeedDefaultMarketplaces and registryForSweep.
 func (m *Manager) acquireStoreLock(ctx context.Context, acquire lockAcquirer, lockPath string, timeout time.Duration) (func(), error) {
 	if err := m.storeRootError(); err != nil {
 		return nil, err

--- a/internal/plugins/locks_test.go
+++ b/internal/plugins/locks_test.go
@@ -72,7 +72,9 @@ func TestAcquireLock_ObservesContextCancellation(t *testing.T) {
 // resolved) or relative resolves against whatever directory the process
 // happens to be in, so a writer that reached the lock without checking planted
 // a store in somebody's project. The check belongs at the acquisition rather
-// than in each writer, where it was forgotten by all but three of them.
+// than in each writer, where it was forgotten. Every caller that takes the
+// store lock is here, so dropping the check from any one acquisition turns
+// this red rather than leaving a single untested site behind.
 func TestStoreWriters_RefuseARootThatIsNotResolved(t *testing.T) {
 	writers := []struct {
 		name  string
@@ -108,6 +110,12 @@ func TestStoreWriters_RefuseARootThatIsNotResolved(t *testing.T) {
 		}},
 		{"RefreshMarketplace", func(ctx context.Context, m *Manager) error {
 			return m.RefreshMarketplace(ctx, "marketplace")
+		}},
+		// Browse mutates too: it clones a marketplace that was only seeded as
+		// a pointer, so on a broken root it cloned into the working directory.
+		{"Browse", func(ctx context.Context, m *Manager) error {
+			_, err := m.Browse(ctx, "marketplace")
+			return err
 		}},
 		// The two sweeps enumerate the registry before they lock anything, so
 		// an empty registry — which is what an ambient working directory

--- a/internal/plugins/locks_test.go
+++ b/internal/plugins/locks_test.go
@@ -109,6 +109,17 @@ func TestStoreWriters_RefuseARootThatIsNotResolved(t *testing.T) {
 		{"RefreshMarketplace", func(ctx context.Context, m *Manager) error {
 			return m.RefreshMarketplace(ctx, "marketplace")
 		}},
+		// The two sweeps enumerate the registry before they lock anything, so
+		// an empty registry — which is what an ambient working directory
+		// hands back — means they never reach the lock at all.
+		{"UpdateAll", func(ctx context.Context, m *Manager) error {
+			_, err := m.UpdateAll(ctx)
+			return err
+		}},
+		{"UpdateAutoUpgrade", func(ctx context.Context, m *Manager) error {
+			_, err := m.UpdateAutoUpgrade(ctx)
+			return err
+		}},
 	}
 	roots := []struct {
 		name    string

--- a/internal/plugins/locks_test.go
+++ b/internal/plugins/locks_test.go
@@ -3,7 +3,11 @@ package plugins
 import (
 	"context"
 	"errors"
+	"io"
+	"io/fs"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -60,5 +64,110 @@ func TestAcquireLock_ObservesContextCancellation(t *testing.T) {
 	// Prompt means bounded by the backoff cap (200ms), not the 30s timeout.
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("acquire took %v after cancellation; want prompt return", elapsed)
+	}
+}
+
+// Every mutation of the store takes the store lock, and creating that lock
+// file is the mutation's first write. A root that is empty (none could be
+// resolved) or relative resolves against whatever directory the process
+// happens to be in, so a writer that reached the lock without checking planted
+// a store in somebody's project. The check belongs at the acquisition rather
+// than in each writer, where it was forgotten by all but three of them.
+func TestStoreWriters_RefuseARootThatIsNotResolved(t *testing.T) {
+	writers := []struct {
+		name  string
+		write func(context.Context, *Manager) error
+	}{
+		{"Install", func(ctx context.Context, m *Manager) error {
+			_, err := m.Install(ctx, "plugin", "marketplace")
+			return err
+		}},
+		{"Upgrade", func(ctx context.Context, m *Manager) error {
+			_, err := m.Upgrade(ctx, "plugin", "marketplace")
+			return err
+		}},
+		{"Remove", func(ctx context.Context, m *Manager) error {
+			return m.Remove(ctx, "plugin", "marketplace")
+		}},
+		{"SetEnabled", func(ctx context.Context, m *Manager) error {
+			return m.SetEnabled(ctx, "plugin", "marketplace", false)
+		}},
+		{"SetAutoUpgrade", func(ctx context.Context, m *Manager) error {
+			return m.SetAutoUpgrade(ctx, "plugin", "marketplace", true)
+		}},
+		{"Gc", func(ctx context.Context, m *Manager) error {
+			_, err := m.Gc(ctx)
+			return err
+		}},
+		{"AddMarketplace", func(ctx context.Context, m *Manager) error {
+			_, err := m.AddMarketplace(ctx, "marketplace", Source{Kind: SourceGitHub, Repo: "acme/plugins"})
+			return err
+		}},
+		{"RemoveMarketplace", func(ctx context.Context, m *Manager) error {
+			return m.RemoveMarketplace(ctx, "marketplace")
+		}},
+		{"RefreshMarketplace", func(ctx context.Context, m *Manager) error {
+			return m.RefreshMarketplace(ctx, "marketplace")
+		}},
+	}
+	roots := []struct {
+		name    string
+		root    string
+		wantErr string
+	}{
+		{"no root could be resolved", "", "no plugin store root is configured"},
+		{"the root names a relative directory", "store", "not an absolute path"},
+	}
+	for _, writer := range writers {
+		for _, root := range roots {
+			t.Run(writer.name+"/"+root.name, func(t *testing.T) {
+				cwd := t.TempDir()
+				t.Chdir(cwd)
+				m := &Manager{Root: root.root, Stderr: io.Discard}
+
+				err := writer.write(context.Background(), m)
+				if err == nil || !strings.Contains(err.Error(), root.wantErr) {
+					t.Fatalf("%s error = %v, want %q", writer.name, err, root.wantErr)
+				}
+				entries, readErr := os.ReadDir(cwd)
+				if readErr != nil {
+					t.Fatal(readErr)
+				}
+				if len(entries) != 0 {
+					t.Errorf("%s wrote %v into the working directory", writer.name, entries)
+				}
+			})
+		}
+	}
+}
+
+// The launch read path reads the registry and the bundled store before
+// anything under the root would be created, so it never reaches the lock: the
+// guard at the acquisition cannot be what protects it, and its own entry check
+// has to stay. A refused launch leaves no lock file — nothing at all — behind.
+func TestResolveForLaunch_RefusesAnUnresolvedRootWithoutTakingTheLock(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	m := &Manager{Root: "", Stderr: io.Discard}
+
+	res, err := m.ResolveForLaunch(context.Background(), nil, &[]string{"coordinator-workflow"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Candidates) != 0 {
+		t.Errorf("Candidates = %+v, want nothing resolved from the working directory", res.Candidates)
+	}
+	if len(res.Diagnostics) != 1 || res.Diagnostics[0].Source != LaunchPluginSourceBundled {
+		t.Fatalf("Diagnostics = %+v, want one bundled diagnostic", res.Diagnostics)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".lock")); !errors.Is(err, fs.ErrNotExist) {
+		t.Errorf("stat .lock = %v, want the launch to have taken no lock", err)
+	}
+	entries, err := os.ReadDir(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("the refused launch wrote %v into the working directory", entries)
 	}
 }

--- a/internal/plugins/marketplaces.go
+++ b/internal/plugins/marketplaces.go
@@ -136,7 +136,7 @@ func (m *Manager) ensureFetched(ctx context.Context, name string) (MarketplaceRe
 // AddMarketplace fetches src, reads its marketplace.json for the name (unless
 // name is given), and records it. Returns the stored ref.
 func (m *Manager) AddMarketplace(ctx context.Context, name string, src Source) (MarketplaceRef, error) {
-	release, err := marketplaceAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, marketplaceAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return MarketplaceRef{}, err
 	}
@@ -199,7 +199,7 @@ func (m *Manager) AddMarketplace(ctx context.Context, name string, src Source) (
 func (m *Manager) ListMarketplaces() (Marketplaces, error) { return m.loadMarketplaces() }
 
 func (m *Manager) RemoveMarketplace(ctx context.Context, name string) error {
-	release, err := marketplaceAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, marketplaceAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func (m *Manager) swapInClone(staging, dest string) error {
 }
 
 func (m *Manager) RefreshMarketplace(ctx context.Context, name string) error {
-	release, err := marketplaceAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, marketplaceAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return err
 	}

--- a/internal/plugins/marketplaces.go
+++ b/internal/plugins/marketplaces.go
@@ -42,17 +42,25 @@ func (m *Manager) catalogRoot(ref MarketplaceRef) string {
 	return ref.InstallLocation
 }
 
+// loadMarketplaces and saveMarketplaces are the only ways this package reaches
+// known_marketplaces.json. Both derive the path through storePath, so
+// ListMarketplaces — which reads without ever taking the store lock — refuses
+// an unresolved root instead of handing back the working directory's file.
 func (m *Manager) loadMarketplaces() (Marketplaces, error) {
-	data, err := marketplaceReadFile(m.marketplacesFile())
+	path, err := m.storePath(marketplacesFileName)
+	if err != nil {
+		return nil, err
+	}
+	data, err := marketplaceReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return Marketplaces{}, nil
 		}
-		return nil, fmt.Errorf("reading %s: %w", m.marketplacesFile(), err)
+		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 	var mk Marketplaces
 	if err := json.Unmarshal(data, &mk); err != nil {
-		return nil, fmt.Errorf("parsing %s: %w", m.marketplacesFile(), err)
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 	if mk == nil {
 		mk = Marketplaces{}
@@ -61,11 +69,15 @@ func (m *Manager) loadMarketplaces() (Marketplaces, error) {
 }
 
 func (m *Manager) saveMarketplaces(mk Marketplaces) error {
+	path, err := m.storePath(marketplacesFileName)
+	if err != nil {
+		return err
+	}
 	body, err := marketplaceMarshalIndent(mk, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshalling marketplaces: %w", err)
 	}
-	return marketplaceAtomicWriteFile(m.marketplacesFile(), append(body, '\n'), 0o644)
+	return marketplaceAtomicWriteFile(path, append(body, '\n'), 0o644)
 }
 
 // fetchMarketplaceContainer clones/references src into destDir and returns the

--- a/internal/plugins/paths.go
+++ b/internal/plugins/paths.go
@@ -49,16 +49,21 @@ const (
 // against whatever directory the process happens to be in — an empty root
 // (none could be resolved) or a relative one.
 //
-// acquireStoreLock is the same refusal for everything a writer does while it
-// holds the store lock. This is the refusal for the store access that never
-// takes a lock: reading the registry or the marketplaces file, and preparing
-// the bundled store. A reader has no lock to inherit the check from, and List
-// and ListMarketplaces used to hand back whatever installed_plugins.json or
-// known_marketplaces.json the working directory happened to hold. Deriving the
-// path here is what refuses, so a new reader cannot forget.
+// Deriving the path is what refuses, so a caller cannot forget: List and
+// ListMarketplaces used to hand back whatever installed_plugins.json or
+// known_marketplaces.json the working directory happened to hold, because a
+// reader has no store lock to inherit a check from. Every access that reaches
+// the filesystem without holding the lock derives here — the registry and
+// marketplaces accessors, the bundled store, Doctor's writability probe, and
+// the marketplaces stat that seeding does before it locks.
 //
-// The plain joins below stay unchecked: their callers either already hold the
-// store lock or are tests naming a path to plant a file at.
+// The plain joins below stay unchecked, and the invariant that keeps them safe
+// is that each is only reached once the root is known to be usable: under the
+// store lock, which acquireStoreLock would not have granted otherwise (the
+// cache, marketplace and plugin directories in install, gc and the marketplace
+// verbs); past Doctor's own refusal (doctorOrphanCacheDirs walks cacheDir with
+// no lock at all); or in a test naming a path to plant a file at. A new caller
+// that fits none of those derives here instead.
 func (m *Manager) storePath(parts ...string) (string, error) {
 	if err := m.storeRootError(); err != nil {
 		return "", err

--- a/internal/plugins/paths.go
+++ b/internal/plugins/paths.go
@@ -35,12 +35,47 @@ func DefaultRoot() string {
 	return userdirs.Subdir(userdirs.ConfigRoot(envvars.XDGConfigHome.Getenv(), pluginUserHomeDir), "plugins")
 }
 
-func (m *Manager) registryPath() string { return filepath.Join(m.Root, "installed_plugins.json") }
-func (m *Manager) marketplacesFile() string {
-	return filepath.Join(m.Root, "known_marketplaces.json")
+// The store's own files and directories, named once so storePath and the
+// plain joins below cannot drift apart.
+const (
+	registryFileName     = "installed_plugins.json"
+	marketplacesFileName = "known_marketplaces.json"
+	bundledDirName       = "bundled"
+	cacheDirName         = "cache"
+	marketplacesDirName  = "marketplaces"
+)
+
+// storePath derives a path inside the store, refusing a root that resolves
+// against whatever directory the process happens to be in — an empty root
+// (none could be resolved) or a relative one.
+//
+// acquireStoreLock is the same refusal for everything a writer does while it
+// holds the store lock. This is the refusal for the store access that never
+// takes a lock: reading the registry or the marketplaces file, and preparing
+// the bundled store. A reader has no lock to inherit the check from, and List
+// and ListMarketplaces used to hand back whatever installed_plugins.json or
+// known_marketplaces.json the working directory happened to hold. Deriving the
+// path here is what refuses, so a new reader cannot forget.
+//
+// The plain joins below stay unchecked: their callers either already hold the
+// store lock or are tests naming a path to plant a file at.
+func (m *Manager) storePath(parts ...string) (string, error) {
+	if err := m.storeRootError(); err != nil {
+		return "", err
+	}
+	return filepath.Join(append([]string{m.Root}, parts...)...), nil
 }
-func (m *Manager) marketplacesDir() string { return filepath.Join(m.Root, "marketplaces") }
-func (m *Manager) cacheDir() string        { return filepath.Join(m.Root, "cache") }
+
+// registryPath and marketplacesFile are the unchecked joins, for tests naming
+// a path to plant a file at. Production reads and writes go through
+// loadRegistry/saveRegistry and loadMarketplaces/saveMarketplaces, which
+// derive the same paths through storePath.
+func (m *Manager) registryPath() string { return filepath.Join(m.Root, registryFileName) }
+func (m *Manager) marketplacesFile() string {
+	return filepath.Join(m.Root, marketplacesFileName)
+}
+func (m *Manager) marketplacesDir() string { return filepath.Join(m.Root, marketplacesDirName) }
+func (m *Manager) cacheDir() string        { return filepath.Join(m.Root, cacheDirName) }
 func (m *Manager) lockPath() string        { return filepath.Join(m.Root, ".lock") }
 
 // bundledDir is evener's content-addressed cache of the plugins the running

--- a/internal/plugins/paths_test.go
+++ b/internal/plugins/paths_test.go
@@ -1,7 +1,10 @@
 package plugins
 
 import (
+	"io"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -30,6 +33,76 @@ func TestManagerPaths(t *testing.T) {
 	for got, want := range cases {
 		if got != want {
 			t.Errorf("path = %q, want %q", got, want)
+		}
+	}
+}
+
+// plantAmbientStore writes the two files a store keeps at its root into dir,
+// each naming something a reader would hand back. A reader that derived its
+// path from an unresolved root would find these and answer with them.
+func plantAmbientStore(t *testing.T, dir string) {
+	t.Helper()
+	registry := `{"version":2,"plugins":{"ambient@ambient":[{"installPath":"/nowhere","version":"9.9.9","enabled":true}]}}`
+	if err := os.WriteFile(filepath.Join(dir, "installed_plugins.json"), []byte(registry), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	marketplaces := `{"ambient":{"source":{"source":"github","repo":"ambient/ambient"},"installLocation":"/nowhere","lastUpdated":"2026-01-01T00:00:00Z"}}`
+	if err := os.WriteFile(filepath.Join(dir, "known_marketplaces.json"), []byte(marketplaces), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Reading the store is as rooted as writing it. The store lock is the writers'
+// choke point and cannot help a reader that never takes one: with an empty or
+// relative root, List and ListMarketplaces derived a path relative to whatever
+// directory the process happened to be in and handed back that directory's
+// installed_plugins.json or known_marketplaces.json as the user's store. Every
+// store path is derived through storePath, so a reader refuses by construction
+// rather than by remembering.
+func TestStoreReaders_RefuseARootThatIsNotResolved(t *testing.T) {
+	readers := []struct {
+		name string
+		read func(*Manager) (int, error)
+	}{
+		{"List", func(m *Manager) (int, error) {
+			items, err := m.List()
+			return len(items), err
+		}},
+		{"ListMarketplaces", func(m *Manager) (int, error) {
+			mk, err := m.ListMarketplaces()
+			return len(mk), err
+		}},
+	}
+	roots := []struct {
+		name    string
+		root    string
+		wantErr string
+	}{
+		{"no root could be resolved", "", "no plugin store root is configured"},
+		{"the root names a relative directory", "store", "not an absolute path"},
+	}
+	for _, reader := range readers {
+		for _, root := range roots {
+			t.Run(reader.name+"/"+root.name, func(t *testing.T) {
+				cwd := t.TempDir()
+				t.Chdir(cwd)
+				plantAmbientStore(t, cwd)
+				// The relative root's own directory, planted too: "store" is
+				// as ambient as "." when it sits in somebody's project.
+				ambientStore := filepath.Join(cwd, "store")
+				if err := os.MkdirAll(ambientStore, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				plantAmbientStore(t, ambientStore)
+
+				n, err := reader.read(&Manager{Root: root.root, Stderr: io.Discard})
+				if err == nil || !strings.Contains(err.Error(), root.wantErr) {
+					t.Fatalf("%s error = %v, want %q", reader.name, err, root.wantErr)
+				}
+				if n != 0 {
+					t.Errorf("%s returned %d entries from the working directory", reader.name, n)
+				}
+			})
 		}
 	}
 }

--- a/internal/plugins/resolve.go
+++ b/internal/plugins/resolve.go
@@ -561,18 +561,16 @@ func (m *Manager) prepareBundledStore(ctx context.Context, name string, intent b
 	if err != nil {
 		return "", nil, nil, err
 	}
-	// The resolver rejects an unresolved root before it reads or builds
-	// anything; this is the same guard on the function that does the creating,
-	// for any caller that arrives here directly. acquireStoreLock refuses the
-	// same roots, but the store directories below are created before the lock
-	// is taken, so the guard has to be here too. Checked after the digest so a
-	// name that is not bundled at all still reports fs.ErrNotExist rather than
-	// a store complaint.
-	if err := m.storeRootError(); err != nil {
+	// Deriving the bundled store is what rejects an unresolved root, for the
+	// resolver and for any caller that arrives here directly. The guard cannot
+	// wait for the lock below: the directories are created before it is taken.
+	// Derived after the digest so a name that is not bundled at all still
+	// reports fs.ErrNotExist rather than a store complaint.
+	store, err := m.storePath(bundledDirName)
+	if err != nil {
 		return "", nil, nil, fmt.Errorf("materialize bundled plugin %s: %w", name, err)
 	}
-	dest := m.bundledPluginPath(name, digest)
-	store := filepath.Dir(dest)
+	dest := filepath.Join(store, name+"-"+digest)
 	// A launch resolves plugins before the startup call that creates the user
 	// config tree privately, so any parent this is first to create gets that
 	// call's own 0o700 rather than the store root's readable mode. They are
@@ -865,6 +863,9 @@ func (m *Manager) storeRootError() error {
 	return nil
 }
 
+// bundledPluginPath names where a bundled plugin's published copy lives. It is
+// the unchecked join, for tests naming a path; prepareBundledStore derives the
+// same path through storePath so an unresolved root is refused.
 func (m *Manager) bundledPluginPath(name, digest string) string {
 	return filepath.Join(m.bundledDir(), name+"-"+digest)
 }

--- a/internal/plugins/resolve.go
+++ b/internal/plugins/resolve.go
@@ -563,7 +563,9 @@ func (m *Manager) prepareBundledStore(ctx context.Context, name string, intent b
 	}
 	// The resolver rejects an unresolved root before it reads or builds
 	// anything; this is the same guard on the function that does the creating,
-	// for any caller that arrives here directly. Checked after the digest so a
+	// for any caller that arrives here directly. acquireStoreLock refuses the
+	// same roots, but the store directories below are created before the lock
+	// is taken, so the guard has to be here too. Checked after the digest so a
 	// name that is not bundled at all still reports fs.ErrNotExist rather than
 	// a store complaint.
 	if err := m.storeRootError(); err != nil {

--- a/internal/plugins/resolve.go
+++ b/internal/plugins/resolve.go
@@ -570,7 +570,7 @@ func (m *Manager) prepareBundledStore(ctx context.Context, name string, intent b
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("materialize bundled plugin %s: %w", name, err)
 	}
-	dest := filepath.Join(store, name+"-"+digest)
+	dest := filepath.Join(store, bundledPluginDirName(name, digest))
 	// A launch resolves plugins before the startup call that creates the user
 	// config tree privately, so any parent this is first to create gets that
 	// call's own 0o700 rather than the store root's readable mode. They are
@@ -863,11 +863,19 @@ func (m *Manager) storeRootError() error {
 	return nil
 }
 
+// bundledPluginDirName is the directory a bundled plugin's published copy sits
+// in inside the bundled store: the plugin's name and the digest of the
+// contents published under it, so a build whose contents changed publishes
+// alongside the copy a running session still holds rather than over it.
+func bundledPluginDirName(name, digest string) string {
+	return name + "-" + digest
+}
+
 // bundledPluginPath names where a bundled plugin's published copy lives. It is
 // the unchecked join, for tests naming a path; prepareBundledStore derives the
 // same path through storePath so an unresolved root is refused.
 func (m *Manager) bundledPluginPath(name, digest string) string {
-	return filepath.Join(m.bundledDir(), name+"-"+digest)
+	return filepath.Join(m.bundledDir(), bundledPluginDirName(name, digest))
 }
 
 // bundledPluginDigest identifies the embedded contents of the bundled plugin

--- a/internal/plugins/seed.go
+++ b/internal/plugins/seed.go
@@ -23,16 +23,16 @@ func DefaultMarketplaceSeeds() map[string]Source {
 func (m *Manager) SeedDefaultMarketplaces(ctx context.Context) (bool, error) {
 	// Every path under an unresolved root is relative, so seeding would write
 	// the marketplaces file and take its lock in whatever directory the
-	// process happens to be in. Launches seed on the way past and carry a
-	// seeding failure as a warning, so refusing here is what keeps a store
-	// out of somebody's project. acquireStoreLock refuses the same roots, but
-	// only once this gets that far: the stat below is a read of an ambient
-	// known_marketplaces.json that would answer "already seeded" and skip the
-	// lock entirely.
-	if err := m.storeRootError(); err != nil {
+	// process happens to be in. Deriving the path is what refuses: the stat
+	// below runs before the lock, and an ambient known_marketplaces.json would
+	// otherwise answer "already seeded" and skip the lock entirely. Launches
+	// seed on the way past and carry a seeding failure as a warning, so
+	// refusing is the whole answer.
+	marketplaces, err := m.storePath(marketplacesFileName)
+	if err != nil {
 		return false, err
 	}
-	if _, err := marketplaceStat(m.marketplacesFile()); err == nil {
+	if _, err := marketplaceStat(marketplaces); err == nil {
 		return false, nil
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return false, err
@@ -43,7 +43,7 @@ func (m *Manager) SeedDefaultMarketplaces(ctx context.Context) (bool, error) {
 	}
 	defer release()
 	// re-check under lock
-	if _, err := marketplaceStat(m.marketplacesFile()); err == nil {
+	if _, err := marketplaceStat(marketplaces); err == nil {
 		return false, nil
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return false, err

--- a/internal/plugins/seed.go
+++ b/internal/plugins/seed.go
@@ -25,7 +25,10 @@ func (m *Manager) SeedDefaultMarketplaces(ctx context.Context) (bool, error) {
 	// the marketplaces file and take its lock in whatever directory the
 	// process happens to be in. Launches seed on the way past and carry a
 	// seeding failure as a warning, so refusing here is what keeps a store
-	// out of somebody's project.
+	// out of somebody's project. acquireStoreLock refuses the same roots, but
+	// only once this gets that far: the stat below is a read of an ambient
+	// known_marketplaces.json that would answer "already seeded" and skip the
+	// lock entirely.
 	if err := m.storeRootError(); err != nil {
 		return false, err
 	}
@@ -34,7 +37,7 @@ func (m *Manager) SeedDefaultMarketplaces(ctx context.Context) (bool, error) {
 	} else if !errors.Is(err, fs.ErrNotExist) {
 		return false, err
 	}
-	release, err := marketplaceAcquireLock(ctx, m.lockPath(), 30*time.Second)
+	release, err := m.acquireStoreLock(ctx, marketplaceAcquireLock, m.lockPath(), 30*time.Second)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## The factoring problem

`Manager.storeRootError` refuses a store root that is empty (`DefaultRoot` returns `""` when there is no `XDG_CONFIG_HOME` and no home directory) or relative, because every path built from such a root resolves against whatever directory the process happens to be in. Calling it was each caller's own job, and most callers did not.

Every writer that took the store lock — `Install`, `Upgrade`, `Remove`, `SetEnabled`, `SetAutoUpgrade`, `Gc`, `AddMarketplace`, `RemoveMarketplace`, `RefreshMarketplace`, and `Browse`, which clones a marketplace lazily — wrote into the process working directory instead. The new test caught `AddMarketplace` git-cloning a marketplace into it. `UpdateAll` and `UpdateAutoUpgrade` lock once per plugin, so they enumerate the registry before taking any lock and reported a clean sweep of a store that was not there. `List` and `ListMarketplaces` handed back whatever `installed_plugins.json` or `known_marketplaces.json` the working directory held, as the user's installed plugins and registered marketplaces. `Doctor`, which promises to mutate nothing, wrote its writability probe's temp file into the working directory under a root of `.`.

## Where the check lives now

**`Manager.storePath` (internal/plugins/paths.go) is the derivation choke point.** It joins under the root and refuses the roots `storeRootError` refuses, so a caller is turned away where the path it would have used is built. There was no single derivation helper before — each path was its own `filepath.Join(m.Root, …)` — so every access that reaches the filesystem without holding the store lock now derives through it:

- **Registry**: new `m.loadRegistry` / `m.saveRegistry`. Nine callers were spelling `installLoadRegistry(m.registryPath())` by hand; there is one way in now. `registryForSweep` no longer exists — it was only ever the check plus the load, and `loadRegistry` is that.
- **Marketplaces file**: `loadMarketplaces` / `saveMarketplaces`, already the only reach for it, plus the stat `SeedDefaultMarketplaces` does *before* it locks.
- **Bundled store**: `prepareBundledStore` derives its destination through `storePath`.
- **The root itself**: `checkStoreWritable` derives it through `storePath()` with no parts, so the probe never reaches `CreateTemp` on a root it should not touch.

**`Manager.acquireStoreLock` (internal/plugins/locks.go) is the second guard.** `storePath` cannot cover the lock file: the lock is taken before any of those paths is derived. Creating it is the first write every mutation makes, so a writer cannot forget the check without also forgetting the lock — and a second acquire site, such as the bundled cache's own `<Root>/bundled/.lock` in the sibling PR, inherits it by calling the same helper rather than `acquireLock` directly.

## The three explicit checks that remain

Outside `storePath`, `storeRootError` is called in exactly three places, each because a bare error is the wrong answer or arrives too late:

1. **`acquireStoreLock`** — the lock file is created before any store path is derived.
2. **`resolveForLaunch`** — a launch continues without plugins rather than failing, so an unusable store is a launch diagnostic, not an error.
3. **`Doctor`** — reporting the environment is what Doctor is for, so an unusable root is a `FAIL` finding under `environment` with a remediation, and the only store finding; the git check still runs alongside it, since git is on `PATH` rather than in the store.

`storePath`'s comment states the invariant that keeps the remaining plain joins safe: each is only reached once the root is known usable — under the store lock, past Doctor's own refusal (`doctorOrphanCacheDirs` walks `cacheDir` with no lock), or in a test naming a path to plant a file at.

## What the tests prove

- **`TestStoreWriters_RefuseARootThatIsNotResolved`** — a table over all eleven writers plus `Browse`, crossed with an empty and a relative root. Each subtest `t.Chdir`s into a fresh temp directory, asserts the writer returns `storeRootError`'s message, and asserts the directory is still empty: no lock file, no registry, no marketplace clone. Watched failing first; the `Browse` row was watched failing with the check bypassed at that one call site, so no acquire site is untested.
- **`TestStoreReaders_RefuseARootThatIsNotResolved`** — plants a real `installed_plugins.json` and `known_marketplaces.json` in the working directory (and in `./store`, for the relative root) and calls `List` and `ListMarketplaces`. Before the fix all four subtests returned the ambient store with a nil error.
- **`TestDoctor_ReportsARootThatIsNotResolvedWithoutWriting`** — covers `""`, `"."` and `"store"`: the git finding plus the single root `FAIL`, no error, `checkStoreWritable` refusing on its own, and — via the `doctorCreateTemp` seam, since the probe deletes its own file — that nothing was created. Reverting just the probe's derivation reproduces the report verbatim: `the writability probe created a file under "."`.
- **`TestResolveForLaunch_RefusesAnUnresolvedRootWithoutTakingTheLock`** — the read path still refuses with no lock file and an untouched working directory, which is why its own check has to stay.

## Gates

`gofmt -l internal/`, `go vet ./internal/plugins/...`, `GOOS=windows go vet ./internal/plugins/...`, `go vet -tags evenerfuzz ./internal/...`, `golangci-lint run ./internal/... ./cmd/...`, `go test -race ./internal/plugins/... -count=1`, `go test ./internal/... ./cmd/... -count=1` — all pass.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
