### PR TITLE
fix: dispose unadopted scratch on discard, failed clear, and provisioning failure

### DIFF
--- a/agent/delegate_resource_create_test.go
+++ b/agent/delegate_resource_create_test.go
@@ -1024,7 +1024,7 @@ func TestDelegateResourceCreate_MissingRestoreInputsCloseResumabilityBeforeClean
 	// This boundary models process loss, not a graceful shutdown. A graceful
 	// Close now durably stops committed generations and therefore waits for the
 	// construction owner that a crash fixture intentionally does not retain.
-	root.discardRestoredCandidate()
+	root.discardRestoredCandidate(true)
 
 	restored, err := restoreDelegateResourceBootstrapSession(client, profile, workspace, meta, stateDir)
 	if err != nil {

--- a/agent/delegate_resource_runtime_test.go
+++ b/agent/delegate_resource_runtime_test.go
@@ -109,7 +109,7 @@ func TestRestoredDelegatePostStartPopulationEmitsTaskCorrection(t *testing.T) {
 		t.Fatal("restoreIdle unexpectedly reused a resident child")
 	}
 	defer func() {
-		sub.sess.discardRestoredCandidate()
+		sub.sess.discardRestoredCandidate(sub.ownsEnv)
 		_, _ = root.delegateController.FailCommittedRestart(started.lease, delegatePermanentStartFailure(context.Canceled, "test_cleanup"))
 	}()
 
@@ -2250,7 +2250,7 @@ func TestDelegateResourceRuntime_ColdIdleUsesCommittedConfigTemplatesAndToolCeil
 	if !restored {
 		t.Fatal("cold idle delegate was reported retained")
 	}
-	defer sub.sess.discardRestoredCandidate()
+	defer sub.sess.discardRestoredCandidate(sub.ownsEnv)
 	if sub.sess.cfg.MaxToolRoundsPerInput != 17 || sub.sess.cfg.ReasoningEffort != "high" {
 		t.Fatalf("restored config = rounds:%d effort:%q", sub.sess.cfg.MaxToolRoundsPerInput, sub.sess.cfg.ReasoningEffort)
 	}
@@ -2293,7 +2293,7 @@ func TestDelegateResourceRuntime_ColdIdleInheritsLiveLifetimeContext(t *testing.
 	if !restored {
 		t.Fatal("cold idle delegate was reported retained")
 	}
-	defer sub.sess.discardRestoredCandidate()
+	defer sub.sess.discardRestoredCandidate(sub.ownsEnv)
 
 	cancelOwner()
 	select {
@@ -2326,7 +2326,7 @@ func TestDelegateResourceRuntime_ColdIdleReusesExactSharedRootTaskStore(t *testi
 	if err != nil {
 		t.Fatalf("restoreIdle: %v", err)
 	}
-	defer sub.sess.discardRestoredCandidate()
+	defer sub.sess.discardRestoredCandidate(sub.ownsEnv)
 	if got := sub.sess.getOrCreateTaskStore(); got != want {
 		t.Fatalf("shared TaskStore pointer = %p, want exact root pointer %p", got, want)
 	}

--- a/agent/delegate_resource_worktree_test.go
+++ b/agent/delegate_resource_worktree_test.go
@@ -416,7 +416,7 @@ func TestStableDelegateWorktree_SandboxRestoreUsesDescriptorNotLegacyJob(t *test
 		t.Fatal("stable descriptor restore unexpectedly reused a resident child")
 	}
 	defer func() {
-		sub.sess.discardRestoredCandidate()
+		sub.sess.discardRestoredCandidate(sub.ownsEnv)
 		_, _ = root.delegateController.FailCommittedRestart(started.lease, delegatePermanentStartFailure(context.Canceled, "test_cleanup"))
 	}()
 	if got := sub.sess.currentEnv().WorkingDirectory(); got != descriptorDir {

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1486,13 +1486,11 @@ func delegateSandboxFallbackHint(s *Session, args delegateArgs, err error) error
 
 func (isolation delegateIsolation) cleanup(s *Session, delegateID string) {
 	if isolation.ownsFreshEnv {
-		if local, ok := isolation.env.(*execenv.LocalExecutionEnvironment); ok {
-			// Both scratch dirs go. createSubagent leaves a PREPARED environment
-			// alone (it belongs to this isolation step), so this is the only
-			// rollback for the scratch the construction's git snapshot minted on
-			// an unsandboxed lane, as well as for a sandboxed lane's owned one.
-			local.DisposeUnadoptedScratch()
-		}
+		// prepareSubagentRunFromSelection leaves a PREPARED environment alone (it
+		// belongs to this isolation step), so this is the only rollback for the
+		// scratch the construction's git snapshot minted on an unsandboxed lane,
+		// as well as for a sandboxed lane's owned one.
+		disposeUnadoptedScratch(isolation.env)
 	}
 	if isolation.worktreePath != "" {
 		s.rollbackFreshDelegateWorktree(delegateID, isolation.worktreePath, isolation.worktreeProject)
@@ -1596,14 +1594,11 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 	}
 	discardEnv := true
 	defer func() {
+		// The construction below runs the child's git snapshot, which is what
+		// mints an unsandboxed environment's scratch, so a failure after that
+		// point has one to drop as surely as a sandboxed restore has its owned one.
 		if discardEnv && ownsFresh {
-			if local, ok := childEnv.(*execenv.LocalExecutionEnvironment); ok {
-				// Both scratch dirs go. The construction below runs the child's
-				// git snapshot, which is what mints an unsandboxed environment's
-				// scratch, so a failure after that point has one to drop as
-				// surely as a sandboxed restore has its owned one.
-				local.DisposeUnadoptedScratch()
-			}
+			disposeUnadoptedScratch(childEnv)
 		}
 	}()
 	if childEnv == nil || childEnv.WorkingDirectory() != descriptor.WorkingDir || localEnvPolicyName(childEnv) != descriptor.LocalEnvPolicy || !frozenStableDelegateSandboxMatches(childEnv, descriptor.Sandbox) {

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -498,12 +498,12 @@ func (s *Session) reconstructDelegateAttentionRuntime(owner *Session, started de
 		candidate := sub
 		tracked, inserted, trackErr := owner.subagents.admitReconstructed(candidate, attach)
 		if trackErr != nil {
-			candidate.sess.discardRestoredCandidate()
+			candidate.sess.discardRestoredCandidate(candidate.ownsEnv)
 			finishRestore(nil, trackErr)
 			return nil, trackErr
 		}
 		if !inserted {
-			candidate.sess.discardRestoredCandidate()
+			candidate.sess.discardRestoredCandidate(candidate.ownsEnv)
 			sub = tracked
 			restored = false
 		}
@@ -669,7 +669,7 @@ func (s *Session) prepareDeferredOwedStart(start deferredOwedDelegateAttentionSt
 		return false, errors.New("owed candidate conflicts with controller runtime state")
 	}
 	start.owner.subagents.removeSession(start.sub.id, start.sub.sess)
-	start.sub.sess.discardRestoredCandidate()
+	start.sub.sess.discardRestoredCandidate(start.sub.ownsEnv)
 	return false, persistErr
 }
 
@@ -847,13 +847,13 @@ func (runtime delegateRuntime) send(ctx context.Context, delegateID, message str
 			return s.delegateController.AttachRuntime(started.lease, selected.sess)
 		})
 		if trackErr != nil {
-			candidate.sess.discardRestoredCandidate()
+			candidate.sess.discardRestoredCandidate(candidate.ownsEnv)
 			return runtime.failStableSendStartAfterDispatch(ctx, started, delegateID, waiter, maxWaitMS, trackErr, func() {
 				finishRestore(nil, trackErr)
 			})
 		}
 		if !inserted {
-			candidate.sess.discardRestoredCandidate()
+			candidate.sess.discardRestoredCandidate(candidate.ownsEnv)
 			sub = tracked
 			restored = false
 		}
@@ -1661,12 +1661,12 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 	}
 	discardEnv = false
 	if child.delegateController != s.delegateController || child.owningDelegateID != started.lease.delegateID {
-		child.discardRestoredCandidate()
+		child.discardRestoredCandidate(ownsFresh)
 		return nil, false, errors.New("restored delegate did not inherit the exact controller binding")
 	}
 	for name := range child.reg.RegisteredNames() {
 		if !hasString(descriptor.ToolNameCeiling, name) {
-			child.discardRestoredCandidate()
+			child.discardRestoredCandidate(ownsFresh)
 			return nil, false, fmt.Errorf("restored delegate tool %q exceeds the committed ceiling", name)
 		}
 	}
@@ -1683,7 +1683,7 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 			child.emit(events.EventTaskUpdated, taskUpdatedData(summary, child.taskStoreOwnerSessionID(), epoch, revision))
 			return nil
 		}); err != nil {
-			child.discardRestoredCandidate()
+			child.discardRestoredCandidate(ownsFresh)
 			return nil, false, fmt.Errorf("restore committed delegate tasks: %w", err)
 		}
 	}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1594,7 +1594,11 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 	defer func() {
 		if discardEnv && ownsFresh {
 			if local, ok := childEnv.(*execenv.LocalExecutionEnvironment); ok {
-				local.DisposeSandboxScratch()
+				// Both scratch dirs go. The construction below runs the child's
+				// git snapshot, which is what mints an unsandboxed environment's
+				// scratch, so a failure after that point has one to drop as
+				// surely as a sandboxed restore has its owned one.
+				local.DisposeUnadoptedScratch()
 			}
 		}
 	}()

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1487,7 +1487,11 @@ func delegateSandboxFallbackHint(s *Session, args delegateArgs, err error) error
 func (isolation delegateIsolation) cleanup(s *Session, delegateID string) {
 	if isolation.ownsFreshEnv {
 		if local, ok := isolation.env.(*execenv.LocalExecutionEnvironment); ok {
-			local.DisposeSandboxScratch()
+			// Both scratch dirs go. createSubagent leaves a PREPARED environment
+			// alone (it belongs to this isolation step), so this is the only
+			// rollback for the scratch the construction's git snapshot minted on
+			// an unsandboxed lane, as well as for a sandboxed lane's owned one.
+			local.DisposeUnadoptedScratch()
 		}
 	}
 	if isolation.worktreePath != "" {

--- a/agent/sandbox_delegate_role_floor_test.go
+++ b/agent/sandbox_delegate_role_floor_test.go
@@ -337,7 +337,7 @@ func TestRestoreDelegate_ReadOnlyRoleSandboxFloor(t *testing.T) {
 			if sub == nil || !restored {
 				t.Fatalf("compatible restored role policy = sub:%v restored:%t", sub, restored)
 			}
-			defer sub.sess.discardRestoredCandidate()
+			defer sub.sess.discardRestoredCandidate(sub.ownsEnv)
 			assertReadOnlyDelegateBackend(t, sub.sess, tc.wantMode, tc.wantWriteBlocked)
 		})
 	}

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/delegatestore"
 	"primeradiant.com/evener/agent/sandbox"
+	"primeradiant.com/evener/envvars"
 	"primeradiant.com/evener/llm"
 )
 
@@ -280,4 +282,69 @@ func sbxDelegateSessionWithProber(t *testing.T, prober sandbox.Prober) *Session 
 			sandboxProber:       prober,
 		},
 	}))
+}
+
+// scratchDirsIn lists the session scratch directories under base. Tests that
+// cannot reach an internally built environment point TMPDIR here instead and
+// read the disposal off the filesystem, the way an operator would.
+func scratchDirsIn(t *testing.T, base string) []string {
+	t.Helper()
+	found, err := filepath.Glob(filepath.Join(base, "evener-sandbox-*"))
+	if err != nil {
+		t.Fatalf("glob session scratch dirs: %v", err)
+	}
+	return found
+}
+
+// A committed delegate's restore builds the child its own environment and then
+// constructs the session on it — and the construction runs the git snapshot,
+// which is what mints an unsandboxed environment's scratch dir. A restore that
+// fails after that point (a fault anywhere inside initSessionState) leaves no
+// session to own the scratch, so the abort has to drop it and its lease.
+func TestRestoreIdleFailureDisposesTheChildScratch(t *testing.T) {
+	// A write-capable ceiling keeps the restore off the read-only floor, so the
+	// child gets a plain unsandboxed environment — the default shape, which mints
+	// its scratch lazily rather than owning one from EnableSandbox.
+	fixture := newColdStableDelegateFixtureConfigured(t, "", func(descriptor *delegatestore.Descriptor) {
+		descriptor.ToolNameCeiling = []string{"communicate", "write_file"}
+	})
+	// The snapshot only runs commands in a repo, and running commands is what
+	// mints that scratch.
+	sbxGit(t, fixture.workspace, "init", "-q")
+	root, err := restoreDelegateResourceBootstrapSession(fixture.client, fixture.profile, fixture.workspace, fixture.meta, fixture.stateDir)
+	if err != nil {
+		t.Fatalf("restore root: %v", err)
+	}
+	defer root.Close()
+
+	scratchBase := t.TempDir()
+	t.Setenv(envvars.TmpDir.Name, scratchBase)
+	// The child takes production's snapshot path, so its environment mints a
+	// scratch before anything can fail; the fault then fails the construction
+	// after it, which is the shape this abort has to clean up after.
+	boom := errors.New("restored delegate construction failed")
+	root.cfg.testOnly.skipGitSnapshot = false
+	root.cfg.testOnly.sessionInitFault = func(point string) error {
+		if point == "builtin_agents" {
+			return boom
+		}
+		return nil
+	}
+
+	reservation, err := root.delegateController.ReserveStart(rootDelegateActor(root.id), fixture.delegateID)
+	if err != nil {
+		t.Fatalf("ReserveStart: %v", err)
+	}
+	started, err := root.delegateController.CommitStart(reservation)
+	if err != nil {
+		t.Fatalf("CommitStart: %v", err)
+	}
+	if _, _, err := (delegateRuntime{owner: root}).restoreIdle(started); !errors.Is(err, boom) {
+		t.Fatalf("restoreIdle error = %v, want %v", err, boom)
+	}
+	_, _ = root.delegateController.FailCommittedRestart(started.lease, delegatePermanentStartFailure(context.Canceled, "test_cleanup"))
+
+	if leaked := scratchDirsIn(t, scratchBase); len(leaked) != 0 {
+		t.Errorf("failed delegate restore left scratch %v, which nothing will ever release", leaked)
+	}
 }

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -348,3 +348,40 @@ func TestRestoreIdleFailureDisposesTheChildScratch(t *testing.T) {
 		t.Errorf("failed delegate restore left scratch %v, which nothing will ever release", leaked)
 	}
 }
+
+// The create path builds a spawning delegate its own environment and then
+// constructs the session on it, running the same git snapshot the restore does.
+// A NewSession that fails after the snapshot leaves nothing to own the scratch
+// that snapshot minted, so the spawn's own rollback has to drop it.
+func TestSpawnedSubagentSessionFailureDisposesTheChildScratch(t *testing.T) {
+	workspace := t.TempDir()
+	// The snapshot only runs commands in a repo, and running commands is what
+	// mints the scratch.
+	sbxGit(t, workspace, "init", "-q")
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	root := newSession(t, withClient(client), withDir(workspace), withoutGitSnapshot())
+
+	scratchBase := t.TempDir()
+	t.Setenv(envvars.TmpDir.Name, scratchBase)
+	// The child takes production's snapshot path, and the fault then fails its
+	// construction after it.
+	boom := errors.New("spawned delegate construction failed")
+	root.cfg.testOnly.skipGitSnapshot = false
+	root.cfg.testOnly.sessionInitFault = func(point string) error {
+		if point == "builtin_agents" {
+			return boom
+		}
+		return nil
+	}
+
+	// A working dir is what makes the child's environment its own rather than
+	// the parent's, which is the case whose scratch nobody else releases.
+	if _, err := root.spawnAgent(context.Background(), "child task", "", workspace, 1, "", "", nil, nil); !errors.Is(err, boom) {
+		t.Fatalf("spawnAgent error = %v, want %v", err, boom)
+	}
+
+	if leaked := scratchDirsIn(t, scratchBase); len(leaked) != 0 {
+		t.Errorf("failed subagent spawn left scratch %v, which nothing will ever release", leaked)
+	}
+}

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -471,3 +471,44 @@ func TestDelegateIsolationCleanupDisposesEveryScratchItOwns(t *testing.T) {
 		t.Errorf("delegate isolation rollback retained scratch %s: stat err = %v", scratch, err)
 	}
 }
+
+// Worktree re-entry (a resume of a session that was working in a worktree)
+// REPLACES the session's environment with a clone rooted in that worktree, and
+// initSessionState's snapshot then mints THAT clone's scratch. The caller's own
+// failure path can only dispose the environment it handed in, so a restore that
+// fails after re-entry has to drop what it re-rooted onto itself.
+func TestWorktreeReentryRestoreFailureDisposesTheReenteredScratch(t *testing.T) {
+	lane, _ := sbxLane(t)
+	launchDir := t.TempDir()
+	stateDir := t.TempDir()
+	meta := artifactRestoreMeta(t)
+	meta.WorktreePath = lane
+	meta.WorktreeRestoreRoot = launchDir
+
+	scratchBase := t.TempDir()
+	t.Setenv(envvars.TmpDir.Name, scratchBase)
+	boom := errors.New("restore failed after the snapshot")
+	cfg := artifactRestoreConfig(t, stateDir)
+	// Production's snapshot path, so the re-entered environment mints its scratch
+	// before the fault fails the restore after it.
+	cfg.testOnly.skipGitSnapshot = false
+	cfg.testOnly.sessionInitFault = func(point string) error {
+		if point == "builtin_agents" {
+			return boom
+		}
+		return nil
+	}
+
+	launchEnv := execenv.NewLocalExecutionEnvironment(launchDir)
+	if _, err := RestoreSessionFromMetaWithConfig(newArtifactTestClient(), NewOpenAIProfile("gpt-5.2"), launchEnv, meta, cfg); !errors.Is(err, boom) {
+		t.Fatalf("restore error = %v, want %v", err, boom)
+	}
+	// The launch environment belongs to the caller, whose own failure path
+	// disposes it (run.go, serve.go, restoreIdle); everything left after that is
+	// the restore's own.
+	launchEnv.DisposeUnadoptedScratch()
+
+	if leaked := scratchDirsIn(t, scratchBase); len(leaked) != 0 {
+		t.Errorf("failed worktree re-entry restore left scratch %v, which nothing will ever release", leaked)
+	}
+}

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -423,7 +423,11 @@ func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T)
 		t.Fatalf("ExecCommand: %v", err)
 	}
 	sharedScratch := shared.SessionScratchDir()
-	sharing, err := NewSession(client, parent.currentProfile(), shared, SessionConfig{
+	// Counting Cleanup is how the second decision is observable: Cleanup is what
+	// releases the environment's live scratch leases and signals the processes it
+	// tracks, and on a shared environment both belong to the live parent.
+	counted := &cleanupCountingEnv{ExecutionEnvironment: shared}
+	sharing, err := NewSession(client, parent.currentProfile(), counted, SessionConfig{
 		MaxSubagentDepth: 1,
 		testOnly:         testConfig{skipGitSnapshot: true},
 	})
@@ -433,6 +437,9 @@ func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T)
 
 	disposeUnadoptedSubagentSession(sharing, false)
 
+	if got := counted.count(); got != 0 {
+		t.Errorf("unadopted child ran Cleanup %d time(s) on the parent's environment, releasing the parent's live scratch lease and signalling the processes it tracks", got)
+	}
 	if _, err := os.Stat(sharedScratch); err != nil {
 		t.Errorf("disposing a child on the parent's shared environment removed its scratch %s: %v", sharedScratch, err)
 	}

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -131,6 +132,38 @@ func TestDiscardRestoredCandidateDisposesSandboxScratch(t *testing.T) {
 	child.discardRestoredCandidate()
 	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
 		t.Errorf("discarded restore candidate retained sandbox scratch: %v", err)
+	}
+}
+
+// The DEFAULT session environment is unsandboxed, and it mints a session scratch
+// of its own on its first command rather than at construction. A discarded
+// candidate was never adopted, so no Close is ever coming to release that
+// directory or the flock lease under it: disposing only the sandbox-owned
+// scratch leaves the unsandboxed one, and its lease, for the life of the process.
+func TestDiscardRestoredCandidateDisposesUnsandboxedScratch(t *testing.T) {
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	candidate := newSession(t, withClient(client), withDir(t.TempDir()), withoutGitSnapshot())
+	local, ok := candidate.currentEnv().(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatalf("restore candidate env = %T, want a local environment", candidate.currentEnv())
+	}
+	// Running a command is what mints the unsandboxed scratch, exactly as a
+	// restore's own first command does.
+	if _, err := local.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand: %v", err)
+	}
+	scratch := local.SessionScratchDir()
+	if scratch == "" {
+		t.Fatal("an unsandboxed env minted no session scratch, so there is nothing to dispose")
+	}
+
+	candidate.discardRestoredCandidate()
+
+	// The lease file lives inside the scratch dir, so the directory's removal is
+	// the lease's removal too.
+	if _, err := os.Stat(scratch); !os.IsNotExist(err) {
+		t.Errorf("discarded restore candidate retained unsandboxed scratch %s: stat err = %v", scratch, err)
 	}
 }
 

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
-	"time"
 
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/delegatestore"
@@ -553,17 +552,18 @@ func TestDisposeUnadoptedSubagentSessionLeavesTheParentsProcessesAlone(t *testin
 
 	disposeUnadoptedSubagentSession(child, true)
 
+	// No bound needed: a Cleanup that reached this process would have signalled
+	// it, waited out the termination grace and killed it, all before the dispose
+	// call returned — so its exit is already visible here if it happened at all.
 	select {
 	case <-exited:
 		t.Fatalf("disposing an unadopted child ended the parent's in-flight process %d", handle.Pid)
-	case <-time.After(200 * time.Millisecond):
+	default:
 	}
 	// The other half: the process is still the parent's to end, so it never left
-	// the environment that tracks it.
+	// the environment that tracks it. Awaiting the real exit rather than a bound;
+	// a cleanup that never ends it hangs until the package deadline, which is the
+	// same failure with a clearer report.
 	parentEnv.Cleanup()
-	select {
-	case <-exited:
-	case <-time.After(30 * time.Second):
-		t.Fatal("the parent's own cleanup did not end the process it tracks")
-	}
+	<-exited
 }

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -410,6 +410,9 @@ func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T)
 
 	disposeUnadoptedSubagentSession(owned, true)
 
+	if got := owned.State(); got != SessionClosed {
+		t.Errorf("unadopted child state = %q, want %q", got, SessionClosed)
+	}
 	if _, err := os.Stat(ownedScratch); !os.IsNotExist(err) {
 		t.Errorf("unadopted child retained its scratch %s: stat err = %v", ownedScratch, err)
 	}
@@ -437,6 +440,9 @@ func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T)
 
 	disposeUnadoptedSubagentSession(sharing, false)
 
+	if got := sharing.State(); got != SessionClosed {
+		t.Errorf("child sharing the parent's environment was left %q, want %q", got, SessionClosed)
+	}
 	if got := counted.count(); got != 0 {
 		t.Errorf("unadopted child ran Cleanup %d time(s) on the parent's environment, releasing the parent's live scratch lease and signalling the processes it tracks", got)
 	}

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -129,7 +129,7 @@ func TestDiscardRestoredCandidateDisposesSandboxScratch(t *testing.T) {
 		t.Fatalf("EnableSandbox: %v", err)
 	}
 	tmp := local.Wrapper.SessionTmp()
-	child.discardRestoredCandidate()
+	child.discardRestoredCandidate(true)
 	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
 		t.Errorf("discarded restore candidate retained sandbox scratch: %v", err)
 	}
@@ -158,12 +158,54 @@ func TestDiscardRestoredCandidateDisposesUnsandboxedScratch(t *testing.T) {
 		t.Fatal("an unsandboxed env minted no session scratch, so there is nothing to dispose")
 	}
 
-	candidate.discardRestoredCandidate()
+	candidate.discardRestoredCandidate(true)
 
 	// The lease file lives inside the scratch dir, so the directory's removal is
 	// the lease's removal too.
 	if _, err := os.Stat(scratch); !os.IsNotExist(err) {
 		t.Errorf("discarded restore candidate retained unsandboxed scratch %s: stat err = %v", scratch, err)
+	}
+}
+
+// A candidate does not always OWN what it holds: prepareSubagentEnvironment
+// hands back the parent's environment untouched when the delegate needs neither
+// a working-dir re-root nor a box of its own. close() already guards its scratch
+// handoff on the subagent's ownsEnv for exactly that reason, and the discard path
+// has to make the same distinction — otherwise aborting one candidate deletes the
+// scratch dir out from under the live parent still working in it.
+func TestDiscardRestoredCandidateLeavesASharedEnvironmentAlone(t *testing.T) {
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	parent := newSession(t, withClient(client), withDir(t.TempDir()), withoutGitSnapshot())
+	shared, ok := parent.currentEnv().(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatalf("parent env = %T, want a local environment", parent.currentEnv())
+	}
+	if _, err := shared.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand: %v", err)
+	}
+	sharedScratch := shared.SessionScratchDir()
+	if sharedScratch == "" {
+		t.Fatal("the parent minted no session scratch, so there is nothing to protect")
+	}
+
+	// A candidate on the parent's own environment, exactly as a delegate with no
+	// working dir and no per-delegate box gets one.
+	candidate, err := NewSession(client, parent.currentProfile(), shared, SessionConfig{
+		MaxSubagentDepth: 1,
+		testOnly:         testConfig{skipGitSnapshot: true},
+	})
+	if err != nil {
+		t.Fatalf("NewSession on the parent's environment: %v", err)
+	}
+
+	candidate.discardRestoredCandidate(false)
+
+	if _, err := os.Stat(sharedScratch); err != nil {
+		t.Errorf("discarding a candidate on the parent's shared environment removed its scratch %s: %v", sharedScratch, err)
+	}
+	if got := shared.SessionScratchDir(); got != sharedScratch {
+		t.Errorf("parent scratch = %q after the discard, want the one it is still using %q", got, sharedScratch)
 	}
 }
 

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -385,3 +385,55 @@ func TestSpawnedSubagentSessionFailureDisposesTheChildScratch(t *testing.T) {
 		t.Errorf("failed subagent spawn left scratch %v, which nothing will ever release", leaked)
 	}
 }
+
+// disposeUnadoptedSubagentSession is the create-path twin of
+// discardRestoredCandidate, and the two have to make the same two decisions:
+// drop BOTH scratch dirs of an environment built for the child (Close only
+// releases the unsandboxed one's lease and keeps the directory), and leave a
+// shared environment alone, since it belongs to the live parent.
+func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T) {
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+
+	owned := newSession(t, withClient(client), withDir(t.TempDir()), withoutGitSnapshot())
+	ownedEnv, ok := owned.currentEnv().(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatalf("child env = %T, want a local environment", owned.currentEnv())
+	}
+	if _, err := ownedEnv.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand: %v", err)
+	}
+	ownedScratch := ownedEnv.SessionScratchDir()
+	if ownedScratch == "" {
+		t.Fatal("the child env minted no session scratch, so there is nothing to dispose")
+	}
+
+	disposeUnadoptedSubagentSession(owned, true)
+
+	if _, err := os.Stat(ownedScratch); !os.IsNotExist(err) {
+		t.Errorf("unadopted child retained its scratch %s: stat err = %v", ownedScratch, err)
+	}
+
+	parent := newSession(t, withClient(client), withDir(t.TempDir()), withoutGitSnapshot())
+	shared, ok := parent.currentEnv().(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatalf("parent env = %T, want a local environment", parent.currentEnv())
+	}
+	if _, err := shared.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand: %v", err)
+	}
+	sharedScratch := shared.SessionScratchDir()
+	sharing, err := NewSession(client, parent.currentProfile(), shared, SessionConfig{
+		MaxSubagentDepth: 1,
+		testOnly:         testConfig{skipGitSnapshot: true},
+	})
+	if err != nil {
+		t.Fatalf("NewSession on the parent's environment: %v", err)
+	}
+
+	disposeUnadoptedSubagentSession(sharing, false)
+
+	if _, err := os.Stat(sharedScratch); err != nil {
+		t.Errorf("disposing a child on the parent's shared environment removed its scratch %s: %v", sharedScratch, err)
+	}
+}

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -444,3 +444,30 @@ func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T)
 		t.Errorf("disposing a child on the parent's shared environment removed its scratch %s: %v", sharedScratch, err)
 	}
 }
+
+// A stable delegate's construction hands createSubagent an environment the
+// isolation step already prepared, so the spawn's own rollback deliberately
+// leaves that environment alone and delegateIsolation.cleanup is what rolls it
+// back. The construction it wraps runs the child's git snapshot, which mints an
+// unsandboxed environment's scratch, so this rollback has to drop both dirs too.
+func TestDelegateIsolationCleanupDisposesEveryScratchItOwns(t *testing.T) {
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	owner := newSession(t, withClient(client), withDir(t.TempDir()), withoutGitSnapshot())
+	fresh := owner.currentEnv().(*execenv.LocalExecutionEnvironment).WithWorkingDirectory(t.TempDir())
+	if _, err := fresh.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand: %v", err)
+	}
+	scratch := fresh.SessionScratchDir()
+	if scratch == "" {
+		t.Fatal("the isolated env minted no session scratch, so there is nothing to dispose")
+	}
+
+	// No worktree path: this is the plain re-rooted/boxed lane, whose rollback is
+	// only the environment.
+	delegateIsolation{env: fresh, ownsFreshEnv: true}.cleanup(owner, "")
+
+	if _, err := os.Stat(scratch); !os.IsNotExist(err) {
+		t.Errorf("delegate isolation rollback retained scratch %s: stat err = %v", scratch, err)
+	}
+}

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -453,10 +453,10 @@ func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T)
 	}
 }
 
-// A stable delegate's construction hands createSubagent an environment the
-// isolation step already prepared, so the spawn's own rollback deliberately
-// leaves that environment alone and delegateIsolation.cleanup is what rolls it
-// back. The construction it wraps runs the child's git snapshot, which mints an
+// A stable delegate's construction hands prepareSubagentRunFromSelection an
+// environment the isolation step already prepared, so the spawn's own rollback
+// deliberately leaves that environment alone and delegateIsolation.cleanup is
+// what rolls it back. The construction it wraps runs the child's git snapshot, which mints an
 // unsandboxed environment's scratch, so this rollback has to drop both dirs too.
 func TestDelegateIsolationCleanupDisposesEveryScratchItOwns(t *testing.T) {
 	client := llm.NewClient()

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"testing"
+	"time"
 
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/internal/delegatestore"
@@ -516,5 +518,52 @@ func TestWorktreeReentryRestoreFailureDisposesTheReenteredScratch(t *testing.T) 
 
 	if leaked := scratchDirsIn(t, scratchBase); len(leaked) != 0 {
 		t.Errorf("failed worktree re-entry restore left scratch %v, which nothing will ever release", leaked)
+	}
+}
+
+// A fresh WithWorkingDirectory clone SHARES the parent's process table -- the
+// runningPIDs map is copied by pointer -- so Cleanup on a child's OWN clone
+// signals the parent's in-flight tools, not just the child's. An unadopted child
+// therefore never runs its environment's Cleanup at all: it closes the session
+// and disposes the scratch it owns, and every tracked process stays with the
+// environment that tracks it.
+func TestDisposeUnadoptedSubagentSessionLeavesTheParentsProcessesAlone(t *testing.T) {
+	dir := t.TempDir()
+	parentEnv := execenv.NewLocalExecutionEnvironment(dir)
+	t.Cleanup(parentEnv.Cleanup)
+	handle, err := parentEnv.StreamCommand(context.Background(), "sleep 30", dir, nil, io.Discard)
+	if err != nil {
+		t.Fatalf("StreamCommand: %v", err)
+	}
+	exited := make(chan struct{})
+	go func() {
+		_, _ = handle.Wait()
+		close(exited)
+	}()
+
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	child, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), parentEnv.WithWorkingDirectory(t.TempDir()), SessionConfig{
+		MaxSubagentDepth: 1,
+		testOnly:         testConfig{skipGitSnapshot: true},
+	})
+	if err != nil {
+		t.Fatalf("NewSession on a fresh clone: %v", err)
+	}
+
+	disposeUnadoptedSubagentSession(child, true)
+
+	select {
+	case <-exited:
+		t.Fatalf("disposing an unadopted child ended the parent's in-flight process %d", handle.Pid)
+	case <-time.After(200 * time.Millisecond):
+	}
+	// The other half: the process is still the parent's to end, so it never left
+	// the environment that tracks it.
+	parentEnv.Cleanup()
+	select {
+	case <-exited:
+	case <-time.After(30 * time.Second):
+		t.Fatal("the parent's own cleanup did not end the process it tracks")
 	}
 }

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -977,6 +977,22 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	if err := s.resumeWorktreeReentry(meta); err != nil {
 		return nil, err
 	}
+	// Re-entry REPLACES the environment with a clone rooted in the persisted
+	// worktree, and initSessionState's snapshot below is what mints that clone's
+	// scratch. A caller's own failure path can only dispose the environment it
+	// handed in (it has no reference to the clone), so a restore that fails from
+	// here on disposes what it re-rooted onto itself — otherwise the directory
+	// and its live lease outlive every owner. Never the caller's own env: that
+	// one is the caller's to dispose or to keep.
+	reenteredEnv := s.env
+	defer func() {
+		if restoreComplete || reenteredEnv == env {
+			return
+		}
+		if local, ok := reenteredEnv.(*execenv.LocalExecutionEnvironment); ok {
+			local.DisposeUnadoptedScratch()
+		}
+	}()
 
 	promptSources, err := s.initSessionState(cfg.SessionStartKind, !restoreCfg.deferRestoreSideEffects)
 	if err != nil {

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -989,9 +989,7 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 		if restoreComplete || reenteredEnv == env {
 			return
 		}
-		if local, ok := reenteredEnv.(*execenv.LocalExecutionEnvironment); ok {
-			local.DisposeUnadoptedScratch()
-		}
+		disposeUnadoptedScratch(reenteredEnv)
 	}()
 
 	promptSources, err := s.initSessionState(cfg.SessionStartKind, !restoreCfg.deferRestoreSideEffects)

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -369,7 +369,15 @@ func (s *Session) close(ctx context.Context, cleanupEnv bool) {
 	})
 }
 
-func (s *Session) discardRestoredCandidate() {
+// discardRestoredCandidate tears down a restore candidate nothing ever adopted.
+// ownsEnv says whether the candidate's execution environment is one built FOR it
+// (a working-dir re-root and/or a per-delegate box) rather than the parent's own:
+// prepareSubagentEnvironment returns the parent's environment untouched when the
+// delegate needs neither, and a shared environment belongs to the live parent
+// still working in it. It is the same distinction close() makes before retaining
+// a child's scratch (subagent.ownsEnv), read here so an aborted candidate never
+// deletes a scratch dir out from under its parent.
+func (s *Session) discardRestoredCandidate(ownsEnv bool) {
 	s.closeOnce.Do(func() {
 		s.responseSideEffectsMu.Lock()
 		s.mu.Lock()
@@ -390,25 +398,22 @@ func (s *Session) discardRestoredCandidate() {
 			_ = s.jobManager.store.Close()
 		}
 		for _, sub := range subs {
-			sub.sess.discardRestoredCandidate()
+			sub.sess.discardRestoredCandidate(sub.ownsEnv)
 		}
 		if s.ownsArtifactStore && s.artifactStore != nil {
 			_ = s.artifactStore.Close()
 		}
 		_ = s.closeOwnedDelegateStore()
-		// A restore always hands the candidate a FRESH environment (a re-rooted
-		// clone, and its own per-lane sandbox scratch when sandboxed) — never the
-		// parent's shared one: prepareSubagentEnvironment re-roots for the
-		// descriptor's working dir, which every committed delegate carries. A
-		// discarded candidate was never adopted by anything, so unlike close()'s
+		// A discarded candidate was never adopted by anything, so unlike close()'s
 		// RetainSandboxScratch (which hands a normally torn-down delegate's
 		// scratch to a human), there is no one left to retain it for; dispose it
 		// outright, mirroring disposeUnadoptedSubagentSession's unadopted-env
 		// discipline on the create-path twin of this abort. Both scratch dirs go:
 		// the sandbox-owned one AND the one an unsandboxed env — the default
 		// shape — mints on its first command, whose lease would otherwise be held
-		// for the life of the process. A no-op on an env that minted neither.
-		if le, ok := s.currentEnv().(*execenv.LocalExecutionEnvironment); ok {
+		// for the life of the process. Only ever for an env built FOR this
+		// candidate: a shared one belongs to the live parent still working in it.
+		if le, ok := s.currentEnv().(*execenv.LocalExecutionEnvironment); ok && ownsEnv {
 			le.DisposeUnadoptedScratch()
 		}
 		if s.mcpMgr != nil {

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -404,15 +404,15 @@ func (s *Session) discardRestoredCandidate(ownsEnv bool) {
 			_ = s.artifactStore.Close()
 		}
 		_ = s.closeOwnedDelegateStore()
-		// A discarded candidate was never adopted by anything, so unlike close()'s
-		// RetainSandboxScratch (which hands a normally torn-down delegate's
-		// scratch to a human), there is no one left to retain it for; dispose it
-		// outright, mirroring disposeUnadoptedSubagentSession's unadopted-env
-		// discipline on the create-path twin of this abort. Both scratch dirs go:
-		// the sandbox-owned one AND the one an unsandboxed env — the default
-		// shape — mints on its first command, whose lease would otherwise be held
-		// for the life of the process. Only ever for an env built FOR this
-		// candidate: a shared one belongs to the live parent still working in it.
+		// A discarded candidate was never adopted by anything, so unlike a normal
+		// teardown (which RETAINS both scratch dirs for the human handoff), there
+		// is no one left to retain them for. Both go: the sandbox-owned one AND
+		// the one an unsandboxed env — the default shape — mints on its first
+		// command, whose lease would otherwise be held for the life of the
+		// process. Only ever for an env built FOR this candidate: a shared one
+		// belongs to the live parent still working in it. Byte for byte the same
+		// two decisions disposeUnadoptedSubagentSession makes on the create-path
+		// twin of this abort.
 		if le, ok := s.currentEnv().(*execenv.LocalExecutionEnvironment); ok && ownsEnv {
 			le.DisposeUnadoptedScratch()
 		}

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -413,8 +413,8 @@ func (s *Session) discardRestoredCandidate(ownsEnv bool) {
 		// belongs to the live parent still working in it. Byte for byte the same
 		// two decisions disposeUnadoptedSubagentSession makes on the create-path
 		// twin of this abort.
-		if le, ok := s.currentEnv().(*execenv.LocalExecutionEnvironment); ok && ownsEnv {
-			le.DisposeUnadoptedScratch()
+		if ownsEnv {
+			disposeUnadoptedScratch(s.currentEnv())
 		}
 		if s.mcpMgr != nil {
 			s.mcpMgr.Close()

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -396,18 +396,20 @@ func (s *Session) discardRestoredCandidate() {
 			_ = s.artifactStore.Close()
 		}
 		_ = s.closeOwnedDelegateStore()
-		// restoreDelegateChildEnvironment always hands a restored delegate a
-		// FRESH environment (a re-rooted clone, and its own per-lane sandbox
-		// scratch when sandboxed) — never the parent's shared one. A discarded
-		// candidate was never adopted by anything, so unlike close()'s
+		// A restore always hands the candidate a FRESH environment (a re-rooted
+		// clone, and its own per-lane sandbox scratch when sandboxed) — never the
+		// parent's shared one: prepareSubagentEnvironment re-roots for the
+		// descriptor's working dir, which every committed delegate carries. A
+		// discarded candidate was never adopted by anything, so unlike close()'s
 		// RetainSandboxScratch (which hands a normally torn-down delegate's
 		// scratch to a human), there is no one left to retain it for; dispose it
 		// outright, mirroring disposeUnadoptedSubagentSession's unadopted-env
-		// discipline on the create-path twin of this abort. A no-op on a shared
-		// or never-sandboxed env (DisposeSandboxScratch is a no-op without an
-		// owned tmp).
+		// discipline on the create-path twin of this abort. Both scratch dirs go:
+		// the sandbox-owned one AND the one an unsandboxed env — the default
+		// shape — mints on its first command, whose lease would otherwise be held
+		// for the life of the process. A no-op on an env that minted neither.
 		if le, ok := s.currentEnv().(*execenv.LocalExecutionEnvironment); ok {
-			le.DisposeSandboxScratch()
+			le.DisposeUnadoptedScratch()
 		}
 		if s.mcpMgr != nil {
 			s.mcpMgr.Close()

--- a/agent/session_lifecycle_slots_fuzz_test.go
+++ b/agent/session_lifecycle_slots_fuzz_test.go
@@ -318,7 +318,7 @@ func FuzzLcyc_DiscardRestoredCandidate(f *testing.F) {
 
 		for _, code := range teardown {
 			if code == 0 {
-				parent.discardRestoredCandidate()
+				parent.discardRestoredCandidate(true)
 			} else {
 				parent.Close()
 			}
@@ -327,7 +327,7 @@ func FuzzLcyc_DiscardRestoredCandidate(f *testing.F) {
 			}
 		}
 		// Idempotence: a final round of both must remain a no-op.
-		parent.discardRestoredCandidate()
+		parent.discardRestoredCandidate(true)
 		parent.Close()
 		if st := parent.State(); st != SessionClosed {
 			t.Fatalf("post-idempotence state %q, want %q", st, SessionClosed)

--- a/agent/session_lifecycle_tail_coverage_fuzz_test.go
+++ b/agent/session_lifecycle_tail_coverage_fuzz_test.go
@@ -202,7 +202,7 @@ func FuzzSessionLifecycleTeardownCoverage(f *testing.F) {
 
 		discard := sltcNewSession(t, false, false)
 		discard.mcpMgr = &mcp.Manager{}
-		discard.discardRestoredCandidate()
+		discard.discardRestoredCandidate(true)
 
 		parent := sltcNewSession(t, false, false)
 		parent.mcpMgr = &mcp.Manager{}

--- a/agent/session_tool_artifacts_test.go
+++ b/agent/session_tool_artifacts_test.go
@@ -459,7 +459,7 @@ func TestSessionArtifactStoreDiscardOwnedRestoredCandidateClosesStore(t *testing
 	if err != nil {
 		t.Fatalf("restore candidate: %v", err)
 	}
-	candidate.discardRestoredCandidate()
+	candidate.discardRestoredCandidate(true)
 	if got := store.closeCount.Load(); got != 1 {
 		t.Fatalf("discard owned candidate close count = %d, want 1", got)
 	}

--- a/agent/session_worktree_resume.go
+++ b/agent/session_worktree_resume.go
@@ -70,6 +70,11 @@ func (s *Session) resumeWorktreeReentry(meta schema.SessionMeta) error {
 	// ExecCommand confines a workingDir override to the env's own RootDir, and
 	// local is rooted at the launch cwd, not at target.
 	rootedAtTarget := local.WithWorkingDirectory(target)
+	// The probe clones here and below run git through their own environments, and
+	// running a command is what mints a scratch dir and takes its lease. Nothing
+	// keeps a reference to either past this function, so nothing else would ever
+	// release what they minted — on a successful re-entry as much as a refused one.
+	defer rootedAtTarget.DisposeUnadoptedScratch()
 	project, err := identifier.ResolveProjectWith(target, execenv.NewProjectResolver(rootedAtTarget))
 	if err != nil {
 		notice(fmt.Sprintf("previous working directory %s is no longer part of a git repository (%v)", target, err))
@@ -93,6 +98,7 @@ func (s *Session) resumeWorktreeReentry(meta schema.SessionMeta) error {
 	}
 	mainRoot := project.CanonicalPath
 	controlEnv := local.WithWorkingDirectory(mainRoot)
+	defer controlEnv.DisposeUnadoptedScratch()
 	run := s.newWorktreeGitRunner(context.Background(), controlEnv)
 
 	// The path must still be a worktree git's own registry knows about (spec

--- a/agent/subagent_manager_test.go
+++ b/agent/subagent_manager_test.go
@@ -199,7 +199,7 @@ func trackSyntheticChild(t *testing.T, sess *Session, id string, status Subagent
 // TestRetention_FailLoudAtCap fills the retention cap with UNCONSUMED terminal
 // records (none reclaimable), then asserts the next spawn fails loudly naming the
 // remedy and does NOT track a new child (no leak — the created session is Closed
-// before the error return).
+// before the error return, without touching the parent's shared environment).
 //
 // Load-bearing: if the cap were not enforced, spawn would succeed and the tracked
 // count would grow; if the error did not name the remedy, the message assertion
@@ -239,10 +239,15 @@ func TestRetention_FailLoudAtCap(t *testing.T) {
 	if after := countTracked(sess.subagents); after != before {
 		t.Errorf("failed spawn must not track a child: tracked %d → %d", before, after)
 	}
-	// No leak: the already-created child Session was Closed before the error return,
-	// which invokes the (shared) env's Cleanup exactly once during the spawn call.
-	if got := env.count() - cleanupsBefore; got != 1 {
-		t.Errorf("failed spawn must Close the created child session (env Cleanup delta = %d, want 1)", got)
+	// The already-created child Session was Closed before the error return, but
+	// this child SHARES the live parent's environment (no working dir, no box of
+	// its own), and Cleanup on that environment would release the parent's live
+	// scratch leases and signal the processes the parent tracks. So the close has
+	// to skip it — the same skip the parent's own teardown makes for its children.
+	// That the close still happens is asserted directly, on a held reference, in
+	// TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns.
+	if got := env.count() - cleanupsBefore; got != 0 {
+		t.Errorf("failed spawn ran Cleanup %d time(s) on the live parent's environment, want 0", got)
 	}
 }
 

--- a/agent/subagent_manager_test.go
+++ b/agent/subagent_manager_test.go
@@ -28,6 +28,31 @@ func (e *cleanupCountingEnv) Cleanup() {
 
 func (e *cleanupCountingEnv) count() int32 { return e.cleanups.Load() }
 
+// apiLogRouteReleases records the sessions whose API-log route was released. A
+// session releases its route exactly once, when it closes, so this proves a
+// session was closed without holding a reference to it — and without going
+// through its execution environment, which an unadopted child must not touch.
+type apiLogRouteReleases struct {
+	mu       sync.Mutex
+	released []string
+}
+
+func (r *apiLogRouteReleases) WrapComplete(next llm.CompleteFunc) llm.CompleteFunc { return next }
+func (r *apiLogRouteReleases) WrapStream(next llm.StreamFunc) llm.StreamFunc       { return next }
+
+func (r *apiLogRouteReleases) ReleaseSession(sessionID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.released = append(r.released, sessionID)
+	return nil
+}
+
+func (r *apiLogRouteReleases) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.released)
+}
+
 // fakeEmit records the events forwarded through a manager's emit closure.
 type fakeEmit struct {
 	mu     sync.Mutex
@@ -209,6 +234,8 @@ func TestRetention_FailLoudAtCap(t *testing.T) {
 	dir := t.TempDir()
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
+	routes := &apiLogRouteReleases{}
+	c.Use(routes)
 	env := &cleanupCountingEnv{ExecutionEnvironment: execenv.NewLocalExecutionEnvironment(dir)}
 	sess, err := NewSession(c, NewOpenAIProfile("gpt-5.2"), env, SessionConfig{
 		MaxSubagentDepth: 1,
@@ -225,6 +252,7 @@ func TestRetention_FailLoudAtCap(t *testing.T) {
 
 	before := countTracked(sess.subagents)
 	cleanupsBefore := env.count()
+	releasesBefore := routes.count()
 
 	_, err = sess.spawnAgent(context.Background(), "overflow", "", "", 0, "", "", nil, nil)
 	if err == nil {
@@ -248,6 +276,11 @@ func TestRetention_FailLoudAtCap(t *testing.T) {
 	// TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns.
 	if got := env.count() - cleanupsBefore; got != 0 {
 		t.Errorf("failed spawn ran Cleanup %d time(s) on the live parent's environment, want 0", got)
+	}
+	// And it IS closed: closing releases the session's API-log route, which the
+	// child holds alone, so exactly one release lands during the spawn call.
+	if got := routes.count() - releasesBefore; got != 1 {
+		t.Errorf("failed spawn must Close the created child session (API-log route releases = %d, want 1)", got)
 	}
 }
 

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -932,11 +932,13 @@ func (s *Session) prepareSubagentRunFromSelection(
 	}
 	if err != nil {
 		// A fresh environment that failed before session adoption never reaches the
-		// session cleanup path, so dispose any scratch it provisioned. A worktree-only
-		// re-root has no owned scratch, making this safe when reqSandbox is nil.
+		// session cleanup path, so dispose every scratch it provisioned: the
+		// sandbox-owned one AND the one an unsandboxed environment mints on its
+		// first command, which the construction above reaches through its own git
+		// snapshot. A prepared environment belongs to whoever prepared it.
 		if ownsFreshEnv && !hasPreparedEnv {
 			if le, ok := subEnv.(*execenv.LocalExecutionEnvironment); ok {
-				le.DisposeSandboxScratch()
+				le.DisposeUnadoptedScratch()
 			}
 		}
 		return nil, err

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -158,6 +158,22 @@ type preparedSubagentRun struct {
 	treeSlot *treeReservation
 }
 
+// disposeUnadoptedScratch drops every per-session scratch directory env
+// provisioned — the sandbox-owned one and the one an unsandboxed environment
+// mints on its first command — releasing each lease with its directory. Every
+// caller is a path that provisioned an environment and then failed before any
+// session adopted it: both releases belong to a session's own teardown, so
+// without this nothing ever runs them and each failure leaves a directory and a
+// live lease behind. A no-op for an environment with no scratch to drop,
+// including one that is not local. It must run only on an environment built for
+// the failed thing, never on a shared parent's, whose scratch the parent is
+// still working in.
+func disposeUnadoptedScratch(env execenv.ExecutionEnvironment) {
+	if local, ok := env.(*execenv.LocalExecutionEnvironment); ok {
+		local.DisposeUnadoptedScratch()
+	}
+}
+
 // disposeUnadoptedSubagentSession tears down a child that never became a
 // tracked/adopted delegate. It is the create-path twin of
 // discardRestoredCandidate and makes the same decisions it does. Normal teardown
@@ -182,9 +198,7 @@ func disposeUnadoptedSubagentSession(sess *Session, ownsEnv bool) {
 	if !ownsEnv {
 		return
 	}
-	if le, ok := sess.currentEnv().(*execenv.LocalExecutionEnvironment); ok {
-		le.DisposeUnadoptedScratch()
-	}
+	disposeUnadoptedScratch(sess.currentEnv())
 }
 
 func (p *preparedSubagentRun) disposeUnadopted() {
@@ -949,9 +963,7 @@ func (s *Session) prepareSubagentRunFromSelection(
 		// first command, which the construction above reaches through its own git
 		// snapshot. A prepared environment belongs to whoever prepared it.
 		if ownsFreshEnv && !hasPreparedEnv {
-			if le, ok := subEnv.(*execenv.LocalExecutionEnvironment); ok {
-				le.DisposeUnadoptedScratch()
-			}
+			disposeUnadoptedScratch(subEnv)
 		}
 		return nil, err
 	}

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -171,7 +171,11 @@ func disposeUnadoptedSubagentSession(sess *Session, ownsEnv bool) {
 	if sess == nil {
 		return
 	}
-	sess.Close()
+	// The environment's Cleanup belongs to whoever owns it: on a shared one it
+	// would release the LIVE parent's scratch leases and signal the processes the
+	// parent tracks. Skipping it for a non-owned env is the same call the
+	// parent's own teardown makes for its children (close(ctx, false)).
+	sess.close(context.Background(), ownsEnv)
 	if !ownsEnv {
 		return
 	}

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -159,9 +159,14 @@ type preparedSubagentRun struct {
 }
 
 // disposeUnadoptedSubagentSession tears down a child that never became a
-// tracked/adopted delegate. Normal session cleanup retains sandbox scratch for
-// the human handoff, but an unadopted fresh environment has no owner left to
-// perform that handoff, so its scratch is rolled back here.
+// tracked/adopted delegate. It is the create-path twin of
+// discardRestoredCandidate and makes the same two decisions it does. Normal
+// cleanup RETAINS both of a session's scratch dirs for the human handoff — Close
+// releases the leases and keeps the directories — but an unadopted child has no
+// owner left to hand anything to, so both go: the sandbox-owned one and the one
+// an unsandboxed environment (the default shape) mints on its first command.
+// Only for an environment built FOR this child, though: a shared one belongs to
+// the live parent still working in it.
 func disposeUnadoptedSubagentSession(sess *Session, ownsEnv bool) {
 	if sess == nil {
 		return
@@ -171,7 +176,7 @@ func disposeUnadoptedSubagentSession(sess *Session, ownsEnv bool) {
 		return
 	}
 	if le, ok := sess.currentEnv().(*execenv.LocalExecutionEnvironment); ok {
-		le.DisposeSandboxScratch()
+		le.DisposeUnadoptedScratch()
 	}
 }
 

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -160,22 +160,25 @@ type preparedSubagentRun struct {
 
 // disposeUnadoptedSubagentSession tears down a child that never became a
 // tracked/adopted delegate. It is the create-path twin of
-// discardRestoredCandidate and makes the same two decisions it does. Normal
-// cleanup RETAINS both of a session's scratch dirs for the human handoff — Close
-// releases the leases and keeps the directories — but an unadopted child has no
-// owner left to hand anything to, so both go: the sandbox-owned one and the one
-// an unsandboxed environment (the default shape) mints on its first command.
-// Only for an environment built FOR this child, though: a shared one belongs to
-// the live parent still working in it.
+// discardRestoredCandidate and makes the same decisions it does. Normal teardown
+// RETAINS both of a session's scratch dirs for the human handoff — the leases go,
+// the directories stay — but an unadopted child has no owner left to hand
+// anything to, so both go: the sandbox-owned one and the one an unsandboxed
+// environment (the default shape) mints on its first command. Only for an
+// environment built FOR this child, though: a shared one belongs to the live
+// parent still working in it.
 func disposeUnadoptedSubagentSession(sess *Session, ownsEnv bool) {
 	if sess == nil {
 		return
 	}
-	// The environment's Cleanup belongs to whoever owns it: on a shared one it
-	// would release the LIVE parent's scratch leases and signal the processes the
-	// parent tracks. Skipping it for a non-owned env is the same call the
-	// parent's own teardown makes for its children (close(ctx, false)).
-	sess.close(context.Background(), ownsEnv)
+	// The environment's Cleanup is never this child's to run, whichever
+	// environment it holds. A shared one is the live parent's outright; a FRESH
+	// clone still shares the parent's PROCESS TABLE, since WithWorkingDirectory
+	// copies runningPIDs by pointer, so cleaning up a clone signals the parent's
+	// in-flight tools too. The child's own processes live in that same map and
+	// end with the environment that owns it — the same skip the parent's own
+	// teardown makes for its children.
+	sess.close(context.Background(), false)
 	if !ownsEnv {
 		return
 	}

--- a/cmd/evener/sandbox_test.go
+++ b/cmd/evener/sandbox_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -306,4 +307,75 @@ func TestParseSandboxNet(t *testing.T) {
 			t.Errorf("parseSandboxNet(%q) = %v, %v; want %v, nil", tc.in, got, err, tc.want)
 		}
 	}
+}
+
+// backendlessSandboxHost resolves a mode successfully and then has no binary to
+// enforce it with: EnableSandbox mints the session scratch it would have wrapped
+// and only THEN refuses. It is the one provisioning failure that could leave a
+// scratch directory, and the lease under it, behind.
+func backendlessSandboxHost(t *testing.T) sandbox.HostFacts {
+	t.Helper()
+	return sandbox.HostFacts{OS: "linux", Home: t.TempDir(), BwrapCapable: true}
+}
+
+// TestLaunchProvisioningFailureLeavesNoScratch pins why the provisioning-failure
+// return in run and serve disposes nothing: there is nothing there to dispose. A
+// session scratch appears in exactly two ways -- EnableSandbox provisions one for
+// an enforced (or write-blocked) policy, and an unsandboxed environment mints one
+// the first time it builds a command environment -- and neither has happened when
+// provisioning fails: no command runs through the environment before it, and
+// EnableSandbox disposes the scratch it minted on every way out. A step added
+// before provisioning that DOES spawn a command fails here rather than silently
+// leaking a directory and a live lease per failed launch.
+func TestLaunchProvisioningFailureLeavesNoScratch(t *testing.T) {
+	assertNoScratch := func(t *testing.T, err error, env *execenv.LocalExecutionEnvironment) {
+		t.Helper()
+		if !errors.As(err, new(*sandbox.RefusalError)) {
+			t.Fatalf("launch error = %v, want a provisioning refusal", err)
+		}
+		// Pin WHICH refusal: the one EnableSandbox raises after it has already
+		// minted the scratch. A refusal from the resolver instead would never
+		// have created one, and the assertion below would prove nothing.
+		if !strings.Contains(err.Error(), "no bwrap backend binary is available") {
+			t.Fatalf("launch error = %v, want the refusal that follows the scratch mint", err)
+		}
+		if env == nil {
+			t.Fatal("provisioning never ran, so the launch failed somewhere else")
+		}
+		if scratch := env.SessionScratchDir(); scratch != "" {
+			t.Errorf("environment holds scratch %q after a failed provisioning, which nothing on this path disposes", scratch)
+		}
+	}
+
+	t.Run("run", func(t *testing.T) {
+		installRunScriptedProvider(t, &scriptedProvider{name: "openai"})
+		facts := backendlessSandboxHost(t)
+		var provisioned *execenv.LocalExecutionEnvironment
+		old := runProvisionSandbox
+		runProvisionSandbox = func(env *execenv.LocalExecutionEnvironment, cfg *agent.SessionConfig, cwd string) error {
+			provisioned = env
+			return provisionSandboxWithHost(env, cfg, cwd, facts)
+		}
+		t.Cleanup(func() { runProvisionSandbox = old })
+
+		err := run(context.Background(), runConfig{
+			prompt: "prompt", model: "openai/gpt-test", workDir: t.TempDir(), stateDir: t.TempDir(),
+			noDefaultMarketplaces: true, sandboxMode: "restricted",
+			stdout: io.Discard, stderr: io.Discard,
+		})
+		assertNoScratch(t, err, provisioned)
+	})
+
+	t.Run("serve", func(t *testing.T) {
+		deps, _, args := newClearServeDeps(t)
+		facts := backendlessSandboxHost(t)
+		var provisioned *execenv.LocalExecutionEnvironment
+		deps.provisionSandbox = func(env *execenv.LocalExecutionEnvironment, cfg *agent.SessionConfig, cwd string) error {
+			provisioned = env
+			return provisionSandboxWithHost(env, cfg, cwd, facts)
+		}
+
+		err := runServeWithDeps(append(args, "--sandbox", "restricted"), deps)
+		assertNoScratch(t, err, provisioned)
+	})
 }

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -1021,7 +1021,15 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 		}
 		newSess, err := deps.newClearSession(client, profile, clearEnv, clearCfg)
 		if err != nil {
+			// Cleanup stops whatever the failed construction left running and
+			// RETAINS the session scratch — the handoff convention for a session
+			// someone may still want to inspect. No session was built to hand
+			// anything to here, so the scratch this env provisioned (and the one
+			// an unsandboxed env minted on its first command) is disposed
+			// outright; otherwise every failed clear leaves a directory and a
+			// live flock lease behind for the daemon's whole uptime.
 			clearEnv.Cleanup()
+			clearEnv.DisposeUnadoptedScratch()
 			return fmt.Errorf("new session: %w", err)
 		}
 		// Everything that can fail happens before anything shared moves, so the

--- a/cmd/evener/serve_state_test.go
+++ b/cmd/evener/serve_state_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -895,6 +896,54 @@ func TestRunServeClearRendezvousFailureKeepsOldIdentity(t *testing.T) {
 	assertClearKeptOldIdentity(t, obs)
 	if len(obs.steps) < 2 || obs.steps[0] != "prepare" || obs.steps[1] != "rendezvous" {
 		t.Fatalf("clear steps = %v, want prepare then rendezvous before any install", obs.steps)
+	}
+}
+
+// TestRunServeClearSessionFailureDisposesUnadoptedScratch drives the clear that
+// provisions a fresh environment and then fails to build the session that would
+// have owned it. Cleanup() RETAINS a session scratch -- the handoff convention
+// for a session someone might still want to inspect -- so a clear that never
+// produced a session has to dispose it instead, or every failed clear leaves a
+// directory and a live flock lease behind for the daemon's whole uptime.
+func TestRunServeClearSessionFailureDisposesUnadoptedScratch(t *testing.T) {
+	deps, state, args := newClearServeDeps(t)
+	var clearScratch string
+	deps.newClearSession = func(_ *llm.Client, _ *provider.Profile, env execenv.ExecutionEnvironment, _ agent.SessionConfig) (*agent.Session, error) {
+		local, ok := env.(*execenv.LocalExecutionEnvironment)
+		if !ok {
+			t.Errorf("clear environment = %T, want a local environment", env)
+			return nil, errClearProbe
+		}
+		// The real NewSession runs commands through the environment (the git
+		// snapshot among them) before it can fail, and an unsandboxed env mints
+		// its session scratch, with the lease under it, on that first command.
+		if _, err := local.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+			t.Errorf("mint the cleared session scratch: %v", err)
+		}
+		clearScratch = local.SessionScratchDir()
+		return nil, errClearProbe
+	}
+
+	obs := runClearAttempt(t, deps, state, args, nil)
+
+	// This failure lands before any replacement session exists, so the shared
+	// assertion (which inspects one) does not apply; the old session stays live.
+	if !errors.Is(obs.clearErr, errClearProbe) {
+		t.Fatalf("clear error = %v, want %v", obs.clearErr, errClearProbe)
+	}
+	if obs.currentSessionID != obs.oldSessionID {
+		t.Errorf("current session = %q, want the old session %q", obs.currentSessionID, obs.oldSessionID)
+	}
+	if obs.oldSessionState == agent.SessionClosed {
+		t.Error("old session was closed by an aborted clear")
+	}
+	if clearScratch == "" {
+		t.Fatal("the cleared session environment minted no scratch, so there is nothing to dispose")
+	}
+	// The lease file lives inside the scratch dir, so the directory's removal is
+	// the lease's removal too.
+	if _, err := os.Stat(clearScratch); !os.IsNotExist(err) {
+		t.Errorf("failed clear retained the unadopted scratch %s: stat err = %v", clearScratch, err)
 	}
 }
 


### PR DESCRIPTION
Three neighbours of the scratch leaks #842 fixed. Every session environment can hold up to two scratch directories — the sandbox-owned one `EnableSandbox` provisions and the one an unsandboxed environment mints lazily on its first command — each with an flock lease under it, and only a session's own teardown ever releases either.

**A discarded restore candidate leaked its unsandboxed scratch.** `discardRestoredCandidate` disposed only the sandbox-owned scratch, so a candidate discarded on the default (unsandboxed) environment left the directory it minted on its first command, and the lease under it, for the life of the process — nothing else was ever going to release them, since the candidate was never adopted. It now disposes both via `DisposeUnadoptedScratch`. `TestDiscardRestoredCandidateDisposesUnsandboxedScratch` (agent/sandbox_delegate_test.go) runs a command on the candidate's environment, discards it, and requires the scratch directory to be gone; it fails on the old code with the directory still present. The disposal is guarded on ownership: `prepareSubagentEnvironment` hands back the parent's environment untouched when a delegate needs neither a working-dir re-root nor a box of its own, so `discardRestoredCandidate` now takes the same `ownsEnv` answer `close()` reads from `subagent.ownsEnv` and leaves a shared environment's scratch to the live parent still working in it (`TestDiscardRestoredCandidateLeavesASharedEnvironmentAlone`, which fails on the unguarded version with the parent's scratch deleted).

**A failed `/clear` leaked one scratch per attempt.** `/clear` provisions a fresh environment before it touches anything shared; when the session that would have owned it could not be built, `clearEnv.Cleanup()` RETAINED the scratch — the handoff convention for a session someone may still want to inspect — so each failed clear left a directory and a live lease behind for the daemon's whole uptime. It now disposes it after Cleanup. `TestRunServeClearSessionFailureDisposesUnadoptedScratch` (cmd/evener/serve_state_test.go) drives a real serve through the daemon's own clear callback with a session constructor that mints the scratch (as `NewSession` does on its first command) and then fails, and requires the directory to be gone; it fails on the old code with the directory still present.

**The provisioning-failure return needs no disposal — provably.** run.go and serve.go return from a failed `provisionSandbox` without disposing anything. Nothing can be there: no command runs through the environment between its construction and provisioning, so the lazily minted unsandboxed scratch does not exist yet, and `EnableSandbox` disposes the tmp it minted on every one of its failure paths — including the refusal that fires only AFTER the mint (no backend binary for a mode that resolved). No production change; `TestLaunchProvisioningFailureLeavesNoScratch` (cmd/evener/sandbox_test.go) pins it for both launches by driving each through that exact post-mint refusal and asserting the environment holds no scratch, so a step added before provisioning that DOES spawn a command fails there instead of leaking a directory and a lease per failed launch.

Review follow-up, three siblings of the same leak. A delegate restore that fails inside `initSessionState` (`restoreIdle`'s rollback defer) disposed only the sandbox-owned scratch, though the construction has already run the child's git snapshot and so minted the unsandboxed one — `TestRestoreIdleFailureDisposesTheChildScratch` drives a real restore into a post-snapshot fault and finds the leaked directory under a redirected `TMPDIR`. The create path had the identical shape when `NewSession` fails after its own snapshot, fixed the same way and covered by `TestSpawnedSubagentSessionFailureDisposesTheChildScratch`. And `disposeUnadoptedSubagentSession` kept the unsandboxed directory (Close releases its lease but keeps the path, the handoff convention for a session someone may inspect) while the discard path's comment claimed to mirror its discipline; both now dispose both dirs for an owned environment and leave a shared one to the live parent, which `TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns` pins in both directions.

Gates: gofmt, `go vet` (plain and `-tags evenerfuzz`), golangci-lint, `go test ./agent/execenv/...`, `./agent/`, and `./cmd/evener/` (targeted and full).

## The consequential change

An unadopted child session never runs its environment's `Cleanup` any more, whether it owned the environment or not. A child environment cloned with a new working directory shares its parent's running-process table, so cleaning it up sent SIGTERM to the parent's in-flight commands; a test reproduces a parent's `sleep` dying after a child cleanup before the fix. The child now closes with `cleanupEnv=false` and disposes only the scratch it owns. The remaining ownership hazards outside this PR's scope are tracked in #877.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT

