### PR TITLE
feat(web): keybindings Phase 4a - final map, cheatsheet overlay, hold-modifier hints

### DIFF
--- a/cmd/evener-hub/frontend/src/keybindings/actions.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/actions.ts
@@ -1,7 +1,9 @@
 // Canonical shell action ids. Where a palette command already owns the
 // behavior, the action id IS the palette command id (see
-// shell/palette/commands.ts: "next-needs-you"); the rest are shell action ids.
-// Task 2 registers each id's real run function against the registry.
+// shell/palette/commands.ts: "next-needs-you" and "settings"); the rest are
+// shell action ids. The components that own each behavior register its run
+// function against the registry (AppShell, RailHost, Settings,
+// SelectionQuote, the session transcript's useTranscriptScrollKeys).
 
 export const ACTIONS = {
   paletteOpen: "palette.open",
@@ -15,11 +17,12 @@ export const ACTIONS = {
   transcriptLineDown: "transcript.lineDown",
   transcriptPageUp: "transcript.pageUp",
   transcriptPageDown: "transcript.pageDown",
-  // No DEFAULT_BINDINGS entries for these two: their handlers exist (the
-  // session transcript registers them per pane) but the Phase 4 keymap
-  // decides whether they get a chord at all.
   transcriptScrollTop: "transcript.scrollTop",
   transcriptScrollBottom: "transcript.scrollBottom",
+  // Reuses the palette's "settings" command id: that command's run owns the
+  // behavior (navigate("/settings")), exactly the next-needs-you precedent
+  // above.
+  settingsOpen: "settings",
   settingsClose: "settings.close",
 } as const;
 

--- a/cmd/evener-hub/frontend/src/keybindings/actions.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/actions.ts
@@ -24,6 +24,11 @@ export const ACTIONS = {
   // above.
   settingsOpen: "settings",
   settingsClose: "settings.close",
+  // Phase 4a (the p4 plan's Design decision 3): the cheatsheet overlay's
+  // open/toggle and close. toggle's handler lives in the CheatsheetOverlay
+  // component (shell/cheatsheet/), close's next to it, scope-gated.
+  cheatsheetToggle: "cheatsheet.toggle",
+  cheatsheetClose: "cheatsheet.close",
 } as const;
 
 export type ActionId = (typeof ACTIONS)[keyof typeof ACTIONS];

--- a/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
@@ -112,10 +112,10 @@ describe("chordsOverlap", () => {
 
   test("an exact-required chord overlaps a chord that lists the rest as OPTIONAL", () => {
     // The dispatch-time shadowing the whole-branch review flagged: Control+K
-    // matches palette.open's Control+[Meta]+[Shift]+[Alt]+K default.
-    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+[Meta]+[Shift]+[Alt]+K"))).toBe(true);
+    // matches palette.open's Control+[Meta]+K default.
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+[Meta]+K"))).toBe(true);
     // Symmetrically, the fully-loaded press also overlaps the plain one.
-    expect(chordsOverlap(parseChord("Control+[Meta]+[Shift]+[Alt]+K"), parseChord("Control+K"))).toBe(true);
+    expect(chordsOverlap(parseChord("Control+[Meta]+K"), parseChord("Control+K"))).toBe(true);
   });
 
   test("an extra REQUIRED modifier escapes the overlap when the other side does not allow it", () => {

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -61,9 +61,9 @@ export function serializeChord(sequence: KeySequence): string {
  * set is a subset of the other side's required ∪ optional set - the exact
  * condition for one KeyboardEvent's modifier state to satisfy both. This is
  * the conflict predicate for validation and rebind: serialization equality
- * alone misses e.g. Control+K vs a default's Control+[Meta]+[Shift]+[Alt]+K,
- * which the same event matches (the earlier-registered binding shadows the
- * later one at dispatch).
+ * alone misses e.g. Control+K vs a default's Control+[Meta]+K, which the
+ * same event matches (the earlier-registered binding shadows the later one
+ * at dispatch).
  *
  * Multi-press sequences keep the old serialization-equality check: a
  * per-press overlap extension is out of scope (user multi-press overrides

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { ACTIONS } from "./actions";
 import { formatSequence, parseChord, serializeChord } from "./chord";
-import { DEFAULT_BINDINGS, registerDefaultBindings, SETTINGS_SCOPE } from "./defaults";
+import {
+  CHARACTER_KEY_TRIGGER_BINDING_ID,
+  CHEATSHEET_SCOPE,
+  DEFAULT_BINDINGS,
+  registerDefaultBindings,
+  SETTINGS_SCOPE,
+} from "./defaults";
 import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
 import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
@@ -27,6 +33,9 @@ describe("default binding map", () => {
       ACTIONS.transcriptScrollTop,
       ACTIONS.transcriptScrollBottom,
       ACTIONS.settingsClose,
+      ACTIONS.cheatsheetToggle,
+      ACTIONS.cheatsheetToggle, // the "?" character-key trigger is a second entry for the same action
+      ACTIONS.cheatsheetClose,
     ]);
   });
 
@@ -55,10 +64,18 @@ describe("default binding map", () => {
     [ACTIONS.transcriptPageDown, "Alt+Shift+ArrowDown"],
     [ACTIONS.transcriptScrollTop, "Alt+Home"],
     [ACTIONS.transcriptScrollBottom, "Alt+End"],
+    [ACTIONS.cheatsheetToggle, "$mod+/"],
+    [ACTIONS.cheatsheetClose, "[Control]+[Alt]+[Shift]+[Meta]+Escape"],
   ])("%s is bound to %s", (actionId, chord) => {
     const binding = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
     expect(binding).toBeDefined();
     expect(serializeChord(parseChord(String(binding?.chord)))).toBe(serializeChord(parseChord(chord)));
+  });
+
+  test('the "?" trigger lists Shift as OPTIONAL (every common layout types ? with Shift held; a bare binding would never fire)', () => {
+    const binding = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+    expect(binding?.actionId).toBe(ACTIONS.cheatsheetToggle);
+    expect(serializeChord(parseChord(String(binding?.chord)))).toBe(serializeChord(parseChord("[Shift]+?")));
   });
 
   test("editable-target policy matches today's per-chord behavior", () => {
@@ -83,12 +100,25 @@ describe("default binding map", () => {
     expect(policy.get(ACTIONS.transcriptPageDown)).toBe(false);
     expect(policy.get(ACTIONS.transcriptScrollTop)).toBe(false);
     expect(policy.get(ACTIONS.transcriptScrollBottom)).toBe(false);
+    // cheatsheet.toggle's $mod+/ fires from editable targets (never collides
+    // with typing); the "?" character-key trigger does NOT (it is itself a
+    // printable character). cheatsheet.close mirrors settings.close.
+    // (Asserted per-entry, not via the policy map: the two toggle entries
+    // share one action id.)
+    const toggleBase = DEFAULT_BINDINGS.find((b) => b.id === ACTIONS.cheatsheetToggle);
+    const toggleQuestion = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+    const close = DEFAULT_BINDINGS.find((b) => b.id === ACTIONS.cheatsheetClose);
+    expect(toggleBase?.allowInEditable).toBe(true);
+    expect(toggleQuestion?.allowInEditable).toBe(false);
+    expect(close?.allowInEditable).toBe(true);
   });
 
-  test("settings.close is scope-gated, not global", () => {
-    const binding = DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.settingsClose);
-    expect(binding?.scope).toBe(SETTINGS_SCOPE);
-    for (const other of DEFAULT_BINDINGS.filter((b) => b.actionId !== ACTIONS.settingsClose)) {
+  test("settings.close and cheatsheet.close are scope-gated, not global", () => {
+    expect(DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.settingsClose)?.scope).toBe(SETTINGS_SCOPE);
+    expect(DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.cheatsheetClose)?.scope).toBe(CHEATSHEET_SCOPE);
+    for (const other of DEFAULT_BINDINGS.filter(
+      (b) => b.actionId !== ACTIONS.settingsClose && b.actionId !== ACTIONS.cheatsheetClose,
+    )) {
       expect(other.scope ?? GLOBAL_SCOPE).toBe(GLOBAL_SCOPE);
     }
   });
@@ -122,6 +152,16 @@ describe("default binding map", () => {
     // settings.open keeps the default suppression too (the p4 plan, Design
     // decision 2: allowInModal: false).
     expect(policy.get(ACTIONS.settingsOpen)).toBe(false);
+    // cheatsheet.toggle's $mod+/ is exempt so the same chord toggles the
+    // overlay CLOSED while it (or another modal) is open; the "?" trigger
+    // and cheatsheet.close keep the default suppression (the OverlayPanel's
+    // own Escape handler owns close while focus is inside the dialog).
+    const toggleBase = DEFAULT_BINDINGS.find((b) => b.id === ACTIONS.cheatsheetToggle);
+    const toggleQuestion = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+    const close = DEFAULT_BINDINGS.find((b) => b.id === ACTIONS.cheatsheetClose);
+    expect(toggleBase?.allowInModal).toBe(true);
+    expect(toggleQuestion?.allowInModal ?? false).toBe(false);
+    expect(close?.allowInModal ?? false).toBe(false);
   });
 });
 
@@ -211,6 +251,27 @@ describe("default bindings through the dispatcher", () => {
     registry.getState().pushScope(SETTINGS_SCOPE);
     window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
     expect(calls).toEqual([ACTIONS.settingsClose]);
+  });
+
+  test('the "?" trigger fires with or without Shift held, and is suppressed in an editable target', () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "?", code: "Slash", shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "?", code: "Slash" }));
+    expect(calls).toEqual([ACTIONS.cheatsheetToggle, ACTIONS.cheatsheetToggle]);
+    calls = [];
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(keydown({ key: "?", code: "Slash", shiftKey: true }));
+    expect(calls).toEqual([]);
+  });
+
+  test("Escape only closes the cheatsheet while the cheatsheet scope is pushed", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
+    expect(calls).toEqual([]);
+    registry.getState().pushScope(CHEATSHEET_SCOPE);
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
+    expect(calls).toEqual([ACTIONS.cheatsheetClose]);
   });
 
   test("Mod+B is suppressed in an editable target while Mod+K still fires", () => {

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -17,36 +17,35 @@ describe("default binding map", () => {
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.settingsOpen,
       ACTIONS.sessionNext,
       ACTIONS.sessionPrevious,
       ACTIONS.transcriptLineUp,
       ACTIONS.transcriptLineDown,
       ACTIONS.transcriptPageUp,
       ACTIONS.transcriptPageDown,
+      ACTIONS.transcriptScrollTop,
+      ACTIONS.transcriptScrollBottom,
       ACTIONS.settingsClose,
     ]);
   });
 
-  // Phase 3 registers the scrollTop/scrollBottom ACTIONS (their handlers are
-  // the session transcript's) but deliberately ships no default chord for
-  // them - the Phase 4 keymap decides whether they get one.
-  test("transcript.scrollTop/scrollBottom ship with no default chord", () => {
-    expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollTop)).toBe(false);
-    expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollBottom)).toBe(false);
-  });
-
   // Chords are compared through parse+serialize so the assertion is
   // platform-independent ("$mod" resolves per host platform at parse time).
-  // The optional modifiers are the legacy-faithful semantics: the AppShell
-  // K/I/J listener had no shift/alt guard, SelectionQuote guarded only
-  // AltGr (alt), rail.toggle guarded both, and the Settings Escape listener
-  // had no modifier guard at all.
+  // palette.open / composer.focus / next-needs-you are STRICT single-press
+  // chords since Phase 4a - docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md
+  // (Design decision 1) is the authority for dropping the 2a map's OPTIONAL
+  // Shift/Alt, which hijacked the browser's DevTools chords (⌘⌥I,
+  // Ctrl+Shift+J). The remaining optional modifiers are the legacy-faithful
+  // semantics: SelectionQuote guarded only AltGr (alt), rail.toggle guarded
+  // both, and the Settings Escape listener had no modifier guard at all.
   test.each([
-    [ACTIONS.paletteOpen, "$mod+[Shift]+[Alt]+K"],
+    [ACTIONS.paletteOpen, "$mod+K"],
     [ACTIONS.railToggle, "$mod+B"],
-    [ACTIONS.composerFocus, "$mod+[Shift]+[Alt]+I"],
-    [ACTIONS.nextNeedsYou, "$mod+[Shift]+[Alt]+J"],
+    [ACTIONS.composerFocus, "$mod+I"],
+    [ACTIONS.nextNeedsYou, "$mod+J"],
     [ACTIONS.selectionQuote, "$mod+[Shift]+'"],
+    [ACTIONS.settingsOpen, "$mod+,"],
     [ACTIONS.settingsClose, "[Control]+[Alt]+[Shift]+[Meta]+Escape"],
     [ACTIONS.sessionNext, "Alt+ArrowRight"],
     [ACTIONS.sessionPrevious, "Alt+ArrowLeft"],
@@ -54,6 +53,8 @@ describe("default binding map", () => {
     [ACTIONS.transcriptLineDown, "Alt+ArrowDown"],
     [ACTIONS.transcriptPageUp, "Alt+Shift+ArrowUp"],
     [ACTIONS.transcriptPageDown, "Alt+Shift+ArrowDown"],
+    [ACTIONS.transcriptScrollTop, "Alt+Home"],
+    [ACTIONS.transcriptScrollBottom, "Alt+End"],
   ])("%s is bound to %s", (actionId, chord) => {
     const binding = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
     expect(binding).toBeDefined();
@@ -67,15 +68,21 @@ describe("default binding map", () => {
     expect(policy.get(ACTIONS.nextNeedsYou)).toBe(true);
     expect(policy.get(ACTIONS.selectionQuote)).toBe(true);
     expect(policy.get(ACTIONS.railToggle)).toBe(false);
-    // The Phase 3 navigation chords all suppress in editable targets: plain
-    // Alt+Arrow and Alt+Shift+Arrow keep their native text-editing meanings
-    // (word/selection movement) inside inputs and the composer.
+    // settings.open fires from editable targets (the p4 plan, Design
+    // decision 2): ⌘, never collides with typing.
+    expect(policy.get(ACTIONS.settingsOpen)).toBe(true);
+    // The Phase 3/4 navigation chords all suppress in editable targets:
+    // plain Alt+Arrow, Alt+Shift+Arrow and Alt+Home/End keep their native
+    // text-editing meanings (word/selection movement, caret to line
+    // start/end) inside inputs and the composer.
     expect(policy.get(ACTIONS.sessionNext)).toBe(false);
     expect(policy.get(ACTIONS.sessionPrevious)).toBe(false);
     expect(policy.get(ACTIONS.transcriptLineUp)).toBe(false);
     expect(policy.get(ACTIONS.transcriptLineDown)).toBe(false);
     expect(policy.get(ACTIONS.transcriptPageUp)).toBe(false);
     expect(policy.get(ACTIONS.transcriptPageDown)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptScrollTop)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptScrollBottom)).toBe(false);
   });
 
   test("settings.close is scope-gated, not global", () => {
@@ -112,6 +119,9 @@ describe("default binding map", () => {
     expect(policy.get(ACTIONS.composerFocus)).toBe(false);
     expect(policy.get(ACTIONS.nextNeedsYou)).toBe(false);
     expect(policy.get(ACTIONS.settingsClose)).toBe(false);
+    // settings.open keeps the default suppression too (the p4 plan, Design
+    // decision 2: allowInModal: false).
+    expect(policy.get(ACTIONS.settingsOpen)).toBe(false);
   });
 });
 
@@ -147,35 +157,51 @@ describe("default bindings through the dispatcher", () => {
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "'", code: "Quote", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: ",", code: "Comma", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowRight", code: "ArrowRight", altKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowLeft", code: "ArrowLeft", altKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true, shiftKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "Home", code: "Home", altKey: true }));
+    window.dispatchEvent(keydown({ key: "End", code: "End", altKey: true }));
     expect(calls).toEqual([
       ACTIONS.paletteOpen,
       ACTIONS.railToggle,
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.settingsOpen,
       ACTIONS.sessionNext,
       ACTIONS.sessionPrevious,
       ACTIONS.transcriptLineUp,
       ACTIONS.transcriptLineDown,
       ACTIONS.transcriptPageUp,
       ACTIONS.transcriptPageDown,
+      ACTIONS.transcriptScrollTop,
+      ACTIONS.transcriptScrollBottom,
     ]);
   });
 
-  test("the Alt+Arrow chords are suppressed in an editable target", () => {
+  test("the Alt+Arrow and Alt+Home/End chords are suppressed in an editable target", () => {
     setup();
     const input = document.createElement("input");
     document.body.appendChild(input);
     input.dispatchEvent(keydown({ key: "ArrowRight", code: "ArrowRight", altKey: true }));
     input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
     input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+    input.dispatchEvent(keydown({ key: "Home", code: "Home", altKey: true }));
+    input.dispatchEvent(keydown({ key: "End", code: "End", altKey: true }));
     expect(calls).toEqual([]);
+  });
+
+  test("⌘, fires settings.open from an editable target (it never collides with typing)", () => {
+    setup();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(keydown({ key: ",", code: "Comma", ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.settingsOpen]);
   });
 
   test("Escape only closes settings while the settings scope is pushed", () => {
@@ -197,18 +223,23 @@ describe("default bindings through the dispatcher", () => {
     expect(calls).toEqual([ACTIONS.paletteOpen]);
   });
 
-  // Extra-modifier variants: the legacy AppShell ⌘K/⌘I/⌘J listener checked
-  // only metaKey||ctrlKey + key (NO shift/alt guard), and the legacy
-  // Settings Escape listener checked only key === "Escape" - so these all
-  // fired legacy and must still fire.
-  test("⌘⇧K and ⌘⌥K fire palette.open (legacy had no shift/alt guard)", () => {
+  // STRICT extra-modifier contract (Phase 4a): the 2a map listed Shift/Alt
+  // as OPTIONAL on palette.open/composer.focus/next-needs-you because the
+  // legacy AppShell ⌘K/⌘I/⌘J listener checked only metaKey||ctrlKey + key
+  // with NO shift/alt guard - which hijacked the browser's DevTools chords
+  // (⌘⌥I, Ctrl+Shift+J). docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md
+  // (Design decision 1) is the authority for the deliberate change: these
+  // extra-modifier presses must NOT fire, so the browser gets its chords
+  // back. legacyEitherMod is retained - Meta+Ctrl together still fires
+  // (pinned below).
+  test("⌘⇧K and ⌘⌥K do NOT fire palette.open (strict per the p4 plan)", () => {
     setup();
     window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, shiftKey: true }));
     window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, altKey: true }));
-    expect(calls).toEqual([ACTIONS.paletteOpen, ACTIONS.paletteOpen]);
+    expect(calls).toEqual([]);
   });
 
-  test("Meta+Ctrl+K fires palette.open (legacy accepted either or both modifiers)", () => {
+  test("Meta+Ctrl+K fires palette.open (legacyEitherMod kept: either or both modifiers)", () => {
     setup();
     window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, ctrlKey: true }));
     expect(calls).toEqual([ACTIONS.paletteOpen]);
@@ -226,16 +257,18 @@ describe("default bindings through the dispatcher", () => {
     expect(calls).toEqual([ACTIONS.selectionQuote]);
   });
 
-  test("⌘⇧I fires composer.focus", () => {
+  test("⌘⌥I does NOT fire composer.focus (the browser's DevTools chord reverts to the browser)", () => {
     setup();
+    window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true, altKey: true }));
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true, shiftKey: true }));
-    expect(calls).toEqual([ACTIONS.composerFocus]);
+    expect(calls).toEqual([]);
   });
 
-  test("Ctrl+Shift+J fires next-needs-you", () => {
+  test("Ctrl+Shift+J and ⌘⇧J do NOT fire next-needs-you (DevTools/downloads chords revert to the browser)", () => {
     setup();
     window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true, shiftKey: true }));
-    expect(calls).toEqual([ACTIONS.nextNeedsYou]);
+    window.dispatchEvent(keydown({ key: "j", code: "KeyJ", metaKey: true, shiftKey: true }));
+    expect(calls).toEqual([]);
   });
 
   test("Shift+Escape closes settings while the settings scope is pushed (legacy had no modifier guard)", () => {
@@ -271,12 +304,14 @@ describe("default bindings through the dispatcher", () => {
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true }));
     window.dispatchEvent(keydown({ key: "j", code: "KeyJ", metaKey: true }));
     window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true }));
+    window.dispatchEvent(keydown({ key: ",", code: "Comma", metaKey: true }));
     expect(calls).toEqual([
       ACTIONS.paletteOpen,
       ACTIONS.railToggle,
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.settingsOpen,
     ]);
   });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -51,6 +51,14 @@ import { type KeySequence, parseChord, serializeChord, withOptionalModifier } fr
 import { type Binding, type BindingInput, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
 export const SETTINGS_SCOPE = "settings";
+export const CHEATSHEET_SCOPE = "cheatsheet";
+
+/** The default-map id of the "?" character-key trigger for the cheatsheet
+ * overlay. It is the one CONDITIONAL entry in the map: registered only while
+ * the characterKeyTriggers pref (stores/prefs.ts) is on - the WCAG 2.1.4
+ * character-key turn-off. shell/cheatsheet/cheatsheetController.ts's
+ * reconcile owns that invariant; this module only names the entry. */
+export const CHARACTER_KEY_TRIGGER_BINDING_ID = "cheatsheet.toggle#question";
 
 /** A default-map entry: a BindingInput plus the module-internal
  * legacyEitherMod marker (stripped before registerBinding - see modPair). */
@@ -210,6 +218,53 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     scope: SETTINGS_SCOPE,
     allowInEditable: true,
   },
+  // Phase 4a (the p4 plan's Design decision 3): the cheatsheet overlay's
+  // triggers. $mod+/ is the primary (Slack precedent): not a printable
+  // character, so it fires from editable targets, and allowInModal so the
+  // same chord toggles the overlay CLOSED while it is open (the dialog's
+  // aria-modal would otherwise suppress it). Strict chord, NO
+  // legacyEitherMod - a new binding with no legacy listener to match.
+  {
+    id: ACTIONS.cheatsheetToggle,
+    actionId: ACTIONS.cheatsheetToggle,
+    title: "Show the keyboard shortcuts overlay",
+    chord: "$mod+/",
+    allowInEditable: true,
+    allowInModal: true,
+  },
+  // "?" is the secondary trigger (Design decision 3). It IS a printable
+  // character, so it never fires from an editable target (allowInEditable
+  // stays false) or over a modal. The chord lists Shift as OPTIONAL because
+  // tinykeys rejects an event carrying any modifier the binding does not
+  // name, and every common layout types "?" WITH Shift held - a bare "?"
+  // binding would never fire. Display drops optional modifiers
+  // (chordDisplayKeys), so the row still reads "?". The entry is
+  // CONDITIONAL: shell/cheatsheet/cheatsheetController.ts keeps it
+  // registered only while the characterKeyTriggers pref is on.
+  // Listed SECOND for the action so defaultInputFor (overrides.ts) keeps
+  // the $mod+/ entry's policy flags for overrides.
+  {
+    id: CHARACTER_KEY_TRIGGER_BINDING_ID,
+    actionId: ACTIONS.cheatsheetToggle,
+    title: "Show the keyboard shortcuts overlay",
+    chord: "[Shift]+?",
+    allowInEditable: false,
+  },
+  // The overlay's own Escape, scope-gated exactly like settings.close: the
+  // CheatsheetOverlay component pushes CHEATSHEET_SCOPE while it is open.
+  // In practice the OverlayPanel's own Escape handler claims the key first
+  // (it preventDefaults, which this binding's default
+  // ignoreIfDefaultPrevented gate then honors); this binding is the
+  // window-level backstop for a keydown whose target sits outside the
+  // dialog, and makes the close chord remappable like every other.
+  {
+    id: ACTIONS.cheatsheetClose,
+    actionId: ACTIONS.cheatsheetClose,
+    title: "Close the keyboard shortcuts overlay",
+    chord: "[Control]+[Alt]+[Shift]+[Meta]+Escape",
+    scope: CHEATSHEET_SCOPE,
+    allowInEditable: true,
+  },
 ];
 
 // tinykeys resolves "$mod" to Meta on Apple platforms and Control everywhere
@@ -285,6 +340,7 @@ export function registerDefaultBindingsForAction(registry: KeybindingsRegistry, 
 }
 
 export interface DefaultBindingShape {
+  id: string;
   scope: string;
   sequence: KeySequence;
 }
@@ -301,6 +357,7 @@ export function defaultBindingShapesForAction(actionId: string): DefaultBindingS
     const pair = modPair(input);
     for (const entry of pair ?? [input]) {
       shapes.push({
+        id: entry.id,
         scope: entry.scope ?? GLOBAL_SCOPE,
         sequence: typeof entry.chord === "string" ? parseChord(entry.chord) : entry.chord,
       });
@@ -310,6 +367,7 @@ export function defaultBindingShapesForAction(actionId: string): DefaultBindingS
 }
 
 export interface DefaultChordInfo {
+  id: string;
   scope: string;
   serialized: string;
 }
@@ -319,6 +377,7 @@ export interface DefaultChordInfo {
  * customized-marker comparison. */
 export function defaultBindingChordsForAction(actionId: string): DefaultChordInfo[] {
   return defaultBindingShapesForAction(actionId).map((shape) => ({
+    id: shape.id,
     scope: shape.scope,
     serialized: serializeChord(shape.sequence),
   }));

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -1,8 +1,10 @@
 // The default binding map: the six legacy shell chords that lived in six
 // independent keydown listeners (AppShell, RailHost, SelectionQuote,
 // Settings), plus the Phase 3 navigation chords (session-pane cycling and
-// transcript scroll). For the legacy six, per-binding policy per chord
-// matches the pre-dispatcher behavior:
+// transcript scroll) and the Phase 4a additions (settings.open and
+// transcript.scrollTop/scrollBottom - the p4 plan's Design decision 2). For
+// the legacy six, per-binding policy per chord matches the pre-dispatcher
+// behavior:
 //
 //   - ⌘K / ⌘I / ⌘J / ⌘' fire from editable targets (allowInEditable: true):
 //     none of today's listeners for these chords guards on the target.
@@ -21,19 +23,19 @@
 //     handler, which the dispatcher's per-binding defaultPrevented gate
 //     reproduces.
 //
-// Extra-modifier semantics are equally legacy-faithful (tinykeys matches
-// strictly, so each chord lists as OPTIONAL exactly the modifiers the legacy
-// listener ignored):
+// Extra-modifier semantics (tinykeys matches strictly, so each chord lists as
+// OPTIONAL exactly the modifiers it should tolerate):
 //
-//   - ⌘K / ⌘I / ⌘J: the legacy AppShell listener checked only
-//     metaKey||ctrlKey + key - NO shift/alt guard - so ⌘⇧K, ⌘⌥I,
-//     Ctrl+Shift+J etc. all fired, on either OR BOTH of Meta/Ctrl. Chords
-//     are $mod+[Shift]+[Alt]+… plus legacyEitherMod (the other of
-//     Meta/Ctrl also optional on the entry and its twin). RATIONALE: this
-//     permissiveness means these chords keep hijacking the browser's
-//     DevTools shortcuts (⌘⌥I, Ctrl+Shift+J) exactly like the legacy
-//     listeners did - deliberately revisiting THAT is Phase 3 policy, not
-//     this PR.
+//   - ⌘K / ⌘I / ⌘J: STRICT single-press chords since Phase 4a. The 2a map
+//     kept the legacy AppShell listener's missing shift/alt guard as
+//     OPTIONAL Shift/Alt - so ⌘⌥I fired composer.focus and Ctrl+Shift+J
+//     fired next-needs-you, hijacking the browser's DevTools chords.
+//     docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md
+//     (Design decision 1) is the authority for dropping that optionality;
+//     ⌘⌥I, Ctrl+Shift+J and ⌘⇧J now revert to the browser. legacyEitherMod
+//     STAYS (the other of Meta/Ctrl optional on the entry and its twin):
+//     every legacy listener accepted metaKey||ctrlKey on every platform,
+//     and no browser-reserved chord collides with Meta+Ctrl.
 //   - ⌘': extra Shift allowed ([Shift] - the legacy listener had no shift
 //     guard), extra Alt NOT (the legacy !event.altKey AltGr guard).
 //   - ⌘B: strict - the legacy listener guarded !event.altKey &&
@@ -73,7 +75,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     id: ACTIONS.paletteOpen,
     actionId: ACTIONS.paletteOpen,
     title: "Open the command palette",
-    chord: "$mod+[Shift]+[Alt]+K",
+    chord: "$mod+K",
     allowInEditable: true,
     allowInModal: true,
     legacyEitherMod: true,
@@ -95,7 +97,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     id: ACTIONS.composerFocus,
     actionId: ACTIONS.composerFocus,
     title: "Focus the composer",
-    chord: "$mod+[Shift]+[Alt]+I",
+    chord: "$mod+I",
     allowInEditable: true,
     legacyEitherMod: true,
   },
@@ -103,7 +105,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     id: ACTIONS.nextNeedsYou,
     actionId: ACTIONS.nextNeedsYou,
     title: "Go to the next session needing you",
-    chord: "$mod+[Shift]+[Alt]+J",
+    chord: "$mod+J",
     allowInEditable: true,
     legacyEitherMod: true,
   },
@@ -118,6 +120,19 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     allowInEditable: true,
     allowInModal: true,
     legacyEitherMod: true,
+  },
+  // Phase 4a (the p4 plan's Design decision 2): settings.open's action id IS
+  // the palette's "settings" command id, whose run owns the behavior
+  // (shell/palette/commands.ts; AppShell registers the action against the
+  // registry). Strict $mod chord - NO legacyEitherMod, only the plain
+  // cross-platform modPair twin. allowInEditable: ⌘, never collides with
+  // typing; the default modal suppression stays.
+  {
+    id: ACTIONS.settingsOpen,
+    actionId: ACTIONS.settingsOpen,
+    title: "Open settings",
+    chord: "$mod+,",
+    allowInEditable: true,
   },
   // Phase 3 navigation chords (the webui-keybindings-p3 approved map). All
   // six are strict single-modifier-family Alt chords with NO optional
@@ -168,6 +183,24 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     actionId: ACTIONS.transcriptPageDown,
     title: "Scroll the transcript down one page",
     chord: "Alt+Shift+ArrowDown",
+  },
+  // Phase 4a completes the Alt-scroll family (Alt = transcript, Shift =
+  // bigger step, Home/End = the ends) with the SAME plain policy as the
+  // Alt-arrow entries above: suppressed in editable targets so Home/End keep
+  // their native caret meaning there. The per-pane handlers were registered
+  // in Phase 3 (panes/session/transcript/flow/useTranscriptScrollKeys.ts);
+  // these entries only assign the chords.
+  {
+    id: ACTIONS.transcriptScrollTop,
+    actionId: ACTIONS.transcriptScrollTop,
+    title: "Scroll the transcript to the top",
+    chord: "Alt+Home",
+  },
+  {
+    id: ACTIONS.transcriptScrollBottom,
+    actionId: ACTIONS.transcriptScrollBottom,
+    title: "Scroll the transcript to the bottom",
+    chord: "Alt+End",
   },
   {
     id: ACTIONS.settingsClose,

--- a/cmd/evener-hub/frontend/src/keybindings/display.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/display.ts
@@ -1,0 +1,76 @@
+// Display sourcing for the two binding-list UIs (the Settings keybindings
+// section and the cheatsheet overlay): WHICH actions to list, in what order,
+// and which of an action's registered bindings is the one to show. Both
+// consumers read this module so the list can never drift into two
+// hand-maintained copies - the survey's stale-HELP_ROWS lesson, named as a
+// binding constraint in docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md.
+//
+// Deliberately React-free and store-free like the rest of src/keybindings/:
+// the registry's bindings array and the characterKeyTriggers pref value are
+// passed in by the caller.
+
+import { serializeChord } from "./chord";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS, defaultBindingChordsForAction } from "./defaults";
+import type { Binding } from "./registry";
+
+export interface ActionDisplayRow {
+  actionId: string;
+  title: string;
+}
+
+/** One row per action, in default-map order. Module-level because it derives
+ * entirely from the compiled-in default map; the effective chord each row
+ * shows is read from the live registry at render. */
+export const ACTION_DISPLAY_ROWS: readonly ActionDisplayRow[] = (() => {
+  const seen = new Set<string>();
+  const rows: ActionDisplayRow[] = [];
+  for (const input of DEFAULT_BINDINGS) {
+    if (seen.has(input.actionId)) continue;
+    seen.add(input.actionId);
+    rows.push({ actionId: input.actionId, title: input.title });
+  }
+  return rows;
+})();
+
+/** The bindings to display for an action, as the effective chord list: the
+ * override alone when one is applied (it replaces the action's whole chord
+ * set), else every non-twin default entry - the platform base entry plus any
+ * extra default chords of the same action (cheatsheet.toggle's "?" alongside
+ * "$mod+/"). The `#mod-twin` entries are the same chord's cross-platform
+ * spelling, never shown. Empty when the action is unbound. */
+export function displayBindingsFor(bindings: readonly Binding[], actionId: string): Binding[] {
+  const owned = bindings.filter((b) => b.actionId === actionId);
+  const override = owned.find((b) => b.id === `${actionId}#override`);
+  if (override !== undefined) return [override];
+  const nonTwin = owned.filter((b) => !b.id.endsWith("#mod-twin"));
+  return nonTwin.length > 0 ? nonTwin : owned;
+}
+
+/** The single-binding form of displayBindingsFor (the Settings section shows
+ * one chord per row): the override when present, else the platform base
+ * entry, else whatever binding the action has left. */
+export function displayBindingFor(bindings: readonly Binding[], actionId: string): Binding | undefined {
+  return displayBindingsFor(bindings, actionId)[0];
+}
+
+/** Whether the action's effective bindings differ from its default map
+ * entries - including the unbound (override `chord: null`) case, where the
+ * effective set is empty. The comparison is pref-aware about the ONE
+ * conditional default entry: the "?" character-key trigger is part of the
+ * default map only while characterKeyTriggers is on, so turning the pref off
+ * (which unregisters that binding) is not itself a customization. */
+export function isActionCustomized(
+  bindings: readonly Binding[],
+  actionId: string,
+  characterKeyTriggers: boolean,
+): boolean {
+  const effective = bindings
+    .filter((b) => b.actionId === actionId)
+    .map((b) => `${b.scope} ${serializeChord(b.chord)}`)
+    .sort();
+  const defaults = defaultBindingChordsForAction(actionId)
+    .filter((info) => characterKeyTriggers || info.id !== CHARACTER_KEY_TRIGGER_BINDING_ID)
+    .map((info) => `${info.scope} ${info.serialized}`)
+    .sort();
+  return effective.length !== defaults.length || effective.some((entry, i) => entry !== defaults[i]);
+}

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
@@ -151,8 +151,8 @@ describe("restoreDefaultBinding", () => {
 
 describe("rebindAction overlap conflicts", () => {
   test("throws when the chord only overlaps another action's OPTIONAL modifiers, atomically", () => {
-    // Control+K matches palette.open's Control+[Meta]+[Shift]+[Alt]+K at
-    // dispatch time; the earlier-registered default would shadow the override.
+    // Control+K matches palette.open's Control+[Meta]+K at dispatch time;
+    // the earlier-registered default would shadow the override.
     const registry = withDefaults();
     const before = registry.getState().bindings;
     expect(() => rebindAction(registry, ACTIONS.composerFocus, "Control+K")).toThrow(/conflict/);

--- a/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
@@ -256,9 +256,9 @@ describe("validateOverrideRules dropped-override restorations", () => {
 
 describe("validateOverrideRules overlap conflicts", () => {
   test("flags an override whose exact chord overlaps a default's OPTIONAL modifiers (dispatch would shadow it)", () => {
-    // palette.open's default is Control+[Meta]+[Shift]+[Alt]+K: a plain
-    // Control+K matches it at dispatch time, and the earlier-registered
-    // default would win - so this is a conflict, not a valid remap.
+    // palette.open's default is Control+[Meta]+K: a plain Control+K matches
+    // it at dispatch time, and the earlier-registered default would win -
+    // so this is a conflict, not a valid remap.
     const registry = withDefaults();
     const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: "Control+K" }], registry);
     expect(result.rules).toHaveLength(0);

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -1217,7 +1217,9 @@ export function Composer({ ref }: ComposerProps) {
         </ConfirmDialog>
       )}
       {(!ended || showFollowUpCard) && (
-        <div className={CLASS.formAnchor}>
+        // data-composer is the hold-hints overlay's anchor (shell/holdhints):
+        // the composer.focus chip positions itself above this wrapper.
+        <div className={CLASS.formAnchor} data-composer="">
           {/* Anchored above the control row inside the card below, opening
               upward the same way GoalControl's own popover does - see
               slashcompletionmenu.module.css's header comment. Mounted only

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.test.tsx
@@ -146,34 +146,37 @@ test("unmounting a pane unregisters only that pane's handlers", () => {
   expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
 });
 
-test("transcript.scrollTop/scrollBottom ship with NO default chord (Phase 4's map decides)", () => {
-  expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollTop)).toBe(false);
-  expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollBottom)).toBe(false);
+// Phase 4a assigned the default chords (the p4 plan's Design decision 2):
+// Alt+Home/Alt+End complete the Alt-arrow scroll family, same plain policy.
+test("transcript.scrollTop/scrollBottom default to Alt+Home/Alt+End", () => {
+  expect(DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.transcriptScrollTop)?.chord).toBe("Alt+Home");
+  expect(DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.transcriptScrollBottom)?.chord).toBe("Alt+End");
 });
 
-test("scrollTop/scrollBottom drive the focused pane's virtualizer (bound to test chords here)", () => {
+test("Alt+Home/Alt+End drive the focused pane's virtualizer (the real default chords)", () => {
   const a = renderPaneKeys("pane_a");
   const b = renderPaneKeys("pane_b");
   workspaceStore.setState({ focusedPaneId: "pane_a" });
-  const registry = keybindingsRegistry.getState();
-  registry.registerBinding({ id: "test.transcript.scrollTop", actionId: ACTIONS.transcriptScrollTop, chord: "F8" });
-  registry.registerBinding({
-    id: "test.transcript.scrollBottom",
-    actionId: ACTIONS.transcriptScrollBottom,
-    chord: "F9",
-  });
-  try {
-    window.dispatchEvent(keydown({ key: "F8", code: "F8" }));
-    expect(a.scrollToIndex).toHaveBeenCalledWith(0, { align: "start" });
-    expect(b.scrollToIndex).not.toHaveBeenCalled();
 
-    window.dispatchEvent(keydown({ key: "F9", code: "F9" }));
-    expect(a.jumpToBottom).toHaveBeenCalledOnce();
-    expect(b.jumpToBottom).not.toHaveBeenCalled();
-  } finally {
-    registry.unregisterBinding("test.transcript.scrollTop");
-    registry.unregisterBinding("test.transcript.scrollBottom");
-  }
+  window.dispatchEvent(keydown({ key: "Home", code: "Home", altKey: true }));
+  expect(a.scrollToIndex).toHaveBeenCalledWith(0, { align: "start" });
+  expect(b.scrollToIndex).not.toHaveBeenCalled();
+
+  window.dispatchEvent(keydown({ key: "End", code: "End", altKey: true }));
+  expect(a.jumpToBottom).toHaveBeenCalledOnce();
+  expect(b.jumpToBottom).not.toHaveBeenCalled();
+});
+
+test("Alt+Home/Alt+End are suppressed from editable targets (Home/End keep their caret meaning)", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+
+  input.dispatchEvent(keydown({ key: "Home", code: "Home", altKey: true }));
+  input.dispatchEvent(keydown({ key: "End", code: "End", altKey: true }));
+  expect(a.scrollToIndex).not.toHaveBeenCalled();
+  expect(a.jumpToBottom).not.toHaveBeenCalled();
 });
 
 // jsdom has no matchMedia at all (useIsMobile.test.ts's header documents the

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
@@ -12,6 +12,19 @@
   line-height: var(--line-height-body);
 }
 
+.toggle {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.help {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
 .status {
   margin: 0;
   color: var(--ink-mid);

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -61,12 +61,15 @@ test("lists every default action with its title and effective chord, none custom
     expect.stringContaining("Focus the composer"),
     expect.stringContaining("Go to the next session needing you"),
     expect.stringContaining("Quote the selection into the composer"),
+    expect.stringContaining("Open settings"),
     expect.stringContaining("Focus the next session pane"),
     expect.stringContaining("Focus the previous session pane"),
     expect.stringContaining("Scroll the transcript up one line"),
     expect.stringContaining("Scroll the transcript down one line"),
     expect.stringContaining("Scroll the transcript up one page"),
     expect.stringContaining("Scroll the transcript down one page"),
+    expect.stringContaining("Scroll the transcript to the top"),
+    expect.stringContaining("Scroll the transcript to the bottom"),
     expect.stringContaining("Close settings"),
   ]);
   expect(screen.queryByText("Customized")).toBeNull();

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
-import { afterEach, beforeEach, expect, test } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, beforeEach, expect, test } from "vitest";
 import { ACTIONS } from "../../../keybindings/actions";
 import { DEFAULT_BINDINGS, registerDefaultBindings } from "../../../keybindings/defaults";
 import { keybindingsRegistry } from "../../../keybindings/registry";
@@ -7,7 +8,33 @@ import { FakeClient } from "../../../protocol/testing/fakeClient";
 import type { KeybindingsOverrides, KeybindingsRule } from "../../../protocol/types.gen";
 import { connectionStore } from "../../../stores/connection";
 import { keybindingsStore, resetKeybindingsStoreForTests } from "../../../stores/keybindings";
+import { prefsStore, resetPrefsStoreForTests } from "../../../stores/prefs";
 import { KeybindingsSection } from "./keybindings";
+
+// Node 26 shadows jsdom's real window.localStorage with its own
+// (non-functional under vitest) global, so every test file that touches
+// localStorage (the prefs store does) needs this same small in-memory
+// stand-in - see stores/prefs.test.ts's own comment.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeAll(() => {
+  // @ts-expect-error see MemoryStorage's own comment for why this is needed
+  globalThis.localStorage = new MemoryStorage();
+});
 
 function resetRegistryToDefaults(): void {
   for (const binding of keybindingsRegistry.getState().bindings) {
@@ -32,6 +59,8 @@ beforeEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
   resetKeybindingsStoreForTests();
   resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
 });
 
 afterEach(() => {
@@ -39,6 +68,8 @@ afterEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
   resetKeybindingsStoreForTests();
   resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
 });
 
 function rowFor(title: string): HTMLElement {
@@ -52,9 +83,10 @@ test("lists every default action with its title and effective chord, none custom
   render(<KeybindingsSection />);
 
   // The row list is sourced live from the keybindings module's default map,
-  // never a hand-maintained copy: one row per action, in default-map order.
+  // never a hand-maintained copy: one row per ACTION (the cheatsheet's two
+  // trigger entries share one action id), in default-map order.
   const rows = screen.getAllByRole("listitem");
-  expect(rows).toHaveLength(DEFAULT_BINDINGS.length);
+  expect(rows).toHaveLength(new Set(DEFAULT_BINDINGS.map((b) => b.actionId)).size);
   expect(rows.map((row) => row.textContent)).toEqual([
     expect.stringContaining("Open the command palette"),
     expect.stringContaining("Toggle the sidebar"),
@@ -71,6 +103,8 @@ test("lists every default action with its title and effective chord, none custom
     expect.stringContaining("Scroll the transcript to the top"),
     expect.stringContaining("Scroll the transcript to the bottom"),
     expect.stringContaining("Close settings"),
+    expect.stringContaining("Show the keyboard shortcuts overlay"),
+    expect.stringContaining("Close the keyboard shortcuts overlay"),
   ]);
   expect(screen.queryByText("Customized")).toBeNull();
 
@@ -83,6 +117,31 @@ test("lists every default action with its title and effective chord, none custom
   // the Escape key renders.
   const settingsRow = rowFor("Close settings");
   expect(within(settingsRow).getByText("Escape")).toBeTruthy();
+});
+
+test("the cheatsheet row shows the platform $mod chord (its ? trigger is a second entry of the same action)", () => {
+  render(<KeybindingsSection />);
+  const row = rowFor("Show the keyboard shortcuts overlay");
+  // jsdom resolves $mod to Control; the section's single-chord display shows
+  // the base entry (keybindings/display.ts's displayBindingFor).
+  expect(within(row).getByText("Ctrl")).toBeTruthy();
+  expect(within(row).getByText("/")).toBeTruthy();
+});
+
+test("the character-key toggle persists through the prefs store", async () => {
+  render(<KeybindingsSection />);
+  const toggle = screen.getByRole("switch", { name: "Character-key shortcuts" });
+  // Default ON (the WCAG 2.1.4 turn-off exists, per the p4 plan's Design
+  // decision 3).
+  expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+  await userEvent.setup().click(toggle);
+  expect(prefsStore.getState().characterKeyTriggers).toBe(false);
+  expect(localStorage.getItem("evener.prefs.characterKeyTriggers")).toBe("0");
+
+  // A fresh hydration (what the next page load does) reads it back.
+  resetPrefsStoreForTests();
+  expect(prefsStore.getState().characterKeyTriggers).toBe(false);
 });
 
 test("with no hub connection the section waits quietly and still shows the defaults", () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -1,23 +1,27 @@
-// Settings -> Keybindings: a READ-ONLY listing of the effective bindings.
-// The action list is sourced live from the keybindings module's default map
-// (DEFAULT_BINDINGS is also the validator's action universe), never a
-// hand-maintained copy - the survey's stale-HELP_ROWS lesson. The chords come
-// from the live registry, so hub overrides applied by the keybindings store
-// show up the moment they reconcile. Editing affordances are deliberately
-// absent; the shortcuts editor is a later phase.
+// Settings -> Keybindings: a READ-ONLY listing of the effective bindings,
+// plus the character-key-triggers toggle. The action list and the per-action
+// display binding are sourced from keybindings/display.ts - the same module
+// the cheatsheet overlay reads - never a hand-maintained copy (the survey's
+// stale-HELP_ROWS lesson). The chords come from the live registry, so hub
+// overrides applied by the keybindings store show up the moment they
+// reconcile. Editing affordances are deliberately absent; the shortcuts
+// editor is a later phase (4b).
 
 import { useStore } from "zustand";
 import { chordDisplayKeys, serializeChord } from "../../../keybindings/chord";
-import { DEFAULT_BINDINGS, defaultBindingChordsForAction } from "../../../keybindings/defaults";
-import { type Binding, keybindingsRegistry } from "../../../keybindings/registry";
+import { ACTION_DISPLAY_ROWS, displayBindingFor, isActionCustomized } from "../../../keybindings/display";
+import { keybindingsRegistry } from "../../../keybindings/registry";
 import { useKeybindingsStore } from "../../../stores/keybindings";
-import { KeyHint } from "../../../widgets";
+import { prefsStore, usePrefsStore } from "../../../stores/prefs";
+import { KeyHint, Switch } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import styles from "./keybindings.module.css";
 
 const CLASS = {
   root: requireClass(styles.root, "keybindings.module.css", "root"),
   intro: requireClass(styles.intro, "keybindings.module.css", "intro"),
+  toggle: requireClass(styles.toggle, "keybindings.module.css", "toggle"),
+  help: requireClass(styles.help, "keybindings.module.css", "help"),
   status: requireClass(styles.status, "keybindings.module.css", "status"),
   warningList: requireClass(styles.warningList, "keybindings.module.css", "warningList"),
   error: requireClass(styles.error, "keybindings.module.css", "error"),
@@ -29,52 +33,12 @@ const CLASS = {
   chord: requireClass(styles.chord, "keybindings.module.css", "chord"),
 };
 
-interface ActionRow {
-  actionId: string;
-  title: string;
-}
-
-// One row per action, in default-map order. Module-level because it derives
-// entirely from the compiled-in default map; the effective chord each row
-// shows is read from the live registry at render.
-const ACTION_ROWS: readonly ActionRow[] = (() => {
-  const seen = new Set<string>();
-  const rows: ActionRow[] = [];
-  for (const input of DEFAULT_BINDINGS) {
-    if (seen.has(input.actionId)) continue;
-    seen.add(input.actionId);
-    rows.push({ actionId: input.actionId, title: input.title });
-  }
-  return rows;
-})();
-
-/** The binding to display for an action: the override when present, else the
- * platform base entry (its `#mod-twin` shows the same chord on this
- * platform), else whatever binding the action has left. */
-function displayBindingFor(bindings: readonly Binding[], actionId: string): Binding | undefined {
-  const owned = bindings.filter((b) => b.actionId === actionId);
-  return owned.find((b) => b.id === `${actionId}#override`) ?? owned.find((b) => b.id === actionId) ?? owned[0];
-}
-
-/** Whether the action's effective bindings differ from its default map
- * entries - including the unbound (override `chord: null`) case, where the
- * effective set is empty. */
-function isCustomized(bindings: readonly Binding[], actionId: string): boolean {
-  const effective = bindings
-    .filter((b) => b.actionId === actionId)
-    .map((b) => `${b.scope} ${serializeChord(b.chord)}`)
-    .sort();
-  const defaults = defaultBindingChordsForAction(actionId)
-    .map((d) => `${d.scope} ${d.serialized}`)
-    .sort();
-  return effective.length !== defaults.length || effective.some((entry, i) => entry !== defaults[i]);
-}
-
 export function KeybindingsSection() {
   const hubSupport = useKeybindingsStore((s) => s.hubSupport);
   const hubError = useKeybindingsStore((s) => s.hubError);
   const warnings = useKeybindingsStore((s) => s.warnings);
   const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
+  const characterKeyTriggers = usePrefsStore((s) => s.characterKeyTriggers);
 
   let status: string | undefined;
   if (hubSupport === "unknown") {
@@ -88,6 +52,22 @@ export function KeybindingsSection() {
       <p className={CLASS.intro}>
         The keyboard shortcuts currently in effect. Bindings marked Customized come from this hub's synced overrides.
       </p>
+
+      {/* The WCAG 2.1.4 character-key turn-off (the p4 plan's Design
+          decision 3): off unregisters the "?" cheatsheet trigger, leaving
+          every shortcut on a modifier chord. Browser-local (prefs store),
+          by controller ruling. */}
+      <div className={CLASS.toggle}>
+        <Switch
+          label="Character-key shortcuts"
+          checked={characterKeyTriggers}
+          onChange={(value) => prefsStore.getState().setCharacterKeyTriggers(value)}
+        />
+        <p className={CLASS.help}>
+          When on, pressing ? outside a text field opens the keyboard shortcuts overlay. Turn off to keep every shortcut
+          on a modifier chord.
+        </p>
+      </div>
 
       {status !== undefined && (
         <p className={CLASS.status} role="status">
@@ -111,13 +91,15 @@ export function KeybindingsSection() {
       )}
 
       <ul className={CLASS.list}>
-        {ACTION_ROWS.map((row) => {
+        {ACTION_DISPLAY_ROWS.map((row) => {
           const binding = displayBindingFor(bindings, row.actionId);
           return (
             <li className={CLASS.row} key={row.actionId}>
               <span className={CLASS.label}>
                 {row.title}
-                {isCustomized(bindings, row.actionId) && <span className={CLASS.marker}>Customized</span>}
+                {isActionCustomized(bindings, row.actionId, characterKeyTriggers) && (
+                  <span className={CLASS.marker}>Customized</span>
+                )}
               </span>
               {binding === undefined ? (
                 <span className={CLASS.unbound}>Unbound</span>

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -32,7 +32,7 @@ import { CommandPalette } from "./palette/CommandPalette";
 import { openPalette, paletteStore } from "./palette/paletteController";
 import { RailHost } from "./rail";
 import { needsYouRefs, nextNeedsYouRef, openNeedsYouSession } from "./rail/needsYouCycle";
-import { urlToPane } from "./routing";
+import { navigate, urlToPane } from "./routing";
 import { cycleSessionPane } from "./sessionCycle";
 import { openNestedSessionWithOwner, openTopLevelSession } from "./sessionPlacement";
 import { isSinglePaneRoute } from "./singlePane";
@@ -483,6 +483,13 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
   // cycling no-ops (fewer than two session panes): Alt+ArrowLeft is the
   // browser's Back shortcut, and declining would navigate the SPA's history
   // underneath a user who has one session open.
+  //
+  // ⌘, (settings.open, Phase 4a) joins this desktop-only group per the p4
+  // plan's mobile-inert constraint. Its behavior IS the palette "settings"
+  // command's - the action id reuses that command's id (keybindings/
+  // actions.ts), and navigate("/settings") is exactly its run body
+  // (shell/palette/commands.ts); same shared-seam precedent as
+  // next-needs-you above.
   useEffect(() => {
     if (isMobile) return undefined;
     installKeybindings();
@@ -490,6 +497,7 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
     const unregister = [
       registry.registerAction(ACTIONS.sessionNext, () => cycleSessionPane("next")),
       registry.registerAction(ACTIONS.sessionPrevious, () => cycleSessionPane("previous")),
+      registry.registerAction(ACTIONS.settingsOpen, () => navigate("/settings")),
     ];
     return () => {
       for (const dispose of unregister) dispose();

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -22,6 +22,7 @@ import { navigationStore, useNavigationStore } from "../stores/navigation/store"
 import { isNavigationUnavailable, keyID } from "../stores/navigation/types";
 import { initTranscriptDisplay } from "../stores/transcriptDisplay";
 import { ConnectionBanner } from "./ConnectionBanner";
+import { CheatsheetOverlay } from "./cheatsheet/CheatsheetOverlay";
 import { ToastRegion } from "./chrome/ToastRegion";
 import { ClientProvider } from "./clientContext";
 import { DockRegion } from "./DockRegion";
@@ -654,6 +655,11 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
         <ConnectionBanner state={connectionState} delayMs={bannerDelayMs} />
         <ToastRegion />
         <CommandPalette />
+        {/* The cheatsheet overlay (Phase 4a): desktop-only, so on a touch
+            viewport no cheatsheet action is ever registered and its trigger
+            chords stay inert - RailHost's rail.toggle no-registration
+            pattern. */}
+        {!isMobile && <CheatsheetOverlay />}
         <div className={styles.content}>
           {/* Desktop: the rail sits as a flex sibling of DockHost and
               collapses itself. Mobile (<900px): StackHost owns the whole

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -26,6 +26,7 @@ import { CheatsheetOverlay } from "./cheatsheet/CheatsheetOverlay";
 import { ToastRegion } from "./chrome/ToastRegion";
 import { ClientProvider } from "./clientContext";
 import { DockRegion } from "./DockRegion";
+import { HoldHints } from "./holdhints/HoldHints";
 import { installKeybindings } from "./installKeybindings";
 import { StackHost } from "./mobile/StackHost";
 import { NotFound } from "./NotFound";
@@ -655,11 +656,13 @@ export function AppShell({ client: injectedClient, bannerDelayMs }: AppShellProp
         <ConnectionBanner state={connectionState} delayMs={bannerDelayMs} />
         <ToastRegion />
         <CommandPalette />
-        {/* The cheatsheet overlay (Phase 4a): desktop-only, so on a touch
-            viewport no cheatsheet action is ever registered and its trigger
-            chords stay inert - RailHost's rail.toggle no-registration
-            pattern. */}
+        {/* The cheatsheet overlay and the hold-modifier hints (Phase 4a):
+            desktop-only, so on a touch viewport no cheatsheet action is ever
+            registered and its trigger chords stay inert - RailHost's
+            rail.toggle no-registration pattern - and no hold-hint listener
+            is ever installed. */}
         {!isMobile && <CheatsheetOverlay />}
+        {!isMobile && <HoldHints />}
         <div className={styles.content}>
           {/* Desktop: the rail sits as a flex sibling of DockHost and
               collapses itself. Mobile (<900px): StackHost owns the whole

--- a/cmd/evener-hub/frontend/src/shell/PaneTab.tsx
+++ b/cmd/evener-hub/frontend/src/shell/PaneTab.tsx
@@ -45,7 +45,9 @@ export function PaneTab(props: IDockviewPanelHeaderProps<PanePanelParams>) {
   const statusType = useThreadsStore((s) => (ref === undefined ? undefined : s.threads.get(ref)?.status.type));
   const state = statusType === undefined ? undefined : cadenceStateForStatus(statusType);
   return (
-    <span className={styles.tab}>
+    // data-session-tab is the hold-hints overlay's anchor (shell/holdhints):
+    // the session-cycling chip positions itself over the first session tab.
+    <span className={styles.tab} data-session-tab={ref !== undefined ? "" : undefined}>
       <DockviewDefaultTab {...props} />
       {state !== undefined && DOT_STATES.has(state) && (
         <span className={styles.dot}>

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.test.tsx
@@ -1,0 +1,292 @@
+// Tests for the cheatsheet overlay (Phase 4a, the p4 plan's Design
+// decision 3): trigger chords (⌘/ primary, "?" secondary and
+// pref-conditional), editable-target policy, Escape/⌘/ toggle-close,
+// registry-sourced rows (an applied override shows its own chord), the
+// prefs-persisted character-key toggle, and mobile inertness (AppShell
+// mounts the overlay only off mobile, so no action registers and the chords
+// stay inert - the rail.toggle no-registration pattern).
+//
+// The AppShell render/warm-up/store-reset scaffolding below mirrors
+// shell/keybindingsMigration.test.tsx's own (helpers duplicated, not
+// shared - this project has no cross-test-file test-utils module; see that
+// file's and AppShell.test.tsx's notes on the convention).
+
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { ACTIONS } from "../../keybindings/actions";
+import {
+  CHARACTER_KEY_TRIGGER_BINDING_ID,
+  CHEATSHEET_SCOPE,
+  DEFAULT_BINDINGS,
+  registerDefaultBindings,
+} from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { initNotifications, resetNotificationsForTests } from "../../notifications";
+import { FakeClient } from "../../protocol/testing/fakeClient";
+import type { KeybindingsOverrides, KeybindingsRule } from "../../protocol/types.gen";
+import { connectionStore } from "../../stores/connection";
+import { keybindingsStore, resetKeybindingsStoreForTests } from "../../stores/keybindings";
+import { resetNavigationStoreForTests } from "../../stores/navigation/store";
+import { prefsStore, resetPrefsStoreForTests } from "../../stores/prefs";
+import { AppShell } from "../AppShell";
+import { paletteStore } from "../palette/paletteController";
+import { resetMobileViewportForTests } from "../useIsMobile";
+import { resetWorkspaceStoreForTests } from "../workspace";
+import { CheatsheetOverlay } from "./CheatsheetOverlay";
+import { cheatsheetStore, closeCheatsheet, openCheatsheet } from "./cheatsheetController";
+
+// See AppShell.test.tsx for why both stubs are needed (jsdom has no
+// ResizeObserver; Node 26 shadows jsdom's localStorage accessor).
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+// jsdom implements no matchMedia at all (useIsMobile.test.ts documents the
+// probe), so the mobile test installs one: the mobile query matches, every
+// other query does not - AppShell.test.tsx's installMobileViewport, verbatim.
+function installMobileViewport(): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      media,
+      matches: media === "(max-width: 899px)",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })),
+  );
+}
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+function overridesPayload(revision: number, rules: KeybindingsRule[]): KeybindingsOverrides {
+  return { version: 1, revision, rules };
+}
+
+async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  });
+  await keybindingsStore.getState().refreshOverrides();
+}
+
+function questionTriggerRegistered(): boolean {
+  return keybindingsRegistry.getState().bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+}
+
+async function openDialog(): Promise<HTMLElement> {
+  return screen.findByRole("dialog", { name: "Keyboard shortcuts" });
+}
+
+beforeAll(async () => {
+  globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver;
+  // @ts-expect-error MemoryStorage deliberately implements only the Storage
+  // methods the stores actually call - see AppShell.test.tsx's own stub.
+  globalThis.localStorage = new MemoryStorage();
+  // Await the lazy pane/dock modules once up front, then pay react-dom's
+  // per-boundary fallback throttle in one warm render - see
+  // keybindingsMigration.test.tsx's beforeAll for the full reasoning.
+  await import("../../panes/welcome/Welcome");
+  await import("../DockHost");
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+});
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetWorkspaceStoreForTests();
+  resetNavigationStoreForTests();
+  resetKeybindingsStoreForTests();
+  // @ts-expect-error see the beforeAll stub.
+  globalThis.localStorage = new MemoryStorage();
+  localStorage.clear();
+  resetPrefsStoreForTests();
+  resetRegistryToDefaults();
+  closeCheatsheet();
+});
+
+afterEach(() => {
+  cleanup();
+  window.history.pushState({}, "", "/");
+  paletteStore.setState({ open: false, query: "" });
+  closeCheatsheet();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetNavigationStoreForTests();
+  resetKeybindingsStoreForTests();
+  resetNotificationsForTests();
+  initNotifications();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test("opens on ⌘/ and lists every action with its effective chord, grouped", async () => {
+  render(<CheatsheetOverlay />);
+  fireEvent.keyDown(document.body, { key: "/", code: "Slash", ctrlKey: true });
+
+  const dialog = await openDialog();
+  for (const group of ["Sessions", "Transcript", "Composer", "General"]) {
+    expect(within(dialog).getByText(group)).toBeTruthy();
+  }
+  // One row per action (the overlay's two trigger entries share one action
+  // id), sourced live from the default map via keybindings/display.ts.
+  const rows = within(dialog).getAllByRole("listitem");
+  expect(rows).toHaveLength(new Set(DEFAULT_BINDINGS.map((b) => b.actionId)).size);
+  // jsdom resolves $mod to Control: palette.open's row shows Ctrl + K, and
+  // the cheatsheet row shows Ctrl + / with the "?" trigger alongside.
+  const paletteRow = within(dialog).getByText("Open the command palette").closest("li");
+  if (paletteRow === null) throw new Error("no palette row");
+  expect(within(paletteRow).getByText("Ctrl")).toBeTruthy();
+  expect(within(paletteRow).getByText("K")).toBeTruthy();
+  const cheatsheetRow = within(dialog).getByText("Show the keyboard shortcuts overlay").closest("li");
+  if (cheatsheetRow === null) throw new Error("no cheatsheet row");
+  expect(within(cheatsheetRow).getByText("/")).toBeTruthy();
+  expect(within(cheatsheetRow).getByText("?")).toBeTruthy();
+  // The hold-hints footer line (the feature itself is the next task).
+  expect(within(dialog).getByText(/to see hints/)).toBeTruthy();
+});
+
+test("opens on ? outside editable targets", async () => {
+  render(<CheatsheetOverlay />);
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  await openDialog();
+});
+
+test("? does NOT fire inside an editable target (it is a printable character)", () => {
+  render(<CheatsheetOverlay />);
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  fireEvent.keyDown(input, { key: "?", code: "Slash", shiftKey: true });
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(cheatsheetStore.getState().open).toBe(false);
+  input.remove();
+});
+
+test("⌘/ fires inside an editable target (it never collides with typing)", async () => {
+  render(<CheatsheetOverlay />);
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  fireEvent.keyDown(input, { key: "/", code: "Slash", ctrlKey: true });
+  await openDialog();
+  input.remove();
+});
+
+test("? does NOT fire while the character-key toggle is off, and comes back when it returns", async () => {
+  render(<CheatsheetOverlay />);
+  act(() => prefsStore.getState().setCharacterKeyTriggers(false));
+
+  // The binding is unregistered, not merely suppressed - and the open
+  // overlay's row stops offering "?".
+  expect(questionTriggerRegistered()).toBe(false);
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  expect(screen.queryByRole("dialog")).toBeNull();
+
+  // ⌘/ is unaffected (it is not a character-key trigger).
+  fireEvent.keyDown(document.body, { key: "/", code: "Slash", ctrlKey: true });
+  const dialog = await openDialog();
+  const row = within(dialog).getByText("Show the keyboard shortcuts overlay").closest("li");
+  if (row === null) throw new Error("no cheatsheet row");
+  expect(within(row).queryByText("?")).toBeNull();
+  expect(within(row).getByText("/")).toBeTruthy();
+  act(() => closeCheatsheet());
+
+  act(() => prefsStore.getState().setCharacterKeyTriggers(true));
+  expect(questionTriggerRegistered()).toBe(true);
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  await openDialog();
+});
+
+test("a pref seeded off before mount never registers the ? trigger", () => {
+  localStorage.setItem("evener.prefs.characterKeyTriggers", "0");
+  resetPrefsStoreForTests();
+  render(<CheatsheetOverlay />);
+  expect(questionTriggerRegistered()).toBe(false);
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+test("Escape closes the overlay (and the cheatsheet scope is live only while open)", async () => {
+  render(<CheatsheetOverlay />);
+  expect(keybindingsRegistry.getState().scopeStack).not.toContain(CHEATSHEET_SCOPE);
+  act(() => openCheatsheet());
+  const dialog = await openDialog();
+  expect(keybindingsRegistry.getState().scopeStack).toContain(CHEATSHEET_SCOPE);
+
+  // The OverlayPanel's own Escape handler owns the close (focus is trapped
+  // inside the dialog); it preventDefaults, which the scope-gated
+  // cheatsheet.close binding then honors via ignoreIfDefaultPrevented.
+  const target = document.activeElement ?? dialog;
+  fireEvent.keyDown(target, { key: "Escape", code: "Escape" });
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  expect(keybindingsRegistry.getState().scopeStack).not.toContain(CHEATSHEET_SCOPE);
+});
+
+test("⌘/ toggles the overlay closed while it is open", async () => {
+  render(<CheatsheetOverlay />);
+  act(() => openCheatsheet());
+  const dialog = await openDialog();
+  // Fired from inside the dialog (an aria-modal target): the binding's
+  // allowInModal is what lets the same chord close what it opened.
+  const target = document.activeElement ?? dialog;
+  fireEvent.keyDown(target, { key: "/", code: "Slash", ctrlKey: true });
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+});
+
+test("rows reflect an applied hub override (registry-sourced, not hardcoded)", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  await wireClient(client, true);
+  render(<CheatsheetOverlay />);
+  act(() => openCheatsheet());
+
+  const dialog = await openDialog();
+  const paletteRow = within(dialog).getByText("Open the command palette").closest("li");
+  if (paletteRow === null) throw new Error("no palette row");
+  expect(within(paletteRow).getByText("P")).toBeTruthy();
+  expect(within(paletteRow).queryByText("K")).toBeNull();
+});
+
+test("mobile: nothing mounts, registers, or intercepts on a touch viewport", async () => {
+  installMobileViewport();
+  resetMobileViewportForTests();
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+
+  // No overlay mounted, no action registered - the trigger chords are inert.
+  expect(keybindingsRegistry.getState().actions.get(ACTIONS.cheatsheetToggle)).toBeUndefined();
+  fireEvent.keyDown(document.body, { key: "/", code: "Slash", ctrlKey: true });
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  // (StackHost's own "Sessions" drawer is a role=dialog too - the assertion
+  // is specifically that the CHEATSHEET never appears.)
+  expect(screen.queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull();
+  expect(cheatsheetStore.getState().open).toBe(false);
+});

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.test.tsx
@@ -274,6 +274,75 @@ test("rows reflect an applied hub override (registry-sourced, not hardcoded)", a
   expect(within(paletteRow).queryByText("K")).toBeNull();
 });
 
+// The override-restore half of the character-key reconcile (the stated
+// reason for its keybindingsStore subscription): removing an override on
+// cheatsheet.toggle re-registers EVERY default entry for the action - "?"
+// included - through registerDefaultBindingsForAction, and the reconcile
+// must then strip "?" again when the pref is off. A regression here is
+// silent, so the invariant is pinned at the registry level in both pref
+// states.
+test("override removal with the pref OFF restores the defaults and strips the ? trigger again", async () => {
+  render(<CheatsheetOverlay />);
+  act(() => prefsStore.getState().setCharacterKeyTriggers(false));
+  expect(questionTriggerRegistered()).toBe(false);
+
+  let payload = overridesPayload(3, [{ action: ACTIONS.cheatsheetToggle, chord: "Control+P" }]);
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => payload);
+  await wireClient(client, true);
+
+  // Overridden: the override owns the action's whole chord set ("?" does not
+  // come back while the override is applied).
+  expect(
+    keybindingsRegistry
+      .getState()
+      .bindings.filter((b) => b.actionId === ACTIONS.cheatsheetToggle)
+      .map((b) => b.id),
+  ).toEqual([`${ACTIONS.cheatsheetToggle}#override`]);
+
+  // Removing the override restores the default map - which re-registers "?"
+  // with no knowledge of the pref - and the reconcile strips it again
+  // without throwing (a rollback would surface as hubError).
+  payload = overridesPayload(4, []);
+  await keybindingsStore.getState().refreshOverrides();
+  expect(keybindingsStore.getState().hubError).toBeNull();
+  expect(questionTriggerRegistered()).toBe(false);
+  expect(
+    keybindingsRegistry
+      .getState()
+      .bindings.filter((b) => b.actionId === ACTIONS.cheatsheetToggle)
+      .map((b) => b.id)
+      .sort(),
+  ).toEqual([ACTIONS.cheatsheetToggle, `${ACTIONS.cheatsheetToggle}#mod-twin`]);
+});
+
+test("override removal with the pref ON restores the defaults with exactly one ? binding (no duplicate-id throw)", async () => {
+  render(<CheatsheetOverlay />);
+  expect(questionTriggerRegistered()).toBe(true);
+
+  let payload = overridesPayload(3, [{ action: ACTIONS.cheatsheetToggle, chord: "Control+P" }]);
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => payload);
+  await wireClient(client, true);
+  expect(questionTriggerRegistered()).toBe(false);
+
+  // The restore re-registers "?" itself; the reconcile must be a no-op here -
+  // re-registering the same id would throw into the store's rollback path.
+  payload = overridesPayload(4, []);
+  await keybindingsStore.getState().refreshOverrides();
+  expect(keybindingsStore.getState().hubError).toBeNull();
+  expect(keybindingsRegistry.getState().bindings.filter((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID)).toHaveLength(
+    1,
+  );
+  expect(
+    keybindingsRegistry
+      .getState()
+      .bindings.filter((b) => b.actionId === ACTIONS.cheatsheetToggle)
+      .map((b) => b.id)
+      .sort(),
+  ).toEqual([ACTIONS.cheatsheetToggle, `${ACTIONS.cheatsheetToggle}#mod-twin`, CHARACTER_KEY_TRIGGER_BINDING_ID]);
+});
+
 test("mobile: nothing mounts, registers, or intercepts on a touch viewport", async () => {
   installMobileViewport();
   resetMobileViewportForTests();

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.tsx
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.tsx
@@ -1,0 +1,151 @@
+// The cheatsheet overlay (Phase 4a, the p4 plan's Design decision 3): a
+// modal listing every keybinding action with its EFFECTIVE chord, grouped
+// into Sessions / Transcript / Composer / General. The action list and the
+// chords are sourced live - ACTION_DISPLAY_ROWS derives from the default
+// map, and each row's chord comes from the registry at render via
+// keybindings/display.ts, the same source the Settings keybindings section
+// reads - so hub-synced overrides and unbound actions render truthfully and
+// no hand-maintained copy can go stale (the survey's stale-HELP_ROWS
+// lesson).
+//
+// Triggers live in the default map (keybindings/defaults.ts): ⌘/ (the $mod
+// chord, allowInEditable + allowInModal so it also toggles the overlay
+// closed while open) and the pref-conditional "?" (cheatsheetController.ts's
+// reconcile). Escape closes through the OverlayPanel's own handler, with the
+// scope-gated cheatsheet.close binding as the window-level backstop - the
+// Settings pane's SETTINGS_SCOPE precedent.
+//
+// Desktop-only: AppShell mounts this component only off mobile, so no action
+// is ever registered on a touch viewport and the trigger chords stay inert
+// there (RailHost's rail.toggle no-registration pattern).
+
+import { Fragment, useEffect } from "react";
+import { useStore } from "zustand";
+import { ACTIONS } from "../../keybindings/actions";
+import { chordDisplayKeys, serializeChord } from "../../keybindings/chord";
+import { CHEATSHEET_SCOPE } from "../../keybindings/defaults";
+import { ACTION_DISPLAY_ROWS, displayBindingsFor } from "../../keybindings/display";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { Dialog, KeyHint } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
+import { installKeybindings } from "../installKeybindings";
+import styles from "./cheatsheet.module.css";
+import { closeCheatsheet, toggleCheatsheet, useCheatsheetStore } from "./cheatsheetController";
+
+const CLASS = {
+  groups: requireClass(styles.groups, "cheatsheet.module.css", "groups"),
+  groupTitle: requireClass(styles.groupTitle, "cheatsheet.module.css", "groupTitle"),
+  list: requireClass(styles.list, "cheatsheet.module.css", "list"),
+  row: requireClass(styles.row, "cheatsheet.module.css", "row"),
+  label: requireClass(styles.label, "cheatsheet.module.css", "label"),
+  chord: requireClass(styles.chord, "cheatsheet.module.css", "chord"),
+  or: requireClass(styles.or, "cheatsheet.module.css", "or"),
+  unbound: requireClass(styles.unbound, "cheatsheet.module.css", "unbound"),
+  footerHint: requireClass(styles.footerHint, "cheatsheet.module.css", "footerHint"),
+};
+
+type GroupId = "sessions" | "transcript" | "composer" | "general";
+
+const GROUPS: readonly { id: GroupId; title: string }[] = [
+  { id: "sessions", title: "Sessions" },
+  { id: "transcript", title: "Transcript" },
+  { id: "composer", title: "Composer" },
+  { id: "general", title: "General" },
+];
+
+// Presentation-only grouping (Design decision 3). Anything not named here -
+// including any action a future phase adds to the default map - lands in
+// General, so a new action can never silently vanish from the overlay.
+const GROUP_BY_ACTION: Readonly<Record<string, GroupId>> = {
+  [ACTIONS.sessionNext]: "sessions",
+  [ACTIONS.sessionPrevious]: "sessions",
+  [ACTIONS.nextNeedsYou]: "sessions",
+  [ACTIONS.transcriptLineUp]: "transcript",
+  [ACTIONS.transcriptLineDown]: "transcript",
+  [ACTIONS.transcriptPageUp]: "transcript",
+  [ACTIONS.transcriptPageDown]: "transcript",
+  [ACTIONS.transcriptScrollTop]: "transcript",
+  [ACTIONS.transcriptScrollBottom]: "transcript",
+  [ACTIONS.composerFocus]: "composer",
+  [ACTIONS.selectionQuote]: "composer",
+};
+
+function groupOf(actionId: string): GroupId {
+  return GROUP_BY_ACTION[actionId] ?? "general";
+}
+
+export function CheatsheetOverlay() {
+  const open = useCheatsheetStore((s) => s.open);
+  const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
+
+  // Registers the toggle action (the chord→handler half; the chords
+  // themselves are the default map's, registered by installKeybindings).
+  // Desktop-only by virtue of the mount site, per this file's header.
+  useEffect(() => {
+    installKeybindings();
+    return keybindingsRegistry.getState().registerAction(ACTIONS.cheatsheetToggle, () => toggleCheatsheet());
+  }, []);
+
+  // While open, push the cheatsheet scope and register the close action -
+  // the scope-gated Escape backstop (the OverlayPanel's own Escape handler
+  // claims the key first whenever focus is inside the dialog; this covers a
+  // keydown whose target sits outside it, and keeps the chord remappable).
+  useEffect(() => {
+    if (!open) return undefined;
+    const registry = keybindingsRegistry.getState();
+    const popScope = registry.pushScope(CHEATSHEET_SCOPE);
+    const unregister = registry.registerAction(ACTIONS.cheatsheetClose, () => closeCheatsheet());
+    return () => {
+      unregister();
+      popScope();
+    };
+  }, [open]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={closeCheatsheet}
+      title="Keyboard shortcuts"
+      footer={
+        // The hold-hints feature itself is Phase 4a's next task; this line
+        // is its discoverability hook (Design decision 4). "Mod" renders ⌘
+        // on Apple platforms and Ctrl elsewhere (widgets/keyhint).
+        <span className={CLASS.footerHint}>
+          Hold <KeyHint keys={["Mod"]} /> to see hints
+        </span>
+      }
+    >
+      <div className={CLASS.groups}>
+        {GROUPS.map((group) => (
+          <section key={group.id}>
+            <h3 className={CLASS.groupTitle}>{group.title}</h3>
+            <ul className={CLASS.list}>
+              {ACTION_DISPLAY_ROWS.filter((row) => groupOf(row.actionId) === group.id).map((row) => {
+                const displayed = displayBindingsFor(bindings, row.actionId);
+                return (
+                  <li className={CLASS.row} key={row.actionId}>
+                    <span className={CLASS.label}>{row.title}</span>
+                    {displayed.length === 0 ? (
+                      <span className={CLASS.unbound}>Unbound</span>
+                    ) : (
+                      <span className={CLASS.chord}>
+                        {displayed.map((binding, i) => (
+                          <Fragment key={binding.id}>
+                            {i > 0 && <span className={CLASS.or}>or</span>}
+                            {binding.chord.map((press) => (
+                              <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
+                            ))}
+                          </Fragment>
+                        ))}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </Dialog>
+  );
+}

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheet.module.css
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheet.module.css
@@ -1,0 +1,63 @@
+.groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 22rem;
+}
+
+.groupTitle {
+  margin: 0 0 var(--space-2);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-display);
+  text-transform: uppercase;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.label {
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+  line-height: var(--line-height-body);
+}
+
+.chord {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.or {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  padding: 0 var(--space-1);
+}
+
+.unbound {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+.footerHint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
@@ -1,0 +1,92 @@
+// The cheatsheet overlay's open state and its one piece of registry
+// bookkeeping. The store mirrors shell/palette/paletteController.ts: a
+// vanilla store the mounted <CheatsheetOverlay/> subscribes to, toggled by
+// the cheatsheet.toggle action's handler.
+//
+// The character-key trigger ("?", the default map's one CONDITIONAL entry -
+// keybindings/defaults.ts's CHARACTER_KEY_TRIGGER_BINDING_ID) is live only
+// while the characterKeyTriggers pref (stores/prefs.ts, the WCAG 2.1.4
+// turn-off, default ON) is on. reconcileCharacterKeyTrigger enforces that as
+// an invariant and is subscribed to BOTH sources that can break it:
+//
+//   - the prefs store (the user flips the toggle), and
+//   - the keybindings overrides store (an override restore re-registers
+//     EVERY default entry for the action - "?" included - through
+//     registerDefaultBindingsForAction, with no knowledge of the pref).
+//
+// The registry itself is deliberately NOT subscribed: override application
+// mutates the registry binding-by-binding, and a synchronous registry
+// subscription would observe the half-restored state (base entry present,
+// "?" not yet re-registered) and register "?" itself - making the restore's
+// own re-registration of the same id throw a duplicate-id error into the
+// store's rollback path. Both stores above set their state only after the
+// registry mutation is complete, so the reconcile always sees the final
+// shape.
+
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+import { ACTIONS } from "../../keybindings/actions";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS } from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { keybindingsStore } from "../../stores/keybindings";
+import { prefsStore } from "../../stores/prefs";
+
+export interface CheatsheetState {
+  open: boolean;
+}
+
+export const cheatsheetStore = createStore<CheatsheetState>(() => ({ open: false }));
+
+export function openCheatsheet(): void {
+  cheatsheetStore.setState({ open: true });
+}
+
+export function closeCheatsheet(): void {
+  cheatsheetStore.setState({ open: false });
+}
+
+/** The cheatsheet.toggle action's handler: ⌘/ opens the overlay and - the
+ * binding carries allowInModal so the same chord keeps firing while the
+ * dialog is open - toggles it closed again (the p4 plan's "Escape/⌘/
+ * toggles closed"). */
+export function toggleCheatsheet(): void {
+  cheatsheetStore.setState((s) => ({ open: !s.open }));
+}
+
+export function useCheatsheetStore<T>(selector: (state: CheatsheetState) => T): T {
+  return useStore(cheatsheetStore, selector);
+}
+
+/** Enforces "the ? binding is registered exactly while characterKeyTriggers
+ * is on AND cheatsheet.toggle is on its default map". An applied override
+ * (or unbind) owns the action's whole chord set, so "?" never comes back
+ * there - the override is the user's own replacement for both triggers.
+ * Idempotent and total: safe to run after any pref or override change. */
+export function reconcileCharacterKeyTrigger(): void {
+  const registry = keybindingsRegistry.getState();
+  const present = registry.bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+  if (!prefsStore.getState().characterKeyTriggers) {
+    if (present) registry.unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+    return;
+  }
+  if (present) return;
+  const input = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+  if (input === undefined) return;
+  const onDefaultMap =
+    registry.bindings.some((b) => b.id === ACTIONS.cheatsheetToggle) &&
+    !registry.bindings.some((b) => b.actionId === ACTIONS.cheatsheetToggle && b.id.endsWith("#override"));
+  if (!onDefaultMap) return;
+  registry.registerBinding(input);
+}
+
+/** Installs the reconcile: runs it once against the current state, then on
+ * every pref or applied-override change. Returns the disposer. */
+export function installCharacterKeyTriggerReconcile(): () => void {
+  reconcileCharacterKeyTrigger();
+  const unsubPrefs = prefsStore.subscribe(reconcileCharacterKeyTrigger);
+  const unsubOverrides = keybindingsStore.subscribe(reconcileCharacterKeyTrigger);
+  return () => {
+    unsubPrefs();
+    unsubOverrides();
+  };
+}

--- a/cmd/evener-hub/frontend/src/shell/holdhints/HoldHints.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/HoldHints.test.tsx
@@ -1,0 +1,393 @@
+// Tests for the hold-modifier hints (Phase 4a, the p4 plan's Design
+// decision 4): the ~400ms modifier-alone hold shows the chips, every cleanup
+// path hides them (modifier keyup, window blur, visibilitychange, any
+// non-modifier keydown, and the hard-timeout backstop), the listeners are
+// observers only (no preventDefault, no propagation interference), the
+// reduced-motion instant path, registry-sourced effective chords (an applied
+// override shows its own chord), and mobile inertness (AppShell mounts the
+// component only off mobile - the CheatsheetOverlay pattern, so no listener
+// is ever installed on touch).
+//
+// jsdom's navigator.platform is "" (keybindings/chord.test.ts documents it),
+// so currentKeybindingsPlatform() resolves "other" and the tracked modifier
+// is Control.
+//
+// The AppShell render/warm-up/store-reset scaffolding for the mobile test
+// mirrors CheatsheetOverlay.test.tsx's own (helpers duplicated, not shared -
+// this project has no cross-test-file test-utils module; see that file's
+// header note on the convention).
+
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { ACTIONS } from "../../keybindings/actions";
+import { registerDefaultBindings } from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { resetNotificationsForTests } from "../../notifications";
+import { FakeClient } from "../../protocol/testing/fakeClient";
+import { connectionStore } from "../../stores/connection";
+import { resetKeybindingsStoreForTests } from "../../stores/keybindings";
+import { resetNavigationStoreForTests } from "../../stores/navigation/store";
+import { resetPrefsStoreForTests } from "../../stores/prefs";
+import { AppShell } from "../AppShell";
+import { paletteStore } from "../palette/paletteController";
+import { resetMobileViewportForTests } from "../useIsMobile";
+import { resetWorkspaceStoreForTests } from "../workspace";
+import { HoldHints } from "./HoldHints";
+import { HARD_TIMEOUT_MS, HOLD_THRESHOLD_MS, holdHintsStore, resetHoldHintsForTests } from "./holdHintsController";
+
+// See AppShell.test.tsx for why both stubs are needed (jsdom has no
+// ResizeObserver; Node 26 shadows jsdom's localStorage accessor).
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+// CheatsheetOverlay.test.tsx's installMobileViewport, verbatim: the mobile
+// query matches, every other query (the reduced-motion read included) does
+// not.
+function installMobileViewport(): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      media,
+      matches: media === "(max-width: 899px)",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })),
+  );
+}
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+/** The live affordances the chips anchor to (their data attributes are the
+ * contract - shell/holdhints/HoldHints.tsx's ANCHORS). */
+function addAnchors(): void {
+  for (const attr of ["data-search-trigger", "data-rail-toggle", "data-session-tab", "data-composer"]) {
+    const element = document.createElement("div");
+    element.setAttribute(attr, "");
+    document.body.appendChild(element);
+  }
+}
+
+function removeAnchors(): void {
+  for (const attr of ["data-search-trigger", "data-rail-toggle", "data-session-tab", "data-composer"]) {
+    document.querySelector(`[${attr}]`)?.remove();
+  }
+}
+
+function hintRoot(): HTMLElement | null {
+  return document.querySelector("[data-hold-hints]");
+}
+
+function holdModifier(): void {
+  fireEvent.keyDown(document.body, { key: "Control", code: "ControlLeft", ctrlKey: true });
+}
+
+function showHints(): void {
+  holdModifier();
+  act(() => vi.advanceTimersByTime(HOLD_THRESHOLD_MS));
+}
+
+beforeAll(async () => {
+  globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver;
+  // @ts-expect-error MemoryStorage deliberately implements only the Storage
+  // methods the stores actually call - see AppShell.test.tsx's own stub.
+  globalThis.localStorage = new MemoryStorage();
+  // Await the lazy pane/dock modules once up front, then pay react-dom's
+  // per-boundary fallback throttle in one warm render - see
+  // keybindingsMigration.test.tsx's beforeAll for the full reasoning.
+  await import("../../panes/welcome/Welcome");
+  await import("../DockHost");
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+});
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetWorkspaceStoreForTests();
+  resetNavigationStoreForTests();
+  resetKeybindingsStoreForTests();
+  // @ts-expect-error see the beforeAll stub.
+  globalThis.localStorage = new MemoryStorage();
+  localStorage.clear();
+  resetPrefsStoreForTests();
+  resetRegistryToDefaults();
+  resetHoldHintsForTests();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  removeAnchors();
+  window.history.pushState({}, "", "/");
+  paletteStore.setState({ open: false, query: "" });
+  resetHoldHintsForTests();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetNavigationStoreForTests();
+  resetKeybindingsStoreForTests();
+  resetNotificationsForTests();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test("hints appear after the hold threshold with the modifier held - not before", () => {
+  addAnchors();
+  render(<HoldHints />);
+  expect(hintRoot()).toBeNull();
+
+  holdModifier();
+  act(() => vi.advanceTimersByTime(HOLD_THRESHOLD_MS - 1));
+  expect(hintRoot()).toBeNull();
+
+  act(() => vi.advanceTimersByTime(1));
+  const root = hintRoot();
+  if (root === null) throw new Error("hints did not appear at the threshold");
+  // One chip per mounted anchor; jsdom resolves $mod to Control.
+  const palette = within(root).getByText("K").closest("[data-hint]");
+  expect(palette?.getAttribute("data-hint")).toBe("palette");
+  expect(within(root).getByText("B").closest("[data-hint]")?.getAttribute("data-hint")).toBe("rail-toggle");
+  expect(within(root).getByText("I").closest("[data-hint]")?.getAttribute("data-hint")).toBe("composer");
+  const tabs = root.querySelector('[data-hint="session-tabs"]');
+  if (tabs === null) throw new Error("no session-tabs chip");
+  // The tab chip carries BOTH cycling chords.
+  expect(within(tabs as HTMLElement).getByText("ArrowLeft")).toBeTruthy();
+  expect(within(tabs as HTMLElement).getByText("ArrowRight")).toBeTruthy();
+});
+
+test("modifier keyup hides the hints (and a release before the threshold never shows them)", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  // Released early: no chips.
+  holdModifier();
+  act(() => vi.advanceTimersByTime(HOLD_THRESHOLD_MS - 100));
+  fireEvent.keyUp(document.body, { key: "Control", code: "ControlLeft" });
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+
+  // Shown, then released: gone.
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  fireEvent.keyUp(document.body, { key: "Control", code: "ControlLeft" });
+  expect(hintRoot()).toBeNull();
+  expect(holdHintsStore.getState().visible).toBe(false);
+});
+
+test("window blur hides the hints and cancels a pending hold", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  fireEvent(window, new Event("blur"));
+  expect(hintRoot()).toBeNull();
+
+  holdModifier();
+  fireEvent(window, new Event("blur"));
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("visibilitychange hides the hints and cancels a pending hold", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  fireEvent(document, new Event("visibilitychange"));
+  expect(hintRoot()).toBeNull();
+
+  holdModifier();
+  fireEvent(document, new Event("visibilitychange"));
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("any non-modifier keydown hides the hints and cancels a pending hold", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  // A chord starting while visible hides them (on macOS this keydown may be
+  // the ONLY event the chord ever delivers - the keyup is not delivered).
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  fireEvent.keyDown(document.body, { key: "k", code: "KeyK", ctrlKey: true });
+  expect(hintRoot()).toBeNull();
+
+  // A key pressed during the pending window cancels the hold outright.
+  holdModifier();
+  act(() => vi.advanceTimersByTime(100));
+  fireEvent.keyDown(document.body, { key: "x", code: "KeyX", ctrlKey: true });
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("the hard timeout hides the hints even when every event-based cleanup missed", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  // No keyup, no blur, nothing - the backstop alone must end it.
+  act(() => vi.advanceTimersByTime(HARD_TIMEOUT_MS - 1));
+  expect(hintRoot()).not.toBeNull();
+  act(() => vi.advanceTimersByTime(1));
+  expect(hintRoot()).toBeNull();
+  // And the lapsed hold does not re-arm itself from modifier auto-repeat.
+  fireEvent.keyDown(document.body, { key: "Control", code: "ControlLeft", ctrlKey: true, repeat: true });
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("the hold counts only with the modifier held ALONE", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  fireEvent.keyDown(document.body, { key: "Control", code: "ControlLeft", ctrlKey: true, shiftKey: true });
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("the listeners are observers only: no preventDefault, no propagation interference", () => {
+  addAnchors();
+  const seen: KeyboardEvent[] = [];
+  // Attached BEFORE <HoldHints/> mounts, on a different target (document
+  // sits earlier in the bubble path than window): any stopPropagation or
+  // stopImmediatePropagation from the hold listeners would show here.
+  const recorder = (event: KeyboardEvent) => seen.push(event);
+  document.addEventListener("keydown", recorder);
+  render(<HoldHints />);
+
+  fireEvent.keyDown(document.body, { key: "Control", code: "ControlLeft", ctrlKey: true });
+  act(() => vi.advanceTimersByTime(HOLD_THRESHOLD_MS));
+  expect(hintRoot()).not.toBeNull();
+
+  for (const event of seen) {
+    expect(event.defaultPrevented).toBe(false);
+  }
+  expect(seen.some((event) => event.key === "Control")).toBe(true);
+
+  // And the dispatcher still owns its chords while the hints are visible:
+  // ⌘K reaches it untouched (the hints' own keydown observer hides them).
+  const openPalette = vi.fn();
+  const unregister = keybindingsRegistry.getState().registerAction(ACTIONS.paletteOpen, () => {
+    openPalette();
+  });
+  fireEvent.keyDown(document.body, { key: "k", code: "KeyK", ctrlKey: true });
+  expect(openPalette).toHaveBeenCalledTimes(1);
+  unregister();
+  document.removeEventListener("keydown", recorder);
+});
+
+test("chips show the EFFECTIVE chord: an applied override replaces the default", () => {
+  addAnchors();
+  const registry = keybindingsRegistry.getState();
+  registry.unregisterBinding(ACTIONS.paletteOpen);
+  registry.unregisterBinding(`${ACTIONS.paletteOpen}#mod-twin`);
+  registry.registerBinding({
+    id: `${ACTIONS.paletteOpen}#override`,
+    actionId: ACTIONS.paletteOpen,
+    chord: "Control+P",
+  });
+  render(<HoldHints />);
+
+  showHints();
+  const root = hintRoot();
+  if (root === null) throw new Error("hints did not appear");
+  const chip = root.querySelector('[data-hint="palette"]');
+  if (chip === null) throw new Error("no palette chip");
+  expect(within(chip as HTMLElement).getByText("P")).toBeTruthy();
+  expect(within(chip as HTMLElement).queryByText("K")).toBeNull();
+});
+
+test("an unbound action renders no chip, and a missing anchor renders none either", () => {
+  addAnchors();
+  const registry = keybindingsRegistry.getState();
+  // Unbound-by-override: palette.open's effective binding set is empty.
+  for (const binding of registry.bindings.filter((b) => b.actionId === ACTIONS.paletteOpen)) {
+    registry.unregisterBinding(binding.id);
+  }
+  registry.registerBinding({ id: `${ACTIONS.paletteOpen}#override`, actionId: ACTIONS.paletteOpen, chord: [] });
+  // The composer's anchor is not mounted at all in this test.
+  document.querySelector("[data-composer]")?.remove();
+  render(<HoldHints />);
+
+  showHints();
+  const root = hintRoot();
+  if (root === null) throw new Error("hints did not appear");
+  expect(root.querySelector('[data-hint="palette"]')).toBeNull();
+  expect(root.querySelector('[data-hint="composer"]')).toBeNull();
+  expect(root.querySelector('[data-hint="rail-toggle"]')).not.toBeNull();
+});
+
+test("prefers-reduced-motion marks the root for the instant (no-fade) path", () => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      media,
+      matches: media === "(prefers-reduced-motion: reduce)",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })),
+  );
+  addAnchors();
+  render(<HoldHints />);
+  showHints();
+  expect(hintRoot()?.hasAttribute("data-reduced-motion")).toBe(true);
+});
+
+test("without the reduced-motion preference the root is unmarked", () => {
+  // jsdom has no matchMedia at all: the guarded read degrades to false.
+  addAnchors();
+  render(<HoldHints />);
+  showHints();
+  expect(hintRoot()?.hasAttribute("data-reduced-motion")).toBe(false);
+});
+
+test("mobile: no listeners installed, no chips on a touch viewport", async () => {
+  // Real timers: RTL's findByText cannot advance vitest's fake ones, and
+  // with no listeners installed there is no pending hold timer to advance.
+  vi.useRealTimers();
+  installMobileViewport();
+  resetMobileViewportForTests();
+  addAnchors();
+  const addListener = vi.spyOn(window, "addEventListener");
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+
+  // The component never mounted: nothing subscribed to key/keyup/blur.
+  const watchedTypes = new Set(addListener.mock.calls.map(([type]) => type));
+  expect(watchedTypes.has("keyup")).toBe(false);
+  expect(watchedTypes.has("blur")).toBe(false);
+
+  // And the hold does nothing.
+  holdModifier();
+  expect(holdHintsStore.getState().visible).toBe(false);
+  expect(hintRoot()).toBeNull();
+});

--- a/cmd/evener-hub/frontend/src/shell/holdhints/HoldHints.tsx
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/HoldHints.tsx
@@ -1,0 +1,145 @@
+// The hold-modifier hint chips (Phase 4a, the p4 plan's Design decision 4):
+// hold ⌘ (Apple) / Ctrl (elsewhere) alone for ~400ms and a small chip fades
+// in over each bound affordance, showing the EFFECTIVE chord for the action
+// that affordance triggers. Release - or any of the cleanup paths in
+// holdHintsController.ts - hides them.
+//
+// The chords are registry-sourced through keybindings/display.ts's
+// displayBindingFor - the same read the cheatsheet overlay and the Settings
+// section make - so a hub-synced override (or an unbound action, whose chip
+// then does not render) shows truthfully, and no hand-maintained copy can go
+// stale (the survey's stale-HELP_ROWS lesson).
+//
+// Desktop-only by mount site: AppShell renders this component behind its
+// {!isMobile && ...} gate (the CheatsheetOverlay precedent), so a touch
+// viewport installs no listeners and renders no chips. The detection
+// listeners are observers only (holdHintsController.ts's header).
+//
+// The chips anchor to REAL elements by the data attributes those components
+// carry, queried live at show time - never absolutely-positioned guesses:
+// an affordance that is not mounted (the rail's toggle exists in exactly one
+// of its two states) simply renders no chip.
+
+import { Fragment, type ReactNode, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { useStore } from "zustand";
+import { ACTIONS } from "../../keybindings/actions";
+import { chordDisplayKeys, type KeySequence, serializeChord } from "../../keybindings/chord";
+import { displayBindingFor } from "../../keybindings/display";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { KeyHint } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
+import { installHoldHints, useHoldHintsStore } from "./holdHintsController";
+import styles from "./holdhints.module.css";
+import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
+
+const CLASS = {
+  root: requireClass(styles.root, "holdhints.module.css", "root"),
+  chip: requireClass(styles.chip, "holdhints.module.css", "chip"),
+  below: requireClass(styles.below, "holdhints.module.css", "below"),
+  above: requireClass(styles.above, "holdhints.module.css", "above"),
+  or: requireClass(styles.or, "holdhints.module.css", "or"),
+};
+
+interface AnchorSpec {
+  /** The chip's data-hint value (its stable hook for tests). */
+  id: string;
+  /** Selects the live affordance element the chip anchors to. */
+  selector: string;
+  /** The actions whose effective chords the chip shows (a chip for an
+   * action with NO effective binding - unbound by override - is skipped). */
+  actionIds: readonly string[];
+  /** Chips sit BELOW the top-edge affordances (rail header, tab strip) and
+   * ABOVE the bottom-edge one (the composer). */
+  placement: "above" | "below";
+}
+
+// The bound affordances (Design decision 4): the palette trigger (the rail's
+// search button - data-search-trigger pre-exists as AppShell's click-to-open
+// hook), the rail toggle (Rail's "Hide sidebar" button and RailHost's
+// hidden-state ☰ chip, exactly one of which is mounted), the session tabs
+// (PaneTab's session wrapper - one chip over the first tab carrying BOTH
+// cycling chords), and the composer (Composer's form wrapper).
+const ANCHORS: readonly AnchorSpec[] = [
+  {
+    id: "palette",
+    selector: "[data-search-trigger]",
+    actionIds: [ACTIONS.paletteOpen],
+    placement: "below",
+  },
+  {
+    id: "rail-toggle",
+    selector: "[data-rail-toggle]",
+    actionIds: [ACTIONS.railToggle],
+    placement: "below",
+  },
+  {
+    id: "session-tabs",
+    selector: "[data-session-tab]",
+    actionIds: [ACTIONS.sessionPrevious, ACTIONS.sessionNext],
+    placement: "below",
+  },
+  {
+    id: "composer",
+    selector: "[data-composer]",
+    actionIds: [ACTIONS.composerFocus],
+    placement: "above",
+  },
+];
+
+export function HoldHints() {
+  const visible = useHoldHintsStore((s) => s.visible);
+  const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
+  const reducedMotion = usePrefersReducedMotion();
+
+  // The detection listeners' whole lifetime is this mount (desktop-only, per
+  // the file header), so a touch viewport never installs one.
+  useEffect(() => installHoldHints(), []);
+
+  if (!visible) return null;
+
+  const chips: ReactNode[] = [];
+  for (const spec of ANCHORS) {
+    const anchor = document.querySelector(spec.selector);
+    if (!(anchor instanceof HTMLElement)) continue;
+    // The WHOLE effective sequence per action (an override can be
+    // multi-press); an action with no effective binding contributes nothing.
+    const sequences: KeySequence[] = [];
+    for (const actionId of spec.actionIds) {
+      const sequence = displayBindingFor(bindings, actionId)?.chord;
+      if (sequence !== undefined && sequence.length > 0) sequences.push(sequence);
+    }
+    if (sequences.length === 0) continue;
+    const rect = anchor.getBoundingClientRect();
+    chips.push(
+      <span
+        key={spec.id}
+        data-hint={spec.id}
+        className={`${CLASS.chip} ${spec.placement === "above" ? CLASS.above : CLASS.below}`}
+        style={{ left: rect.left + rect.width / 2, top: spec.placement === "above" ? rect.top : rect.bottom }}
+      >
+        {sequences.map((sequence, i) => (
+          <Fragment key={serializeChord(sequence)}>
+            {i > 0 && <span className={CLASS.or}>/</span>}
+            {sequence.map((press) => (
+              <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
+            ))}
+          </Fragment>
+        ))}
+      </span>,
+    );
+  }
+  if (chips.length === 0) return null;
+
+  return createPortal(
+    <div
+      className={CLASS.root}
+      data-hold-hints=""
+      data-reduced-motion={reducedMotion ? "" : undefined}
+      aria-hidden="true"
+    >
+      {chips}
+    </div>,
+    document.body,
+  );
+}

--- a/cmd/evener-hub/frontend/src/shell/holdhints/holdHintsController.ts
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/holdHintsController.ts
@@ -1,0 +1,136 @@
+// Hold-modifier hint detection (Phase 4a, the p4 plan's Design decision 4):
+// holding the primary modifier ALONE - Meta on Apple platforms, Control
+// elsewhere, the same platform split as keybindings/validation.ts's
+// currentKeybindingsPlatform (and keyhint's Mod glyph) - for
+// HOLD_THRESHOLD_MS shows the hint chips; any cleanup path hides them. The
+// store mirrors cheatsheetController.ts: a vanilla store the mounted
+// <HoldHints/> subscribes to.
+//
+// The listeners installed here are OBSERVERS ONLY - they never preventDefault
+// and never stopPropagation, so the keybindings dispatcher (and every other
+// keydown consumer) sees exactly the events it would see without this module.
+// That is pinned by HoldHints.test.tsx.
+//
+// The cleanup set comes from the feasibility research (docs/web-ui/specs/
+// 2026-09-03-keybinding-system-survey.md): the modifier's keyup IS delivered
+// even on macOS, but a non-modifier keyup while the modifier is held is NOT -
+// so release alone cannot be trusted to end every hold. Every one of these
+// hides the chips, and each is pinned by a test:
+//
+//   - the tracked modifier's keyup (the normal path),
+//   - window blur (⌘-Tab away mid-hold),
+//   - document visibilitychange (tab switch mid-hold),
+//   - ANY keydown that is not the tracked modifier (a chord starting - its
+//     keyup may never arrive on macOS, so the keydown itself is the hide),
+//   - a hard timeout (HARD_TIMEOUT_MS) as the final backstop.
+//
+// A stuck visible state must be impossible.
+
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+import { currentKeybindingsPlatform } from "../../keybindings/validation";
+
+/** How long the modifier must be held alone before the chips appear. */
+export const HOLD_THRESHOLD_MS = 400;
+
+/** The backstop: the chips can never stay up longer than this, even if every
+ * event-based cleanup path missed (a keyup swallowed by an OS-level chord,
+ * a blur that never fired). */
+export const HARD_TIMEOUT_MS = 10_000;
+
+export interface HoldHintsState {
+  visible: boolean;
+}
+
+export const holdHintsStore = createStore<HoldHintsState>(() => ({ visible: false }));
+
+export function useHoldHintsStore<T>(selector: (state: HoldHintsState) => T): T {
+  return useStore(holdHintsStore, selector);
+}
+
+/** Test-only: clears the visible flag between tests. The timers belong to
+ * the install disposer, which the component's unmount runs. */
+export function resetHoldHintsForTests(): void {
+  holdHintsStore.setState({ visible: false });
+}
+
+/** Installs the observer listeners; returns the disposer (which also hides
+ * and clears every pending timer). Per-mount lifetime: <HoldHints/>'s one
+ * effect owns it, and AppShell mounts that component only on desktop, so a
+ * touch viewport never installs a listener. */
+export function installHoldHints(target: Window = window): () => void {
+  const modifierKey = currentKeybindingsPlatform() === "apple" ? "Meta" : "Control";
+  // The OTHER modifier flags: the hold counts only while the tracked modifier
+  // is held ALONE. A keydown arriving with Shift/Alt (or the other of
+  // Meta/Ctrl) already down is the start of a chord, not of a hint hold.
+  // (The tracked modifier's own flag is already true on its keydown, so it
+  // must not be in this list.)
+  const otherFlags: readonly ("ctrlKey" | "metaKey" | "altKey" | "shiftKey")[] =
+    modifierKey === "Meta" ? ["ctrlKey", "altKey", "shiftKey"] : ["metaKey", "altKey", "shiftKey"];
+
+  let holdTimer: ReturnType<typeof setTimeout> | null = null;
+  let hardTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimers(): void {
+    if (holdTimer !== null) {
+      clearTimeout(holdTimer);
+      holdTimer = null;
+    }
+    if (hardTimer !== null) {
+      clearTimeout(hardTimer);
+      hardTimer = null;
+    }
+  }
+
+  function hide(): void {
+    clearTimers();
+    if (holdHintsStore.getState().visible) holdHintsStore.setState({ visible: false });
+  }
+
+  function show(): void {
+    holdTimer = null;
+    holdHintsStore.setState({ visible: true });
+    hardTimer = setTimeout(hide, HARD_TIMEOUT_MS);
+  }
+
+  function onKeyDown(event: KeyboardEvent): void {
+    // Any other key - printable, navigation, or another modifier - ends the
+    // hold (and clears a pending one): the hold is "modifier alone", and on
+    // macOS this keydown may be the ONLY event the chord ever delivers.
+    if (event.key !== modifierKey) {
+      hide();
+      return;
+    }
+    // Held-down modifiers auto-repeat on some platforms; the first keydown
+    // already armed the timer.
+    if (event.repeat) return;
+    if (otherFlags.some((flag) => event[flag])) return;
+    if (holdTimer !== null || holdHintsStore.getState().visible) return;
+    holdTimer = setTimeout(show, HOLD_THRESHOLD_MS);
+  }
+
+  function onKeyUp(event: KeyboardEvent): void {
+    if (event.key === modifierKey) hide();
+  }
+
+  function onBlur(): void {
+    hide();
+  }
+
+  function onVisibilityChange(): void {
+    hide();
+  }
+
+  target.addEventListener("keydown", onKeyDown);
+  target.addEventListener("keyup", onKeyUp);
+  target.addEventListener("blur", onBlur);
+  target.document.addEventListener("visibilitychange", onVisibilityChange);
+
+  return () => {
+    target.removeEventListener("keydown", onKeyDown);
+    target.removeEventListener("keyup", onKeyUp);
+    target.removeEventListener("blur", onBlur);
+    target.document.removeEventListener("visibilitychange", onVisibilityChange);
+    hide();
+  };
+}

--- a/cmd/evener-hub/frontend/src/shell/holdhints/holdhints.module.css
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/holdhints.module.css
@@ -1,0 +1,67 @@
+/* Hold-modifier hint chips (Phase 4a, Design decision 4). The root is a
+ * fixed, pointer-events-none layer portaled to document.body (the popover
+ * pattern): chips get their top/left inline from the anchor's
+ * getBoundingClientRect(), so showing never reflows page content and no
+ * clipping ancestor can cut a chip off. The layer itself is aria-hidden
+ * decoration - the same chords live in the cheatsheet overlay and the
+ * controls' own tooltips. */
+
+.root {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-menu);
+  pointer-events: none;
+  animation: holdHintsIn var(--motion-duration-overlay) var(--motion-easing-standard);
+}
+
+@keyframes holdHintsIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.chip {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px;
+  border-radius: var(--radius-pane);
+  background: var(--surface-2);
+  box-shadow: var(--shadow-overlay);
+}
+
+/* Horizontal centering on the anchor is shared; placement differs only along
+ * the vertical axis - rail/palette/tab affordances sit at the top edge of the
+ * shell (chip BELOW), the composer at the bottom (chip ABOVE its card). */
+.below {
+  transform: translate(-50%, 6px);
+}
+
+.above {
+  transform: translate(-50%, calc(-100% - 6px));
+}
+
+.or {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+/* prefers-reduced-motion: the chips appear/disappear instantly - no fade.
+ * The @media rule is the first-paint source of truth (the house pattern -
+ * widgets/popover et al.); the [data-reduced-motion] mirror is the same
+ * preference read JS-side (usePrefersReducedMotion) so the instant path is
+ * observable where media queries are not evaluated (jsdom tests). */
+@media (prefers-reduced-motion: reduce) {
+  .root {
+    animation: none;
+  }
+}
+
+.root[data-reduced-motion] {
+  animation: none;
+}

--- a/cmd/evener-hub/frontend/src/shell/holdhints/usePrefersReducedMotion.ts
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/usePrefersReducedMotion.ts
@@ -1,0 +1,32 @@
+// The one JS-side read of the reduced-motion preference. Every other consumer
+// in the app is a CSS module's @media (prefers-reduced-motion: reduce) rule
+// (widgets/popover, widgets/sheet, ...), which jsdom cannot evaluate - the
+// hold-hints overlay mirrors the same preference into a data attribute so its
+// instant (no-fade) path is observable and pinned in tests
+// (HoldHints.test.tsx). The CSS @media rule stays the first paint's source of
+// truth; this hook keeps the attribute in sync, including later changes.
+
+import { useEffect, useState } from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function readPreference(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(readPreference);
+  useEffect(() => {
+    // Guarded like stores/prefs.ts's own matchMedia reads: this project's
+    // jsdom has no matchMedia at all, and the no-op path degrades to the
+    // initial (false) value.
+    if (typeof window.matchMedia !== "function") return undefined;
+    const list = window.matchMedia(REDUCED_MOTION_QUERY);
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+    onChange({ matches: list.matches } as MediaQueryListEvent);
+    list.addEventListener("change", onChange);
+    return () => list.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}

--- a/cmd/evener-hub/frontend/src/shell/installKeybindings.ts
+++ b/cmd/evener-hub/frontend/src/shell/installKeybindings.ts
@@ -22,6 +22,7 @@
 import { registerDefaultBindings } from "../keybindings/defaults";
 import { createKeybindingDispatcher, isModalOpenTarget } from "../keybindings/dispatcher";
 import { keybindingsRegistry } from "../keybindings/registry";
+import { installCharacterKeyTriggerReconcile } from "./cheatsheet/cheatsheetController";
 import { paletteStore } from "./palette/paletteController";
 
 let installed = false;
@@ -30,6 +31,12 @@ export function installKeybindings(): void {
   if (installed) return;
   installed = true;
   registerDefaultBindings(keybindingsRegistry);
+  // The "?" character-key trigger's pref-conditional registration (the WCAG
+  // 2.1.4 turn-off). Installed here, not by the overlay component, so the
+  // invariant holds on mobile too - where the overlay never mounts and the
+  // binding is inert for lack of an action - keeping the settings section's
+  // customized-marker comparison truthful there as well.
+  installCharacterKeyTriggerReconcile();
   const dispatcher = createKeybindingDispatcher({
     isModalOpen: (event) => paletteStore.getState().open || isModalOpenTarget(event),
   });

--- a/cmd/evener-hub/frontend/src/shell/keybindingsMigration.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/keybindingsMigration.test.tsx
@@ -281,6 +281,21 @@ test("Mod+J fires while an input is focused", async () => {
   remove();
 });
 
+// settings.open (Phase 4a, the p4 plan's Design decision 2): ⌘, runs exactly
+// what the palette's "settings" command runs - navigate("/settings") - and
+// fires from editable targets (⌘, never collides with typing).
+test("Mod+, opens the Settings pane while an input is focused", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { input, remove } = focusedInput();
+
+  fireEvent.keyDown(input, { key: ",", metaKey: true });
+
+  await waitFor(() => expect(workspaceStore.getState().mainPane()?.type).toBe("settings"));
+  expect(window.location.pathname).toBe("/settings");
+  remove();
+});
+
 test("Mod+B is suppressed from editable targets (Ctrl+B keeps its emacs meaning)", async () => {
   render(<AppShell client={new FakeClient("ready")} />);
   await screen.findByText("No session open");
@@ -350,6 +365,18 @@ test("Mod+I and Mod+J are suppressed while an [aria-modal] dialog is open", asyn
 
   expect(focusSpy).not.toHaveBeenCalled();
   expect(workspaceStore.getState().mainPane()?.params).toMatchObject({ ref: "local:ref_abc123" });
+  close();
+});
+
+test("Mod+, is suppressed while an [aria-modal] dialog is open (allowInModal: false)", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { inside, close } = openFakeModal();
+
+  fireEvent.keyDown(inside, { key: ",", metaKey: true });
+
+  expect(workspaceStore.getState().mainPane()?.type).not.toBe("settings");
+  expect(window.location.pathname).not.toBe("/settings");
   close();
 });
 

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -1091,6 +1091,7 @@ function NavigationRail({
           </Tooltip>
           {onHide && (
             <IconButton
+              data-rail-toggle=""
               label="Hide sidebar"
               icon={<span aria-hidden="true">☰</span>}
               variant="quiet"

--- a/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
@@ -77,6 +77,7 @@ export function RailHost(_props: { railSlot?: never } = {}): JSX.Element {
         <button
           type="button"
           className={CLASS.chip}
+          data-rail-toggle=""
           aria-label={label}
           onClick={() => prefsStore.getState().setSidebarHidden(false)}
         >

--- a/cmd/evener-hub/frontend/src/stores/prefs.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.test.ts
@@ -118,6 +118,11 @@ describe("defaults (empty localStorage)", () => {
   test("notificationsLoudScope defaults to asks", () => {
     expect(prefsStore.getState().notificationsLoudScope).toBe("asks");
   });
+  // The WCAG 2.1.4 character-key turn-off (the p4 plan's Design decision 3):
+  // the turn-off exists, and the default is ON.
+  test("characterKeyTriggers defaults to true", () => {
+    expect(prefsStore.getState().characterKeyTriggers).toBe(true);
+  });
 });
 
 describe("hydration from existing localStorage", () => {
@@ -513,6 +518,19 @@ describe("setNotificationsLoudScope", () => {
     prefsStore.getState().setNotificationsLoudScope("all");
     expect(localStorage.getItem(KEY("notificationsLoudScope"))).toBe("all");
     expect(prefsStore.getState().notificationsLoudScope).toBe("all");
+  });
+});
+
+describe("setCharacterKeyTriggers", () => {
+  test("persists under its own evener.prefs.characterKeyTriggers key and updates state", () => {
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(localStorage.getItem(KEY("characterKeyTriggers"))).toBe("0");
+    expect(prefsStore.getState().characterKeyTriggers).toBe(false);
+    // A fresh hydration (what the next page load does) reads it back.
+    resetPrefsStoreForTests();
+    expect(prefsStore.getState().characterKeyTriggers).toBe(false);
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(localStorage.getItem(KEY("characterKeyTriggers"))).toBe("1");
   });
 });
 

--- a/cmd/evener-hub/frontend/src/stores/prefs.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.ts
@@ -101,6 +101,12 @@ export interface PrefsStoreState {
   // match the PINNED evener.prefs.enterToSend / evener.prefs.showCost keys.
   enterToSend: boolean;
   showCost: boolean;
+  // Keybindings (Settings -> Keybindings): whether character-key triggers -
+  // today exactly the "?" cheatsheet-overlay trigger - are live. WCAG 2.1.4
+  // requires a way to turn single-character shortcuts off; default ON (the
+  // turn-off exists, per the p4 plan's Design decision 3). Browser-local by
+  // controller ruling: NOT a hub settings key.
+  characterKeyTriggers: boolean;
   notifications: Record<NotificationKey, boolean>;
   notificationsLoudScope: NotificationsLoudScopePref;
 
@@ -112,6 +118,7 @@ export interface PrefsStoreState {
   setTranscriptStatus(key: TranscriptStatusKey, value: boolean): void;
   setEnterToSend(value: boolean): void;
   setShowCost(value: boolean): void;
+  setCharacterKeyTriggers(value: boolean): void;
   setNotification(key: NotificationKey, value: boolean): void;
   setNotificationsLoudScope(value: NotificationsLoudScopePref): void;
 }
@@ -453,6 +460,7 @@ function loadInitialState(): Omit<
   | "setTranscriptStatus"
   | "setEnterToSend"
   | "setShowCost"
+  | "setCharacterKeyTriggers"
   | "setNotification"
   | "setNotificationsLoudScope"
 > {
@@ -471,6 +479,7 @@ function loadInitialState(): Omit<
     transcript: loadTranscript(),
     enterToSend: readBool("enterToSend", false),
     showCost: readBool("showCost", false),
+    characterKeyTriggers: readBool("characterKeyTriggers", true),
     notifications: loadNotifications(),
     notificationsLoudScope: readEnum("notificationsLoudScope", LOUD_SCOPE_VALUES, "asks"),
   };
@@ -529,6 +538,11 @@ export const prefsStore = createStore<PrefsStoreState>((set) => ({
   setShowCost(value) {
     writeBool("showCost", value);
     set({ showCost: value });
+  },
+
+  setCharacterKeyTriggers(value) {
+    writeBool("characterKeyTriggers", value);
+    set({ characterKeyTriggers: value });
   },
 
   setNotification(key, value) {

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,16 +1,19 @@
 # Web UI keybindings
 
-Status: **current** (Phase 3). The web hub's global keyboard chords are
+Status: **current** (Phase 4a). The web hub's global keyboard chords are
 owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
 window-level dispatcher, instead of each component installing its own
 `keydown` listener. User overrides persist on the hub and sync to every
-paired browser. Phase 3 added the first navigation bindings (session-pane
+paired browser. Phase 3 added the navigation bindings (session-pane
 cycling, transcript scroll) on that infrastructure, plus full keyboard
-operation of the AskDock ask-user surface.
+operation of the AskDock ask-user surface. Phase 4a finalized the default
+map (strict Mod chords for ⌘K/⌘I/⌘J, new `settings` and transcript
+end-jump bindings) and shipped the two discoverability surfaces: the
+cheatsheet overlay (⌘/ or `?`) and hold-modifier hint chips.
 
 ## Architecture
 
-Four pieces, all in `src/keybindings/` and all React-free:
+Seven pieces, all in `src/keybindings/` and all React-free:
 
 - **chord.ts** — the chord AST (`Chord` = required modifiers + optional
   modifiers + key; `KeySequence` = a list of presses). `parseChord` wraps
@@ -26,16 +29,21 @@ Four pieces, all in `src/keybindings/` and all React-free:
 - **dispatcher.ts** — the single window-level `keydown` listener. On every
   registry change it rebuilds a tinykeys `createKeybindingsHandler` over the
   active scope set: the scope stack top-down, then the `global` scope.
-- **defaults.ts** — the built-in binding map (the six legacy shell chords
-  plus the six Phase 3 navigation chords) and
-  `registerDefaultBindings`, which also registers each `$mod` chord's
-  cross-platform Meta/Control twin (the pre-dispatcher listeners accepted
-  `metaKey || ctrlKey` on every platform, so both work everywhere).
-  `DEFAULT_BINDINGS` is also the canonical action universe: each entry
-  carries the action's user-facing `title`, and the Settings keybindings
-  section enumerates it live. `registerDefaultBindingsForAction` and
-  `defaultBindingChordsForAction` are the per-action variants the overrides
-  layer uses to restore and to simulate restorations.
+- **defaults.ts** — the built-in binding map (the six legacy shell chords,
+  the six Phase 3 navigation chords, and the Phase 4a additions:
+  `settings`, `transcript.scrollTop`/`scrollBottom`, and the cheatsheet
+  triggers) and `registerDefaultBindings`, which also registers each
+  `$mod` chord's cross-platform Meta/Control twin (the pre-dispatcher
+  listeners accepted `metaKey || ctrlKey` on every platform, so both work
+  everywhere). `DEFAULT_BINDINGS` is also the canonical action universe:
+  each entry carries the action's user-facing `title`, and both the
+  Settings keybindings section and the cheatsheet overlay enumerate it
+  live. One entry is CONDITIONAL: the `?` cheatsheet trigger
+  (`CHARACTER_KEY_TRIGGER_BINDING_ID`), registered only while the
+  character-key-triggers pref is on (see the cheatsheet section below).
+  `registerDefaultBindingsForAction` and `defaultBindingChordsForAction`
+  are the per-action variants the overrides layer uses to restore and to
+  simulate restorations.
 - **overrides.ts** — `rebindAction(registry, actionId, chord | null)`
   replaces an action's current bindings (default + `#mod-twin` + any earlier
   `#override`) with a single `#override` binding that keeps the default's
@@ -46,15 +54,23 @@ Four pieces, all in `src/keybindings/` and all React-free:
   never throws: unknown actions, unparseable chords, reserved
   (browser/OS-claimed) chords, and conflicts each become a typed
   `ValidationWarning` and the rule is skipped.
+- **display.ts** — the shared read model for the two binding-list UIs
+  (Settings → Keybindings and the cheatsheet overlay):
+  `ACTION_DISPLAY_ROWS` (one row per action, in default-map order) and
+  `displayBindingsFor`, which picks an action's effective display bindings
+  from the live registry (the override alone when one is applied, else
+  every non-twin default entry). Both UIs read this module so no
+  hand-maintained copy can go stale.
 
 The one wiring point that touches React and the app's stores is
 `src/shell/installKeybindings.ts`: an idempotent per-window installer that
-registers the default bindings and attaches the dispatcher with the real
+registers the default bindings, installs the character-key-trigger
+reconcile (the `?` pref gating), and attaches the dispatcher with the real
 predicates injected. AppShell calls it at mount; every component that
-registers a chord action (RailHost, Settings, SelectionQuote, and every
-Session pane via its transcript-scroll hook) calls it too, so those
-components' chords also work when they are mounted without the shell —
-their unit tests render them standalone.
+registers a chord action (RailHost, Settings, SelectionQuote,
+CheatsheetOverlay, and every Session pane via its transcript-scroll hook)
+calls it too, so those components' chords also work when they are mounted
+without the shell — their unit tests render them standalone.
 
 ## Precedence
 
@@ -98,14 +114,16 @@ equivalent of the per-component listeners the dispatcher replaced.
 Phase 3's transcript scroll uses the same contract, keyed on the focused
 pane instead of a captured selection (see below).
 
-## Default binding map (as shipped after Phase 3)
+## Default binding map (final since Phase 4a)
 
 Every entry of `DEFAULT_BINDINGS` (`src/keybindings/defaults.ts`), in map
 order. Chords are rendered the way `KeyHint`/`formatChord` render them:
 `$mod` reads as ⌘ on Apple platforms and Ctrl elsewhere, every other key
 name is verbatim. "Policy" lists only the flags that differ from the
 defaults (`allowInEditable: false`, `allowInModal: false`,
-`ignoreIfDefaultPrevented: true`).
+`ignoreIfDefaultPrevented: true`). The `?` row is the map's one
+conditional entry: it is live only while the character-key-triggers pref
+is on (see the cheatsheet section below).
 
 | Chord | Action | Scope | Non-default policy | What it does |
 |---|---|---|---|---|
@@ -114,60 +132,63 @@ defaults (`allowInEditable: false`, `allowInModal: false`,
 | ⌘I / Ctrl+I | `composer.focus` | global | `allowInEditable` | Focus the composer |
 | ⌘J / Ctrl+J | `next-needs-you` | global | `allowInEditable` | Go to the next session needing you |
 | ⌘' / Ctrl+' | `selection.quote` | global | `allowInEditable`, `allowInModal` | Quote the selection into the composer |
+| ⌘, / Ctrl+, | `settings` | global | `allowInEditable` | Open settings (the action id IS the palette's `settings` command id) |
 | Alt+ArrowRight | `session.next` | global | — | Focus the next session pane |
 | Alt+ArrowLeft | `session.previous` | global | — | Focus the previous session pane |
 | Alt+ArrowUp | `transcript.lineUp` | global | — | Scroll the focused pane's transcript up one line |
 | Alt+ArrowDown | `transcript.lineDown` | global | — | Scroll the focused pane's transcript down one line |
 | Alt+Shift+ArrowUp | `transcript.pageUp` | global | — | Scroll the focused pane's transcript up one page |
 | Alt+Shift+ArrowDown | `transcript.pageDown` | global | — | Scroll the focused pane's transcript down one page |
+| Alt+Home | `transcript.scrollTop` | global | — | Jump the focused pane's transcript to the top |
+| Alt+End | `transcript.scrollBottom` | global | — | Jump the focused pane's transcript to the bottom |
 | Escape | `settings.close` | settings | `allowInEditable` | Close settings |
+| ⌘/ / Ctrl+/ | `cheatsheet.toggle` | global | `allowInEditable`, `allowInModal` | Open/close the keyboard shortcuts overlay |
+| ? | `cheatsheet.toggle` | global | conditional on the character-key-triggers pref | Open/close the keyboard shortcuts overlay |
+| Escape | `cheatsheet.close` | cheatsheet | `allowInEditable` | Close the keyboard shortcuts overlay |
 
-Match permissiveness, per chord (all of it exact preservation of the
-pre-dispatcher listeners — Phase 2a's ruling was no behavior change):
+Match permissiveness, per chord. The legacy chords preserve the
+pre-dispatcher listeners exactly except where Phase 4a deliberately
+tightened them — called out first:
 
+- **Phase 4a behavior change: ⌘K / ⌘I / ⌘J are now STRICT.** The 2a map
+  had carried the legacy AppShell listener's missing shift/alt guard as
+  `[Shift]+[Alt]` optionality, so ⌘⌥I fired `composer.focus` and
+  Ctrl+Shift+J fired `next-needs-you` — hijacking the browser's DevTools
+  chords. Phase 4a dropped that optionality
+  (`docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md`,
+  Design decision 1): ⌘⌥I, Ctrl+Shift+J, and ⌘⇧J now revert to the
+  browser. The `legacyEitherMod` either/both-Meta-Ctrl permissiveness
+  stays.
 - Every `$mod` chord also registers its cross-platform Meta/Control twin,
   so e.g. Ctrl+K fires on macOS exactly like ⌘K. On top of that, the five
   legacy `$mod` chords carry `legacyEitherMod`: the other of Meta/Ctrl is
   an *optional* modifier on both the entry and its twin, so Meta+Ctrl+K
   fires too.
-- ⌘K / ⌘I / ⌘J list `[Shift]+[Alt]` as optional modifiers (the legacy
-  AppShell listener had no shift/alt guard), so ⌘⇧K, ⌘⌥I, Ctrl+Shift+J
-  etc. all fire. This means `composer.focus` and `next-needs-you` keep
-  hijacking the browser's DevTools chords (⌘⌥I, Ctrl+Shift+J) exactly as
-  the legacy listeners did — see the provisional-status note below.
 - ⌘' allows an extra Shift but never Alt (the legacy `!event.altKey`
   AltGr guard); ⌘B is strict — no extra modifiers at all.
+- ⌘, (`settings`) and ⌘/ (`cheatsheet.toggle`) are new chords with no
+  legacy listener to match: strict `$mod` with the cross-platform twin
+  only, no `legacyEitherMod`.
+- `?` lists Shift as optional because tinykeys rejects an event carrying
+  any modifier the binding does not name, and every common layout types
+  `?` WITH Shift held — a bare `?` binding would never fire. Display
+  drops optional modifiers, so the row still reads `?`.
 - `settings.close`'s Escape lists every modifier optional (the legacy
-  listener checked only `event.key === "Escape"`).
-- The six Phase 3 Alt chords are strict single-family chords with no
+  listener checked only `event.key === "Escape"`); `cheatsheet.close`'s
+  Escape is the same.
+- The eight Alt chords are strict single-family chords with no
   optional modifiers — Alt+ArrowUp and Alt+Shift+ArrowUp must stay
   distinct bindings (line vs page scroll), which forbids a `[Shift]` on
   the plain chord — and no `$mod` twin. All keep the default
-  `allowInEditable: false`, so plain Alt+Arrow keeps its native
-  word-move/selection meaning inside inputs and the composer.
+  `allowInEditable: false`, so plain Alt+Arrow and Alt+Home/End keep
+  their native word-move/selection/caret meaning inside inputs and the
+  composer.
 
-Two registered actions have **no default chord**: `transcript.scrollTop`
-and `transcript.scrollBottom`. Their handlers exist (each Session pane
-registers them), but the Phase 4 keymap decides whether they get a chord
-at all. Because `DEFAULT_BINDINGS` is the Settings section's row source
-and the override validator's action universe, chord-less actions appear in
-neither — an override payload naming one is skipped with an unknown-action
-warning.
-
-### Provisional status
-
-The six Phase 3 chords are provisional: Phase 4 owns the comprehensive
-keymap and may re-cut any of them (they are registry defaults, remappable
-via the Phase 2b overrides store from day one). The ledger records two
-known Phase 4 candidates:
-
-1. **Removing the legacy DevTools-chord hijack permissiveness.** ⌘⌥I and
-   Ctrl+Shift+J fire `composer.focus` and `next-needs-you` today because
-   Phase 2a preserved the legacy listeners' missing shift/alt guards
-   exactly. Revisiting that was deferred policy then and is still open.
-2. **Deciding chords for `transcript.scrollTop`/`scrollBottom`** — and, if
-   they stay chord-less, giving the validator/Settings story for actions
-   that exist outside `DEFAULT_BINDINGS`.
+The map is final as of Phase 4a: the provisional ledger Phase 3 carried
+is closed — the DevTools-chord hijack permissiveness is gone (above) and
+`transcript.scrollTop`/`scrollBottom` have their chords. Every binding
+stays remappable through the hub-synced overrides store (Persistence
+below); the Settings listing is read-only until the Phase 4b editor.
 
 ## Phase 3: session-pane cycling
 
@@ -195,8 +216,8 @@ each:
 
 `transcript.lineUp/lineDown` (Alt+ArrowUp/Down) and
 `transcript.pageUp/pageDown` (Alt+Shift+ArrowUp/Down) scroll the focused
-session pane's transcript; `transcript.scrollTop`/`scrollBottom` jump to
-the ends (chord-less for now). The seam is
+session pane's transcript; `transcript.scrollTop`/`scrollBottom` (Alt+Home
+/ Alt+End since Phase 4a) jump to the ends. The seam is
 `src/panes/session/transcript/flow/useTranscriptScrollKeys.ts`, mounted
 once per Session pane:
 
@@ -257,6 +278,70 @@ overrides store:
   row is still hidden/inert, so focus moves to the first remaining batch's
   entry control instead. A failed send keeps focus in the intact dock; a
   stale outcome is a no-op.
+
+## Phase 4a: cheatsheet overlay
+
+`cheatsheet.toggle` opens a modal "Keyboard shortcuts" overlay
+(`src/shell/cheatsheet/CheatsheetOverlay.tsx`) listing every action with
+its EFFECTIVE chord, grouped Sessions / Transcript / Composer / General
+(anything the grouping doesn't name — including a future action — lands
+in General, so a new action can never silently vanish). Both the row list
+and the chords are live reads (`keybindings/display.ts` over the
+registry), so hub-synced overrides and unbound actions render truthfully
+— an action with no effective binding shows "Unbound".
+
+Triggers:
+
+- **⌘/ (Ctrl+/ elsewhere)** — the primary trigger, an ordinary default-map
+  binding for `cheatsheet.toggle`. `allowInEditable` (not a printable
+  character) and `allowInModal`, so the same chord also toggles the
+  overlay CLOSED while it is open.
+- **?** — the secondary trigger, and the default map's one CONDITIONAL
+  entry (`CHARACTER_KEY_TRIGGER_BINDING_ID`). It is registered exactly
+  while the **Character-key shortcuts** pref
+  (`prefsStore.characterKeyTriggers`, browser-local localStorage, default
+  ON) is on — the WCAG 2.1.4 turn-off for single-character shortcuts. The
+  pref surfaces as a Switch row at the top of Settings → Keybindings;
+  turning it off leaves every shortcut on a modifier chord. Because `?` is
+  a printable character it never fires from an editable target or over a
+  modal. The reconcile (`cheatsheetController.ts`) subscribes to both the
+  prefs store and the overrides store: an applied override (or unbind)
+  owns the action's whole chord set, so `?` never reappears on an
+  overridden `cheatsheet.toggle` — the override is the user's own
+  replacement for both triggers.
+- **Close**: Escape (the OverlayPanel's own handler claims it first
+  whenever focus is inside the dialog; the scope-gated `cheatsheet.close`
+  binding is the window-level backstop) or ⌘/ again.
+
+Desktop-only: AppShell mounts the overlay only off mobile, so no action
+is registered on a touch viewport and the trigger chords stay inert there
+(RailHost's `rail.toggle` no-registration pattern). The `?` reconcile
+installs with the dispatcher, not the overlay, so the pref invariant — and
+the Settings section's customized-marker comparison — holds on mobile too.
+
+## Phase 4a: hold-modifier hints
+
+Holding the primary modifier ALONE — ⌘ on Apple platforms, Ctrl elsewhere
+— for ~400ms fades hint chips in over the bound affordances
+(`src/shell/holdhints/`): the palette trigger, the rail toggle, the
+session tabs (one chip carrying both cycling chords), and the composer.
+Each chip shows the action's effective chord from the live registry (the
+same `display.ts` read the overlay and Settings make), so overrides show
+truthfully and an unbound action renders no chip. Chips anchor to the real
+elements at show time via their data attributes — never
+absolutely-positioned guesses — so an affordance that is not mounted (the
+rail's toggle exists in exactly one of its two states) renders no chip.
+
+Release hides the chips, and so does every other cleanup path: window
+blur, `visibilitychange`, any keydown that is not the tracked modifier (on
+macOS a chord's keyup may never arrive, so the keydown itself is the
+hide), and a 10s hard-timeout backstop. A stuck visible state must be
+impossible. The listeners are observers only — they never preventDefault
+or stopPropagation, so the dispatcher and every other keydown consumer see
+exactly the events they would see without this module. Under
+`prefers-reduced-motion` the chips appear instantly (no fade).
+Desktop-only by AppShell's mount gate: a touch viewport installs no
+listeners and renders no chips.
 
 ## Registering an action and a binding
 
@@ -405,24 +490,22 @@ never escapes the client's notification dispatch.
 ### Settings section
 
 Settings → Keybindings is a **read-only** listing of the effective
-bindings: one row per action from `DEFAULT_BINDINGS` (never a
-hand-maintained copy), the chord rendered with the `KeyHint` widget from
-the live registry, and a "Customized" marker on actions whose effective
-bindings differ from the default map (including unbound actions). The
-store's `hubSupport`/`hubError`/validation warnings surface as quiet status
-or alert text. Editing arrives with the Phase 4 editor.
+bindings: one row per action from `DEFAULT_BINDINGS` via
+`keybindings/display.ts` (never a hand-maintained copy), the chord
+rendered with the `KeyHint` widget from the live registry, and a
+"Customized" marker on actions whose effective bindings differ from the
+default map (including unbound actions; the `?` entry's pref-conditional
+registration is not itself a customization). A **Character-key shortcuts**
+Switch row at the top owns the WCAG 2.1.4 pref. The store's
+`hubSupport`/`hubError`/validation warnings surface as quiet status or
+alert text. Editing arrives with the Phase 4b editor.
 
 ## Deliberately not here yet
 
 Later phases of the webui-keybindings plan add, and this module already
 leaves room for:
 
-- **A keybinding editor** (Phase 4) — the store's `patchOverrides` is the
+- **A keybinding editor** (Phase 4b) — the store's `patchOverrides` is the
   write path it will use; the Settings section stays read-only until then.
-- **A shortcuts overlay / cheatsheet UI** — planned for Phase 3, not landed;
-  Phase 3 as executed shipped the navigation bindings, the AskDock keyboard
-  contract, and this map instead.
-- **Hold-modifier chord hints** (Phase 4) — `formatChord`/`formatSequence`
-  exist for exactly this consumer.
 - `Binding.when` is still stored verbatim and never evaluated; scope-stack
   membership is the only gating the dispatcher applies.


### PR DESCRIPTION
Phase 4a of the WebUI keybinding system (survey: #853, dispatcher: #860, persistence: #861, navigation: #863). Stacked on #863's branch.

## What ships

**Final binding map** (task 1):
- `⌘K` / `⌘I` / `⌘J` are now strict chords — the legacy optional-Shift/Alt permissiveness is gone, so **`⌘⌥I`, `Ctrl+Shift+J`, and `⌘⇧J` revert to the browser** (DevTools/downloads). Meta-or-Ctrl either/both permissiveness is kept. Deliberate, user-approved behavior change; the 2a parity test now pins the strict contract.
- New defaults: `⌘,` opens Settings; `Alt+Home` / `Alt+End` jump the focused transcript to top/bottom (editable-suppressed).

**Cheatsheet overlay** (task 2): `⌘/` (Ctrl+/ elsewhere) opens a grouped overlay listing every action's *effective* chord, live from the registry so overrides show truthfully. Secondary trigger `?` outside editable fields, behind a new character-key-triggers toggle (default ON; WCAG 2.1.4 turn-off; persisted in the frontend prefs store). Escape / `⌘/` close. Mobile: inert.

**Hold-modifier hints** (task 3): hold `⌘` (macOS) / `Ctrl` ~400ms to reveal hint chips over bound affordances, showing effective chords. Observer-only listeners (no preventDefault); hides on release, blur, visibilitychange, any key, or a hard timeout; honors prefers-reduced-motion; desktop-only.

**Docs** (task 4): `docs/web-ui/keybindings.md` finalized — full map table, strict-chord callout, overlay/hints sections; provisional-status note removed.

## Verification

- 4564 frontend tests green (271 files), tsc clean, biome clean.
- `make test-web` PASS; `make test-web-browser` PASS (run with a TMPDIR override for a sandbox Chrome socket-path-length SIGTRAP — environmental, no repo impact).
- SDD per-task reviews + final whole-branch review: **Ready**, 0 Critical / 0 Important; 12 minors triaged as fine-as-deferred (notables: settings section shows only ⌘/ for the cheatsheet row; hint-chip React duplicate-key edge when two chips show identical overridden chords).

## Notes for reviewers

- The `?` binding carries optional Shift because every common layout types `?` with Shift held; tinykeys rejects unlisted modifiers. Documented in defaults.ts.
- `⌘/` has `allowInModal: true` so the same chord toggles the overlay closed from inside its own dialog (same trade-off as the palette's `⌘K` exemption); Escape unwinds top-first.
- Phase 4b (the settings-UI binding *editor*) follows on this branch's base; the settings section remains read-only here.