### PR TITLE
fix(plugins): give the bundled cache its own lock

### DIFF
--- a/appwire/types.go
+++ b/appwire/types.go
@@ -2827,13 +2827,14 @@ type PluginCheckNowResponse struct {
 
 // PluginPreviewParams requests the launch plugin inventory for a working
 // directory and optional per-launch overrides. Preview starts no session and
-// runs no plugin code; for a requested bundled plugin it readies the same store
-// a launch publishes into, staging and removing a marked copy, so it fails
-// wherever the launch it describes would. Readying that store creates the
-// bundled directory under the plugin root when it is missing, and the
-// directory stays behind once the staged copy is removed; a destination
-// holding content the running binary did not publish is reported as the
-// conflict a launch would set aside, and left exactly where it is.
+// runs no plugin code; for a requested bundled plugin it readies the same
+// store a launch publishes into, staging and removing a marked copy, so it
+// fails wherever the launch it describes would. Readying that store creates
+// the bundled directory under the plugin root when it is missing, and the
+// directory stays behind — with the lock file the cache keeps in it — once the
+// staged copy is removed; a destination holding content the running binary did
+// not publish is reported as the conflict a launch would set aside, and left
+// exactly where it is.
 type PluginPreviewParams struct {
 	CWD             string             `json:"cwd"`
 	LaunchOverrides *LaunchConfigLayer `json:"launchOverrides,omitempty"`

--- a/cmd/evener-hub/app_plugin_preview_test.go
+++ b/cmd/evener-hub/app_plugin_preview_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"primeradiant.com/evener/appwire"
@@ -370,6 +371,9 @@ func TestPluginPreviewBundledPluginPublishesNothing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read the bundled store after a preview: %v", err)
 	}
+	// The bundled cache keeps its own lock file, which readying the store
+	// opens; it is not something a preview published.
+	entries = slices.DeleteFunc(entries, func(e os.DirEntry) bool { return e.Name() == ".lock" })
 	if len(entries) != 0 {
 		t.Fatalf("preview left %d entries in the plugin store: %v", len(entries), entries)
 	}

--- a/cmd/evener-hub/app_plugins.go
+++ b/cmd/evener-hub/app_plugins.go
@@ -26,15 +26,16 @@ import (
 // written with no OS-level lock, so an in-process mutex is the only thing
 // preventing a lost update between concurrent Create/Edit/Remove/SetDefault
 // calls. plugins.Manager is different: every mutating call (and Browse's
-// lazy-fetch) takes the manager's own flock on a single per-root lock file
-// (m.lockPath()) for the whole read-modify-atomic-write sequence, and flock
-// serializes by open-file-description rather than by process, so it
-// correctly serializes concurrent in-process goroutines too — Manager itself
-// holds no other mutable state a controller-level mutex could protect. A
-// controller mutex here would add nothing but contention: it would be held
-// across the manager's own blocking (up to 30s) lock acquisition, serializing
-// otherwise-independent mutations (e.g. two unrelated marketplaces) behind
-// whichever one is slowest.
+// lazy-fetch) takes one of the manager's own flocks for the whole
+// read-modify-atomic-write sequence — the store lock for the registry, the
+// marketplaces and the plugin cache, and the bundled cache's own lock for
+// readying <Root>/bundled — and flock serializes by open-file-description
+// rather than by process, so it correctly serializes concurrent in-process
+// goroutines too — Manager itself holds no other mutable state a
+// controller-level mutex could protect. A controller mutex here would add
+// nothing but contention: it would be held across the manager's own blocking
+// (up to 30s) lock acquisition, serializing otherwise-independent mutations
+// (e.g. two unrelated marketplaces) behind whichever one is slowest.
 type hubPluginsController struct {
 	mgr              *plugins.Manager
 	launchConfigRoot string

--- a/cmd/evener-hub/app_plugins_test.go
+++ b/cmd/evener-hub/app_plugins_test.go
@@ -191,7 +191,7 @@ func TestPlugins_Marketplace_BrowseUnknown_Errors(t *testing.T) {
 
 // TestPlugins_ConcurrentAddMarketplace_NoLostUpdate exercises the claim
 // behind hubPluginsController holding no mutex of its own (see app_plugins.go's
-// doc comment): internal/plugins.Manager's single per-root flock — not an
+// doc comment): internal/plugins.Manager's own per-root store flock — not an
 // in-process mutex — is what serializes concurrent mutations, in-process or
 // not. Two goroutines register distinct marketplaces on the same controller
 // concurrently; both must succeed and both must land in the registry. A lost

--- a/cmd/evener-tui/internal/launchconfig/plugins_client.go
+++ b/cmd/evener-tui/internal/launchconfig/plugins_client.go
@@ -171,9 +171,9 @@ func CmdPluginList(client *appwire.Client) tea.Cmd {
 func CmdPluginPreview(client *appwire.Client, params appwire.PluginPreviewParams, key string) tea.Cmd {
 	return func() tea.Msg {
 		// Not a quick read: previewing a bundled plugin readies the store the
-		// way a launch does, which waits on the same flock every mutation
-		// takes. A client deadline under that wait would report a failure the
-		// hub is still working through.
+		// way a launch does, which waits on the bundled cache's flock for the
+		// same budget a publish gets. A client deadline under that wait would
+		// report a failure the hub is still working through.
 		ctx, cancel := context.WithTimeout(context.Background(), pluginsSlowTimeout)
 		defer cancel()
 		resp, err := client.PluginPreview(ctx, params)

--- a/internal/plugins/locks.go
+++ b/internal/plugins/locks.go
@@ -22,6 +22,15 @@ var (
 	lockSleep = time.Sleep
 )
 
+// acquireBundledLock takes the bundled cache's lock for one mutation of
+// <Root>/bundled. Every bundled-cache mutation acquires here and nowhere else,
+// so whatever the acquirer the store lock goes through grows — the store-root
+// check Manager.acquireStoreLock centralizes — has one place to land for this
+// lock too. Callers reaching here have already been through storeRootError.
+func (m *Manager) acquireBundledLock(ctx context.Context, timeout time.Duration) (func(), error) {
+	return acquireLock(ctx, m.bundledLockPath(), timeout)
+}
+
 // acquireLock takes an exclusive flock on lockPath, retrying with capped
 // exponential backoff until ctx is canceled or timeout elapses. The returned
 // release unlocks and closes the file. Callers without a request context pass

--- a/internal/plugins/paths.go
+++ b/internal/plugins/paths.go
@@ -43,6 +43,24 @@ func (m *Manager) marketplacesDir() string { return filepath.Join(m.Root, "marke
 func (m *Manager) cacheDir() string        { return filepath.Join(m.Root, "cache") }
 func (m *Manager) lockPath() string        { return filepath.Join(m.Root, ".lock") }
 
+// bundledDir is evener's content-addressed cache of the plugins the running
+// binary ships.
+func (m *Manager) bundledDir() string { return filepath.Join(m.Root, "bundled") }
+
+// bundledLockName is the lock file the bundled cache keeps beside the copies
+// it holds. Named here because the sweep and every store listing has to know
+// it is not a plugin.
+const bundledLockName = ".lock"
+
+// bundledLockPath excludes bundled publishers from each other and from nobody
+// else. Publishing a bundled copy is a classify, set-aside, stage and rename
+// sequence that touches only bundledDir, so it has no business waiting on the
+// store lock, which install, upgrade, gc, catalog and marketplace refresh hold
+// across git fetches.
+func (m *Manager) bundledLockPath() string {
+	return filepath.Join(m.bundledDir(), bundledLockName)
+}
+
 func (m *Manager) marketplaceDir(name string) string {
 	return filepath.Join(m.marketplacesDir(), name)
 }

--- a/internal/plugins/paths_test.go
+++ b/internal/plugins/paths_test.go
@@ -22,6 +22,8 @@ func TestManagerPaths(t *testing.T) {
 		m.marketplacesDir():                      "/store/marketplaces",
 		m.cacheDir():                             "/store/cache",
 		m.lockPath():                             "/store/.lock",
+		m.bundledDir():                           "/store/bundled",
+		m.bundledLockPath():                      "/store/bundled/.lock",
 		m.marketplaceDir("acme"):                 "/store/marketplaces/acme",
 		m.pluginCacheDir("acme", "widget", "ab"): "/store/cache/acme/widget/ab",
 	}

--- a/internal/plugins/resolve.go
+++ b/internal/plugins/resolve.go
@@ -80,14 +80,14 @@ func (m *Manager) ResolveForLaunch(ctx context.Context, explicitDirs []string, e
 // store the way a launch does, so a destination a launch would reject fails
 // preview the same way, a store a launch could not publish into fails preview
 // too, and an already published copy is the one preview describes. Exactly
-// what it touches: it creates <Root>/bundled if that is missing, it takes the
-// bundled cache's lock while it works there, and for a requested bundled
-// plugin not yet published it stages a marked copy there, reads it, and
-// removes it before returning. A destination holding content this build did
-// not publish is reported as the conflict a launch would act on and left
-// exactly where it is: repairing the store belongs to a launch, and a preview
-// that moved that directory would take a path live sessions read out from
-// under them. It publishes nothing, and it reclaims nothing: collecting
+// what it touches: it creates <Root>/bundled and the lock file the cache keeps
+// there if either is missing, it takes that lock while it works there, and for
+// a requested bundled plugin not yet published it stages a marked copy there,
+// reads it, and removes it before returning. A destination holding content
+// this build did not publish is reported as the conflict a launch would act on
+// and left exactly where it is: repairing the store belongs to a launch, and a
+// preview that moved that directory would take a path live sessions read out
+// from under them. It publishes nothing, and it reclaims nothing: collecting
 // abandoned staging belongs to a launch. Removing what it staged is part of
 // the promise, so a removal that fails is reported as a diagnostic on the
 // inventory it returns rather than as an error that would throw the inventory

--- a/internal/plugins/resolve.go
+++ b/internal/plugins/resolve.go
@@ -607,7 +607,7 @@ func (m *Manager) prepareBundledStore(ctx context.Context, name string, intent b
 			// does not get quickly is left to the next launch rather than
 			// making this one queue behind whatever holds it. Whether the
 			// orphans are really abandoned is decided again under the lock.
-			if release, lockErr := acquireLock(ctx, m.bundledLockPath(), bundledSweepLockWait); lockErr == nil {
+			if release, lockErr := m.acquireBundledLock(ctx, bundledSweepLockWait); lockErr == nil {
 				m.reclaimAbandonedStaging(store)
 				release()
 			}
@@ -626,7 +626,7 @@ func (m *Manager) prepareBundledStore(ctx context.Context, name string, intent b
 	// lock two launches both classify a mismatched destination, and the second
 	// sets aside the copy the first published while deleting the copy the
 	// first preserved.
-	release, err := acquireLock(ctx, m.bundledLockPath(), bundledPublishLockWait)
+	release, err := m.acquireBundledLock(ctx, bundledPublishLockWait)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("stage bundled plugin %s: %w", name, err)
 	}

--- a/internal/plugins/resolve.go
+++ b/internal/plugins/resolve.go
@@ -81,17 +81,18 @@ func (m *Manager) ResolveForLaunch(ctx context.Context, explicitDirs []string, e
 // preview the same way, a store a launch could not publish into fails preview
 // too, and an already published copy is the one preview describes. Exactly
 // what it touches: it creates <Root>/bundled if that is missing, it takes the
-// store lock while it works there, and for a requested bundled plugin not yet
-// published it stages a marked copy there, reads it, and removes it before
-// returning. A destination holding content this build did not publish is
-// reported as the conflict a launch would act on and left exactly where it is:
-// repairing the store belongs to a launch, and a preview that moved that
-// directory would take a path live sessions read out from under them. It
-// publishes nothing, and it reclaims nothing: collecting abandoned staging
-// belongs to a launch. Removing what it staged is part of the promise, so a removal that
-// fails is reported as a diagnostic on the inventory it returns rather than as
-// an error that would throw the inventory away; the marked directory stays in
-// the store until a later launch's sweep reclaims it.
+// bundled cache's lock while it works there, and for a requested bundled
+// plugin not yet published it stages a marked copy there, reads it, and
+// removes it before returning. A destination holding content this build did
+// not publish is reported as the conflict a launch would act on and left
+// exactly where it is: repairing the store belongs to a launch, and a preview
+// that moved that directory would take a path live sessions read out from
+// under them. It publishes nothing, and it reclaims nothing: collecting
+// abandoned staging belongs to a launch. Removing what it staged is part of
+// the promise, so a removal that fails is reported as a diagnostic on the
+// inventory it returns rather than as an error that would throw the inventory
+// away; the marked directory stays in the store until a later launch's sweep
+// reclaims it.
 func (m *Manager) PreviewForLaunch(ctx context.Context, explicitDirs []string, enabledNames *[]string) (LaunchPluginResolution, error) {
 	var scratch []string
 	resolution, err := m.resolveForLaunch(ctx, explicitDirs, enabledNames, func(name string) (bundledCandidate, error) {
@@ -102,8 +103,8 @@ func (m *Manager) PreviewForLaunch(ctx context.Context, explicitDirs []string, e
 		if staging == nil {
 			return bundledCandidate{loadPath: dest, path: dest, warnings: warnings}, nil
 		}
-		// Preview publishes nothing, so the store lock is only wanted for the
-		// staging that fills; reading the copy back needs nothing from the
+		// Preview publishes nothing, so the cache's lock is only wanted for
+		// the staging that fills; reading the copy back needs nothing from the
 		// store, and removing a private directory disturbs nobody.
 		defer staging.release()
 		// The loop that removes staged copies runs on a normal return, so a
@@ -361,11 +362,11 @@ const (
 	// replace it with.
 	previousSuffix = ".previous"
 	// bundledPublishLockWait is how long readying the store waits for the
-	// store lock, the same wait every other mutation takes. Publishing is what
-	// the launch came for, so it waits like one. bundledSweepLockWait is what
-	// the sweep waits on its way past: housekeeping nobody is waiting on, so a
-	// lock that is busy is somebody else's turn rather than something to queue
-	// behind.
+	// bundled cache's lock, the same wait every other mutation takes on the
+	// lock it needs. Publishing is what the launch came for, so it waits like
+	// one. bundledSweepLockWait is what the sweep waits on its way past:
+	// housekeeping nobody is waiting on, so a lock that is busy is somebody
+	// else's turn rather than something to queue behind.
 	bundledPublishLockWait = 30 * time.Second
 	bundledSweepLockWait   = time.Second
 )
@@ -381,11 +382,11 @@ var copyBundledPayload = os.CopyFS
 // below the marked directory, so publishing renames the copy alone and the
 // marker never lands inside a published plugin. digest is what the destination
 // must hold, carried along so a publish that finds the destination taken can
-// tell an identical copy from foreign content. release gives up the store lock
-// the staging was opened under: the lock makes classifying the destination,
-// setting a conflict aside and publishing one sequence, so it is held from the
-// classification this staging was created on until the caller has renamed the
-// copy into place or given up on it.
+// tell an identical copy from foreign content. release gives up the bundled
+// cache's lock the staging was opened under: the lock makes classifying the
+// destination, setting a conflict aside and publishing one sequence, so it is
+// held from the classification this staging was created on until the caller
+// has renamed the copy into place or given up on it.
 type bundledStaging struct {
 	dir     string
 	payload string
@@ -408,7 +409,8 @@ var stageBundledCopy = newBundledStaging
 // newBundledStaging opens a staging directory for base inside store and marks
 // it as this code's to reclaim before anything is copied in, so a publish
 // killed at any moment leaves an orphan a later sweep recognizes. release is
-// the store lock the caller holds, handed over for the staging to carry.
+// the bundled cache's lock the caller holds, handed over for the staging to
+// carry.
 func newBundledStaging(store, base, digest string, release func()) (*bundledStaging, error) {
 	dir, err := os.MkdirTemp(store, stagingPrefix+base+"-")
 	if err != nil {
@@ -465,7 +467,7 @@ func (m *Manager) materializeBundledPlugin(ctx context.Context, name string) (st
 		return failed(warnings, fmt.Errorf("materialize bundled plugin %s: %w", name, err))
 	}
 	if err := os.Rename(staging.payload, dest); err != nil {
-		// The store lock keeps every other publisher out, so a destination
+		// The cache's lock keeps every other publisher out, so a destination
 		// that filled since it was classified was filled by something outside
 		// this package. An identical copy is adopted; anything else is set
 		// aside the way the classification would have, and the publish is
@@ -497,10 +499,10 @@ func (m *Manager) materializeBundledPlugin(ctx context.Context, name string) (st
 // failed to put anything in the name it freed. The destination is the one path
 // live sessions hold — hooks, skills, MCP server commands — so leaving it
 // empty is worse than leaving the mismatched copy that was there. Nothing is
-// restored over a destination that is occupied again: under the store lock the
-// only thing that could have filled it is something outside this package, and
-// that is a conflict for the next launch to classify rather than something to
-// overwrite here.
+// restored over a destination that is occupied again: under the cache's lock
+// the only thing that could have filled it is something outside this package,
+// and that is a conflict for the next launch to classify rather than something
+// to overwrite here.
 func restoreBundledConflict(dest string) []string {
 	aside := dest + conflictSuffix
 	if _, err := os.Lstat(dest); err == nil {
@@ -596,8 +598,8 @@ func (m *Manager) prepareBundledStore(ctx context.Context, name string, intent b
 		}
 		// A launch owes the store its sweep, but only when the store has
 		// something to sweep, and the scan that answers that needs no lock.
-		// Taking one on every launch would park a routine one behind an
-		// auto-upgrade holding the store lock across git fetches.
+		// Taking one on every launch would park a routine one behind whatever
+		// publisher is filling its staging.
 		if publishing && len(m.abandonedStaging(store)) > 0 {
 			// Housekeeping for a launch that is otherwise done: it waits the
 			// housekeeping wait, not the wait a publish is entitled to — the
@@ -605,7 +607,7 @@ func (m *Manager) prepareBundledStore(ctx context.Context, name string, intent b
 			// does not get quickly is left to the next launch rather than
 			// making this one queue behind whatever holds it. Whether the
 			// orphans are really abandoned is decided again under the lock.
-			if release, lockErr := acquireLock(ctx, m.lockPath(), bundledSweepLockWait); lockErr == nil {
+			if release, lockErr := acquireLock(ctx, m.bundledLockPath(), bundledSweepLockWait); lockErr == nil {
 				m.reclaimAbandonedStaging(store)
 				release()
 			}
@@ -624,7 +626,7 @@ func (m *Manager) prepareBundledStore(ctx context.Context, name string, intent b
 	// lock two launches both classify a mismatched destination, and the second
 	// sets aside the copy the first published while deleting the copy the
 	// first preserved.
-	release, err := acquireLock(ctx, m.lockPath(), bundledPublishLockWait)
+	release, err := acquireLock(ctx, m.bundledLockPath(), bundledPublishLockWait)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("stage bundled plugin %s: %w", name, err)
 	}
@@ -735,11 +737,11 @@ func classifyBundledDestination(dest, digest string) (bundledDestination, error)
 // store staying unusable for that plugin forever. The conflicting directory is
 // moved, never deleted, to the single sibling slot kept beside the
 // destination: one preserved copy per plugin, so a store that keeps meeting
-// conflicts does not grow without bound. Callers hold the store lock, so
-// nothing else this package runs is looking at the destination meanwhile. It
-// reports what the caller should say about what it moved: nothing moves when
-// the destination is already gone, which under the lock means something
-// outside this package took it away.
+// conflicts does not grow without bound. Callers hold the bundled cache's
+// lock, so nothing else this package runs is looking at the destination
+// meanwhile. It reports what the caller should say about what it moved:
+// nothing moves when the destination is already gone, which under the lock
+// means something outside this package took it away.
 func setAsideBundledConflict(dest string) ([]string, error) {
 	aside := dest + conflictSuffix
 	previous := aside + previousSuffix
@@ -757,8 +759,8 @@ func setAsideBundledConflict(dest string) ([]string, error) {
 	}
 	// Whatever the slot holds is moved out of the way rather than deleted, so
 	// a destination that turns out not to be movable leaves the copy already
-	// preserved still preserved. Callers hold the store lock, so this name is
-	// nobody else's; anything under it is residue from a publish that died
+	// preserved still preserved. Callers hold the cache's lock, so this name
+	// is nobody else's; anything under it is residue from a publish that died
 	// between the two renames below, and is the occupant being replaced.
 	if err := os.RemoveAll(previous); err != nil {
 		return nil, fmt.Errorf("clear the bundled plugin path %s: %w", previous, err)
@@ -862,7 +864,7 @@ func (m *Manager) storeRootError() error {
 }
 
 func (m *Manager) bundledPluginPath(name, digest string) string {
-	return filepath.Join(m.Root, "bundled", name+"-"+digest)
+	return filepath.Join(m.bundledDir(), name+"-"+digest)
 }
 
 // bundledPluginDigest identifies the embedded contents of the bundled plugin

--- a/internal/plugins/resolve_test.go
+++ b/internal/plugins/resolve_test.go
@@ -383,10 +383,7 @@ func TestMaterializeBundledPlugin_NeverReplacesAPublishedCopy(t *testing.T) {
 	if !os.SameFile(before, after) {
 		t.Fatal("published copy was replaced by a new directory")
 	}
-	entries, err := os.ReadDir(filepath.Join(m.Root, "bundled"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	entries := bundledStoreEntries(t, m.bundledDir())
 	if len(entries) != 1 {
 		t.Fatalf("bundled store has %d entries, want only the published copy: %v", len(entries), entries)
 	}
@@ -415,10 +412,7 @@ func TestMaterializeBundledPlugin_ConcurrentCallsPublishOnce(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(paths[0], ".claude-plugin", "plugin.json")); err != nil {
 		t.Fatalf("published copy incomplete: %v", err)
 	}
-	entries, err := os.ReadDir(filepath.Join(m.Root, "bundled"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	entries := bundledStoreEntries(t, m.bundledDir())
 	if len(entries) != 1 {
 		t.Fatalf("bundled store has %d entries after a race, want one: %v", len(entries), entries)
 	}
@@ -444,10 +438,7 @@ func TestPreviewForLaunch_PublishesNothing(t *testing.T) {
 	if len(res.Candidates) != 1 || res.Candidates[0].Path != want || res.Candidates[0].Source != LaunchPluginSourceBundled || res.Candidates[0].AgentCount < 7 {
 		t.Fatalf("Candidates = %+v, want the bundled coordinator-workflow at %s", res.Candidates, want)
 	}
-	entries, err := os.ReadDir(filepath.Join(m.Root, "bundled"))
-	if err != nil {
-		t.Fatalf("read the bundled store after a preview: %v", err)
-	}
+	entries := bundledStoreEntries(t, m.bundledDir())
 	if len(entries) != 0 {
 		t.Fatalf("preview left %d entries in the plugin store: %v", len(entries), entries)
 	}
@@ -902,10 +893,7 @@ func TestBundledStore_AdoptsOnlyTheContentTheDigestNames(t *testing.T) {
 			if len(res.Candidates) != 1 || res.Candidates[0].Path != published || res.Candidates[0].AgentCount < 7 {
 				t.Fatalf("Candidates = %+v, want the published copy at %s", res.Candidates, published)
 			}
-			entries, err := os.ReadDir(filepath.Join(m.Root, "bundled"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			entries := bundledStoreEntries(t, m.bundledDir())
 			if len(entries) != 1 {
 				t.Errorf("bundled store holds %v, want only the published copy", entries)
 			}
@@ -1013,10 +1001,7 @@ func TestBundledStore_SetsAsideAConflictingDestination(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(aside, "first.md")); !os.IsNotExist(err) {
 			t.Errorf("an earlier set-aside copy survived (stat err = %v), want one slot per plugin", err)
 		}
-		entries, err := os.ReadDir(filepath.Join(m.Root, "bundled"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		entries := bundledStoreEntries(t, m.bundledDir())
 		if len(entries) != 2 {
 			t.Errorf("bundled store holds %v, want the published copy and the one slot beside it", entries)
 		}
@@ -1178,10 +1163,7 @@ func TestSetAsideBundledConflict_RecoversAnInterruptedSetAside(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(dest+conflictSuffix, "newer.md")); err != nil {
 			t.Errorf("the slot does not hold the conflict this launch found: %v", err)
 		}
-		entries, err := os.ReadDir(filepath.Join(m.Root, "bundled"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		entries := bundledStoreEntries(t, m.bundledDir())
 		if len(entries) != 2 {
 			t.Errorf("bundled store holds %v, want the published copy and the one slot beside it", entries)
 		}

--- a/internal/plugins/resolve_unix_test.go
+++ b/internal/plugins/resolve_unix_test.go
@@ -698,29 +698,36 @@ func TestBundledStore_AnUnreadableDestinationIsSetAsideLikeAnyOtherConflict(t *t
 func TestMaterializeBundledPlugin_PublishesWhileTheStoreLockIsHeld(t *testing.T) {
 	m := NewManager(t.TempDir())
 	// Somebody else holds the store lock, the way an auto-upgrade does across
-	// its git fetches.
+	// its git fetches, and goes on holding it past everything below: the
+	// publish has to finish under that lock rather than after it, so the
+	// holder lets go in cleanup and nowhere else.
 	release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer release()
+	t.Cleanup(release)
 
 	digest, err := bundledPluginDigest("coordinator-workflow")
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Well inside the wait a publish is entitled to on its own lock, so a
-	// publish that queued behind the store lock is bounded by this rather than
-	// by the 30 seconds it would otherwise spend before failing.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// A hang tripwire, nothing more. A publish that queued behind the store
+	// lock gives up on its own after the 30s budget and says which lock it was
+	// waiting for, which is the diagnosis worth having, so this sits well past
+	// that and decides nothing about whether the separation holds.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	start := time.Now()
 	published, _, err := m.materializeBundledPlugin(ctx, "coordinator-workflow")
 	if err != nil {
 		t.Fatalf("publishing while the store lock was held: %v", err)
 	}
-	if waited := time.Since(start); waited > 5*time.Second {
-		t.Errorf("publishing took %v, want it not to wait on the store lock at all", waited)
+	// The premise, checked rather than assumed: a publish that succeeded is
+	// only evidence if the store lock was still taken when it did. Nothing
+	// here turns on how long anything took — the lock is contended or the
+	// success above proves nothing.
+	if free, freeErr := acquireLock(context.Background(), m.lockPath(), 0); freeErr == nil {
+		free()
+		t.Error("the store lock was not held when the publish finished, so this proves nothing about the two locks")
 	}
 	if want := m.bundledPluginPath("coordinator-workflow", digest); published != want {
 		t.Fatalf("published %s, want %s", published, want)
@@ -760,8 +767,10 @@ func TestMaterializeBundledPlugin_LeavesTheStoreLockFreeWhilePublishing(t *testi
 	t.Cleanup(unblock)
 	<-publishing
 
-	// Mid-copy: whatever the publish is holding, the store lock is not it.
-	storeLock, err := acquireLock(context.Background(), m.lockPath(), 2*time.Second)
+	// Mid-copy: whatever the publish is holding, the store lock is not it. No
+	// wait budget at all, so nothing here turns on how loaded the machine is —
+	// the lock is free on the first try or the publish is holding it.
+	storeLock, err := acquireLock(context.Background(), m.lockPath(), 0)
 	if err != nil {
 		t.Fatalf("a bundled publish in flight blocked the store lock: %v", err)
 	}

--- a/internal/plugins/resolve_unix_test.go
+++ b/internal/plugins/resolve_unix_test.go
@@ -190,10 +190,7 @@ func TestPreviewForLaunch_ReportsAFailureToRemoveItsStaging(t *testing.T) {
 		!strings.Contains(res.Diagnostics[0].Message, "staged bundled preview") {
 		t.Fatalf("Diagnostics = %+v, want one naming the staging it could not remove", res.Diagnostics)
 	}
-	entries, readErr := os.ReadDir(store)
-	if readErr != nil {
-		t.Fatal(readErr)
-	}
+	entries := bundledStoreEntries(t, store)
 	if len(entries) != 1 || !strings.HasPrefix(entries[0].Name(), stagingPrefix) {
 		t.Fatalf("bundled store holds %v, want the staging the preview could not remove", entries)
 	}
@@ -204,10 +201,10 @@ func TestPreviewForLaunch_ReportsAFailureToRemoveItsStaging(t *testing.T) {
 
 // Two launches meeting the same mismatched destination must not undo each
 // other's work. Classifying, setting aside and publishing run as one sequence
-// under the store lock, so a classification made before the lock is never
-// acted on after it: the slot beside the destination keeps one copy of the
-// foreign content, the destination holds the copy this build publishes, and
-// neither is left vacant for a session that is already pointing at it.
+// under the bundled cache's lock, so a classification made before the lock is
+// never acted on after it: the slot beside the destination keeps one copy of
+// the foreign content, the destination holds the copy this build publishes,
+// and neither is left vacant for a session that is already pointing at it.
 func TestBundledStore_ConcurrentPublishKeepsOneConflictAndOneCopy(t *testing.T) {
 	digest, err := bundledPluginDigest("coordinator-workflow")
 	if err != nil {
@@ -245,10 +242,7 @@ func TestBundledStore_ConcurrentPublishKeepsOneConflictAndOneCopy(t *testing.T) 
 		if err != nil || string(content) != "someone else's data" {
 			t.Fatalf("attempt %d: set-aside content = %q (err %v), want the foreign data preserved", attempt, content, err)
 		}
-		entries, err := os.ReadDir(filepath.Dir(dest))
-		if err != nil {
-			t.Fatal(err)
-		}
+		entries := bundledStoreEntries(t, filepath.Dir(dest))
 		if len(entries) != 2 {
 			t.Fatalf("attempt %d: bundled store holds %v, want the published copy and one set-aside slot", attempt, entries)
 		}
@@ -341,12 +335,12 @@ func TestBundledStore_SetsAsideADestinationHoldingAFIFO(t *testing.T) {
 	}
 }
 
-// Readying the store waits for the store lock, so a caller that has given up
-// has to be able to stop that wait. The hub hands its request context down for
-// exactly this: a client that disconnected, or a TUI whose own deadline
-// passed, must not leave a handler parked on a lock some install is holding
-// for as long as the lock timeout allows.
-func TestResolveForLaunch_StopsWaitingForTheStoreLockWhenCancelled(t *testing.T) {
+// Readying the store waits for the bundled cache's lock, so a caller that has
+// given up has to be able to stop that wait. The hub hands its request context
+// down for exactly this: a client that disconnected, or a TUI whose own
+// deadline passed, must not leave a handler parked on a lock another publisher
+// is holding for as long as the lock timeout allows.
+func TestResolveForLaunch_StopsWaitingForTheBundledLockWhenCancelled(t *testing.T) {
 	tests := []struct {
 		name    string
 		resolve func(context.Context, *Manager) (LaunchPluginResolution, error)
@@ -367,8 +361,8 @@ func TestResolveForLaunch_StopsWaitingForTheStoreLockWhenCancelled(t *testing.T)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			m := NewManager(t.TempDir())
-			// Somebody else is holding the store lock, the way an install does.
-			release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
+			// Another bundled publisher is holding the cache's lock.
+			release, err := acquireLock(context.Background(), m.bundledLockPath(), time.Second)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -400,10 +394,11 @@ func TestResolveForLaunch_StopsWaitingForTheStoreLockWhenCancelled(t *testing.T)
 
 // Staging that looks abandoned may belong to a publisher that is merely slow —
 // paused, swapped out, waiting on a filesystem — and the only thing that tells
-// the two apart is the store lock that publisher holds from its first look at
-// the destination until its copy is in place. So the sweep runs under that
-// lock or not at all: a launch that cannot take it reclaims nothing.
-func TestMaterializeBundledPlugin_SweepsOnlyUnderTheStoreLock(t *testing.T) {
+// the two apart is the bundled cache's lock that publisher holds from its
+// first look at the destination until its copy is in place. So the sweep runs
+// under that lock or not at all: a launch that cannot take it reclaims
+// nothing.
+func TestMaterializeBundledPlugin_SweepsOnlyUnderTheBundledLock(t *testing.T) {
 	// Both ways a launch meets the store: publishing a copy, and adopting one
 	// that is already there. The second reaches the sweep only because it
 	// found something to sweep, and it is still not allowed to sweep unlocked.
@@ -438,8 +433,8 @@ func TestMaterializeBundledPlugin_SweepsOnlyUnderTheStoreLock(t *testing.T) {
 			}
 			m.Now = func() time.Time { return time.Now().Add(24 * time.Hour) }
 
-			// Somebody else holds the lock, so this launch never gets to look.
-			release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
+			// Another publisher holds the lock, so this launch never gets to look.
+			release, err := acquireLock(context.Background(), m.bundledLockPath(), time.Second)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -453,26 +448,26 @@ func TestMaterializeBundledPlugin_SweepsOnlyUnderTheStoreLock(t *testing.T) {
 				t.Fatalf("ResolveForLaunch error = %v, want %v", err, test.wantErr)
 			}
 			if _, err := os.Stat(staging); err != nil {
-				t.Fatalf("staging was swept without holding the store lock: %v", err)
+				t.Fatalf("staging was swept without holding the bundled cache lock: %v", err)
 			}
 		})
 	}
 }
 
 // A launch that only has to adopt a copy already published must not queue
-// behind whatever else is touching the store. Hub start runs the auto-upgrade
-// pass, which holds the store lock across git fetches; a launch that took the
-// lock for housekeeping it has no housekeeping for would wait that out, or
-// fail, for nothing. With no abandoned staging to reclaim there is nothing to
-// take the lock for, and the launch reads its copy and goes.
-func TestMaterializeBundledPlugin_AdoptsAPublishedCopyWithoutTheStoreLock(t *testing.T) {
+// behind whatever else is touching the bundled cache. A publisher of a
+// different plugin holds that cache's lock for its whole copy; a launch that
+// took the lock for housekeeping it has no housekeeping for would wait that
+// out, or fail, for nothing. With no abandoned staging to reclaim there is
+// nothing to take the lock for, and the launch reads its copy and goes.
+func TestMaterializeBundledPlugin_AdoptsAPublishedCopyWithoutTheBundledLock(t *testing.T) {
 	m := NewManager(t.TempDir())
 	published, _, err := m.materializeBundledPlugin(context.Background(), "coordinator-workflow")
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Somebody else is holding the store lock, the way an auto-upgrade does.
-	release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
+	// Another bundled publisher is holding the cache's lock.
+	release, err := acquireLock(context.Background(), m.bundledLockPath(), time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -486,7 +481,7 @@ func TestMaterializeBundledPlugin_AdoptsAPublishedCopyWithoutTheStoreLock(t *tes
 		t.Fatal(err)
 	}
 	if err := res.ValidateSelection(); err != nil {
-		t.Fatalf("a launch could not adopt a published copy while the store lock was held: %v", err)
+		t.Fatalf("a launch could not adopt a published copy while the bundled cache lock was held: %v", err)
 	}
 	if len(res.SelectedDirs) != 1 || res.SelectedDirs[0] != published {
 		t.Fatalf("SelectedDirs = %v, want the published copy at %s", res.SelectedDirs, published)
@@ -497,10 +492,10 @@ func TestMaterializeBundledPlugin_AdoptsAPublishedCopyWithoutTheStoreLock(t *tes
 }
 
 // The sweep is housekeeping a launch does on its way past, so it waits for the
-// store lock the way housekeeping should: briefly. One stale orphan must not
-// put every adopting launch behind an auto-upgrade holding the lock across git
-// fetches, waiting out the budget a publish is entitled to and then leaving
-// the orphan for the next launch to wait out again.
+// bundled cache's lock the way housekeeping should: briefly. One stale orphan
+// must not put every adopting launch behind a publisher that is still copying,
+// waiting out the budget a publish is entitled to and then leaving the orphan
+// for the next launch to wait out again.
 func TestMaterializeBundledPlugin_GivesUpQuicklyOnTheSweepLock(t *testing.T) {
 	m := NewManager(t.TempDir())
 	published, _, err := m.materializeBundledPlugin(context.Background(), "coordinator-workflow")
@@ -516,8 +511,8 @@ func TestMaterializeBundledPlugin_GivesUpQuicklyOnTheSweepLock(t *testing.T) {
 	}
 	m.Now = func() time.Time { return time.Now().Add(24 * time.Hour) }
 
-	// Somebody else is holding the store lock, the way an auto-upgrade does.
-	release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
+	// Another bundled publisher is holding the cache's lock.
+	release, err := acquireLock(context.Background(), m.bundledLockPath(), time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -589,11 +584,12 @@ func TestMaterializeBundledPlugin_LeavesStagingWhoseMarkerIsNotAFile(t *testing.
 	}
 }
 
-// A launch can be given up on while its sweep waits for the store lock. The
-// sweep swallows its own lock failure by design — housekeeping nobody is
-// waiting on — and the caller's cancellation arrives as exactly that failure,
-// so the context has to be read again before the copy is handed back. What the
-// launch has by then is a published copy it is no longer entitled to return.
+// A launch can be given up on while its sweep waits for the bundled cache's
+// lock. The sweep swallows its own lock failure by design — housekeeping
+// nobody is waiting on — and the caller's cancellation arrives as exactly that
+// failure, so the context has to be read again before the copy is handed back.
+// What the launch has by then is a published copy it is no longer entitled to
+// return.
 func TestMaterializeBundledPlugin_StopsForACallerThatLeftDuringTheSweep(t *testing.T) {
 	m := NewManager(t.TempDir())
 	published, _, err := m.materializeBundledPlugin(context.Background(), "coordinator-workflow")
@@ -609,8 +605,8 @@ func TestMaterializeBundledPlugin_StopsForACallerThatLeftDuringTheSweep(t *testi
 	}
 	m.Now = func() time.Time { return time.Now().Add(24 * time.Hour) }
 
-	// Somebody else is holding the store lock, so the sweep has to wait for it.
-	release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
+	// Another publisher holds the lock, so the sweep has to wait for it.
+	release, err := acquireLock(context.Background(), m.bundledLockPath(), time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -689,5 +685,93 @@ func TestBundledStore_AnUnreadableDestinationIsSetAsideLikeAnyOtherConflict(t *t
 	}
 	if string(content) != "someone else's data" {
 		t.Errorf("preserved content = %q, want it untouched", content)
+	}
+}
+
+// Publishing a bundled copy needs exclusion against other bundled publishers
+// and nothing else: it classifies a destination, sets a conflict aside, stages
+// and renames, all of it under <Root>/bundled. So it must not queue behind the
+// plugin store lock, which install, upgrade, gc, catalog and marketplace
+// refresh hold across git fetches for up to 30 seconds. Hub start runs the
+// auto-upgrade sweep, so a first launch after a version bump — the one launch
+// that has a copy to publish — is exactly the launch that meets it.
+func TestMaterializeBundledPlugin_PublishesWhileTheStoreLockIsHeld(t *testing.T) {
+	m := NewManager(t.TempDir())
+	// Somebody else holds the store lock, the way an auto-upgrade does across
+	// its git fetches.
+	release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	digest, err := bundledPluginDigest("coordinator-workflow")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Well inside the wait a publish is entitled to on its own lock, so a
+	// publish that queued behind the store lock is bounded by this rather than
+	// by the 30 seconds it would otherwise spend before failing.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	start := time.Now()
+	published, _, err := m.materializeBundledPlugin(ctx, "coordinator-workflow")
+	if err != nil {
+		t.Fatalf("publishing while the store lock was held: %v", err)
+	}
+	if waited := time.Since(start); waited > 5*time.Second {
+		t.Errorf("publishing took %v, want it not to wait on the store lock at all", waited)
+	}
+	if want := m.bundledPluginPath("coordinator-workflow", digest); published != want {
+		t.Fatalf("published %s, want %s", published, want)
+	}
+	if _, err := os.Stat(filepath.Join(published, ".claude-plugin", "plugin.json")); err != nil {
+		t.Fatalf("published copy incomplete: %v", err)
+	}
+}
+
+// The other direction of the same separation: a publish in flight holds the
+// bundled cache's lock for the whole classify-stage-rename sequence, and an
+// install, an upgrade or an auto-upgrade sweep that wants the store lock must
+// not wait out the copy it has no stake in.
+func TestMaterializeBundledPlugin_LeavesTheStoreLockFreeWhilePublishing(t *testing.T) {
+	m := NewManager(t.TempDir())
+	publishing := make(chan struct{})
+	finish := make(chan struct{})
+	original := copyBundledPayload
+	t.Cleanup(func() { copyBundledPayload = original })
+	copyBundledPayload = func(dir string, fsys fs.FS) error {
+		close(publishing)
+		<-finish
+		return original(dir, fsys)
+	}
+
+	var published string
+	var publishErr error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		published, _, publishErr = m.materializeBundledPlugin(context.Background(), "coordinator-workflow")
+	}()
+	unblock := sync.OnceFunc(func() {
+		close(finish)
+		<-done
+	})
+	t.Cleanup(unblock)
+	<-publishing
+
+	// Mid-copy: whatever the publish is holding, the store lock is not it.
+	storeLock, err := acquireLock(context.Background(), m.lockPath(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("a bundled publish in flight blocked the store lock: %v", err)
+	}
+	storeLock()
+
+	unblock()
+	if publishErr != nil {
+		t.Fatalf("the publish held mid-copy failed: %v", publishErr)
+	}
+	if _, err := os.Stat(filepath.Join(published, ".claude-plugin", "plugin.json")); err != nil {
+		t.Fatalf("published copy incomplete: %v", err)
 	}
 }

--- a/internal/plugins/validate_test.go
+++ b/internal/plugins/validate_test.go
@@ -3,8 +3,24 @@ package plugins
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
+
+// bundledStoreEntries is what the bundled cache holds apart from the lock file
+// publishers keep there. No assertion about published copies, set-aside slots
+// or staging is about that file, and it exists in any store a publish or a
+// preview has touched.
+func bundledStoreEntries(t *testing.T, store string) []os.DirEntry {
+	t.Helper()
+	entries, err := os.ReadDir(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return slices.DeleteFunc(entries, func(e os.DirEntry) bool {
+		return e.Name() == bundledLockName
+	})
+}
 
 func writePlugin(t *testing.T, dir, name string, extra map[string]string) {
 	t.Helper()


### PR DESCRIPTION
## The collision

Publishing a bundled plugin into the content-addressed cache at
`<Root>/bundled/<name>-<digest>` took the plugin store lock, `<Root>/.lock` —
the same lock install, upgrade, gc, catalog and marketplace refresh hold across
git fetches for up to 30 seconds. Hub start runs the auto-upgrade sweep, so a
first launch after a version bump (the one launch that actually has a copy to
publish) waited that out on the caller's context and then failed with `another
evener plugin operation is in progress`.

## The decision

The bundled cache gets its own lock at `<Root>/bundled/.lock`. Publishing a
bundled copy needs exclusion only against other bundled publishers — the
classify, set-aside, stage and rename sequence touches nothing outside
`<Root>/bundled` — and never against a git fetch.

Every bundled-cache mutation now takes that lock instead: the publish sequence,
the adopt path's sweep, and the set-aside and restore that run under the lock
the staging carries. Same acquire helper, same 30s publish budget and 1s
housekeeping budget for the sweep. Nothing in the bundled path takes
`<Root>/.lock` any more; the seeding and marketplace paths keep the store lock.
Acquisition goes through one function, `Manager.acquireBundledLock`, so the
store-root check that `Manager.acquireStoreLock` centralizes in #869 has a
single place to land for this lock too.

The ownership marker, the sweep and the `.conflict` slot are unaffected: they
all live under `<Root>/bundled`, and the sweep only ever considers directories
wearing the staging prefix, so the lock file beside them is never a candidate.

## What the tests prove

- `TestMaterializeBundledPlugin_PublishesWhileTheStoreLockIsHeld` — a launch
  that must publish while `<Root>/.lock` is held publishes promptly instead of
  waiting out the 30s budget and failing. It reproduced the collision before
  the fix: 10s to the deadline with `waiting for plugin lock <Root>/.lock`,
  0.3s after.
- `TestMaterializeBundledPlugin_LeavesTheStoreLockFreeWhilePublishing` — the
  other direction: a publish held mid-copy leaves the store lock free for the
  install or auto-upgrade that wants it.
- `TestMaterializeBundledPlugin_ConcurrentCallsPublishOnce` and
  `TestBundledStore_ConcurrentPublishKeepsOneConflictAndOneCopy` stay green:
  bundled publishers still serialize, one published copy and one set-aside slot.
- The tests that planted a lock explicitly to exercise the bundled path — the
  cancellation wait, the sweep-only-under-the-lock pair, the short sweep
  budget, the adopt path — are retargeted to the new lock.
- Store listings in tests ignore the cache's own lock file, which is now a
  legitimate entry in `<Root>/bundled`.

Docs updated where they said bundled publication takes the store lock:
`PreviewForLaunch`'s account of what it touches, `appwire.PluginPreviewParams`
(which owes callers the on-disk residue), the hub controller's argument for
holding no mutex of its own, and the TUI's reason for giving preview the slow
timeout.

Gates: `gofmt -l internal/`, `go vet ./internal/plugins/...`, `GOOS=windows go
vet ./internal/plugins/...`, `go vet -tags evenerfuzz ./internal/...`,
`golangci-lint run ./internal/... ./cmd/...`, `go test -race
./internal/plugins/... -count=1`, `go test ./internal/... ./cmd/... -count=1` —
all clean.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT