### PR TITLE
test: wait on the real completion in four more load-sensitive tests

### DIFF
--- a/agent/session_jobtree_drain_serve_lifecycle_test.go
+++ b/agent/session_jobtree_drain_serve_lifecycle_test.go
@@ -68,7 +68,19 @@ func TestServeDrainAbandonsARealStopPendingDelegate(t *testing.T) {
 		t.Fatalf("NewSession: %v", err)
 	}
 	t.Cleanup(root.Close)
-	t.Cleanup(wedge.releaseRead)
+	// t.Cleanup is LIFO, so this runs BEFORE root.Close and before t.TempDir
+	// removes StateDir. Releasing the wedged read restarts the delegate run the
+	// drain abandoned, and nothing else joins it: abandonment is precisely the
+	// parent giving up on that child, and Close's own join of the detached
+	// senders is bounded by LaneClosePassBudget, cut to 10ms above. The
+	// restarted run finalizes its child session, which rewrites
+	// StateDir/sessions/<child>.meta.json — a create that lands after Close has
+	// given up and, when it falls inside the RemoveAll walk, fails the temp-dir
+	// cleanup with "sessions: directory not empty". Join the run instead.
+	t.Cleanup(func() {
+		wedge.releaseRead()
+		root.sendersWG.Wait()
+	})
 
 	created := root.createDelegate(context.Background(), delegateArgs{Task: "read the wedged path"})
 	if created.Err != nil {

--- a/internal/devtool/procgroup/procgroup_test.go
+++ b/internal/devtool/procgroup/procgroup_test.go
@@ -13,20 +13,56 @@ import (
 	"time"
 )
 
+// childReadyTripwire bounds the readiness poll below. Reaching a fixture's
+// first write costs a process creation: 440 samples taken on a host at load
+// average ~130 all landed under 65ms, but the two creations the sibling git
+// fixture needed have been measured at up to 10s on that same class of host —
+// which is exactly where the bare 10s ceiling this replaced would have fired,
+// on a fixture that was never in trouble. The bound is a hang guard, never the
+// mechanism: the poll's real exits are the file appearing and the child's own
+// reap.
+const childReadyTripwire = 90 * time.Second
+
+// childWait reaps a started child exactly once and publishes the result, so a
+// readiness poll can watch the child's own exit while the test keeps ownership
+// of the reap signal Stop needs.
+type childWait struct {
+	done chan struct{}
+	err  error // valid once done is closed
+}
+
+func reapChild(cmd *exec.Cmd) *childWait {
+	w := &childWait{done: make(chan struct{})}
+	go func() {
+		w.err = cmd.Wait()
+		close(w.done)
+	}()
+	return w
+}
+
 // waitForFile polls for a fixture file the child writes once it is ready,
-// so tests synchronize on real child state instead of sleeps.
-func waitForFile(t *testing.T, path string) string {
+// so tests synchronize on real child state instead of sleeps. It watches the
+// child's own reap alongside the file: a fixture that dies before writing —
+// a bad script, a failed exec, a sandbox refusal — names that exit instead of
+// spending the whole tripwire and then blaming a file that was never coming.
+func waitForFile(t *testing.T, path string, child *childWait) string {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
+	deadline := time.Now().Add(childReadyTripwire)
+	for {
 		b, err := os.ReadFile(path)
 		if err == nil && len(b) > 0 && strings.HasSuffix(string(b), "\n") {
 			return strings.TrimSpace(string(b))
 		}
+		select {
+		case <-child.done:
+			t.Fatalf("child exited before writing %s: %v", path, child.err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("child never wrote %s within %v", path, childReadyTripwire)
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("child never wrote %s", path)
-	return ""
 }
 
 func pidAlive(pid int) bool {
@@ -63,17 +99,13 @@ func TestStopTerminatesWholeGroup(t *testing.T) {
 	if err := Start(cmd); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	grandchild, err := strconv.Atoi(waitForFile(t, pidFile))
+	child := reapChild(cmd)
+	grandchild, err := strconv.Atoi(waitForFile(t, pidFile, child))
 	if err != nil {
 		t.Fatalf("grandchild pid: %v", err)
 	}
-	reaped := make(chan struct{})
-	go func() {
-		_ = cmd.Wait()
-		close(reaped)
-	}()
-	Stop(cmd.Process.Pid, reaped, 5*time.Second)
-	<-reaped
+	Stop(cmd.Process.Pid, child.done, 5*time.Second)
+	<-child.done
 	deadline := time.Now().Add(5 * time.Second)
 	for pidAlive(grandchild) && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
@@ -91,24 +123,21 @@ func TestStopEscalatesToKillWhenTermIgnored(t *testing.T) {
 	if err := Start(cmd); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	waitForFile(t, readyFile)
-	reaped := make(chan struct{})
-	waitErr := make(chan error, 1)
-	go func() {
-		waitErr <- cmd.Wait()
-		close(reaped)
-	}()
+	child := reapChild(cmd)
+	waitForFile(t, readyFile, child)
 	start := time.Now()
-	Stop(cmd.Process.Pid, reaped, 200*time.Millisecond)
+	Stop(cmd.Process.Pid, child.done, 200*time.Millisecond)
+	// TRIPWIRE: the KILL is already sent by the time Stop returns, so the reap
+	// is one signal delivery away; this only fires if it never lands at all.
 	select {
-	case <-reaped:
+	case <-child.done:
 	case <-time.After(10 * time.Second):
 		t.Fatal("TERM-ignoring child was never killed")
 	}
 	if elapsed := time.Since(start); elapsed < 200*time.Millisecond {
 		t.Errorf("Stop returned in %v, before the TERM grace elapsed", elapsed)
 	}
-	err := <-waitErr
+	err := child.err
 	ws, ok := cmd.ProcessState.Sys().(syscall.WaitStatus)
 	if err == nil || !ok || !ws.Signaled() || ws.Signal() != syscall.SIGKILL {
 		t.Errorf("TERM-ignoring child died with %v (state %v), want SIGKILL", err, cmd.ProcessState)
@@ -122,18 +151,14 @@ func TestStopReturnsWithoutKillWhenChildHonorsTerm(t *testing.T) {
 	if err := Start(cmd); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	waitForFile(t, readyFile)
-	reaped := make(chan struct{})
-	go func() {
-		_ = cmd.Wait()
-		close(reaped)
-	}()
+	child := reapChild(cmd)
+	waitForFile(t, readyFile, child)
 	// The grace is a tripwire, not a mechanism: a child that honors TERM
 	// must release Stop long before it, or interrupted runs would always
 	// stall for the full escalation window.
 	start := time.Now()
-	Stop(cmd.Process.Pid, reaped, 30*time.Second)
-	<-reaped
+	Stop(cmd.Process.Pid, child.done, 30*time.Second)
+	<-child.done
 	if elapsed := time.Since(start); elapsed > 25*time.Second {
 		t.Errorf("Stop took %v against a cooperative child; it waited out the grace instead of the reap", elapsed)
 	}
@@ -158,12 +183,8 @@ func TestStopNeverSignalsAnAlreadyReapedChild(t *testing.T) {
 	if err := Start(decoy); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	decoyReaped := make(chan struct{})
-	go func() {
-		_ = decoy.Wait()
-		close(decoyReaped)
-	}()
-	waitForFile(t, readyFile)
+	decoyChild := reapChild(decoy)
+	waitForFile(t, readyFile, decoyChild)
 	alreadyReaped := make(chan struct{})
 	close(alreadyReaped)
 	Stop(decoy.Process.Pid, alreadyReaped, 50*time.Millisecond)
@@ -177,8 +198,8 @@ func TestStopNeverSignalsAnAlreadyReapedChild(t *testing.T) {
 	if !pidAlive(decoy.Process.Pid) {
 		t.Error("decoy died during a Stop that should have sent nothing")
 	}
-	Stop(decoy.Process.Pid, decoyReaped, 5*time.Second)
-	<-decoyReaped
+	Stop(decoy.Process.Pid, decoyChild.done, 5*time.Second)
+	<-decoyChild.done
 }
 
 func TestExitCodeMapsSignalDeathsLikeAShell(t *testing.T) {


### PR DESCRIPTION
Round two of the #852 pattern: prove the hole by forcing the interleaving, then make the test wait on the real condition. Two tests changed, two investigated and left with their evidence.

**agent `TestServeDrainAbandonsARealStopPendingDelegate`.** The test released the wedged read in a `t.Cleanup` and joined nothing. Abandonment is precisely the parent giving up on that delegate, so no production path waits for it either, and `Close`'s join of the detached senders is bounded by `LaneClosePassBudget`, which this test cuts to 10ms. The released run finalizes its child session and rewrites `StateDir/sessions/<child>.meta.json` after `Close` has already given up; landing inside `t.TempDir`'s `RemoveAll` walk, that create fails the cleanup with `sessions: directory not empty`. The cleanup now releases the read and then joins `sendersWG`, the same join `session_fold_publication_test.go` already uses.

Forced-interleaving proof: a delay in the wedge's read path after the release, plus padding `StateDir/sessions` to 2047 entries — `RemoveAll` drains a directory 1024 names per open/readdir pass and only unlinks it after a short pass, so an entry created during that last pass is the one that survives to the `unlinkat`, and 2047 makes that pass half the walk. Instrumentation first pinned the mechanism exactly: at a 200ms delay, `root.Close` returned at +6.4ms and the child recreated `sessions/<child>.meta.json` at +207ms, well after the removal. With the padding, delays of 80ms, 110ms and 130ms reproduced the CI failure verbatim (`TempDir RemoveAll cleanup: unlinkat .../sessions: directory not empty`). With the join in place the same three delays passed 6/6, and the state dir never reappeared in the 3s after cleanup. Delay and padding removed.

**internal/devtool/procgroup `waitForFile`.** Same bare 10s readiness ceiling the git fixture carried before #852, and it could only ever report `child never wrote <path>` — the one thing it cannot know. The poll now watches the child's own reap alongside the file, through a `childWait` that owns the single `cmd.Wait` each test was already running in its own goroutine, and the ceiling is a named 90s tripwire. Forced proof of the blind spot: pointing the cooperative-child fixture at a script that exits 7 without writing readiness. Old helper, 10.01s: `child never wrote .../ready`. New helper, 0.03s: `child exited before writing .../ready: exit status 7`. The ceiling itself did not reproduce — 440 readiness samples taken on a host at load average ~130 all landed under 65ms — so the tripwire's doc comment carries those numbers and the git fixture's measured up-to-10s two-spawn cost, rather than a guess.

**cmd/evener `TestRunDrainContinuesWhenNotificationTurnStartsAnotherShell` — left, now covered by #864.** This one has no completion barrier by design (shell A is released at drain start) and rested on finalization beating the drain's 250ms recheck; the 500ms delay in `armFinalizedJob` that reproduced the #864 bug used to fail it. Re-run under that exact delay on current main: 16/16 pass, with the forced sleep verified on the path (it logs twice per run, once per managed shell). Reverting just `session_jobtree_drain.go` to its pre-#864 content with the same sleep still installed fails 3/3 with `shell A notification request count = 0, want 1`. So the hole was in production and #864 closed it; the test needs no barrier and none was added.

**agent/execenv `TestCleanupRetainsOwnedTmpAfterChildGrace` — left, not reproduced.** The early signal is a readiness file the child touches after installing its TERM trap, polled under a bare 5s bound; the evidence the test then wants is a sentinel the trap writes, which must land inside `Cleanup`'s TERM→grace→KILL window (200ms for the whole test binary, per `grace_test.go`). Both bounds were measured under a bounded `go test ./internal/... ./cmd/... -p 4` alongside: 30/30 runs passed, readiness peaked at 5.6ms against the 5s bound, and the trap's sentinel landed at a worst of 956µs against the 200ms grace — a 200x margin. Forced attempts: a `sleep 0.3` inside the trap (longer than the grace) fails 3/3 with the recorded `sentinel missing` message, so the shape of the gap is real but needs a child 300x slower than measured; a `sleep 0.5` between the readiness write and the `wait` park still passed with the trap at ~300µs, which rules out the "readiness precedes the park" theory outright — bash runs the trap immediately regardless of what it is doing. The only lever that would widen the margin is a longer grace, and `Cleanup` sleeps its grace unconditionally, so that buys margin at a per-run wall-clock cost against a gap I cannot demonstrate. Left alone, with the numbers recorded here.

Test-only changes; no production code.

## Gates

`gofmt -l agent internal/devtool/procgroup` (clean), `go vet ./agent/ ./internal/devtool/procgroup/`, `golangci-lint run ./agent/...` and `./internal/devtool/procgroup/...` (0 issues each), `go test ./agent/ -run TestServeDrainAbandonsARealStopPendingDelegate -count=20 -race`, `go test ./internal/devtool/procgroup/ -count=20`, `go test ./agent/ -count=1` (541s), `go test ./internal/devtool/procgroup/ -count=1`, `go test ./agent/ -run 'Drain|Serve' -count=1`, and `TestNoBareWallClockDeadlineInAgentTests` — all pass.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
