### PR TITLE
feat(web): keybindings Phase 4b - capture-based binding editor in settings

### DIFF
--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -117,6 +117,13 @@ export function chordDisplayKeys(chord: Chord): string[] {
   return [...chord.modifiers.map((m) => MODIFIER_DISPLAY[m] ?? m), key];
 }
 
+/** One modifier's display label (Ctrl / ⌘ / verbatim) - the chordDisplayKeys
+ * mapping for the capture editor's modifier-only live preview, which has no
+ * key yet. */
+export function modifierDisplayKey(modifier: string): string {
+  return MODIFIER_DISPLAY[modifier] ?? modifier;
+}
+
 /** One press as speakable words: "⌘+K" on Apple platforms, "Ctrl+K" elsewhere. */
 export function formatChord(chord: Chord): string {
   return chordDisplayKeys(chord).join("+");

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -5,7 +5,9 @@ import {
   CHARACTER_KEY_TRIGGER_BINDING_ID,
   CHEATSHEET_SCOPE,
   DEFAULT_BINDINGS,
+  defaultBindingShapesForAction,
   registerDefaultBindings,
+  registerDefaultBindingsForAction,
   SETTINGS_SCOPE,
 } from "./defaults";
 import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
@@ -374,5 +376,25 @@ describe("default bindings through the dispatcher", () => {
       ACTIONS.selectionQuote,
       ACTIONS.settingsOpen,
     ]);
+  });
+});
+
+describe("register vs shapes agreement", () => {
+  // The preflight (defaultBindingShapesForAction) and the mutation
+  // (registerDefaultBindingsForAction) share one predicate for the
+  // conditional "?" entry; if they ever diverge the validation can accept a
+  // restore that then throws, or reject one that would succeed.
+  test("both paths include or exclude the ? trigger for the SAME pref value", () => {
+    for (const pref of [true, false]) {
+      const registry = createKeybindingsRegistry();
+      const registered = registerDefaultBindingsForAction(registry, ACTIONS.cheatsheetToggle, {
+        characterKeyTriggers: pref,
+      }).map((b) => b.id);
+      const shaped = defaultBindingShapesForAction(ACTIONS.cheatsheetToggle, {
+        characterKeyTriggers: pref,
+      }).map((s) => s.id);
+      expect(registered).toEqual(shaped);
+      expect(registered.includes(CHARACTER_KEY_TRIGGER_BINDING_ID)).toBe(pref);
+    }
   });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -323,16 +323,39 @@ export function registerDefaultBindings(registry: KeybindingsRegistry): Binding[
   return registered;
 }
 
+/** The one CONDITIONAL default-map entry's inclusion test, shared by the
+ * registration path here and the simulation path
+ * (defaultBindingShapesForAction) so the actual restore and the validation
+ * simulation can never disagree (finding 27): the "?" character-key
+ * trigger exists only while the characterKeyTriggers pref is on. */
+function includeDefaultEntry(entryId: string, options?: { characterKeyTriggers?: boolean }): boolean {
+  return !(options?.characterKeyTriggers === false && entryId === CHARACTER_KEY_TRIGGER_BINDING_ID);
+}
+
 /** Registers only the given action's default entries (plus the $mod twin),
  * the per-action equivalent of registerDefaultBindings the overrides store
- * uses to restore one action's defaults. Throws on an unknown action id. */
-export function registerDefaultBindingsForAction(registry: KeybindingsRegistry, actionId: string): Binding[] {
+ * uses to restore one action's defaults. Throws on an unknown action id.
+ *
+ * `characterKeyTriggers: false` mirrors the live registry when the
+ * cheatsheet character-key pref is off (the cheatsheetController has no
+ * "?" binding registered then): the restore skips the conditional entry,
+ * so it cannot collide with a user rule claiming exactly [Shift]+? -
+ * registerBinding throws on an exact same-scope serialization match, and
+ * the reconcile's strip runs AFTER this mutation (the ordering contract),
+ * so the collision would precede the cleanup. The controller re-registers
+ * the entry itself when the pref turns back on. */
+export function registerDefaultBindingsForAction(
+  registry: KeybindingsRegistry,
+  actionId: string,
+  options?: { characterKeyTriggers?: boolean },
+): Binding[] {
   const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
   if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
   const registered: Binding[] = [];
   for (const input of inputs) {
     const pair = modPair(input);
     for (const entry of pair ?? [input]) {
+      if (!includeDefaultEntry(entry.id, options)) continue;
       registered.push(registry.getState().registerBinding(entry));
     }
   }
@@ -365,7 +388,7 @@ export function defaultBindingShapesForAction(
   for (const input of inputs) {
     const pair = modPair(input);
     for (const entry of pair ?? [input]) {
-      if (options?.characterKeyTriggers === false && entry.id === CHARACTER_KEY_TRIGGER_BINDING_ID) continue;
+      if (!includeDefaultEntry(entry.id, options)) continue;
       shapes.push({
         id: entry.id,
         scope: entry.scope ?? GLOBAL_SCOPE,

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -348,14 +348,24 @@ export interface DefaultBindingShape {
 /** The (scope, parsed chord) pairs registerDefaultBindingsForAction would
  * register for the action, WITHOUT registering them: the validation layer
  * simulates dropped-override restorations against these. Throws on an
- * unknown action id. */
-export function defaultBindingShapesForAction(actionId: string): DefaultBindingShape[] {
+ * unknown action id.
+ *
+ * `characterKeyTriggers: false` mirrors the live registry when the
+ * cheatsheet character-key pref is off (the cheatsheetController
+ * unregisters the "?" entry while the pref is off): the restored set then
+ * excludes the character-key trigger binding, so the simulation cannot
+ * report a conflict against a binding that will not exist. */
+export function defaultBindingShapesForAction(
+  actionId: string,
+  options?: { characterKeyTriggers?: boolean },
+): DefaultBindingShape[] {
   const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
   if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
   const shapes: DefaultBindingShape[] = [];
   for (const input of inputs) {
     const pair = modPair(input);
     for (const entry of pair ?? [input]) {
+      if (options?.characterKeyTriggers === false && entry.id === CHARACTER_KEY_TRIGGER_BINDING_ID) continue;
       shapes.push({
         id: entry.id,
         scope: entry.scope ?? GLOBAL_SCOPE,

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { ACTIONS } from "./actions";
 import { serializeChord } from "./chord";
-import { registerDefaultBindings } from "./defaults";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, registerDefaultBindings } from "./defaults";
 import { rebindAction, restoreDefaultBinding } from "./overrides";
 import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
@@ -124,6 +124,32 @@ describe("restoreDefaultBinding", () => {
     expect(bindingsFor(registry, ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
       ACTIONS.paletteOpen,
       `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("with the character-key pref off, the restore does not re-register the ? trigger", () => {
+    const registry = withDefaults();
+    // What the cheatsheetController does while the pref is off: the live
+    // registry has no "?" entry. A restore that re-registered it would
+    // resurrect a binding the user turned off (and could exact-match a
+    // surviving "Shift+?" override elsewhere).
+    registry.getState().unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+    rebindAction(registry, ACTIONS.cheatsheetToggle, "Control+Shift+/");
+    restoreDefaultBinding(registry, ACTIONS.cheatsheetToggle, { characterKeyTriggers: false });
+    expect(bindingsFor(registry, ACTIONS.cheatsheetToggle).map((b) => b.id)).toEqual([
+      ACTIONS.cheatsheetToggle,
+      `${ACTIONS.cheatsheetToggle}#mod-twin`,
+    ]);
+  });
+
+  test("without the pref option the restore still registers the ? trigger (pref-on default)", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.cheatsheetToggle, "Control+Shift+/");
+    restoreDefaultBinding(registry, ACTIONS.cheatsheetToggle);
+    expect(bindingsFor(registry, ACTIONS.cheatsheetToggle).map((b) => b.id)).toEqual([
+      ACTIONS.cheatsheetToggle,
+      `${ACTIONS.cheatsheetToggle}#mod-twin`,
+      CHARACTER_KEY_TRIGGER_BINDING_ID,
     ]);
   });
 

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.ts
@@ -68,9 +68,20 @@ export function rebindAction(registry: KeybindingsRegistry, actionId: string, ch
 
 /** Restores the action's default binding(s) (plus the `$mod` twin), removing
  * any override or unbind. Idempotent on an action that was never overridden.
- * Throws on an unknown action id. */
-export function restoreDefaultBinding(registry: KeybindingsRegistry, actionId: string): void {
+ * Throws on an unknown action id.
+ *
+ * `characterKeyTriggers: false` mirrors the character-key pref into the
+ * restore (finding 27): with the pref off the conditional "?" entry is not
+ * re-registered - the cheatsheetController owns it and re-adds it when the
+ * pref turns on. The caller (the overrides store) knows the pref; the
+ * simulation (validation.ts via defaultBindingShapesForAction) consults the
+ * SAME inclusion test, so restore and simulation stay in lockstep. */
+export function restoreDefaultBinding(
+  registry: KeybindingsRegistry,
+  actionId: string,
+  options?: { characterKeyTriggers?: boolean },
+): void {
   defaultInputFor(actionId);
   removeActionBindings(registry, actionId);
-  registerDefaultBindingsForAction(registry, actionId);
+  registerDefaultBindingsForAction(registry, actionId, options);
 }

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -28,6 +28,19 @@ export function currentKeybindingsPlatform(): KeybindingsPlatform {
   return /Mac|iPhone|iPad|iPod/.test(window.navigator.platform) ? "apple" : "other";
 }
 
+/** User-facing label for an action id in conflict messages: the default
+ * map's title plus the id when the action is known
+ * ("Open the command palette" (palette.open)); the bare id otherwise (a
+ * binding registered outside the default map - e.g. a test double or a
+ * conditional entry - has no title here). A conflict message names the
+ * HOLDER of the chord the user tried to claim; a bare action id meant
+ * nothing in the editor's inline error or the skipped-overrides warnings
+ * list, where the rows themselves are titled. */
+export function actionDisplayLabel(actionId: string): string {
+  const title = DEFAULT_BINDINGS.find((b) => b.actionId === actionId)?.title;
+  return title === undefined ? `"${actionId}"` : `"${title}" (${actionId})`;
+}
+
 // The survey's verified never-use list ("not interceptable by pages"),
 // platform-split. The Control family is listed unqualified in the survey, so
 // it is reserved on every platform. Two survey entries are deliberately NOT
@@ -335,7 +348,7 @@ export function validateOverrideRules(
         rule: removed.rule,
         reason: "conflict",
         conflictWith,
-        message: `chord "${removed.rule.chord ?? ""}" in scope "${scope}" is already bound by "${conflictWith}"`,
+        message: `chord "${removed.rule.chord ?? ""}" in scope "${scope}" is already bound by ${actionDisplayLabel(conflictWith)}`,
       });
       if (appliedActionIds.has(removed.rule.action)) dropped.add(removed.rule.action);
       skipped = true;

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -105,7 +105,17 @@ export interface OverrideRule {
   chord: string | null;
 }
 
-export type ValidationWarningReason = "unknown-action" | "unparseable-chord" | "reserved-chord" | "conflict";
+export type ValidationWarningReason =
+  | "unknown-action"
+  | "unparseable-chord"
+  | "reserved-chord"
+  | "conflict"
+  /** Not a validation outcome: the cheatsheetController's conditional "?"
+   * entry skipped registration because a live binding of ANOTHER action
+   * overlaps it (the chord was claimed while the character-key pref kept
+   * the entry unregistered, so nothing conflicted at bind time). Surfaces
+   * through the same store warnings channel as skipped override rules. */
+  | "character-key-conflict";
 
 export interface ValidationWarning {
   rule: OverrideRule;

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -147,12 +147,17 @@ interface EffectiveBinding {
  * alternative (deferring the restore) would strand the dropped action on an
  * override the hub payload no longer contains, diverging the registry from
  * the payload indefinitely. Defaults never conflict with each other, so a
- * conflict always has a rule claim to blame. */
+ * conflict always has a rule claim to blame.
+ *
+ * `characterKeyTriggers: false` mirrors the cheatsheet character-key pref:
+ * the live registry has no "?" cheatsheet binding while the pref is off, so
+ * the dropped-restore simulation must not claim one either. */
 export function validateOverrideRules(
   rules: readonly OverrideRule[],
   registry: KeybindingsRegistry,
   platform: KeybindingsPlatform = currentKeybindingsPlatform(),
   appliedActionIds: ReadonlySet<string> = new Set(),
+  characterKeyTriggers = true,
 ): ValidatedOverrides {
   const warnings: ValidationWarning[] = [];
   const reserved = RESERVED_BY_PLATFORM[platform];
@@ -231,7 +236,10 @@ export function validateOverrideRules(
     for (const action of dropped) {
       final.set(
         action,
-        defaultBindingShapesForAction(action).map((shape) => ({ scope: shape.scope, sequence: shape.sequence })),
+        defaultBindingShapesForAction(action, { characterKeyTriggers }).map((shape) => ({
+          scope: shape.scope,
+          sequence: shape.sequence,
+        })),
       );
     }
     for (const candidate of candidates) {

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -13,8 +13,9 @@
 // the offending rule is skipped, so persisted data can degrade to defaults
 // but can never crash the shell.
 
-import { chordsOverlap, type KeySequence, parseChord } from "./chord";
-import { DEFAULT_BINDINGS, defaultBindingShapesForAction } from "./defaults";
+import { ACTIONS } from "./actions";
+import { chordsOverlap, type KeySequence, parseChord, serializeChord } from "./chord";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS, defaultBindingShapesForAction } from "./defaults";
 import { GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
 export type KeybindingsPlatform = "apple" | "other";
@@ -227,6 +228,37 @@ export function validateOverrideRules(
     const list = live.get(binding.actionId) ?? [];
     list.push({ scope: binding.scope, sequence: binding.chord });
     live.set(binding.actionId, list);
+  }
+  // The pref is authoritative over the live registry for the conditional
+  // "?" entry: a pref-flip re-apply (stores/keybindings.ts's prefs
+  // subscription) runs in the flip instant, BEFORE the cheatsheetController's
+  // reconcile has unregistered or re-registered "?", and must simulate the
+  // map the reconcile is about to establish - otherwise a pref-off re-apply
+  // would keep skipping a claim that is now valid, and a pref-on re-apply
+  // would leave a now-conflicting claim applied. Steady state (registry
+  // already mirrors the pref) is untouched. Only the default-map shape is
+  // adjusted: a cheatsheet.toggle override candidate or a dropped restore
+  // overwrites the action's whole final entry below anyway.
+  const questionShape = defaultBindingShapesForAction(ACTIONS.cheatsheetToggle, {
+    characterKeyTriggers: true,
+  }).find((shape) => shape.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+  if (questionShape !== undefined) {
+    const questionSerialized = serializeChord(questionShape.sequence);
+    const isQuestion = (binding: EffectiveBinding) =>
+      binding.scope === questionShape.scope && serializeChord(binding.sequence) === questionSerialized;
+    const toggleLive = live.get(ACTIONS.cheatsheetToggle) ?? [];
+    const liveHasQuestion = toggleLive.some(isQuestion);
+    if (characterKeyTriggers && !liveHasQuestion) {
+      live.set(ACTIONS.cheatsheetToggle, [
+        ...toggleLive,
+        { scope: questionShape.scope, sequence: questionShape.sequence },
+      ]);
+    } else if (!characterKeyTriggers && liveHasQuestion) {
+      live.set(
+        ACTIONS.cheatsheetToggle,
+        toggleLive.filter((binding) => !isQuestion(binding)),
+      );
+    }
   }
   const dropped = new Set<string>();
   for (const action of appliedActionIds) {

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.test.tsx
@@ -1,12 +1,38 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, expect, test, vi } from "vitest";
+import { afterEach, beforeAll, expect, test, vi } from "vitest";
 import { FakeClient } from "../../protocol/testing/fakeClient";
 import { chromeStore, resetChromeStoreForTests } from "../../shell/chromeStore";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../../shell/workspace";
 import { connectionStore } from "../../stores/connection";
 import { resetCredentialsStoreForTests } from "../../stores/credentials";
+import { prefsStore, resetPrefsStoreForTests } from "../../stores/prefs";
 import Settings from "./Settings";
+
+// Node 26 shadows jsdom's real window.localStorage with its own
+// (non-functional under vitest) global - the same MemoryStorage stand-in
+// stores/prefs.test.ts's own comment documents, needed here because the
+// last-visited-section memory persists through localStorage.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeAll(() => {
+  // @ts-expect-error see MemoryStorage's own comment for why this is needed
+  globalThis.localStorage = new MemoryStorage();
+});
 
 // jsdom does not implement window.matchMedia at all - useIsMobile.test.ts's
 // own header comment documents this; every test file that drives mobile
@@ -27,6 +53,8 @@ afterEach(() => {
   window.history.pushState({}, "", "/");
   // @ts-expect-error restores jsdom's own honest default between tests.
   delete window.matchMedia;
+  localStorage.clear();
+  resetPrefsStoreForTests();
   resetWorkspaceStoreForTests();
   resetChromeStoreForTests();
   connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
@@ -244,4 +272,70 @@ test("the pane title reflects the focused section", () => {
   stubMatchMedia(false);
   render(<Settings params={{ section: "credentials" }} paneId="settings-1" focused={true} />);
   expect(screen.getByRole("heading", { name: "Providers & credentials" })).toBeTruthy();
+});
+
+// Reopening Settings returns to the section the user last visited
+// (prefs.ts's lastSettingsSection), not always the first nav entry. The
+// memory is prefs-backed, so it survives a full reload; the bare URL stays
+// bare (the mobile list depends on that shape).
+test("a bare /settings reopens on the last visited section", async () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  const first = render(<Settings params={{ section: "keybindings" }} paneId="settings-1" focused={true} />);
+  // The visit is recorded - and persisted - while the section is shown.
+  expect(prefsStore.getState().lastSettingsSection).toBe("keybindings");
+  expect(localStorage.getItem("evener.prefs.lastSettingsSection")).toBe("keybindings");
+  first.unmount();
+
+  render(<Settings params={{}} paneId="settings-1" focused={true} />);
+
+  expect(await screen.findByRole("heading", { name: "Keybindings" })).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Keybindings" }).getAttribute("aria-current")).toBe("page");
+});
+
+test("a bare /settings opens on General when no section has been visited", () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  render(<Settings params={{}} paneId="settings-1" focused={true} />);
+
+  expect(screen.getByRole("heading", { name: "General" })).toBeTruthy();
+});
+
+test("a remembered section that is no longer a known section falls back to General", () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  localStorage.setItem("evener.prefs.lastSettingsSection", "retired.section");
+  resetPrefsStoreForTests();
+  render(<Settings params={{}} paneId="settings-1" focused={true} />);
+
+  expect(screen.getByRole("heading", { name: "General" })).toBeTruthy();
+});
+
+test("the project section is not remembered (it has no nav row and needs its ?cwd= context)", () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  render(<Settings params={{ section: "project" }} paneId="settings-1" focused={true} />);
+
+  expect(prefsStore.getState().lastSettingsSection).toBeNull();
+});
+
+// The flow that motivated the memory: open Keybindings, leave, reopen, and
+// the character-key toggle is right there - one click, pref flipped, no
+// re-navigation.
+test("the remembered section carries the character-key toggle flow", async () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  const first = render(<Settings params={{ section: "keybindings" }} paneId="settings-1" focused={true} />);
+  first.unmount();
+
+  render(<Settings params={{}} paneId="settings-1" focused={true} />);
+  const toggle = await screen.findByRole("switch", { name: "Character-key shortcuts" });
+  // Default ON (the WCAG 2.1.4 turn-off exists, per the p4 plan's Design
+  // decision 3).
+  expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+  await userEvent.setup().click(toggle);
+
+  expect(prefsStore.getState().characterKeyTriggers).toBe(false);
+  expect(localStorage.getItem("evener.prefs.characterKeyTriggers")).toBe("0");
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
@@ -9,12 +9,13 @@ import type { PaneProps } from "../../shell/paneRegistry";
 import { navigate, paneToURL } from "../../shell/routing";
 import { useIsMobile } from "../../shell/useIsMobile";
 import { workspaceStore } from "../../shell/workspace";
+import { prefsStore, usePrefsStore } from "../../stores/prefs";
 import { useSettingsOverviewStore } from "../../stores/settingsOverview";
 import { IconButton, PaneScaffold } from "../../widgets";
 import { CloseIcon } from "../../widgets/dialog/CloseIcon";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { SettingsNav } from "./SettingsNav";
-import { DEFAULT_SECTION_ID, settingsSectionLabel } from "./sections";
+import { DEFAULT_SECTION_ID, isKnownSettingsSection, settingsSectionLabel } from "./sections";
 import { AboutSection } from "./sections/about";
 import { AgentsSection } from "./sections/agents";
 import { CredentialsSection } from "./sections/credentials/CredentialsSection";
@@ -111,8 +112,12 @@ function showSettingsList(): void {
  * each level is addressable (routing.ts already resolves both forms;
  * AppShell's replacePrimary glue updates this singleton pane's params in
  * place on every popstate). Desktop is unchanged: nav and content sit side
- * by side, and a bare /settings still resolves its content to
- * DEFAULT_SECTION_ID.
+ * by side, and a bare /settings resolves its content to the section the
+ * user last visited (prefs.ts's lastSettingsSection), falling back to
+ * DEFAULT_SECTION_ID when there is no remembered section or the remembered
+ * id is no longer a known section. Mobile keeps the bare URL as the section
+ * LIST (the drill-down root) - the remembered section only picks the
+ * desktop content, never the mobile view.
  *
  * Back on mobile lives in the shell's top bar, not in the content: a
  * focused section publishes showSettingsList to the chrome store's paneBack
@@ -130,7 +135,10 @@ function showSettingsList(): void {
  * text and scroll position survive the drill-down round trip.
  */
 export default function Settings({ params, paneId }: PaneProps<SettingsPaneParams>) {
-  const activeId = params.section ?? DEFAULT_SECTION_ID;
+  const rememberedSection = usePrefsStore((s) => s.lastSettingsSection);
+  const activeId =
+    params.section ??
+    (rememberedSection !== null && isKnownSettingsSection(rememberedSection) ? rememberedSection : DEFAULT_SECTION_ID);
   const isMobile = useIsMobile();
   const SectionComponent = SECTION_COMPONENTS[activeId] ?? PlaceholderSection;
   // Mobile list view: bare /settings on a phone. No row is "active" - there
@@ -142,6 +150,16 @@ export default function Settings({ params, paneId }: PaneProps<SettingsPaneParam
     const url = paneToURL("settings", { section: sectionId });
     if (url !== null) navigate(url);
   }
+
+  // Record the visited section so the next bare /settings reopens here.
+  // Only KNOWN nav sections are remembered: "project" is a valid dispatch
+  // target (SECTION_COMPONENTS) but no nav row and needs its ?cwd= context,
+  // so restoring it would land on a meaningless page.
+  useEffect(() => {
+    if (params.section !== undefined && isKnownSettingsSection(params.section)) {
+      prefsStore.getState().setLastSettingsSection(params.section);
+    }
+  }, [params.section]);
 
   // paneBack is published whenever a section is focused, in EITHER host -
   // host-agnostic like the title channel. The effect (not render) owns the

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
@@ -65,6 +65,9 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
+  /* The read-only note and the inline error sit UNDER the label/controls
+     line, full width. */
+  flex-wrap: wrap;
 }
 
 .label {
@@ -94,4 +97,127 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
+}
+
+.controls {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* The chord cell made clickable: same look as the read-only chord run, plus
+   a hover/focus affordance. */
+.chordButton {
+  appearance: none;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-chip);
+  padding: var(--space-1) var(--space-2);
+  margin: calc(-1 * var(--space-1)) calc(-1 * var(--space-2));
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.chordButton:hover {
+  border-color: var(--edge);
+}
+
+.chordButton:focus-visible {
+  outline: 2px solid var(--accent-edge);
+  outline-offset: 1px;
+}
+
+/* The row's small text-level actions (Unbind / Reset). */
+.actionButton {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: var(--space-1) var(--space-2);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+  cursor: pointer;
+  border-radius: var(--radius-chip);
+}
+
+.actionButton:hover {
+  color: var(--ink-hi);
+  background: var(--surface-inset);
+}
+
+.actionButton:focus-visible {
+  outline: 2px solid var(--accent-edge);
+  outline-offset: 1px;
+}
+
+.note {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.rowError {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--danger-ink);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+/* The capture widget plus its inline error, stacked under the row label. */
+.captureWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+/* The capture widget: an inset box that replaces the row's controls while a
+   chord is being recorded. */
+.capture {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--surface-inset);
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-chip);
+  padding: var(--space-1) var(--space-2);
+  min-width: 0;
+}
+
+.capture:focus-visible {
+  outline: 2px solid var(--accent-edge);
+  outline-offset: 1px;
+}
+
+.capturePrompt {
+  color: var(--ink-hi);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+.captureHint {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+  white-space: nowrap;
+}
+
+.captureError {
+  margin: 0;
+  color: var(--danger-ink);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
 }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
@@ -128,7 +128,7 @@
 }
 
 .chordButton:focus-visible {
-  outline: 2px solid var(--accent-edge);
+  outline: var(--focus-ring);
   outline-offset: 1px;
 }
 
@@ -151,7 +151,7 @@
 }
 
 .actionButton:focus-visible {
-  outline: 2px solid var(--accent-edge);
+  outline: var(--focus-ring);
   outline-offset: 1px;
 }
 
@@ -198,7 +198,7 @@
 }
 
 .capture:focus-visible {
-  outline: 2px solid var(--accent-edge);
+  outline: var(--focus-ring);
   outline-offset: 1px;
 }
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -270,6 +270,59 @@ test("an unsupported hub keeps every row read-only (no editing affordances)", as
   expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
 });
 
+// The stale-hub window: a supported hub whose override state has not landed
+// (or failed to) for the CURRENT client must not offer editing - a PATCH
+// composed there would carry the previous hub's revision and payload.
+test("the section is read-only while the hub's overrides are still loading, then editing unlocks", async () => {
+  const client = new FakeClient("ready");
+  let resolveGet: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/get",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolveGet = resolve;
+      }),
+  );
+  client.on("evener/settings/keybindings/patch", (params) => overridesPayload(2, params.config.rules));
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: true },
+  });
+  render(<KeybindingsSection />);
+
+  // hubSupport is "supported" but nothing is loaded for THIS hub yet: no
+  // editing affordances, and a status line says why.
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  expect(screen.getByRole("status").textContent).toContain("read-only until they arrive");
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+
+  // The refresh lands: editing unlocks and a save round-trips.
+  // (FakeClient defers the handler to a microtask, like a real RPC.)
+  await waitFor(() => expect(resolveGet).toBeDefined());
+  resolveGet?.(overridesPayload(1, []));
+  const chordButton = await screen.findByRole("button", {
+    name: "Change the shortcut for Open the command palette",
+  });
+  await userEvent.setup().click(chordButton);
+  fireEvent.keyDown(captureBox(), { key: "p", ctrlKey: true });
+  fireEvent.keyDown(captureBox(), { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+});
+
+test("a refresh error leaves the section read-only with a truthful status", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => {
+    throw new Error("socket went away");
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  expect(screen.getByRole("alert").textContent).toContain("socket went away");
+  expect(screen.getByRole("status").textContent).toContain("Editing is unavailable");
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
 test("a hub with unknown support keeps every row read-only", () => {
   render(<KeybindingsSection />);
   expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
@@ -559,6 +612,54 @@ test("IME composition events neither record nor save; a non-composing press stil
     expectedRevision: 1,
     config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
   });
+});
+
+// "+" is tinykeys' modifier DELIMITER, so a naive read says a captured "+"
+// chord ("Shift++", "Control++") cannot parse. The installed tinykeys splits
+// modifiers with a lookbehind (/(?<=\w|\])\+/), so a trailing "+" parses as
+// the key, and capture records the modifiers actually held - the chord
+// matches the very keydown that produced it. This test pins that end-to-end
+// through the REAL dispatcher so a tinykeys regression turns red here.
+test("capturing + saves a chord that round-trips and fires on a real + keydown", async () => {
+  const client = await wireEditableClient();
+  const focusSpy = vi.fn();
+  const unregister = keybindingsRegistry.getState().registerAction(ACTIONS.composerFocus, focusSpy);
+  try {
+    await withDispatcher(async () => {
+      render(<KeybindingsSection />);
+      const box = await enterCapture("Focus the composer");
+
+      // US layout: "+" is Shift+=, so the keydown carries Shift.
+      fireEvent.keyDown(box, { key: "+", shiftKey: true });
+      // KeyHint renders "+" SEPARATORS between kbds, so assert the kbd run
+      // itself rather than a bare text match.
+      expect([...box.querySelectorAll("kbd")].map((kbd) => kbd.textContent)).toEqual(["Shift", "+"]);
+      fireEvent.keyDown(box, { key: "Enter" });
+
+      await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+      expect(patchCallsOf(client)[0]?.params).toEqual({
+        expectedRevision: 1,
+        config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Shift++" }] },
+      });
+      // The serialized chord parses back to itself (a delimiter collision
+      // would throw or misparse the key).
+      expect(serializeChord(parseChord("Shift++"))).toBe("Shift++");
+      expect(serializeChord(parseChord("Control++"))).toBe("Control++");
+
+      // The confirmed payload reconciled, and the REAL dispatcher's matcher
+      // fires the action on the + keydown.
+      await waitFor(() =>
+        expect([...rowFor("Focus the composer").querySelectorAll("kbd")].map((kbd) => kbd.textContent)).toEqual([
+          "Shift",
+          "+",
+        ]),
+      );
+      fireEvent.keyDown(document.body, { key: "+", shiftKey: true });
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+    });
+  } finally {
+    unregister();
+  }
 });
 
 test("a conflicting chord is rejected pre-flight: inline message, no hub write, capture stays open", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1297,3 +1297,37 @@ test("a generation-fenced queued write's row error clears on the next confirmed 
   });
   await waitFor(() => expect(within(composerRow).queryByRole("alert")).toBeNull());
 });
+
+// Finding 35: after an un-apply ROLLBACK on support loss the hubError alert
+// reports the old overrides still in effect; the status line must not
+// contradict it by claiming the built-in defaults. (Clean unsupported keeps
+// the defaults wording - pinned by the pre-existing "does not support synced
+// keybinding overrides" test.)
+test("a wedged support loss keeps the overrides firing and the status does not claim the defaults are in effect", async () => {
+  const client = await wireEditableClient([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+  render(<KeybindingsSection />);
+
+  // The wedge: a foreign binding squatting palette.open's DEFAULT chord, so
+  // the support drop's un-apply restore exact-matches, throws, and rolls
+  // back. palette.open's default is $mod+K with legacyEitherMod, so the
+  // restored base serializes "Control+[Meta]+K" (Meta OPTIONAL).
+  keybindingsRegistry.getState().registerBinding({
+    id: "foreign.squatter",
+    actionId: "foreign.action",
+    chord: "Control+[Meta]+K",
+  });
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain("still in effect");
+  const status = screen.getByRole("status");
+  expect(status.textContent).not.toContain("built-in defaults are in effect");
+  expect(status.textContent).toContain("still in effect");
+  // ...and the listing backs it up: the palette override is still firing
+  // and still marked Customized.
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("Customized")).toBeTruthy();
+  expect(within(row).getByText("P")).toBeTruthy();
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -396,6 +396,48 @@ test("Escape cancels the capture without a hub write and leaves the chord unchan
   );
 });
 
+test("a second non-modifier key does NOT overwrite the captured chord; Enter saves the FIRST", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  expect(within(box).getByText("P")).toBeTruthy();
+  // The stray press before Enter: the recorded chord stands (cancel and
+  // re-capture to change it) - the box keeps showing P and W never appears.
+  fireEvent.keyDown(box, { key: "w" });
+  expect(within(box).getByText("P")).toBeTruthy();
+  expect(within(box).queryByText("W")).toBeNull();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.paletteOpen, chord: "Control+P" }] },
+  });
+});
+
+test("after capture, modifier presses do not replace the preview and Escape still cancels", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  expect(within(box).getByText("P")).toBeTruthy();
+  // The held-modifier echo still updates internally, but the recorded chord
+  // owns the preview.
+  fireEvent.keyDown(box, { key: "Shift" });
+  expect(within(box).getByText("P")).toBeTruthy();
+  fireEvent.keyUp(box, { key: "Shift" });
+  fireEvent.keyDown(box, { key: "Escape" });
+
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(0);
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("K")).toBeTruthy();
+  expect(within(row).queryByText("Customized")).toBeNull();
+});
+
 // Plain Escape is cancel, permanently: it cannot be assigned through the
 // editor (the VS Code keybinding-editor convention), so the built-in Escape
 // bindings come back via Reset, never via capture. Escape WITH a modifier is
@@ -850,9 +892,15 @@ test("a conflicting chord is rejected pre-flight: inline message, no hub write, 
       .bindings.filter((b) => b.actionId === ACTIONS.composerFocus)
       .map((b) => b.id),
   ).toEqual([ACTIONS.composerFocus, `${ACTIONS.composerFocus}#mod-twin`]);
-  // A subsequent valid chord still saves from the same capture.
+  // The recorded (conflicting) chord stands while this capture lives
+  // (finding 30): the way to another chord is cancel and RE-CAPTURE, and
+  // the fresh capture then saves clean.
   fireEvent.keyDown(captureBox(), { key: "m", ctrlKey: true });
-  fireEvent.keyDown(captureBox(), { key: "Enter" });
+  expect(within(captureBox()).getByText("P")).toBeTruthy();
+  fireEvent.keyDown(captureBox(), { key: "Escape" });
+  const box2 = await enterCapture("Focus the composer");
+  fireEvent.keyDown(box2, { key: "m", ctrlKey: true });
+  fireEvent.keyDown(box2, { key: "Enter" });
   await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -614,6 +614,101 @@ test("IME composition events neither record nor save; a non-composing press stil
   });
 });
 
+// Browsers that signal IME input ONLY through keyCode 229 (no isComposing,
+// an ordinary-looking key) hit the dispatcher's second guard; capture must
+// run the same one or composition input / a commit Enter records as a chord.
+test("a keydown reported only via keyCode 229 records nothing and does not save", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "a", keyCode: 229 });
+  expect(box.textContent).toContain("Press new shortcut…");
+  fireEvent.keyDown(box, { key: "Enter", keyCode: 229 });
+  expect(patchCallsOf(client)).toHaveLength(0);
+  expect(captureBox()).toBeTruthy();
+
+  // A real press afterwards still records and saves.
+  fireEvent.keyDown(box, { key: "m", ctrlKey: true });
+  expect(within(box).getByText("M")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+});
+
+// A save is a hub round trip; a click-away cancel closes the box while the
+// PATCH is in flight. The per-capture generation token keeps the stale
+// continuation from closing or repainting a capture it did not start.
+test("a save resolving after a click-away cancel does not clobber a reopened capture", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/patch",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolvePatch = resolve;
+      }),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // Open a capture and start a save; the PATCH hangs.
+  const box = await enterCapture("Open the command palette");
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+
+  // Click away: the capture cancels while the save is in flight...
+  fireEvent.pointerDown(document.body);
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+
+  // ...and the user reopens the same row's capture.
+  const reopened = await enterCapture("Open the command palette");
+  expect(reopened.textContent).toContain("Press new shortcut…");
+
+  // The stale save resolves: the reopened capture stays open and untouched.
+  resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+  await waitFor(() => expect(keybindingsStore.getState().revision).toBe(2));
+  expect(screen.getByRole("textbox", { name: /Press the new shortcut/ })).toBe(reopened);
+  expect(reopened.textContent).toContain("Press new shortcut…");
+});
+
+test("a stale save's error does not surface into a reopened capture", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  let rejectPatch: ((error: Error) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/patch",
+    () =>
+      new Promise<KeybindingsOverrides>((_resolve, reject) => {
+        rejectPatch = reject;
+      }),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  const box = await enterCapture("Open the command palette");
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+
+  fireEvent.pointerDown(document.body);
+  const reopened = await enterCapture("Open the command palette");
+
+  // The old save FAILS: its error belongs to the cancelled capture and must
+  // not surface on the ROW or inside the new capture. (The store still
+  // records the failed patch as hubError - the section-level alert is the
+  // store's contract for any failed patch, capture or not; what the
+  // generation token guards is the row/capture continuation.)
+  rejectPatch?.(new Error("hub exploded"));
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  expect(within(rowFor("Open the command palette")).queryByRole("alert")).toBeNull();
+  expect(screen.getByRole("textbox", { name: /Press the new shortcut/ })).toBe(reopened);
+  expect(reopened.textContent).toContain("Press new shortcut…");
+});
+
 // "+" is tinykeys' modifier DELIMITER, so a naive read says a captured "+"
 // chord ("Shift++", "Control++") cannot parse. The installed tinykeys splits
 // modifiers with a lookbehind (/(?<=\w|\])\+/), so a trailing "+" parses as

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1,8 +1,14 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeAll, beforeEach, expect, test } from "vitest";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { ACTIONS } from "../../../keybindings/actions";
-import { DEFAULT_BINDINGS, registerDefaultBindings } from "../../../keybindings/defaults";
+import {
+  CHARACTER_KEY_TRIGGER_BINDING_ID,
+  DEFAULT_BINDINGS,
+  registerDefaultBindings,
+  SETTINGS_SCOPE,
+} from "../../../keybindings/defaults";
+import { createKeybindingDispatcher } from "../../../keybindings/dispatcher";
 import { keybindingsRegistry } from "../../../keybindings/registry";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import type { KeybindingsOverrides, KeybindingsRule } from "../../../protocol/types.gen";
@@ -220,4 +226,330 @@ test("validation warnings from the applied payload are listed quietly", async ()
   expect(status.textContent).toContain('chord "Control+W" is reserved');
   // Both bad rules were skipped: every action stays on its default.
   expect(screen.queryByText("Customized")).toBeNull();
+});
+
+// --- Phase 4b: the capture-based editor ------------------------------------
+
+/** A supported hub whose patch echoes the requested rules back at the next
+ * revision - the hub's real apply-and-confirm behavior, minimal. */
+async function wireEditableClient(initial: KeybindingsRule[] = []): Promise<FakeClient> {
+  const client = new FakeClient("ready");
+  let revision = 1;
+  client.on("evener/settings/keybindings/get", () => overridesPayload(revision, initial));
+  client.on("evener/settings/keybindings/patch", (params) => {
+    revision += 1;
+    return overridesPayload(revision, params.config.rules);
+  });
+  await wireClient(client, true);
+  return client;
+}
+
+function patchCallsOf(client: FakeClient) {
+  return client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+}
+
+function captureBox(): HTMLElement {
+  return screen.getByRole("textbox", { name: /Press the new shortcut/ });
+}
+
+async function enterCapture(title: string): Promise<HTMLElement> {
+  await userEvent.setup().click(screen.getByRole("button", { name: `Change the shortcut for ${title}` }));
+  return captureBox();
+}
+
+test("an unsupported hub keeps every row read-only (no editing affordances)", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  await wireClient(client, false);
+  render(<KeybindingsSection />);
+
+  expect(screen.getByRole("status").textContent).toContain("does not support synced keybinding overrides");
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  expect(screen.queryByRole("button", { name: "Unbind" })).toBeNull();
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
+test("a hub with unknown support keeps every row read-only", () => {
+  render(<KeybindingsSection />);
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
+test("clicking a chord enters capture mode with the prompt focused", async () => {
+  await wireEditableClient();
+  render(<KeybindingsSection />);
+
+  const box = await enterCapture("Open the command palette");
+
+  expect(box.textContent).toContain("Press new shortcut…");
+  expect(box.textContent).toContain("Enter to save");
+  expect(document.activeElement).toBe(box);
+});
+
+test("held modifiers render live while capturing, before any key is recorded", async () => {
+  await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "Control", ctrlKey: true });
+  expect(within(box).getByText("Ctrl")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Shift", ctrlKey: true, shiftKey: true });
+  expect(within(box).getByText("Shift")).toBeTruthy();
+  // Releasing keeps the preview in step.
+  fireEvent.keyUp(box, { key: "Shift", ctrlKey: true });
+  expect(within(box).queryByText("Shift")).toBeNull();
+  // No chord recorded yet, and no hub write.
+  expect(box.textContent).toContain("Enter to save");
+});
+
+test("Enter saves the captured chord through patchOverrides and the row shows the new chord", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  expect(within(box).getByText("P")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.paletteOpen, chord: "Control+P" }] },
+  });
+  // The confirmed payload reconciled: capture closed, row shows the override.
+  await waitFor(() => expect(within(rowFor("Open the command palette")).getByText("P")).toBeTruthy());
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(within(rowFor("Open the command palette")).getByText("Customized")).toBeTruthy();
+});
+
+test("Escape cancels the capture without a hub write and leaves the chord unchanged", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Escape" });
+
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(0);
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("K")).toBeTruthy();
+  expect(within(row).queryByText("Customized")).toBeNull();
+  // A keyboard-ended capture returns focus to the chord button it started
+  // from (a click-away cancel does not - focus went where the user put it).
+  expect(document.activeElement).toBe(
+    within(row).getByRole("button", { name: "Change the shortcut for Open the command palette" }),
+  );
+});
+
+test("a plain Enter with nothing captured neither saves nor cancels", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  expect(screen.getByText("Press new shortcut…")).toBeTruthy();
+  expect(patchCallsOf(client)).toHaveLength(0);
+});
+
+test("a conflicting chord is rejected pre-flight: inline message, no hub write, capture stays open", async () => {
+  const client = await wireEditableClient([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain(
+    `chord "Control+P" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`,
+  );
+  expect(patchCallsOf(client)).toHaveLength(0);
+  // The capture stays open so the user can try another chord or cancel...
+  expect(captureBox()).toBeTruthy();
+  // ...and composer.focus's registry bindings never moved off the default
+  // (the row itself shows the capture box while capturing, so assert the
+  // registry, not the render).
+  expect(
+    keybindingsRegistry
+      .getState()
+      .bindings.filter((b) => b.actionId === ACTIONS.composerFocus)
+      .map((b) => b.id),
+  ).toEqual([ACTIONS.composerFocus, `${ACTIONS.composerFocus}#mod-twin`]);
+  // A subsequent valid chord still saves from the same capture.
+  fireEvent.keyDown(captureBox(), { key: "m", ctrlKey: true });
+  fireEvent.keyDown(captureBox(), { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+});
+
+test("a platform-reserved chord is rejected pre-flight with the validation message", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "w", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain('chord "Control+W" is reserved');
+  expect(patchCallsOf(client)).toHaveLength(0);
+});
+
+test("Unbind writes a chord:null rule and the row renders Unbound and Customized", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.paletteOpen, chord: null }] },
+  });
+  const row = rowFor("Open the command palette");
+  await waitFor(() => expect(within(row).getByText("Unbound")).toBeTruthy());
+  expect(within(row).getByText("Customized")).toBeTruthy();
+  // An unbound action offers capture (to set a new chord) but not Unbind.
+  expect(within(row).getByRole("button", { name: "Set a shortcut for Open the command palette" })).toBeTruthy();
+  expect(within(row).queryByRole("button", { name: "Unbind" })).toBeNull();
+});
+
+test("Reset removes the action's rule and restores the default chord", async () => {
+  const client = await wireEditableClient([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+  render(<KeybindingsSection />);
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("P")).toBeTruthy();
+  expect(within(row).getByText("Customized")).toBeTruthy();
+
+  await userEvent.setup().click(within(row).getByRole("button", { name: "Reset" }));
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  // The patch drops the action's rule entirely (the payload is the whole
+  // desired rule set).
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [] },
+  });
+  await waitFor(() => expect(within(row).getByText("K")).toBeTruthy());
+  expect(within(row).queryByText("Customized")).toBeNull();
+  expect(within(row).queryByRole("button", { name: "Reset" })).toBeNull();
+});
+
+test("a failed Unbind surfaces the hub error inline on the row", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  client.on("evener/settings/keybindings/patch", () => {
+    throw new Error("socket went away");
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+
+  const row = rowFor("Open the command palette");
+  await waitFor(() => expect(within(row).getByRole("alert").textContent).toContain("socket went away"));
+  expect(within(row).getByText("K")).toBeTruthy();
+});
+
+// The cheatsheet.toggle row is the one multi-entry action: the editor edits
+// the base ($mod+/) chord only; the conditional "?" trigger is the
+// character-key setting's own entry, shown read-only with a note.
+test("the cheatsheet row shows the conditional ? trigger as a read-only note", async () => {
+  await wireEditableClient();
+  render(<KeybindingsSection />);
+
+  const row = rowFor("Show the keyboard shortcuts overlay");
+  // One editable chord button (the base entry)...
+  expect(
+    within(row).getByRole("button", { name: "Change the shortcut for Show the keyboard shortcuts overlay" }),
+  ).toBeTruthy();
+  expect(within(row).getAllByRole("button", { name: /shortcut for/ })).toHaveLength(1);
+  // ...and the "?" entry as a note, not a second editable chord.
+  const note = row.querySelector("p");
+  expect(note?.textContent).toContain("character-key setting");
+  expect(within(row).getByText("?")).toBeTruthy();
+});
+
+test("the ? note disappears with the conditional binding (character-key setting off)", async () => {
+  await wireEditableClient();
+  keybindingsRegistry.getState().unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+  render(<KeybindingsSection />);
+
+  const row = rowFor("Show the keyboard shortcuts overlay");
+  expect(row.textContent).not.toContain("character-key setting");
+});
+
+test("an override on cheatsheet.toggle owns the whole chord set: no ? note", async () => {
+  await wireEditableClient([{ action: ACTIONS.cheatsheetToggle, chord: "Control+Slash" }]);
+  render(<KeybindingsSection />);
+
+  const row = rowFor("Show the keyboard shortcuts overlay");
+  expect(row.textContent).not.toContain("character-key setting");
+  expect(within(row).getByText("Customized")).toBeTruthy();
+});
+
+// While capture is active the window-level dispatcher must not act: the
+// capture box consumes every keydown (preventDefault + stopPropagation).
+// These tests wire the REAL dispatcher and settings scope, the same way
+// Settings.tsx does for the live pane.
+async function withDispatcher(run: () => Promise<void>): Promise<void> {
+  const dispatcher = createKeybindingDispatcher();
+  const detach = dispatcher.attach(window);
+  try {
+    await run();
+  } finally {
+    detach();
+    dispatcher.dispose();
+  }
+}
+
+test("a captured chord never reaches the dispatcher (rail.toggle opts out of defaultPrevented)", async () => {
+  await wireEditableClient();
+  const railSpy = vi.fn();
+  const unregister = keybindingsRegistry.getState().registerAction(ACTIONS.railToggle, railSpy);
+  try {
+    await withDispatcher(async () => {
+      render(<KeybindingsSection />);
+      const box = await enterCapture("Open the command palette");
+
+      // Control+B is rail.toggle's live default chord; capturing it must not
+      // toggle the rail - rail.toggle's binding even opts OUT of the
+      // defaultPrevented gate, so only the capture box's stopPropagation
+      // keeps the press from the dispatcher.
+      fireEvent.keyDown(box, { key: "b", ctrlKey: true });
+
+      expect(railSpy).not.toHaveBeenCalled();
+      expect(within(box).getByText("Ctrl")).toBeTruthy();
+      expect(within(box).getByText("B")).toBeTruthy();
+    });
+  } finally {
+    unregister();
+  }
+});
+
+test("Escape cancels the capture and does NOT fire settings.close; outside capture it closes", async () => {
+  await wireEditableClient();
+  const closeSpy = vi.fn();
+  const popScope = keybindingsRegistry.getState().pushScope(SETTINGS_SCOPE);
+  const unregister = keybindingsRegistry.getState().registerAction(ACTIONS.settingsClose, closeSpy);
+  try {
+    await withDispatcher(async () => {
+      render(<KeybindingsSection />);
+      const box = await enterCapture("Open the command palette");
+
+      fireEvent.keyDown(box, { key: "Escape" });
+
+      // Capture cancelled, pane still open.
+      expect(screen.queryByText("Press new shortcut…")).toBeNull();
+      expect(closeSpy).not.toHaveBeenCalled();
+
+      // Not capturing: Escape reaches the settings scope's close binding.
+      fireEvent.keyDown(document.body, { key: "Escape" });
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    });
+  } finally {
+    unregister();
+    popScope();
+  }
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { ACTIONS } from "../../../keybindings/actions";
+import { parseChord, serializeChord } from "../../../keybindings/chord";
 import {
   CHARACTER_KEY_TRIGGER_BINDING_ID,
   DEFAULT_BINDINGS,
@@ -506,6 +507,58 @@ test("a plain Enter with nothing captured neither saves nor cancels", async () =
 
   expect(screen.getByText("Press new shortcut…")).toBeTruthy();
   expect(patchCallsOf(client)).toHaveLength(0);
+});
+
+// The spacebar's event.key is a literal " " - the tinykeys grammar's press
+// SEPARATOR - so capture maps it to the canonical, matchable name "Space"
+// (tinykeys' matcher also compares event.code, which IS "Space"). A literal
+// " " would not survive parseChord at all.
+test("capturing Space records the canonical name and the chord round-trips through the grammar", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: " " });
+  expect(within(box).getByText("Space")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Space" }] },
+  });
+  // The saved chord parses back to the same press (it would throw on " ").
+  expect(serializeChord(parseChord("Space"))).toBe("Space");
+  // The confirmed payload reconciled onto the registry with the same chord.
+  await waitFor(() => expect(within(rowFor("Focus the composer")).getByText("Space")).toBeTruthy());
+});
+
+// IME composition keydowns (isComposing, key "Process"/"Unidentified") are
+// not presses: they record nothing and an IME commit Enter must not save.
+test("IME composition events neither record nor save; a non-composing press still works", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  // Mid-composition keydowns: no chord recorded.
+  fireEvent.keyDown(box, { key: "Process", isComposing: true });
+  fireEvent.keyDown(box, { key: "a", isComposing: true });
+  expect(box.textContent).toContain("Press new shortcut…");
+  // A composition-commit Enter does NOT save...
+  fireEvent.keyDown(box, { key: "Enter", isComposing: true });
+  fireEvent.keyDown(box, { key: "Unidentified" });
+  expect(patchCallsOf(client)).toHaveLength(0);
+  expect(captureBox()).toBeTruthy();
+
+  // ...and a real press afterwards still records and saves.
+  fireEvent.keyDown(box, { key: "m", ctrlKey: true });
+  expect(within(box).getByText("M")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
+  });
 });
 
 test("a conflicting chord is rejected pre-flight: inline message, no hub write, capture stays open", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1091,3 +1091,31 @@ test("editable true → false → true leaves the row read-only then editable ag
   await userEvent.setup().click(chordButton);
   expect(captureBox().textContent).toContain("Press new shortcut…");
 });
+
+// Reset availability derives from the hub's RAW rules: a persisted rule
+// validation skips (reserved here) never reaches the validated set, but
+// dropping it is exactly the meaningful action - so the row must offer
+// Reset even though the effective bindings never changed.
+test("a persisted rule skipped by validation shows Reset, and clicking it drops the rule from the hub payload", async () => {
+  // Control+W is reserved on every platform: the rule is skipped with a
+  // warning and never applies.
+  const client = await wireEditableClient([{ action: ACTIONS.railToggle, chord: "Control+W" }]);
+  render(<KeybindingsSection />);
+
+  const row = rowFor("Toggle the sidebar");
+  const reset = within(row).getByRole("button", { name: "Reset" });
+  // An action with no raw rule shows no Reset (regression).
+  expect(within(rowFor("Open the command palette")).queryByRole("button", { name: "Reset" })).toBeNull();
+  // The Customized marker stays on the effective bindings: the skipped rule
+  // changed nothing, so no marker.
+  expect(within(row).queryByText("Customized")).toBeNull();
+
+  await userEvent.setup().click(reset);
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  // The PATCH drops the rule: the full replacement rule set without it.
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [] },
+  });
+  await waitFor(() => expect(within(rowFor("Toggle the sidebar")).queryByRole("button", { name: "Reset" })).toBeNull());
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1331,3 +1331,124 @@ test("a wedged support loss keeps the overrides firing and the status does not c
   expect(within(row).getByText("Customized")).toBeTruthy();
   expect(within(row).getByText("P")).toBeTruthy();
 });
+
+// Finding 37: the round-3 gate locks editing while hubError is set, and a
+// successful refresh clears it - the error block offers a Retry control that
+// re-drives the refresh. The control unmounts the moment the refresh starts
+// (refreshFor's entry clears hubError), so a double-click has no second
+// target; the in-flight window with a PRESERVED rollback error disables it
+// instead (separate test).
+test("a failed patch locks editing and shows a Retry that re-drives the refresh and restores editability (finding 37)", async () => {
+  const client = new FakeClient("ready");
+  let pending: Promise<KeybindingsOverrides> | undefined;
+  client.on("evener/settings/keybindings/get", () => pending ?? overridesPayload(1, []));
+  let failPatch = true;
+  client.on("evener/settings/keybindings/patch", (params) => {
+    if (failPatch) throw new Error("hub exploded");
+    return overridesPayload(2, params.config.rules);
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // A transient server error: the PATCH rejects on the live generation, so
+  // hubError surfaces and editing locks behind the round-3 gate.
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+  await waitFor(() => expect(keybindingsStore.getState().hubError).toBe("hub exploded"));
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  const retry = screen.getByRole("button", { name: "Retry" });
+
+  // The hub recovers. Arm a hanging get so the in-flight window is
+  // observable: clicking Retry starts the refresh, which clears hubError at
+  // entry - the alert and the Retry control unmount, leaving no second
+  // click target (the double-fire guard on this path).
+  failPatch = false;
+  let resolveGet: ((p: KeybindingsOverrides) => void) | undefined;
+  pending = new Promise<KeybindingsOverrides>((resolve) => {
+    resolveGet = resolve;
+  });
+  const getCalls = () => client.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+  const before = getCalls();
+  await userEvent.setup().click(retry);
+  await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+  expect(getCalls()).toBe(before + 1);
+  expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+
+  // The refresh lands: hubError clears and editability returns.
+  resolveGet?.(overridesPayload(1, []));
+  await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
+  await screen.findByRole("button", { name: "Change the shortcut for Open the command palette" });
+});
+
+// Finding 37: on an unsupported hub a refresh cannot help (refreshFor's
+// entry guard refuses it) - no Retry, even when the rollback alert is
+// showing (that state's retry is connection-change-driven, findings 31/35).
+test("Retry does not appear on an unsupported hub, even with the rollback alert (finding 37)", async () => {
+  const client = await wireEditableClient([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+  render(<KeybindingsSection />);
+  // The wedge rolls the support drop's un-apply back (finding-35 staging):
+  // the rollback alert shows, but the hub is unsupported - no Retry.
+  keybindingsRegistry.getState().registerBinding({
+    id: "foreign.squatter",
+    actionId: "foreign.action",
+    chord: "Control+[Meta]+K",
+  });
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain("still in effect");
+  expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+});
+
+// Finding 37, in-flight window: through a rewire rollback the hubError is
+// PRESERVED while the new hub's refresh is in flight (unapplyRolledBack), so
+// the Retry control stays mounted - disabled while hubLoading, making a
+// double-click a no-op. When the refresh lands and clears the error, the
+// control unmounts.
+test("Retry is disabled while a refresh is in flight through the rollback window (finding 37)", async () => {
+  const clientA = new FakeClient("ready");
+  clientA.on("evener/settings/keybindings/get", () =>
+    overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  await wireClient(clientA, true);
+  render(<KeybindingsSection />);
+
+  // The wedge: a foreign binding squatting palette.open's default chord, so
+  // the rewire's un-apply restore throws and rolls back.
+  keybindingsRegistry.getState().registerBinding({
+    id: "foreign.squatter",
+    actionId: "foreign.action",
+    chord: "Control+[Meta]+K",
+  });
+  const clientB = new FakeClient("ready");
+  let resolveGet: ((p: KeybindingsOverrides) => void) | undefined;
+  clientB.on(
+    "evener/settings/keybindings/get",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolveGet = resolve;
+      }),
+  );
+  connectionStore.getState().connect(clientB);
+  connectionStore.setState({
+    features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+  });
+  await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+  expect(keybindingsStore.getState().hubError).toContain("still in effect");
+
+  // Retry is mounted (supported hub, hubError present) but disabled for the
+  // flight: clicking it fires no second get.
+  const retry = screen.getByRole("button", { name: "Retry" });
+  expect((retry as HTMLButtonElement).disabled).toBe(true);
+  const getCalls = () => clientB.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+  const before = getCalls();
+  await userEvent.setup().click(retry);
+  expect(getCalls()).toBe(before);
+
+  // Unwedge; the refresh lands, clears the rollback error, and the control
+  // unmounts.
+  keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+  resolveGet?.(overridesPayload(1, []));
+  await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
+  expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -709,6 +709,70 @@ test("a stale save's error does not surface into a reopened capture", async () =
   expect(reopened.textContent).toContain("Press new shortcut…");
 });
 
+// Writes serialize at the store: an edit made while ANOTHER row's write is
+// in flight queues behind it (no controls are disabled - the queue absorbs
+// the concurrency), composes its expectedRevision and payload from the
+// first write's confirmed state, and - via the finding-13 generation token
+// - still cannot touch a capture that was cancelled while it queued.
+test("a save queued behind another row's in-flight write lands in order and ignores its cancelled capture", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  let firstExpectedRevision: number | undefined;
+  let resolveFirstPatch: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on("evener/settings/keybindings/patch", (params) => {
+    if (firstExpectedRevision === undefined) {
+      firstExpectedRevision = params.expectedRevision;
+      return new Promise<KeybindingsOverrides>((resolve) => {
+        resolveFirstPatch = resolve;
+      });
+    }
+    return overridesPayload(params.expectedRevision + 1, params.config.rules);
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // Row B (command palette) Reset starts PATCH #1, which hangs in flight.
+  const resetButton = within(rowFor("Open the command palette")).getByRole("button", { name: "Reset" });
+  await userEvent.setup().click(resetButton);
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+
+  // While it hangs, the composer row's controls stay ENABLED (the queue
+  // absorbs the concurrency - nothing is disabled during a write)...
+  const chordButton = screen.getByRole("button", { name: "Change the shortcut for Focus the composer" });
+  expect((chordButton as HTMLButtonElement).disabled).toBe(false);
+  await userEvent.setup().click(chordButton);
+  const box = captureBox();
+  fireEvent.keyDown(box, { key: "m", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+  // ...and the save QUEUES: no second PATCH has hit the wire yet.
+  expect(patchCallsOf(client)).toHaveLength(1);
+
+  // The capture is cancelled before its save executes.
+  fireEvent.pointerDown(document.body);
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+
+  // PATCH #1 lands: the queued save composes against the post-Reset state
+  // (expectedRevision 2, rules WITHOUT the dropped palette override) and
+  // applies to the store...
+  resolveFirstPatch?.(overridesPayload((firstExpectedRevision ?? 0) + 1, []));
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(2));
+  expect(patchCallsOf(client)[1]?.params).toEqual({
+    expectedRevision: 2,
+    config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
+  });
+  await waitFor(() => expect(keybindingsStore.getState().revision).toBe(3));
+
+  // ...but the cancelled capture is never touched: it stays closed, no row
+  // error appears, focus is not stolen back to the chord button.
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+  expect(within(rowFor("Focus the composer")).queryByRole("alert")).toBeNull();
+  expect(document.activeElement).not.toBe(
+    screen.getByRole("button", { name: "Change the shortcut for Focus the composer" }),
+  );
+});
+
 // "+" is tinykeys' modifier DELIMITER, so a naive read says a captured "+"
 // chord ("Shift++", "Control++") cannot parse. The installed tinykeys splits
 // modifiers with a lookbehind (/(?<=\w|\])\+/), so a trailing "+" parses as

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1208,3 +1208,92 @@ test("a persisted rule skipped by validation shows Reset, and clicking it drops 
   });
   await waitFor(() => expect(within(rowFor("Toggle the sidebar")).queryByRole("button", { name: "Reset" })).toBeNull());
 });
+
+// Finding 33: a preflight rejection (a Reset that would re-conflict a
+// restored default) sets ONLY the row error - hubError stays null by design,
+// so the hubError transition cannot clear it. The next confirmed hub payload
+// (here a `changed` notification from an edit made elsewhere) supersedes the
+// bindings the error described, and the apply-serial bump clears the row error.
+test("a Reset preflight rejection's row error clears on the next confirmed payload", async () => {
+  const client = await wireEditableClient([
+    { action: ACTIONS.composerFocus, chord: "Control+K" },
+    { action: ACTIONS.paletteOpen, chord: "Control+P" },
+  ]);
+  render(<KeybindingsSection />);
+
+  // Reset on the palette row drops the palette override: the simulation
+  // restores palette.open's default Control+K, which composer's override
+  // still claims - an introduced conflict the hub write never sees.
+  const row = rowFor("Open the command palette");
+  await userEvent.setup().click(within(row).getByRole("button", { name: "Reset" }));
+  const alert = await within(row).findByRole("alert");
+  expect(alert.textContent).toContain(`already bound by "${ACTIONS.paletteOpen}"`);
+  expect(patchCallsOf(client)).toHaveLength(0);
+  expect(keybindingsStore.getState().hubError).toBeNull();
+
+  // Nothing hub-sourced follows on its own: the error persists until a
+  // confirmed payload lands (the composer rule was removed through another
+  // client), then clears with the apply.
+  client.emitNotification({
+    method: "evener/settings/keybindings/changed",
+    params: overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  });
+  await waitFor(() => expect(within(row).queryByRole("alert")).toBeNull());
+  expect(keybindingsStore.getState().hubError).toBeNull();
+});
+
+// Finding 33, fence half: a write QUEUED in a ready generation that a
+// support flap ends rejects at the call-time fence - throw-only, hubError
+// stays null by design (finding 22) - leaving a row error no hubError
+// transition can clear. The next confirmed payload clears it.
+test("a generation-fenced queued write's row error clears on the next confirmed payload", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/patch",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolvePatch = resolve;
+      }),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // Write 1 (palette Unbind) hangs in flight; write 2 (composer Unbind)
+  // queues behind it in the same generation.
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  await userEvent.setup().click(within(rowFor("Focus the composer")).getByRole("button", { name: "Unbind" }));
+
+  // A support flap ends the ready generation: the flap-back begins a NEW
+  // generation and re-refreshes (revision 3 again), confirming state - that
+  // apply-serial bump happens BEFORE either row error exists.
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: true },
+  });
+  await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+  // Write 1's response lands in the DEAD generation (dropped, synthesized
+  // resolution); write 2 then executes and the call-time fence throws - the
+  // composer row shows the error while hubError stays null.
+  resolvePatch?.(overridesPayload(4, []));
+  const composerRow = rowFor("Focus the composer");
+  const alert = await within(composerRow).findByRole("alert");
+  expect(alert.textContent).toContain("unavailable");
+  expect(keybindingsStore.getState().hubError).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(1);
+
+  // A confirmed payload for the NEW generation supersedes the bindings the
+  // error described: the row error clears.
+  client.emitNotification({
+    method: "evener/settings/keybindings/changed",
+    params: overridesPayload(5, []),
+  });
+  await waitFor(() => expect(within(composerRow).queryByRole("alert")).toBeNull());
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -878,7 +878,7 @@ test("a conflicting chord is rejected pre-flight: inline message, no hub write, 
 
   const alert = await screen.findByRole("alert");
   expect(alert.textContent).toContain(
-    `chord "Control+P" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`,
+    `chord "Control+P" in scope "global" is already bound by "Open the command palette" (${ACTIONS.paletteOpen})`,
   );
   expect(patchCallsOf(client)).toHaveLength(0);
   // The capture stays open so the user can try another chord or cancel...
@@ -1185,6 +1185,23 @@ test("editable true → false → true leaves the row read-only then editable ag
 // validation skips (reserved here) never reaches the validated set, but
 // dropping it is exactly the meaningful action - so the row must offer
 // Reset even though the effective bindings never changed.
+// A conflict-skip warning names the holder the way the rows do - by TITLE
+// (with the action id alongside) - not by bare action id: this list is what
+// the user reads to understand why a saved rule did not apply.
+test("a persisted rule skipped for conflicting with a default names the holder by title in the warnings list", async () => {
+  // composerFocus claiming Control+K collides with palette.open's default.
+  await wireEditableClient([{ action: ACTIONS.composerFocus, chord: "Control+K" }]);
+  render(<KeybindingsSection />);
+
+  await waitFor(() =>
+    expect(screen.getByRole("status").textContent).toContain(
+      `chord "Control+K" in scope "global" is already bound by "Open the command palette" (${ACTIONS.paletteOpen})`,
+    ),
+  );
+  // The skipped rule changed nothing: composer stays on its default.
+  expect(within(rowFor("Focus the composer")).queryByText("Customized")).toBeNull();
+});
+
 test("a persisted rule skipped by validation shows Reset, and clicking it drops the rule from the hub payload", async () => {
   // Control+W is reserved on every platform: the rule is skipped with a
   // warning and never applies.
@@ -1227,7 +1244,7 @@ test("a Reset preflight rejection's row error clears on the next confirmed paylo
   const row = rowFor("Open the command palette");
   await userEvent.setup().click(within(row).getByRole("button", { name: "Reset" }));
   const alert = await within(row).findByRole("alert");
-  expect(alert.textContent).toContain(`already bound by "${ACTIONS.paletteOpen}"`);
+  expect(alert.textContent).toContain(`already bound by "Open the command palette" (${ACTIONS.paletteOpen})`);
   expect(patchCallsOf(client)).toHaveLength(0);
   expect(keybindingsStore.getState().hubError).toBeNull();
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -342,6 +342,161 @@ test("Escape cancels the capture without a hub write and leaves the chord unchan
   );
 });
 
+// Plain Escape is cancel, permanently: it cannot be assigned through the
+// editor (the VS Code keybinding-editor convention), so the built-in Escape
+// bindings come back via Reset, never via capture. Escape WITH a modifier is
+// a normal chord and records. settings.close's own default is Escape with
+// every modifier optional, so overriding THAT action with Shift+Escape
+// conflicts with nothing.
+test("plain Escape cancels but Shift+Escape records as a chord", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  let box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "Escape" });
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(0);
+
+  box = await enterCapture("Close settings");
+  fireEvent.keyDown(box, { key: "Escape", shiftKey: true });
+  expect(within(box).getByText("Shift")).toBeTruthy();
+  expect(within(box).getByText("Escape")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.settingsClose, chord: "Shift+Escape" }] },
+  });
+});
+
+// Uppercase normalization is ASCII-only: String.toUpperCase can change
+// LENGTH on non-ASCII input ("ß" -> "SS"), which would corrupt the chord.
+test("a non-ASCII character records verbatim; ASCII letters still normalize to uppercase", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  let box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "ß" });
+  expect(within(box).getByText("ß")).toBeTruthy();
+  expect(within(box).queryByText("SS")).toBeNull();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "ß" }] },
+  });
+
+  box = await enterCapture("Quote the selection into the composer");
+  fireEvent.keyDown(box, { key: "a" });
+  expect(within(box).getByText("A")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(2));
+  expect(patchCallsOf(client)[1]?.params).toEqual({
+    expectedRevision: 2,
+    config: {
+      version: 1,
+      rules: [
+        { action: ACTIONS.composerFocus, chord: "ß" },
+        { action: ACTIONS.selectionQuote, chord: "A" },
+      ],
+    },
+  });
+});
+
+// Click-away cancels even when the click target cannot take focus: onBlur
+// alone only fires when focus MOVES, so a document-level pointerdown listener
+// (capture phase) covers non-focusable clicks while the capture is live.
+test("pointerdown outside the capture box cancels without refocusing the chord button", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.pointerDown(document.body);
+
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(0);
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("K")).toBeTruthy();
+  // refocus:false - a click-away cancel leaves focus where the user put it,
+  // unlike the keyboard cancel which returns focus to the chord button.
+  expect(document.activeElement).not.toBe(
+    within(row).getByRole("button", { name: "Change the shortcut for Open the command palette" }),
+  );
+});
+
+test("pointerdown INSIDE the capture box does not cancel", async () => {
+  await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.pointerDown(box);
+
+  expect(captureBox()).toBeTruthy();
+  expect(screen.getByText("Press new shortcut…")).toBeTruthy();
+});
+
+test("the outside-pointerdown listener is removed when the capture closes", async () => {
+  const addSpy = vi.spyOn(document, "addEventListener");
+  const removeSpy = vi.spyOn(document, "removeEventListener");
+  try {
+    await wireEditableClient();
+    render(<KeybindingsSection />);
+    await enterCapture("Open the command palette");
+
+    // The capture box's listener is the pointerdown one in the capture phase.
+    const added = addSpy.mock.calls.filter((call) => call[0] === "pointerdown" && call[2] === true);
+    expect(added).not.toHaveLength(0);
+    const listener = added[added.length - 1]?.[1];
+
+    fireEvent.keyDown(captureBox(), { key: "Escape" });
+    expect(screen.queryByText("Press new shortcut…")).toBeNull();
+
+    expect(
+      removeSpy.mock.calls.some((call) => call[0] === "pointerdown" && call[1] === listener && call[2] === true),
+    ).toBe(true);
+  } finally {
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  }
+});
+
+// Whole-payload PATCHes are composed from the hub's RAW rules: a rule
+// validation skipped (here: an action this client does not know, written by
+// a newer one) is still the hub's state and must survive an unrelated edit.
+test("an unrelated edit preserves a hub rule validation skips (unknown action survives in the PATCH payload)", async () => {
+  const client = await wireEditableClient([{ action: "future.new.action", chord: "Control+Alt+9" }]);
+  render(<KeybindingsSection />);
+
+  // The skipped rule stays a quiet warning; nothing is customized.
+  expect(screen.getByRole("status").textContent).toContain('unknown keybinding action "future.new.action"');
+  expect(screen.queryByText("Customized")).toBeNull();
+
+  const box = await enterCapture("Open the command palette");
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  // The unknown-action rule passes through untouched, alongside the edit.
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: {
+      version: 1,
+      rules: [
+        { action: "future.new.action", chord: "Control+Alt+9" },
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+      ],
+    },
+  });
+  // The preserved rule's pre-existing warning did not block the save, and
+  // the confirmed payload still lists it as a (skipped) warning.
+  await waitFor(() => expect(within(rowFor("Open the command palette")).getByText("P")).toBeTruthy());
+  expect(screen.getByRole("status").textContent).toContain('unknown keybinding action "future.new.action"');
+});
+
 test("a plain Enter with nothing captured neither saves nor cancels", async () => {
   const client = await wireEditableClient();
   render(<KeybindingsSection />);

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -925,6 +925,47 @@ test("a failed Unbind surfaces the hub error inline on the row", async () => {
   expect(within(row).getByText("K")).toBeTruthy();
 });
 
+test("a confirmed hub payload clears a stale row error - and leaves an unrelated capture alone", async () => {
+  // The hub rejects writes while it recovers; the failed PATCH never
+  // confirmed, so the GET stays at revision 1 and the refresh re-confirms
+  // the SAME payload (the stale guard is `<`: an equal-revision refresh
+  // still applies and clears hubError).
+  let failPatch = true;
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  client.on("evener/settings/keybindings/patch", (params) => {
+    if (failPatch) throw new Error("state unavailable");
+    return overridesPayload(2, params.config.rules);
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+  const row = rowFor("Open the command palette");
+  await waitFor(() => expect(within(row).getByRole("alert").textContent).toContain("state unavailable"));
+  expect(keybindingsStore.getState().hubError).not.toBeNull();
+
+  // The hub answers a refresh again: hubError clears, and the row's stale
+  // inline error clears WITH it - the bindings it described are no longer
+  // the truth (the palette was never unbound).
+  failPatch = false;
+  await keybindingsStore.getState().refreshOverrides();
+  expect(keybindingsStore.getState().hubError).toBeNull();
+  await waitFor(() => expect(within(row).queryByRole("alert")).toBeNull());
+
+  // The clearing is scoped to the stale error: a capture open on another
+  // row rides through a later confirmed payload untouched. A NOTIFICATION,
+  // not a refresh: a refresh flips hubLoading, which makes the section
+  // read-only for the flight and cancels captures by design (finding 18) -
+  // the notification path confirms a payload without the loading gate.
+  const box = await enterCapture("Focus the composer");
+  client.emitNotification({
+    method: "evener/settings/keybindings/changed",
+    params: overridesPayload(1, []),
+  });
+  expect(screen.getByRole("textbox", { name: /Press the new shortcut/ })).toBe(box);
+});
+
 // The cheatsheet.toggle row is the one multi-entry action: the editor edits
 // the base ($mod+/) chord only; the conditional "?" trigger is the
 // character-key setting's own entry, shown read-only with a note.

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -694,19 +694,24 @@ test("a stale save's error does not surface into a reopened capture", async () =
 
   fireEvent.pointerDown(document.body);
   const reopened = await enterCapture("Open the command palette");
+  expect(reopened.textContent).toContain("Press new shortcut…");
 
   // The old save FAILS: its error belongs to the cancelled capture and must
-  // not surface on the ROW or inside the new capture. (The store still
-  // records the failed patch as hubError - the section-level alert is the
-  // store's contract for any failed patch, capture or not; what the
-  // generation token guards is the row/capture continuation.)
+  // not surface on the ROW. (The store still records the failed patch as
+  // hubError - the section-level alert is the store's contract for any
+  // failed patch, capture or not; what the generation token guards is the
+  // row/capture continuation.)
   rejectPatch?.(new Error("hub exploded"));
   await new Promise((resolve) => {
     setTimeout(resolve, 0);
   });
   expect(within(rowFor("Open the command palette")).queryByRole("alert")).toBeNull();
-  expect(screen.getByRole("textbox", { name: /Press the new shortcut/ })).toBe(reopened);
-  expect(reopened.textContent).toContain("Press new shortcut…");
+  // hubError also makes the whole section read-only (editable includes
+  // hubError === null), so the reopened capture CLOSES: an interactive box
+  // must not strand in a section whose controls have all gone read-only.
+  // The finding-13 guarantee this test pins is the error's containment, not
+  // the capture's survival across an editability loss.
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
 });
 
 // Writes serialize at the store: an edit made while ANOTHER row's write is
@@ -1020,4 +1025,69 @@ test("Escape cancels the capture and does NOT fire settings.close; outside captu
     unregister();
     popScope();
   }
+});
+
+// Editability is a per-render prop driven by hub support; a capture is row
+// state with a save in flight on the wire. Support loss mid-capture must
+// cancel the capture like a click-away (generation bumped, no refocus):
+// otherwise the interactive box strands in a read-only section and the
+// resolving save's continuation would repaint it.
+test("editable flipping false mid-capture closes the box and a resolving in-flight save does not touch the row", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/patch",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolvePatch = resolve;
+      }),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // Open a capture and start a save; the PATCH hangs.
+  const box = await enterCapture("Open the command palette");
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+
+  // Support drops while the save is in flight: the row goes read-only and
+  // the capture must close with it.
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+  await waitFor(() => expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull());
+  expect(screen.queryByRole("button", { name: /shortcut for Open the command palette/ })).toBeNull();
+
+  // The stale save resolves: no capture reopens, no row-level error.
+  resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+  expect(within(rowFor("Open the command palette")).queryByRole("alert")).toBeNull();
+});
+
+test("editable true → false → true leaves the row read-only then editable again, and a fresh capture opens", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+
+  await enterCapture("Open the command palette");
+
+  // Support drops: capture cancelled, editing affordance gone.
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+  await waitFor(() => expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull());
+  expect(screen.queryByRole("button", { name: /shortcut for Open the command palette/ })).toBeNull();
+
+  // Support returns (the store re-refreshes the hub payload on its own):
+  // the chord button comes back and opens a NEW capture.
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: true },
+  });
+  const chordButton = await screen.findByRole("button", { name: "Change the shortcut for Open the command palette" });
+  await userEvent.setup().click(chordButton);
+  expect(captureBox().textContent).toContain("Press new shortcut…");
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -84,9 +84,13 @@ function errorMessage(error: unknown): string {
 /** The full replacement rule set a single-action edit produces: the store's
  * patch semantics are whole-payload (an action the payload drops gets its
  * defaults restored), so every edit re-sends the current overrides with this
- * action's rule swapped - or REMOVED (chord undefined) for reset-to-default. */
+ * action's rule swapped - or REMOVED (chord undefined) for reset-to-default.
+ * Composition is from the hub's RAW rules (rawOverrides), NOT the validated
+ * `overrides`: a rule validation skipped (an unknown action from a newer
+ * client, an unparseable chord) is still the hub's state and passes through
+ * untouched - composing from the validated set would silently delete it. */
 function replacementRules(actionId: string, chord: string | null | undefined): OverrideRule[] {
-  const current = keybindingsStore.getState().overrides;
+  const current = keybindingsStore.getState().rawOverrides;
   const rest = current.filter((rule) => rule.action !== actionId);
   if (chord === undefined) return [...rest];
   return [...rest, { action: actionId, chord }];
@@ -128,6 +132,24 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
     boxRef.current?.focus();
   }, []);
 
+  // Click-away cancels even when the click target is not focusable: onBlur
+  // alone only fires when focus MOVES (to another control), so clicking
+  // non-focusable text or empty space would leave the capture live. A
+  // document-level pointerdown in the capture phase sees every press,
+  // wherever it lands; a press outside the box cancels with refocus:false
+  // (focus goes where the user put it - or stays, for a non-focusable
+  // target). The listener dies with the box (unmount on cancel/save).
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent): void {
+      const box = boxRef.current;
+      if (box !== null && event.target instanceof Node && !box.contains(event.target)) {
+        onCancel(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [onCancel]);
+
   function handleKeyDown(event: ReactKeyboardEvent<HTMLDivElement>): void {
     event.preventDefault();
     event.stopPropagation();
@@ -154,15 +176,17 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
       return;
     }
     setError(null);
-    // Single-character keys normalize to uppercase: KeyboardEvent.key for a
+    // ASCII letters normalize to uppercase: KeyboardEvent.key for a
     // mod chord arrives lowercase ("p" for Ctrl+P) while the default map
     // writes letters uppercase, and tinykeys matches case-insensitively, so
     // normalizing keeps display and serialization consistent with the
-    // existing rows without changing what matches.
+    // existing rows without changing what matches. The test is ASCII-only on
+    // purpose: String.toUpperCase can CHANGE LENGTH on non-ASCII input
+    // ("ß".toUpperCase() === "SS"), which would corrupt the chord.
     setCaptured({
       modifiers,
       optionalModifiers: [],
-      key: event.key.length === 1 ? event.key.toUpperCase() : event.key,
+      key: /^[a-z]$/.test(event.key) ? event.key.toUpperCase() : event.key,
     });
   }
 
@@ -173,7 +197,9 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
   return (
     <div className={CLASS.captureWrap}>
       {/* Clicking away cancels: the box is modal-ish, and focus leaving it
-          (another row's chord button, the toggle) ends the capture. The
+          (another row's chord button, the toggle) ends the capture via
+          onBlur; the pointerdown listener above covers clicks that never
+          move focus (non-focusable text, empty space). The
           textbox role names what it is - a keyboard-capture surface in the
           spirit of HotkeyRecorder's input; aria-readonly because every key
           is intercepted rather than typed. */}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -172,7 +172,15 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
     // guard the window dispatcher runs (keybindings/dispatcher.ts); here it
     // precedes preventDefault/stopPropagation, and the dispatcher's own
     // isComposing guard covers the propagation we let through.
-    if (event.nativeEvent.isComposing || event.key === "Process" || event.key === "Unidentified") return;
+    // keyCode 229 is the fallback for browsers that report IME input only
+    // through it (the dispatcher's guard pairs the two the same way).
+    if (
+      event.nativeEvent.isComposing ||
+      event.nativeEvent.keyCode === 229 ||
+      event.key === "Process" ||
+      event.key === "Unidentified"
+    )
+      return;
     event.preventDefault();
     event.stopPropagation();
     if (savingRef.current) return;
@@ -275,6 +283,15 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
   // it started. A click-away cancel does NOT set it - focus already went
   // where the user put it.
   const refocusOnCloseRef = useRef(false);
+  // A save is a hub round trip and OUTLIVES the capture that started it: a
+  // click-away cancel closes the box while the PATCH is in flight, and the
+  // user can open a NEW capture before the old save resolves. Every capture
+  // open/cancel bumps this generation; a resolving save applies its result
+  // (closing the box, clearing the row error, refocusing) only while its
+  // generation is still current, so a stale continuation cannot close or
+  // repaint a capture it did not start. Same role as CaptureBox's
+  // savingRef, one level up.
+  const captureGenerationRef = useRef(0);
 
   useEffect(() => {
     if (!capturing && refocusOnCloseRef.current) {
@@ -294,11 +311,16 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
   );
 
   async function saveCapture(chord: Chord): Promise<string | null> {
+    const generation = captureGenerationRef.current;
     try {
       await keybindingsStore.getState().patchOverrides(replacementRules(actionId, serializeChord([chord])));
     } catch (saveError) {
       return errorMessage(saveError);
     }
+    // Cancelled (or cancelled-and-reopened) while the PATCH was in flight:
+    // the capture this save belongs to is gone; its resolution must not
+    // touch the row's current capture state.
+    if (captureGenerationRef.current !== generation) return null;
     refocusOnCloseRef.current = true;
     setCapturing(false);
     setError(null);
@@ -306,6 +328,7 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
   }
 
   function cancelCapture(refocus: boolean): void {
+    captureGenerationRef.current += 1;
     refocusOnCloseRef.current = refocus;
     setCapturing(false);
   }
@@ -346,6 +369,7 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
             className={CLASS.chordButton}
             aria-label={binding === undefined ? `Set a shortcut for ${title}` : `Change the shortcut for ${title}`}
             onClick={() => {
+              captureGenerationRef.current += 1;
               setError(null);
               setCapturing(true);
             }}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -291,6 +291,16 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
   useEffect(() => {
     if (hubError === null) setError(null);
   }, [hubError]);
+  // Finding 33: preflight and generation-fence rejections deliberately never
+  // set hubError, so the hubError transition above cannot clear a row error
+  // they left behind. Every confirmed hub payload (refresh, notification, or
+  // a later successful patch) supersedes the bindings that error described,
+  // so clear on the apply serial instead.
+  const appliedSerial = useKeybindingsStore((s) => s.appliedSerial);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: appliedSerial is a deliberate trigger-only dep - the effect's whole job is to re-run on the serial bump
+  useEffect(() => {
+    setError(null);
+  }, [appliedSerial]);
   // Reset availability derives from the hub's RAW rules, not the validated
   // set: a persisted rule validation skips (reserved/malformed/conflicting)
   // never reaches `overrides`, but dropping it is exactly the meaningful

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -300,6 +300,20 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
     }
   }, [capturing]);
 
+  // A capture must not outlive editability: a disconnect, support loss, or
+  // hub replacement mid-capture would strand an interactive box in a
+  // read-only section (the store side already rejects the save). Cancel
+  // like a click-away: bump the generation so an in-flight save's
+  // continuation no-ops, and do NOT refocus - the controls focus would
+  // return to are going away with editability.
+  useEffect(() => {
+    if (!editable && capturing) {
+      captureGenerationRef.current += 1;
+      refocusOnCloseRef.current = false;
+      setCapturing(false);
+    }
+  }, [editable, capturing]);
+
   const binding = displayBindingFor(bindings, actionId);
   const customized = isActionCustomized(bindings, actionId, characterKeyTriggers);
   // Extra default entries beyond the platform base entry - in practice
@@ -487,7 +501,11 @@ export function KeybindingsSection() {
       )}
       {warnings.length > 0 && (
         <div className={CLASS.status} role="status">
-          <p>Some saved overrides were skipped:</p>
+          <p>
+            {warnings.some((warning) => warning.reason === "character-key-conflict")
+              ? "Keybinding warnings:"
+              : "Some saved overrides were skipped:"}
+          </p>
           <ul className={CLASS.warningList}>
             {warnings.map((warning) => (
               <li key={warning.message}>{warning.message}</li>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -479,7 +479,13 @@ export function KeybindingsSection() {
   if (hubSupport === "unknown") {
     status = "Waiting for the hub connection to report keybindings support.";
   } else if (hubSupport === "unsupported") {
-    status = "This hub does not support synced keybinding overrides. The built-in defaults are in effect.";
+    // Finding 35: after an un-apply ROLLBACK the hubError alert says the
+    // old overrides are still in effect - the status must not contradict it
+    // by claiming the built-in defaults.
+    status =
+      hubError === null
+        ? "This hub does not support synced keybinding overrides. The built-in defaults are in effect."
+        : "This hub does not support synced keybinding overrides. The previously synced overrides are still in effect; restoring the built-in defaults is retried on the next connection change.";
   } else if (hubLoading || !loaded) {
     // The stale-hub window: a client replacement reset the loaded state and
     // the new hub's refresh has not landed (or failed - the alert below

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -1,17 +1,36 @@
-// Settings -> Keybindings: a READ-ONLY listing of the effective bindings,
-// plus the character-key-triggers toggle. The action list and the per-action
-// display binding are sourced from keybindings/display.ts - the same module
-// the cheatsheet overlay reads - never a hand-maintained copy (the survey's
-// stale-HELP_ROWS lesson). The chords come from the live registry, so hub
-// overrides applied by the keybindings store show up the moment they
-// reconcile. Editing affordances are deliberately absent; the shortcuts
-// editor is a later phase (4b).
+// Settings -> Keybindings: the capture-based binding editor (Phase 4b).
+// Clicking a row's chord enters capture mode (HotkeyRecorder-style: the
+// prompt shows held modifiers live, the first non-modifier press records the
+// chord, Enter saves, Escape cancels); per-action Unbind and Reset affordances
+// sit beside it. Writes go through the keybindings store's patchOverrides,
+// whose pre-flight validation rejects a conflicting (or reserved, or
+// unparseable) chord BEFORE the hub write - that message renders inline on
+// the row. The action list and per-action display bindings are sourced from
+// keybindings/display.ts - the same module the cheatsheet overlay reads -
+// never a hand-maintained copy (the survey's stale-HELP_ROWS lesson).
+//
+// Editing requires a hub with synced-override support (hubSupport ===
+// "supported"): the overrides layer is hub-only by design, so unknown and
+// unsupported hubs get the read-only listing with the existing status text.
+//
+// The overrides model owns an action's WHOLE chord set, so the editor edits
+// each action's base chord only; cheatsheet.toggle's conditional "?" entry
+// (managed by the character-key setting, per shell/cheatsheet/
+// cheatsheetController.ts) renders read-only with a note.
 
+import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from "react";
 import { useStore } from "zustand";
-import { chordDisplayKeys, serializeChord } from "../../../keybindings/chord";
-import { ACTION_DISPLAY_ROWS, displayBindingFor, isActionCustomized } from "../../../keybindings/display";
-import { keybindingsRegistry } from "../../../keybindings/registry";
-import { useKeybindingsStore } from "../../../stores/keybindings";
+import { type Chord, chordDisplayKeys, modifierDisplayKey, serializeChord } from "../../../keybindings/chord";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID } from "../../../keybindings/defaults";
+import {
+  ACTION_DISPLAY_ROWS,
+  displayBindingFor,
+  displayBindingsFor,
+  isActionCustomized,
+} from "../../../keybindings/display";
+import { type Binding, keybindingsRegistry } from "../../../keybindings/registry";
+import type { OverrideRule } from "../../../keybindings/validation";
+import { keybindingsStore, useKeybindingsStore } from "../../../stores/keybindings";
 import { prefsStore, usePrefsStore } from "../../../stores/prefs";
 import { KeyHint, Switch } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
@@ -31,7 +50,299 @@ const CLASS = {
   marker: requireClass(styles.marker, "keybindings.module.css", "marker"),
   unbound: requireClass(styles.unbound, "keybindings.module.css", "unbound"),
   chord: requireClass(styles.chord, "keybindings.module.css", "chord"),
+  chordButton: requireClass(styles.chordButton, "keybindings.module.css", "chordButton"),
+  controls: requireClass(styles.controls, "keybindings.module.css", "controls"),
+  rowError: requireClass(styles.rowError, "keybindings.module.css", "rowError"),
+  note: requireClass(styles.note, "keybindings.module.css", "note"),
+  actionButton: requireClass(styles.actionButton, "keybindings.module.css", "actionButton"),
+  captureWrap: requireClass(styles.captureWrap, "keybindings.module.css", "captureWrap"),
+  capture: requireClass(styles.capture, "keybindings.module.css", "capture"),
+  capturePrompt: requireClass(styles.capturePrompt, "keybindings.module.css", "capturePrompt"),
+  captureHint: requireClass(styles.captureHint, "keybindings.module.css", "captureHint"),
+  captureError: requireClass(styles.captureError, "keybindings.module.css", "captureError"),
 };
+
+// The keys that are modifiers themselves: holding one updates the live
+// preview but never records a chord.
+const MODIFIER_KEYS = new Set(["Control", "Alt", "Shift", "Meta"]);
+
+/** The held modifiers of a key event, in the chord module's canonical order
+ * (chord.ts's MODIFIER_ORDER), so a recorded chord serializes canonically. */
+function eventModifiers(event: ReactKeyboardEvent): string[] {
+  const modifiers: string[] = [];
+  if (event.ctrlKey) modifiers.push("Control");
+  if (event.altKey) modifiers.push("Alt");
+  if (event.shiftKey) modifiers.push("Shift");
+  if (event.metaKey) modifiers.push("Meta");
+  return modifiers;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** The full replacement rule set a single-action edit produces: the store's
+ * patch semantics are whole-payload (an action the payload drops gets its
+ * defaults restored), so every edit re-sends the current overrides with this
+ * action's rule swapped - or REMOVED (chord undefined) for reset-to-default. */
+function replacementRules(actionId: string, chord: string | null | undefined): OverrideRule[] {
+  const current = keybindingsStore.getState().overrides;
+  const rest = current.filter((rule) => rule.action !== actionId);
+  if (chord === undefined) return [...rest];
+  return [...rest, { action: actionId, chord }];
+}
+
+interface CaptureBoxProps {
+  title: string;
+  /** Returns null on success (the box unmounts) or the message to show. */
+  onSave: (chord: Chord) => Promise<string | null>;
+  /** `refocus` is true when the capture ended from the keyboard (Escape) -
+   * the row returns focus to its chord button - and false when it ended by
+   * clicking away (focus already went where the user put it). */
+  onCancel: (refocus: boolean) => void;
+}
+
+/** The capture widget: a focusable box that consumes EVERY keydown while it
+ * is alive. preventDefault + stopPropagation keep each press from the
+ * window-level dispatcher - a captured chord must never fire the action it
+ * would replace, and rail.toggle's binding opts out of the
+ * defaultPrevented gate, so stopping propagation is the load-bearing half -
+ * and from the settings scope's own Escape (settings.close's
+ * ignoreIfDefaultPrevented gate is the backstop there, so capture's Escape
+ * cancels the capture instead of closing the pane).
+ *
+ * Single-press chords only: the default map is single-press throughout and
+ * multi-press overlap checking is deliberately coarser (chord.ts's
+ * chordsOverlap), so the editor does not author sequences. Plain Enter saves
+ * and plain Escape cancels; either key WITH a modifier records as a chord. */
+function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
+  const [held, setHeld] = useState<string[]>([]);
+  const [captured, setCaptured] = useState<Chord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+  // A save is a hub round trip; keypresses that land while it is in flight
+  // are ignored rather than queued into a second patch.
+  const savingRef = useRef(false);
+
+  useEffect(() => {
+    boxRef.current?.focus();
+  }, []);
+
+  function handleKeyDown(event: ReactKeyboardEvent<HTMLDivElement>): void {
+    event.preventDefault();
+    event.stopPropagation();
+    if (savingRef.current) return;
+    const modifiers = eventModifiers(event);
+    if (MODIFIER_KEYS.has(event.key)) {
+      setHeld(modifiers);
+      return;
+    }
+    if (event.key === "Escape" && modifiers.length === 0) {
+      onCancel(true);
+      return;
+    }
+    if (event.key === "Enter" && modifiers.length === 0) {
+      if (captured === null) return;
+      savingRef.current = true;
+      const chord = captured;
+      void onSave(chord).then((saveError) => {
+        savingRef.current = false;
+        // On success the parent unmounted this box; only a failure needs
+        // the state write.
+        if (saveError !== null) setError(saveError);
+      });
+      return;
+    }
+    setError(null);
+    // Single-character keys normalize to uppercase: KeyboardEvent.key for a
+    // mod chord arrives lowercase ("p" for Ctrl+P) while the default map
+    // writes letters uppercase, and tinykeys matches case-insensitively, so
+    // normalizing keeps display and serialization consistent with the
+    // existing rows without changing what matches.
+    setCaptured({
+      modifiers,
+      optionalModifiers: [],
+      key: event.key.length === 1 ? event.key.toUpperCase() : event.key,
+    });
+  }
+
+  function handleKeyUp(event: ReactKeyboardEvent<HTMLDivElement>): void {
+    if (MODIFIER_KEYS.has(event.key)) setHeld(eventModifiers(event));
+  }
+
+  return (
+    <div className={CLASS.captureWrap}>
+      {/* Clicking away cancels: the box is modal-ish, and focus leaving it
+          (another row's chord button, the toggle) ends the capture. The
+          textbox role names what it is - a keyboard-capture surface in the
+          spirit of HotkeyRecorder's input; aria-readonly because every key
+          is intercepted rather than typed. */}
+      {/* biome-ignore lint/a11y/useSemanticElements: a real <input> cannot hold the KeyHint kbd rendering or the save/cancel hint - only its role is wanted */}
+      <div
+        ref={boxRef}
+        className={CLASS.capture}
+        role="textbox"
+        aria-readonly="true"
+        tabIndex={-1}
+        aria-label={`Press the new shortcut for ${title}. Enter saves, Escape cancels.`}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        onBlur={() => onCancel(false)}
+      >
+        {captured !== null ? (
+          <KeyHint keys={chordDisplayKeys(captured)} />
+        ) : held.length > 0 ? (
+          <KeyHint keys={held.map(modifierDisplayKey)} />
+        ) : (
+          <span className={CLASS.capturePrompt}>Press new shortcut…</span>
+        )}
+        <span className={CLASS.captureHint}>Enter to save · Esc to cancel</span>
+      </div>
+      {error !== null && (
+        <p className={CLASS.captureError} role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface KeybindingRowProps {
+  actionId: string;
+  title: string;
+  /** False on hubs without synced-override support: the row renders read-only. */
+  editable: boolean;
+  bindings: readonly Binding[];
+  characterKeyTriggers: boolean;
+}
+
+function KeybindingRow({ actionId, title, editable, bindings, characterKeyTriggers }: KeybindingRowProps) {
+  const [capturing, setCapturing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const hasOverride = useKeybindingsStore((s) => s.overrides.some((rule) => rule.action === actionId));
+  const chordButtonRef = useRef<HTMLButtonElement>(null);
+  // Set when a capture ends from the keyboard (Escape cancel, Enter save):
+  // focus returns to the chord button so the keyboard flow continues where
+  // it started. A click-away cancel does NOT set it - focus already went
+  // where the user put it.
+  const refocusOnCloseRef = useRef(false);
+
+  useEffect(() => {
+    if (!capturing && refocusOnCloseRef.current) {
+      refocusOnCloseRef.current = false;
+      chordButtonRef.current?.focus();
+    }
+  }, [capturing]);
+
+  const binding = displayBindingFor(bindings, actionId);
+  const customized = isActionCustomized(bindings, actionId, characterKeyTriggers);
+  // Extra default entries beyond the platform base entry - in practice
+  // exactly cheatsheet.toggle's conditional "?" trigger. The overrides model
+  // owns an action's whole chord set, so these are the setting's to manage,
+  // not the editor's: read-only, with the consequence spelled out.
+  const conditionalEntries = displayBindingsFor(bindings, actionId).filter(
+    (entry) => entry.id === CHARACTER_KEY_TRIGGER_BINDING_ID,
+  );
+
+  async function saveCapture(chord: Chord): Promise<string | null> {
+    try {
+      await keybindingsStore.getState().patchOverrides(replacementRules(actionId, serializeChord([chord])));
+    } catch (saveError) {
+      return errorMessage(saveError);
+    }
+    refocusOnCloseRef.current = true;
+    setCapturing(false);
+    setError(null);
+    return null;
+  }
+
+  function cancelCapture(refocus: boolean): void {
+    refocusOnCloseRef.current = refocus;
+    setCapturing(false);
+  }
+
+  async function applyRules(rules: OverrideRule[]): Promise<void> {
+    try {
+      await keybindingsStore.getState().patchOverrides(rules);
+      setError(null);
+    } catch (patchError) {
+      setError(errorMessage(patchError));
+    }
+  }
+
+  const chordCell =
+    binding === undefined ? (
+      <span className={CLASS.unbound}>Unbound</span>
+    ) : (
+      <span className={CLASS.chord}>
+        {binding.chord.map((press) => (
+          <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
+        ))}
+      </span>
+    );
+
+  return (
+    <li className={CLASS.row}>
+      <span className={CLASS.label}>
+        {title}
+        {customized && <span className={CLASS.marker}>Customized</span>}
+      </span>
+      {capturing ? (
+        <CaptureBox title={title} onSave={saveCapture} onCancel={cancelCapture} />
+      ) : editable ? (
+        <span className={CLASS.controls}>
+          <button
+            ref={chordButtonRef}
+            type="button"
+            className={CLASS.chordButton}
+            aria-label={binding === undefined ? `Set a shortcut for ${title}` : `Change the shortcut for ${title}`}
+            onClick={() => {
+              setError(null);
+              setCapturing(true);
+            }}
+          >
+            {binding === undefined ? <span className={CLASS.unbound}>Unbound</span> : chordCell}
+          </button>
+          {binding !== undefined && (
+            <button
+              type="button"
+              className={CLASS.actionButton}
+              onClick={() => void applyRules(replacementRules(actionId, null))}
+            >
+              Unbind
+            </button>
+          )}
+          {hasOverride && (
+            <button
+              type="button"
+              className={CLASS.actionButton}
+              onClick={() => void applyRules(replacementRules(actionId, undefined))}
+            >
+              Reset
+            </button>
+          )}
+        </span>
+      ) : (
+        chordCell
+      )}
+      {conditionalEntries.length > 0 && (
+        <p className={CLASS.note}>
+          Also opens on{" "}
+          {conditionalEntries.map((entry) =>
+            entry.chord.map((press) => <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />),
+          )}{" "}
+          while the character-key setting above is on. That entry follows the setting, not this editor; changing or
+          unbinding this shortcut replaces it too.
+        </p>
+      )}
+      {error !== null && (
+        <p className={CLASS.rowError} role="alert">
+          {error}
+        </p>
+      )}
+    </li>
+  );
+}
 
 export function KeybindingsSection() {
   const hubSupport = useKeybindingsStore((s) => s.hubSupport);
@@ -39,6 +350,7 @@ export function KeybindingsSection() {
   const warnings = useKeybindingsStore((s) => s.warnings);
   const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
   const characterKeyTriggers = usePrefsStore((s) => s.characterKeyTriggers);
+  const editable = hubSupport === "supported";
 
   let status: string | undefined;
   if (hubSupport === "unknown") {
@@ -50,7 +362,9 @@ export function KeybindingsSection() {
   return (
     <div className={CLASS.root}>
       <p className={CLASS.intro}>
-        The keyboard shortcuts currently in effect. Bindings marked Customized come from this hub's synced overrides.
+        {editable
+          ? "Click a shortcut to change it; Enter saves and Escape cancels. Changes sync to this hub. Bindings marked Customized come from this hub's synced overrides."
+          : "The keyboard shortcuts currently in effect. Bindings marked Customized come from this hub's synced overrides."}
       </p>
 
       {/* The WCAG 2.1.4 character-key turn-off (the p4 plan's Design
@@ -91,28 +405,16 @@ export function KeybindingsSection() {
       )}
 
       <ul className={CLASS.list}>
-        {ACTION_DISPLAY_ROWS.map((row) => {
-          const binding = displayBindingFor(bindings, row.actionId);
-          return (
-            <li className={CLASS.row} key={row.actionId}>
-              <span className={CLASS.label}>
-                {row.title}
-                {isActionCustomized(bindings, row.actionId, characterKeyTriggers) && (
-                  <span className={CLASS.marker}>Customized</span>
-                )}
-              </span>
-              {binding === undefined ? (
-                <span className={CLASS.unbound}>Unbound</span>
-              ) : (
-                <span className={CLASS.chord}>
-                  {binding.chord.map((press) => (
-                    <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
-                  ))}
-                </span>
-              )}
-            </li>
-          );
-        })}
+        {ACTION_DISPLAY_ROWS.map((row) => (
+          <KeybindingRow
+            key={row.actionId}
+            actionId={row.actionId}
+            title={row.title}
+            editable={editable}
+            bindings={bindings}
+            characterKeyTriggers={characterKeyTriggers}
+          />
+        ))}
       </ul>
     </div>
   );

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -66,6 +66,18 @@ const CLASS = {
 // preview but never records a chord.
 const MODIFIER_KEYS = new Set(["Control", "Alt", "Shift", "Meta"]);
 
+// Browser key values that collide with the tinykeys GRAMMAR need the
+// grammar's canonical, matchable spelling. The spacebar is the one case:
+// its event.key is a literal " ", which is the grammar's press SEPARATOR -
+// parseChord(" ") throws on the empty string and "Control+ " parses to an
+// empty key, so a saved " " binding is dead on the next reconcile.
+// tinykeys' matcher (matchKeybindingPress) accepts event.code as well as
+// event.key, and the spacebar's code is "Space", so "Space" both survives
+// the grammar and matches the key. Every other whitespace-adjacent key
+// already arrives grammar-safe (Tab -> "Tab", Enter -> "Enter"). Kept at
+// the capture seam on purpose: chord.ts's parser stays grammar-pure.
+const CAPTURE_KEY_NAMES: Record<string, string> = { " ": "Space" };
+
 /** The held modifiers of a key event, in the chord module's canonical order
  * (chord.ts's MODIFIER_ORDER), so a recorded chord serializes canonically. */
 function eventModifiers(event: ReactKeyboardEvent): string[] {
@@ -151,6 +163,13 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
   }, [onCancel]);
 
   function handleKeyDown(event: ReactKeyboardEvent<HTMLDivElement>): void {
+    // IME composition keydowns are not presses: during composition events
+    // arrive with isComposing set and key "Process"/"Unidentified", and an
+    // IME COMMIT Enter would otherwise hit the save branch below. The same
+    // guard the window dispatcher runs (keybindings/dispatcher.ts); here it
+    // precedes preventDefault/stopPropagation, and the dispatcher's own
+    // isComposing guard covers the propagation we let through.
+    if (event.nativeEvent.isComposing || event.key === "Process" || event.key === "Unidentified") return;
     event.preventDefault();
     event.stopPropagation();
     if (savingRef.current) return;
@@ -183,10 +202,11 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
     // existing rows without changing what matches. The test is ASCII-only on
     // purpose: String.toUpperCase can CHANGE LENGTH on non-ASCII input
     // ("ß".toUpperCase() === "SS"), which would corrupt the chord.
+    const key = /^[a-z]$/.test(event.key) ? event.key.toUpperCase() : event.key;
     setCaptured({
       modifiers,
       optionalModifiers: [],
-      key: /^[a-z]$/.test(event.key) ? event.key.toUpperCase() : event.key,
+      key: CAPTURE_KEY_NAMES[key] ?? key,
     });
   }
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -9,9 +9,12 @@
 // keybindings/display.ts - the same module the cheatsheet overlay reads -
 // never a hand-maintained copy (the survey's stale-HELP_ROWS lesson).
 //
-// Editing requires a hub with synced-override support (hubSupport ===
-// "supported"): the overrides layer is hub-only by design, so unknown and
-// unsupported hubs get the read-only listing with the existing status text.
+// Editing requires a hub with synced-override support whose override state
+// is CURRENT: hubSupport === "supported" plus the store's `loaded` flag (set
+// only by a confirmed apply in the current ready generation, cleared on
+// rewire/disconnect), no in-flight refresh, and no hub error. Anything less
+// gets the read-only listing with a truthful status line - a PATCH composed
+// in the stale window would carry the previous hub's revision and payload.
 //
 // The overrides model owns an action's WHOLE chord set, so the editor edits
 // each action's base chord only; cheatsheet.toggle's conditional "?" entry
@@ -392,17 +395,32 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
 
 export function KeybindingsSection() {
   const hubSupport = useKeybindingsStore((s) => s.hubSupport);
+  const hubLoading = useKeybindingsStore((s) => s.hubLoading);
   const hubError = useKeybindingsStore((s) => s.hubError);
+  const loaded = useKeybindingsStore((s) => s.loaded);
   const warnings = useKeybindingsStore((s) => s.warnings);
   const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
   const characterKeyTriggers = usePrefsStore((s) => s.characterKeyTriggers);
-  const editable = hubSupport === "supported";
+  const editable = hubSupport === "supported" && hubError === null && !hubLoading && loaded;
 
   let status: string | undefined;
   if (hubSupport === "unknown") {
     status = "Waiting for the hub connection to report keybindings support.";
   } else if (hubSupport === "unsupported") {
     status = "This hub does not support synced keybinding overrides. The built-in defaults are in effect.";
+  } else if (hubLoading || !loaded) {
+    // The stale-hub window: a client replacement reset the loaded state and
+    // the new hub's refresh has not landed (or failed - the alert below
+    // carries that message). Read-only until the overrides are current.
+    status =
+      hubError === null
+        ? "Loading this hub's synced keybinding overrides; the shortcuts shown are read-only until they arrive."
+        : "Editing is unavailable until this hub's synced keybinding overrides load cleanly.";
+  } else if (hubError !== null) {
+    // A patch or re-refresh failed AFTER a successful load: the listing is
+    // current, but editing waits for a clean reload (the alert carries the
+    // failure itself).
+    status = "Editing is unavailable until this hub's synced keybinding overrides load cleanly.";
   }
 
   return (

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -313,7 +313,11 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
   async function saveCapture(chord: Chord): Promise<string | null> {
     const generation = captureGenerationRef.current;
     try {
-      await keybindingsStore.getState().patchOverrides(replacementRules(actionId, serializeChord([chord])));
+      // A THUNK: the store serializes writes, so this composition must run
+      // when the write executes (against the raw set the previous write left
+      // behind), not now - composing at call time would race an in-flight
+      // edit from another row with a stale expectedRevision and payload.
+      await keybindingsStore.getState().patchOverrides(() => replacementRules(actionId, serializeChord([chord])));
     } catch (saveError) {
       return errorMessage(saveError);
     }
@@ -333,7 +337,7 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
     setCapturing(false);
   }
 
-  async function applyRules(rules: OverrideRule[]): Promise<void> {
+  async function applyRules(rules: readonly OverrideRule[] | (() => readonly OverrideRule[])): Promise<void> {
     try {
       await keybindingsStore.getState().patchOverrides(rules);
       setError(null);
@@ -380,7 +384,7 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
             <button
               type="button"
               className={CLASS.actionButton}
-              onClick={() => void applyRules(replacementRules(actionId, null))}
+              onClick={() => void applyRules(() => replacementRules(actionId, null))}
             >
               Unbind
             </button>
@@ -389,7 +393,7 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
             <button
               type="button"
               className={CLASS.actionButton}
-              onClick={() => void applyRules(replacementRules(actionId, undefined))}
+              onClick={() => void applyRules(() => replacementRules(actionId, undefined))}
             >
               Reset
             </button>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -133,7 +133,10 @@ interface CaptureBoxProps {
  * Single-press chords only: the default map is single-press throughout and
  * multi-press overlap checking is deliberately coarser (chord.ts's
  * chordsOverlap), so the editor does not author sequences. Plain Enter saves
- * and plain Escape cancels; either key WITH a modifier records as a chord. */
+ * and plain Escape cancels; either key WITH a modifier records as a chord.
+ * The FIRST non-modifier press records the chord; later presses are ignored
+ * (a stray key before Enter must not silently replace what is saved) - to
+ * change the chord, cancel and re-capture. */
 function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
   const [held, setHeld] = useState<string[]>([]);
   const [captured, setCaptured] = useState<Chord | null>(null);
@@ -205,6 +208,9 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
       });
       return;
     }
+    // The recorded chord stands: further non-modifier presses are consumed
+    // (preventDefault/stopPropagation above) but do NOT overwrite it.
+    if (captured !== null) return;
     setError(null);
     // ASCII letters normalize to uppercase: KeyboardEvent.key for a
     // mod chord arrives lowercase ("p" for Ctrl+P) while the default map

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -533,6 +533,23 @@ export function KeybindingsSection() {
       {hubError !== null && (
         <p className={CLASS.error} role="alert">
           Could not load keybinding overrides: {hubError}
+          {hubSupport === "supported" && (
+            // Finding 37: the round-3 gate locks editing while hubError is
+            // set, and a successful refresh clears it - offer the recovery
+            // inline. Supported hubs only: on an unsupported hub a refresh
+            // cannot help (refreshFor's entry guard refuses it), and the
+            // rollback message's own retry is connection-change-driven.
+            // Disabled while hubLoading so a double-click cannot double-fire
+            // the refresh.
+            <button
+              type="button"
+              className={CLASS.actionButton}
+              disabled={hubLoading}
+              onClick={() => void keybindingsStore.getState().refreshOverrides()}
+            >
+              Retry
+            </button>
+          )}
         </p>
       )}
       {warnings.length > 0 && (

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -276,7 +276,12 @@ interface KeybindingRowProps {
 function KeybindingRow({ actionId, title, editable, bindings, characterKeyTriggers }: KeybindingRowProps) {
   const [capturing, setCapturing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const hasOverride = useKeybindingsStore((s) => s.overrides.some((rule) => rule.action === actionId));
+  // Reset availability derives from the hub's RAW rules, not the validated
+  // set: a persisted rule validation skips (reserved/malformed/conflicting)
+  // never reaches `overrides`, but dropping it is exactly the meaningful
+  // action - replacementRules composes from rawOverrides for the same
+  // reason. The Customized marker stays on the effective bindings.
+  const hasOverride = useKeybindingsStore((s) => s.rawOverrides.some((rule) => rule.action === actionId));
   const chordButtonRef = useRef<HTMLButtonElement>(null);
   // Set when a capture ends from the keyboard (Escape cancel, Enter save):
   // focus returns to the chord button so the keyboard flow continues where

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -276,6 +276,15 @@ interface KeybindingRowProps {
 function KeybindingRow({ actionId, title, editable, bindings, characterKeyTriggers }: KeybindingRowProps) {
   const [capturing, setCapturing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A failed save leaves this row's inline error AND the store's hubError
+  // set. When a later confirmed hub payload (refresh or notification) clears
+  // hubError, the row's stale error clears with it - the bindings it
+  // described are no longer the truth, and the store's isEditable gate
+  // already reopens. Local state only: an unrelated capture is untouched.
+  const hubError = useKeybindingsStore((s) => s.hubError);
+  useEffect(() => {
+    if (hubError === null) setError(null);
+  }, [hubError]);
   // Reset availability derives from the hub's RAW rules, not the validated
   // set: a persisted rule validation skips (reserved/malformed/conflicting)
   // never reaches `overrides`, but dropping it is exactly the meaningful

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -19,6 +19,7 @@ import type {
 import { connectionStore } from "../stores/connection";
 import { type NavigationStoreState, navigationStore, resetNavigationStoreForTests } from "../stores/navigation/store";
 import { keyID } from "../stores/navigation/types";
+import { resetPrefsStoreForTests } from "../stores/prefs";
 import { resetSettingsOverviewStoreForTests } from "../stores/settingsOverview";
 import { AppShell } from "./AppShell";
 import { DockHost } from "./DockHost";
@@ -426,6 +427,11 @@ beforeEach(() => {
   // @ts-expect-error MemoryStorage implements the subset used by DockHost.
   globalThis.localStorage = new MemoryStorage();
   localStorage.clear();
+  // The settings pane's last-visited-section memory (prefs.ts's
+  // lastSettingsSection) is a module-singleton field backed by this same
+  // storage: rehydrate against the cleared storage, or one test's settings
+  // visit picks the next test's bare-/settings landing section.
+  resetPrefsStoreForTests();
 });
 
 afterEach(() => {

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.test.ts
@@ -7,7 +7,7 @@ import type { KeybindingsOverrides, KeybindingsRule } from "../../protocol/types
 import { connectionStore } from "../../stores/connection";
 import { keybindingsStore, resetKeybindingsStoreForTests } from "../../stores/keybindings";
 import { prefsStore, resetPrefsStoreForTests } from "../../stores/prefs";
-import { installCharacterKeyTriggerReconcile } from "./cheatsheetController";
+import { installCharacterKeyTriggerReconcile, reconcileCharacterKeyTrigger } from "./cheatsheetController";
 
 // Node 26 shadows jsdom's real window.localStorage with its own
 // (non-functional under vitest) global - the same in-memory stand-in
@@ -98,7 +98,13 @@ describe("cheatsheet controller: character-key trigger reconcile", () => {
     expect(characterKeyWarnings()).toEqual([]);
   });
 
-  test("pref flip with a conflicting Shift+? override does NOT register ?, surfaces a warning, and recovers when the conflict clears", async () => {
+  // The pref-flip flow is owned by the STORE's re-apply (finding 20): the
+  // simulation treats "?" as pref-authoritative, so a flip ON un-applies an
+  // overlapping override through the validation layer's restore-wins rule -
+  // the reconcile's own overlap skip (the next test) is the guard for
+  // overlaps validation does not manage (a foreign binding squatting the
+  // chord).
+  test("pref flip ON un-applies a conflicting Shift+? override (restore wins), registers ?, and clearing the rule clears the warning", async () => {
     disposers.push(installCharacterKeyTriggerReconcile());
 
     // Pref off: "?" unregisters, so a Shift+? claim by another action
@@ -117,27 +123,63 @@ describe("cheatsheet controller: character-key trigger reconcile", () => {
       true,
     );
 
-    // Pref back on: "?" cannot come back - it would overlap the live
-    // composer Shift+?. The reconcile must SKIP the registration and say
-    // why on the warnings channel, not shadow or be shadowed.
+    // Pref back on: the store's re-apply simulates "?" as present (the
+    // pref is authoritative over the flip-instant registry), so the
+    // composer claim conflicts, the restore wins, and the override is
+    // UN-APPLIED with a validation conflict warning - then the reconcile
+    // registers "?" against a clean map.
     prefsStore.getState().setCharacterKeyTriggers(true);
-    expect(questionTriggerRegistered()).toBe(false);
-    const warnings = characterKeyWarnings();
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]?.rule).toEqual({ action: ACTIONS.cheatsheetToggle, chord: "[Shift]+?" });
-    expect(warnings[0]?.conflictWith).toBe(ACTIONS.composerFocus);
-    expect(warnings[0]?.message).toBe(
-      `the "?" cheatsheet trigger was not registered: chord "[Shift]+?" in scope "global" is already bound by "${ACTIONS.composerFocus}"`,
+    expect(keybindingsRegistry.getState().bindings.some((b) => b.id === `${ACTIONS.composerFocus}#override`)).toBe(
+      false,
     );
+    expect(questionTriggerRegistered()).toBe(true);
+    const warnings = keybindingsStore.getState().warnings;
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.reason).toBe("conflict");
+    expect(warnings[0]?.rule).toEqual({ action: ACTIONS.composerFocus, chord: "Shift+?" });
+    expect(warnings[0]?.conflictWith).toBe(ACTIONS.cheatsheetToggle);
 
-    // The overlap clearing (here: the hub drops the composer override)
-    // re-runs the reconcile through the overrides-store subscription: "?"
-    // registers and exactly the character-key warning clears.
+    // The hub dropping the rule re-validates clean: the warning clears and
+    // nothing else moves.
     client.emitNotification({
       method: "evener/settings/keybindings/changed",
       params: overridesPayload(2, []),
     });
     expect(keybindingsStore.getState().revision).toBe(2);
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+  });
+
+  // The reconcile's own overlap guard (finding 17): an overlap validation
+  // does not manage - a FOREIGN binding squatting the "?" chord - skips the
+  // registration with a character-key-conflict warning, and clearing the
+  // squatter lets the next reconcile register "?" and clear the warning.
+  test("a foreign binding overlapping ? skips the registration with a character-key-conflict warning until it clears", () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(questionTriggerRegistered()).toBe(false);
+    // A bare "?" squatter: chordsOverlap treats the entry's Shift as
+    // OPTIONAL, so the bare form overlaps - but its serialization differs
+    // from "[Shift]+?", so the registry's exact-match registration allows it.
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "?",
+    });
+
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(questionTriggerRegistered()).toBe(false);
+    const warnings = characterKeyWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.rule).toEqual({ action: ACTIONS.cheatsheetToggle, chord: "[Shift]+?" });
+    expect(warnings[0]?.conflictWith).toBe("foreign.action");
+    expect(warnings[0]?.message).toBe(
+      'the "?" cheatsheet trigger was not registered: chord "[Shift]+?" in scope "global" is already bound by "foreign.action"',
+    );
+
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    reconcileCharacterKeyTrigger();
     expect(questionTriggerRegistered()).toBe(true);
     expect(characterKeyWarnings()).toEqual([]);
   });

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.test.ts
@@ -183,4 +183,46 @@ describe("cheatsheet controller: character-key trigger reconcile", () => {
     expect(questionTriggerRegistered()).toBe(true);
     expect(characterKeyWarnings()).toEqual([]);
   });
+
+  // Finding 29: present no longer implies checked. A foreign binding that
+  // lands AFTER "?" registered (a direct registration bypasses the overrides
+  // store's validation, and registerBinding's exact-match gate allows bare
+  // "?" against "[Shift]+?") must not co-fire with the built-in: the next
+  // reconcile unregisters "?" and warns, the foreign binding wins - and its
+  // removal re-registers "?" and clears the warning (total both ways).
+  test("a foreign binding landing AFTER ? was registered unregisters it with the warning until it clears", () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+    expect(questionTriggerRegistered()).toBe(true);
+
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "?",
+    });
+    reconcileCharacterKeyTrigger();
+    expect(questionTriggerRegistered()).toBe(false);
+    const warnings = characterKeyWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.rule).toEqual({ action: ACTIONS.cheatsheetToggle, chord: "[Shift]+?" });
+    expect(warnings[0]?.conflictWith).toBe("foreign.action");
+
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    reconcileCharacterKeyTrigger();
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(characterKeyWarnings()).toEqual([]);
+  });
+
+  test("present without overlap stays quiet across repeated reconciles (regression)", () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+    expect(questionTriggerRegistered()).toBe(true);
+
+    // The present-path re-check must not churn: no warning, and the entry
+    // stays registered no matter how often the reconcile runs.
+    reconcileCharacterKeyTrigger();
+    reconcileCharacterKeyTrigger();
+    reconcileCharacterKeyTrigger();
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(characterKeyWarnings()).toEqual([]);
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+  });
 });

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { ACTIONS } from "../../keybindings/actions";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, registerDefaultBindings } from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { FakeClient } from "../../protocol/testing/fakeClient";
+import type { KeybindingsOverrides, KeybindingsRule } from "../../protocol/types.gen";
+import { connectionStore } from "../../stores/connection";
+import { keybindingsStore, resetKeybindingsStoreForTests } from "../../stores/keybindings";
+import { prefsStore, resetPrefsStoreForTests } from "../../stores/prefs";
+import { installCharacterKeyTriggerReconcile } from "./cheatsheetController";
+
+// Node 26 shadows jsdom's real window.localStorage with its own
+// (non-functional under vitest) global - the same in-memory stand-in
+// stores/keybindings.test.ts carries, needed here because the prefs store
+// (the characterKeyTriggers pref this controller reconciles against) reads
+// and writes localStorage.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeAll(() => {
+  // @ts-expect-error see MemoryStorage's own comment for why this is needed
+  globalThis.localStorage = new MemoryStorage();
+});
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+function overridesPayload(revision: number, rules: KeybindingsRule[]): KeybindingsOverrides {
+  return { version: 1, revision, rules };
+}
+
+async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  });
+  await keybindingsStore.getState().refreshOverrides();
+}
+
+function questionTriggerRegistered(): boolean {
+  return keybindingsRegistry.getState().bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+}
+
+function characterKeyWarnings() {
+  return keybindingsStore.getState().warnings.filter((w) => w.reason === "character-key-conflict");
+}
+
+// A leaked reconcile subscription would keep firing into later tests (the
+// store resets above do not remove subscriptions), so every install is
+// tracked and disposed here.
+const disposers: Array<() => void> = [];
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
+});
+
+afterEach(() => {
+  while (disposers.length > 0) disposers.pop()?.();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
+});
+
+describe("cheatsheet controller: character-key trigger reconcile", () => {
+  test("pref off then on registers and unregisters the ? trigger with no warning (regression)", () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+    expect(questionTriggerRegistered()).toBe(true);
+
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(questionTriggerRegistered()).toBe(false);
+    expect(characterKeyWarnings()).toEqual([]);
+
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(characterKeyWarnings()).toEqual([]);
+  });
+
+  test("pref flip with a conflicting Shift+? override does NOT register ?, surfaces a warning, and recovers when the conflict clears", async () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+
+    // Pref off: "?" unregisters, so a Shift+? claim by another action
+    // conflicts with NOTHING and must apply clean.
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(questionTriggerRegistered()).toBe(false);
+
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.composerFocus, chord: "Shift+?" }]),
+    );
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+    expect(keybindingsRegistry.getState().bindings.some((b) => b.id === `${ACTIONS.composerFocus}#override`)).toBe(
+      true,
+    );
+
+    // Pref back on: "?" cannot come back - it would overlap the live
+    // composer Shift+?. The reconcile must SKIP the registration and say
+    // why on the warnings channel, not shadow or be shadowed.
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(questionTriggerRegistered()).toBe(false);
+    const warnings = characterKeyWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.rule).toEqual({ action: ACTIONS.cheatsheetToggle, chord: "[Shift]+?" });
+    expect(warnings[0]?.conflictWith).toBe(ACTIONS.composerFocus);
+    expect(warnings[0]?.message).toBe(
+      `the "?" cheatsheet trigger was not registered: chord "[Shift]+?" in scope "global" is already bound by "${ACTIONS.composerFocus}"`,
+    );
+
+    // The overlap clearing (here: the hub drops the composer override)
+    // re-runs the reconcile through the overrides-store subscription: "?"
+    // registers and exactly the character-key warning clears.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, []),
+    });
+    expect(keybindingsStore.getState().revision).toBe(2);
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(characterKeyWarnings()).toEqual([]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
@@ -85,10 +85,11 @@ function setCharacterKeyWarning(conflictWith: string | null): void {
 }
 
 /** Enforces "the ? binding is registered exactly while characterKeyTriggers
- * is on AND cheatsheet.toggle is on its default map". An applied override
- * (or unbind) owns the action's whole chord set, so "?" never comes back
- * there - the override is the user's own replacement for both triggers.
- * Idempotent and total: safe to run after any pref or override change. */
+ * is on AND cheatsheet.toggle is on its default map AND no foreign binding
+ * overlaps the chord". An applied override (or unbind) owns the action's
+ * whole chord set, so "?" never comes back there - the override is the
+ * user's own replacement for both triggers. Idempotent and total: safe to
+ * run after any pref or override change. */
 export function reconcileCharacterKeyTrigger(): void {
   const registry = keybindingsRegistry.getState();
   const present = registry.bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
@@ -97,19 +98,8 @@ export function reconcileCharacterKeyTrigger(): void {
     setCharacterKeyWarning(null);
     return;
   }
-  if (present) {
-    setCharacterKeyWarning(null);
-    return;
-  }
   const input = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
   if (input === undefined) return;
-  const onDefaultMap =
-    registry.bindings.some((b) => b.id === ACTIONS.cheatsheetToggle) &&
-    !registry.bindings.some((b) => b.actionId === ACTIONS.cheatsheetToggle && b.id.endsWith("#override"));
-  if (!onDefaultMap) {
-    setCharacterKeyWarning(null);
-    return;
-  }
   // The entry registers with NO validation layer: a chord claimed while the
   // pref was off (the entry was not registered, so nothing conflicted at
   // bind time) must not end up shadowing or shadowed by the built-in. The
@@ -125,6 +115,29 @@ export function reconcileCharacterKeyTrigger(): void {
       binding.scope === scope &&
       chordsOverlap(binding.chord, sequence),
   );
+  if (present) {
+    // Present does NOT imply checked: a foreign binding registered AFTER
+    // "?" (registerBinding's exact-match gate allows bare "?" against
+    // "[Shift]+?", and a direct registration bypasses the overrides store's
+    // validation) would co-fire with the built-in forever. The foreign
+    // binding wins - same precedence as the not-present path - so the entry
+    // unregisters and the warning surfaces; the foreign binding's removal
+    // re-registers "?" on a later pass and clears the warning.
+    if (overlapping !== undefined) {
+      registry.unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+      setCharacterKeyWarning(overlapping.actionId);
+      return;
+    }
+    setCharacterKeyWarning(null);
+    return;
+  }
+  const onDefaultMap =
+    registry.bindings.some((b) => b.id === ACTIONS.cheatsheetToggle) &&
+    !registry.bindings.some((b) => b.actionId === ACTIONS.cheatsheetToggle && b.id.endsWith("#override"));
+  if (!onDefaultMap) {
+    setCharacterKeyWarning(null);
+    return;
+  }
   if (overlapping !== undefined) {
     // Do not register; surface the skip. The reconcile is total and
     // subscribed to the overrides store, so removing the overlapping

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
@@ -26,8 +26,10 @@
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 import { ACTIONS } from "../../keybindings/actions";
+import { chordsOverlap, parseChord } from "../../keybindings/chord";
 import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS } from "../../keybindings/defaults";
-import { keybindingsRegistry } from "../../keybindings/registry";
+import { GLOBAL_SCOPE, keybindingsRegistry } from "../../keybindings/registry";
+import type { ValidationWarning } from "../../keybindings/validation";
 import { keybindingsStore } from "../../stores/keybindings";
 import { prefsStore } from "../../stores/prefs";
 
@@ -57,6 +59,31 @@ export function useCheatsheetStore<T>(selector: (state: CheatsheetState) => T): 
   return useStore(cheatsheetStore, selector);
 }
 
+/** The store's warnings channel doubles as the surface for the conditional
+ * entry's overlap skip (the same list skipped override rules render in).
+ * The controller's warning is identified by its reason so the reconcile can
+ * replace or clear exactly its own entry. setState fires only on a CHANGE:
+ * the reconcile is subscribed to the keybindings store, and a redundant
+ * write would re-enter it. */
+function setCharacterKeyWarning(conflictWith: string | null): void {
+  const state = keybindingsStore.getState();
+  const rest = state.warnings.filter((warning) => warning.reason !== "character-key-conflict");
+  if (conflictWith === null) {
+    if (rest.length !== state.warnings.length) keybindingsStore.setState({ warnings: rest });
+    return;
+  }
+  const message = `the "?" cheatsheet trigger was not registered: chord "[Shift]+?" in scope "global" is already bound by "${conflictWith}"`;
+  if (state.warnings.some((warning) => warning.reason === "character-key-conflict" && warning.message === message))
+    return;
+  const warning: ValidationWarning = {
+    rule: { action: ACTIONS.cheatsheetToggle, chord: "[Shift]+?" },
+    reason: "character-key-conflict",
+    conflictWith,
+    message,
+  };
+  keybindingsStore.setState({ warnings: [...rest, warning] });
+}
+
 /** Enforces "the ? binding is registered exactly while characterKeyTriggers
  * is on AND cheatsheet.toggle is on its default map". An applied override
  * (or unbind) owns the action's whole chord set, so "?" never comes back
@@ -67,16 +94,46 @@ export function reconcileCharacterKeyTrigger(): void {
   const present = registry.bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
   if (!prefsStore.getState().characterKeyTriggers) {
     if (present) registry.unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+    setCharacterKeyWarning(null);
     return;
   }
-  if (present) return;
+  if (present) {
+    setCharacterKeyWarning(null);
+    return;
+  }
   const input = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
   if (input === undefined) return;
   const onDefaultMap =
     registry.bindings.some((b) => b.id === ACTIONS.cheatsheetToggle) &&
     !registry.bindings.some((b) => b.actionId === ACTIONS.cheatsheetToggle && b.id.endsWith("#override"));
-  if (!onDefaultMap) return;
+  if (!onDefaultMap) {
+    setCharacterKeyWarning(null);
+    return;
+  }
+  // The entry registers with NO validation layer: a chord claimed while the
+  // pref was off (the entry was not registered, so nothing conflicted at
+  // bind time) must not end up shadowing or shadowed by the built-in. The
+  // entry's Shift is OPTIONAL, and chordsOverlap's modifier check treats
+  // optionals as allowed on both sides, so this one predicate covers both
+  // the bare "?" and the Shift+"?" forms. Only bindings of OTHER actions
+  // count - cheatsheet.toggle's own base chord never overlaps "?".
+  const sequence = typeof input.chord === "string" ? parseChord(input.chord) : input.chord;
+  const scope = input.scope ?? GLOBAL_SCOPE;
+  const overlapping = registry.bindings.find(
+    (binding) =>
+      binding.actionId !== ACTIONS.cheatsheetToggle &&
+      binding.scope === scope &&
+      chordsOverlap(binding.chord, sequence),
+  );
+  if (overlapping !== undefined) {
+    // Do not register; surface the skip. The reconcile is total and
+    // subscribed to the overrides store, so removing the overlapping
+    // override registers "?" on the next pass and clears the warning.
+    setCharacterKeyWarning(overlapping.actionId);
+    return;
+  }
   registry.registerBinding(input);
+  setCharacterKeyWarning(null);
 }
 
 /** Installs the reconcile: runs it once against the current state, then on

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
@@ -29,7 +29,7 @@ import { ACTIONS } from "../../keybindings/actions";
 import { chordsOverlap, parseChord } from "../../keybindings/chord";
 import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS } from "../../keybindings/defaults";
 import { GLOBAL_SCOPE, keybindingsRegistry } from "../../keybindings/registry";
-import type { ValidationWarning } from "../../keybindings/validation";
+import { actionDisplayLabel, type ValidationWarning } from "../../keybindings/validation";
 import { keybindingsStore } from "../../stores/keybindings";
 import { prefsStore } from "../../stores/prefs";
 
@@ -72,7 +72,7 @@ function setCharacterKeyWarning(conflictWith: string | null): void {
     if (rest.length !== state.warnings.length) keybindingsStore.setState({ warnings: rest });
     return;
   }
-  const message = `the "?" cheatsheet trigger was not registered: chord "[Shift]+?" in scope "global" is already bound by "${conflictWith}"`;
+  const message = `the "?" cheatsheet trigger was not registered: chord "[Shift]+?" in scope "global" is already bound by ${actionDisplayLabel(conflictWith)}`;
   if (state.warnings.some((warning) => warning.reason === "character-key-conflict" && warning.message === message))
     return;
   const warning: ValidationWarning = {

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1033,7 +1033,12 @@ describe("keybindings store: support loss", () => {
     // once the wedge clears) and the error says so, retryably.
     const retained = keybindingsStore.getState();
     expect(retained.loaded).toBe(true);
-    expect(retained.revision).toBe(3);
+    // revision RESETS to 0 even on the rollback (finding 34): revision
+    // numbering is hub-scoped, and a retained old-hub revision would let
+    // the stale guard discard a flap-back refresh carrying a LOWER
+    // revision, stranding the rollback state. The raw set stays retained -
+    // it is what re-drives the retry.
+    expect(retained.revision).toBe(0);
     expect(retained.rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
     expect(retained.hubError).toContain("still in effect");
 
@@ -1050,6 +1055,77 @@ describe("keybindings store: support loss", () => {
     expect(reset.loaded).toBe(false);
     expect(reset.revision).toBe(0);
     expect(reset.rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a support-loss rollback resets revision, so a LOWER-revision flap-back refresh applies and reconciles (finding 34)", async () => {
+    let payload = overridesPayload(5, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => payload);
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The wedge (a foreign binding squatting palette.open's default chord)
+    // rolls the support drop's un-apply back: the override keeps firing.
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    const rolled = keybindingsStore.getState();
+    expect(rolled.hubSupport).toBe("unsupported");
+    expect(rolled.hubError).toContain("still in effect");
+    expect(rolled.rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(rolled.revision).toBe(0);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // Unwedge, then flap back: the hub's state was reset elsewhere, so the
+    // refresh carries a LOWER revision than the pre-drop state. It must
+    // APPLY (not be eaten by the stale guard against the retained
+    // revision), clearing the rollback error and reconciling the registry.
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    payload = overridesPayload(2, []);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
+    expect(keybindingsStore.getState().revision).toBe(2);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a flap-back refresh with a HIGHER revision still applies after a support-loss rollback (regression)", async () => {
+    let payload = overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => payload);
+    await wireClient(client, true);
+
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(keybindingsStore.getState().hubError).toContain("still in effect");
+
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    payload = overridesPayload(7, []);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().revision).toBe(7));
+    expect(keybindingsStore.getState().hubError).toBeNull();
     expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
       ACTIONS.paletteOpen,
       `${ACTIONS.paletteOpen}#mod-twin`,

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -321,7 +321,9 @@ describe("keybindings store: patch", () => {
     // strict Control+K claim by another action.
     await expect(
       keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+K" }]),
-    ).rejects.toThrow(`chord "Control+K" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`);
+    ).rejects.toThrow(
+      `chord "Control+K" in scope "global" is already bound by "Open the command palette" (${ACTIONS.paletteOpen})`,
+    );
 
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
     // A client-side authoring error is not hub-sourced: neither hubError nor
@@ -455,7 +457,9 @@ describe("keybindings store: patch", () => {
         { action: "no.such.action", chord: "Control+P" },
         { action: ACTIONS.composerFocus, chord: "Control+K" },
       ]),
-    ).rejects.toThrow(`chord "Control+K" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`);
+    ).rejects.toThrow(
+      `chord "Control+K" in scope "global" is already bound by "Open the command palette" (${ACTIONS.paletteOpen})`,
+    );
 
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
     expect(keybindingsStore.getState().hubError).toBeNull();

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -450,6 +450,102 @@ describe("keybindings store: patch", () => {
   });
 });
 
+// The stale-hub window: replacing the client must not let the previous
+// hub's payload present as current (a PATCH composed from it would carry
+// the old expectedRevision and rules to the NEW hub), and the registry must
+// not keep firing the old hub's overrides one layer down.
+describe("keybindings store: client replacement (stale-hub window)", () => {
+  /** Replaces the wired client with one whose get never resolves: the
+   * refresh starts (hubLoading) but never lands, holding the store in the
+   * stale window. */
+  async function rewireToHangingClient(): Promise<FakeClient> {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => new Promise<KeybindingsOverrides>(() => {}));
+    connectionStore.getState().connect(client);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    return client;
+  }
+
+  async function wireClientAWithPaletteOverride(): Promise<FakeClient> {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(7, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(keybindingsStore.getState().revision).toBe(7);
+    expect(keybindingsStore.getState().loaded).toBe(true);
+    return client;
+  }
+
+  test("client replacement un-applies the old hub's overrides from the registry and resets the hub state", async () => {
+    await wireClientAWithPaletteOverride();
+
+    await rewireToHangingClient();
+
+    // Immediately - hub B's refresh is still in flight - the registry is
+    // back on defaults and the store carries none of hub A's payload.
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    const state = keybindingsStore.getState();
+    expect(state.revision).toBe(0);
+    expect(state.overrides).toEqual([]);
+    expect(state.rawOverrides).toEqual([]);
+    expect(state.warnings).toEqual([]);
+    expect(state.loaded).toBe(false);
+  });
+
+  test("a patch attempted in the stale window throws before any wire request", async () => {
+    await wireClientAWithPaletteOverride();
+    const clientB = await rewireToHangingClient();
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    ).rejects.toThrow(/unavailable/);
+
+    expect(clientB.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    // Hub A's override stays un-applied: the rejected patch changed nothing.
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("after the new hub's refresh lands, patching works with the NEW hub's revision and rules", async () => {
+    const clientA = await wireClientAWithPaletteOverride();
+
+    // Hub B holds its own state at a COLLIDING revision (the overwrite the
+    // stale window would have caused): the patch must compose from B's
+    // (empty) rule set with B's expectedRevision, never A's payload.
+    const clientB = new FakeClient("ready");
+    clientB.on("evener/settings/keybindings/get", () => overridesPayload(7, []));
+    clientB.on("evener/settings/keybindings/patch", (params) => overridesPayload(8, params.config.rules));
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+    await keybindingsStore.getState().refreshOverrides();
+
+    expect(keybindingsStore.getState().loaded).toBe(true);
+    const result = await keybindingsStore
+      .getState()
+      .patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(result.revision).toBe(8);
+    const patchCalls = clientB.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 7,
+      config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
+    });
+    // Hub A never saw a patch.
+    expect(clientA.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+});
+
 describe("keybindings store: reconcile resilience", () => {
   test("dropping an override whose default chord was reclaimed degrades to a warning and restores every action", async () => {
     // The reviewer's reproduction. Payload 1 is legal via freed-chord

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1032,7 +1032,11 @@ describe("keybindings store: support loss", () => {
     // behavior: the hub payload is RETAINED (it re-drives reconciliation
     // once the wedge clears) and the error says so, retryably.
     const retained = keybindingsStore.getState();
-    expect(retained.loaded).toBe(true);
+    // loaded drops even on the rollback (finding 36): the retained payload
+    // is retained-but-UNCONFIRMED, so a changed-notification landing
+    // between a flap-back and its refresh must take the finding-25
+    // dirty-flag path instead of applying against the pre-flap state.
+    expect(retained.loaded).toBe(false);
     // revision RESETS to 0 even on the rollback (finding 34): revision
     // numbering is hub-scoped, and a retained old-hub revision would let
     // the stale guard discard a flap-back refresh carrying a LOWER
@@ -1130,6 +1134,102 @@ describe("keybindings store: support loss", () => {
       ACTIONS.paletteOpen,
       `${ACTIONS.paletteOpen}#mod-twin`,
     ]);
+  });
+
+  test("a notification landing between flap-back and its refresh is dropped to the dirty-flag path, and the refresh converges to the hub's truth (finding 36)", async () => {
+    let payload = overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    let pending: Promise<KeybindingsOverrides> | undefined;
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => pending ?? payload);
+    await wireClient(client, true);
+
+    // Wedge + support drop: the un-apply rolls back, retaining the payload
+    // UNCONFIRMED (loaded false) with revision reset.
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(keybindingsStore.getState().hubError).toContain("still in effect");
+    expect(keybindingsStore.getState().loaded).toBe(false);
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+
+    // Support returns; the flap-back refresh hangs in flight.
+    let resolveGet: ((p: KeybindingsOverrides) => void) | undefined;
+    pending = new Promise<KeybindingsOverrides>((resolve) => {
+      resolveGet = resolve;
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    // The hub changes the override to Control+Y (revision 4); the
+    // notification arrives BEFORE the refresh lands. With loaded false it
+    // must NOT apply against the pre-flap state - it marks the generation
+    // dirty instead.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    });
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The in-flight get's response PREDATES the change (revision 3): it
+    // confirms the state (loaded flips true) and the dirty flag fires ONE
+    // follow-up fetch, which lands the hub's truth (revision 4).
+    payload = overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]);
+    const getCalls = () => client.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+    resolveGet?.(overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    pending = undefined;
+    await waitFor(() => expect(keybindingsStore.getState().revision).toBe(4));
+    // wireClient's connect refresh + its explicit refreshOverrides, the
+    // flap-back refresh, and the dirty-flag follow-up. Without the finding-36
+    // gate the notification applies and no follow-up fires (3 calls).
+    expect(getCalls()).toBe(4);
+    expect(keybindingsStore.getState().loaded).toBe(true);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => serializeChord(b.chord))).toEqual(["Control+Y"]);
+  });
+
+  test("a notification landing AFTER the confirmed flap-back refresh applies normally (regression)", async () => {
+    let payload = overridesPayload(5, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => payload);
+    await wireClient(client, true);
+
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(keybindingsStore.getState().loaded).toBe(false);
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+
+    // Flap back; the refresh confirms revision 6, flipping loaded back.
+    payload = overridesPayload(6, []);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+    expect(keybindingsStore.getState().hubError).toBeNull();
+
+    // A notification on the CONFIRMED state applies directly.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(7, [{ action: ACTIONS.paletteOpen, chord: "Control+M" }]),
+    });
+    await waitFor(() => expect(keybindingsStore.getState().revision).toBe(7));
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+M" }]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => serializeChord(b.chord))).toEqual(["Control+M"]);
   });
 
   test("a transient disconnect of a SUPPORTED hub keeps the overrides applied", async () => {

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -982,3 +982,213 @@ describe("keybindings store: support loss", () => {
     expect(serializeChord(bindingsFor(ACTIONS.paletteOpen)[0]?.chord ?? [])).toBe("Control+P");
   });
 });
+
+describe("keybindings store: support flap discards hub state", () => {
+  test("a lower-revision refresh after an unsupported flap is ACCEPTED, and edits compose from the new payload", async () => {
+    const client = new FakeClient("ready");
+    let current = overridesPayload(7, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    client.on("evener/settings/keybindings/get", () => current);
+    client.on("evener/settings/keybindings/patch", (params) =>
+      overridesPayload(params.expectedRevision + 1, params.config.rules),
+    );
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().revision).toBe(7);
+
+    // Support drops: the registry un-applies AND the hub payload state
+    // resets - a retained revision 7 would eat the returning hub's
+    // lower-revision refresh via the stale guard.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    const dropped = keybindingsStore.getState();
+    expect(dropped.hubSupport).toBe("unsupported");
+    expect(dropped.loaded).toBe(false);
+    expect(dropped.revision).toBe(0);
+    expect(dropped.overrides).toEqual([]);
+    expect(dropped.rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+
+    // The same hub returns at a LOWER revision (restored backup, reset
+    // state file): the refresh must not be discarded as stale.
+    current = overridesPayload(3, [{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+    expect(keybindingsStore.getState().revision).toBe(3);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+
+    // An edit composes from the NEW hub's payload with the NEW revision.
+    await keybindingsStore
+      .getState()
+      .patchOverrides([
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+      ]);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 3,
+      config: {
+        version: 1,
+        rules: [
+          { action: ACTIONS.composerFocus, chord: "Control+M" },
+          { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        ],
+      },
+    });
+  });
+
+  test("a changed notification arriving while UNSUPPORTED does not touch the registry or the store", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+
+    // A late notification from before the support drop must not re-install
+    // overrides into the registry that was just un-applied.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(9, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    const state = keybindingsStore.getState();
+    expect(state.revision).toBe(0);
+    expect(state.loaded).toBe(false);
+    expect(state.hubError).toBeNull();
+  });
+
+  test("a patch response landing after support loss does not apply", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const patch = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() => expect(resolvePatch).toBeDefined());
+
+    // Support drops while the PATCH is in flight: the response must not
+    // re-apply over the un-applied registry and reset hub state.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    const result = await patch;
+
+    expect(result.revision).toBe(0);
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+});
+
+describe("keybindings store: write serialization", () => {
+  test("concurrent patches serialize: each composes expectedRevision and payload after the previous lands", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    client.on("evener/settings/keybindings/patch", (params) =>
+      overridesPayload(params.expectedRevision + 1, params.config.rules),
+    );
+    await wireClient(client, true);
+
+    // Two edits in the SAME tick. Both thunks compose against the raw set,
+    // but the second runs only after the first has fully landed, so it
+    // folds the first edit's confirmed payload in instead of racing it with
+    // the same expectedRevision (a self-inflicted conflict).
+    const first = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+      ]);
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.revision).toBe(2);
+    expect(secondResult.revision).toBe(3);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 1,
+      config: { version: 1, rules: [{ action: ACTIONS.paletteOpen, chord: "Control+P" }] },
+    });
+    expect(patchCalls[1]?.params).toEqual({
+      expectedRevision: 2,
+      config: {
+        version: 1,
+        rules: [
+          { action: ACTIONS.paletteOpen, chord: "Control+P" },
+          { action: ACTIONS.composerFocus, chord: "Control+M" },
+        ],
+      },
+    });
+    expect(keybindingsStore.getState().revision).toBe(3);
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+  });
+
+  test("a failed write does not block the queue: the next write runs against the post-failure state", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let failFirst = true;
+    client.on("evener/settings/keybindings/patch", (params) => {
+      if (failFirst) {
+        failFirst = false;
+        throw new Error("socket went away");
+      }
+      return overridesPayload(params.expectedRevision + 1, params.config.rules);
+    });
+    await wireClient(client, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    await expect(first).rejects.toThrow("socket went away");
+    // The first write failed WITHOUT touching the hub: the second still
+    // composes from revision 1 and lands.
+    const secondResult = await second;
+    expect(secondResult.revision).toBe(2);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[1]?.params).toEqual({
+      expectedRevision: 1,
+      config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
+    });
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -346,6 +346,108 @@ describe("keybindings store: patch", () => {
     expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
     expect(bindingsFor(ACTIONS.nextNeedsYou)).toHaveLength(2);
   });
+
+  // The store retains the hub's RAW rules (rawOverrides) so a PATCH composed
+  // from them preserves rules validation skips; pre-flight then tolerates
+  // warnings the current raw set already produces (baseline), rejecting only
+  // what the edit itself introduced.
+  test("the raw rule set is retained verbatim while the validated set drives application", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]),
+    );
+    await wireClient(client, true);
+
+    const state = keybindingsStore.getState();
+    expect(state.rawOverrides).toEqual([
+      { action: "no.such.action", chord: "Control+P" },
+      { action: ACTIONS.composerFocus, chord: "Control+M" },
+    ]);
+    // Application/display still see only the validated rule.
+    expect(state.overrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(state.warnings.map((w) => w.message)).toEqual(['unknown keybinding action "no.such.action"']);
+  });
+
+  test("a patch carrying a preserved invalid rule passes pre-flight and the rule reaches the hub verbatim", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: "no.such.action", chord: "Control+P" }]),
+    );
+    client.on("evener/settings/keybindings/patch", (params) => overridesPayload(4, params.config.rules));
+    await wireClient(client, true);
+
+    // Composed the way the editor composes: raw rules with one swapped. The
+    // unknown-action warning is baseline (the current raw set already
+    // produces it), so it must NOT reject the edit.
+    const result = await keybindingsStore.getState().patchOverrides([
+      { action: "no.such.action", chord: "Control+P" },
+      { action: ACTIONS.composerFocus, chord: "Control+M" },
+    ]);
+
+    expect(result.revision).toBe(4);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 3,
+      config: {
+        version: 1,
+        rules: [
+          { action: "no.such.action", chord: "Control+P" },
+          { action: ACTIONS.composerFocus, chord: "Control+M" },
+        ],
+      },
+    });
+    // The preserved rule is still skipped (never applied) after the confirm.
+    expect(keybindingsStore.getState().rawOverrides).toEqual([
+      { action: "no.such.action", chord: "Control+P" },
+      { action: ACTIONS.composerFocus, chord: "Control+M" },
+    ]);
+    expect(keybindingsStore.getState().overrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+  });
+
+  test("baseline tolerance does NOT mask a conflict the edit itself introduces", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: "no.such.action", chord: "Control+P" }]),
+    );
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    // palette.open's default overlaps a strict Control+K claim: a NEW
+    // warning, not one the raw set already produces.
+    await expect(
+      keybindingsStore.getState().patchOverrides([
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.composerFocus, chord: "Control+K" },
+      ]),
+    ).rejects.toThrow(`chord "Control+K" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`);
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+  });
+
+  test("the edited action's own invalid chord still rejects pre-flight alongside a preserved invalid rule", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: "no.such.action", chord: "Control+P" }]),
+    );
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.railToggle, chord: "Control+W" }, // reserved on this platform
+      ]),
+    ).rejects.toThrow('chord "Control+W" is reserved');
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: "no.such.action", chord: "Control+P" }]);
+  });
 });
 
 describe("keybindings store: reconcile resilience", () => {

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1617,3 +1617,124 @@ describe("keybindings store: pref flips re-validate persisted overrides", () => 
     expect(keybindingsStore.getState().revision).toBe(1);
   });
 });
+
+// A changed-notification dropped by the loaded gate during the INITIAL load
+// must not be lost (finding 25): the in-flight get's response may predate
+// the change, so the drop marks the generation dirty and the refresh that
+// confirms its state fires ONE follow-up fetch.
+describe("keybindings store: notifications during the initial load", () => {
+  test("a notification dropped mid-initial-refresh is converged by one follow-up refresh", async () => {
+    // The FIRST get hangs so the notification lands inside the initial-load
+    // window; its resolved response (revision 3) PREDATES the change
+    // (revision 4) the notification announced. Follow-up gets serve the
+    // latest.
+    const client = new FakeClient("ready");
+    let resolveGet: ((value: KeybindingsOverrides) => void) | undefined;
+    let hang = true;
+    const current = overridesPayload(4, [{ action: ACTIONS.railToggle, chord: "Control+R" }]);
+    client.on("evener/settings/keybindings/get", () => {
+      if (hang)
+        return new Promise<KeybindingsOverrides>((resolve) => {
+          resolveGet = resolve;
+        });
+      return current;
+    });
+    connectionStore.getState().connect(client);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    // The change arrives mid-load: dropped by the loaded gate (finding 24),
+    // marked dirty.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: current,
+    });
+
+    // The get's response predates the change: the store settles on revision
+    // 3 momentarily, then the follow-up fetch converges to revision 4.
+    // Delta-based: the wiring fires its own refresh(es) before this point,
+    // so the pin is exactly ONE additional get (the dirty-flag refetch).
+    const getsBefore = client.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+    hang = false;
+    resolveGet?.(overridesPayload(3, []));
+    await waitFor(() => expect(keybindingsStore.getState().revision).toBe(4));
+
+    const state = keybindingsStore.getState();
+    expect(state.loaded).toBe(true);
+    expect(state.hubLoading).toBe(false);
+    expect(state.rawOverrides).toEqual([{ action: ACTIONS.railToggle, chord: "Control+R" }]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/get")).toHaveLength(getsBefore + 1);
+  });
+
+  test("a notification arriving when loaded applies once, with no follow-up refresh", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    await wireClient(client, true);
+    const getsBefore = client.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+    });
+
+    expect(keybindingsStore.getState().revision).toBe(4);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+    // No drop, no dirty flag, no refetch: the new path must not double-apply.
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/get")).toHaveLength(getsBefore);
+  });
+});
+
+// A write rejected because support resolved to UNSUPPORTED throws WITHOUT
+// setting hubError (finding 26): the unsupported state is deliberately
+// clean - the section says the built-in defaults are in effect - and the
+// write no longer owns it. Both orderings: queued while supported and
+// executing after the drop, and composed while unsupported.
+describe("keybindings store: unsupported write rejection", () => {
+  test("rejection due to unsupported support leaves hubError null, whether queued across the drop or composed in it", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() =>
+      expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1),
+    );
+    // Write #2 queues behind the in-flight write, created while supported.
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    // Support drops (no flap-back): a plain unsupported transition does not
+    // bump the generation, so write #2 reaches the guard - and rejects via
+    // the unsupported branch, throwing without hubError.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await first;
+    await expect(second).rejects.toThrow(/unavailable/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+
+    // Composed while unsupported: the same clean rejection.
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow(/unavailable/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -275,6 +275,77 @@ describe("keybindings store: patch", () => {
     ).rejects.toThrow(/unavailable/);
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
   });
+
+  // Pre-flight semantic validation (the parked 2b minor, made live by the
+  // settings editor): a rule the reconcile would skip is rejected BEFORE the
+  // hub write, with the validation layer's message.
+  test("a chord conflicting with a live binding is rejected pre-flight, without any hub request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    // palette.open's default (Control+[Meta]+K with its twin) overlaps a
+    // strict Control+K claim by another action.
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+K" }]),
+    ).rejects.toThrow(`chord "Control+K" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`);
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    // A client-side authoring error is not hub-sourced: neither hubError nor
+    // conflict moves, and the registry is untouched.
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+  });
+
+  test("a platform-reserved chord is rejected pre-flight, without any hub request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    // Control+W is on the every-platform reserved list (the browser never
+    // delivers it to the page).
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+W" }]),
+    ).rejects.toThrow('chord "Control+W" is reserved');
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+
+  test("an unknown action is rejected pre-flight, without any hub request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: "no.such.action", chord: "Control+M" }]),
+    ).rejects.toThrow('unknown keybinding action "no.such.action"');
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+
+  test("a conflicting rule inside a larger payload rejects the whole patch pre-flight", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    // The editor submits the FULL desired rule set; two rules claiming the
+    // same chord must not reach the hub at all.
+    await expect(
+      keybindingsStore.getState().patchOverrides([
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+        { action: ACTIONS.nextNeedsYou, chord: "Control+M" },
+      ]),
+    ).rejects.toThrow("already bound by");
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+    expect(bindingsFor(ACTIONS.nextNeedsYou)).toHaveLength(2);
+  });
 });
 
 describe("keybindings store: reconcile resilience", () => {
@@ -382,5 +453,76 @@ describe("keybindings store: reconcile resilience", () => {
     expect(() => resetKeybindingsStoreForTests()).not.toThrow();
     expect(keybindingsStore.getState().revision).toBe(0);
     expect(keybindingsStore.getState().overrides).toEqual([]);
+  });
+});
+
+describe("keybindings store: hubError/conflict clear symmetry", () => {
+  // The parked 2b asymmetry: conflict was cleared ONLY by a successful patch
+  // while hubError cleared on any successful apply, so a revision-race notice
+  // outlived the state it described. Both now clear together.
+  async function stageConflict(client: FakeClient): Promise<void> {
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => {
+      throw new WireError("revision conflict", -32013, {
+        evenerErrorInfo: "conflict",
+        current: overridesPayload(6, []),
+      });
+    });
+    await wireClient(client, true);
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow("revision conflict");
+    expect(keybindingsStore.getState().conflict).toBe("revision conflict");
+    expect(keybindingsStore.getState().hubError).toBe("revision conflict");
+  }
+
+  test("a successful changed notification after a conflict clears BOTH conflict and hubError", async () => {
+    const client = new FakeClient("ready");
+    await stageConflict(client);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(7, []),
+    });
+
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(7);
+  });
+
+  test("a successful refresh after a conflict clears BOTH conflict and hubError", async () => {
+    const client = new FakeClient("ready");
+    await stageConflict(client);
+    client.on("evener/settings/keybindings/get", () => overridesPayload(7, []));
+
+    await keybindingsStore.getState().refreshOverrides();
+
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+  });
+
+  test("a support drop after a conflict clears BOTH conflict and hubError", async () => {
+    const client = new FakeClient("ready");
+    await stageConflict(client);
+
+    // The connection losing its feature set (disconnect/reconnect without
+    // the feature) makes the conflict notice as stale as hubError.
+    connectionStore.setState({ features: undefined });
+
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+  });
+
+  test("a stale changed notification (older revision) clears NEITHER conflict nor hubError", async () => {
+    const client = new FakeClient("ready");
+    await stageConflict(client);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, []),
+    });
+
+    expect(keybindingsStore.getState().conflict).toBe("revision conflict");
+    expect(keybindingsStore.getState().hubError).toBe("revision conflict");
   });
 });

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1,13 +1,41 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { ACTIONS } from "../keybindings/actions";
 import { serializeChord } from "../keybindings/chord";
-import { registerDefaultBindings } from "../keybindings/defaults";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, registerDefaultBindings } from "../keybindings/defaults";
 import { type Binding, keybindingsRegistry } from "../keybindings/registry";
 import { WireError } from "../protocol/errors";
 import { FakeClient } from "../protocol/testing/fakeClient";
 import type { KeybindingsOverrides, KeybindingsRule } from "../protocol/types.gen";
 import { connectionStore } from "./connection";
 import { keybindingsStore, resetKeybindingsStoreForTests } from "./keybindings";
+import { prefsStore, resetPrefsStoreForTests } from "./prefs";
+
+// Node 26 shadows jsdom's real window.localStorage with its own
+// (non-functional under vitest) global, so every test file that touches
+// localStorage (the prefs store does, and keybindings.ts now reads the
+// character-key pref through it) needs this same small in-memory stand-in -
+// see stores/prefs.test.ts's own comment.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeAll(() => {
+  // @ts-expect-error see MemoryStorage's own comment for why this is needed
+  globalThis.localStorage = new MemoryStorage();
+});
 
 function resetRegistryToDefaults(): void {
   for (const binding of keybindingsRegistry.getState().bindings) {
@@ -42,12 +70,16 @@ beforeEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
   resetKeybindingsStoreForTests();
   resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
 });
 
 afterEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
   resetKeybindingsStoreForTests();
   resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
   vi.restoreAllMocks();
 });
 
@@ -722,5 +754,189 @@ describe("keybindings store: hubError/conflict clear symmetry", () => {
 
     expect(keybindingsStore.getState().conflict).toBe("revision conflict");
     expect(keybindingsStore.getState().hubError).toBe("revision conflict");
+  });
+});
+
+describe("keybindings store: atomic un-apply", () => {
+  /** Replaces the wired client with one whose get never resolves: the
+   * refresh starts (hubLoading) but never lands. Same shape as the
+   * stale-window describe's helper. */
+  async function rewireToHangingClient(): Promise<FakeClient> {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => new Promise<KeybindingsOverrides>(() => {}));
+    connectionStore.getState().connect(client);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    return client;
+  }
+
+  test("client replacement un-applies a reclaimed-chord pair atomically", async () => {
+    // Payload 1 is legal via freed-chord reclaim: palette.open moves away,
+    // rail.toggle claims palette.open's default chord. Restoring BOTH on
+    // un-apply needs the two-phase unwind: restoring palette.open while
+    // rail.toggle's override still squats its default chord throws.
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        { action: ACTIONS.railToggle, chord: paletteDefault },
+      ]),
+    );
+    await wireClient(clientA, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+
+    await rewireToHangingClient();
+
+    // BOTH actions are back at their defaults: no orphaned override binding.
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([
+      ACTIONS.railToggle,
+      `${ACTIONS.railToggle}#mod-twin`,
+    ]);
+  });
+
+  test("a wedged unwind rolls the registry back, keeps the applied map, and never throws", async () => {
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    );
+    await wireClient(clientA, true);
+
+    // Out-of-band wedge: free the override binding and squat palette.open's
+    // default chord with a foreign binding, so restoring the default throws.
+    keybindingsRegistry.getState().unregisterBinding(`${ACTIONS.paletteOpen}#override`);
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: paletteDefault,
+    });
+
+    // Client replacement's un-apply must NOT throw and must roll back: the
+    // registry keeps the wedged shape exactly.
+    const clientB = new FakeClient("ready");
+    let resolveGet: ((payload: KeybindingsOverrides) => void) | undefined;
+    clientB.on(
+      "evener/settings/keybindings/get",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolveGet = resolve;
+        }),
+    );
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen)).toEqual([]);
+    expect(keybindingsRegistry.getState().bindings.some((b) => b.id === "foreign.squatter")).toBe(true);
+
+    // Hub B's refresh lands an EMPTY payload. Because the applied map
+    // survived the rolled-back unwind, the reconcile RETRIES the restore of
+    // palette.open, hits the same wedge, rolls back, and surfaces hubError -
+    // the revision does not advance and the state never presents as loaded.
+    // (Had the unwind cleared the map, the empty payload would apply clean
+    // against the wedged registry and confirm revision 1.)
+    await waitFor(() => expect(resolveGet).toBeDefined());
+    resolveGet?.(overridesPayload(1, []));
+    await waitFor(() => expect(keybindingsStore.getState().hubError).not.toBeNull());
+
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().loaded).toBe(false);
+    expect(bindingsFor(ACTIONS.paletteOpen)).toEqual([]);
+    expect(keybindingsRegistry.getState().bindings.some((b) => b.id === "foreign.squatter")).toBe(true);
+  });
+});
+
+describe("keybindings store: patch gating", () => {
+  test("a patch attempted while a refresh is in flight throws before any wire request", async () => {
+    let pending: Promise<KeybindingsOverrides> | undefined;
+    let resolvePending: ((payload: KeybindingsOverrides) => void) | undefined;
+    const client = new FakeClient("ready");
+    client.on(
+      "evener/settings/keybindings/get",
+      () => pending ?? overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    client.on("evener/settings/keybindings/patch", (params) => overridesPayload(2, params.config.rules));
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().loaded).toBe(true);
+
+    // A refresh is in flight (hubLoading): its payload can land at ANY
+    // revision, so a concurrent PATCH's expectedRevision would race it.
+    pending = new Promise<KeybindingsOverrides>((resolve) => {
+      resolvePending = resolve;
+    });
+    const refresh = keybindingsStore.getState().refreshOverrides();
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    ).rejects.toThrow(/unavailable/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+
+    resolvePending?.(overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await refresh;
+    expect(keybindingsStore.getState().hubLoading).toBe(false);
+  });
+});
+
+describe("keybindings store: character-key pref in the restore simulation", () => {
+  /** What the cheatsheetController does while the pref is off. */
+  function turnCharacterKeyPrefOff(): void {
+    prefsStore.setState({ characterKeyTriggers: false });
+    keybindingsRegistry.getState().unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+  }
+
+  function wireCharacterKeyPayload(): Promise<FakeClient> {
+    // composer.focus takes "Shift+?" (the character-key chord with a
+    // REQUIRED shift); cheatsheet.toggle moves to Control+Slash. With the
+    // pref OFF there is no "?" binding to conflict with, so this payload
+    // must apply clean.
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [
+        { action: ACTIONS.composerFocus, chord: "Shift+?" },
+        { action: ACTIONS.cheatsheetToggle, chord: "Control+Slash" },
+      ]),
+    );
+    client.on("evener/settings/keybindings/patch", (params) => overridesPayload(2, params.config.rules));
+    return wireClient(client, true).then(() => client);
+  }
+
+  test("with the pref off, resetting cheatsheet.toggle past a composer Shift+? override is accepted", async () => {
+    turnCharacterKeyPrefOff();
+    const client = await wireCharacterKeyPayload();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(1);
+
+    // The Reset: the PATCH payload drops cheatsheet.toggle's override, so
+    // its defaults restore. The restore simulation must mirror the pref -
+    // with the "?" trigger absent from the live registry, the restored set
+    // must not claim it either, so it cannot phantom-conflict with the
+    // composer override that survives the patch.
+    const result = await keybindingsStore
+      .getState()
+      .patchOverrides([{ action: ACTIONS.composerFocus, chord: "Shift+?" }]);
+    expect(result.revision).toBe(2);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1);
+    expect(serializeChord(bindingsFor(ACTIONS.cheatsheetToggle)[0]?.chord ?? [])).toBe("Control+/");
+  });
+
+  test("with the pref on, the same reset still rejects: the restored ? binding would conflict", async () => {
+    const client = await wireCharacterKeyPayload();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+
+    // Pref ON: the restore legitimately reclaims "?", which overlaps the
+    // surviving composer Shift+? - the preflight must still reject.
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Shift+?" }]),
+    ).rejects.toThrow(/already bound by/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
   });
 });

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1826,3 +1826,70 @@ describe("keybindings store: unsupported write rejection", () => {
     expect(keybindingsStore.getState().hubError).toBeNull();
   });
 });
+
+describe("keybindings store: rewire rollback retention (finding 32)", () => {
+  test("a wedged un-apply on client replacement retains the old hub's payload, resets revision, and reconciles after the wedge clears", async () => {
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(clientA, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // Out-of-band wedge: squat palette.open's default chord with a foreign
+    // binding, so restoring the default during the rewire's un-apply throws
+    // and the unwind rolls back - the OLD hub's override keeps firing.
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: paletteDefault,
+    });
+
+    // Client B's refresh hangs, so the ONLY hubError in the first phase is
+    // the rewire's own rollback signal.
+    const clientB = new FakeClient("ready");
+    let resolveGet: ((payload: KeybindingsOverrides) => void) | undefined;
+    clientB.on(
+      "evener/settings/keybindings/get",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolveGet = resolve;
+        }),
+    );
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+
+    const retained = keybindingsStore.getState();
+    // The display stays truthful: the payload that is STILL FIRING is the
+    // one shown (rawOverrides/overrides/warnings retained). revision resets
+    // to 0 regardless: revision sequences are per-hub, and carrying the old
+    // hub's revision would eat the new hub's lower revisions via
+    // applyHubOverrides' stale guard.
+    expect(retained.revision).toBe(0);
+    expect(retained.rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    // loaded still drops (invalidateReadyGeneration, pinned by the round-15
+    // wedged-unwind test): the retained payload is the OLD hub's, so editing
+    // must wait for the NEW hub's own confirmation - but the retained raw
+    // set keeps the display truthful about what is still firing.
+    expect(retained.loaded).toBe(false);
+    expect(retained.hubError).toContain("still in effect");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The wedge clears; hub B's refresh lands an EMPTY payload. The intact
+    // applied map lets the reconcile restore palette.open's default.
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    await waitFor(() => expect(resolveGet).toBeDefined());
+    resolveGet?.(overridesPayload(1, []));
+    await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
+
+    expect(keybindingsStore.getState().revision).toBe(1);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1003,6 +1003,59 @@ describe("keybindings store: support loss", () => {
     ]);
   });
 
+  test("support loss against a WEDGED registry RETAINS the hub state with a retryable hubError, and the retry after unwedging resets", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The wedge: a foreign binding squatting palette.open's DEFAULT chord,
+    // so the un-apply's restore exact-matches, throws, and rolls back - the
+    // registry keeps firing the override. palette.open's default is $mod+K
+    // with legacyEitherMod, so the restored base serializes
+    // "Control+[Meta]+K" (Meta OPTIONAL) - the squatter must hold exactly
+    // that, not bare "Control+K".
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+
+    expect(keybindingsStore.getState().hubSupport).toBe("unsupported");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    // The store must not claim "defaults in effect" against live user
+    // behavior: the hub payload is RETAINED (it re-drives reconciliation
+    // once the wedge clears) and the error says so, retryably.
+    const retained = keybindingsStore.getState();
+    expect(retained.loaded).toBe(true);
+    expect(retained.revision).toBe(3);
+    expect(retained.rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(retained.hubError).toContain("still in effect");
+
+    // Unwedge; the next connection change re-runs the unsupported branch,
+    // the restore succeeds, and the drop proceeds exactly as on the clean
+    // path (the regression test above).
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+
+    const reset = keybindingsStore.getState();
+    expect(reset.hubError).toBeNull();
+    expect(reset.loaded).toBe(false);
+    expect(reset.revision).toBe(0);
+    expect(reset.rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
   test("a transient disconnect of a SUPPORTED hub keeps the overrides applied", async () => {
     // The ruled behavior, pinned: while a supported hub is temporarily
     // unreachable the feature set is unknown, not contradicted - the rows

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -940,3 +940,45 @@ describe("keybindings store: character-key pref in the restore simulation", () =
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
   });
 });
+
+describe("keybindings store: support loss", () => {
+  test("support resolving to UNSUPPORTED un-applies the hub's overrides from the registry", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The feature set is KNOWN and no longer advertises keybindings: the
+    // section claims "the built-in defaults are in effect", so the registry
+    // must stop firing the override.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+
+    expect(keybindingsStore.getState().hubSupport).toBe("unsupported");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a transient disconnect of a SUPPORTED hub keeps the overrides applied", async () => {
+    // The ruled behavior, pinned: while a supported hub is temporarily
+    // unreachable the feature set is unknown, not contradicted - the rows
+    // show the overrides read-only and the chords keep firing.
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    connectionStore.setState({ state: "idle", features: undefined });
+
+    expect(keybindingsStore.getState().hubSupport).toBe("unknown");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(serializeChord(bindingsFor(ACTIONS.paletteOpen)[0]?.chord ?? [])).toBe("Control+P");
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -879,6 +879,10 @@ describe("keybindings store: patch gating", () => {
       keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
     ).rejects.toThrow(/unavailable/);
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    // The rejection applies to the CURRENT generation (the loading-window
+    // race), so hubError still surfaces: the fence's throw-only posture is
+    // only for writes whose generation has ended (finding 22).
+    expect(keybindingsStore.getState().hubError).toBe("Hub keybindings settings are unavailable.");
 
     resolvePending?.(overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
     await refresh;
@@ -1105,6 +1109,49 @@ describe("keybindings store: support flap discards hub state", () => {
       `${ACTIONS.paletteOpen}#mod-twin`,
     ]);
   });
+
+  test("a refresh rejecting after support loss leaves the state clean (no hubError)", async () => {
+    // The FIRST get lands normally; the second hangs so support can drop
+    // while the refresh is in flight.
+    const client = new FakeClient("ready");
+    let rejectGet: ((error: Error) => void) | undefined;
+    let hang = false;
+    client.on("evener/settings/keybindings/get", () => {
+      if (!hang) return overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+      return new Promise<KeybindingsOverrides>((_, reject) => {
+        rejectGet = reject;
+      });
+    });
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().loaded).toBe(true);
+
+    hang = true;
+    const refresh = keybindingsStore.getState().refreshOverrides();
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    // Support drops mid-flight: the cleanup un-applies and resets the hub
+    // state (hubLoading false, hubError null).
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(keybindingsStore.getState().hubSupport).toBe("unsupported");
+    expect(keybindingsStore.getState().hubLoading).toBe(false);
+
+    // The in-flight refresh now rejects: the catch/finally must not
+    // overwrite the support-drop cleanup with a stale "could not load"
+    // hubError - the section claims the built-in defaults are in effect
+    // (finding 23).
+    rejectGet?.(new Error("socket went away"));
+    await refresh;
+
+    const state = keybindingsStore.getState();
+    expect(state.hubError).toBeNull();
+    expect(state.hubLoading).toBe(false);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
 });
 
 describe("keybindings store: write serialization", () => {
@@ -1252,6 +1299,62 @@ describe("keybindings store: write generation fence", () => {
     expect(keybindingsStore.getState().revision).toBe(1);
     expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
     expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  test("the fence rejection leaves the NEW hub's clean state untouched: no hubError, still editable", async () => {
+    // Same setup as the fence test: write #2 queues behind A's hanging
+    // PATCH, the client is replaced mid-flight, hub B loads cleanly.
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatchA: ((value: KeybindingsOverrides) => void) | undefined;
+    clientA.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatchA = resolve;
+        }),
+    );
+    await wireClient(clientA, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() =>
+      expect(clientA.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1),
+    );
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    const clientB = new FakeClient("ready");
+    clientB.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    clientB.on("evener/settings/keybindings/patch", (params) =>
+      overridesPayload(params.expectedRevision + 1, params.config.rules),
+    );
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+    resolvePatchA?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await first;
+    await expect(second).rejects.toThrow(/unavailable/);
+
+    // The rejection belonged to the DEAD generation: setting hubError would
+    // land "settings are unavailable" on hub B's freshly-loaded state, and
+    // the round-3 editing gate would read the clean new hub read-only until
+    // something cleared it (finding 22). hubError stays null ...
+    const state = keybindingsStore.getState();
+    expect(state.hubError).toBeNull();
+    expect(state.loaded).toBe(true);
+    // ... and the new hub stays editable: a fresh write under B's generation
+    // composes and lands.
+    const result = await keybindingsStore
+      .getState()
+      .patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(result.revision).toBe(2);
   });
 
   // The same-generation half is pinned by "concurrent patches serialize"

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1258,3 +1258,72 @@ describe("keybindings store: write generation fence", () => {
   // (write serialization describe): two writes created in one tick under one
   // generation both land in order - the fence must not reject them.
 });
+
+// A characterKeyTriggers flip re-validates the persisted rules against the
+// new pref: the simulation treats the "?" entry as pref-authoritative (the
+// re-apply runs in the flip instant, before the controller's reconcile has
+// re-registered/unregistered it), so a rule skipped under one pref applies
+// under the other - and vice versa - with the warnings list following.
+describe("keybindings store: pref flips re-validate persisted overrides", () => {
+  test("a Shift+? override skipped while the pref is on applies when the pref flips off, and is skipped again when it flips back on", async () => {
+    // Pref ON (default), "?" live: the claim conflicts with the built-in
+    // trigger and is skipped with a conflict warning.
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.composerFocus, chord: "Shift+?" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([
+      ACTIONS.composerFocus,
+      `${ACTIONS.composerFocus}#mod-twin`,
+    ]);
+    const skipped = keybindingsStore.getState().warnings;
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.reason).toBe("conflict");
+    expect(skipped[0]?.conflictWith).toBe(ACTIONS.cheatsheetToggle);
+    // The RAW set retains the skipped rule - it is still the hub's state.
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Shift+?" }]);
+
+    // Pref OFF: the re-apply simulates "?" as absent (it is still live in
+    // the registry for this instant - the controller's reconcile has not
+    // unregistered it yet, and in this test file no reconcile is installed
+    // at all), so the claim validates clean and APPLIES; the warning clears.
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Shift+?" }]);
+
+    // Pref ON again: symmetric - the claim stops validating (the simulated
+    // map claims "?" again), the restore wins, and the warning returns.
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([
+      ACTIONS.composerFocus,
+      `${ACTIONS.composerFocus}#mod-twin`,
+    ]);
+    const reskipped = keybindingsStore.getState().warnings;
+    expect(reskipped).toHaveLength(1);
+    expect(reskipped[0]?.reason).toBe("conflict");
+    expect(reskipped[0]?.conflictWith).toBe(ACTIONS.cheatsheetToggle);
+  });
+
+  test("a pref flip with no ?-related overrides changes nothing", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    const before = bindingsFor(ACTIONS.paletteOpen);
+    expect(before.map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    prefsStore.getState().setCharacterKeyTriggers(true);
+
+    // Same effective map - same binding OBJECTS, nothing torn down - and no
+    // warnings appeared.
+    expect(bindingsFor(ACTIONS.paletteOpen)).toEqual(before);
+    expect(bindingsFor(ACTIONS.paletteOpen)[0]).toBe(before[0]);
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+    expect(keybindingsStore.getState().overrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(keybindingsStore.getState().revision).toBe(1);
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1192,3 +1192,69 @@ describe("keybindings store: write serialization", () => {
     });
   });
 });
+
+// A queued write is fenced to the ready generation it was CREATED under:
+// compose-at-execution (finding 16) is right within one generation, but a
+// write whose generation ended while it queued carries edit intent made
+// against the hub the user was looking at - it must die with that
+// generation, never land on the new hub.
+describe("keybindings store: write generation fence", () => {
+  test("a write queued behind an in-flight write rejects after a mid-flight client replacement, with no wire request to the new hub", async () => {
+    // Hub A: get lands immediately; the PATCH hangs so a second write queues.
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatchA: ((value: KeybindingsOverrides) => void) | undefined;
+    clientA.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatchA = resolve;
+        }),
+    );
+    await wireClient(clientA, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() =>
+      expect(clientA.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1),
+    );
+    // Write #2 queues behind the in-flight write, created while hub A's
+    // state is the displayed state.
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    // The client is replaced mid-flight: hub B loads cleanly at revision 1.
+    const clientB = new FakeClient("ready");
+    clientB.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    clientB.on("evener/settings/keybindings/patch", (params) =>
+      overridesPayload(params.expectedRevision + 1, params.config.rules),
+    );
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+    // A's hanging PATCH resolves: its response must not apply (the
+    // post-response staleness branch), and write #2 - created under A's
+    // generation - must REJECT with the unavailable-class error having sent
+    // NO request to B. Without the call-time fence, run #2 would recompute
+    // against B's now-loaded state, pass every execution-time guard, and
+    // land the A-era edit on B.
+    resolvePatchA?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await first;
+    await expect(second).rejects.toThrow(/unavailable/);
+
+    expect(clientB.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    expect(keybindingsStore.getState().revision).toBe(1);
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  // The same-generation half is pinned by "concurrent patches serialize"
+  // (write serialization describe): two writes created in one tick under one
+  // generation both land in order - the fence must not reject them.
+});

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -943,6 +943,41 @@ describe("keybindings store: character-key pref in the restore simulation", () =
     ).rejects.toThrow(/already bound by/);
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
   });
+
+  test("with the pref off, a hub notification that drops an override restores defaults WITHOUT reclaiming the ? trigger", async () => {
+    // Pref off BEFORE the initial load: railToggle holds "Shift+?" (the
+    // character-key chord with a required shift), cheatsheet.toggle is
+    // overridden away. Both validate clean because the "?" entry is absent.
+    turnCharacterKeyPrefOff();
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [
+        { action: ACTIONS.cheatsheetToggle, chord: "Control+Shift+/" },
+        { action: ACTIONS.railToggle, chord: "Shift+?" },
+      ]),
+    );
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+
+    // The notification drops cheatsheet.toggle's override, so its defaults
+    // restore. The restore MUTATION must mirror the pref just like the
+    // preflight does: re-registering "?" would exact-match railToggle's
+    // surviving "Shift+?" override ("[Shift]+?" and "Shift+?" both serialize
+    // "Shift+?") and registerBinding would throw, surfacing a hubError from
+    // a payload the preflight already accepted.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, [{ action: ACTIONS.railToggle, chord: "Shift+?" }]),
+    });
+
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(2);
+    expect(bindingsFor(ACTIONS.cheatsheetToggle).map((b) => b.id)).toEqual([
+      ACTIONS.cheatsheetToggle,
+      `${ACTIONS.cheatsheetToggle}#mod-twin`,
+    ]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+  });
 });
 
 describe("keybindings store: support loss", () => {

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1154,6 +1154,193 @@ describe("keybindings store: support flap discards hub state", () => {
   });
 });
 
+// A support flap (supported -> unsupported -> supported, SAME client) begins
+// a new ready generation on the flap-BACK (finding 24): every token captured
+// under the pre-flap generation dies with it, while the new generation's own
+// refresh - fired after the bump - applies normally.
+describe("keybindings store: support flap generation fence", () => {
+  test("a patch response landing after a support flap is dropped, leaving the refreshed state", async () => {
+    const client = new FakeClient("ready");
+    let current = overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    client.on("evener/settings/keybindings/get", () => current);
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const patch = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]);
+    await waitFor(() => expect(resolvePatch).toBeDefined());
+
+    // The flap: down (un-apply + reset), then back - the hub now serves
+    // revision 5 with a DIFFERENT override, and the flap-back refresh lands
+    // it under the new generation.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    current = overridesPayload(5, [{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+    expect(keybindingsStore.getState().revision).toBe(5);
+
+    // The pre-flap patch's response lands now: composed against the pre-flap
+    // revision, it must not re-apply over the refreshed state.
+    resolvePatch?.(overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]));
+    const result = await patch;
+
+    expect(result.revision).toBe(5);
+    const state = keybindingsStore.getState();
+    expect(state.revision).toBe(5);
+    expect(state.rawOverrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a write queued pre-flap rejects after the flap with no wire request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() =>
+      expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1),
+    );
+    // Write #2 queues behind the in-flight write, created under the pre-flap
+    // generation.
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    // The flap: the same client loses and regains support; the flap-back
+    // refresh (revision 1, empty) lands under the new generation.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+    // The first write's response is dropped (pre-flap generation); write #2
+    // must REJECT at the call-time fence - its generation ended with the
+    // flap - having sent no request, and (finding 22) without stamping
+    // hubError onto the refreshed state.
+    resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await first;
+    await expect(second).rejects.toThrow(/unavailable/);
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(1);
+  });
+
+  test("a notification landing in the post-flap pre-refresh window is dropped; the refresh and later notifications apply", async () => {
+    // The first get lands; the flap-back get hangs so a notification can
+    // arrive inside the post-flap pre-refresh window.
+    const client = new FakeClient("ready");
+    let resolveGet: ((value: KeybindingsOverrides) => void) | undefined;
+    let hang = false;
+    client.on("evener/settings/keybindings/get", () => {
+      if (!hang) return overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+      return new Promise<KeybindingsOverrides>((resolve) => {
+        resolveGet = resolve;
+      });
+    });
+    await wireClient(client, true);
+
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    hang = true;
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    // Pre-flap cargo (revision 9, higher than anything the returning hub
+    // will serve) lands before the new generation's refresh has confirmed
+    // state: dropped. Applied, it would also eat the refresh's lower-but-
+    // current revision 5 via the stale guard.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(9, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+    });
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().loaded).toBe(false);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([
+      ACTIONS.railToggle,
+      `${ACTIONS.railToggle}#mod-twin`,
+    ]);
+
+    // The new generation's own refresh is NOT fenced out by the transition
+    // bump: revision 5 applies ...
+    resolveGet?.(overridesPayload(5, [{ action: ACTIONS.composerFocus, chord: "Control+M" }]));
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+    expect(keybindingsStore.getState().revision).toBe(5);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+
+    // ... and post-refresh notifications apply normally.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(6, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+    });
+    expect(keybindingsStore.getState().revision).toBe(6);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+  });
+
+  test("a same-value support re-notification does NOT fence in-flight work", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const patch = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]);
+    await waitFor(() => expect(resolvePatch).toBeDefined());
+
+    // The features object is re-set with the SAME supported value: not a
+    // transition, so no generation bump - the in-flight patch's response
+    // must still apply.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    resolvePatch?.(overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]));
+    const result = await patch;
+
+    expect(result.revision).toBe(4);
+    expect(keybindingsStore.getState().revision).toBe(4);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+  });
+});
+
 describe("keybindings store: write serialization", () => {
   test("concurrent patches serialize: each composes expectedRevision and payload after the previous lands", async () => {
     const client = new FakeClient("ready");

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -32,6 +32,12 @@ export interface KeybindingsStoreState {
   revision: number;
   /** The validated rules currently applied to the registry. */
   overrides: readonly OverrideRule[];
+  /** The hub payload's rules VERBATIM, before validation filtering. The
+   * editor composes whole-payload PATCHes from THIS set, not from
+   * `overrides`: a rule validation skips (an unknown action from a newer
+   * client, an unparseable chord) is still the hub's state, and a PATCH
+   * composed from the validated set would silently delete it. */
+  rawOverrides: readonly OverrideRule[];
   /** Semantic-validation warnings from the last applied payload. */
   warnings: readonly ValidationWarning[];
   /** Set when a patch lost the revision race; the store has already refreshed
@@ -48,6 +54,7 @@ function initialState(): Omit<KeybindingsStoreState, "refreshOverrides" | "patch
     hubError: null,
     revision: 0,
     overrides: [],
+    rawOverrides: [],
     warnings: [],
     conflict: null,
   };
@@ -169,7 +176,17 @@ function applyHubOverrides(payload: KeybindingsOverrides): void {
   // at this payload either way. Clearing one without the other was the
   // parked 2b asymmetry: a stale conflict notice outlived the state it
   // described (only a successful PATCH cleared it).
-  keybindingsStore.setState({ revision: payload.revision, hubError: null, conflict: null });
+  // rawOverrides is retained VERBATIM (validation filtering already happened
+  // inside applyOverrideRules): an edit's whole-payload PATCH is composed
+  // from this set so a rule validation skips survives an unrelated edit.
+  // Only a successful reconcile advances it - a failed apply leaves the last
+  // good raw set beside the last good revision.
+  keybindingsStore.setState({
+    rawOverrides: payload.rules.map((rule) => ({ action: rule.action, chord: rule.chord })),
+    revision: payload.revision,
+    hubError: null,
+    conflict: null,
+  });
 }
 
 function currentSupport(): "unknown" | "supported" | "unsupported" {
@@ -347,12 +364,22 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
     // by the hub (the server validates structure only) and then silently not
     // apply. Reject instead, with the validation layer's own message, and
     // leave hubError/conflict untouched: nothing hub-sourced happened. The
-    // currently-applied set re-validates clean (it did at apply time and the
-    // reserved lists are platform-static), so a warning always names a rule
-    // this call introduced.
-    const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, new Set(appliedOverrides.keys()));
-    if (preflight.warnings.length > 0) {
-      throw new Error(preflight.warnings.map((warning) => warning.message).join("\n"));
+    // payload is composed from the hub's RAW rules (rawOverrides), so it can
+    // carry a PRESERVED rule validation skips - an unknown action from a
+    // newer client, say. That is a pre-existing condition, not a defect this
+    // call introduced: reject only on warnings the CURRENT raw set does not
+    // already produce, keyed by action+message (the baseline simulation runs
+    // against the same live registry and applied set, so a preserved rule
+    // reproduces its apply-time warning verbatim).
+    const applied = new Set(appliedOverrides.keys());
+    const baseline = validateOverrideRules(state.rawOverrides, keybindingsRegistry, undefined, applied);
+    const baselineKeys = new Set(baseline.warnings.map((warning) => `${warning.rule.action} ${warning.message}`));
+    const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, applied);
+    const introduced = preflight.warnings.filter(
+      (warning) => !baselineKeys.has(`${warning.rule.action} ${warning.message}`),
+    );
+    if (introduced.length > 0) {
+      throw new Error(introduced.map((warning) => warning.message).join("\n"));
     }
     const token = ++patchSerial;
     try {
@@ -362,7 +389,7 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
       });
       if (token !== patchSerial || !isCurrentReady(client, generation)) {
         const current = keybindingsStore.getState();
-        return { version: 1, revision: current.revision, rules: [...current.overrides] };
+        return { version: 1, revision: current.revision, rules: [...current.rawOverrides] };
       }
       const payload = fromWireOverrides(result);
       if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -377,11 +377,16 @@ async function refreshFor(client: AppwireClientLike, epoch: number): Promise<voi
     if (payload === undefined) throw new Error("Hub returned malformed keybindings overrides");
     applyHubOverrides(payload);
   } catch (error) {
-    if (isCurrentReady(client, epoch) && serial === refreshSerial) {
+    // currentSupport() is rechecked here as on the success path: a refresh
+    // rejecting after support was lost would otherwise overwrite the
+    // support-drop cleanup with a stale "could not load" hubError while the
+    // section claims the built-in defaults are in effect (finding 23).
+    if (isCurrentReady(client, epoch) && serial === refreshSerial && currentSupport() === "supported") {
       keybindingsStore.setState({ hubError: error instanceof Error ? error.message : String(error) });
     }
   } finally {
-    if (isCurrentReady(client, epoch) && serial === refreshSerial) keybindingsStore.setState({ hubLoading: false });
+    if (isCurrentReady(client, epoch) && serial === refreshSerial && currentSupport() === "supported")
+      keybindingsStore.setState({ hubLoading: false });
   }
 }
 
@@ -487,6 +492,16 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
       const state = keybindingsStore.getState();
       const client = currentClient();
       const generation = client === activeReadyClient ? activeReadyEpoch : -1;
+      // The call-time fence is checked SEPARATELY from the current-state
+      // guard below (finding 22): this write was created under a ready
+      // generation that has since ended, so the rejection belongs to a DEAD
+      // generation. Setting hubError here would land on the LIVING hub's
+      // freshly-loaded clean state - "Hub keybindings settings are
+      // unavailable" plus the round-3 editing gate would read the new hub
+      // read-only until something cleared it. Throw only.
+      if (callClient === null || callGeneration < 0 || !isCurrentReady(callClient, callGeneration)) {
+        throw new Error("Hub keybindings settings are unavailable.");
+      }
       if (
         state.hubSupport !== "supported" ||
         state.loaded !== true ||
@@ -495,10 +510,7 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
         client === null ||
         client !== wiredClient ||
         generation < 0 ||
-        client.state !== "ready" ||
-        callClient === null ||
-        callGeneration < 0 ||
-        !isCurrentReady(callClient, callGeneration)
+        client.state !== "ready"
       ) {
         // `loaded` is the defense-in-depth half of the editor's gate: the UI
         // is not the store's contract, and a patch composed from a STALE
@@ -507,8 +519,6 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
         // `hubLoading` is the same race WITHIN one generation: an in-flight
         // refresh is about to land a payload whose revision may differ from
         // the one a concurrent PATCH would send as expectedRevision.
-        // The call-time fence is the same staleness across the QUEUE: this
-        // write was created under a generation that has since ended.
         const error = "Hub keybindings settings are unavailable.";
         keybindingsStore.setState({ hubError: error });
         throw new Error(error);

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -403,6 +403,12 @@ function setSupportFromConnection(): void {
   // behavior with no way to re-drive reconciliation - retain the hub state
   // and surface a retryable hubError instead (finding 31). The setState
   // stays AFTER the registry mutation, per the reconcile ordering contract.
+  // Even on the rollback the REVISION resets (finding 34, aligned with the
+  // rewire path's finding 32): revision numbering is hub-scoped, so a
+  // retained old revision would let applyHubOverrides' stale guard silently
+  // discard a flap-back refresh carrying a LOWER revision (a restored
+  // backup, a reset state file), stranding the rollback state indefinitely.
+  // The raw set stays retained either way - it is what re-drives the retry.
   const dropHubState =
     support === "unsupported" &&
     !unrestored &&
@@ -427,6 +433,7 @@ function setSupportFromConnection(): void {
       hubError: unrestored || unapplyRolledBack ? UNAPPLY_ROLLED_BACK_MESSAGE : null,
       conflict: null,
       ...(dropHubState ? { loaded: false, revision: 0, overrides: [], rawOverrides: [], warnings: [] } : {}),
+      ...(unrestored ? { revision: 0 } : {}),
     });
 }
 

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -307,6 +307,25 @@ function setSupportFromConnection(): void {
   const support = currentSupport();
   const state = keybindingsStore.getState();
   if (support === "supported") {
+    // A flap BACK from unsupported (finding 24): the pre-flap generation's
+    // in-flight work must not survive into the refreshed state - a patch
+    // response composed against the pre-flap revision, a queued write
+    // fenced at call time under the pre-flap generation, a notification
+    // dispatched before the transition. Begin a NEW ready generation on
+    // the transition (the clientEpoch bump fences all three paths; the
+    // notification rewire drops the old wrapper): isCurrentReady fails for
+    // every token captured pre-flap. The flap-back refresh trigger in
+    // onConnectionChange runs AFTER this and fires under the NEW epoch, so
+    // the new generation's own refresh is not fenced out by its own bump.
+    // Only the TRANSITION bumps: a same-value re-notification (hubSupport
+    // already "supported") and the unknown window (a transient disconnect
+    // keeps its state and its in-flight work) leave the generation intact.
+    // The DOWNWARD flap needs no bump: currentSupport() gates every path
+    // for the unsupported window itself, and refreshFor's entry guard
+    // refuses to run while unsupported.
+    if (state.hubSupport === "unsupported" && wiredClient !== null && activeReadyClient === wiredClient) {
+      beginReadyGeneration(wiredClient);
+    }
     if (state.hubSupport !== support) keybindingsStore.setState({ hubSupport: support });
     return;
   }
@@ -354,6 +373,12 @@ function onNotification(notification: AnyNotification): void {
   // A late notification landing during an unsupported window must not
   // re-install overrides into a registry the support drop just un-applied.
   if (currentSupport() !== "supported") return;
+  // A notification arriving before the CURRENT generation's refresh has
+  // confirmed state carries pre-refresh - potentially pre-flap - cargo
+  // (finding 24): its revision predates the flap, and applying it over the
+  // reset state would let the stale guard eat the in-flight refresh's
+  // older-but-current payload. Drop it; the refresh fetches the truth.
+  if (!keybindingsStore.getState().loaded) return;
   const payload = fromWireOverrides(notification.params);
   if (payload === undefined) return;
   try {
@@ -451,6 +476,9 @@ function onConnectionChange(
     previous.features?.keybindingsSettings !== true &&
     state.client?.state === "ready"
   ) {
+    // setSupportFromConnection runs FIRST: on a flap-back it has already
+    // begun the new ready generation (finding 24), so this refresh belongs
+    // to the NEW epoch and is not fenced out by the transition bump.
     if (activeReadyClient === state.client) void refreshFor(state.client, activeReadyEpoch);
   }
 }

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -467,6 +467,17 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
     await refreshFor(client, activeReadyEpoch);
   },
   patchOverrides: (rulesOrCompose): Promise<KeybindingsOverrides> => {
+    // Fence the write to the ready generation it was CREATED under. A queued
+    // write executes only after the previous write settles, which can be
+    // after a rewire to a NEW hub: the thunk's compose-at-execution is right
+    // WITHIN one generation (finding 16), but a write whose generation has
+    // ended carries edit intent made against the hub whose state the user
+    // was looking at - landing it on the new hub's config is the wrong
+    // default even though the payload would compose cleanly there. It
+    // rejects with the same unavailable-class error instead, before any
+    // wire request.
+    const callClient = currentClient();
+    const callGeneration = callClient !== null && callClient === activeReadyClient ? activeReadyEpoch : -1;
     const run = async (): Promise<KeybindingsOverrides> => {
       // Compose at EXECUTION time: a thunk reads the raw set as the
       // previous write left it, folding its confirmed payload into this
@@ -483,7 +494,10 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
         client === null ||
         client !== wiredClient ||
         generation < 0 ||
-        client.state !== "ready"
+        client.state !== "ready" ||
+        callClient === null ||
+        callGeneration < 0 ||
+        !isCurrentReady(callClient, callGeneration)
       ) {
         // `loaded` is the defense-in-depth half of the editor's gate: the UI
         // is not the store's contract, and a patch composed from a STALE
@@ -492,6 +506,8 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
         // `hubLoading` is the same race WITHIN one generation: an in-flight
         // refresh is about to land a payload whose revision may differ from
         // the one a concurrent PATCH would send as expectedRevision.
+        // The call-time fence is the same staleness across the QUEUE: this
+        // write was created under a generation that has since ended.
         const error = "Hub keybindings settings are unavailable.";
         keybindingsStore.setState({ hubError: error });
         throw new Error(error);

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -32,6 +32,11 @@ export interface KeybindingsStoreState {
   hubError: string | null;
   /** Revision of the last confirmed hub payload (0 = shipped defaults). */
   revision: number;
+  /** Bumps on every successful applyHubOverrides - a confirmed payload for
+   * the current generation. Row-level error clearing keys on this (finding
+   * 33): preflight and generation-fence rejections deliberately never set
+   * hubError, so the hubError transition alone cannot clear their errors. */
+  appliedSerial: number;
   /** The validated rules currently applied to the registry. */
   overrides: readonly OverrideRule[];
   /** The hub payload's rules VERBATIM, before validation filtering. The
@@ -69,6 +74,7 @@ function initialState(): Omit<KeybindingsStoreState, "refreshOverrides" | "patch
     hubLoading: false,
     hubError: null,
     revision: 0,
+    appliedSerial: 0,
     overrides: [],
     rawOverrides: [],
     warnings: [],
@@ -85,6 +91,12 @@ let activeReadyClient: AppwireClientLike | null = null;
 let activeReadyEpoch = -1;
 let refreshSerial = 0;
 let patchSerial = 0;
+/** Set when an un-apply rolled back against a wedged registry (findings 31
+ * and 32): the overrides are STILL firing, so the rollback hubError is not
+ * stale and refreshFor's entry clear must not wipe it. Cleared by the next
+ * successful apply (which reconciles the registry past the wedge) and by
+ * resetKeybindingsStoreForTests. */
+let unapplyRolledBack = false;
 /** Set when a changed-notification is dropped because the current
  * generation has no confirmed state yet (finding 25): the refresh that
  * lands the state may carry a response PREDATING the dropped change, so a
@@ -151,12 +163,13 @@ function unapplyAllOverrides(): boolean {
   return true;
 }
 
-/** Surfaced when support loss could not un-apply the overrides (the restore
- * rolled back against a wedged registry): the overrides are still in effect
- * and the hub payload state is RETAINED, so the next connection change -
- * which re-runs setSupportFromConnection - gets a fresh attempt. */
+/** Surfaced when support loss or a client rewire could not un-apply the
+ * overrides (the restore rolled back against a wedged registry): the
+ * overrides are still in effect and the hub payload state is RETAINED, so
+ * the next refresh or connection change - which re-runs the un-apply or
+ * reconciles from the intact applied map - gets a fresh attempt. */
 const UNAPPLY_ROLLED_BACK_MESSAGE =
-  "Could not restore the built-in default shortcuts: a conflicting binding is holding a default chord. This hub's keybinding overrides are still in effect; restoring retries on the next connection change.";
+  "Could not restore the built-in default shortcuts: a conflicting binding is holding a default chord. This hub's keybinding overrides are still in effect; restoring retries on the next refresh or connection change.";
 
 /** Structural check for a wire payload (get result, changed params, patch
  * response, conflict `current`). The server's own validation already ran; this
@@ -267,6 +280,9 @@ function applyHubOverrides(payload: KeybindingsOverrides): void {
   const state = keybindingsStore.getState();
   if (payload.revision < state.revision) return;
   applyOverrideRules(payload.rules);
+  // The reconcile succeeded, so any rolled-back un-apply's wedge is cleared
+  // with it: the rollback hubError is now stale and may clear normally.
+  unapplyRolledBack = false;
   // A successful apply supersedes any earlier apply failure's hubError AND
   // any earlier patch's revision-race conflict - the store is now confirmed
   // at this payload either way. Clearing one without the other was the
@@ -280,6 +296,10 @@ function applyHubOverrides(payload: KeybindingsOverrides): void {
   keybindingsStore.setState({
     rawOverrides: payload.rules.map((rule) => ({ action: rule.action, chord: rule.chord })),
     revision: payload.revision,
+    // Row-level error clearing keys on this bump (finding 33): preflight and
+    // generation-fence rejections deliberately never set hubError, so the
+    // hubError transition alone cannot clear a row error they left behind.
+    appliedSerial: state.appliedSerial + 1,
     // Every call site is generation-guarded (refreshFor, the notification
     // wrapper, patchOverrides), so a successful apply confirms the state for
     // the CURRENT ready generation - editing and patching gate on this.
@@ -370,6 +390,7 @@ function setSupportFromConnection(): void {
     // BEFORE the setState - the character-key reconcile subscribes to the
     // store and must see the final registry shape (see unapplyAllOverrides).
     unrestored = !unapplyAllOverrides();
+    unapplyRolledBack = unrestored;
   }
   // The unsupported drop also discards the hub PAYLOAD state: retaining
   // loaded/revision/rawOverrides across a flap would let a later supported
@@ -399,7 +420,11 @@ function setSupportFromConnection(): void {
     keybindingsStore.setState({
       hubSupport: support,
       hubLoading: false,
-      hubError: unrestored ? UNAPPLY_ROLLED_BACK_MESSAGE : null,
+      // A rolled-back un-apply's message survives the unknown window too
+      // (finding 32: a client swap re-runs this with support "unknown"
+      // before the new hub's features resolve, and the wedge it describes
+      // is still live in the registry).
+      hubError: unrestored || unapplyRolledBack ? UNAPPLY_ROLLED_BACK_MESSAGE : null,
       conflict: null,
       ...(dropHubState ? { loaded: false, revision: 0, overrides: [], rawOverrides: [], warnings: [] } : {}),
     });
@@ -439,7 +464,7 @@ function onNotification(notification: AnyNotification): void {
 async function refreshFor(client: AppwireClientLike, epoch: number): Promise<void> {
   if (!isCurrentReady(client, epoch) || currentSupport() !== "supported") return;
   const serial = ++refreshSerial;
-  keybindingsStore.setState({ hubLoading: true, hubError: null });
+  keybindingsStore.setState({ hubLoading: true, ...(unapplyRolledBack ? {} : { hubError: null }) });
   try {
     const result = await client.request("evener/settings/keybindings/get", {});
     if (!isCurrentReady(client, epoch) || serial !== refreshSerial || currentSupport() !== "supported") return;
@@ -485,16 +510,19 @@ function rewireClient(client: AppwireClientLike): void {
   // see the final registry shape (see unapplyAllOverrides). hubSupport is
   // connection-sourced, not hub state, so it is left to
   // setSupportFromConnection.
-  unapplyAllOverrides();
-  keybindingsStore.setState({
-    revision: 0,
-    overrides: [],
-    rawOverrides: [],
-    warnings: [],
-    hubLoading: false,
-    hubError: null,
-    conflict: null,
-  });
+  const unrestored = !unapplyAllOverrides();
+  unapplyRolledBack = unrestored;
+  if (!unrestored) {
+    keybindingsStore.setState({
+      revision: 0,
+      overrides: [],
+      rawOverrides: [],
+      warnings: [],
+      hubLoading: false,
+      hubError: null,
+      conflict: null,
+    });
+  }
   unwireReady = client.onReady(() => {
     const epoch = beginReadyGeneration(client);
     void refreshFor(client, epoch);
@@ -502,6 +530,25 @@ function rewireClient(client: AppwireClientLike): void {
   if (client.state === "ready") {
     const epoch = beginReadyGeneration(client);
     void refreshFor(client, epoch);
+  }
+  if (unrestored) {
+    // Finding 32 (mirror of finding 31's support-loss rollback): the restore
+    // rolled back against a wedged registry, so the OLD hub's overrides are
+    // still firing. Retain its confirmed payload (rawOverrides/overrides/
+    // warnings) so the display stays truthful and the new hub's incoming
+    // applies can reconcile from the intact applied map - but reset revision
+    // to 0: revision sequences are per-hub, and carrying the old hub's
+    // revision would eat the new hub's lower revisions via applyHubOverrides'
+    // stale guard. This setState comes AFTER the refresh kick above because
+    // refreshFor's entry clears hubError; when the refresh lands it either
+    // confirms (applyHubOverrides clears hubError) or re-fails the reconcile
+    // against the same wedge and surfaces its own hubError. hubLoading is
+    // left to the in-flight refresh.
+    keybindingsStore.setState({
+      revision: 0,
+      hubError: UNAPPLY_ROLLED_BACK_MESSAGE,
+      conflict: null,
+    });
   }
 }
 
@@ -729,6 +776,7 @@ export function resetKeybindingsStoreForTests(): void {
   refreshSerial += 1;
   patchSerial += 1;
   missedChangeNotification = false;
+  unapplyRolledBack = false;
   writeQueue = Promise.resolve();
   // Restore defaults for every applied override so the registry singleton
   // cannot leak overrides into the next test (the next test rebuilds the

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -53,7 +53,13 @@ export interface KeybindingsStoreState {
    * to the server's current state when this is non-null. */
   conflict: string | null;
   refreshOverrides(): Promise<void>;
-  patchOverrides(rules: readonly OverrideRule[]): Promise<KeybindingsOverrides>;
+  /** Writes SERIALIZE at the store: at most one PATCH is in flight, and each
+   * write runs only after the previous one has fully landed. Pass a THUNK
+   * to compose the whole-payload rule set at execution time (against the
+   * then-current rawOverrides) - a rules array composed at call time would
+   * race the in-flight write it queues behind: same expectedRevision, and a
+   * payload missing the first edit's confirmed change. */
+  patchOverrides(rules: readonly OverrideRule[] | (() => readonly OverrideRule[])): Promise<KeybindingsOverrides>;
 }
 
 function initialState(): Omit<KeybindingsStoreState, "refreshOverrides" | "patchOverrides"> {
@@ -78,6 +84,11 @@ let activeReadyClient: AppwireClientLike | null = null;
 let activeReadyEpoch = -1;
 let refreshSerial = 0;
 let patchSerial = 0;
+/** The write-serialization chain: every patchOverrides queues behind the
+ * previous write's full settlement (success OR failure). Reset with the
+ * rest of the store's wiring state in resetKeybindingsStoreForTests so a
+ * never-resolving write cannot leak into the next test. */
+let writeQueue: Promise<void> = Promise.resolve();
 
 /** The action -> effective override (serialized chord, or null for an unbind)
  * currently applied to the registry. Module-level like the template's wiring
@@ -308,15 +319,40 @@ function setSupportFromConnection(): void {
     // store and must see the final registry shape (see unapplyAllOverrides).
     unapplyAllOverrides();
   }
+  // The unsupported drop also discards the hub PAYLOAD state: retaining
+  // loaded/revision/rawOverrides across a flap would let a later supported
+  // reconnect's refresh be eaten by the stale guard (the retained revision
+  // can be HIGHER than the returning hub's - a restored backup, a reset
+  // state file) and would leave edits composing from the old hub's raw set
+  // with the old expectedRevision. The setState stays AFTER the registry
+  // mutation, per the reconcile ordering contract.
+  const dropHubState =
+    support === "unsupported" &&
+    (state.loaded || state.revision !== 0 || state.overrides.length > 0 || state.rawOverrides.length > 0);
   // The conflict notice clears with hubError here too (the 2b clear
   // asymmetry): a support drop disconnects the store from the hub state the
   // conflict described, so keeping it would be as stale as keeping hubError.
-  if (state.hubSupport !== support || state.hubLoading || state.hubError !== null || state.conflict !== null)
-    keybindingsStore.setState({ hubSupport: support, hubLoading: false, hubError: null, conflict: null });
+  if (
+    state.hubSupport !== support ||
+    state.hubLoading ||
+    state.hubError !== null ||
+    state.conflict !== null ||
+    dropHubState
+  )
+    keybindingsStore.setState({
+      hubSupport: support,
+      hubLoading: false,
+      hubError: null,
+      conflict: null,
+      ...(dropHubState ? { loaded: false, revision: 0, overrides: [], rawOverrides: [], warnings: [] } : {}),
+    });
 }
 
 function onNotification(notification: AnyNotification): void {
   if (notification.method !== "evener/settings/keybindings/changed") return;
+  // A late notification landing during an unsupported window must not
+  // re-install overrides into a registry the support drop just un-applied.
+  if (currentSupport() !== "supported") return;
   const payload = fromWireOverrides(notification.params);
   if (payload === undefined) return;
   try {
@@ -430,83 +466,100 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
     if (client === null || client !== wiredClient || activeReadyClient !== client) return;
     await refreshFor(client, activeReadyEpoch);
   },
-  patchOverrides: async (rules): Promise<KeybindingsOverrides> => {
-    const state = keybindingsStore.getState();
-    const client = currentClient();
-    const generation = client === activeReadyClient ? activeReadyEpoch : -1;
-    if (
-      state.hubSupport !== "supported" ||
-      state.loaded !== true ||
-      state.hubLoading ||
-      currentSupport() !== "supported" ||
-      client === null ||
-      client !== wiredClient ||
-      generation < 0 ||
-      client.state !== "ready"
-    ) {
-      // `loaded` is the defense-in-depth half of the editor's gate: the UI
-      // is not the store's contract, and a patch composed from a STALE
-      // generation's raw set (client replaced, refresh not yet landed) would
-      // send the old hub's expectedRevision and rules to the new hub.
-      // `hubLoading` is the same race WITHIN one generation: an in-flight
-      // refresh is about to land a payload whose revision may differ from
-      // the one a concurrent PATCH would send as expectedRevision.
-      const error = "Hub keybindings settings are unavailable.";
-      keybindingsStore.setState({ hubError: error });
-      throw new Error(error);
-    }
-    // Pre-flight semantic validation (the parked 2b minor the settings
-    // editor makes live): the SAME simulation the reconcile path runs on a
-    // confirmed payload, run BEFORE the hub write. A rule the reconcile
-    // would skip - unknown action, unparseable or platform-reserved chord,
-    // or a conflict on the simulated final map - would otherwise be accepted
-    // by the hub (the server validates structure only) and then silently not
-    // apply. Reject instead, with the validation layer's own message, and
-    // leave hubError/conflict untouched: nothing hub-sourced happened. The
-    // payload is composed from the hub's RAW rules (rawOverrides), so it can
-    // carry a PRESERVED rule validation skips - an unknown action from a
-    // newer client, say. That is a pre-existing condition, not a defect this
-    // call introduced: reject only on warnings the CURRENT raw set does not
-    // already produce, keyed by action+message (the baseline simulation runs
-    // against the same live registry and applied set, so a preserved rule
-    // reproduces its apply-time warning verbatim).
-    const applied = new Set(appliedOverrides.keys());
-    const pref = prefsStore.getState().characterKeyTriggers;
-    const baseline = validateOverrideRules(state.rawOverrides, keybindingsRegistry, undefined, applied, pref);
-    const baselineKeys = new Set(baseline.warnings.map((warning) => `${warning.rule.action} ${warning.message}`));
-    const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, applied, pref);
-    const introduced = preflight.warnings.filter(
-      (warning) => !baselineKeys.has(`${warning.rule.action} ${warning.message}`),
-    );
-    if (introduced.length > 0) {
-      throw new Error(introduced.map((warning) => warning.message).join("\n"));
-    }
-    const token = ++patchSerial;
-    try {
-      const result = await client.request("evener/settings/keybindings/patch", {
-        expectedRevision: state.revision,
-        config: { version: 1, rules: rules.map((rule) => ({ action: rule.action, chord: rule.chord })) },
-      });
-      if (token !== patchSerial || !isCurrentReady(client, generation)) {
-        const current = keybindingsStore.getState();
-        return { version: 1, revision: current.revision, rules: [...current.rawOverrides] };
+  patchOverrides: (rulesOrCompose): Promise<KeybindingsOverrides> => {
+    const run = async (): Promise<KeybindingsOverrides> => {
+      // Compose at EXECUTION time: a thunk reads the raw set as the
+      // previous write left it, folding its confirmed payload into this
+      // write's rules instead of racing it.
+      const rules = typeof rulesOrCompose === "function" ? rulesOrCompose() : rulesOrCompose;
+      const state = keybindingsStore.getState();
+      const client = currentClient();
+      const generation = client === activeReadyClient ? activeReadyEpoch : -1;
+      if (
+        state.hubSupport !== "supported" ||
+        state.loaded !== true ||
+        state.hubLoading ||
+        currentSupport() !== "supported" ||
+        client === null ||
+        client !== wiredClient ||
+        generation < 0 ||
+        client.state !== "ready"
+      ) {
+        // `loaded` is the defense-in-depth half of the editor's gate: the UI
+        // is not the store's contract, and a patch composed from a STALE
+        // generation's raw set (client replaced, refresh not yet landed) would
+        // send the old hub's expectedRevision and rules to the new hub.
+        // `hubLoading` is the same race WITHIN one generation: an in-flight
+        // refresh is about to land a payload whose revision may differ from
+        // the one a concurrent PATCH would send as expectedRevision.
+        const error = "Hub keybindings settings are unavailable.";
+        keybindingsStore.setState({ hubError: error });
+        throw new Error(error);
       }
-      const payload = fromWireOverrides(result);
-      if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");
-      applyHubOverrides(payload);
-      return payload;
-    } catch (error) {
-      if (token === patchSerial && isCurrentReady(client, generation)) {
-        const current = conflictCurrent(error);
-        if (current !== undefined) applyHubOverrides(current);
-        const message = error instanceof Error ? error.message : String(error);
-        keybindingsStore.setState({
-          hubError: message,
-          ...(current === undefined ? {} : { conflict: message }),
+      // Pre-flight semantic validation (the parked 2b minor the settings
+      // editor makes live): the SAME simulation the reconcile path runs on a
+      // confirmed payload, run BEFORE the hub write. A rule the reconcile
+      // would skip - unknown action, unparseable or platform-reserved chord,
+      // or a conflict on the simulated final map - would otherwise be accepted
+      // by the hub (the server validates structure only) and then silently not
+      // apply. Reject instead, with the validation layer's own message, and
+      // leave hubError/conflict untouched: nothing hub-sourced happened. The
+      // payload is composed from the hub's RAW rules (rawOverrides), so it can
+      // carry a PRESERVED rule validation skips - an unknown action from a
+      // newer client, say. That is a pre-existing condition, not a defect this
+      // call introduced: reject only on warnings the CURRENT raw set does not
+      // already produce, keyed by action+message (the baseline simulation runs
+      // against the same live registry and applied set, so a preserved rule
+      // reproduces its apply-time warning verbatim).
+      const applied = new Set(appliedOverrides.keys());
+      const pref = prefsStore.getState().characterKeyTriggers;
+      const baseline = validateOverrideRules(state.rawOverrides, keybindingsRegistry, undefined, applied, pref);
+      const baselineKeys = new Set(baseline.warnings.map((warning) => `${warning.rule.action} ${warning.message}`));
+      const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, applied, pref);
+      const introduced = preflight.warnings.filter(
+        (warning) => !baselineKeys.has(`${warning.rule.action} ${warning.message}`),
+      );
+      if (introduced.length > 0) {
+        throw new Error(introduced.map((warning) => warning.message).join("\n"));
+      }
+      const token = ++patchSerial;
+      try {
+        const result = await client.request("evener/settings/keybindings/patch", {
+          expectedRevision: state.revision,
+          config: { version: 1, rules: rules.map((rule) => ({ action: rule.action, chord: rule.chord })) },
         });
+        if (token !== patchSerial || !isCurrentReady(client, generation) || currentSupport() !== "supported") {
+          // A response landing after support loss must not re-apply: the
+          // unsupported branch already un-applied and reset the hub state.
+          const current = keybindingsStore.getState();
+          return { version: 1, revision: current.revision, rules: [...current.rawOverrides] };
+        }
+        const payload = fromWireOverrides(result);
+        if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");
+        applyHubOverrides(payload);
+        return payload;
+      } catch (error) {
+        if (token === patchSerial && isCurrentReady(client, generation) && currentSupport() === "supported") {
+          const current = conflictCurrent(error);
+          if (current !== undefined) applyHubOverrides(current);
+          const message = error instanceof Error ? error.message : String(error);
+          keybindingsStore.setState({
+            hubError: message,
+            ...(current === undefined ? {} : { conflict: message }),
+          });
+        }
+        throw error;
       }
-      throw error;
-    }
+    };
+    // Chain behind the previous write's SETTLEMENT: a failed write must not
+    // block the queue, and the next write composes against whatever state
+    // the failure left (the conflict path already refreshed it).
+    const result = writeQueue.then(run, run);
+    writeQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   },
 }));
 
@@ -521,6 +574,7 @@ export function resetKeybindingsStoreForTests(): void {
   wiredClient = null;
   refreshSerial += 1;
   patchSerial += 1;
+  writeQueue = Promise.resolve();
   // Restore defaults for every applied override so the registry singleton
   // cannot leak overrides into the next test (the next test rebuilds the
   // registry from scratch, which removes any binding a wedged restore left).

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -164,8 +164,12 @@ function applyHubOverrides(payload: KeybindingsOverrides): void {
   const state = keybindingsStore.getState();
   if (payload.revision < state.revision) return;
   applyOverrideRules(payload.rules);
-  // A successful apply also supersedes any earlier apply failure's hubError.
-  keybindingsStore.setState({ revision: payload.revision, hubError: null });
+  // A successful apply supersedes any earlier apply failure's hubError AND
+  // any earlier patch's revision-race conflict - the store is now confirmed
+  // at this payload either way. Clearing one without the other was the
+  // parked 2b asymmetry: a stale conflict notice outlived the state it
+  // described (only a successful PATCH cleared it).
+  keybindingsStore.setState({ revision: payload.revision, hubError: null, conflict: null });
 }
 
 function currentSupport(): "unknown" | "supported" | "unsupported" {
@@ -216,8 +220,11 @@ function setSupportFromConnection(): void {
     if (state.hubSupport !== support) keybindingsStore.setState({ hubSupport: support });
     return;
   }
-  if (state.hubSupport !== support || state.hubLoading || state.hubError !== null)
-    keybindingsStore.setState({ hubSupport: support, hubLoading: false, hubError: null });
+  // The conflict notice clears with hubError here too (the 2b clear
+  // asymmetry): a support drop disconnects the store from the hub state the
+  // conflict described, so keeping it would be as stale as keeping hubError.
+  if (state.hubSupport !== support || state.hubLoading || state.hubError !== null || state.conflict !== null)
+    keybindingsStore.setState({ hubSupport: support, hubLoading: false, hubError: null, conflict: null });
 }
 
 function onNotification(notification: AnyNotification): void {
@@ -332,6 +339,21 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
       keybindingsStore.setState({ hubError: error });
       throw new Error(error);
     }
+    // Pre-flight semantic validation (the parked 2b minor the settings
+    // editor makes live): the SAME simulation the reconcile path runs on a
+    // confirmed payload, run BEFORE the hub write. A rule the reconcile
+    // would skip - unknown action, unparseable or platform-reserved chord,
+    // or a conflict on the simulated final map - would otherwise be accepted
+    // by the hub (the server validates structure only) and then silently not
+    // apply. Reject instead, with the validation layer's own message, and
+    // leave hubError/conflict untouched: nothing hub-sourced happened. The
+    // currently-applied set re-validates clean (it did at apply time and the
+    // reserved lists are platform-static), so a warning always names a rule
+    // this call introduced.
+    const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, new Set(appliedOverrides.keys()));
+    if (preflight.warnings.length > 0) {
+      throw new Error(preflight.warnings.map((warning) => warning.message).join("\n"));
+    }
     const token = ++patchSerial;
     try {
       const result = await client.request("evener/settings/keybindings/patch", {
@@ -345,7 +367,6 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
       const payload = fromWireOverrides(result);
       if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");
       applyHubOverrides(payload);
-      keybindingsStore.setState({ hubError: null, conflict: null });
       return payload;
     } catch (error) {
       if (token === patchSerial && isCurrentReady(client, generation)) {

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -23,6 +23,7 @@ import { WireError } from "../protocol/errors";
 import type { AppwireClientLike } from "../protocol/testing/fakeClient";
 import type { AnyNotification, KeybindingsOverrides } from "../protocol/types.gen";
 import { connectionStore } from "./connection";
+import { prefsStore } from "./prefs";
 
 export interface KeybindingsStoreState {
   hubSupport: "unknown" | "supported" | "unsupported";
@@ -86,11 +87,17 @@ const appliedOverrides = new Map<string, string | null>();
 /** Restores defaults for every applied override and clears the applied map:
  * the registry must stop presenting a hub's overrides the moment that hub's
  * state stops being current (client replacement, test reset) - that
- * staleness one layer down is the same defect as a stale store payload. A
- * wedged registry (a foreign binding squatting a default chord) must not
- * make the reset itself throw; a failed restore leaves the override binding
- * in place and the next reconcile (or the next test's registry rebuild)
- * removes it.
+ * staleness one layer down is the same defect as a stale store payload.
+ * Atomic, mirroring applyOverrideRules: two-phase (strip every applied
+ * action's bindings first, THEN restore each default) so a chord that moved
+ * between two overridden actions never trips a transient conflict mid-unwind,
+ * and any throw rolls the registry back to its pre-unwind snapshot. On
+ * rollback the applied map stays INTACT - clearing it while the registry
+ * still holds overrides would detach the unwind bookkeeping from the
+ * registry, and the next reconcile's delta math would misread the wedged
+ * bindings. The reset itself never propagates (a wedged registry - a foreign
+ * binding squatting a default chord - must not make reset throw); the next
+ * reconcile or the next test's registry rebuild retries from the intact map.
  *
  * ORDERING (the cheatsheetController contract): this mutates the registry
  * ONLY. Callers must fire any store setState - which is what the
@@ -99,12 +106,15 @@ const appliedOverrides = new Map<string, string | null>();
  * entry with no knowledge of the pref; the reconcile then removes it if the
  * pref is off). */
 function unapplyAllOverrides(): void {
-  for (const action of appliedOverrides.keys()) {
-    try {
-      restoreDefaultBinding(keybindingsRegistry, action);
-    } catch {
-      // See the doc comment: a wedged registry must not make reset throw.
-    }
+  if (appliedOverrides.size === 0) return;
+  const snapshot = keybindingsRegistry.getState().bindings;
+  try {
+    for (const action of appliedOverrides.keys()) removeActionBindings(keybindingsRegistry, action);
+    for (const action of appliedOverrides.keys()) restoreDefaultBinding(keybindingsRegistry, action);
+  } catch {
+    // See the doc comment: roll back, keep the applied map, never propagate.
+    rollbackBindings(snapshot);
+    return;
   }
   appliedOverrides.clear();
 }
@@ -158,7 +168,16 @@ function rollbackBindings(snapshot: readonly Binding[]): void {
  * state before propagating, so callers surface the failure with the last
  * good bindings intact. */
 function applyOverrideRules(rules: readonly OverrideRule[]): void {
-  const validated = validateOverrideRules(rules, keybindingsRegistry, undefined, new Set(appliedOverrides.keys()));
+  // The pref gates the restore simulation: with character-key triggers off
+  // the live registry has no "?" cheatsheet binding, so a simulated restore
+  // must not claim one either.
+  const validated = validateOverrideRules(
+    rules,
+    keybindingsRegistry,
+    undefined,
+    new Set(appliedOverrides.keys()),
+    prefsStore.getState().characterKeyTriggers,
+  );
   const next = new Map<string, string | null>();
   for (const rule of validated.rules) {
     next.set(rule.action, rule.chord === null ? null : serializeChord(rule.chord));
@@ -408,6 +427,7 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
     if (
       state.hubSupport !== "supported" ||
       state.loaded !== true ||
+      state.hubLoading ||
       currentSupport() !== "supported" ||
       client === null ||
       client !== wiredClient ||
@@ -418,6 +438,9 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
       // is not the store's contract, and a patch composed from a STALE
       // generation's raw set (client replaced, refresh not yet landed) would
       // send the old hub's expectedRevision and rules to the new hub.
+      // `hubLoading` is the same race WITHIN one generation: an in-flight
+      // refresh is about to land a payload whose revision may differ from
+      // the one a concurrent PATCH would send as expectedRevision.
       const error = "Hub keybindings settings are unavailable.";
       keybindingsStore.setState({ hubError: error });
       throw new Error(error);
@@ -438,9 +461,10 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
     // against the same live registry and applied set, so a preserved rule
     // reproduces its apply-time warning verbatim).
     const applied = new Set(appliedOverrides.keys());
-    const baseline = validateOverrideRules(state.rawOverrides, keybindingsRegistry, undefined, applied);
+    const pref = prefsStore.getState().characterKeyTriggers;
+    const baseline = validateOverrideRules(state.rawOverrides, keybindingsRegistry, undefined, applied, pref);
     const baselineKeys = new Set(baseline.warnings.map((warning) => `${warning.rule.action} ${warning.message}`));
-    const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, applied);
+    const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, applied, pref);
     const introduced = preflight.warnings.filter(
       (warning) => !baselineKeys.has(`${warning.rule.action} ${warning.message}`),
     );

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -298,6 +298,16 @@ function setSupportFromConnection(): void {
     if (state.hubSupport !== support) keybindingsStore.setState({ hubSupport: support });
     return;
   }
+  if (support === "unsupported") {
+    // Support resolving to UNSUPPORTED is not the transient-disconnect case
+    // (a supported hub that is temporarily unreachable keeps its overrides
+    // firing - the ruled behavior): the feature set is KNOWN and does not
+    // advertise keybindings, so the settings section claims "the built-in
+    // defaults are in effect". The registry must match that claim. Un-apply
+    // BEFORE the setState - the character-key reconcile subscribes to the
+    // store and must see the final registry shape (see unapplyAllOverrides).
+    unapplyAllOverrides();
+  }
   // The conflict notice clears with hubError here too (the 2b clear
   // asymmetry): a support drop disconnects the store from the hub state the
   // conflict described, so keeping it would be as stale as keeping hubError.

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -40,6 +40,14 @@ export interface KeybindingsStoreState {
   rawOverrides: readonly OverrideRule[];
   /** Semantic-validation warnings from the last applied payload. */
   warnings: readonly ValidationWarning[];
+  /** True only while the applied state (revision/overrides/rawOverrides and
+   * the registry's effective bindings) was confirmed by the hub for the
+   * CURRENT ready generation. Set on every successful payload apply; cleared
+   * when the ready generation ends (disconnect, client replacement, test
+   * reset). Editing and patchOverrides both gate on it: a PATCH composed
+   * from the previous hub's raw set with the previous hub's revision would
+   * overwrite the new hub's config on a revision collision. */
+  loaded: boolean;
   /** Set when a patch lost the revision race; the store has already refreshed
    * to the server's current state when this is non-null. */
   conflict: string | null;
@@ -56,6 +64,7 @@ function initialState(): Omit<KeybindingsStoreState, "refreshOverrides" | "patch
     overrides: [],
     rawOverrides: [],
     warnings: [],
+    loaded: false,
     conflict: null,
   };
 }
@@ -73,6 +82,32 @@ let patchSerial = 0;
  * currently applied to the registry. Module-level like the template's wiring
  * state: it describes the registry singleton, not store state. */
 const appliedOverrides = new Map<string, string | null>();
+
+/** Restores defaults for every applied override and clears the applied map:
+ * the registry must stop presenting a hub's overrides the moment that hub's
+ * state stops being current (client replacement, test reset) - that
+ * staleness one layer down is the same defect as a stale store payload. A
+ * wedged registry (a foreign binding squatting a default chord) must not
+ * make the reset itself throw; a failed restore leaves the override binding
+ * in place and the next reconcile (or the next test's registry rebuild)
+ * removes it.
+ *
+ * ORDERING (the cheatsheetController contract): this mutates the registry
+ * ONLY. Callers must fire any store setState - which is what the
+ * character-key reconcile subscribes to - AFTER this returns, so the
+ * reconcile sees the final shape (restore re-registers the conditional "?"
+ * entry with no knowledge of the pref; the reconcile then removes it if the
+ * pref is off). */
+function unapplyAllOverrides(): void {
+  for (const action of appliedOverrides.keys()) {
+    try {
+      restoreDefaultBinding(keybindingsRegistry, action);
+    } catch {
+      // See the doc comment: a wedged registry must not make reset throw.
+    }
+  }
+  appliedOverrides.clear();
+}
 
 /** Structural check for a wire payload (get result, changed params, patch
  * response, conflict `current`). The server's own validation already ran; this
@@ -184,6 +219,10 @@ function applyHubOverrides(payload: KeybindingsOverrides): void {
   keybindingsStore.setState({
     rawOverrides: payload.rules.map((rule) => ({ action: rule.action, chord: rule.chord })),
     revision: payload.revision,
+    // Every call site is generation-guarded (refreshFor, the notification
+    // wrapper, patchOverrides), so a successful apply confirms the state for
+    // the CURRENT ready generation - editing and patching gate on this.
+    loaded: true,
     hubError: null,
     conflict: null,
   });
@@ -216,6 +255,9 @@ function invalidateReadyGeneration(): void {
   clientEpoch += 1;
   unwireNotification?.();
   unwireNotification = null;
+  // The ready generation that confirmed the loaded state just ended; nothing
+  // hub-sourced is current until the next generation's refresh lands.
+  if (keybindingsStore.getState().loaded) keybindingsStore.setState({ loaded: false });
 }
 
 function beginReadyGeneration(client: AppwireClientLike): number {
@@ -283,6 +325,25 @@ function rewireClient(client: AppwireClientLike): void {
   unwireReady?.();
   unwireReady = null;
   wiredClient = client;
+  // The loaded state belongs to the PREVIOUS hub. Until this client's
+  // refresh lands it must not present as current: a patch composed from the
+  // old raw set with the old expectedRevision can overwrite the new hub's
+  // config on a revision collision, and the registry firing the old hub's
+  // overrides is the same staleness one layer down. Un-apply first, THEN
+  // setState - the character-key reconcile subscribes to the store and must
+  // see the final registry shape (see unapplyAllOverrides). hubSupport is
+  // connection-sourced, not hub state, so it is left to
+  // setSupportFromConnection.
+  unapplyAllOverrides();
+  keybindingsStore.setState({
+    revision: 0,
+    overrides: [],
+    rawOverrides: [],
+    warnings: [],
+    hubLoading: false,
+    hubError: null,
+    conflict: null,
+  });
   unwireReady = client.onReady(() => {
     const epoch = beginReadyGeneration(client);
     void refreshFor(client, epoch);
@@ -346,12 +407,17 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
     const generation = client === activeReadyClient ? activeReadyEpoch : -1;
     if (
       state.hubSupport !== "supported" ||
+      state.loaded !== true ||
       currentSupport() !== "supported" ||
       client === null ||
       client !== wiredClient ||
       generation < 0 ||
       client.state !== "ready"
     ) {
+      // `loaded` is the defense-in-depth half of the editor's gate: the UI
+      // is not the store's contract, and a patch composed from a STALE
+      // generation's raw set (client replaced, refresh not yet landed) would
+      // send the old hub's expectedRevision and rules to the new hub.
       const error = "Hub keybindings settings are unavailable.";
       keybindingsStore.setState({ hubError: error });
       throw new Error(error);
@@ -422,17 +488,9 @@ export function resetKeybindingsStoreForTests(): void {
   refreshSerial += 1;
   patchSerial += 1;
   // Restore defaults for every applied override so the registry singleton
-  // cannot leak overrides into the next test. A wedged registry (a foreign
-  // binding squatting a default chord) must not make reset itself throw.
-  for (const action of appliedOverrides.keys()) {
-    try {
-      restoreDefaultBinding(keybindingsRegistry, action);
-    } catch {
-      // The next test rebuilds the registry from scratch; a failed restore
-      // here leaves the override binding in place, which that rebuild removes.
-    }
-  }
-  appliedOverrides.clear();
+  // cannot leak overrides into the next test (the next test rebuilds the
+  // registry from scratch, which removes any binding a wedged restore left).
+  unapplyAllOverrides();
   keybindingsStore.setState({ ...initialState() });
   setSupportFromConnection();
 }

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -128,7 +128,14 @@ function unapplyAllOverrides(): void {
   const snapshot = keybindingsRegistry.getState().bindings;
   try {
     for (const action of appliedOverrides.keys()) removeActionBindings(keybindingsRegistry, action);
-    for (const action of appliedOverrides.keys()) restoreDefaultBinding(keybindingsRegistry, action);
+    // Pref-aware like the reconcile's restore: while the character-key
+    // pref is off the conditional "?" entry is not re-registered (the
+    // cheatsheetController owns it), so the restore cannot collide with a
+    // user rule holding exactly [Shift]+? (finding 27).
+    for (const action of appliedOverrides.keys())
+      restoreDefaultBinding(keybindingsRegistry, action, {
+        characterKeyTriggers: prefsStore.getState().characterKeyTriggers,
+      });
   } catch {
     // See the doc comment: roll back, keep the applied map, never propagate.
     rollbackBindings(snapshot);
@@ -186,15 +193,18 @@ function rollbackBindings(snapshot: readonly Binding[]): void {
  * state before propagating, so callers surface the failure with the last
  * good bindings intact. */
 function applyOverrideRules(rules: readonly OverrideRule[]): void {
-  // The pref gates the restore simulation: with character-key triggers off
-  // the live registry has no "?" cheatsheet binding, so a simulated restore
-  // must not claim one either.
+  // The pref gates BOTH the restore simulation and the actual restore
+  // below (finding 27): with character-key triggers off the live registry
+  // has no "?" cheatsheet binding, so neither a simulated nor a real
+  // restore may claim one - a real restore registering it would collide
+  // with a user rule holding exactly [Shift]+? and throw mid-reconcile.
+  const characterKeyTriggers = prefsStore.getState().characterKeyTriggers;
   const validated = validateOverrideRules(
     rules,
     keybindingsRegistry,
     undefined,
     new Set(appliedOverrides.keys()),
-    prefsStore.getState().characterKeyTriggers,
+    characterKeyTriggers,
   );
   const next = new Map<string, string | null>();
   for (const rule of validated.rules) {
@@ -215,7 +225,7 @@ function applyOverrideRules(rules: readonly OverrideRule[]): void {
         if (next.has(action)) {
           rebindAction(keybindingsRegistry, action, next.get(action) ?? null);
         } else {
-          restoreDefaultBinding(keybindingsRegistry, action);
+          restoreDefaultBinding(keybindingsRegistry, action, { characterKeyTriggers });
         }
       }
     } catch (error) {

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -85,6 +85,12 @@ let activeReadyClient: AppwireClientLike | null = null;
 let activeReadyEpoch = -1;
 let refreshSerial = 0;
 let patchSerial = 0;
+/** Set when a changed-notification is dropped because the current
+ * generation has no confirmed state yet (finding 25): the refresh that
+ * lands the state may carry a response PREDATING the dropped change, so a
+ * successful refresh with the flag set fires ONE follow-up fetch. Per
+ * generation: beginReadyGeneration starts every generation clean. */
+let missedChangeNotification = false;
 /** The write-serialization chain: every patchOverrides queues behind the
  * previous write's full settlement (success OR failure). Reset with the
  * rest of the store's wiring state in resetKeybindingsStoreForTests so a
@@ -294,6 +300,7 @@ function invalidateReadyGeneration(): void {
 function beginReadyGeneration(client: AppwireClientLike): number {
   activeReadyClient = client;
   activeReadyEpoch = ++clientEpoch;
+  missedChangeNotification = false;
   const epoch = activeReadyEpoch;
   unwireNotification?.();
   unwireNotification = client.onNotification((notification) => {
@@ -378,7 +385,15 @@ function onNotification(notification: AnyNotification): void {
   // (finding 24): its revision predates the flap, and applying it over the
   // reset state would let the stale guard eat the in-flight refresh's
   // older-but-current payload. Drop it; the refresh fetches the truth.
-  if (!keybindingsStore.getState().loaded) return;
+  // Not lost, though (finding 25): mark the generation dirty so the
+  // refresh that confirms its state fires ONE follow-up fetch - the
+  // in-flight get's response may PREDATE the dropped change, and without
+  // the follow-up the store would settle on the older snapshot until the
+  // next unrelated refresh.
+  if (!keybindingsStore.getState().loaded) {
+    missedChangeNotification = true;
+    return;
+  }
   const payload = fromWireOverrides(notification.params);
   if (payload === undefined) return;
   try {
@@ -401,6 +416,16 @@ async function refreshFor(client: AppwireClientLike, epoch: number): Promise<voi
     const payload = fromWireOverrides(result);
     if (payload === undefined) throw new Error("Hub returned malformed keybindings overrides");
     applyHubOverrides(payload);
+    if (missedChangeNotification) {
+      // A changed-notification was dropped while this generation had no
+      // confirmed state (finding 25) and THIS get's response may predate
+      // it. One follow-up fetch converges: the serial guard makes any
+      // older in-flight refresh lose, and the flag is cleared FIRST so it
+      // cannot loop - a notification arriving after this load applies
+      // directly (loaded is now true) instead of re-arming the flag.
+      missedChangeNotification = false;
+      void refreshFor(client, epoch);
+    }
   } catch (error) {
     // currentSupport() is rechecked here as on the success path: a refresh
     // rejecting after support was lost would otherwise overwrite the
@@ -528,6 +553,16 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
       // unavailable" plus the round-3 editing gate would read the new hub
       // read-only until something cleared it. Throw only.
       if (callClient === null || callGeneration < 0 || !isCurrentReady(callClient, callGeneration)) {
+        throw new Error("Hub keybindings settings are unavailable.");
+      }
+      // Support resolved to UNSUPPORTED is the same hygiene class as the
+      // fence (finding 26): the unsupported state is deliberately clean -
+      // the section says the built-in defaults are in effect - and the
+      // write no longer owns it. A plain unsupported transition does not
+      // bump the generation (finding 24: currentSupport() gates the
+      // window), so a write QUEUED while supported can reach this point,
+      // as can one composed while unsupported. Both throw without hubError.
+      if (currentSupport() === "unsupported") {
         throw new Error("Hub keybindings settings are unavailable.");
       }
       if (
@@ -663,6 +698,7 @@ export function resetKeybindingsStoreForTests(): void {
   wiredClient = null;
   refreshSerial += 1;
   patchSerial += 1;
+  missedChangeNotification = false;
   writeQueue = Promise.resolve();
   // Restore defaults for every applied override so the registry singleton
   // cannot leak overrides into the next test (the next test rebuilds the

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -16,6 +16,7 @@
 import { useStore } from "zustand";
 import { createStore, type StoreApi } from "zustand/vanilla";
 import { serializeChord } from "../keybindings/chord";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID } from "../keybindings/defaults";
 import { rebindAction, removeActionBindings, restoreDefaultBinding } from "../keybindings/overrides";
 import { type Binding, keybindingsRegistry } from "../keybindings/registry";
 import { type OverrideRule, type ValidationWarning, validateOverrideRules } from "../keybindings/validation";
@@ -582,6 +583,40 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
 connectionStore.subscribe(onConnectionChange);
 const initialClient = connectionStore.getState().client;
 if (initialClient !== null) rewireClient(initialClient);
+
+// A characterKeyTriggers flip changes what the persisted rules MEAN: a rule
+// skipped while the pref was on (a Shift+? claim conflicting with the
+// built-in "?" trigger) validates clean once the pref is off, and an applied
+// rule that overlaps "?" stops validating when the pref flips back on.
+// Re-apply the hub's raw set through the same pref-aware simulation so the
+// effective map and the warnings list always reflect the CURRENT pref -
+// without the flip the skip (and its warning) would go stale in both
+// directions. Idempotent like every apply: an unchanged effective map
+// mutates nothing. The setState re-fires this store's subscribers - the
+// cheatsheetController's reconcile among them - which is total and
+// idempotent, so the two compose in either subscription order.
+prefsStore.subscribe((state, previous) => {
+  if (state.characterKeyTriggers === previous.characterKeyTriggers) return;
+  // The registry must mirror the pref BEFORE the re-apply mutates: tinykeys
+  // canonicalizes the shifted character, so the conditional entry and a
+  // Shift+? claim serialize identically - a pref-off re-apply registering
+  // that claim while the entry is still live would hit registerBinding's
+  // exact-match conflict and roll back. Unregistering is idempotent and
+  // mirrors what the cheatsheetController's reconcile is about to do (it
+  // re-derives the same end state and no-ops). The pref-ON direction needs
+  // no mirror: the re-apply's pref-authoritative simulation un-applies a
+  // conflicting claim first, and the reconcile - fired by the setState
+  // below - registers "?" against the clean map.
+  if (!state.characterKeyTriggers) keybindingsRegistry.getState().unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+  try {
+    applyOverrideRules(keybindingsStore.getState().rawOverrides);
+  } catch (error) {
+    // Same posture as the changed-notification path: a reconcile failure
+    // surfaces as hubError (the registry has already rolled back to its last
+    // good state), never as an exception escaping the prefs dispatch.
+    keybindingsStore.setState({ hubError: error instanceof Error ? error.message : String(error) });
+  }
+});
 
 export function resetKeybindingsStoreForTests(): void {
   invalidateReadyGeneration();

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -409,6 +409,15 @@ function setSupportFromConnection(): void {
   // discard a flap-back refresh carrying a LOWER revision (a restored
   // backup, a reset state file), stranding the rollback state indefinitely.
   // The raw set stays retained either way - it is what re-drives the retry.
+  // loaded drops too (finding 36, now fully aligned with the rewire path):
+  // the retained payload is retained-but-UNCONFIRMED - that is exactly what
+  // loaded means. Keeping it true would let a changed-notification landing
+  // between the flap-back and its refresh pass onNotification's loaded gate
+  // and apply against the pre-flap state, after which the authoritative
+  // refresh (revision possibly lower, or equal-but-different) is discarded
+  // by the stale guard - the notification's version stays unverified. With
+  // loaded false the notification takes the finding-25 dirty-flag path and
+  // the flap-back refresh is the confirmation point that flips loaded back.
   const dropHubState =
     support === "unsupported" &&
     !unrestored &&
@@ -433,7 +442,7 @@ function setSupportFromConnection(): void {
       hubError: unrestored || unapplyRolledBack ? UNAPPLY_ROLLED_BACK_MESSAGE : null,
       conflict: null,
       ...(dropHubState ? { loaded: false, revision: 0, overrides: [], rawOverrides: [], warnings: [] } : {}),
-      ...(unrestored ? { revision: 0 } : {}),
+      ...(unrestored ? { loaded: false, revision: 0 } : {}),
     });
 }
 

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -122,9 +122,15 @@ const appliedOverrides = new Map<string, string | null>();
  * character-key reconcile subscribes to - AFTER this returns, so the
  * reconcile sees the final shape (restore re-registers the conditional "?"
  * entry with no knowledge of the pref; the reconcile then removes it if the
- * pref is off). */
-function unapplyAllOverrides(): void {
-  if (appliedOverrides.size === 0) return;
+ * pref is off).
+ *
+ * Returns false when the restore rolled back (the registry still holds the
+ * overrides and the applied map is intact), true otherwise - callers that
+ * discard the hub payload state after un-applying must NOT do so on false:
+ * the retained payload is the only thing that can re-drive reconciliation
+ * once the wedge clears (finding 31). */
+function unapplyAllOverrides(): boolean {
+  if (appliedOverrides.size === 0) return true;
   const snapshot = keybindingsRegistry.getState().bindings;
   try {
     for (const action of appliedOverrides.keys()) removeActionBindings(keybindingsRegistry, action);
@@ -139,10 +145,18 @@ function unapplyAllOverrides(): void {
   } catch {
     // See the doc comment: roll back, keep the applied map, never propagate.
     rollbackBindings(snapshot);
-    return;
+    return false;
   }
   appliedOverrides.clear();
+  return true;
 }
+
+/** Surfaced when support loss could not un-apply the overrides (the restore
+ * rolled back against a wedged registry): the overrides are still in effect
+ * and the hub payload state is RETAINED, so the next connection change -
+ * which re-runs setSupportFromConnection - gets a fresh attempt. */
+const UNAPPLY_ROLLED_BACK_MESSAGE =
+  "Could not restore the built-in default shortcuts: a conflicting binding is holding a default chord. This hub's keybinding overrides are still in effect; restoring retries on the next connection change.";
 
 /** Structural check for a wire payload (get result, changed params, patch
  * response, conflict `current`). The server's own validation already ran; this
@@ -346,6 +360,7 @@ function setSupportFromConnection(): void {
     if (state.hubSupport !== support) keybindingsStore.setState({ hubSupport: support });
     return;
   }
+  let unrestored = false;
   if (support === "unsupported") {
     // Support resolving to UNSUPPORTED is not the transient-disconnect case
     // (a supported hub that is temporarily unreachable keeps its overrides
@@ -354,17 +369,22 @@ function setSupportFromConnection(): void {
     // defaults are in effect". The registry must match that claim. Un-apply
     // BEFORE the setState - the character-key reconcile subscribes to the
     // store and must see the final registry shape (see unapplyAllOverrides).
-    unapplyAllOverrides();
+    unrestored = !unapplyAllOverrides();
   }
   // The unsupported drop also discards the hub PAYLOAD state: retaining
   // loaded/revision/rawOverrides across a flap would let a later supported
   // reconnect's refresh be eaten by the stale guard (the retained revision
   // can be HIGHER than the returning hub's - a restored backup, a reset
   // state file) and would leave edits composing from the old hub's raw set
-  // with the old expectedRevision. The setState stays AFTER the registry
-  // mutation, per the reconcile ordering contract.
+  // with the old expectedRevision. EXCEPT when the un-apply rolled back:
+  // the registry still fires the overrides, so forgetting the payload would
+  // strand the section claiming "defaults in effect" against live user
+  // behavior with no way to re-drive reconciliation - retain the hub state
+  // and surface a retryable hubError instead (finding 31). The setState
+  // stays AFTER the registry mutation, per the reconcile ordering contract.
   const dropHubState =
     support === "unsupported" &&
+    !unrestored &&
     (state.loaded || state.revision !== 0 || state.overrides.length > 0 || state.rawOverrides.length > 0);
   // The conflict notice clears with hubError here too (the 2b clear
   // asymmetry): a support drop disconnects the store from the hub state the
@@ -379,7 +399,7 @@ function setSupportFromConnection(): void {
     keybindingsStore.setState({
       hubSupport: support,
       hubLoading: false,
-      hubError: null,
+      hubError: unrestored ? UNAPPLY_ROLLED_BACK_MESSAGE : null,
       conflict: null,
       ...(dropHubState ? { loaded: false, revision: 0, overrides: [], rawOverrides: [], warnings: [] } : {}),
     });

--- a/cmd/evener-hub/frontend/src/stores/prefs.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.test.ts
@@ -534,6 +534,22 @@ describe("setCharacterKeyTriggers", () => {
   });
 });
 
+describe("setLastSettingsSection", () => {
+  test("persists under its own evener.prefs.lastSettingsSection key and updates state", () => {
+    expect(prefsStore.getState().lastSettingsSection).toBeNull();
+    prefsStore.getState().setLastSettingsSection("keybindings");
+    expect(localStorage.getItem(KEY("lastSettingsSection"))).toBe("keybindings");
+    expect(prefsStore.getState().lastSettingsSection).toBe("keybindings");
+    // A fresh hydration (what the next page load does) reads it back.
+    resetPrefsStoreForTests();
+    expect(prefsStore.getState().lastSettingsSection).toBe("keybindings");
+    // null is absence: the key is removed, never a literal "null" string.
+    prefsStore.getState().setLastSettingsSection(null);
+    expect(localStorage.getItem(KEY("lastSettingsSection"))).toBeNull();
+    expect(prefsStore.getState().lastSettingsSection).toBeNull();
+  });
+});
+
 describe("localStorage unavailable (e.g. Safari private mode)", () => {
   test("reading falls back to defaults rather than throwing", () => {
     vi.spyOn(MemoryStorage.prototype, "getItem").mockImplementation(() => {

--- a/cmd/evener-hub/frontend/src/stores/prefs.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.ts
@@ -107,6 +107,14 @@ export interface PrefsStoreState {
   // turn-off exists, per the p4 plan's Design decision 3). Browser-local by
   // controller ruling: NOT a hub settings key.
   characterKeyTriggers: boolean;
+  // The settings section the user last visited (a sections.ts id), so
+  // reopening Settings returns there instead of always landing on General.
+  // null = never visited (or cleared). Persisted as the RAW section-id
+  // string with no validation here - this store must not import the
+  // settings section inventory (layering), so an unrecognized stored value
+  // round-trips and the CONSUMER (Settings.tsx) falls back to the default
+  // section via isKnownSettingsSection.
+  lastSettingsSection: string | null;
   notifications: Record<NotificationKey, boolean>;
   notificationsLoudScope: NotificationsLoudScopePref;
 
@@ -119,6 +127,7 @@ export interface PrefsStoreState {
   setEnterToSend(value: boolean): void;
   setShowCost(value: boolean): void;
   setCharacterKeyTriggers(value: boolean): void;
+  setLastSettingsSection(value: string | null): void;
   setNotification(key: NotificationKey, value: boolean): void;
   setNotificationsLoudScope(value: NotificationsLoudScopePref): void;
 }
@@ -461,6 +470,7 @@ function loadInitialState(): Omit<
   | "setEnterToSend"
   | "setShowCost"
   | "setCharacterKeyTriggers"
+  | "setLastSettingsSection"
   | "setNotification"
   | "setNotificationsLoudScope"
 > {
@@ -480,6 +490,7 @@ function loadInitialState(): Omit<
     enterToSend: readBool("enterToSend", false),
     showCost: readBool("showCost", false),
     characterKeyTriggers: readBool("characterKeyTriggers", true),
+    lastSettingsSection: readRaw("lastSettingsSection"),
     notifications: loadNotifications(),
     notificationsLoudScope: readEnum("notificationsLoudScope", LOUD_SCOPE_VALUES, "asks"),
   };
@@ -543,6 +554,17 @@ export const prefsStore = createStore<PrefsStoreState>((set) => ({
   setCharacterKeyTriggers(value) {
     writeBool("characterKeyTriggers", value);
     set({ characterKeyTriggers: value });
+  },
+
+  setLastSettingsSection(value) {
+    // null is absence (never written as a literal), same contract as
+    // theme's "system".
+    if (value === null) {
+      removeRaw("lastSettingsSection");
+    } else {
+      writeRaw("lastSettingsSection", value);
+    }
+    set({ lastSettingsSection: value });
   },
 
   setNotification(key, value) {

--- a/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
@@ -520,6 +520,15 @@ const WIDGET_STYLESHEET_RE = /^widgets\/([a-z0-9-]+)\/\1\.module\.css$/;
 // .dangerText — failure text for a delegate's not-resumable reason and last
 // failed outcome reason. Error text is the danger hue's canonical, ungateable
 // job, the same as railDialog.module.css's .pickerError above.
+//
+// webui-keybindings-p4 task 6: panes/settings/sections/keybindings.module.css
+// earns the same exception for the same structural reason - it lives under
+// panes/settings/sections/, not widgets/<name>/, so it can never match
+// WIDGET_STYLESHEET_RE either. Its one semantic reach is --danger-ink on
+// .rowError and .captureError, the keybindings editor's inline validation and
+// hub-error text. Error text is the danger hue's canonical, ungateable job,
+// the same as railDialog.module.css's .pickerError and
+// delegateStatus.module.css's .dangerText above.
 const SEMANTIC_PATH_EXCEPTIONS = new Set([
   "shell/rail/RailRow.module.css",
   "shell/rail/railDialog.module.css",
@@ -531,6 +540,7 @@ const SEMANTIC_PATH_EXCEPTIONS = new Set([
   "panes/session/chrome/taskspanel.module.css",
   "panes/session/transcript/tools/sandboxescalation.module.css",
   "panes/session/transcript/tools/delegateStatus.module.css",
+  "panes/settings/sections/keybindings.module.css",
 ]);
 
 for (const [path, text] of OTHER_STYLESHEETS) {

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -511,8 +511,13 @@ the **Character-key shortcuts** Switch row at the top owning the WCAG
   or "Set a shortcut" when unbound) swaps the row's controls for a focused
   capture box showing "Press new shortcut…". Held modifiers echo live as
   `KeyHint` chips; the first non-modifier press records the chord. Plain
-  Enter saves, plain Escape cancels, Enter/Escape WITH a modifier record
-  as chords (Escape itself stays bindable). Clicking away cancels. The
+  Enter saves. Plain Escape ALWAYS cancels the capture — bare Escape
+  cannot be assigned through the editor (Escape-as-cancel is the
+  keybinding-editor convention), so the two built-in Escape bindings
+  (Close settings, Close the keyboard shortcuts overlay) are restored via
+  **Reset to default** rather than re-captured. Enter/Escape WITH a
+  modifier still record as chords (Shift+Escape is bindable). Clicking
+  away cancels, whether or not the click target can take focus. The
   capture box preventDefaults and stopPropagations every keydown, so the
   dispatcher and `settings.close`'s own Escape stay inert while capturing.
 - **Single-press only.** Capture records one press — no multi-press

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,6 +1,6 @@
 # Web UI keybindings
 
-Status: **current** (Phase 4a). The web hub's global keyboard chords are
+Status: **current** (Phase 4b). The web hub's global keyboard chords are
 owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
 window-level dispatcher, instead of each component installing its own
 `keydown` listener. User overrides persist on the hub and sync to every
@@ -10,6 +10,9 @@ operation of the AskDock ask-user surface. Phase 4a finalized the default
 map (strict Mod chords for ⌘K/⌘I/⌘J, new `settings` and transcript
 end-jump bindings) and shipped the two discoverability surfaces: the
 cheatsheet overlay (⌘/ or `?`) and hold-modifier hint chips.
+Phase 4b turned Settings → Keybindings into a capture-based editor over
+the synced overrides: pre-flight conflict validation, per-action
+unbind/reset (the Settings section below).
 
 ## Architecture
 
@@ -188,7 +191,8 @@ The map is final as of Phase 4a: the provisional ledger Phase 3 carried
 is closed — the DevTools-chord hijack permissiveness is gone (above) and
 `transcript.scrollTop`/`scrollBottom` have their chords. Every binding
 stays remappable through the hub-synced overrides store (Persistence
-below); the Settings listing is read-only until the Phase 4b editor.
+below); Settings → Keybindings edits them directly (the Settings section
+at the end of this document).
 
 ## Phase 3: session-pane cycling
 
@@ -474,7 +478,7 @@ not the store; the store carries `hubSupport`, `revision`, the validated
   advances only after a successful apply, so a failed payload stays
   retryable (a later `changed` with the same revision is not eaten by the
   stale guard).
-- **Patch** (used by the future editor): sends `expectedRevision` +
+- **Patch** (the editor's write path): sends `expectedRevision` +
   `{version: 1, rules}`; on success the canonical response is applied; on a
   conflict rejection the store refreshes to `data.current`, sets `conflict`
   and `hubError`, and rethrows.
@@ -487,25 +491,63 @@ warnings or a surfaced `hubError` with the last good (or default) bindings
 in place; the `changed`-notification path catches so a reconcile failure
 never escapes the client's notification dispatch.
 
-### Settings section
+### Settings section (Phase 4b editor)
 
-Settings → Keybindings is a **read-only** listing of the effective
-bindings: one row per action from `DEFAULT_BINDINGS` via
-`keybindings/display.ts` (never a hand-maintained copy), the chord
-rendered with the `KeyHint` widget from the live registry, and a
-"Customized" marker on actions whose effective bindings differ from the
-default map (including unbound actions; the `?` entry's pref-conditional
-registration is not itself a customization). A **Character-key shortcuts**
-Switch row at the top owns the WCAG 2.1.4 pref. The store's
-`hubSupport`/`hubError`/validation warnings surface as quiet status or
-alert text. Editing arrives with the Phase 4b editor.
+Settings → Keybindings edits the synced overrides, not just lists them.
+Whenever the hub advertises `features.keybindingsSettings`
+(`hubSupport === "supported"`) every row is editable; an `unknown` or
+`unsupported` hub keeps the read-only listing and its status text — the
+overrides layer is hub-only by design, so there is nothing to edit
+against. The rows themselves are unchanged from Phase 4a: one per action
+from `DEFAULT_BINDINGS` via `keybindings/display.ts` (never a
+hand-maintained copy), the chord rendered with the `KeyHint` widget from
+the live registry, a "Customized" marker on actions whose effective
+bindings differ from the default map (including unbound actions; the `?`
+entry's pref-conditional registration is not itself a customization), and
+the **Character-key shortcuts** Switch row at the top owning the WCAG
+2.1.4 pref.
+
+- **Capture.** Clicking a row's chord ("Change the shortcut for {title}",
+  or "Set a shortcut" when unbound) swaps the row's controls for a focused
+  capture box showing "Press new shortcut…". Held modifiers echo live as
+  `KeyHint` chips; the first non-modifier press records the chord. Plain
+  Enter saves, plain Escape cancels, Enter/Escape WITH a modifier record
+  as chords (Escape itself stays bindable). Clicking away cancels. The
+  capture box preventDefaults and stopPropagations every keydown, so the
+  dispatcher and `settings.close`'s own Escape stay inert while capturing.
+- **Single-press only.** Capture records one press — no multi-press
+  sequences — matching the all-single-press default map (multi-press
+  conflict checking is deliberately coarser). Bare-character chords (a
+  plain "A") CAN be authored; the character-key pref governs only the
+  built-in `?` trigger, not user-authored character chords, so bind bare
+  characters only if you know you mean it.
+- **Conflict semantics.** Every save is pre-flight validated in the store
+  — the same `validateOverrideRules` simulation over the final effective
+  map the reconcile path uses — BEFORE any hub request. A chord already
+  held by another binding in the same scope is rejected inline with a
+  message naming the chord, the scope, and the action holding it; the
+  capture box stays open so another chord can be tried, and nothing
+  reaches the hub. Reserved (browser/OS-claimed) and unparseable chords
+  reject the same way. A passing save sends the FULL replacement rule set
+  with `expectedRevision` optimistic concurrency (the apply flow above); a
+  revision conflict refreshes to the server's current payload.
+- **Unbind / Reset.** "Unbind" (bound actions) writes a `chord: null`
+  rule; "Reset" (actions carrying an override) drops the action from the
+  payload, restoring its defaults through the reconcile's
+  `restoreDefaultBinding`. Failures surface inline under the row.
+- **cheatsheet.toggle.** The ⌘/ base chord edits like any other. The `?`
+  character-key entry renders read-only with a note while it is
+  registered: it follows the character-key pref and the
+  cheatsheetController reconcile, not this editor — and because an
+  override owns the action's whole chord set, rebinding or unbinding the
+  base chord replaces `?` too.
+
+The store's `hubSupport`/`hubError`/validation warnings surface as the
+same quiet status or alert text as before.
 
 ## Deliberately not here yet
 
-Later phases of the webui-keybindings plan add, and this module already
-leaves room for:
-
-- **A keybinding editor** (Phase 4b) — the store's `patchOverrides` is the
-  write path it will use; the Settings section stays read-only until then.
 - `Binding.when` is still stored verbatim and never evaluated; scope-stack
   membership is the only gating the dispatcher applies.
+- Multi-press (sequence) chords — the default map is single-press
+  throughout and the editor's capture records one press, by design.

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -454,7 +454,10 @@ default.
   wins** — the rule is skipped with a `conflict` warning and its action
   falls back to its own defaults, so every action stays bound. A chord freed
   earlier in the same payload (rebind-away or unbind) can be claimed by a
-  later rule.
+  later rule. The restored set mirrors the character-key pref: while the
+  pref is off the live registry has no `?` binding, so the simulated restore
+  does not claim one either — resetting `cheatsheet.toggle` cannot
+  phantom-conflict with a user chord that overlaps `?`.
 
 ### Apply flow
 
@@ -481,7 +484,9 @@ not the store; the store carries `hubSupport`, `revision`, the validated
 - **Patch** (the editor's write path): sends `expectedRevision` +
   `{version: 1, rules}`; on success the canonical response is applied; on a
   conflict rejection the store refreshes to `data.current`, sets `conflict`
-  and `hubError`, and rethrows.
+  and `hubError`, and rethrows. The store rejects a patch while any refresh
+  is in flight (`hubLoading`): the in-flight payload can land at any
+  revision, and a concurrent PATCH's `expectedRevision` would race it.
 
 ### Failure posture
 

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -514,7 +514,13 @@ not the store; the store carries `hubSupport`, `revision`, the validated
   behind — composing at call time would race the queued-ahead write with a
   stale `expectedRevision` and a payload missing its confirmed change (a
   self-inflicted conflict). A failed write settles the queue entry without
-  blocking the next one.
+  blocking the next one. Each write is also fenced to the ready generation
+  it was CREATED under: the client and epoch are captured at call time, and
+  a queued write whose generation ended while it waited (client replaced,
+  generation bumped) rejects with the same unavailable-class error before
+  any wire request — compose-at-execution is right within one generation,
+  but an edit made against one hub's displayed state must not land on the
+  next hub's config.
 
 ### Failure posture
 

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -312,7 +312,14 @@ Triggers:
   prefs store and the overrides store: an applied override (or unbind)
   owns the action's whole chord set, so `?` never reappears on an
   overridden `cheatsheet.toggle` — the override is the user's own
-  replacement for both triggers.
+  replacement for both triggers. The register path is also
+  overlap-checked: a chord claimed while the pref was off (say
+  `composer.focus` on Shift+?) conflicts with nothing at bind time, so
+  when the pref flips back on the reconcile must NOT register `?` over it
+  — it skips the registration and surfaces a `character-key-conflict`
+  warning naming the holding action in the Settings section's warnings
+  list, and removing the overlap registers `?` on the next reconcile
+  pass.
 - **Close**: Escape (the OverlayPanel's own handler claims it first
   whenever focus is inside the dialog; the scope-gated `cheatsheet.close`
   binding is the window-level backstop) or ⌘/ again.
@@ -552,7 +559,11 @@ the **Character-key shortcuts** Switch row at the top owning the WCAG
   hub round trip that can outlive the box: a click-away cancel mid-save
   bumps a per-capture generation token, and the stale save's resolution
   applies only while its generation is current — it cannot close or
-  repaint a capture the user reopened before it landed.
+  repaint a capture the user reopened before it landed. Editability loss
+  (a disconnect, support loss, hub replacement, or a hub error making the
+  section read-only) cancels an open capture the same way — generation
+  bumped, no focus return — so an interactive box never strands in the
+  read-only listing.
 - **Single-press only.** Capture records one press — no multi-press
   sequences — matching the all-single-press default map (multi-press
   conflict checking is deliberately coarser). Bare-character chords (a

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -403,7 +403,13 @@ it pushes `SETTINGS_SCOPE` and registers `settings.close` in one effect.
 
 Overrides are stored **on the hub**, not in the browser. There is no
 localStorage layer: an unsupported or unreachable hub means built-in
-defaults only, never a local fallback copy.
+defaults only, never a local fallback copy. Live-registry posture follows
+the same claim: when support resolves to **unsupported** (the feature set
+is known and does not advertise keybindings) any applied overrides are
+un-applied through the same atomic unwind the reconcile uses, because the
+settings section tells the user the built-in defaults are in effect. A
+supported hub that is merely **unreachable** (transient disconnect) keeps
+its overrides firing — the rows show them read-only until the hub returns.
 
 ### Server side
 
@@ -525,6 +531,13 @@ the **Character-key shortcuts** Switch row at the top owning the WCAG
   away cancels, whether or not the click target can take focus. The
   capture box preventDefaults and stopPropagations every keydown, so the
   dispatcher and `settings.close`'s own Escape stay inert while capturing.
+  IME composition keydowns are ignored with the dispatcher's own guard
+  (`isComposing` / `keyCode === 229` / `Process` / `Unidentified`), so a
+  composition or its commit Enter can never record or save. A save is a
+  hub round trip that can outlive the box: a click-away cancel mid-save
+  bumps a per-capture generation token, and the stale save's resolution
+  applies only while its generation is current — it cannot close or
+  repaint a capture the user reopened before it landed.
 - **Single-press only.** Capture records one press — no multi-press
   sequences — matching the all-single-press default map (multi-press
   conflict checking is deliberately coarser). Bare-character chords (a

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -407,9 +407,15 @@ defaults only, never a local fallback copy. Live-registry posture follows
 the same claim: when support resolves to **unsupported** (the feature set
 is known and does not advertise keybindings) any applied overrides are
 un-applied through the same atomic unwind the reconcile uses, because the
-settings section tells the user the built-in defaults are in effect. A
-supported hub that is merely **unreachable** (transient disconnect) keeps
-its overrides firing — the rows show them read-only until the hub returns.
+settings section tells the user the built-in defaults are in effect — and
+the hub payload state (`loaded`/`revision`/`overrides`/`rawOverrides`) is
+discarded with them, so a supported reconnect accepts the returning hub's
+revision whatever it is (a restored backup can be LOWER than the old hub's)
+and edits compose from the new payload. Late `changed` notifications and
+in-flight PATCH responses landing during an unsupported window are dropped,
+not applied. A supported hub that is merely **unreachable** (transient
+disconnect) keeps its overrides firing — the rows show them read-only
+until the hub returns.
 
 ### Server side
 
@@ -493,6 +499,15 @@ not the store; the store carries `hubSupport`, `revision`, the validated
   and `hubError`, and rethrows. The store rejects a patch while any refresh
   is in flight (`hubLoading`): the in-flight payload can land at any
   revision, and a concurrent PATCH's `expectedRevision` would race it.
+  Writes also **serialize at the store**: `patchOverrides` calls chain onto
+  a pending-write queue, so at most one PATCH is in flight and each write
+  runs only after the previous one settles. Callers pass a composition
+  THUNK (`() => replacementRules(...)`) so the whole-payload rule set is
+  composed at execution time against the raw set the previous write left
+  behind — composing at call time would race the queued-ahead write with a
+  stale `expectedRevision` and a payload missing its confirmed change (a
+  self-inflicted conflict). A failed write settles the queue entry without
+  blocking the next one.
 
 ### Failure posture
 

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -312,14 +312,20 @@ Triggers:
   prefs store and the overrides store: an applied override (or unbind)
   owns the action's whole chord set, so `?` never reappears on an
   overridden `cheatsheet.toggle` — the override is the user's own
-  replacement for both triggers. The register path is also
-  overlap-checked: a chord claimed while the pref was off (say
-  `composer.focus` on Shift+?) conflicts with nothing at bind time, so
-  when the pref flips back on the reconcile must NOT register `?` over it
-  — it skips the registration and surfaces a `character-key-conflict`
-  warning naming the holding action in the Settings section's warnings
-  list, and removing the overlap registers `?` on the next reconcile
-  pass.
+  replacement for both triggers. A pref flip also RE-VALIDATES the
+  persisted rules (the overrides store's prefs subscription re-applies
+  the raw set): the simulation treats `?` as pref-authoritative — the
+  re-apply runs in the flip instant, before the reconcile has
+  unregistered/re-registered the entry, and must simulate the map the
+  reconcile is about to establish — so a chord claimed while the pref
+  was off (say `composer.focus` on Shift+?) is un-applied by the
+  restore-wins rule with a conflict warning when the pref flips back
+  on, and a rule skipped while the pref was on applies when it flips
+  off. The reconcile's register path is separately overlap-checked as
+  the guard for overlaps validation does not manage (a foreign binding
+  squatting the chord): it skips the registration and surfaces a
+  `character-key-conflict` warning naming the holder in the Settings
+  section's warnings list until the overlap clears.
 - **Close**: Escape (the OverlayPanel's own handler claims it first
   whenever focus is inside the dialog; the scope-gated `cheatsheet.close`
   binding is the window-level backstop) or ⌘/ again.
@@ -587,9 +593,11 @@ the **Character-key shortcuts** Switch row at the top owning the WCAG
   with `expectedRevision` optimistic concurrency (the apply flow above); a
   revision conflict refreshes to the server's current payload.
 - **Unbind / Reset.** "Unbind" (bound actions) writes a `chord: null`
-  rule; "Reset" (actions carrying an override) drops the action from the
-  payload, restoring its defaults through the reconcile's
-  `restoreDefaultBinding`. Failures surface inline under the row.
+  rule; "Reset" (actions carrying a RAW override rule — including a
+  persisted rule validation skips, where dropping it is exactly the
+  meaningful action) drops the action from the payload, restoring its
+  defaults through the reconcile's `restoreDefaultBinding`. Failures
+  surface inline under the row.
 - **cheatsheet.toggle.** The ⌘/ base chord edits like any other. The `?`
   character-key entry renders read-only with a note while it is
   registered: it follows the character-key pref and the


### PR DESCRIPTION
Phase 4b of the WebUI keybinding system, stacked on #871 (Phase 4a). Full stack: #853 survey → #860 dispatcher → #861 persistence → #863 navigation → #871 final map + cheatsheet + hold hints → **this PR: the editor**.

## What ships

**Capture-based binding editor** in Settings → Keybindings (replaces the read-only listing):
- Click a row's chord to enter capture mode — "Press new shortcut…" with live modifier echo; **Enter** saves, **Escape** cancels (capture's Escape wins over the settings pane's close binding; pinned against the real dispatcher).
- **Pre-flight conflict rejection**: an edit that would collide with another binding is rejected *before any hub write*, with an inline message naming the chord, scope, and the holding action. The pre-flight simulation is argument-identical to the reconcile path's own validation call, so the editor never accepts what the hub reconcile would skip.
- **Unbind** and **Reset to default** per action.
- Unsupported hubs keep the read-only listing with the existing status text.
- The cheatsheet row's `?` character-key trigger stays managed by its toggle (read-only note in the editor); the `⌘/` base chord is editable. Capture is single-press only by design (the default map is single-press throughout).
- Folds in the two parked 2b items the editor makes live: patchOverrides pre-flight validation, and symmetric hubError/conflict clearing.

**Docs**: keybindings.md documents the editing workflow, conflict semantics, and reset behavior.

**Also**: a disclosed repair to the 4a-era editor stylesheet for the design-token contract (3 focus-ring lines + one exact-path exception) — surfaced by `make test-web`'s web-lint, which the Task 5 acceptance gate didn't run.

## Verification

- 4581 frontend tests green (272 files), tsc clean, biome clean.
- `make test-web` PASS (web-typecheck, web-test, web-lint), re-verified independently by the controller.
- SDD per-task reviews + final whole-branch review: **Ready**, 0 Critical / 0 Important; 8 deferred minors triaged fine-as-deferred (notables: Reset in a reclaimed-chord state is rejected with a recoverable-but-confusing message; a failed patch surfaces both inline and in the pre-existing top-level error block).

## Notes for reviewers

- Capture mode `preventDefault()`s + `stopPropagation()`s every keydown; the dispatcher listens on window in bubble phase and keydown-only, so captured keys cannot leak to the shell (pinned by a test against the real dispatcher using rail.toggle, which opts out of the defaultPrevented gate).
- Bare-character chords (plain `A`) are authorable and intentionally NOT governed by the character-key toggle (which manages only the built-in `?` trigger); documented.