### PR TITLE
refactor(job_watch): drop watch lineage; a re-created watch starts fresh

### DIFF
--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -163,15 +163,9 @@ type watchKey struct {
 type watchConfig struct {
 	// id is a stable per-session handle for this watch, assigned at install and
 	// preserved across idempotent re-configure; a replacement gets a fresh id.
-	id         string
-	watchID    string
-	configHash string
-	// lineageWatchIDs carries the watchIDs of PREDECESSOR configs replaced in
-	// this slot (same watch key). The runaway fuse counts delivered priors
-	// across the whole lineage so a self-reconfiguring loop cannot reset the
-	// fuse by replacing itself; capped, most-recent kept. In-memory only,
-	// like the volume-budget deliveries counter.
-	lineageWatchIDs    []string
+	id                 string
+	watchID            string
+	configHash         string
 	sourcePublic       string
 	receiverSessionID  string
 	receiverDelegateID string
@@ -753,7 +747,6 @@ func (jm *jobManager) configureWatchWithHooks(a watchArgs, hooks watchConfigureH
 		}
 		jm.recordWatchEndedLocked(key, existing, "replaced")
 		closeWatchConfig(existing)
-		jm.adoptWatchLineageLocked(key, cfg)
 		stop := cfg.initProgressStop()
 		jm.watches[key] = cfg
 		result := watchResultFromConfig(cfg, true)
@@ -794,7 +787,6 @@ func (jm *jobManager) configureWatchWithHooks(a watchArgs, hooks watchConfigureH
 		jm.mu.Unlock()
 		return watchResult{}, err
 	}
-	jm.adoptWatchLineageLocked(key, cfg)
 	stop := cfg.initProgressStop()
 	jm.watches[key] = cfg
 	result := watchResultFromConfig(cfg, false)
@@ -2177,7 +2169,6 @@ func (jm *jobManager) recordWatchEndedLocked(key watchKey, cfg *watchConfig, rea
 	if cfg.receiverDelegateID != "" {
 		sendTo = ""
 	}
-	jm.rememberWatchLineageLocked(key, cfg)
 	jm.watchHistory = append(jm.watchHistory, watchHistoryEntry{
 		id:                 cfg.id,
 		source:             cfg.sourcePublic,
@@ -2690,62 +2681,14 @@ type selfInfluence struct {
 	truncated     bool // self-influenced AND the diagnostic chain was truncated (depth may undercount)
 }
 
-// watchLineageCap bounds how many predecessor watchIDs a config retains: a
-// loop replacing itself thousands of times must not grow the slice or the
-// classify cost unboundedly. Most-recent predecessors are kept — stale ids stop
-// appearing in fresh chains anyway. watchLineageKeyCap bounds how many watch
-// KEYS keep a lineage tombstone after their watch ended.
-const (
-	watchLineageCap    = 15
-	watchLineageKeyCap = 64
-)
-
-// inheritWatchLineage returns the lineage a successor config inherits from the
-// config that ended: the predecessor's lineage plus the predecessor's own
-// watchID, capped to the most recent watchLineageCap entries.
-func inheritWatchLineage(existing *watchConfig) []string {
-	lineage := append(append([]string{}, existing.lineageWatchIDs...), existing.watchID)
-	if len(lineage) > watchLineageCap {
-		lineage = lineage[len(lineage)-watchLineageCap:]
-	}
-	return lineage
-}
-
-// rememberWatchLineageLocked stashes the ended config's lineage under its key
-// so the NEXT install for the same key (recreate after clear/expiry, or the
-// replacement install) adopts it — a self-influenced loop cannot reset the
-// runaway fuse by tearing its watch down and recreating it. Caller holds jm.mu.
-func (jm *jobManager) rememberWatchLineageLocked(key watchKey, cfg *watchConfig) {
-	if jm.watchLineage == nil {
-		jm.watchLineage = make(map[watchKey][]string)
-	}
-	if _, exists := jm.watchLineage[key]; !exists {
-		jm.watchLineageOrder = append(jm.watchLineageOrder, key)
-		if len(jm.watchLineageOrder) > watchLineageKeyCap {
-			evict := jm.watchLineageOrder[0]
-			jm.watchLineageOrder = jm.watchLineageOrder[1:]
-			delete(jm.watchLineage, evict)
-		}
-	}
-	jm.watchLineage[key] = inheritWatchLineage(cfg)
-}
-
-// adoptWatchLineageLocked moves any remembered lineage for key onto a config
-// being installed in that slot. Caller holds jm.mu.
-func (jm *jobManager) adoptWatchLineageLocked(key watchKey, cfg *watchConfig) {
-	if lineage := jm.watchLineage[key]; len(lineage) > 0 {
-		cfg.lineageWatchIDs = lineage
-	}
-}
-
 // classifySelfInfluenceLocked classifies triggering provenance p for watch cfg.
 // gradientDepth is scoped to the CURRENT identity and generation (a genuine
 // re-arm or reconfiguration reads as fresh to the sidecar); fuseDepth is
-// generation-agnostic AND lineage-wide (neither a re-arm-every-delivery watch
-// nor a replace-itself loop can reset the fuse). truncated is the runaway
-// backstop: WatchKeys never truncate so `self` stays reliable, but a truncated
-// Chain can undercount the depths. Caller holds jm.mu (reads the delivered set
-// via watchSendDeliveredLocked).
+// generation-agnostic (a re-arm-every-delivery watch cannot reset the fuse)
+// but scoped to the current watchID, so a re-created watch starts fresh.
+// truncated is the runaway backstop: WatchKeys never truncate so `self` stays
+// reliable, but a truncated Chain can undercount the depths. Caller holds
+// jm.mu (reads the delivered set via watchSendDeliveredLocked).
 func (jm *jobManager) classifySelfInfluenceLocked(cfg *watchConfig, p *provenance.Causal) selfInfluence {
 	self := provenance.ContainsWatch(p, cfg.watchID, cfg.generation)
 	return selfInfluence{
@@ -2757,14 +2700,9 @@ func (jm *jobManager) classifySelfInfluenceLocked(cfg *watchConfig, p *provenanc
 }
 
 // fuseDepthLocked is the runaway fuse's read of provenance p for cfg: delivered
-// priors of the current identity plus every lineage predecessor (distinct
-// watchIDs mark disjoint chain hops, so per-id depths sum). Caller holds jm.mu.
+// priors of the current identity across every generation. Caller holds jm.mu.
 func (jm *jobManager) fuseDepthLocked(cfg *watchConfig, p *provenance.Causal) int {
-	depth := provenance.SelfInfluenceDepth(p, cfg.watchID, "", jm.watchSendDeliveredLocked)
-	for _, id := range cfg.lineageWatchIDs {
-		depth += provenance.SelfInfluenceDepth(p, id, "", jm.watchSendDeliveredLocked)
-	}
-	return depth
+	return provenance.SelfInfluenceDepth(p, cfg.watchID, "", jm.watchSendDeliveredLocked)
 }
 
 // selfInfluenceNotice is the breaker's worker-facing line for a self-influenced

--- a/agent/job_watch_breaker_test.go
+++ b/agent/job_watch_breaker_test.go
@@ -378,26 +378,30 @@ func TestRecordWatchSendRunawayFuseSeesCoalescedDepth(t *testing.T) {
 // delivered priors of the CURRENT identity, never the predecessor's.
 func TestClassifySelfInfluenceRecreatedWatchStartsFresh(t *testing.T) {
 	t.Parallel()
-	args := watchArgs{
-		Target: "caller",
-		Events: []string{"job.notification"},
-		Send:   &watchSendArgs{To: runtimeMessageAliasCaller, Message: "v1"},
+	// Built fresh per call: configureWatch writes through args.Send, and the
+	// subtests run in parallel.
+	newArgs := func() watchArgs {
+		return watchArgs{
+			Target: "caller",
+			Events: []string{"job.notification"},
+			Send:   &watchSendArgs{To: runtimeMessageAliasCaller, Message: "v1"},
+		}
 	}
 	recreates := map[string]func(t *testing.T, jm *jobManager){
 		"replaced": func(t *testing.T, jm *jobManager) {
-			replaced := args
-			replaced.Send = &watchSendArgs{To: runtimeMessageAliasCaller, Message: "v2 changed"}
+			replaced := newArgs()
+			replaced.Send.Message = "v2 changed"
 			if _, err := jm.configureWatch(replaced); err != nil {
 				t.Fatalf("configure v2 (replace): %v", err)
 			}
 		},
 		"cleared and recreated": func(t *testing.T, jm *jobManager) {
-			clearArgs := args
+			clearArgs := newArgs()
 			clearArgs.Clear = true
 			if _, err := jm.configureWatch(clearArgs); err != nil {
 				t.Fatalf("clear: %v", err)
 			}
-			if _, err := jm.configureWatch(args); err != nil {
+			if _, err := jm.configureWatch(newArgs()); err != nil {
 				t.Fatalf("recreate: %v", err)
 			}
 		},
@@ -406,7 +410,7 @@ func TestClassifySelfInfluenceRecreatedWatchStartsFresh(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			jm := newTestJM(t)
-			if _, err := jm.configureWatch(args); err != nil {
+			if _, err := jm.configureWatch(newArgs()); err != nil {
 				t.Fatalf("configure v1: %v", err)
 			}
 			oldCfg := onlyWatchConfigForTest(t, jm)

--- a/agent/job_watch_breaker_test.go
+++ b/agent/job_watch_breaker_test.go
@@ -372,104 +372,77 @@ func TestRecordWatchSendRunawayFuseSeesCoalescedDepth(t *testing.T) {
 	}
 }
 
-// TestClassifySelfInfluenceCountsReplacedLineage: replacing a watch (same key,
-// changed config) mints a fresh watchID — the fuse must not reset. The new
-// config inherits the predecessor's watchID lineage, and fuseDepth counts
-// delivered priors across the whole lineage; gradientDepth stays scoped to the
-// CURRENT identity (a genuine reconfiguration reads fresh to the sidecar).
-func TestClassifySelfInfluenceCountsReplacedLineage(t *testing.T) {
+// TestClassifySelfInfluenceRecreatedWatchStartsFresh: a watch re-created on
+// the same key (replaced with a changed config, or cleared and configured
+// again) mints a fresh watchID and starts fresh — fuseDepth counts only the
+// delivered priors of the CURRENT identity, never the predecessor's.
+func TestClassifySelfInfluenceRecreatedWatchStartsFresh(t *testing.T) {
 	t.Parallel()
-	jm := newTestJM(t)
-	if _, err := jm.configureWatch(watchArgs{
-		Target: "caller",
-		Events: []string{"job.notification"},
-		Send:   &watchSendArgs{To: runtimeMessageAliasCaller, Message: "v1"},
-	}); err != nil {
-		t.Fatalf("configure v1: %v", err)
-	}
-	oldCfg := onlyWatchConfigForTest(t, jm)
-	oldID, oldGen := oldCfg.watchID, oldCfg.generation
-
-	// Replace: same key (target+send target), changed config.
-	if _, err := jm.configureWatch(watchArgs{
-		Target: "caller",
-		Events: []string{"job.notification"},
-		Send:   &watchSendArgs{To: runtimeMessageAliasCaller, Message: "v2 changed"},
-	}); err != nil {
-		t.Fatalf("configure v2 (replace): %v", err)
-	}
-	cfg := onlyWatchConfigForTest(t, jm)
-	if cfg.watchID == oldID {
-		t.Fatal("test premise broken: replacement did not mint a fresh watchID")
-	}
-
-	// An event descending from delivered priors of the OLD identity.
-	p := &provenance.Causal{
-		WatchKeys: []provenance.WatchKey{{WatchID: oldID, WatchGeneration: oldGen}},
-		Chain: []provenance.Entry{
-			{Kind: "watch", WatchID: oldID, WatchGeneration: oldGen, DeliveryID: "wd_old1"},
-			{Kind: "watch", WatchID: oldID, WatchGeneration: oldGen, DeliveryID: "wd_old2"},
-		},
-	}
-	jm.mu.Lock()
-	jm.deliveredWatchSendIDs["wd_old1"] = struct{}{}
-	jm.deliveredWatchSendIDs["wd_old2"] = struct{}{}
-	got := jm.classifySelfInfluenceLocked(cfg, p)
-	jm.mu.Unlock()
-
-	if got.fuseDepth != 2 {
-		t.Fatalf("fuseDepth = %d, want 2 (replaced-lineage priors count toward the fuse)", got.fuseDepth)
-	}
-	if got.gradientDepth != 0 {
-		t.Fatalf("gradientDepth = %d, want 0 (gradient stays scoped to the current identity)", got.gradientDepth)
-	}
-}
-
-// TestClassifySelfInfluenceCountsClearedLineage: clearing a watch and
-// recreating the same key must not reset the fuse either — the lineage
-// survives as a bounded tombstone keyed by the watch key and is adopted by
-// the next install.
-func TestClassifySelfInfluenceCountsClearedLineage(t *testing.T) {
-	t.Parallel()
-	jm := newTestJM(t)
 	args := watchArgs{
 		Target: "caller",
 		Events: []string{"job.notification"},
-		Send:   &watchSendArgs{To: runtimeMessageAliasCaller, Message: "observe"},
+		Send:   &watchSendArgs{To: runtimeMessageAliasCaller, Message: "v1"},
 	}
-	if _, err := jm.configureWatch(args); err != nil {
-		t.Fatalf("configure: %v", err)
-	}
-	oldCfg := onlyWatchConfigForTest(t, jm)
-	oldID, oldGen := oldCfg.watchID, oldCfg.generation
-
-	clearArgs := args
-	clearArgs.Clear = true
-	if _, err := jm.configureWatch(clearArgs); err != nil {
-		t.Fatalf("clear: %v", err)
-	}
-	if _, err := jm.configureWatch(args); err != nil {
-		t.Fatalf("recreate: %v", err)
-	}
-	cfg := onlyWatchConfigForTest(t, jm)
-	if cfg.watchID == oldID {
-		t.Fatal("test premise broken: recreate did not mint a fresh watchID")
-	}
-
-	p := &provenance.Causal{
-		WatchKeys: []provenance.WatchKey{{WatchID: oldID, WatchGeneration: oldGen}},
-		Chain: []provenance.Entry{
-			{Kind: "watch", WatchID: oldID, WatchGeneration: oldGen, DeliveryID: "wd_c1"},
-			{Kind: "watch", WatchID: oldID, WatchGeneration: oldGen, DeliveryID: "wd_c2"},
+	recreates := map[string]func(t *testing.T, jm *jobManager){
+		"replaced": func(t *testing.T, jm *jobManager) {
+			replaced := args
+			replaced.Send = &watchSendArgs{To: runtimeMessageAliasCaller, Message: "v2 changed"}
+			if _, err := jm.configureWatch(replaced); err != nil {
+				t.Fatalf("configure v2 (replace): %v", err)
+			}
+		},
+		"cleared and recreated": func(t *testing.T, jm *jobManager) {
+			clearArgs := args
+			clearArgs.Clear = true
+			if _, err := jm.configureWatch(clearArgs); err != nil {
+				t.Fatalf("clear: %v", err)
+			}
+			if _, err := jm.configureWatch(args); err != nil {
+				t.Fatalf("recreate: %v", err)
+			}
 		},
 	}
-	jm.mu.Lock()
-	jm.deliveredWatchSendIDs["wd_c1"] = struct{}{}
-	jm.deliveredWatchSendIDs["wd_c2"] = struct{}{}
-	got := jm.classifySelfInfluenceLocked(cfg, p)
-	jm.mu.Unlock()
+	for name, recreate := range recreates {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			jm := newTestJM(t)
+			if _, err := jm.configureWatch(args); err != nil {
+				t.Fatalf("configure v1: %v", err)
+			}
+			oldCfg := onlyWatchConfigForTest(t, jm)
+			oldID, oldGen := oldCfg.watchID, oldCfg.generation
+			recreate(t, jm)
+			cfg := onlyWatchConfigForTest(t, jm)
+			if cfg.watchID == oldID {
+				t.Fatal("test premise broken: re-create did not mint a fresh watchID")
+			}
 
-	if got.fuseDepth != 2 {
-		t.Fatalf("fuseDepth = %d, want 2 (cleared-lineage priors count toward the fuse)", got.fuseDepth)
+			// An event descending from two delivered priors of the OLD identity
+			// and one delivered prior of the re-created watch.
+			p := &provenance.Causal{
+				WatchKeys: []provenance.WatchKey{
+					{WatchID: oldID, WatchGeneration: oldGen},
+					{WatchID: cfg.watchID, WatchGeneration: cfg.generation},
+				},
+				Chain: []provenance.Entry{
+					{Kind: "watch", WatchID: oldID, WatchGeneration: oldGen, DeliveryID: "wd_old1"},
+					{Kind: "watch", WatchID: oldID, WatchGeneration: oldGen, DeliveryID: "wd_old2"},
+					{Kind: "watch", WatchID: cfg.watchID, WatchGeneration: cfg.generation, DeliveryID: "wd_new1"},
+				},
+			}
+			jm.mu.Lock()
+			for _, id := range []string{"wd_old1", "wd_old2", "wd_new1"} {
+				jm.deliveredWatchSendIDs[id] = struct{}{}
+			}
+			got := jm.classifySelfInfluenceLocked(cfg, p)
+			jm.mu.Unlock()
+
+			if got.fuseDepth != 1 {
+				t.Fatalf("fuseDepth = %d, want 1 (only the re-created watch's own delivered priors count)", got.fuseDepth)
+			}
+			if got.gradientDepth != 1 {
+				t.Fatalf("gradientDepth = %d, want 1 (gradient stays scoped to the current identity)", got.gradientDepth)
+			}
+		})
 	}
 }

--- a/agent/job_watch_cov_test.go
+++ b/agent/job_watch_cov_test.go
@@ -232,44 +232,6 @@ func TestLiveWatchSummariesForReceiver(t *testing.T) {
 	}
 }
 
-// TestRememberWatchLineageEviction covers the eviction branch of
-// rememberWatchLineageLocked (job_watch.go:2352-2356) which fires when the
-// lineage key order exceeds watchLineageKeyCap (64).
-func TestRememberWatchLineageEviction(t *testing.T) {
-	t.Parallel()
-	jm := newTestJM(t)
-
-	// Fill the lineage beyond the cap to trigger eviction.
-	for i := range watchLineageKeyCap + 2 {
-		key := watchKey{
-			VisibleSessionID: jm.sessionID,
-			Target:           "job_evict_" + string(rune('a'+i%26)) + string(rune('a'+i/26)),
-			SendTo:           runtimeMessageAliasCaller,
-		}
-		cfg, err := newWatchConfig(watchArgs{
-			Target: key.Target,
-			Events: []string{"assistant.tool"},
-			Send:   &watchSendArgs{To: runtimeMessageAliasCaller, Message: "m"},
-		}, jm.now(), "")
-		if err != nil {
-			t.Fatalf("newWatchConfig: %v", err)
-		}
-		jm.mu.Lock()
-		jm.rememberWatchLineageLocked(key, cfg)
-		jm.mu.Unlock()
-	}
-
-	jm.mu.Lock()
-	defer jm.mu.Unlock()
-	if len(jm.watchLineageOrder) > watchLineageKeyCap {
-		t.Fatalf("lineage order = %d, want <= %d", len(jm.watchLineageOrder), watchLineageKeyCap)
-	}
-	// The first two keys should have been evicted.
-	if len(jm.watchLineage) != len(jm.watchLineageOrder) {
-		t.Fatalf("lineage map size %d != order size %d", len(jm.watchLineage), len(jm.watchLineageOrder))
-	}
-}
-
 // TestClearReceiverWatchByIDTerminalFlushLookup covers the terminalFlush
 // lookup branch in clearReceiverWatchByID (job_watch.go:1442-1448) which
 // finds a watch config in the terminalFlush set when it's not in jm.watches.

--- a/agent/job_watch_events_output_fuzz_test.go
+++ b/agent/job_watch_events_output_fuzz_test.go
@@ -15,12 +15,12 @@ import (
 	"primeradiant.com/evener/agent/internal/jobstore"
 )
 
-// FuzzJobWatchEventsOutput exercises the event, lineage, output, terminal
+// FuzzJobWatchEventsOutput exercises the event, output, terminal
 // catch-up, and progress-timer rails against a real manager and store. The byte
 // selects a deterministic scenario; the seeds keep every edge in the default
 // fuzz corpus.
 func FuzzJobWatchEventsOutput(f *testing.F) {
-	for scenario := uint8(0); scenario < 24; scenario++ {
+	for scenario := uint8(0); scenario < 21; scenario++ {
 		f.Add(scenario)
 	}
 	f.Fuzz(func(t *testing.T, scenario uint8) {
@@ -30,7 +30,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			_ = jm.close()
 		})
 
-		switch scenario % 24 {
+		switch scenario % 21 {
 		case 0:
 			dec := evaluateWatchEvent(watchEventSnapshot{
 				target: runtimeMessageAliasCaller, targetActive: true,
@@ -41,29 +41,8 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 				t.Fatalf("send-to-watched session decision = %+v", dec)
 			}
 		case 1:
-			cfg := &watchConfig{watchID: "latest"}
-			for i := 0; i <= watchLineageCap; i++ {
-				cfg.lineageWatchIDs = append(cfg.lineageWatchIDs, string(rune('a'+i)))
-			}
-			if got := inheritWatchLineage(cfg); len(got) != watchLineageCap || got[len(got)-1] != "latest" {
-				t.Fatalf("capped lineage = %#v", got)
-			}
-		case 2:
-			jm.watchLineage = nil
-			jm.rememberWatchLineageLocked(watchKey{Target: "job_a"}, &watchConfig{watchID: "w"})
-			if jm.watchLineage == nil {
-				t.Fatal("lineage map not initialized")
-			}
-		case 3:
-			for i := 0; i <= watchLineageKeyCap; i++ {
-				jm.rememberWatchLineageLocked(watchKey{Target: "job_" + string(rune(i+1))}, &watchConfig{watchID: "w"})
-			}
-			if len(jm.watchLineageOrder) != watchLineageKeyCap {
-				t.Fatalf("lineage order length = %d", len(jm.watchLineageOrder))
-			}
-		case 4:
 			jm.feedJobOutput("missing", nil, 0)
-		case 5:
+		case 2:
 			rec := createWatchOutputJob(t, jm)
 			cfg, err := newWatchConfig(watchArgs{Target: rec.JobID, OutputMatch: "hit"}, jm.now(), "")
 			if err != nil {
@@ -73,7 +52,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			cfg.conditionFires = watchDeliveryBudget - 1 // the next fire crosses the budget
 			jm.watches[watchKey{Target: rec.JobID}] = cfg
 			jm.feedJobOutput(rec.JobID, []byte("hit\n"), 4)
-		case 6:
+		case 3:
 			rec := createWatchOutputJob(t, jm)
 			cfg, err := newWatchConfig(watchArgs{Target: rec.JobID, OutputMatch: "hit"}, jm.now(), "")
 			if err != nil {
@@ -88,7 +67,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if gotErr == nil {
 				t.Fatal("missing output did not fail attach preparation")
 			}
-		case 7:
+		case 4:
 			cfg, err := newWatchConfig(watchArgs{Target: "job_x", OutputMatch: "hit"}, jm.now(), "")
 			if err != nil {
 				t.Fatal(err)
@@ -96,7 +75,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if jm.completeAttachScan(cfg, "job_x", nil, true, errors.New("read failed")) {
 				t.Fatal("failed attach preparation fired")
 			}
-		case 8:
+		case 5:
 			cfg, err := newWatchConfig(watchArgs{Target: "job_x", OutputMatch: "hit"}, jm.now(), "")
 			if err != nil {
 				t.Fatal(err)
@@ -107,17 +86,17 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if !jm.fireAttachScan(cfg, "job_x", []byte("hit\n")) {
 				t.Fatal("attach scan did not fire")
 			}
-		case 9:
+		case 6:
 			_, err := jm.runTerminalCatchup(watchArgs{Target: "job_x", OutputMatch: "["}, watchKey{Target: "job_x"}, jobstore.StatusCompleted)
 			if err == nil {
 				t.Fatal("invalid terminal regexp accepted")
 			}
-		case 10:
+		case 7:
 			_, err := jm.runTerminalCatchup(watchArgs{Target: "job_missing", OutputMatch: "hit"}, watchKey{Target: "job_missing"}, jobstore.StatusCompleted)
 			if err == nil {
 				t.Fatal("missing terminal output accepted")
 			}
-		case 11:
+		case 8:
 			key := watchKey{Target: "job_x"}
 			cfg := &watchConfig{target: "job_x"}
 			jm.watches[key] = &watchConfig{}
@@ -125,11 +104,11 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if jm.watches[key] == nil {
 				t.Fatal("replacement watch removed")
 			}
-		case 12:
+		case 9:
 			if dec := decideProgressTick(progressTickSnapshot{stillRegistered: true, target: "job_gone"}); dec.keepAlive {
 				t.Fatalf("dead concrete target kept progress timer alive: %+v", dec)
 			}
-		case 13:
+		case 10:
 			filter := &watchEventFilter{ToolName: "wanted", Status: "error"}
 			cases := []events.SessionEvent{
 				{Kind: events.EventError},
@@ -141,7 +120,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			for _, ev := range cases {
 				_ = watchEventFilterMatches(filter, ev)
 			}
-		case 14:
+		case 11:
 			for _, data := range []events.EventData{
 				events.JobStartedData{JobID: "job_started"},
 				events.JobFinishedData{JobID: "job_finished"},
@@ -153,7 +132,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if got := watchEventWatchedIdentity("job_concrete", events.ErrorData{}); got != "job_concrete" {
 				t.Fatal(got)
 			}
-		case 15:
+		case 12:
 			snap := watchEventSnapshot{target: "*", targetActive: true, eventKinds: map[events.EventKind]bool{events.EventError: true}, triggerKind: events.EventError, triggerEvery: 2}
 			if dec := evaluateWatchEvent(snap, events.SessionEvent{Kind: events.EventError}); dec.matched || dec.eventCount != 1 {
 				t.Fatalf("throttled decision = %+v", dec)
@@ -162,7 +141,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if dec := evaluateWatchEvent(snap, events.SessionEvent{Kind: events.EventError}); !dec.matched || dec.notifyJobID != "" {
 				t.Fatalf("session notify decision = %+v", dec)
 			}
-		case 16:
+		case 13:
 			cfg, err := newWatchConfig(watchArgs{Target: "*", Events: []string{"communicate"}}, jm.now(), "")
 			if err != nil {
 				t.Fatal(err)
@@ -171,10 +150,10 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			cfg.conditionFires = watchDeliveryBudget - 1 // the next fire crosses the budget
 			jm.watches[watchKey{Target: "*"}] = cfg
 			jm.onSessionEvent(events.SessionEvent{Kind: events.EventCommunicate})
-		case 17:
+		case 14:
 			jm.feedJobOutput("job_x", []byte("later"), 10)
 			jm.feedJobOutput("job_x", []byte("earlier"), 5)
-		case 18:
+		case 15:
 			cfg, err := newWatchConfig(watchArgs{Target: "job_x", OutputMatch: "hit"}, jm.now(), "")
 			if err != nil {
 				t.Fatal(err)
@@ -188,13 +167,13 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if scan || prepErr == nil || !strings.Contains(prepErr.Error(), "no readable output store") {
 				t.Fatalf("output-less run scan=%v err=%v", scan, prepErr)
 			}
-		case 19:
+		case 16:
 			rec := createWatchOutputJob(t, jm)
 			res, err := jm.runTerminalCatchup(watchArgs{Target: rec.JobID, OutputMatch: "absent"}, watchKey{Target: rec.JobID}, jobstore.StatusCompleted)
 			if err != nil || res.Fired {
 				t.Fatalf("unmatched catchup = %+v, %v", res, err)
 			}
-		case 20:
+		case 17:
 			key := watchKey{Target: "job_x", SendTo: "dlg_x"}
 			cfg, err := newWatchConfig(watchArgs{Target: "job_x", OutputMatch: "hit", Send: &watchSendArgs{To: "dlg_x"}}, jm.now(), "")
 			if err != nil {
@@ -206,7 +185,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if len(deliveries) != 1 {
 				t.Fatalf("terminal flush deliveries = %d", len(deliveries))
 			}
-		case 21:
+		case 18:
 			key := watchKey{Target: "job_x", SendTo: "dlg_x"}
 			cfg := &watchConfig{target: "job_x", watchID: "w", generation: "g", pending: map[jobstore.WatchSendKey]*jobstore.WatchSendState{{}: {}}}
 			jm.watches[key] = cfg
@@ -214,7 +193,7 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 			if !jm.terminalFlush[cfg] {
 				t.Fatal("pending watch not detached")
 			}
-		case 22:
+		case 19:
 			clk := agenttest.NewFakeClockAt(time.Unix(1000, 0).UTC())
 			jm.clock = clk
 			fired := make(chan struct{}, 1)
@@ -252,8 +231,8 @@ func FuzzJobWatchEventsOutput(f *testing.F) {
 				t.Fatal("inactive progress watch stayed alive")
 			}
 			close(stop)
-		case 23:
-			// The send twin of case 8. The attach scan's send rail counts its
+		case 20:
+			// The send twin of case 5. The attach scan's send rail counts its
 			// fire at the match and its delivery only when the frame settles,
 			// which nothing here drains, so the breaker has to latch at the
 			// match or the watch matches without bound.

--- a/agent/jobs.go
+++ b/agent/jobs.go
@@ -100,13 +100,6 @@ type jobManager struct {
 	// self-influence depth metric consults so a coalesced-away (never delivered)
 	// predecessor cannot inflate depth. Guarded by jm.mu.
 	deliveredWatchSendIDs map[string]struct{}
-	// watchLineage remembers, per watch key, the watchID lineage of configs
-	// that ENDED in that slot (cleared/replaced/expired) so the next install
-	// for the same key inherits it and a clear-and-recreate loop cannot reset
-	// the runaway fuse. Bounded (watchLineageKeyCap keys, oldest evicted);
-	// in-memory like the volume-budget counter. Guarded by jm.mu.
-	watchLineage      map[watchKey][]string
-	watchLineageOrder []watchKey
 	// watchesLostAtRestore holds the durable records of the watches this restore
 	// ended (clearUnrestoredActiveWatches), owed a callback-cancellation or send
 	// end notice by noticeUnrestoredWatchEnds. Written once at construction, read
@@ -633,7 +626,6 @@ func newJobManagerWithRestore(stateDir, sessionID string, enqueue func(jobNotifi
 		watches:               make(map[watchKey]*watchConfig),
 		lastFedOffset:         make(map[string]int64),
 		deliveredWatchSendIDs: make(map[string]struct{}),
-		watchLineage:          make(map[watchKey][]string),
 		appendEvent:           store.Append,
 		appendEvents:          store.AppendBatch,
 		createOutput:          createOutput,

--- a/agent/watch_pure_covtest_test.go
+++ b/agent/watch_pure_covtest_test.go
@@ -553,38 +553,6 @@ func TestCovLimitWatchText(t *testing.T) {
 	}
 }
 
-// TestCovInheritWatchLineage covers inheritWatchLineage (job_watch.go lines 2334-2340).
-func TestCovInheritWatchLineage(t *testing.T) {
-	// No existing lineage.
-	cfg := &watchConfig{watchID: "w3"}
-	got := inheritWatchLineage(cfg)
-	if len(got) != 1 || got[0] != "w3" {
-		t.Fatalf("no lineage = %v", got)
-	}
-
-	// With existing lineage.
-	cfg = &watchConfig{watchID: "w3", lineageWatchIDs: []string{"w1", "w2"}}
-	got = inheritWatchLineage(cfg)
-	if len(got) != 3 || got[0] != "w1" || got[1] != "w2" || got[2] != "w3" {
-		t.Fatalf("with lineage = %v", got)
-	}
-
-	// Over cap → trimmed.
-	long := make([]string, watchLineageCap+5)
-	for i := range long {
-		long[i] = "w" + string(rune('a'+i))
-	}
-	cfg = &watchConfig{watchID: "w_new", lineageWatchIDs: long}
-	got = inheritWatchLineage(cfg)
-	if len(got) != watchLineageCap {
-		t.Fatalf("over cap = %d, want exactly %d", len(got), watchLineageCap)
-	}
-	want := append(append([]string{}, long[len(long)-watchLineageCap+1:]...), "w_new")
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("retained lineage = %v, want most-recent lineage %v", got, want)
-	}
-}
-
 // TestCovWatchFrameJob covers watchFrameJob (job_watch.go lines 3247-3259).
 func TestCovWatchFrameJob(t *testing.T) {
 	// JobFinishedData value.

--- a/docs/superpowers/specs/2026-09-02-job-watch-timer-design.md
+++ b/docs/superpowers/specs/2026-09-02-job-watch-timer-design.md
@@ -214,7 +214,7 @@ burned on a clear or a rejected create.
   `configureWatch` under `jm.mu`. The ninth is `invalid_request: too many
   timers (8 live); clear one first`.
 - `watchArgsHasCondition` counts both time fields as conditions.
-- Timer ends enter watch history and lineage like any other watch.
+- Timer ends enter watch history like any other watch.
 - The clear contract is unchanged: clearing an inactive or unknown id is
   the existing no-op success.
 


### PR DESCRIPTION
## What the mechanism was

`watchConfig.lineageWatchIDs` carried the watch ids of predecessor configs replaced in the same slot (same watch key). `inheritWatchLineage` built the successor's list (capped at `watchLineageCap = 15`); `rememberWatchLineageLocked` stashed an ended config's lineage under its key in `jm.watchLineage`, a FIFO of `watchLineageKeyCap = 64` keys; `adoptWatchLineageLocked` handed it to the next config installed on the same key; and `fuseDepthLocked` summed delivered priors across the whole lineage for the runaway fuse (`selfInfluence.fuseDepth`).

## Where it came from

Added 2026-07-02 in the reland review round 3 (commit 910ff8925, "lineage-proof fuse") against a hypothesized loop where a self-influenced watch resets its fuse by replacing or clear-and-recreating itself. That loop was never observed.

## Why it goes

- The per-generation 50-condition-fire budget and the turn cost of each re-create already bound the hypothesized loop; the lineage added a second, in-memory-only guard for the same thing.
- The 64-key ring evicted real entries under timer churn (every timer create is its own key), so the guard was unreliable exactly where it was most exercised.
- Jesse's ruling: overbuilding. A re-created watch starts fresh.

## What stays

- The runaway fuse: `fuseDepthLocked` still counts delivered priors of the current config, across every generation, from provenance. `gradientDepth` and the rest of the self-influence classification are untouched.
- The 50-condition-fire budget per generation.

## Changes

- `agent/job_watch.go`: field, four functions, two caps, both `adopt` call sites and the `remember` call site removed; `fuseDepthLocked` reads only the current watch id; comments updated.
- `agent/jobs.go`: `watchLineage` map and `watchLineageOrder` removed from `jobManager` and its constructor.
- Tests: `TestClassifySelfInfluenceCountsReplacedLineage` and `TestClassifySelfInfluenceCountsClearedLineage` replaced by `TestClassifySelfInfluenceRecreatedWatchStartsFresh` (replaced / cleared-and-recreated subtests; failed first with fuseDepth = 3, want 1). `TestCovInheritWatchLineage`, `TestRememberWatchLineageEviction`, and `FuzzJobWatchEventsOutput` scenarios 1-3 (lineage oracles) dropped, remaining scenarios renumbered.
- Docs: timer spec no longer says timer ends enter lineage.

7 files changed, 98 insertions(+), 286 deletions(-); net -188 lines.

## Gates

gofmt, `go vet` (plain and `-tags evenerfuzz`), golangci-lint (0 issues), `go test ./agent/ -run 'Watch|Fuse|SelfInfluence|Seqfuzz|seqfuzz|Lineage'`, `go test ./agent/provenance/...`, `go test -race ./agent/ -run 'Watch|Fuse'`, evenerfuzz compile plus the full agent-module seed replay, and `go test ./agent/ -count=1 -timeout 30m` (464s) all pass.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
