### PR TITLE
fix(llm): support GPT-6 Astra over Codex OAuth

### DIFF
--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -124,7 +124,7 @@ provider glob beats an upstream row fact, and a user-layer instance-wide
 
 The live layer sits between the curated overlay and the user config. It
 establishes existence for models the catalog lacks and supplies `Tools`,
-`InputModalities`, `ContextWindow`, `MaxOutputTokens`, `EffortValues`,
+`InputModalities`, `ContextWindow`, `MaxOutputTokens`, `EffortValues`, `DefaultEffort`,
 `Cost`, `Reasoning`, plus `ThinkingAlwaysOn` (only when OpenRouter's
 `reasoning.mandatory` is `true`). It overrides catalog and curated facts but
 **never a field the user layer (layer 4) set**, and it never touches any
@@ -512,6 +512,24 @@ transport with behavior beyond authentication:
 - the backend enforces a model allowlist: an unknown id is a resolve error,
   not a synthesized row (the exception in [Unknown models](#unknown-models)
   above).
+
+`openai-codex/gpt-6-astra` is available in the curated catalog, including on
+named instances with `base = "openai-codex"`; discovery is not required to
+select it. Its subscription context defaults to 272,000 tokens. Live discovery
+can override that value and the default reasoning effort; the public API's
+larger context window is not the subscription default.
+
+Astra uses Responses Lite: the routing header is set, tools and instructions
+are sent as developer input items, and `reasoning.context = "all_turns"`
+preserves reasoning across tool turns. Images use `detail = "original"`.
+`parallel_tool_calls` is false on this route. These settings follow the
+[Codex request builder](https://github.com/openai/codex/blob/459a79eb85400af759e9220c7bafb4429ae07516/codex-rs/core/src/client.rs#L907).
+
+The selectable reasoning efforts are `low`, `medium`, `high`, `xhigh`, and
+`max`; reasoning cannot be disabled. Codex discovery also advertises `ultra`,
+but Evener omits it: it is a
+[Codex delegation preset](https://github.com/openai/codex/blob/459a79eb85400af759e9220c7bafb4429ae07516/codex-rs/core/src/client.rs#L186),
+not an API effort. Astra does not change the instance's default or cheap model.
 
 ## The fields denylist and `evener models inspect`
 

--- a/llm/providers/responses/models.go
+++ b/llm/providers/responses/models.go
@@ -94,7 +94,7 @@ func (m codexModelListEntry) row() registry.Model {
 	}
 	// The Codex backend is the only listing that states the effort a model
 	// runs at when the request omits one (spec §7.4).
-	if d := strings.TrimSpace(m.DefaultReasoningLevel); d != "" {
+	if d := strings.TrimSpace(m.DefaultReasoningLevel); d != "" && !strings.EqualFold(d, "ultra") {
 		caps.DefaultEffort = new(d)
 	}
 	if len(m.InputModalities) > 0 {
@@ -104,7 +104,8 @@ func (m codexModelListEntry) row() registry.Model {
 }
 
 // codexReasoningEfforts dedupes and trims a Codex row's reasoning-level
-// list into the effort names it advertises.
+// list into API effort names. Ultra is a Codex client delegation preset,
+// not an effort the Responses API accepts.
 func codexReasoningEfforts(levels []codexReasoningLevel) []string {
 	if len(levels) == 0 {
 		return nil
@@ -113,7 +114,7 @@ func codexReasoningEfforts(levels []codexReasoningLevel) []string {
 	seen := make(map[string]bool, len(levels))
 	for _, level := range levels {
 		effort := strings.TrimSpace(level.Effort)
-		if effort == "" || seen[effort] {
+		if effort == "" || strings.EqualFold(effort, "ultra") || seen[effort] {
 			continue
 		}
 		seen[effort] = true

--- a/llm/providers/responses/models_test.go
+++ b/llm/providers/responses/models_test.go
@@ -3,11 +3,40 @@ package responses
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"primeradiant.com/evener/llm"
 	"primeradiant.com/evener/llm/registry"
 )
+
+// Codex advertises ultra alongside API efforts, but it is a client-side
+// delegation preset. Evener must offer only the actual reasoning efforts.
+func TestListModelsCodexOmitsDelegationPreset(t *testing.T) {
+	for _, defaultEffort := range []string{"medium", "ultra"} {
+		t.Run(defaultEffort, func(t *testing.T) {
+			srv, _ := server(t, 200, `{"models":[{"slug":"gpt-6-astra","context_window":272000,"max_context_window":872000,"supported_reasoning_levels":[{"effort":"low"},{"effort":"medium"},{"effort":"high"},{"effort":"xhigh"},{"effort":"max"},{"effort":"ultra"}],"default_reasoning_level":"`+defaultEffort+`"}]}`)
+			rows, err := (&Protocol{Client: srv.Client()}).ListModels(context.Background(), liveRes(srv, nil))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(rows) != 1 || rows[0].ID != "gpt-6-astra" {
+				t.Fatalf("rows = %+v", rows)
+			}
+			caps := rows[0].Caps
+			if !slices.Equal(caps.EffortValues, []string{"low", "medium", "high", "xhigh", "max"}) {
+				t.Fatalf("selectable efforts = %v", caps.EffortValues)
+			}
+			wantDefault := defaultEffort
+			if defaultEffort == "ultra" {
+				wantDefault = ""
+			}
+			if registry.StringValue(caps.DefaultEffort) != wantDefault || caps.ContextWindow == nil || *caps.ContextWindow != 272000 {
+				t.Fatalf("model facts = %+v", caps)
+			}
+		})
+	}
+}
 
 func TestListModelsPlatformAndCodexShapes(t *testing.T) {
 	srv, got := server(t, 200, `{"data":[{"id":"gpt-5.5","context_window":1050000,"max_input_tokens":922000,"max_output_tokens":128000},{"id":"text-embedding-3-large"}]}`)

--- a/llm/providers/wirecapture/astra_test.go
+++ b/llm/providers/wirecapture/astra_test.go
@@ -1,0 +1,51 @@
+package wirecapture
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/llm"
+)
+
+// A catalog refresh must not be required to select Astra, and every request
+// must use the Codex Lite route while retaining tools, instructions, and images.
+func TestCodexAstraRequests(t *testing.T) {
+	h := newHarness(t)
+	for _, effort := range []string{"", "high"} {
+		t.Run("effort="+effort, func(t *testing.T) {
+			req := toolsRequest(effort)
+			req.Messages[1].Content = append(req.Messages[1].Content, llm.ContentPart{
+				Kind:  llm.ContentImage,
+				Image: &llm.ImageData{URL: "https://example.com/image.png"},
+			})
+			got := h.run(t, wireCase{"codex-astra", "openai-codex/gpt-6-astra", true, req})
+			body := bodyOf(t, got)
+			if got.Headers["X-Openai-Internal-Codex-Responses-Lite"] != "true" {
+				t.Fatalf("Lite routing header missing: %v", got.Headers)
+			}
+			if body["model"] != "gpt-6-astra" || body["instructions"] != "" || body["tools"] != nil || body["parallel_tool_calls"] != false {
+				t.Fatalf("incorrect Astra request framing: %s", got.Body)
+			}
+			input := body["input"].([]any)
+			tools := input[0].(map[string]any)
+			if tools["type"] != "additional_tools" || len(tools["tools"].([]any)) != 1 || input[1].(map[string]any)["role"] != "developer" {
+				t.Fatalf("tools/instructions missing from Lite input: %v", input)
+			}
+			user := input[2].(map[string]any)["content"].([]any)
+			if user[1].(map[string]any)["detail"] != "original" {
+				t.Fatalf("Astra image detail = %v", user[1])
+			}
+			reasoning, ok := body["reasoning"].(map[string]any)
+			if !ok || reasoning["context"] != "all_turns" || body["include"] == nil {
+				t.Fatalf("reasoning replay disabled: %v", body)
+			}
+			if effort != "" && reasoning["effort"] != effort {
+				t.Fatalf("wire effort = %v, want %s", reasoning["effort"], effort)
+			}
+			for _, field := range []string{"temperature", "top_p", "max_output_tokens", "prompt_cache_retention"} {
+				if body[field] != nil {
+					t.Errorf("unsupported Codex field %s sent", field)
+				}
+			}
+		})
+	}
+}

--- a/llm/providers/wirecapture/astra_test.go
+++ b/llm/providers/wirecapture/astra_test.go
@@ -1,6 +1,7 @@
 package wirecapture
 
 import (
+	"slices"
 	"testing"
 
 	"primeradiant.com/evener/llm"
@@ -13,6 +14,7 @@ func TestCodexAstraRequests(t *testing.T) {
 	for _, effort := range []string{"", "high"} {
 		t.Run("effort="+effort, func(t *testing.T) {
 			req := toolsRequest(effort)
+			req.Temperature, req.TopP = new(0.3), new(0.7)
 			req.Messages[1].Content = append(req.Messages[1].Content, llm.ContentPart{
 				Kind:  llm.ContentImage,
 				Image: &llm.ImageData{URL: "https://example.com/image.png"},
@@ -47,5 +49,36 @@ func TestCodexAstraRequests(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCodexAstraReplaysReasoningAndToolResult(t *testing.T) {
+	h := newHarness(t)
+	req := toolsRequest("max")
+	req.Messages = append(req.Messages, llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
+		{Kind: llm.ContentThinking, Thinking: &llm.ThinkingData{ID: "rs_astra", EncryptedContent: "opaque-reasoning"}},
+		{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: "call_astra", Name: "weather", Arguments: []byte(`{"city":"Oslo"}`)}},
+	}}, llm.ToolResultNamed("call_astra", "weather", "Sunny", false))
+	body := bodyOf(t, h.run(t, wireCase{"codex-astra-replay", "openai-codex/gpt-6-astra", true, req}))
+	var reasoning, call, result map[string]any
+	for _, raw := range body["input"].([]any) {
+		item := raw.(map[string]any)
+		switch item["type"] {
+		case "reasoning":
+			reasoning = item
+		case "function_call":
+			call = item
+		case "function_call_output":
+			result = item
+		}
+	}
+	if reasoning["id"] != "rs_astra" || reasoning["encrypted_content"] != "opaque-reasoning" {
+		t.Fatalf("reasoning lost on replay: %v", reasoning)
+	}
+	if call["call_id"] != "call_astra" || call["name"] != "weather" || result["call_id"] != "call_astra" || result["output"] != "Sunny" {
+		t.Fatalf("tool round trip lost on replay: call=%v result=%v", call, result)
+	}
+	if !slices.Contains(body["include"].([]any), any("reasoning.encrypted_content")) {
+		t.Fatalf("encrypted reasoning not requested: %v", body["include"])
 	}
 }

--- a/llm/registry/astra_test.go
+++ b/llm/registry/astra_test.go
@@ -1,0 +1,22 @@
+package registry
+
+import "testing"
+
+func TestCodexAstraAvailableOnNamedInstance(t *testing.T) {
+	r := fixtureLoad(t, nil, "[providers.subscription]\nbase = \"openai-codex\"\n")
+	res := mustResolve(t, r, "subscription/gpt-6-astra")
+	if res.WireID != "gpt-6-astra" || res.Protocol != ProtocolOpenAIResponses || res.Transport.Auth != AuthOAuthOpenAICodex {
+		t.Fatalf("wrong Astra route: %+v", res)
+	}
+	if res.Caps.ContextWindow == nil || *res.Caps.ContextWindow != 272000 || !BoolValue(res.Caps.Tools) || !BoolValue(res.Caps.Reasoning) {
+		t.Fatalf("missing Codex model facts: %+v", res.Caps)
+	}
+	if res.Caps.EffortOffCapable() {
+		t.Fatal("Astra must not advertise reasoning off")
+	}
+	r.ApplyLive("subscription", []Model{{ID: "gpt-6-astra", Caps: Caps{ContextWindow: new(872000), DefaultEffort: new("medium")}}})
+	res = mustResolve(t, r, "subscription/gpt-6-astra")
+	if *res.Caps.ContextWindow != 872000 || StringValue(res.Caps.DefaultEffort) != "medium" || !BoolValue(res.Caps.ResponsesLite) {
+		t.Fatalf("live facts must update without losing Lite framing: %+v", res.Caps)
+	}
+}

--- a/llm/registry/data/providers_overlay.toml
+++ b/llm/registry/data/providers_overlay.toml
@@ -242,6 +242,24 @@ image_detail = "omit"
 reasoning_summary = "detailed"
 body = { "reasoning.context" = "all_turns", "text.verbosity" = "low", parallel_tool_calls = false }
 
+# Astra uses the Codex Lite route. The subscription's default context is
+# smaller than the public API window; live model facts can override it.
+[providers."openai-codex".models."gpt-6-astra"]
+context_window = 272000
+max_output_tokens = 128000
+tools = true
+structured_output = true
+sampling = false
+reasoning = true
+effort_values = ["low", "medium", "high", "xhigh", "max"]
+default_effort = "low"
+input_modalities = ["text", "image"]
+responses_lite = true
+thinking_always_on = true
+image_detail = "original"
+reasoning_summary = "detailed"
+body = { "reasoning.context" = "all_turns", "text.verbosity" = "low", parallel_tool_calls = false }
+
 # ---------------------------------------------------------------------------
 # Azure (§9.2)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Selecting `gpt-6-astra` through Codex OAuth could fail before model discovery or use the wrong request framing after discovery. Add an explicit Astra catalog entry with the required Responses Lite routing, tools and instructions in developer input, reasoning replay across turns, and original image detail.

Astra exposes `low` through `max` reasoning, with subscription context and defaults that live discovery can update. Filter Codex's `ultra` delegation preset out of discovery because it is not an API effort. This opts in only `gpt-6-astra`; the existing `gpt-5.6*` rule and model defaults are unchanged.

Validation on `74afa724ed79ea972aeb957bd8023173a2221e05`:

- `make merge-approval-gate`, `make vet`, and `make test-web-browser` passed.
- Regression tests cover selection without discovery, named instances, discovery filtering, Lite framing, sampling exclusion, images, and reasoning/tool-result replay.
- Opt-in live OAuth adapter checks returned HTTP 200 for an ordinary function call and its result follow-up, image input at `max`, and strict JSON output at `low`.
- The short live turns emitted no encrypted reasoning; that replay path is covered deterministically.
- Independent review found no correctness issues.
