### PR TITLE
fix(web): bound outbox storage stalls without unsafe retries

### DIFF
--- a/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
@@ -433,12 +433,16 @@ async function exerciseDirectoryPicker() {
   nameInput.form?.requestSubmit();
   const created = `${directoryRoot}/a-new-directory-with-a-long-readable-name`;
   const deadline = performance.now() + 10_000;
-  while (document.querySelector<HTMLInputElement>('input[aria-label="Path"]')?.value !== created || confirm.disabled) {
+  // The path can render before the effect restores focus to a persistent control.
+  while (
+    document.querySelector<HTMLInputElement>('input[aria-label="Path"]')?.value !== created ||
+    confirm.disabled ||
+    !dialog.contains(document.activeElement)
+  ) {
     if (performance.now() > deadline) throw new Error("Directory creation did not settle");
     await new Promise((resolve) => requestAnimationFrame(resolve));
   }
   measure("created");
-  if (!dialog.contains(document.activeElement)) failures.push("Creation lost dialog focus");
   confirm.click();
   await new Promise((resolve) => requestAnimationFrame(resolve));
   if (!trigger.textContent?.includes(created)) failures.push("Confirmed path was not stored on the launch form");

--- a/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
@@ -24,7 +24,11 @@ import virtualListStyles from "../../widgets/virtuallist/virtuallist.module.css"
 import * as SessionChromeModule from "./chrome/SessionChrome";
 import { resetAskDockStoreForTests } from "./composer/askDock/askDockStore";
 import * as ComposerModule from "./composer/Composer";
-import { refreshPendingTurnsProjection, resetPendingTurnsStoreForTests } from "./composer/queue/pendingTurnsStore";
+import {
+  flushPendingTurnsProjectionForTests,
+  refreshPendingTurnsProjection,
+  resetPendingTurnsStoreForTests,
+} from "./composer/queue/pendingTurnsStore";
 import Session from "./Session";
 import { writeSeenWatermark } from "./transcript/flow/seenWatermark";
 import * as useTranscriptScrollModule from "./transcript/flow/useTranscriptScroll";
@@ -463,6 +467,7 @@ async function seedPendingSend(ref = "ref_a"): Promise<string> {
     optimisticDisplay: { method: "turn/start", input: [{ type: "text", text: "hello" }] },
   });
   await refreshPendingTurnsProjection(ref);
+  await flushPendingTurnsProjectionForTests();
   return record.clientMutationId;
 }
 

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
@@ -386,6 +386,8 @@ test.each([
   { edited: true, fromStrip: false },
   { edited: false, fromStrip: true },
   { edited: true, fromStrip: true },
+  { edited: "same", fromStrip: false },
+  { edited: "same", fromStrip: true },
 ])("a pending submission survives a composer remount ($edited, $fromStrip)", async ({ edited, fromStrip }) => {
   const fake = await mountComposer(
     "ref_a",
@@ -437,13 +439,16 @@ test.each([
     expect(actionButton().disabled).toBe(true);
     fireEvent.click(actionButton());
     if (edited) fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "new draft" } });
+    if (edited === "same")
+      fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "original message" } });
   } finally {
     await act(async () => hold?.release());
     vi.useRealTimers();
     await flushPendingTurnsProjectionForTests();
   }
-  expect(textarea()?.value).toBe(edited ? "new draft" : "");
-  expect(readDraft("ref_a")).toBe(edited ? "new draft" : "");
+  const expectedDraft = edited === "same" ? "original message" : edited ? "new draft" : "";
+  expect(textarea()?.value).toBe(expectedDraft);
+  expect(readDraft("ref_a")).toBe(expectedDraft);
   await waitFor(() => expect(fake.calls.filter((call) => call.method === method)).toHaveLength(1));
 });
 

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
@@ -17,13 +17,23 @@ import { ClientProvider } from "../../../shell/clientContext";
 import { connectionStore } from "../../../stores/connection";
 import { MutationOutboxIndexedDB } from "../../../stores/mutationOutboxIndexedDB";
 import { holdIndexedDBEvent } from "../../../stores/testing/stalledIndexedDB";
-import { resetThreadsStoreForTests, setMutationStorageForTests, threadsStore } from "../../../stores/threads";
+import {
+  resetThreadsStoreForTests,
+  setMutationStorageForTests,
+  subscribeMutationPersistence,
+  threadsStore,
+} from "../../../stores/threads";
 import { Toast } from "../../../widgets";
 import { resetToastStoreForTests } from "../../../widgets/toast/store";
 import { askDockStore, resetAskDockStoreForTests } from "./askDock/askDockStore";
 import { Composer as ComposerView } from "./Composer";
+import { readDraft } from "./draft";
 import { usePendingTurnEntries } from "./queue";
-import { flushPendingTurnsProjectionForTests, resetPendingTurnsStoreForTests } from "./queue/pendingTurnsStore";
+import {
+  flushPendingTurnsProjectionForTests,
+  resetPendingTurnsStoreForTests,
+  subscribeComposerSubmissionCommitted,
+} from "./queue/pendingTurnsStore";
 
 function Composer(props: React.ComponentProps<typeof ComposerView>) {
   const client = connectionStore.getState().client;
@@ -317,6 +327,193 @@ test("a cancelled storage stall keeps the draft, reports the problem, and allows
   await flushPendingTurnsProjectionForTests();
   expect(textarea()?.value).toBe("");
   expect(fake.calls.filter((call) => call.method === "turn/steer")).toHaveLength(1);
+});
+
+test("a second message queues behind a committed start even when recovery projection reads stall", async () => {
+  const fake = await mountComposer("ref_a", {
+    status: { type: "idle" },
+    evener: {
+      ref: "ref_a",
+      capabilities: { ...FULL_CAPABILITIES, queue: false, steer: false, interrupt: false },
+      queue: { revision: 0 },
+    },
+    turns: [],
+  });
+  await flushPendingTurnsProjectionForTests();
+  const getAll = IDBObjectStore.prototype.getAll;
+  const held: ReturnType<typeof holdIndexedDBEvent>[] = [];
+  const spy = vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (this: IDBObjectStore, ...args) {
+    const request = getAll.apply(this, args);
+    if (this.name === "recovery") held.push(holdIndexedDBEvent(request, "success"));
+    return request;
+  });
+  let acceptSecond: ((method: string) => void) | undefined;
+  const secondRequest = new Promise<string>((resolve) => {
+    acceptSecond = resolve;
+  });
+  let requests = 0;
+  for (const method of ["turn/start", "turn/queue"] as const) {
+    fake.on(method, (params) => {
+      requests += 1;
+      if (requests === 2) acceptSecond?.(method);
+      return {
+        receipt: {
+          clientMutationId: params.clientMutationId,
+          disposition: "applied",
+          threadId: "thr_ref_a",
+          projectionState: "pending",
+        },
+      };
+    });
+  }
+  const user = userEvent.setup();
+  try {
+    await user.type(textarea() as HTMLTextAreaElement, "first message");
+    await user.click(screen.getByTestId("composer-submit"));
+    await waitFor(() => expect(textarea()?.value).toBe(""));
+    await user.type(textarea() as HTMLTextAreaElement, "second message");
+    await user.click(screen.getByTestId("composer-submit"));
+    expect(await secondRequest).toBe("turn/queue");
+  } finally {
+    spy.mockRestore();
+    for (const hold of held) hold.release();
+    await flushPendingTurnsProjectionForTests();
+  }
+});
+
+test.each([
+  { edited: false, fromStrip: false },
+  { edited: true, fromStrip: false },
+  { edited: false, fromStrip: true },
+  { edited: true, fromStrip: true },
+])("a pending submission survives a composer remount ($edited, $fromStrip)", async ({ edited, fromStrip }) => {
+  const fake = await mountComposer(
+    "ref_a",
+    fromStrip
+      ? {
+          evener: {
+            ref: "ref_a",
+            capabilities: FULL_CAPABILITIES,
+            activeTurnId: "turn_1",
+            queue: { revision: 1, depth: 1, ids: ["q1"], texts: ["queued hello"], preview: ["queued hello"] },
+          },
+        }
+      : {},
+  );
+  const method = fromStrip ? "turn/drainAsSteer" : "turn/steer";
+  const actionButton = fromStrip ? drainButton : composerSteerButton;
+  fake.on(method, (params) => ({
+    receipt: {
+      clientMutationId: params.clientMutationId,
+      disposition: "applied",
+      threadId: "thr_ref_a",
+      projectionState: "reflected",
+    },
+  }));
+  await flushPendingTurnsProjectionForTests();
+  const transact = IDBDatabase.prototype.transaction;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let announceCommit: (() => void) | undefined;
+  const committed = new Promise<void>((resolve) => {
+    announceCommit = resolve;
+  });
+  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+    const transaction = transact.apply(this, args);
+    if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
+      hold = holdIndexedDBEvent(transaction, "complete");
+      void hold.reached.then(() => announceCommit?.());
+    }
+    return transaction;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  try {
+    await act(async () => {
+      fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "original message" } });
+      fireEvent.click(actionButton());
+      await committed;
+    });
+    cleanup();
+    render(<Composer ref="ref_a" />);
+    expect(actionButton().disabled).toBe(true);
+    fireEvent.click(actionButton());
+    if (edited) fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "new draft" } });
+  } finally {
+    await act(async () => hold?.release());
+    vi.useRealTimers();
+    await flushPendingTurnsProjectionForTests();
+  }
+  expect(textarea()?.value).toBe(edited ? "new draft" : "");
+  expect(readDraft("ref_a")).toBe(edited ? "new draft" : "");
+  await waitFor(() => expect(fake.calls.filter((call) => call.method === method)).toHaveLength(1));
+});
+
+test.each(["storage", "composer"] as const)(
+  "a throwing %s subscriber cannot fail a committed submission",
+  async (source) => {
+    const subscribe = source === "storage" ? subscribeMutationPersistence : subscribeComposerSubmissionCommitted;
+    const failure = new Error("subscriber failed");
+    const report = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const unsubscribeFailure = subscribe(() => {
+      throw failure;
+    });
+    const observed = vi.fn();
+    const unsubscribeObserved = subscribe(observed);
+    try {
+      const fake = await mountComposer("ref_a");
+      fake.on("turn/steer", () => new Promise<never>(() => undefined));
+      const user = userEvent.setup();
+      await user.type(textarea() as HTMLTextAreaElement, "one submission");
+      await user.click(composerSteerButton());
+      await flushPendingTurnsProjectionForTests();
+      expect(textarea()?.value).toBe("");
+      expect(readDraft("ref_a")).toBe("");
+      expect(screen.getByRole("region", { name: "Notifications" }).textContent).toBe("");
+      expect(observed).toHaveBeenCalled();
+      await waitFor(() => expect(fake.calls.filter((call) => call.method === "turn/steer")).toHaveLength(1));
+      expect(report).toHaveBeenCalledWith(expect.any(String), failure);
+    } finally {
+      unsubscribeFailure();
+      unsubscribeObserved();
+    }
+  },
+);
+
+test("the composer resends recovered text while recovery projection callbacks are stalled", async () => {
+  const storage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(storage);
+  const original = await storage.enqueueIntent({
+    targetRef: "ref_a",
+    method: "turn/start",
+    payload: { ref: "ref_a", input: [{ type: "text", text: "recover me" }] },
+    attachments: [],
+    optimisticDisplay: { method: "turn/start", input: [{ type: "text", text: "recover me" }] },
+  });
+  await storage.transferToRecovery(original.clientMutationId, "rejected");
+  const fake = await mountComposer("ref_a");
+  fake.on("turn/steer", () => new Promise<never>(() => undefined));
+  await flushPendingTurnsProjectionForTests();
+  expect(textarea()?.value).toBe("recover me");
+  const getAll = IDBObjectStore.prototype.getAll;
+  const held: ReturnType<typeof holdIndexedDBEvent>[] = [];
+  const spy = vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (this: IDBObjectStore, ...args) {
+    const request = getAll.apply(this, args);
+    if (this.name === "recovery") held.push(holdIndexedDBEvent(request, "success"));
+    return request;
+  });
+  try {
+    const user = userEvent.setup();
+    await user.type(textarea() as HTMLTextAreaElement, " edited");
+    await user.click(composerSteerButton());
+    await waitFor(() => expect(textarea()?.value).toBe(""));
+    expect(await storage.getRecovery(original.clientMutationId)).toBeUndefined();
+    await waitFor(() => expect(fake.calls.filter((call) => call.method === "turn/steer")).toHaveLength(1));
+    const call = fake.calls.find((call) => call.method === "turn/steer");
+    expect(call?.params).toEqual(expect.objectContaining({ input: [{ type: "text", text: "recover me edited" }] }));
+  } finally {
+    spy.mockRestore();
+    for (const hold of held) hold.release();
+    await flushPendingTurnsProjectionForTests();
+  }
 });
 
 // --- ask_user wire fixtures (mirrors AskDock.test.tsx's own harness) -------

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
@@ -382,75 +382,86 @@ test("a second message queues behind a committed start even when recovery projec
 });
 
 test.each([
-  { edited: false, fromStrip: false },
-  { edited: true, fromStrip: false },
-  { edited: false, fromStrip: true },
-  { edited: true, fromStrip: true },
-  { edited: "same", fromStrip: false },
-  { edited: "same", fromStrip: true },
-])("a pending submission survives a composer remount ($edited, $fromStrip)", async ({ edited, fromStrip }) => {
-  const fake = await mountComposer(
-    "ref_a",
-    fromStrip
-      ? {
-          evener: {
-            ref: "ref_a",
-            capabilities: FULL_CAPABILITIES,
-            activeTurnId: "turn_1",
-            queue: { revision: 1, depth: 1, ids: ["q1"], texts: ["queued hello"], preview: ["queued hello"] },
-          },
-        }
-      : {},
-  );
-  const method = fromStrip ? "turn/drainAsSteer" : "turn/steer";
-  const actionButton = fromStrip ? drainButton : composerSteerButton;
-  fake.on(method, (params) => ({
-    receipt: {
-      clientMutationId: params.clientMutationId,
-      disposition: "applied",
-      threadId: "thr_ref_a",
-      projectionState: "reflected",
-    },
-  }));
-  await flushPendingTurnsProjectionForTests();
-  const transact = IDBDatabase.prototype.transaction;
-  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
-  let announceCommit: (() => void) | undefined;
-  const committed = new Promise<void>((resolve) => {
-    announceCommit = resolve;
-  });
-  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
-    const transaction = transact.apply(this, args);
-    if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
-      hold = holdIndexedDBEvent(transaction, "complete");
-      void hold.reached.then(() => announceCommit?.());
-    }
-    return transaction;
-  });
-  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-  try {
-    await act(async () => {
-      fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "original message" } });
-      fireEvent.click(actionButton());
-      await committed;
-    });
-    cleanup();
-    render(<Composer ref="ref_a" />);
-    expect(actionButton().disabled).toBe(true);
-    fireEvent.click(actionButton());
-    if (edited) fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "new draft" } });
-    if (edited === "same")
-      fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "original message" } });
-  } finally {
-    await act(async () => hold?.release());
-    vi.useRealTimers();
+  { edited: false, fromStrip: false, remount: true },
+  { edited: false, fromStrip: false, remount: false },
+  { edited: true, fromStrip: false, remount: true },
+  { edited: true, fromStrip: false, remount: false },
+  { edited: false, fromStrip: true, remount: true },
+  { edited: false, fromStrip: true, remount: false },
+  { edited: true, fromStrip: true, remount: true },
+  { edited: true, fromStrip: true, remount: false },
+  { edited: "same", fromStrip: false, remount: true },
+  { edited: "same", fromStrip: false, remount: false },
+  { edited: "same", fromStrip: true, remount: true },
+  { edited: "same", fromStrip: true, remount: false },
+])(
+  "pending submissions preserve draft ownership ($edited, strip $fromStrip, remount $remount)",
+  async ({ edited, fromStrip, remount }) => {
+    const fake = await mountComposer(
+      "ref_a",
+      fromStrip
+        ? {
+            evener: {
+              ref: "ref_a",
+              capabilities: FULL_CAPABILITIES,
+              activeTurnId: "turn_1",
+              queue: { revision: 1, depth: 1, ids: ["q1"], texts: ["queued hello"], preview: ["queued hello"] },
+            },
+          }
+        : {},
+    );
+    const method = fromStrip ? "turn/drainAsSteer" : "turn/steer";
+    const actionButton = fromStrip ? drainButton : composerSteerButton;
+    fake.on(method, (params) => ({
+      receipt: {
+        clientMutationId: params.clientMutationId,
+        disposition: "applied",
+        threadId: "thr_ref_a",
+        projectionState: "reflected",
+      },
+    }));
     await flushPendingTurnsProjectionForTests();
-  }
-  const expectedDraft = edited === "same" ? "original message" : edited ? "new draft" : "";
-  expect(textarea()?.value).toBe(expectedDraft);
-  expect(readDraft("ref_a")).toBe(expectedDraft);
-  await waitFor(() => expect(fake.calls.filter((call) => call.method === method)).toHaveLength(1));
-});
+    const transact = IDBDatabase.prototype.transaction;
+    let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+    let announceCommit: (() => void) | undefined;
+    const committed = new Promise<void>((resolve) => {
+      announceCommit = resolve;
+    });
+    vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+      const transaction = transact.apply(this, args);
+      if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
+        hold = holdIndexedDBEvent(transaction, "complete");
+        void hold.reached.then(() => announceCommit?.());
+      }
+      return transaction;
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      await act(async () => {
+        fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "original message" } });
+        fireEvent.click(actionButton());
+        await committed;
+      });
+      if (remount) {
+        cleanup();
+        render(<Composer ref="ref_a" />);
+      }
+      expect(actionButton().disabled).toBe(true);
+      fireEvent.click(actionButton());
+      if (edited) fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "new draft" } });
+      if (edited === "same")
+        fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "original message" } });
+    } finally {
+      await act(async () => hold?.release());
+      vi.useRealTimers();
+      await flushPendingTurnsProjectionForTests();
+    }
+    const expectedDraft = edited === "same" ? "original message" : edited ? "new draft" : "";
+    expect(textarea()?.value).toBe(expectedDraft);
+    expect(readDraft("ref_a")).toBe(expectedDraft);
+    await waitFor(() => expect(fake.calls.filter((call) => call.method === method)).toHaveLength(1));
+  },
+);
 
 test.each(["storage", "composer"] as const)(
   "a throwing %s subscriber cannot fail a committed submission",

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
@@ -9,13 +9,14 @@
 // AskDock's own already-covered internal behavior.
 import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { IDBFactory } from "fake-indexeddb";
+import { IDBDatabase, IDBFactory, IDBObjectStore } from "fake-indexeddb";
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import type { MethodTypes, Thread, ThreadCapabilities, ThreadReadResponse } from "../../../protocol/types.gen";
 import { ClientProvider } from "../../../shell/clientContext";
 import { connectionStore } from "../../../stores/connection";
 import { MutationOutboxIndexedDB } from "../../../stores/mutationOutboxIndexedDB";
+import { holdIndexedDBEvent } from "../../../stores/testing/stalledIndexedDB";
 import { resetThreadsStoreForTests, setMutationStorageForTests, threadsStore } from "../../../stores/threads";
 import { Toast } from "../../../widgets";
 import { resetToastStoreForTests } from "../../../widgets/toast/store";
@@ -215,6 +216,108 @@ function drainButton(): HTMLButtonElement {
 function composerSteerButton(): HTMLButtonElement {
   return screen.getByTestId("composer-steer") as HTMLButtonElement;
 }
+
+test("an unconfirmed storage commit stays visible and repeated Steer clicks cannot duplicate it", async () => {
+  const fake = await mountComposer("ref_a");
+  fake.on("turn/steer", (params) => ({
+    receipt: {
+      clientMutationId: params.clientMutationId,
+      disposition: "applied",
+      threadId: "thr_ref_a",
+      projectionState: "reflected",
+    },
+  }));
+  await flushPendingTurnsProjectionForTests();
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let commitObserved: (() => void) | undefined;
+  const committed = new Promise<void>((resolve) => {
+    commitObserved = resolve;
+  });
+  const transact = IDBDatabase.prototype.transaction;
+  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+    const transaction = transact.apply(this, args);
+    if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
+      hold = holdIndexedDBEvent(transaction, "complete");
+      void hold.reached.then(() => commitObserved?.());
+    }
+    return transaction;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  try {
+    await act(async () => {
+      fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "one message only" } });
+      fireEvent.click(composerSteerButton());
+      await committed;
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(screen.getByRole("status", { name: "Message storage" }).textContent).toBeTruthy();
+    expect(textarea()?.value).toBe("one message only");
+    expect(textarea()?.disabled).toBe(false);
+    expect(composerSteerButton().disabled).toBe(true);
+    fireEvent.click(composerSteerButton());
+  } finally {
+    await act(async () => hold?.release());
+    vi.useRealTimers();
+    await flushPendingTurnsProjectionForTests();
+  }
+  expect(textarea()?.value).toBe("");
+  expect(screen.queryByRole("status", { name: "Message storage" })).toBeNull();
+  expect(fake.calls.filter((call) => call.method === "turn/steer")).toHaveLength(1);
+});
+
+test("a cancelled storage stall keeps the draft, reports the problem, and allows one safe retry", async () => {
+  const fake = await mountComposer("ref_a");
+  fake.on("turn/steer", (params) => ({
+    receipt: {
+      clientMutationId: params.clientMutationId,
+      disposition: "applied",
+      threadId: "thr_ref_a",
+      projectionState: "reflected",
+    },
+  }));
+  await flushPendingTurnsProjectionForTests();
+  const get = IDBObjectStore.prototype.get;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let requestObserved: (() => void) | undefined;
+  let keepAlive = true;
+  const reached = new Promise<void>((resolve) => {
+    requestObserved = resolve;
+  });
+  vi.spyOn(IDBObjectStore.prototype, "get").mockImplementationOnce(function (this: IDBObjectStore, ...args) {
+    const request = get.apply(this, args);
+    hold = holdIndexedDBEvent(request, "success");
+    void hold.reached.then(() => requestObserved?.());
+    const pulse = () => {
+      this.count().addEventListener("success", () => {
+        if (keepAlive) pulse();
+      });
+    };
+    pulse();
+    return request;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  try {
+    await act(async () => {
+      fireEvent.change(textarea() as HTMLTextAreaElement, { target: { value: "keep this draft" } });
+      fireEvent.click(composerSteerButton());
+      await reached;
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(screen.getByRole("region", { name: "Notifications" }).textContent).toBeTruthy();
+    expect(textarea()?.value).toBe("keep this draft");
+    expect(composerSteerButton().disabled).toBe(false);
+    expect(fake.calls.filter((call) => call.method === "turn/steer")).toHaveLength(0);
+  } finally {
+    keepAlive = false;
+    hold?.release();
+    vi.useRealTimers();
+    await flushPendingTurnsProjectionForTests();
+  }
+  fireEvent.click(composerSteerButton());
+  await flushPendingTurnsProjectionForTests();
+  expect(textarea()?.value).toBe("");
+  expect(fake.calls.filter((call) => call.method === "turn/steer")).toHaveLength(1);
+});
 
 // --- ask_user wire fixtures (mirrors AskDock.test.tsx's own harness) -------
 

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -2551,47 +2551,87 @@ test("pasting an image renders a removable attachment tile and inserts its marke
   expect(screen.getByRole("button", { name: /remove/i })).toBeTruthy();
 });
 
-test("a remounted draft with a reused image marker survives the old submission committing", async () => {
-  installCanvasStubs();
-  const fake = await mountComposer("ref_a");
-  fake.on("turn/start", () => new Promise<never>(() => undefined));
-  const user = userEvent.setup();
-  pastePngInto(textarea(), "original.png");
-  await waitFor(() => expect(submitButton().disabled).toBe(false));
-  await flushPendingTurnsProjectionForTests();
-
-  const transact = IDBDatabase.prototype.transaction;
-  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
-  let announceCommit: (() => void) | undefined;
-  const committed = new Promise<void>((resolve) => {
-    announceCommit = resolve;
-  });
-  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
-    const transaction = transact.apply(this, args);
-    if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
-      hold = holdIndexedDBEvent(transaction, "complete");
-      void hold.reached.then(() => announceCommit?.());
+test.each([
+  { remount: true, edited: true, recovery: false, drain: false },
+  { remount: false, edited: true, recovery: false, drain: false },
+  { remount: false, edited: false, recovery: false, drain: false },
+  { remount: false, edited: true, recovery: true, drain: false },
+  { remount: false, edited: false, recovery: true, drain: false },
+  { remount: false, edited: true, recovery: false, drain: true },
+  { remount: false, edited: false, recovery: false, drain: true },
+])(
+  "committing respects attachment draft ownership ($remount, $edited, $recovery, $drain)",
+  async ({ remount, edited, recovery, drain }) => {
+    installCanvasStubs();
+    if (recovery) {
+      const storage = new MutationOutboxIndexedDB();
+      setMutationStorageForTests(storage);
+      await seedRejectedRecoveryWithAttachment(storage, "ref_a");
     }
-    return transaction;
-  });
-  try {
-    await user.click(submitButton());
-    await committed;
-    cleanup();
-    render(<Composer ref="ref_a" />);
-    fireEvent.change(textarea(), { target: { value: "" } });
-    pastePngInto(textarea(), "replacement.png");
-    await waitFor(() => expect(screen.getByRole("button", { name: "Remove replacement.png" })).toBeTruthy());
-    expect(textarea().value).toBe("[image 1]");
-  } finally {
-    await act(async () => hold?.release());
+    const fake = await mountComposer(
+      "ref_a",
+      drain
+        ? {
+            status: { type: "active" },
+            evener: {
+              ref: "ref_a",
+              activeTurnId: "turn_1",
+              capabilities: FULL_CAPABILITIES,
+              queue: { revision: 1, depth: 1, ids: ["q1"], texts: ["queued"], preview: ["queued"] },
+            },
+          }
+        : {},
+    );
+    const method = drain ? "turn/drainAsSteer" : "turn/start";
+    fake.on(method, () => new Promise<never>(() => undefined));
+    const actionButton = () =>
+      drain ? screen.getByRole<HTMLButtonElement>("button", { name: "Steer queue now" }) : submitButton();
+    const user = userEvent.setup();
+    if (!recovery) pastePngInto(textarea(), "original.png");
     await flushPendingTurnsProjectionForTests();
-  }
-  expect(textarea().value).toBe("[image 1]");
-  expect(readDraft("ref_a")).toBe("[image 1]");
-  expect(screen.getByRole("button", { name: "Remove replacement.png" })).toBeTruthy();
-  await waitFor(() => expect(fake.calls.filter((call) => call.method === "turn/start")).toHaveLength(1));
-});
+    await waitFor(() => expect(actionButton().disabled).toBe(false));
+    const submittedText = textarea().value;
+    const originalAttachment = recovery ? "proof.png" : "original.png";
+
+    const transact = IDBDatabase.prototype.transaction;
+    let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+    let announceCommit: (() => void) | undefined;
+    const committed = new Promise<void>((resolve) => {
+      announceCommit = resolve;
+    });
+    vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+      const transaction = transact.apply(this, args);
+      if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
+        hold = holdIndexedDBEvent(transaction, "complete");
+        void hold.reached.then(() => announceCommit?.());
+      }
+      return transaction;
+    });
+    try {
+      await user.click(actionButton());
+      await committed;
+      if (remount) {
+        cleanup();
+        render(<Composer ref="ref_a" />);
+        fireEvent.change(textarea(), { target: { value: "" } });
+        pastePngInto(textarea(), "replacement.png");
+        await waitFor(() => expect(screen.getByRole("button", { name: "Remove replacement.png" })).toBeTruthy());
+      } else if (edited) {
+        fireEvent.change(textarea(), { target: { value: `${submittedText} edited` } });
+        fireEvent.change(textarea(), { target: { value: submittedText } });
+      }
+      expect(textarea().value).toBe(submittedText);
+    } finally {
+      await act(async () => hold?.release());
+      await flushPendingTurnsProjectionForTests();
+    }
+    expect(textarea().value).toBe(edited ? submittedText : "");
+    expect(readDraft("ref_a")).toBe(edited ? submittedText : "");
+    const retainedAttachment = remount ? "replacement.png" : originalAttachment;
+    expect(screen.queryByRole("button", { name: `Remove ${retainedAttachment}` }) !== null).toBe(edited);
+    await waitFor(() => expect(fake.calls.filter((call) => call.method === method)).toHaveLength(1));
+  },
+);
 
 test("the remove button names the specific attachment it removes", async () => {
   installCanvasStubs();

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { IDBFactory } from "fake-indexeddb";
+import { IDBDatabase, IDBFactory } from "fake-indexeddb";
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { WireError } from "../../../protocol/errors";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
@@ -15,6 +15,7 @@ import { useCommandCatalog } from "../../../stores/commandCatalog";
 import { connectionStore } from "../../../stores/connection";
 import { MutationOutboxIndexedDB } from "../../../stores/mutationOutboxIndexedDB";
 import { prefsStore, resetPrefsStoreForTests } from "../../../stores/prefs";
+import { holdIndexedDBEvent } from "../../../stores/testing/stalledIndexedDB";
 import {
   readMutationPersistence,
   resetThreadsStoreForTests,
@@ -2548,6 +2549,48 @@ test("pasting an image renders a removable attachment tile and inserts its marke
   pastePngInto(textarea());
   await waitFor(() => expect(textarea().value).toBe("[image 1]"));
   expect(screen.getByRole("button", { name: /remove/i })).toBeTruthy();
+});
+
+test("a remounted draft with a reused image marker survives the old submission committing", async () => {
+  installCanvasStubs();
+  const fake = await mountComposer("ref_a");
+  fake.on("turn/start", () => new Promise<never>(() => undefined));
+  const user = userEvent.setup();
+  pastePngInto(textarea(), "original.png");
+  await waitFor(() => expect(submitButton().disabled).toBe(false));
+  await flushPendingTurnsProjectionForTests();
+
+  const transact = IDBDatabase.prototype.transaction;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let announceCommit: (() => void) | undefined;
+  const committed = new Promise<void>((resolve) => {
+    announceCommit = resolve;
+  });
+  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+    const transaction = transact.apply(this, args);
+    if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
+      hold = holdIndexedDBEvent(transaction, "complete");
+      void hold.reached.then(() => announceCommit?.());
+    }
+    return transaction;
+  });
+  try {
+    await user.click(submitButton());
+    await committed;
+    cleanup();
+    render(<Composer ref="ref_a" />);
+    fireEvent.change(textarea(), { target: { value: "" } });
+    pastePngInto(textarea(), "replacement.png");
+    await waitFor(() => expect(screen.getByRole("button", { name: "Remove replacement.png" })).toBeTruthy());
+    expect(textarea().value).toBe("[image 1]");
+  } finally {
+    await act(async () => hold?.release());
+    await flushPendingTurnsProjectionForTests();
+  }
+  expect(textarea().value).toBe("[image 1]");
+  expect(readDraft("ref_a")).toBe("[image 1]");
+  expect(screen.getByRole("button", { name: "Remove replacement.png" })).toBeTruthy();
+  await waitFor(() => expect(fake.calls.filter((call) => call.method === "turn/start")).toHaveLength(1));
 });
 
 test("the remove button names the specific attachment it removes", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -26,7 +26,7 @@ import { Toast } from "../../../widgets";
 import buttonStyles from "../../../widgets/button/button.module.css";
 import iconButtonStyles from "../../../widgets/iconbutton/iconbutton.module.css";
 import promptCardStyles from "../../../widgets/promptcard/promptcard.module.css";
-import { resetToastStoreForTests } from "../../../widgets/toast/store";
+import { getToasts, resetToastStoreForTests } from "../../../widgets/toast/store";
 import { installMobileViewport } from "../testing/mobileViewport";
 import { resetAskDockStoreForTests } from "./askDock/askDockStore";
 import { Composer as ComposerView } from "./Composer";
@@ -2131,6 +2131,7 @@ test("a losing cross-tab recovered send does not issue a second request", async 
 
   await waitFor(() => expect(textarea().value).toBe(""));
   expect(fake.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+  expect(getToasts().map((toast) => toast.kind)).toEqual(["info"]);
   otherTab.close();
 });
 
@@ -2213,6 +2214,69 @@ test("recovered edits and attachment removal survive Composer remount", async ()
   // report "gone" for an attachment still sitting there - and a query naming
   // the file would report the same if only the label changed.
   expect(screen.queryAllByRole("button", { name: /^Remove/ })).toHaveLength(0);
+});
+
+test.each([
+  { edit: "unchanged", image: false },
+  { edit: "edited", image: false },
+  { edit: "same text", image: false },
+  { edit: "unchanged", image: true },
+  { edit: "edited", image: true },
+  { edit: "same text", image: true },
+])("a recovery resend releases its remounted owner ($edit, image=$image)", async ({ edit, image }) => {
+  const storage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(storage);
+  const recovered = image
+    ? await seedRejectedRecoveryWithAttachment(storage, "ref_a")
+    : await seedRejectedRecovery(storage, "ref_a", "retry me");
+  const fake = await mountComposer("ref_a");
+  fake.on("turn/start", () => new Promise<never>(() => undefined));
+  await flushPendingTurnsProjectionForTests();
+  const submittedText = image ? "edit me [image 1]" : "retry me";
+  expect(textarea().value).toBe(submittedText);
+
+  const transact = IDBDatabase.prototype.transaction;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let announceWrite: (() => void) | undefined;
+  const written = new Promise<void>((resolve) => {
+    announceWrite = resolve;
+  });
+  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+    const transaction = transact.apply(this, args);
+    if (
+      !hold &&
+      transaction.mode === "readwrite" &&
+      transaction.objectStoreNames.length === 1 &&
+      transaction.objectStoreNames.contains("recovery")
+    ) {
+      hold = holdIndexedDBEvent(transaction, "complete");
+      void hold.reached.then(() => announceWrite?.());
+    }
+    return transaction;
+  });
+  try {
+    fireEvent.click(submitButton());
+    await written;
+    cleanup();
+    render(<Composer ref="ref_a" />);
+    await waitFor(() => expect(textarea().value).toBe(submittedText));
+    if (edit !== "unchanged") {
+      fireEvent.change(textarea(), { target: { value: "new draft" } });
+      if (edit === "same text") fireEvent.change(textarea(), { target: { value: submittedText } });
+    }
+  } finally {
+    await act(async () => hold?.release());
+    await flushPendingTurnsProjectionForTests();
+  }
+  const expected = edit === "unchanged" ? "" : edit === "edited" ? "new draft" : image ? "edit me " : "retry me";
+  expect(textarea().value).toBe(expected);
+  expect(readDraft("ref_a")).toBe(expected);
+  expect(await storage.getRecovery(recovered.clientMutationId)).toBeUndefined();
+  expect(screen.queryByRole("button", { name: "Remove proof.png" })).toBeNull();
+  fireEvent.change(textarea(), { target: { value: "follow up" } });
+  fireEvent.click(submitButton());
+  await flushPendingTurnsProjectionForTests();
+  expect(await storage.listOutbox("ref_a")).toHaveLength(2);
 });
 
 test("blanking an attachment-free recovered draft discards it durably", async () => {
@@ -2625,11 +2689,83 @@ test.each([
       await act(async () => hold?.release());
       await flushPendingTurnsProjectionForTests();
     }
-    expect(textarea().value).toBe(edited ? submittedText : "");
-    expect(readDraft("ref_a")).toBe(edited ? submittedText : "");
+    const remainingText = remount ? submittedText : edited && recovery ? "edit me " : "";
+    expect(textarea().value).toBe(remainingText);
+    expect(readDraft("ref_a")).toBe(remainingText);
     const retainedAttachment = remount ? "replacement.png" : originalAttachment;
-    expect(screen.queryByRole("button", { name: `Remove ${retainedAttachment}` }) !== null).toBe(edited);
+    expect(screen.queryByRole("button", { name: `Remove ${retainedAttachment}` }) !== null).toBe(remount);
     await waitFor(() => expect(fake.calls.filter((call) => call.method === method)).toHaveLength(1));
+  },
+);
+
+test.each(["keep marker", "delete marker", "add attachment", "replace attachment", "merge recovery"])(
+  "a pending send retires only its submitted attachment (%s)",
+  async (edit) => {
+    installCanvasStubs();
+    const storage = new MutationOutboxIndexedDB();
+    setMutationStorageForTests(storage);
+    const fake = await mountComposer("ref_a", { evener: currentWorkEvener({ goal: true }) });
+    fake.on("turn/start", () => new Promise<never>(() => undefined));
+    pastePngInto(textarea(), "original.png");
+    await screen.findByRole("button", { name: "View original.png" });
+
+    const transact = IDBDatabase.prototype.transaction;
+    let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+    let announceCommit: (() => void) | undefined;
+    const committed = new Promise<void>((resolve) => {
+      announceCommit = resolve;
+    });
+    vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+      const transaction = transact.apply(this, args);
+      if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
+        hold = holdIndexedDBEvent(transaction, "complete");
+        void hold.reached.then(() => announceCommit?.());
+      }
+      return transaction;
+    });
+    try {
+      fireEvent.click(submitButton());
+      await committed;
+      if (edit === "replace attachment") {
+        fireEvent.click(screen.getByRole("button", { name: "Edit goal: Keep the session focused" }));
+        fireEvent.click(screen.getByRole("button", { name: "Replace draft" }));
+      }
+      fireEvent.change(textarea(), {
+        target: { value: edit === "keep marker" ? "follow up [image 1]" : "follow up " },
+      });
+      if (edit === "add attachment" || edit === "replace attachment") {
+        const name = edit === "replace attachment" ? "original.png" : "replacement.png";
+        pastePngInto(textarea(), name);
+        await screen.findByRole("button", { name: `View ${name}` });
+      }
+      if (edit === "merge recovery") {
+        await seedRejectedRecovery(storage, "ref_a", "merge me");
+        await act(async () => {
+          await refreshPendingTurnsProjection("ref_a");
+        });
+        const row = screen.getByText("merge me").closest("li");
+        if (!row) throw new Error("missing rejected queue row");
+        fireEvent.click(within(row).getByRole("button", { name: "Edit message" }));
+      }
+    } finally {
+      await act(async () => hold?.release());
+      await flushPendingTurnsProjectionForTests();
+    }
+    expect(screen.queryByRole("button", { name: "Remove original.png" }) !== null).toBe(edit === "replace attachment");
+    expect(screen.queryByRole("button", { name: "Remove replacement.png" }) !== null).toBe(edit === "add attachment");
+    expect(textarea().value).toContain("follow up");
+    if (edit === "merge recovery") {
+      expect((await storage.listRecovery("ref_a"))[0]?.composerText).toBe(textarea().value);
+    } else {
+      expect(readDraft("ref_a")).toBe(textarea().value);
+    }
+    fireEvent.click(submitButton());
+    await flushPendingTurnsProjectionForTests();
+    const records = await storage.listOutbox("ref_a");
+    expect(records).toHaveLength(2);
+    expect(records[1]?.attachments.map((item) => item.name)).toEqual(
+      edit === "replace attachment" ? ["original.png"] : edit === "add attachment" ? ["replacement.png"] : [],
+    );
   },
 );
 

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -2298,6 +2298,96 @@ test("blanking an attachment-free recovered draft discards it durably", async ()
   expect(screen.queryByText("discard me")).toBeNull();
 });
 
+test("draining an active recovery consumes its owner before the next submission", async () => {
+  const storage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(storage);
+  const recovery = await seedRejectedRecovery(storage, "ref_a", "retry me");
+  const fake = await mountComposer("ref_a", {
+    status: { type: "active" },
+    evener: {
+      ref: "ref_a",
+      activeTurnId: "turn_1",
+      capabilities: FULL_CAPABILITIES,
+      queue: { revision: 1, depth: 1, ids: ["q1"], texts: ["queued"], preview: ["queued"] },
+    },
+  });
+  fake.on("turn/drainAsSteer", () => new Promise<never>(() => undefined));
+  await flushPendingTurnsProjectionForTests();
+  expect(textarea().value).toBe("retry me");
+  const transact = IDBDatabase.prototype.transaction;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  const committed = deferred<void>();
+  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+    const transaction = transact.apply(this, args);
+    if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
+      hold = holdIndexedDBEvent(transaction, "complete");
+      void hold.reached.then(() => committed.resolve());
+    }
+    return transaction;
+  });
+  try {
+    fireEvent.click(screen.getByRole("button", { name: "Steer queue now" }));
+    await committed.promise;
+    // Recovery ownership must be consumed by the same durable write, before
+    // the mounted composer's success callback can clear or autosave its draft.
+    expect(await storage.getRecovery(recovery.clientMutationId)).toBeUndefined();
+  } finally {
+    await act(async () => hold?.release());
+    await flushPendingTurnsProjectionForTests();
+  }
+  expect(await storage.getRecovery(recovery.clientMutationId)).toBeUndefined();
+  expect(textarea().value).toBe("");
+  fireEvent.change(textarea(), { target: { value: "follow up" } });
+  fireEvent.click(submitButton());
+  await flushPendingTurnsProjectionForTests();
+  expect((await storage.listOutbox("ref_a")).map((record) => record.method)).toEqual([
+    "turn/drainAsSteer",
+    "turn/queue",
+  ]);
+});
+
+test.each([false, true])(
+  "a pending submission cannot clear a draft edited by another mounted Composer (image=%s)",
+  async (image) => {
+    const fake = await mountComposer("ref_a");
+    fake.on("turn/start", () => new Promise<never>(() => undefined));
+    fireEvent.change(textarea(), { target: { value: "send me" } });
+    if (image) {
+      installCanvasStubs();
+      pastePngInto(textarea());
+      await waitFor(() => expect(submitButton().disabled).toBe(false));
+      expect(screen.getByRole("button", { name: "Remove shot.png" })).toBeTruthy();
+    }
+    const firstInput = textarea();
+    const firstButton = submitButton();
+    const second = render(<Composer ref="ref_a" />);
+    const secondInput = within(second.container).getByRole<HTMLTextAreaElement>("textbox");
+    await flushPendingTurnsProjectionForTests();
+    const transact = IDBDatabase.prototype.transaction;
+    let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+    const committed = deferred<void>();
+    vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementation(function (this: IDBDatabase, ...args) {
+      const transaction = transact.apply(this, args);
+      if (!hold && transaction.mode === "readwrite" && transaction.objectStoreNames.contains("sequences")) {
+        hold = holdIndexedDBEvent(transaction, "complete");
+        void hold.reached.then(() => committed.resolve());
+      }
+      return transaction;
+    });
+    try {
+      fireEvent.click(firstButton);
+      await committed.promise;
+      fireEvent.change(secondInput, { target: { value: "newer shared draft" } });
+    } finally {
+      await act(async () => hold?.release());
+      await flushPendingTurnsProjectionForTests();
+    }
+    expect(firstInput.value).toBe("");
+    expect(secondInput.value).toBe("newer shared draft");
+    expect(readDraft("ref_a")).toBe("newer shared draft");
+  },
+);
+
 test("a remounted Composer does not activate a stale recovery projection", async () => {
   const storage = new PausedRecoveryReadStorage();
   setMutationStorageForTests(storage);

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -175,13 +175,17 @@ export function Composer({ ref }: ComposerProps) {
   // still clear the composer (only if unchanged since THAT read, mirroring
   // clearIfUnchanged's own submittedText snapshot for the classic drain
   // path below).
-  const lastDrainSnapshotRef = useRef<{ text: string; attachments: PendingAttachment[]; revision: number } | null>(
-    null,
-  );
+  const lastDrainSnapshotRef = useRef<{
+    text: string;
+    attachments: PendingAttachment[];
+    revision: number;
+    draftRevision: number;
+  } | null>(null);
   // Tracks edits within this mount, including recovery drafts whose persistence
   // writes can finish without an edit. Commit notifications only update the
   // display; they must still let this mount remove its submitted attachments.
   const draftEditRevisionRef = useRef(0);
+  const ownedDraftRevisionRef = useRef(readDraftRevision(ref));
 
   // Restore-on-mount is unconditional, not leak-guarded: under dockview a
   // session pane's `ref` never changes across a mounted Composer's
@@ -312,10 +316,21 @@ export function Composer({ ref }: ComposerProps) {
   const editText = useCallback(
     (nextText: string): void => {
       draftEditRevisionRef.current += 1;
-      if (activeRecoveryIdRef.current !== null) markDraftEdited(ref);
+      if (activeRecoveryIdRef.current !== null) {
+        markDraftEdited(ref);
+        ownedDraftRevisionRef.current = readDraftRevision(ref);
+      }
       updateText(nextText);
     },
     [ref, updateText],
+  );
+
+  const persistDraft = useCallback(
+    (nextText: string): void => {
+      writeDraft(ref, nextText);
+      ownedDraftRevisionRef.current = readDraftRevision(ref);
+    },
+    [ref],
   );
 
   useLayoutEffect(() => {
@@ -323,9 +338,12 @@ export function Composer({ ref }: ComposerProps) {
     // Re-read at subscription time so a commit between render and mount
     // cannot leave an already-cleared sticky draft in a fresh composer.
     updateText(readDraft(ref));
+    ownedDraftRevisionRef.current = readDraftRevision(ref);
     const unsubscribe = subscribeComposerSubmissionCommitted((targetRef, submittedText, recovery) => {
       if (targetRef !== ref) return;
       if (recovery && activeRecoveryIdRef.current === recovery.clientMutationId) {
+        if (recovery.draftUnchanged) ownedDraftRevisionRef.current = readDraftRevision(ref);
+        const ownsDraft = ownedDraftRevisionRef.current === readDraftRevision(ref);
         recoveryOwnsLocalDraftRef.current = false;
         recoveryWriteVersionRef.current += 1;
         recoveryReplacementEpochRef.current += 1;
@@ -348,8 +366,9 @@ export function Composer({ ref }: ComposerProps) {
             .map((item) => item.marker),
         );
         clearSubmittedAttachmentsRef.current(markers);
-        writeDraft(ref, textRef.current);
+        if (ownsDraft) persistDraft(textRef.current);
       } else if (!recovery && activeRecoveryIdRef.current === null && textRef.current === submittedText) {
+        ownedDraftRevisionRef.current = readDraftRevision(ref);
         updateText("");
       }
     });
@@ -357,7 +376,7 @@ export function Composer({ ref }: ComposerProps) {
       mountedRef.current = false;
       unsubscribe();
     };
-  }, [ref, setActiveRecoveryId, updateText]);
+  }, [ref, setActiveRecoveryId, updateText, persistDraft]);
 
   // Bridges useAttachments' pure string-splice logic to this component's
   // own controlled `text` state, instead of a direct DOM `.value` mutation
@@ -390,9 +409,13 @@ export function Composer({ ref }: ComposerProps) {
       text: textRef.current,
       cursor: cursorToRestoreRef.current ?? textareaRef.current?.selectionStart ?? textRef.current.length,
     }),
-    write: (nextText, cursor) => {
-      editText(nextText);
-      if (activeRecoveryIdRef.current === null) writeDraft(ref, nextText);
+    write: (nextText, cursor, source) => {
+      // Submission cleanup retires this mount's markers without claiming a
+      // shared draft that another composer has edited in the meantime.
+      const mayPersist = source !== "submission" || ownedDraftRevisionRef.current === readDraftRevision(ref);
+      if (source === "submission") updateText(nextText);
+      else editText(nextText);
+      if (mayPersist && activeRecoveryIdRef.current === null) persistDraft(nextText);
       cursorToRestoreRef.current = cursor;
     },
   };
@@ -788,7 +811,7 @@ export function Composer({ ref }: ComposerProps) {
 
   function handleTextChange(event: { target: { value: string; selectionStart?: number | null } }): void {
     editText(event.target.value);
-    if (activeRecoveryIdRef.current === null) writeDraft(ref, event.target.value);
+    if (activeRecoveryIdRef.current === null) persistDraft(event.target.value);
     // Every keystroke re-evaluates the trailing-token match fresh - a token
     // Escape just closed (slashToken's own doc comment above) reopens on the
     // very next text change rather than staying closed indefinitely.
@@ -821,11 +844,14 @@ export function Composer({ ref }: ComposerProps) {
   // Equal text can belong to a newer edit, including a reused image marker.
   // A commit notification may already have cleared the display without editing
   // the draft; its original attachment cleanup still belongs to this revision.
-  function clearIfUnchanged(submittedText: string, submittedRevision: number): boolean {
+  function clearIfUnchanged(submittedText: string, submittedRevision: number, submittedDraftRevision: number): boolean {
     if (!mountedRef.current || draftEditRevisionRef.current !== submittedRevision) return false;
     if (textRef.current === submittedText) {
       updateText("");
-      clearDraft(ref);
+      if (readDraftRevision(ref) === submittedDraftRevision) {
+        clearDraft(ref);
+        ownedDraftRevisionRef.current = readDraftRevision(ref);
+      }
     }
     return true;
   }
@@ -835,7 +861,7 @@ export function Composer({ ref }: ComposerProps) {
   function handleDrainSuccess(): void {
     const snapshot = lastDrainSnapshotRef.current;
     if (!snapshot || !mountedRef.current) return;
-    clearIfUnchanged(snapshot.text, snapshot.revision);
+    clearIfUnchanged(snapshot.text, snapshot.revision, snapshot.draftRevision);
     clearSubmittedAttachments(snapshot.attachments);
   }
 
@@ -928,6 +954,7 @@ export function Composer({ ref }: ComposerProps) {
       text: textRef.current,
       attachments: attachments.items,
       revision: draftEditRevisionRef.current,
+      draftRevision: readDraftRevision(ref),
     };
     return {
       text: textRef.current,
@@ -957,6 +984,7 @@ export function Composer({ ref }: ComposerProps) {
     const submittedText = textRef.current;
     const submittedAttachments = attachments.items;
     const submittedRevision = draftEditRevisionRef.current;
+    const submittedDraftRevision = readDraftRevision(ref);
     const payload = attachments.toInputAttachments();
     const submittedRecoveryId = activeRecoveryIdRef.current;
     let wonRecoveryResend = true;
@@ -988,7 +1016,7 @@ export function Composer({ ref }: ComposerProps) {
       );
       if (!mountedRef.current) return;
       if (!wonRecoveryResend) toasts.push("info", "This message was already sent in another tab.");
-      clearIfUnchanged(submittedText, submittedRevision);
+      clearIfUnchanged(submittedText, submittedRevision, submittedDraftRevision);
       clearSubmittedAttachments(submittedAttachments);
     } catch {
       // The local durable write failed. The submitted composer payload stays
@@ -1013,6 +1041,7 @@ export function Composer({ ref }: ComposerProps) {
   async function handleBuiltinSubmit(match: BuiltinMatch): Promise<void> {
     const submittedText = textRef.current;
     const submittedRevision = draftEditRevisionRef.current;
+    const submittedDraftRevision = readDraftRevision(ref);
     setBusyAction("submit");
     const ctx: PaletteRunContext = {
       sessionRef: ref,
@@ -1025,7 +1054,7 @@ export function Composer({ ref }: ComposerProps) {
     };
     const outcome = await runBuiltinCommand(match, ctx);
     setBusyAction(null);
-    if (outcome.ok) clearIfUnchanged(submittedText, submittedRevision);
+    if (outcome.ok) clearIfUnchanged(submittedText, submittedRevision, submittedDraftRevision);
     // On failure: the draft is left exactly as typed (clearIfUnchanged is
     // simply never called) - runBuiltinCommand has already toasted why.
   }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -93,6 +93,7 @@ export interface ComposerProps {
 
 const CLASS = {
   composer: requireClass(styles.composer, "composer.module.css", "composer"),
+  storageStatus: requireClass(styles.storageStatus, "composer.module.css", "storageStatus"),
   attachments: requireClass(styles.attachments, "composer.module.css", "attachments"),
   leading: requireClass(styles.leading, "composer.module.css", "leading"),
   visuallyHidden: requireClass(styles.visuallyHidden, "composer.module.css", "visuallyHidden"),
@@ -154,6 +155,7 @@ const ENDED_STATUSES: ReadonlySet<string> = new Set(["ended", "closed", "notLoad
 
 export function Composer({ ref }: ComposerProps) {
   const model = useThreadsStore((s) => s.threads.get(ref));
+  const mutationWriteStalled = useThreadsStore((s) => s.mutationWriteStalled);
   const pendingSendEntries = usePendingTurnEntries(ref, "send");
   const toasts = useToasts();
   const isMobile = useIsMobile();
@@ -1150,6 +1152,12 @@ export function Composer({ ref }: ComposerProps) {
 
   return (
     <div className={CLASS.composer}>
+      {mutationWriteStalled && (
+        <div className={CLASS.storageStatus} role="status" aria-label="Message storage">
+          Browser storage has stalled. A message update is still pending; keep this tab open while Evener waits for
+          confirmation.
+        </div>
+      )}
       {/* The ask dock no longer renders here: pending questions are the
           transcript's trailing row (Session.tsx passes AskDock as
           TranscriptBody's trailingRow), so the answering surface scrolls

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -70,7 +70,9 @@ import {
   discardRecoveryPendingTurn,
   refreshPendingTurnsProjection,
   resendRecoveryPendingTurn,
+  subscribeComposerSubmissionCommitted,
   updateRecoveryPendingTurn,
+  useComposerSubmitting,
   useRecoveryEntries,
 } from "./queue/pendingTurnsStore";
 import { consumeQuoteInsert, type QuoteInsertPlacement, useQuoteInsertRequest } from "./quoteInsert";
@@ -156,6 +158,7 @@ const ENDED_STATUSES: ReadonlySet<string> = new Set(["ended", "closed", "notLoad
 export function Composer({ ref }: ComposerProps) {
   const model = useThreadsStore((s) => s.threads.get(ref));
   const mutationWriteStalled = useThreadsStore((s) => s.mutationWriteStalled);
+  const submitting = useComposerSubmitting(ref);
   const pendingSendEntries = usePendingTurnEntries(ref, "send");
   const toasts = useToasts();
   const isMobile = useIsMobile();
@@ -199,6 +202,8 @@ export function Composer({ ref }: ComposerProps) {
   const recoveryReplacementEpochRef = useRef(0);
   const recoveryOwnsLocalDraftRef = useRef(false);
   const [busyAction, setBusyAction] = useState<BusyAction>(null);
+  const actionPending = busyAction !== null || submitting || mutationWriteStalled;
+  const mountedRef = useRef(false);
   const [pendingGoalReplacement, setPendingGoalReplacement] = useState<string | null>(null);
   // Whether a FINISHED session's collapsed follow-up field currently has focus,
   // which is what expands it from its one-line resting state. Only read on that
@@ -301,6 +306,22 @@ export function Composer({ ref }: ComposerProps) {
     textRef.current = nextText;
     setText(nextText);
   }, []);
+
+  useLayoutEffect(() => {
+    mountedRef.current = true;
+    // Re-read at subscription time so a commit between render and mount
+    // cannot leave an already-cleared sticky draft in a fresh composer.
+    updateText(readDraft(ref));
+    const unsubscribe = subscribeComposerSubmissionCommitted((targetRef, submittedText) => {
+      if (targetRef === ref && activeRecoveryIdRef.current === null && textRef.current === submittedText) {
+        updateText("");
+      }
+    });
+    return () => {
+      mountedRef.current = false;
+      unsubscribe();
+    };
+  }, [ref, updateText]);
 
   // Bridges useAttachments' pure string-splice logic to this component's
   // own controlled `text` state, instead of a direct DOM `.value` mutation
@@ -781,6 +802,7 @@ export function Composer({ ref }: ComposerProps) {
   // unconditional clear that could silently discard an edit made while the
   // strip's own drain request was still in flight.
   function handleDrainSuccess(): void {
+    if (!mountedRef.current) return;
     const snapshot = lastDrainSnapshotRef.current;
     if (snapshot === null) return; // defensive only: onDrainSuccess never fires without a prior getComposerText() call
     if (textRef.current === snapshot.text) {
@@ -928,6 +950,7 @@ export function Composer({ ref }: ComposerProps) {
           return threadsStore.getState().drainAsSteer(ref, submittedText, payload);
         },
       );
+      if (!mountedRef.current) return;
       if (submittedRecoveryId !== null && activeRecoveryIdRef.current === submittedRecoveryId) {
         recoveryOwnsLocalDraftRef.current = false;
         setActiveRecoveryId(null);
@@ -942,7 +965,7 @@ export function Composer({ ref }: ComposerProps) {
       // The local durable write failed. The submitted composer payload stays
       // untouched and no network request was eligible to start.
     } finally {
-      setBusyAction(null);
+      if (mountedRef.current) setBusyAction(null);
     }
   }
 
@@ -979,7 +1002,7 @@ export function Composer({ ref }: ComposerProps) {
 
   function handleFormSubmit(event: FormEvent): void {
     event.preventDefault();
-    if (busyAction !== null) return;
+    if (actionPending) return;
     if (!hasContent) return; // empty composer: no-op, no request, no message
     if (attachments.hasPending) {
       toasts.push("error", "Image attachment is still processing");
@@ -1014,7 +1037,7 @@ export function Composer({ ref }: ComposerProps) {
   }
 
   function handleSteerClick(): void {
-    if (busyAction !== null) return;
+    if (actionPending) return;
     if (attachments.hasPending) {
       toasts.push("error", "Image attachment is still processing");
       return;
@@ -1036,7 +1059,7 @@ export function Composer({ ref }: ComposerProps) {
   }
 
   async function handleInterruptClick(): Promise<void> {
-    if (busyAction !== null) return;
+    if (actionPending) return;
     setBusyAction("interrupt");
     try {
       await threadsStore.getState().interrupt(ref);
@@ -1189,8 +1212,10 @@ export function Composer({ ref }: ComposerProps) {
         activeRecoveryId={activeRecoveryId ?? undefined}
         onEditRecovery={activateRecovery}
         onDrainSuccess={handleDrainSuccess}
-        busy={busyAction !== null}
-        onDrainBusyChange={(draining) => setBusyAction(draining ? "drain" : null)}
+        busy={actionPending}
+        onDrainBusyChange={(draining) => {
+          if (mountedRef.current) setBusyAction(draining ? "drain" : null);
+        }}
       />
       {/* Staged attachments. One rendering for every state, so nothing here
           swaps element types under a user mid-gesture - AttachmentTile.tsx's
@@ -1320,7 +1345,7 @@ export function Composer({ ref }: ComposerProps) {
                             // busy + the interrupt capability are already what
                             // makes this render at all, so only an in-flight
                             // request of our own is left to gate on.
-                            disabled={busyAction !== null}
+                            disabled={actionPending}
                           >
                             Stop
                           </Button>
@@ -1346,7 +1371,7 @@ export function Composer({ ref }: ComposerProps) {
                           // the authority there, the same way it is for whether
                           // this card renders at all - otherwise a session the hub
                           // will happily resume shows a permanently dead Send.
-                          disabled={busyAction !== null || !hasContent || !(ended ? canSendWhenEnded : canCompose)}
+                          disabled={actionPending || !hasContent || !(ended ? canSendWhenEnded : canCompose)}
                         >
                           <span className={CLASS.submitLabel}>Send</span>
                         </Button>
@@ -1367,7 +1392,7 @@ export function Composer({ ref }: ComposerProps) {
                             onClick={handleSteerClick}
                             // Same as Stop above: busy + the steer capability
                             // already gate this control's existence.
-                            disabled={busyAction !== null}
+                            disabled={actionPending}
                           >
                             Steer
                           </Button>

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -64,7 +64,7 @@ import { type BuiltinMatch, matchBuiltinInvocation, runBuiltinCommand } from "./
 import { CurrentWork } from "./CurrentWork";
 import styles from "./composer.module.css";
 import { consumeComposerFocus, requestComposerFocus, useComposerFocusRequest } from "./composerFocus";
-import { clearDraft, readDraft, writeDraft } from "./draft";
+import { clearDraft, clearPersistedDraft, markDraftEdited, readDraft, readDraftRevision, writeDraft } from "./draft";
 import { QueueStrip, submitWithPendingTracking, usePendingTurnEntries } from "./queue";
 import {
   discardRecoveryPendingTurn,
@@ -175,7 +175,9 @@ export function Composer({ ref }: ComposerProps) {
   // still clear the composer (only if unchanged since THAT read, mirroring
   // clearIfUnchanged's own submittedText snapshot for the classic drain
   // path below).
-  const lastDrainSnapshotRef = useRef<{ text: string; markers: Set<number>; revision: number } | null>(null);
+  const lastDrainSnapshotRef = useRef<{ text: string; attachments: PendingAttachment[]; revision: number } | null>(
+    null,
+  );
   // Tracks edits within this mount, including recovery drafts whose persistence
   // writes can finish without an edit. Commit notifications only update the
   // display; they must still let this mount remove its submitted attachments.
@@ -310,9 +312,10 @@ export function Composer({ ref }: ComposerProps) {
   const editText = useCallback(
     (nextText: string): void => {
       draftEditRevisionRef.current += 1;
+      if (activeRecoveryIdRef.current !== null) markDraftEdited(ref);
       updateText(nextText);
     },
-    [updateText],
+    [ref, updateText],
   );
 
   useLayoutEffect(() => {
@@ -320,8 +323,33 @@ export function Composer({ ref }: ComposerProps) {
     // Re-read at subscription time so a commit between render and mount
     // cannot leave an already-cleared sticky draft in a fresh composer.
     updateText(readDraft(ref));
-    const unsubscribe = subscribeComposerSubmissionCommitted((targetRef, submittedText) => {
-      if (targetRef === ref && activeRecoveryIdRef.current === null && textRef.current === submittedText) {
+    const unsubscribe = subscribeComposerSubmissionCommitted((targetRef, submittedText, recovery) => {
+      if (targetRef !== ref) return;
+      if (recovery && activeRecoveryIdRef.current === recovery.clientMutationId) {
+        recoveryOwnsLocalDraftRef.current = false;
+        recoveryWriteVersionRef.current += 1;
+        recoveryReplacementEpochRef.current += 1;
+        setActiveRecoveryId(null);
+        if (recovery.draftUnchanged && textRef.current === submittedText) updateText("");
+        // Restoring the same recovery in another mount recreates its items.
+        // Match the submitted payload under that recovery owner; newly staged
+        // items have distinct markers, and replacing the draft exits ownership.
+        const markers = new Set(
+          attachmentItemsRef.current
+            .filter((item) =>
+              recovery.attachments.some(
+                (submitted) =>
+                  submitted.marker === item.marker &&
+                  submitted.data === item.data &&
+                  submitted.name === item.name &&
+                  submitted.mediaType === item.mediaType,
+              ),
+            )
+            .map((item) => item.marker),
+        );
+        clearSubmittedAttachmentsRef.current(markers);
+        writeDraft(ref, textRef.current);
+      } else if (!recovery && activeRecoveryIdRef.current === null && textRef.current === submittedText) {
         updateText("");
       }
     });
@@ -329,7 +357,7 @@ export function Composer({ ref }: ComposerProps) {
       mountedRef.current = false;
       unsubscribe();
     };
-  }, [ref, updateText]);
+  }, [ref, setActiveRecoveryId, updateText]);
 
   // Bridges useAttachments' pure string-splice logic to this component's
   // own controlled `text` state, instead of a direct DOM `.value` mutation
@@ -371,6 +399,8 @@ export function Composer({ ref }: ComposerProps) {
   const attachments = useAttachments(textEditor);
   const attachmentItemsRef = useRef(attachments.items);
   attachmentItemsRef.current = attachments.items;
+  const clearSubmittedAttachmentsRef = useRef(attachments.clearSubmitted);
+  clearSubmittedAttachmentsRef.current = attachments.clearSubmitted;
   const recoveryEntries = useRecoveryEntries(ref);
 
   const replaceComposerWithGoalDraft = (objective: string): void => {
@@ -431,6 +461,7 @@ export function Composer({ ref }: ComposerProps) {
     ): Promise<void> => {
       const version = ++recoveryWriteVersionRef.current;
       const replacementEpoch = recoveryReplacementEpochRef.current;
+      const draftRevision = readDraftRevision(ref);
       const operation = recoveryWrites.current
         .catch(() => undefined)
         .then(async () => {
@@ -448,12 +479,13 @@ export function Composer({ ref }: ComposerProps) {
             );
             if (
               activeRecoveryIdRef.current === clientMutationId &&
+              readDraftRevision(ref) === draftRevision &&
               textRef.current.trim() === "" &&
               attachmentItemsRef.current.length === 0
             ) {
               recoveryOwnsLocalDraftRef.current = false;
               setActiveRecoveryId(null);
-              clearDraft(ref);
+              clearPersistedDraft(ref);
             }
             return;
           }
@@ -462,10 +494,11 @@ export function Composer({ ref }: ComposerProps) {
             updated &&
             recoveryOwnsLocalDraftRef.current &&
             recoveryWriteVersionRef.current === version &&
+            readDraftRevision(ref) === draftRevision &&
             activeRecoveryIdRef.current === clientMutationId
           ) {
             recoveryOwnsLocalDraftRef.current = false;
-            clearDraft(ref);
+            clearPersistedDraft(ref);
           }
         });
       recoveryWrites.current = operation;
@@ -506,9 +539,12 @@ export function Composer({ ref }: ComposerProps) {
     const recovered = recoveryComposerDraft(record);
     recoveryOwnsLocalDraftRef.current = false;
     setActiveRecoveryId(record.clientMutationId);
-    editText(recovered.text);
+    // Restoration replaces this mount's local owner without editing the
+    // shared recovery draft that an earlier mount may still be submitting.
+    draftEditRevisionRef.current += 1;
+    updateText(recovered.text);
     attachments.replaceWithSettled(recovered.attachments);
-    clearDraft(ref);
+    clearPersistedDraft(ref);
     cursorToRestoreRef.current = recovered.text.length;
   }, [
     activeRecoveryId,
@@ -517,7 +553,7 @@ export function Composer({ ref }: ComposerProps) {
     recoveryEntries,
     ref,
     setActiveRecoveryId,
-    editText,
+    updateText,
   ]);
 
   // askPending gates hiding/inerting the input row below (AskDock's own
@@ -798,9 +834,18 @@ export function Composer({ ref }: ComposerProps) {
   // getComposerText before it starts the drain's durable write.
   function handleDrainSuccess(): void {
     const snapshot = lastDrainSnapshotRef.current;
-    if (snapshot && clearIfUnchanged(snapshot.text, snapshot.revision)) {
-      attachments.clearSubmitted(snapshot.markers);
-    }
+    if (!snapshot || !mountedRef.current) return;
+    clearIfUnchanged(snapshot.text, snapshot.revision);
+    clearSubmittedAttachments(snapshot.attachments);
+  }
+
+  function clearSubmittedAttachments(submitted: PendingAttachment[]): void {
+    // Text edits do not replace an attachment. Object identity distinguishes
+    // the submitted item from a replacement that reuses its marker number.
+    const markers = new Set(
+      attachmentItemsRef.current.filter((item) => submitted.includes(item)).map((item) => item.marker),
+    );
+    attachments.clearSubmitted(markers);
   }
 
   // restoreTextToComposer implements the shared "put text back into the
@@ -873,14 +918,17 @@ export function Composer({ ref }: ComposerProps) {
   // image missing (toInputAttachments() itself only ever filters incomplete
   // items without signaling it - see that function's own doc comment) - see
   // w5-integration-wiring-report.md Concern #3. Also stashes a snapshot into
-  // lastDrainSnapshotRef (text, edit revision, and the currently-staged marker set) so
+  // lastDrainSnapshotRef (text, edit revision, and the currently-staged attachments) so
   // handleDrainSuccess can later tell whether the composer changed between
   // THIS read and the drain actually resolving - QueueStrip only ever calls
   // this once per handleDrain invocation, immediately before starting the
   // request, so the snapshot always reflects exactly what that drain sent.
   function getComposerText() {
-    const markers = new Set(attachments.items.map((item) => item.marker));
-    lastDrainSnapshotRef.current = { text: textRef.current, markers, revision: draftEditRevisionRef.current };
+    lastDrainSnapshotRef.current = {
+      text: textRef.current,
+      attachments: attachments.items,
+      revision: draftEditRevisionRef.current,
+    };
     return {
       text: textRef.current,
       attachments: attachments.toInputAttachments(),
@@ -907,7 +955,7 @@ export function Composer({ ref }: ComposerProps) {
   // SAME failure; this is the fix, not a pre-existing split.
   async function submitAction(kind: "send" | "queue" | "steer" | "drain"): Promise<void> {
     const submittedText = textRef.current;
-    const submittedMarkers = new Set(attachments.items.map((item) => item.marker));
+    const submittedAttachments = attachments.items;
     const submittedRevision = draftEditRevisionRef.current;
     const payload = attachments.toInputAttachments();
     const submittedRecoveryId = activeRecoveryIdRef.current;
@@ -920,6 +968,7 @@ export function Composer({ ref }: ComposerProps) {
           method: kind,
           text: submittedText,
           attachments: payload,
+          recoveryId: submittedRecoveryId ?? undefined,
           onFailure: (err) => {
             const label = kind === "send" ? "Send" : kind === "queue" ? "Queue" : kind === "steer" ? "Steer" : "Drain";
             toasts.push("error", sessionActionError(`${label} failed`, err));
@@ -938,15 +987,9 @@ export function Composer({ ref }: ComposerProps) {
         },
       );
       if (!mountedRef.current) return;
-      if (submittedRecoveryId !== null && activeRecoveryIdRef.current === submittedRecoveryId) {
-        recoveryOwnsLocalDraftRef.current = false;
-        setActiveRecoveryId(null);
-        if (!wonRecoveryResend) toasts.push("info", "This message was already sent in another tab.");
-        if (draftEditRevisionRef.current !== submittedRevision) writeDraft(ref, textRef.current);
-      }
-      if (clearIfUnchanged(submittedText, submittedRevision)) {
-        attachments.clearSubmitted(submittedMarkers);
-      }
+      if (!wonRecoveryResend) toasts.push("info", "This message was already sent in another tab.");
+      clearIfUnchanged(submittedText, submittedRevision);
+      clearSubmittedAttachments(submittedAttachments);
     } catch {
       // The local durable write failed. The submitted composer payload stays
       // untouched and no network request was eligible to start.

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -175,11 +175,11 @@ export function Composer({ ref }: ComposerProps) {
   // still clear the composer (only if unchanged since THAT read, mirroring
   // clearIfUnchanged's own submittedText snapshot for the classic drain
   // path below).
-  const lastDrainSnapshotRef = useRef<{ text: string; markers: Set<number> } | null>(null);
-  // Invalidates the post-request cleanup captured by a submit that predates a
-  // canonical goal replacement. In particular, old marker ids may be reused
-  // after attachments.reset(), so stale cleanup must not strip new content.
-  const submissionVersionRef = useRef(0);
+  const lastDrainSnapshotRef = useRef<{ text: string; markers: Set<number>; revision: number } | null>(null);
+  // Tracks edits within this mount, including recovery drafts whose persistence
+  // writes can finish without an edit. Commit notifications only update the
+  // display; they must still let this mount remove its submitted attachments.
+  const draftEditRevisionRef = useRef(0);
 
   // Restore-on-mount is unconditional, not leak-guarded: under dockview a
   // session pane's `ref` never changes across a mounted Composer's
@@ -307,6 +307,14 @@ export function Composer({ ref }: ComposerProps) {
     setText(nextText);
   }, []);
 
+  const editText = useCallback(
+    (nextText: string): void => {
+      draftEditRevisionRef.current += 1;
+      updateText(nextText);
+    },
+    [updateText],
+  );
+
   useLayoutEffect(() => {
     mountedRef.current = true;
     // Re-read at subscription time so a commit between render and mount
@@ -355,7 +363,7 @@ export function Composer({ ref }: ComposerProps) {
       cursor: cursorToRestoreRef.current ?? textareaRef.current?.selectionStart ?? textRef.current.length,
     }),
     write: (nextText, cursor) => {
-      updateText(nextText);
+      editText(nextText);
       if (activeRecoveryIdRef.current === null) writeDraft(ref, nextText);
       cursorToRestoreRef.current = cursor;
     },
@@ -377,7 +385,6 @@ export function Composer({ ref }: ComposerProps) {
     setSlashToken(null);
     setSlashHighlighted(0);
     lastDrainSnapshotRef.current = null;
-    submissionVersionRef.current += 1;
     const command = `/goal ${objective}`;
     textEditor.write(command, command.length);
     setPendingGoalReplacement(null);
@@ -499,7 +506,7 @@ export function Composer({ ref }: ComposerProps) {
     const recovered = recoveryComposerDraft(record);
     recoveryOwnsLocalDraftRef.current = false;
     setActiveRecoveryId(record.clientMutationId);
-    updateText(recovered.text);
+    editText(recovered.text);
     attachments.replaceWithSettled(recovered.attachments);
     clearDraft(ref);
     cursorToRestoreRef.current = recovered.text.length;
@@ -510,7 +517,7 @@ export function Composer({ ref }: ComposerProps) {
     recoveryEntries,
     ref,
     setActiveRecoveryId,
-    updateText,
+    editText,
   ]);
 
   // askPending gates hiding/inerting the input row below (AskDock's own
@@ -744,7 +751,7 @@ export function Composer({ ref }: ComposerProps) {
   const followUpEngaged = followUpFocused || hasContent;
 
   function handleTextChange(event: { target: { value: string; selectionStart?: number | null } }): void {
-    updateText(event.target.value);
+    editText(event.target.value);
     if (activeRecoveryIdRef.current === null) writeDraft(ref, event.target.value);
     // Every keystroke re-evaluates the trailing-token match fresh - a token
     // Escape just closed (slashToken's own doc comment above) reopens on the
@@ -775,45 +782,25 @@ export function Composer({ ref }: ComposerProps) {
     textareaRef.current?.focus();
   }
 
-  // clearIfUnchanged mirrors clearComposerDraftIfUnchanged (parity-m5-
-  // composer.md §A): reads textRef.current, not `submittedText` (a `const`
-  // closed over by this async handler at call time, which never changes
-  // after that point regardless of later renders) - textRef.current is
-  // kept synchronously current by updateText() regardless of which
-  // render's closure this particular submitAction call started from.
-  function clearIfUnchanged(submittedText: string): void {
+  // Equal text can belong to a newer edit, including a reused image marker.
+  // A commit notification may already have cleared the display without editing
+  // the draft; its original attachment cleanup still belongs to this revision.
+  function clearIfUnchanged(submittedText: string, submittedRevision: number): boolean {
+    if (!mountedRef.current || draftEditRevisionRef.current !== submittedRevision) return false;
     if (textRef.current === submittedText) {
       updateText("");
       clearDraft(ref);
     }
+    return true;
   }
 
-  // handleDrainSuccess is QueueStrip's own onDrainSuccess seam (its "Steer
-  // now" button, a SEPARATE trigger from this component's own classic
-  // steer/drain path below): mirrors the legacy "the textarea clears" rule
-  // after the drain is durably recorded, gated the SAME way
-  // clearIfUnchanged gates this
-  // component's own drain path - only if the text is unchanged since the
-  // drain was TRIGGERED (lastDrainSnapshotRef, populated by getComposerText
-  // below at the moment QueueStrip actually read it), not unconditionally.
-  // QueueStripProps.onDrainSuccess itself takes no arguments, so this ref is
-  // the seam's own way of recovering a submitted-snapshot to compare
-  // against - see w5-integration-wiring-report.md Concern #2, previously an
-  // unconditional clear that could silently discard an edit made while the
-  // strip's own drain request was still in flight.
+  // QueueStrip captures this mount's payload and edit revision through
+  // getComposerText before it starts the drain's durable write.
   function handleDrainSuccess(): void {
-    if (!mountedRef.current) return;
     const snapshot = lastDrainSnapshotRef.current;
-    if (snapshot === null) return; // defensive only: onDrainSuccess never fires without a prior getComposerText() call
-    if (textRef.current === snapshot.text) {
-      updateText("");
-      clearDraft(ref);
+    if (snapshot && clearIfUnchanged(snapshot.text, snapshot.revision)) {
+      attachments.clearSubmitted(snapshot.markers);
     }
-    // Unconditional, like submitAction's own clearSubmitted call below: safe
-    // regardless of the text-unchanged check above, since it only ever
-    // removes the SPECIFIC markers this drain's own snapshot captured - an
-    // attachment staged after that snapshot survives untouched either way.
-    attachments.clearSubmitted(snapshot.markers);
   }
 
   // restoreTextToComposer implements the shared "put text back into the
@@ -853,7 +840,7 @@ export function Composer({ ref }: ComposerProps) {
       recoveryOwnsLocalDraftRef.current = true;
       setActiveRecoveryId(record.clientMutationId);
     }
-    updateText(merged.text);
+    editText(merged.text);
     attachments.replaceWithSettled(merged.attachments);
     cursorToRestoreRef.current = merged.text.length;
     textareaRef.current?.focus();
@@ -886,14 +873,14 @@ export function Composer({ ref }: ComposerProps) {
   // image missing (toInputAttachments() itself only ever filters incomplete
   // items without signaling it - see that function's own doc comment) - see
   // w5-integration-wiring-report.md Concern #3. Also stashes a snapshot into
-  // lastDrainSnapshotRef (text + the currently-staged marker set) so
+  // lastDrainSnapshotRef (text, edit revision, and the currently-staged marker set) so
   // handleDrainSuccess can later tell whether the composer changed between
   // THIS read and the drain actually resolving - QueueStrip only ever calls
   // this once per handleDrain invocation, immediately before starting the
   // request, so the snapshot always reflects exactly what that drain sent.
   function getComposerText() {
     const markers = new Set(attachments.items.map((item) => item.marker));
-    lastDrainSnapshotRef.current = { text: textRef.current, markers };
+    lastDrainSnapshotRef.current = { text: textRef.current, markers, revision: draftEditRevisionRef.current };
     return {
       text: textRef.current,
       attachments: attachments.toInputAttachments(),
@@ -921,7 +908,7 @@ export function Composer({ ref }: ComposerProps) {
   async function submitAction(kind: "send" | "queue" | "steer" | "drain"): Promise<void> {
     const submittedText = textRef.current;
     const submittedMarkers = new Set(attachments.items.map((item) => item.marker));
-    const submissionVersion = submissionVersionRef.current;
+    const submittedRevision = draftEditRevisionRef.current;
     const payload = attachments.toInputAttachments();
     const submittedRecoveryId = activeRecoveryIdRef.current;
     let wonRecoveryResend = true;
@@ -955,10 +942,9 @@ export function Composer({ ref }: ComposerProps) {
         recoveryOwnsLocalDraftRef.current = false;
         setActiveRecoveryId(null);
         if (!wonRecoveryResend) toasts.push("info", "This message was already sent in another tab.");
-        if (textRef.current !== submittedText) writeDraft(ref, textRef.current);
+        if (draftEditRevisionRef.current !== submittedRevision) writeDraft(ref, textRef.current);
       }
-      if (submissionVersionRef.current === submissionVersion) {
-        clearIfUnchanged(submittedText);
+      if (clearIfUnchanged(submittedText, submittedRevision)) {
         attachments.clearSubmitted(submittedMarkers);
       }
     } catch {
@@ -983,6 +969,7 @@ export function Composer({ ref }: ComposerProps) {
   // while the RPC was still in flight.
   async function handleBuiltinSubmit(match: BuiltinMatch): Promise<void> {
     const submittedText = textRef.current;
+    const submittedRevision = draftEditRevisionRef.current;
     setBusyAction("submit");
     const ctx: PaletteRunContext = {
       sessionRef: ref,
@@ -995,7 +982,7 @@ export function Composer({ ref }: ComposerProps) {
     };
     const outcome = await runBuiltinCommand(match, ctx);
     setBusyAction(null);
-    if (outcome.ok) clearIfUnchanged(submittedText);
+    if (outcome.ok) clearIfUnchanged(submittedText, submittedRevision);
     // On failure: the draft is left exactly as typed (clearIfUnchanged is
     // simply never called) - runBuiltinCommand has already toasted why.
   }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/attachments/useAttachments.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/attachments/useAttachments.ts
@@ -139,7 +139,9 @@ export function useAttachments(editor: TextEditor): UseAttachmentsResult {
 
   const replaceWithSettled = useCallback((nextItems: PendingAttachment[]) => {
     nextMarkerRef.current = nextItems.reduce((highest, item) => Math.max(highest, item.marker), 0);
-    setItems(nextItems.map((item) => ({ ...item })));
+    // A recovery merge carries existing staged objects alongside new items.
+    // Preserve those identities so an in-flight send can still retire them.
+    setItems((previous) => nextItems.map((item) => (previous.includes(item) ? item : { ...item })));
   }, []);
 
   const reset = useCallback(() => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/attachments/useAttachments.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/attachments/useAttachments.ts
@@ -57,7 +57,7 @@ export interface PendingAttachment {
 // class - Composer.test.tsx's own regression test is what has to.
 export interface TextEditor {
   read(): { text: string; cursor: number };
-  write(text: string, cursor: number): void;
+  write(text: string, cursor: number, source?: "edit" | "submission"): void;
 }
 
 export interface UseAttachmentsResult {
@@ -252,7 +252,7 @@ export function useAttachments(editor: TextEditor): UseAttachmentsResult {
           const stripped = stripMarker(current.text, current.cursor, marker);
           current = { text: stripped.value, cursor: stripped.cursor ?? current.cursor };
         }
-        editor.write(current.text, current.cursor);
+        editor.write(current.text, current.cursor, "submission");
       }
       setItems((prev) => {
         const next = prev.filter((item) => !submittedMarkers.has(item.marker));

--- a/cmd/evener-hub/frontend/src/panes/session/composer/composer.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/composer.module.css
@@ -17,6 +17,11 @@
   container-type: inline-size;
 }
 
+.storageStatus {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
 /* Positions SlashCompletionMenu (an absolutely-positioned child) above the
  * form it wraps, without affecting this element's own layout - see that
  * component's own slashcompletionmenu.module.css header comment for the

--- a/cmd/evener-hub/frontend/src/panes/session/composer/draft.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/draft.ts
@@ -14,6 +14,13 @@
 // different ref" for a fresh mount to ever see. Restoring this ref's draft
 // on mount (Composer.tsx) is therefore unconditional, not guarded.
 const STORAGE_PREFIX = "evener.composer.draft.v1.";
+const draftRevisions = new Map<string, number>();
+
+// A remount inherits the same draft revision. Editing or replacing its
+// contents changes ownership even when the resulting text is identical.
+export function readDraftRevision(ref: string): number {
+  return draftRevisions.get(ref) ?? 0;
+}
 
 export function draftStorageKey(ref: string): string {
   return `${STORAGE_PREFIX}${ref}`;
@@ -33,6 +40,7 @@ export function readDraft(ref: string): string {
 // Blank/whitespace-only content removes the key rather than storing an
 // empty string - a draft that would never send is never persisted.
 export function writeDraft(ref: string, value: string): void {
+  draftRevisions.set(ref, readDraftRevision(ref) + 1);
   try {
     if (value.trim() === "") {
       localStorage.removeItem(draftStorageKey(ref));
@@ -49,6 +57,7 @@ export function writeDraft(ref: string, value: string): void {
 // successful send/steer/queue/drain (never on failure), mirroring the
 // legacy clearComposerDraftIfUnchanged convention.
 export function clearDraft(ref: string): void {
+  draftRevisions.set(ref, readDraftRevision(ref) + 1);
   try {
     localStorage.removeItem(draftStorageKey(ref));
   } catch {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/draft.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/draft.ts
@@ -22,6 +22,10 @@ export function readDraftRevision(ref: string): number {
   return draftRevisions.get(ref) ?? 0;
 }
 
+export function markDraftEdited(ref: string): void {
+  draftRevisions.set(ref, readDraftRevision(ref) + 1);
+}
+
 export function draftStorageKey(ref: string): string {
   return `${STORAGE_PREFIX}${ref}`;
 }
@@ -40,7 +44,7 @@ export function readDraft(ref: string): string {
 // Blank/whitespace-only content removes the key rather than storing an
 // empty string - a draft that would never send is never persisted.
 export function writeDraft(ref: string, value: string): void {
-  draftRevisions.set(ref, readDraftRevision(ref) + 1);
+  markDraftEdited(ref);
   try {
     if (value.trim() === "") {
       localStorage.removeItem(draftStorageKey(ref));
@@ -57,7 +61,13 @@ export function writeDraft(ref: string, value: string): void {
 // successful send/steer/queue/drain (never on failure), mirroring the
 // legacy clearComposerDraftIfUnchanged convention.
 export function clearDraft(ref: string): void {
-  draftRevisions.set(ref, readDraftRevision(ref) + 1);
+  markDraftEdited(ref);
+  clearPersistedDraft(ref);
+}
+
+// Recovery persistence owns the text in IndexedDB. Removing its redundant
+// localStorage copy does not represent a new edit of that draft.
+export function clearPersistedDraft(ref: string): void {
   try {
     localStorage.removeItem(draftStorageKey(ref));
   } catch {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/QueueStrip.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/QueueStrip.tsx
@@ -18,6 +18,7 @@ import { Button, IconButton, type IconButtonProps, Tooltip, useToasts } from "..
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import {
   discardRecoveryPendingTurn,
+  resendRecoveryPendingTurn,
   retryBlockedPendingTurn,
   submitWithPendingTracking,
   useBlockedMutationEntries,
@@ -235,20 +236,35 @@ export function QueueStrip({
       toasts.push("error", "Image attachment is still processing");
       return;
     }
+    let wonRecoveryResend = true;
     onDrainBusyChange(true);
     try {
       await submitWithPendingTracking(
         {
           ref: sessionRef,
           method: "drain",
+          recoveryId: activeRecoveryId,
           text,
           attachments,
           onFailure: (err) => {
             toasts.push("error", sessionActionError("Drain failed", err));
           },
         },
-        () => threadsStore.getState().drainAsSteer(sessionRef, text, attachments),
+        async () => {
+          if (activeRecoveryId) {
+            wonRecoveryResend = await resendRecoveryPendingTurn(
+              activeRecoveryId,
+              sessionRef,
+              "drain",
+              text,
+              attachments ?? [],
+            );
+            return;
+          }
+          return threadsStore.getState().drainAsSteer(sessionRef, text, attachments);
+        },
       );
+      if (!wonRecoveryResend) toasts.push("info", "This message was already sent in another tab.");
       onDrainSuccess();
     } catch {
       // Already reported via onFailure above; swallow so the rejection

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.edge.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.edge.test.ts
@@ -7,6 +7,7 @@ import type { MutationIntent } from "../../../../stores/mutationOutbox";
 import { MutationOutboxIndexedDB } from "../../../../stores/mutationOutboxIndexedDB";
 import { resetThreadsStoreForTests, setMutationStorageForTests } from "../../../../stores/threads";
 import {
+  flushPendingTurnsProjectionForTests,
   refreshPendingTurnsProjection,
   resetPendingTurnsStoreForTests,
   useBlockedMutationEntries,
@@ -55,6 +56,9 @@ test("an all-target refresh replaces the complete blocked projection", async () 
   await act(async () => {
     expect(await refreshPendingTurnsProjection()).toBe(true);
   });
+
+  // Startup discovery can start a newer projection while the explicit read runs.
+  await flushPendingTurnsProjectionForTests();
 
   const refA = renderHook(() => useBlockedMutationEntries("ref-a"));
   const refB = renderHook(() => useBlockedMutationEntries("ref-b"));

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
@@ -166,6 +166,59 @@ test("a committed submission releases its caller while recovery projection reads
   }
 });
 
+test.each([
+  [undefined, undefined],
+  [undefined, "ref_a"],
+  ["ref_a", undefined],
+  ["ref_a", "ref_a"],
+])("a failed newer refresh fences an older pending snapshot (%s then %s)", async (olderRef, ref) => {
+  const storage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(storage);
+  await connect();
+  const pending = renderHook(() => usePendingTurnEntries("ref_a", "send"));
+  await flushPendingTurnsProjectionForTests();
+  const record = await storage.enqueueIntent({
+    targetRef: "ref_a",
+    method: "turn/start",
+    payload: { ref: "ref_a", input: [{ type: "text", text: "settled send" }] },
+    attachments: [],
+    optimisticDisplay: { method: "turn/start", input: [{ type: "text", text: "settled send" }] },
+  });
+  const getAll = IDBObjectStore.prototype.getAll;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let reached: () => void = () => {};
+  const reading = new Promise<void>((resolve) => {
+    reached = resolve;
+  });
+  const spy = vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (this: IDBObjectStore, ...args) {
+    const request = getAll.apply(this, args);
+    if (this.name === "recovery" && !hold) {
+      hold = holdIndexedDBEvent(request, "success");
+      void hold.reached.then(reached);
+    }
+    return request;
+  });
+  const older = refreshPendingTurnsProjection(olderRef);
+  try {
+    await reading;
+    await storage.settleApplied(record.clientMutationId);
+    spy.mockImplementationOnce(() => {
+      throw new Error("storage read failed");
+    });
+    expect(await refreshPendingTurnsProjection(ref)).toBe(false);
+    await act(async () => {
+      hold?.release();
+      await older;
+    });
+    expect(pending.result.current).toEqual([]);
+  } finally {
+    spy.mockRestore();
+    hold?.release();
+    await older;
+    await flushPendingTurnsProjectionForTests();
+  }
+});
+
 test("an older all-target projection cannot erase a newly committed send", async () => {
   const fake = await connect();
   fake.on("turn/start", () => new Promise<never>(() => undefined));

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
@@ -20,6 +20,7 @@ import {
   updateRecoveryPendingTurn,
   useAwaitingFirstFrameSend,
   usePendingTurnEntries,
+  useRecoveryEntries,
 } from "./pendingTurnsStore";
 
 function thread(overrides: Partial<Thread> = {}): Thread {
@@ -165,6 +166,42 @@ test("a committed submission releases its caller while recovery projection reads
   }
 });
 
+test("an older all-target projection cannot erase a newly committed send", async () => {
+  const fake = await connect();
+  fake.on("turn/start", () => new Promise<never>(() => undefined));
+  const pending = renderHook(() => usePendingTurnEntries("ref_a", "send"));
+  await flushPendingTurnsProjectionForTests();
+  const getAll = IDBObjectStore.prototype.getAll;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let announceRead: (() => void) | undefined;
+  const readHeld = new Promise<void>((resolve) => {
+    announceRead = resolve;
+  });
+  const spy = vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (this: IDBObjectStore, ...args) {
+    const request = getAll.apply(this, args);
+    if (this.name === "recovery" && !hold) {
+      hold = holdIndexedDBEvent(request, "success");
+      void hold.reached.then(() => announceRead?.());
+    }
+    return request;
+  });
+  const oldRead = refreshPendingTurnsProjection();
+  try {
+    await readHeld;
+    await act(async () => threadsStore.getState().send("ref_a", "keep the committed send"));
+    expect(pending.result.current).toHaveLength(1);
+    await act(async () => {
+      hold?.release();
+      await oldRead;
+    });
+    expect(pending.result.current).toHaveLength(1);
+  } finally {
+    spy.mockRestore();
+    hold?.release();
+    await flushPendingTurnsProjectionForTests();
+  }
+});
+
 test("a local commit failure reports the exact error and never creates optimistic state", async () => {
   const failure = new Error("IndexedDB commit failed");
   const onFailure = vi.fn();
@@ -250,6 +287,61 @@ test("recovery action wrappers refresh the durable projection", async () => {
   ]);
   expect(await storage.getRecovery(records[1]!.clientMutationId)).toBeUndefined();
   expect(await storage.getRecovery(records[2]!.clientMutationId)).toBeUndefined();
+});
+
+test("a recovery resend publishes its handoff without waiting for recovery projection reads", async () => {
+  const storage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(storage);
+  const original = await storage.enqueueIntent({
+    targetRef: "ref_a",
+    method: "turn/start",
+    payload: { ref: "ref_a", input: [{ type: "text", text: "retry this" }] },
+    attachments: [],
+    optimisticDisplay: { method: "turn/start", input: [{ type: "text", text: "retry this" }] },
+  });
+  await storage.transferToRecovery(original.clientMutationId, "rejected");
+  const fake = await connect();
+  fake.on("turn/start", () => new Promise<never>(() => undefined));
+  const recovery = renderHook(() => useRecoveryEntries("ref_a"));
+  const pending = renderHook(() => usePendingTurnEntries("ref_a", "send"));
+  await flushPendingTurnsProjectionForTests();
+  expect(recovery.result.current).toHaveLength(1);
+
+  const getAll = IDBObjectStore.prototype.getAll;
+  const held: ReturnType<typeof holdIndexedDBEvent>[] = [];
+  let announceRead: (() => void) | undefined;
+  const readHeld = new Promise<void>((resolve) => {
+    announceRead = resolve;
+  });
+  const spy = vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (this: IDBObjectStore, ...args) {
+    const request = getAll.apply(this, args);
+    if (this.name === "recovery") {
+      const hold = holdIndexedDBEvent(request, "success");
+      held.push(hold);
+      void hold.reached.then(() => announceRead?.());
+    }
+    return request;
+  });
+  let accepted = false;
+  const resend = resendRecoveryPendingTurn(original.clientMutationId, "ref_a", "send", "retry this", []).then(
+    (result) => {
+      accepted = result;
+    },
+  );
+  try {
+    await act(async () => {
+      await readHeld;
+      await storage.listOutbox();
+    });
+    expect(accepted).toBe(true);
+    expect(recovery.result.current).toHaveLength(0);
+    expect(pending.result.current).toHaveLength(1);
+  } finally {
+    spy.mockRestore();
+    for (const hold of held) hold.release();
+    await resend;
+    await flushPendingTurnsProjectionForTests();
+  }
 });
 
 test("authoritative pendingMutations reconstruct accepted steering without a browser registry", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { IDBFactory } from "fake-indexeddb";
+import { IDBFactory, IDBObjectStore } from "fake-indexeddb";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { FakeClient } from "../../../../protocol/testing/fakeClient";
 import type { Thread, ThreadReadResponse } from "../../../../protocol/types.gen";
 import { connectionStore } from "../../../../stores/connection";
 import { MutationOutboxIndexedDB } from "../../../../stores/mutationOutboxIndexedDB";
+import { holdIndexedDBEvent } from "../../../../stores/testing/stalledIndexedDB";
 import { resetThreadsStoreForTests, setMutationStorageForTests, threadsStore } from "../../../../stores/threads";
 import { useColdStartSkeleton } from "../../coldStart";
 import {
@@ -121,6 +122,47 @@ test("an action becomes pending only after its durable enqueue commits", async (
   await flushPendingTurnsProjectionForTests();
 
   expect(pending.result.current).toEqual([expect.objectContaining({ text: "hello" })]);
+});
+
+test("a committed submission releases its caller while recovery projection reads are stalled", async () => {
+  const storage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(storage);
+  const fake = await connect();
+  fake.on("turn/steer", () => new Promise<never>(() => undefined));
+  await flushPendingTurnsProjectionForTests();
+  const getAll = IDBObjectStore.prototype.getAll;
+  const held: ReturnType<typeof holdIndexedDBEvent>[] = [];
+  let firstRead: (() => void) | undefined;
+  const readStarted = new Promise<void>((resolve) => {
+    firstRead = resolve;
+  });
+  const spy = vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (this: IDBObjectStore, ...args) {
+    const request = getAll.apply(this, args);
+    if (this.name === "recovery") {
+      const hold = holdIndexedDBEvent(request, "success");
+      held.push(hold);
+      void hold.reached.then(() => firstRead?.());
+    }
+    return request;
+  });
+  let accepted = false;
+  const onFailure = vi.fn();
+  const submit = submitWithPendingTracking({ ref: "ref_a", method: "steer", text: "one send", onFailure }, () =>
+    threadsStore.getState().steer("ref_a", "one send"),
+  ).then(() => {
+    accepted = true;
+  });
+  try {
+    await readStarted;
+    expect(await storage.listOutbox()).toHaveLength(1);
+    expect(accepted).toBe(true);
+    expect(onFailure).not.toHaveBeenCalled();
+  } finally {
+    spy.mockRestore();
+    for (const hold of held) hold.release();
+    await submit;
+    await flushPendingTurnsProjectionForTests();
+  }
 });
 
 test("a local commit failure reports the exact error and never creates optimistic state", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -227,10 +227,17 @@ export interface SubmitWithPendingTrackingOptions {
   method: PendingMethod;
   text: string;
   attachments?: InputAttachment[];
+  recoveryId?: string;
   onFailure: (error: unknown) => void;
 }
 
-type SubmissionCommittedListener = (ref: string, text: string) => void;
+interface RecoverySubmissionCommit {
+  clientMutationId: string;
+  draftUnchanged: boolean;
+  attachments: InputAttachment[];
+}
+
+type SubmissionCommittedListener = (ref: string, text: string, recovery?: RecoverySubmissionCommit) => void;
 const submissionCommittedListeners = new Set<SubmissionCommittedListener>();
 
 export function subscribeComposerSubmissionCommitted(listener: SubmissionCommittedListener): () => void {
@@ -272,15 +279,23 @@ export function submitWithPendingTracking(
         }
         // Submission ownership outlives a mounted composer. A retired mount
         // must not clear a newer draft written after a tab switch.
-        if (
-          epoch === refreshEpoch &&
-          readDraftRevision(opts.ref) === draftRevision &&
-          readDraft(opts.ref) === opts.text
-        ) {
-          clearDraft(opts.ref);
+        const draftUnchanged = readDraftRevision(opts.ref) === draftRevision;
+        const clearStoredDraft = draftUnchanged && readDraft(opts.ref) === opts.text;
+        if (epoch === refreshEpoch && (clearStoredDraft || opts.recoveryId)) {
+          if (clearStoredDraft) clearDraft(opts.ref);
           for (const listener of submissionCommittedListeners) {
             try {
-              listener(opts.ref, opts.text);
+              listener(
+                opts.ref,
+                opts.text,
+                opts.recoveryId
+                  ? {
+                      clientMutationId: opts.recoveryId,
+                      draftUnchanged,
+                      attachments: opts.attachments ?? [],
+                    }
+                  : undefined,
+              );
             } catch (error) {
               console.error("Composer submission listener failed", error);
             }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -56,7 +56,8 @@ const pendingTurnsStore = createStore<PendingTurnsStoreState>(() => ({
 }));
 
 let refreshGeneration = 0;
-const appliedRefreshGenerations = new Map<string, number>();
+let allTargetsRefreshGeneration = 0;
+const refreshGenerations = new Map<string, number>();
 let refreshEpoch = 0;
 
 function replaceTargetRecords<T extends { clientMutationId: string; targetRef: string }>(
@@ -165,6 +166,9 @@ function recordSubmittedHere(snapshot: {
 async function readProjectionIntoStore(ref?: string): Promise<boolean> {
   const epoch = refreshEpoch;
   const generation = ++refreshGeneration;
+  // Starting a newer read supersedes older snapshots even if that read fails.
+  if (ref === undefined) allTargetsRefreshGeneration = generation;
+  else refreshGenerations.set(ref, generation);
   try {
     const snapshot = await readMutationPersistence(ref);
     if (refreshEpoch !== epoch) return false;
@@ -180,7 +184,7 @@ async function readProjectionIntoStore(ref?: string): Promise<boolean> {
     const targets = new Set(
       ref === undefined
         ? [
-            ...appliedRefreshGenerations.keys(),
+            ...refreshGenerations.keys(),
             ...snapshot.outbox.map((record) => record.targetRef),
             ...snapshot.optimistic.map((record) => record.targetRef),
             ...snapshot.recovery.map((record) => record.targetRef),
@@ -188,8 +192,9 @@ async function readProjectionIntoStore(ref?: string): Promise<boolean> {
         : [ref],
     );
     for (const target of targets) {
-      if (generation < (appliedRefreshGenerations.get(target) ?? 0)) targets.delete(target);
-      else appliedRefreshGenerations.set(target, generation);
+      if (generation < Math.max(allTargetsRefreshGeneration, refreshGenerations.get(target) ?? 0))
+        targets.delete(target);
+      else refreshGenerations.set(target, generation);
     }
     pendingTurnsStore.setState((state) => ({
       outbox: replaceTargetRecords(state.outbox, targets, snapshot.outbox),
@@ -207,7 +212,7 @@ async function readProjectionIntoStore(ref?: string): Promise<boolean> {
 subscribeMutationPersistence((targetRefs, committed) => {
   if (committed) {
     const { record, recoveryId } = committed;
-    appliedRefreshGenerations.set(record.targetRef, ++refreshGeneration);
+    refreshGenerations.set(record.targetRef, ++refreshGeneration);
     recordSubmittedHere({ outbox: [record], optimistic: [] });
     pendingTurnsStore.setState((state) => {
       const recovery = new Map(state.recovery);
@@ -445,7 +450,8 @@ export function resendRecoveryPendingTurn(
 export function resetPendingTurnsStoreForTests(): void {
   refreshEpoch += 1;
   refreshGeneration = 0;
-  appliedRefreshGenerations.clear();
+  allTargetsRefreshGeneration = 0;
+  refreshGenerations.clear();
   // The epoch bump already voids anything still running against the previous
   // test's storage, so it is not this test's projection work to wait for.
   inFlightProjectionWork.clear();

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -18,6 +18,7 @@ import {
   updateRecoveryMutation,
   useThreadsStore,
 } from "../../../../stores/threads";
+import { clearDraft, readDraft } from "../draft";
 import { type PendingMethod, type PendingTurnEntry, reconcilePendingEntries } from "./pendingReconcile";
 
 export type { PendingMethod, PendingTurnEntry } from "./pendingReconcile";
@@ -26,6 +27,7 @@ interface PendingTurnsStoreState {
   outbox: Map<string, MutationOutboxRecord>;
   optimistic: Map<string, MutationOptimisticRecord>;
   recovery: Map<string, MutationRecoveryRecord>;
+  submittingRefs: ReadonlySet<string>;
   // Every client mutation id this client's own durable projection has held, for
   // as long as this page lives. The durable records themselves are the primary
   // evidence of "this client submitted it", and they are deliberately short
@@ -35,11 +37,9 @@ interface PendingTurnsStoreState {
   // outlive the record, because routing asks about it after the hydrate too -
   // see reconcilePendingEntries.
   //
-  // Recorded from the projection read rather than the submit call because the
-  // clientMutationId is minted inside the durable enqueue, and the read that
-  // publishes that write always precedes any hydrate that could settle it: the
-  // daemon cannot report an id it has not been sent yet, and the send happens
-  // after the local commit this read follows.
+  // Local commits publish their identity directly, before the composer can
+  // accept another message. Projection reads discover identities from reloads
+  // and other tabs; a stalled read cannot hide a commit made by this page.
   //
   // Ids only, one per mutation this page submits, never pruned - a page that
   // submits enough sends for that to matter has far larger records than these
@@ -51,24 +51,26 @@ const pendingTurnsStore = createStore<PendingTurnsStoreState>(() => ({
   outbox: new Map(),
   optimistic: new Map(),
   recovery: new Map(),
+  submittingRefs: new Set(),
   submittedHere: new Set(),
 }));
 
-const refreshGenerations = new Map<string, number>();
+let refreshGeneration = 0;
 const appliedRefreshGenerations = new Map<string, number>();
 let refreshEpoch = 0;
 
 function replaceTargetRecords<T extends { clientMutationId: string; targetRef: string }>(
   current: Map<string, T>,
-  targetRef: string | undefined,
+  targets: ReadonlySet<string>,
   records: T[],
 ): Map<string, T> {
-  if (targetRef === undefined) return new Map(records.map((record) => [record.clientMutationId, record]));
   const next = new Map(current);
   for (const [id, record] of next) {
-    if (record.targetRef === targetRef) next.delete(id);
+    if (targets.has(record.targetRef)) next.delete(id);
   }
-  for (const record of records) next.set(record.clientMutationId, record);
+  for (const record of records) {
+    if (targets.has(record.targetRef)) next.set(record.clientMutationId, record);
+  }
   return next;
 }
 
@@ -162,9 +164,7 @@ function recordSubmittedHere(snapshot: {
 
 async function readProjectionIntoStore(ref?: string): Promise<boolean> {
   const epoch = refreshEpoch;
-  const key = ref ?? "*";
-  const generation = (refreshGenerations.get(key) ?? 0) + 1;
-  refreshGenerations.set(key, generation);
+  const generation = ++refreshGeneration;
   try {
     const snapshot = await readMutationPersistence(ref);
     if (refreshEpoch !== epoch) return false;
@@ -175,12 +175,26 @@ async function readProjectionIntoStore(ref?: string): Promise<boolean> {
     // later - may be looking at storage that record has since been settled out
     // of. Skipping it there would leave the id known to nobody.
     recordSubmittedHere(snapshot);
-    if (generation < (appliedRefreshGenerations.get(key) ?? 0)) return true;
-    appliedRefreshGenerations.set(key, generation);
+    // Reads of all targets and reads of one target share the same ordering.
+    // An old all-target snapshot must not erase a newer local commit.
+    const targets = new Set(
+      ref === undefined
+        ? [
+            ...appliedRefreshGenerations.keys(),
+            ...snapshot.outbox.map((record) => record.targetRef),
+            ...snapshot.optimistic.map((record) => record.targetRef),
+            ...snapshot.recovery.map((record) => record.targetRef),
+          ]
+        : [ref],
+    );
+    for (const target of targets) {
+      if (generation < (appliedRefreshGenerations.get(target) ?? 0)) targets.delete(target);
+      else appliedRefreshGenerations.set(target, generation);
+    }
     pendingTurnsStore.setState((state) => ({
-      outbox: replaceTargetRecords(state.outbox, ref, snapshot.outbox),
-      optimistic: replaceTargetRecords(state.optimistic, ref, snapshot.optimistic),
-      recovery: replaceTargetRecords(state.recovery, ref, snapshot.recovery),
+      outbox: replaceTargetRecords(state.outbox, targets, snapshot.outbox),
+      optimistic: replaceTargetRecords(state.optimistic, targets, snapshot.optimistic),
+      recovery: replaceTargetRecords(state.recovery, targets, snapshot.recovery),
     }));
     return true;
   } catch {
@@ -190,7 +204,17 @@ async function readProjectionIntoStore(ref?: string): Promise<boolean> {
   }
 }
 
-subscribeMutationPersistence((targetRefs) => {
+subscribeMutationPersistence((targetRefs, committed) => {
+  if (committed) {
+    const { record, recoveryId } = committed;
+    appliedRefreshGenerations.set(record.targetRef, ++refreshGeneration);
+    recordSubmittedHere({ outbox: [record], optimistic: [] });
+    pendingTurnsStore.setState((state) => {
+      const recovery = new Map(state.recovery);
+      if (recoveryId) recovery.delete(recoveryId);
+      return { outbox: new Map(state.outbox).set(record.clientMutationId, record), recovery };
+    });
+  }
   if (targetRefs.length === 0) {
     void refreshPendingTurnsProjection();
     return;
@@ -206,6 +230,18 @@ export interface SubmitWithPendingTrackingOptions {
   onFailure: (error: unknown) => void;
 }
 
+type SubmissionCommittedListener = (ref: string, text: string) => void;
+const submissionCommittedListeners = new Set<SubmissionCommittedListener>();
+
+export function subscribeComposerSubmissionCommitted(listener: SubmissionCommittedListener): () => void {
+  submissionCommittedListeners.add(listener);
+  return () => submissionCommittedListeners.delete(listener);
+}
+
+export function useComposerSubmitting(ref: string): boolean {
+  return useStore(pendingTurnsStore, (state) => state.submittingRefs.has(ref));
+}
+
 // The action resolves at the local IndexedDB commit boundary. Durable state,
 // not a component timer or text echo, is the only optimistic lifecycle.
 //
@@ -219,14 +255,40 @@ export function submitWithPendingTracking(
   opts: SubmitWithPendingTrackingOptions,
   perform: () => Promise<void>,
 ): Promise<void> {
+  if (pendingTurnsStore.getState().submittingRefs.has(opts.ref)) {
+    return Promise.reject(new Error("A message submission is already pending for this task"));
+  }
+  const epoch = refreshEpoch;
+  pendingTurnsStore.setState((state) => ({ submittingRefs: new Set(state.submittingRefs).add(opts.ref) }));
   return trackProjectionWork(
     (async () => {
       try {
-        await perform();
-      } catch (error) {
-        opts.onFailure(error);
-        throw error;
+        try {
+          await perform();
+        } catch (error) {
+          opts.onFailure(error);
+          throw error;
+        }
+        // Submission ownership outlives a mounted composer. A retired mount
+        // must not clear a newer draft written after a tab switch.
+        if (epoch === refreshEpoch && readDraft(opts.ref) === opts.text) {
+          clearDraft(opts.ref);
+          for (const listener of submissionCommittedListeners) {
+            try {
+              listener(opts.ref, opts.text);
+            } catch (error) {
+              console.error("Composer submission listener failed", error);
+            }
+          }
+        }
       } finally {
+        if (epoch === refreshEpoch) {
+          pendingTurnsStore.setState((state) => {
+            const submittingRefs = new Set(state.submittingRefs);
+            submittingRefs.delete(opts.ref);
+            return { submittingRefs };
+          });
+        }
         // Projection reads own their tracking, but cannot delay or change the
         // result of a submission whose durable outcome is already known.
         void refreshPendingTurnsProjection(opts.ref);
@@ -323,7 +385,15 @@ export function updateRecoveryPendingTurn(
   text: string,
   attachments: InputAttachment[],
 ): Promise<boolean> {
-  return mutateThenRefresh(ref, () => updateRecoveryMutation(clientMutationId, ref, text, attachments));
+  // Composer serializes edits before resending. A committed edit must release
+  // that chain even when the recovery tray cannot refresh yet.
+  return trackProjectionWork(
+    (async () => {
+      const updated = await updateRecoveryMutation(clientMutationId, ref, text, attachments);
+      void refreshPendingTurnsProjection(ref);
+      return updated;
+    })(),
+  );
 }
 
 export function discardRecoveryPendingTurn(
@@ -341,15 +411,20 @@ export function resendRecoveryPendingTurn(
   text: string,
   attachments: InputAttachment[],
 ): Promise<boolean> {
-  return mutateThenRefresh(
-    ref,
-    async () => (await resendRecoveryMutation(clientMutationId, ref, route, text, attachments)) !== undefined,
+  // Resend publishes its committed handoff directly. Reading the recovery
+  // tray again cannot hold up a submission that already has a durable owner.
+  return trackProjectionWork(
+    (async () => {
+      const record = await resendRecoveryMutation(clientMutationId, ref, route, text, attachments);
+      void refreshPendingTurnsProjection(ref);
+      return record !== undefined;
+    })(),
   );
 }
 
 export function resetPendingTurnsStoreForTests(): void {
   refreshEpoch += 1;
-  refreshGenerations.clear();
+  refreshGeneration = 0;
   appliedRefreshGenerations.clear();
   // The epoch bump already voids anything still running against the previous
   // test's storage, so it is not this test's projection work to wait for.
@@ -358,6 +433,7 @@ export function resetPendingTurnsStoreForTests(): void {
     outbox: new Map(),
     optimistic: new Map(),
     recovery: new Map(),
+    submittingRefs: new Set(),
     submittedHere: new Set(),
   });
 }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -227,7 +227,9 @@ export function submitWithPendingTracking(
         opts.onFailure(error);
         throw error;
       } finally {
-        await refreshPendingTurnsProjection(opts.ref);
+        // Projection reads own their tracking, but cannot delay or change the
+        // result of a submission whose durable outcome is already known.
+        void refreshPendingTurnsProjection(opts.ref);
       }
     })(),
   );

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -18,7 +18,7 @@ import {
   updateRecoveryMutation,
   useThreadsStore,
 } from "../../../../stores/threads";
-import { clearDraft, readDraft } from "../draft";
+import { clearDraft, readDraft, readDraftRevision } from "../draft";
 import { type PendingMethod, type PendingTurnEntry, reconcilePendingEntries } from "./pendingReconcile";
 
 export type { PendingMethod, PendingTurnEntry } from "./pendingReconcile";
@@ -259,6 +259,7 @@ export function submitWithPendingTracking(
     return Promise.reject(new Error("A message submission is already pending for this task"));
   }
   const epoch = refreshEpoch;
+  const draftRevision = readDraftRevision(opts.ref);
   pendingTurnsStore.setState((state) => ({ submittingRefs: new Set(state.submittingRefs).add(opts.ref) }));
   return trackProjectionWork(
     (async () => {
@@ -271,7 +272,11 @@ export function submitWithPendingTracking(
         }
         // Submission ownership outlives a mounted composer. A retired mount
         // must not clear a newer draft written after a tab switch.
-        if (epoch === refreshEpoch && readDraft(opts.ref) === opts.text) {
+        if (
+          epoch === refreshEpoch &&
+          readDraftRevision(opts.ref) === draftRevision &&
+          readDraft(opts.ref) === opts.text
+        ) {
           clearDraft(opts.ref);
           for (const listener of submissionCommittedListeners) {
             try {

--- a/cmd/evener-hub/frontend/src/panes/session/pending/PendingChips.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/pending/PendingChips.test.tsx
@@ -5,7 +5,11 @@ import { MutationOutboxIndexedDB } from "../../../stores/mutationOutboxIndexedDB
 import type { InputAttachment } from "../../../stores/threads";
 import { resetThreadsStoreForTests } from "../../../stores/threads";
 import type { PendingMethod } from "../composer/queue/pendingReconcile";
-import { refreshPendingTurnsProjection, resetPendingTurnsStoreForTests } from "../composer/queue/pendingTurnsStore";
+import {
+  flushPendingTurnsProjectionForTests,
+  refreshPendingTurnsProjection,
+  resetPendingTurnsStoreForTests,
+} from "../composer/queue/pendingTurnsStore";
 import { PendingChips } from "./PendingChips";
 
 beforeEach(() => {
@@ -64,6 +68,7 @@ async function seedPending(method: PendingMethod, text: string, ref = "ref_a", a
   });
   storage.close();
   await refreshPendingTurnsProjection(ref);
+  await flushPendingTurnsProjectionForTests();
 }
 
 test("renders nothing when there are no pending entries", () => {

--- a/cmd/evener-hub/frontend/src/stores/mutationOutbox.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutbox.test.ts
@@ -542,11 +542,9 @@ describe("MutationOutbox discovery", () => {
     discoveries.length = 0;
 
     await tabA.enqueueIntent(intent("broadcast wake"));
-    await Promise.resolve();
-
-    expect(discoveries).toContainEqual({ targets: [TARGET], reason: "broadcast" });
     await tabA.stop();
     await tabB.stop();
+    expect(discoveries).toContainEqual({ targets: [TARGET], reason: "broadcast" });
   });
 
   test("a discovery failure cannot report a committed message as a failed submission", async () => {
@@ -631,10 +629,15 @@ describe("MutationOutbox discovery", () => {
     const record = await storage.enqueueIntent(intent("discover after storage recovers"));
     const lifecycleWindow = new EventTarget();
     const discoveries: string[] = [];
+    let announceStartup: (() => void) | undefined;
+    const startupDiscovered = new Promise<void>((resolve) => {
+      announceStartup = resolve;
+    });
     const outbox = new MutationOutbox(storage, {
       isReady: () => true,
       onDiscover(_targets, reason) {
         discoveries.push(reason);
+        if (reason === "startup") announceStartup?.();
       },
       createBroadcastChannel: (name) => new TestBroadcastChannel(name, new Set()),
       lifecycleWindow,
@@ -642,6 +645,7 @@ describe("MutationOutbox discovery", () => {
       clearInterval() {},
     });
     await outbox.start();
+    await startupDiscovered;
 
     const getAll = IDBObjectStore.prototype.getAll;
     let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
@@ -730,6 +734,7 @@ describe("MutationOutbox discovery", () => {
       clearInterval() {},
     });
     await survivingTab.start();
+    await survivingTab.connectionReady();
     expect(discoveries).toEqual([]);
 
     await new MutationOutboxIndexedDB({
@@ -758,10 +763,15 @@ describe("MutationOutbox discovery", () => {
     const lifecycleDocument = Object.assign(new EventTarget(), { visibilityState: "visible" });
     const intervals: Array<{ callback: () => void; milliseconds: number }> = [];
     const discoveries: Array<{ targets: string[]; reason: string }> = [];
+    let announceStartup: (() => void) | undefined;
+    const startupDiscovered = new Promise<void>((resolve) => {
+      announceStartup = resolve;
+    });
     const outbox = new MutationOutbox(storage, {
       isReady: () => ready,
       onDiscover: (targets, reason) => {
         discoveries.push({ targets, reason });
+        if (reason === "startup") announceStartup?.();
       },
       createBroadcastChannel: (name) => new TestBroadcastChannel(name, new Set()),
       lifecycleWindow,
@@ -774,6 +784,7 @@ describe("MutationOutbox discovery", () => {
     });
 
     await outbox.start();
+    await startupDiscovered;
     expect(discoveries).toEqual([{ targets: ["local:thread-1", "local:thread-2"], reason: "startup" }]);
     expect(intervals).toHaveLength(1);
     expect(intervals[0]?.milliseconds).toBe(2000);

--- a/cmd/evener-hub/frontend/src/stores/mutationOutbox.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutbox.test.ts
@@ -548,6 +548,107 @@ describe("MutationOutbox discovery", () => {
     await tabB.stop();
   });
 
+  test("a discovery failure cannot report a committed message as a failed submission", async () => {
+    const storage = new MutationOutboxIndexedDB({ indexedDB, databaseName });
+    const outbox = new MutationOutbox(storage, {
+      isReady: () => true,
+      onDiscover() {
+        throw new Error("discovery unavailable");
+      },
+      createBroadcastChannel: (name) => new TestBroadcastChannel(name, new Set()),
+    });
+    await outbox.start();
+    try {
+      const accepted = await outbox.enqueueIntent(intent("already saved"));
+      expect(await storage.listOutbox()).toEqual([accepted]);
+    } finally {
+      await outbox.stop();
+      storage.close();
+    }
+  });
+
+  test("submission does not wait for background discovery to finish", async () => {
+    const storage = new MutationOutboxIndexedDB({ indexedDB, databaseName });
+    let announceDiscovery: (() => void) | undefined;
+    let releaseDiscovery: (() => void) | undefined;
+    const discovered = new Promise<void>((resolve) => {
+      announceDiscovery = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    const outbox = new MutationOutbox(storage, {
+      isReady: () => true,
+      onDiscover() {
+        announceDiscovery?.();
+        return gate;
+      },
+      createBroadcastChannel: (name) => new TestBroadcastChannel(name, new Set()),
+    });
+    await outbox.start();
+    let accepted = false;
+    const submit = outbox.enqueueIntent(intent("saved while discovery waits")).then(() => {
+      accepted = true;
+    });
+    try {
+      await discovered;
+      expect(await storage.listOutbox()).toHaveLength(1);
+      expect(accepted).toBe(true);
+    } finally {
+      releaseDiscovery?.();
+      await submit;
+      await outbox.stop();
+      storage.close();
+    }
+  });
+
+  test("a failed startup scan does not poison later delivery", async () => {
+    const storage = new MutationOutboxIndexedDB({ indexedDB, databaseName });
+    const record = await storage.enqueueIntent(intent("recover at startup"));
+    const discovered: string[] = [];
+    const outbox = new MutationOutbox(storage, {
+      isReady: () => true,
+      onDiscover(targets, reason) {
+        if (reason === "startup") throw new Error("storage was unavailable during startup");
+        discovered.push(...targets);
+      },
+      createBroadcastChannel: (name) => new TestBroadcastChannel(name, new Set()),
+    });
+    try {
+      await outbox.start();
+      await outbox.connectionReady();
+      expect(discovered).toEqual([TARGET]);
+      expect(await storage.listOutbox()).toEqual([record]);
+    } finally {
+      await outbox.stop();
+      storage.close();
+    }
+  });
+
+  test("repeated liveness ticks share an outstanding scan instead of building a backlog", async () => {
+    const storage = new MutationOutboxIndexedDB({ indexedDB, databaseName });
+    await storage.enqueueIntent(intent("already saved"));
+    let tick: (() => void) | undefined;
+    const discoveries: string[] = [];
+    const outbox = new MutationOutbox(storage, {
+      isReady: () => true,
+      onDiscover(_targets, reason) {
+        discoveries.push(reason);
+      },
+      createBroadcastChannel: (name) => new TestBroadcastChannel(name, new Set()),
+      setInterval(callback) {
+        tick = callback;
+        return 1;
+      },
+      clearInterval() {},
+    });
+    await outbox.start();
+    for (let index = 0; index < 20; index += 1) tick?.();
+    await outbox.stop();
+    expect(discoveries).toEqual(["startup", "interval"]);
+    storage.close();
+  });
+
   test("the ready-state timer discovers a commit whose origin crashed before broadcasting", async () => {
     const storage = new MutationOutboxIndexedDB({
       indexedDB,

--- a/cmd/evener-hub/frontend/src/stores/mutationOutbox.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutbox.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
 
-import { IDBFactory } from "fake-indexeddb";
-import { beforeEach, describe, expect, test } from "vitest";
+import { IDBFactory, IDBObjectStore } from "fake-indexeddb";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { type MutationIntent, MutationOutbox } from "./mutationOutbox";
 import { MutationOutboxIndexedDB } from "./mutationOutboxIndexedDB";
+import { holdIndexedDBEvent } from "./testing/stalledIndexedDB";
 
 const TARGET = "local:thread-1";
 
@@ -620,6 +621,65 @@ describe("MutationOutbox discovery", () => {
       expect(discovered).toEqual([TARGET]);
       expect(await storage.listOutbox()).toEqual([record]);
     } finally {
+      await outbox.stop();
+      storage.close();
+    }
+  });
+
+  test("a timed-out ready scan resolves and a later focus retries discovery", async () => {
+    const storage = new MutationOutboxIndexedDB({ indexedDB, databaseName });
+    const record = await storage.enqueueIntent(intent("discover after storage recovers"));
+    const lifecycleWindow = new EventTarget();
+    const discoveries: string[] = [];
+    const outbox = new MutationOutbox(storage, {
+      isReady: () => true,
+      onDiscover(_targets, reason) {
+        discoveries.push(reason);
+      },
+      createBroadcastChannel: (name) => new TestBroadcastChannel(name, new Set()),
+      lifecycleWindow,
+      setInterval: () => 0,
+      clearInterval() {},
+    });
+    await outbox.start();
+
+    const getAll = IDBObjectStore.prototype.getAll;
+    let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+    let announceRead: (() => void) | undefined;
+    const readHeld = new Promise<void>((resolve) => {
+      announceRead = resolve;
+    });
+    const spy = vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (
+      this: IDBObjectStore,
+      ...args
+    ) {
+      const request = getAll.apply(this, args);
+      if (this.name === "outbox" && !hold) {
+        hold = holdIndexedDBEvent(request, "success");
+        void hold.reached.then(() => announceRead?.());
+      }
+      return request;
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let failure: unknown;
+    const ready = outbox.connectionReady().catch((error) => {
+      failure = error;
+    });
+    try {
+      await readHeld;
+      await vi.runOnlyPendingTimersAsync();
+      await ready;
+      expect(failure).toBeUndefined();
+      expect(discoveries).toEqual(["startup"]);
+      hold?.release();
+      lifecycleWindow.dispatchEvent(new Event("focus"));
+      await outbox.stop();
+      expect(discoveries).toEqual(["startup", "focus"]);
+      expect(await storage.getOutbox(record.clientMutationId)).toEqual(record);
+    } finally {
+      spy.mockRestore();
+      hold?.release();
+      vi.useRealTimers();
       await outbox.stop();
       storage.close();
     }

--- a/cmd/evener-hub/frontend/src/stores/mutationOutbox.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutbox.ts
@@ -104,6 +104,7 @@ export class MutationOutbox {
   #intervalId: number | undefined;
   #started = false;
   #pendingDiscovery: Promise<void> = Promise.resolve();
+  readonly #scheduledReadyScans = new Set<MutationDiscoveryReason>();
 
   readonly #handleBroadcast = (event: Event) => {
     if (!this.#isReady()) return;
@@ -145,7 +146,12 @@ export class MutationOutbox {
     this.#lifecycleWindow?.addEventListener("focus", this.#handleFocus);
     this.#lifecycleDocument?.addEventListener("visibilitychange", this.#handleVisibility);
     this.#intervalId = this.#setInterval(() => this.#scheduleReadyScan("interval"), 2000);
-    await this.#discoverAll("startup");
+    try {
+      await this.#discoverAll("startup");
+    } catch {
+      // A failed scan does not invalidate the runtime. Its lifecycle hooks
+      // retry discovery, and new submissions still require their own commit.
+    }
   }
 
   async stop(): Promise<void> {
@@ -164,11 +170,16 @@ export class MutationOutbox {
 
   async enqueueIntent(intent: MutationIntent): Promise<MutationOutboxRecord> {
     const record = await this.#storage.enqueueIntent(intent);
-    this.#broadcastChannel?.postMessage({
-      version: 1,
-      targetRef: record.targetRef,
-    } satisfies MutationOutboxWakeup);
-    if (this.#isReady()) await this.#queueDiscovery(() => this.#discover([record.targetRef], "enqueue"));
+    try {
+      this.#broadcastChannel?.postMessage({
+        version: 1,
+        targetRef: record.targetRef,
+      } satisfies MutationOutboxWakeup);
+    } catch {
+      // The commit owns the message. Lifecycle scans also discover it if a
+      // closing tab cannot broadcast; that cannot turn acceptance into failure.
+    }
+    if (this.#isReady()) this.#scheduleDiscovery([record.targetRef], "enqueue");
     return record;
   }
 
@@ -178,8 +189,15 @@ export class MutationOutbox {
   }
 
   #scheduleReadyScan(reason: MutationDiscoveryReason): void {
-    if (!this.#isReady()) return;
-    this.#schedule(() => this.#discoverAll(reason));
+    if (!this.#isReady() || this.#scheduledReadyScans.has(reason)) return;
+    this.#scheduledReadyScans.add(reason);
+    this.#schedule(async () => {
+      try {
+        await this.#discoverAll(reason);
+      } finally {
+        this.#scheduledReadyScans.delete(reason);
+      }
+    });
   }
 
   #scheduleDiscovery(targetRefs: string[], reason: MutationDiscoveryReason): void {

--- a/cmd/evener-hub/frontend/src/stores/mutationOutbox.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutbox.ts
@@ -185,7 +185,12 @@ export class MutationOutbox {
 
   async connectionReady(): Promise<void> {
     if (!this.#isReady()) return;
-    await this.#queueDiscovery(() => this.#discoverAll("ready"));
+    try {
+      await this.#queueDiscovery(() => this.#discoverAll("ready"));
+    } catch {
+      // Readiness is a lifecycle notification, not a submission result.
+      // Durable work remains available for the next discovery scan.
+    }
   }
 
   #scheduleReadyScan(reason: MutationDiscoveryReason): void {

--- a/cmd/evener-hub/frontend/src/stores/mutationOutbox.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutbox.ts
@@ -146,12 +146,9 @@ export class MutationOutbox {
     this.#lifecycleWindow?.addEventListener("focus", this.#handleFocus);
     this.#lifecycleDocument?.addEventListener("visibilitychange", this.#handleVisibility);
     this.#intervalId = this.#setInterval(() => this.#scheduleReadyScan("interval"), 2000);
-    try {
-      await this.#discoverAll("startup");
-    } catch {
-      // A failed scan does not invalidate the runtime. Its lifecycle hooks
-      // retry discovery, and new submissions still require their own commit.
-    }
+    // Submissions need the runtime's listeners, not a scan of earlier work.
+    // Queue startup discovery so a stalled read cannot delay their own commit.
+    this.#schedule(() => this.#discoverAll("startup"));
   }
 
   async stop(): Promise<void> {

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.stall.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.stall.test.ts
@@ -150,6 +150,35 @@ test.each([undefined, true, false])(
   },
 );
 
+test("a terminal abort rejects while a request callback is still withheld", async () => {
+  const storage = new MutationOutboxIndexedDB({ indexedDB: new IDBFactory() });
+  await storage.listOutbox();
+  const get = IDBObjectStore.prototype.get;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  vi.spyOn(IDBObjectStore.prototype, "get").mockImplementationOnce(function (this: IDBObjectStore, ...args) {
+    const request = get.apply(this, args);
+    request.addEventListener("success", () => this.transaction.abort());
+    hold = holdIndexedDBEvent(request, "success");
+    return request;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  const failure = storage.enqueueIntent(intent).then(
+    () => undefined,
+    (error: unknown) => error,
+  );
+  try {
+    await Promise.resolve();
+    if (!hold) throw new Error("write did not reach IndexedDB");
+    await hold.reached;
+    // Do not release the request callback or advance the watchdog clock.
+    expect(await failure).toBeInstanceOf(Error);
+    expect(await storage.listOutbox()).toEqual([]);
+  } finally {
+    hold?.release();
+    storage.close();
+  }
+});
+
 test("cancelling a stalled write rolls it back before the draft can be retried", async () => {
   const storage = new MutationOutboxIndexedDB({ indexedDB: new IDBFactory() });
   await storage.listOutbox();

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.stall.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.stall.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment node
+
+import { IDBDatabase, IDBFactory, IDBObjectStore } from "fake-indexeddb";
+import { afterEach, expect, test, vi } from "vitest";
+import type { MutationIntent } from "./mutationOutbox";
+import { MutationOutboxIndexedDB } from "./mutationOutboxIndexedDB";
+import { holdIndexedDBEvent } from "./testing/stalledIndexedDB";
+
+const intent: MutationIntent = {
+  targetRef: "local:thread-1",
+  method: "turn/steer",
+  payload: { ref: "local:thread-1", input: [{ type: "text", text: "one message" }] },
+  attachments: [],
+  optimisticDisplay: null,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+test("a stalled read stops waiting and the same adapter can reopen and read its durable messages", async () => {
+  const storage = new MutationOutboxIndexedDB({ indexedDB: new IDBFactory() });
+  const record = await storage.enqueueIntent(intent);
+  const getAll = IDBObjectStore.prototype.getAll;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementationOnce(function (this: IDBObjectStore, ...args) {
+    const request = getAll.apply(this, args);
+    hold = holdIndexedDBEvent(request, "success");
+    return request;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  let failure: unknown;
+  const read = storage.listOutbox().catch((error) => {
+    failure = error;
+  });
+  // #open yields even for an existing connection.
+  await Promise.resolve();
+  if (!hold) throw new Error("read did not reach IndexedDB");
+  await hold.reached;
+  await vi.runOnlyPendingTimersAsync();
+  expect(failure).toMatchObject({ name: "MutationStorageTimeoutError" });
+  await read;
+  hold.release();
+  expect(await storage.listOutbox()).toEqual([record]);
+  storage.close();
+});
+
+test("a timed-out open cannot install its late connection over a recovered connection", async () => {
+  const indexedDB = new IDBFactory();
+  const open = indexedDB.open.bind(indexedDB);
+  let lateDatabase: IDBDatabase | undefined;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  vi.spyOn(indexedDB, "open").mockImplementationOnce((...args) => {
+    const request = open(...args);
+    request.addEventListener("success", () => {
+      lateDatabase = request.result;
+    });
+    hold = holdIndexedDBEvent(request, "success");
+    return request;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  const storage = new MutationOutboxIndexedDB({ indexedDB });
+  let failure: unknown;
+  const read = storage.listOutbox().catch((error) => {
+    failure = error;
+  });
+  if (!hold) throw new Error("open did not reach IndexedDB");
+  await hold.reached;
+  await vi.runOnlyPendingTimersAsync();
+  expect(failure).toMatchObject({ name: "MutationStorageTimeoutError" });
+  await read;
+  const record = await storage.enqueueIntent(intent);
+  hold.release();
+  expect(() => lateDatabase?.transaction("outbox")).toThrow();
+  expect(await storage.listOutbox()).toEqual([record]);
+  storage.close();
+});
+
+test("a write past cancellation stays pending until its original commit is observed", async () => {
+  const stalled: boolean[] = [];
+  const storage = new MutationOutboxIndexedDB({
+    indexedDB: new IDBFactory(),
+    onWriteStalled: (waiting) => stalled.push(waiting),
+  });
+  await storage.listOutbox();
+  const transact = IDBDatabase.prototype.transaction;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementationOnce(function (this: IDBDatabase, ...args) {
+    const transaction = transact.apply(this, args);
+    hold = holdIndexedDBEvent(transaction, "complete");
+    return transaction;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  let settled = false;
+  const enqueue = storage.enqueueIntent(intent).finally(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+  if (!hold) throw new Error("write did not reach IndexedDB");
+  await hold.reached;
+  await vi.runOnlyPendingTimersAsync();
+  expect(stalled).toEqual([true]);
+  expect(settled).toBe(false);
+  hold.release();
+  const record = await enqueue;
+  expect(stalled).toEqual([true, false]);
+  expect(await storage.listOutbox()).toEqual([record]);
+  storage.close();
+});
+
+test("cancelling a stalled write rolls it back before the draft can be retried", async () => {
+  const storage = new MutationOutboxIndexedDB({ indexedDB: new IDBFactory() });
+  await storage.listOutbox();
+  const get = IDBObjectStore.prototype.get;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let keepAlive = true;
+  vi.spyOn(IDBObjectStore.prototype, "get").mockImplementationOnce(function (this: IDBObjectStore, ...args) {
+    const request = get.apply(this, args);
+    hold = holdIndexedDBEvent(request, "success");
+    const pulse = () => {
+      this.count().addEventListener("success", () => {
+        if (keepAlive) pulse();
+      });
+    };
+    pulse();
+    return request;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  let failure: unknown;
+  const enqueue = storage.enqueueIntent(intent).catch((error) => {
+    failure = error;
+  });
+  try {
+    await Promise.resolve();
+    if (!hold) throw new Error("write did not reach IndexedDB");
+    await hold.reached;
+    await vi.runOnlyPendingTimersAsync();
+    expect(failure).toMatchObject({ name: "MutationStorageTimeoutError" });
+    await enqueue;
+  } finally {
+    keepAlive = false;
+    hold?.release();
+  }
+  expect(await storage.listOutbox()).toEqual([]);
+  const retried = await storage.enqueueIntent(intent);
+  expect(await storage.listOutbox()).toEqual([retried]);
+  expect(retried.intentSequence).toBe(1);
+  storage.close();
+});

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.stall.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.stall.test.ts
@@ -77,6 +77,41 @@ test("a timed-out open cannot install its late connection over a recovered conne
   storage.close();
 });
 
+test("a timed-out upgrade releases its lock so the adapter can reopen", async () => {
+  const storage = new MutationOutboxIndexedDB({ indexedDB: new IDBFactory() });
+  const createObjectStore = IDBDatabase.prototype.createObjectStore;
+  let keepAlive = true;
+  let reached: () => void = () => {};
+  const upgrading = new Promise<void>((resolve) => {
+    reached = resolve;
+  });
+  vi.spyOn(IDBDatabase.prototype, "createObjectStore").mockImplementationOnce(function (this: IDBDatabase, ...args) {
+    const store = createObjectStore.apply(this, args);
+    const pulse = () => {
+      store.count().addEventListener("success", () => {
+        reached();
+        if (keepAlive) pulse();
+      });
+    };
+    pulse();
+    return store;
+  });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  const failure = storage.listOutbox().catch((error: unknown) => error);
+  try {
+    await upgrading;
+    await vi.runOnlyPendingTimersAsync();
+    expect(await failure).toMatchObject({ name: "MutationStorageTimeoutError" });
+    // Reopening must finish while the abandoned upgrade would otherwise remain alive.
+    const record = await storage.enqueueIntent(intent);
+    expect(await storage.listOutbox()).toEqual([record]);
+    expect(record.intentSequence).toBe(1);
+  } finally {
+    keepAlive = false;
+    storage.close();
+  }
+});
+
 test("a write past cancellation stays pending until its original commit is observed", async () => {
   const stalled: boolean[] = [];
   const storage = new MutationOutboxIndexedDB({

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.stall.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.stall.test.ts
@@ -112,37 +112,43 @@ test("a timed-out upgrade releases its lock so the adapter can reopen", async ()
   }
 });
 
-test("a write past cancellation stays pending until its original commit is observed", async () => {
-  const stalled: boolean[] = [];
-  const storage = new MutationOutboxIndexedDB({
-    indexedDB: new IDBFactory(),
-    onWriteStalled: (waiting) => stalled.push(waiting),
-  });
-  await storage.listOutbox();
-  const transact = IDBDatabase.prototype.transaction;
-  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
-  vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementationOnce(function (this: IDBDatabase, ...args) {
-    const transaction = transact.apply(this, args);
-    hold = holdIndexedDBEvent(transaction, "complete");
-    return transaction;
-  });
-  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-  let settled = false;
-  const enqueue = storage.enqueueIntent(intent).finally(() => {
-    settled = true;
-  });
-  await Promise.resolve();
-  if (!hold) throw new Error("write did not reach IndexedDB");
-  await hold.reached;
-  await vi.runOnlyPendingTimersAsync();
-  expect(stalled).toEqual([true]);
-  expect(settled).toBe(false);
-  hold.release();
-  const record = await enqueue;
-  expect(stalled).toEqual([true, false]);
-  expect(await storage.listOutbox()).toEqual([record]);
-  storage.close();
-});
+test.each([undefined, true, false])(
+  "a write past cancellation preserves its commit when the status listener throws on %s",
+  async (throwOn) => {
+    const stalled: boolean[] = [];
+    const storage = new MutationOutboxIndexedDB({
+      indexedDB: new IDBFactory(),
+      onWriteStalled: (waiting) => {
+        stalled.push(waiting);
+        if (waiting === throwOn) throw new Error("status listener failed");
+      },
+    });
+    await storage.listOutbox();
+    const transact = IDBDatabase.prototype.transaction;
+    let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+    vi.spyOn(IDBDatabase.prototype, "transaction").mockImplementationOnce(function (this: IDBDatabase, ...args) {
+      const transaction = transact.apply(this, args);
+      hold = holdIndexedDBEvent(transaction, "complete");
+      return transaction;
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let settled = false;
+    const enqueue = storage.enqueueIntent(intent).finally(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    if (!hold) throw new Error("write did not reach IndexedDB");
+    await hold.reached;
+    await vi.runOnlyPendingTimersAsync();
+    expect(stalled).toEqual([true]);
+    expect(settled).toBe(false);
+    hold.release();
+    const record = await enqueue;
+    expect(stalled).toEqual([true, false]);
+    expect(await storage.listOutbox()).toEqual([record]);
+    storage.close();
+  },
+);
 
 test("cancelling a stalled write rolls it back before the draft can be retried", async () => {
   const storage = new MutationOutboxIndexedDB({ indexedDB: new IDBFactory() });

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
@@ -377,17 +377,25 @@ export class MutationOutboxIndexedDB {
     const opening = new Promise<IDBDatabase>((resolve, reject) => {
       const request = this.#indexedDB.open(this.#databaseName, DATABASE_VERSION);
       let abandoned = false;
+      let upgradeTransaction: IDBTransaction | null = null;
       const fail = (error: unknown) => {
         abandoned = true;
         clearTimeout(timer);
+        try {
+          // Release the database open lock if its schema upgrade is still active.
+          upgradeTransaction?.abort();
+        } catch {
+          // A completed upgrade cannot be aborted; late success closes its connection.
+        }
         reject(error);
       };
       const timer = setTimeout(() => fail(new MutationStorageTimeoutError()), STORAGE_WAIT_MS);
       request.addEventListener(
         "upgradeneeded",
         () => {
+          upgradeTransaction = request.transaction;
           if (abandoned || this.#databasePromise !== opening) {
-            request.transaction?.abort();
+            upgradeTransaction?.abort();
             return;
           }
           const database = request.result;

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
@@ -24,6 +24,7 @@ export interface MutationOutboxIndexedDBOptions {
   createMutationId?: () => string;
   createPresentationId?: () => string;
   now?: () => number;
+  onWriteStalled?: (waiting: boolean) => void;
   // Storage-fault seam used to prove IndexedDB rollback at commit boundaries.
   beforeCommit?: (operation: MutationOutboxOperation) => void;
 }
@@ -35,6 +36,14 @@ const OPTIMISTIC_STORE = "optimistic";
 const RECOVERY_STORE = "recovery";
 const SEQUENCE_STORE = "sequences";
 const TARGET_SEQUENCE_INDEX = "byTargetSequence";
+const STORAGE_WAIT_MS = 10_000;
+
+export class MutationStorageTimeoutError extends Error {
+  constructor() {
+    super("Browser message storage is not responding. Your draft has been kept. Try again when storage recovers.");
+    this.name = "MutationStorageTimeoutError";
+  }
+}
 
 interface TargetSequence {
   targetRef: string;
@@ -76,6 +85,8 @@ export class MutationOutboxIndexedDB {
   readonly #createPresentationId: () => string;
   readonly #now: () => number;
   readonly #beforeCommit: ((operation: MutationOutboxOperation) => void) | undefined;
+  readonly #onWriteStalled: ((waiting: boolean) => void) | undefined;
+  #stalledWrites = 0;
   #databasePromise: Promise<IDBDatabase> | undefined;
   #database: IDBDatabase | undefined;
 
@@ -88,6 +99,7 @@ export class MutationOutboxIndexedDB {
     this.#createPresentationId = options.createPresentationId ?? createSecureUUID;
     this.#now = options.now ?? Date.now;
     this.#beforeCommit = options.beforeCommit;
+    this.#onWriteStalled = options.onWriteStalled;
   }
 
   close(): void {
@@ -361,11 +373,23 @@ export class MutationOutboxIndexedDB {
 
   async #open(): Promise<IDBDatabase> {
     if (this.#database) return this.#database;
-    this.#databasePromise ??= new Promise((resolve, reject) => {
+    if (this.#databasePromise) return this.#databasePromise;
+    const opening = new Promise<IDBDatabase>((resolve, reject) => {
       const request = this.#indexedDB.open(this.#databaseName, DATABASE_VERSION);
+      let abandoned = false;
+      const fail = (error: unknown) => {
+        abandoned = true;
+        clearTimeout(timer);
+        reject(error);
+      };
+      const timer = setTimeout(() => fail(new MutationStorageTimeoutError()), STORAGE_WAIT_MS);
       request.addEventListener(
         "upgradeneeded",
         () => {
+          if (abandoned || this.#databasePromise !== opening) {
+            request.transaction?.abort();
+            return;
+          }
           const database = request.result;
           if (!database.objectStoreNames.contains(OUTBOX_STORE)) {
             const outbox = database.createObjectStore(OUTBOX_STORE, { keyPath: "clientMutationId" });
@@ -388,29 +412,45 @@ export class MutationOutboxIndexedDB {
       request.addEventListener(
         "success",
         () => {
-          this.#database = request.result;
-          this.#database.addEventListener("versionchange", () => this.close());
-          resolve(this.#database);
+          clearTimeout(timer);
+          const database = request.result;
+          if (abandoned || this.#databasePromise !== opening) {
+            database.close();
+            reject(new Error("Mutation outbox connection was closed"));
+            return;
+          }
+          this.#database = database;
+          database.addEventListener("versionchange", () => this.#retire(database));
+          database.addEventListener("close", () => this.#retire(database));
+          resolve(database);
         },
         { once: true },
       );
-      request.addEventListener("error", () => reject(request.error ?? new Error("Unable to open mutation outbox")), {
+      request.addEventListener("error", () => fail(request.error ?? new Error("Unable to open mutation outbox")), {
         once: true,
       });
-      request.addEventListener("blocked", () => reject(new Error("Mutation outbox upgrade is blocked")), {
+      request.addEventListener("blocked", () => fail(new Error("Mutation outbox upgrade is blocked")), {
         once: true,
       });
     });
-    return this.#databasePromise;
+    this.#databasePromise = opening;
+    try {
+      return await opening;
+    } catch (error) {
+      if (this.#databasePromise === opening) this.#databasePromise = undefined;
+      throw error;
+    }
+  }
+
+  #retire(database: IDBDatabase): void {
+    database.close();
+    if (this.#database !== database) return;
+    this.#database = undefined;
+    this.#databasePromise = undefined;
   }
 
   async #read<T>(stores: string | string[], body: (transaction: IDBTransaction) => Promise<T>): Promise<T> {
-    const database = await this.#open();
-    const transaction = database.transaction(stores, "readonly");
-    const completed = transactionCompletion(transaction);
-    const result = await body(transaction);
-    await completed;
-    return result;
+    return this.#transaction(stores, "readonly", undefined, body);
   }
 
   async #write<T>(
@@ -418,13 +458,47 @@ export class MutationOutboxIndexedDB {
     operation: MutationOutboxOperation | undefined,
     body: (transaction: IDBTransaction) => Promise<T>,
   ): Promise<T> {
+    return this.#transaction(stores, "readwrite", operation, body);
+  }
+
+  async #transaction<T>(
+    stores: string | string[],
+    mode: "readonly" | "readwrite",
+    operation: MutationOutboxOperation | undefined,
+    body: (transaction: IDBTransaction) => Promise<T>,
+  ): Promise<T> {
     const database = await this.#open();
-    const transaction = database.transaction(stores, "readwrite");
+    const transaction = database.transaction(stores, mode);
     const completed = transactionCompletion(transaction);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let stalledWrite = false;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        this.#retire(database);
+        try {
+          transaction.abort();
+        } catch {
+          if (mode === "readwrite") {
+            // abort() refuses a committing/finished transaction. A deadline
+            // cannot prove rollback: keep the original submission pending
+            // until its complete/abort event establishes its outcome.
+            stalledWrite = true;
+            this.#stalledWrites += 1;
+            if (this.#stalledWrites === 1) this.#onWriteStalled?.(true);
+            return;
+          }
+        }
+        reject(new MutationStorageTimeoutError());
+      }, STORAGE_WAIT_MS);
+    });
     try {
-      const result = await body(transaction);
-      if (operation) this.#beforeCommit?.(operation);
-      await completed;
+      const work = body(transaction).then((result) => {
+        if (operation) this.#beforeCommit?.(operation);
+        return result;
+      });
+      // Observe request and transaction failures together. An abort must
+      // release the caller even when a request callback never arrives.
+      const [result] = await Promise.race([Promise.all([work, completed]), deadline]);
       return result;
     } catch (error) {
       try {
@@ -432,8 +506,13 @@ export class MutationOutboxIndexedDB {
       } catch {
         // The transaction already completed; preserve the original failure.
       }
-      await completed.catch(() => undefined);
       throw error;
+    } finally {
+      clearTimeout(timer);
+      if (stalledWrite) {
+        this.#stalledWrites -= 1;
+        if (this.#stalledWrites === 0) this.#onWriteStalled?.(false);
+      }
     }
   }
 

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
@@ -500,12 +500,16 @@ export class MutationOutboxIndexedDB {
       }, STORAGE_WAIT_MS);
     });
     try {
+      // Bodies only await requests in this transaction, never timers or external
+      // work. Their continuations (and this synchronous fault seam) run before
+      // automatic commit, while failures can still abort the transaction.
       const work = body(transaction).then((result) => {
         if (operation) this.#beforeCommit?.(operation);
         return result;
       });
-      // Observe request and transaction failures together. An abort must
-      // release the caller even when a request callback never arrives.
+      // Promise.all rejects on either failure without waiting for the other
+      // input. A terminal abort therefore releases even a stalled body, while
+      // success requires both the result and the durable commit event.
       const [result] = await Promise.race([Promise.all([work, completed]), deadline]);
       return result;
     } catch (error) {

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
@@ -492,7 +492,7 @@ export class MutationOutboxIndexedDB {
             // until its complete/abort event establishes its outcome.
             stalledWrite = true;
             this.#stalledWrites += 1;
-            if (this.#stalledWrites === 1) this.#onWriteStalled?.(true);
+            if (this.#stalledWrites === 1) this.#notifyWriteStalled(true);
             return;
           }
         }
@@ -519,8 +519,16 @@ export class MutationOutboxIndexedDB {
       clearTimeout(timer);
       if (stalledWrite) {
         this.#stalledWrites -= 1;
-        if (this.#stalledWrites === 0) this.#onWriteStalled?.(false);
+        if (this.#stalledWrites === 0) this.#notifyWriteStalled(false);
       }
+    }
+  }
+
+  #notifyWriteStalled(waiting: boolean): void {
+    try {
+      this.#onWriteStalled?.(waiting);
+    } catch {
+      // Status subscribers cannot change the durable transaction outcome.
     }
   }
 

--- a/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.ts
+++ b/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.ts
@@ -1,0 +1,33 @@
+import { vi } from "vitest";
+
+// Hold browser callbacks while fake-indexeddb performs the real transaction.
+// This distinguishes an unobserved commit from a write that can still abort.
+export function holdIndexedDBEvent(target: EventTarget, type: string) {
+  const held: (() => void)[] = [];
+  let observed: (() => void) | undefined;
+  const reached = new Promise<void>((resolve) => {
+    observed = resolve;
+  });
+  const add = target.addEventListener.bind(target);
+  const spy = vi.spyOn(target, "addEventListener").mockImplementation((eventType, listener, options) => {
+    if (eventType !== type || !listener) return add(eventType, listener, options);
+    add(
+      eventType,
+      (event) => {
+        held.push(() => {
+          if (typeof listener === "function") listener.call(target, event);
+          else listener.handleEvent(event);
+        });
+        observed?.();
+      },
+      options,
+    );
+  });
+  return {
+    reached,
+    release() {
+      spy.mockRestore();
+      for (const deliver of held.splice(0)) deliver();
+    },
+  };
+}

--- a/cmd/evener-hub/frontend/src/stores/threads.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.test.ts
@@ -4852,6 +4852,27 @@ describe("useThreadsStore.listModels", () => {
   });
 });
 
+test.each([false, true])(
+  "a failed enqueue preserves only durable pins (existing mutation: %s)",
+  async (existingMutation) => {
+    const storage = new MutationOutboxIndexedDB();
+    setMutationStorageForTests(storage);
+    const fake = connectMutationClient();
+    await threadsStore.getState().ensureThread("ref_a");
+    fake.on("turn/start", () => new Promise<never>(() => undefined));
+    if (existingMutation) await threadsStore.getState().send("ref_a", "already saved");
+    const unsubscribed = existingMutation ? undefined : nextHandledRequest(fake, "thread/unsubscribe", () => ({}));
+    vi.spyOn(IDBObjectStore.prototype, "add").mockImplementationOnce(() => {
+      throw new DOMException("storage full", "QuotaExceededError");
+    });
+    await expect(threadsStore.getState().send("ref_a", "not saved")).rejects.toThrow("storage full");
+    expect(await storage.listOutbox()).toHaveLength(existingMutation ? 1 : 0);
+    threadsStore.getState().releaseThread("ref_a");
+    expect(threadsStore.getState().threads.has("ref_a")).toBe(existingMutation);
+    await unsubscribed;
+  },
+);
+
 test("the first submission commits while startup discovery is stalled", async ({ onTestFailed }) => {
   const storage = new MutationOutboxIndexedDB();
   setMutationStorageForTests(storage);

--- a/cmd/evener-hub/frontend/src/stores/threads.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.test.ts
@@ -31,6 +31,7 @@ import type {
 } from "../protocol/types.gen";
 import { connectionStore, useConnectionStore } from "./connection";
 import { MutationOutboxIndexedDB } from "./mutationOutboxIndexedDB";
+import { holdIndexedDBEvent } from "./testing/stalledIndexedDB";
 import {
   appendFrameTime,
   ConflictError,
@@ -4851,16 +4852,66 @@ describe("useThreadsStore.listModels", () => {
   });
 });
 
+test("the first submission commits while startup discovery is stalled", async ({ onTestFailed }) => {
+  const storage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(storage);
+  const getAll = IDBObjectStore.prototype.getAll;
+  let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
+  let announceRead: (() => void) | undefined;
+  const readHeld = new Promise<void>((resolve) => {
+    announceRead = resolve;
+  });
+  vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (this: IDBObjectStore, ...args) {
+    const request = getAll.apply(this, args);
+    if (this.name === "outbox" && !hold) {
+      hold = holdIndexedDBEvent(request, "success");
+      void hold.reached.then(() => announceRead?.());
+    }
+    return request;
+  });
+  // Neither the storage watchdog nor lifecycle retries may rescue this send.
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+  const release = () => {
+    hold?.release();
+    vi.useRealTimers();
+  };
+  onTestFailed(release);
+  const fake = connectMutationClient();
+  fake.on("turn/start", () => new Promise<never>(() => undefined));
+  try {
+    await readHeld;
+    await threadsStore.getState().send("ref_a", "saved before startup discovery finishes");
+    expect(await storage.listOutbox("ref_a")).toMatchObject([
+      {
+        state: "submitting",
+        method: "turn/start",
+        payload: { input: [{ type: "text", text: "saved before startup discovery finishes" }] },
+      },
+    ]);
+  } finally {
+    release();
+  }
+});
+
 test("reset retires an outbox discovery before the next runtime starts", async () => {
   const oldStorage = new MutationOutboxIndexedDB();
   let finishOldDiscovery!: (targetRefs: string[]) => void;
   const oldDiscovery = new Promise<string[]>((resolve) => {
     finishOldDiscovery = resolve;
   });
-  vi.spyOn(oldStorage, "listTargetRefs").mockReturnValueOnce(oldDiscovery);
+  let announceDiscovery: (() => void) | undefined;
+  const discoveryStarted = new Promise<void>((resolve) => {
+    announceDiscovery = resolve;
+  });
+  vi.spyOn(oldStorage, "listTargetRefs").mockImplementationOnce(() => {
+    announceDiscovery?.();
+    return oldDiscovery;
+  });
   setMutationStorageForTests(oldStorage);
 
   const oldRead = readMutationPersistence();
+  await discoveryStarted;
+  await oldRead;
   expect(oldStorage.listTargetRefs).toHaveBeenCalledTimes(1);
   resetThreadsStoreForTests();
 
@@ -4884,7 +4935,7 @@ test("reset retires an outbox discovery before the next runtime starts", async (
   await dispatched;
 
   finishOldDiscovery(["stale_ref"]);
-  await Promise.allSettled([oldRead]);
+  await newStorage.listOutbox();
 
   expect(fake.calls.filter((call) => call.method === "thread/read").map((call) => call.params)).not.toContainEqual(
     expect.objectContaining({ ref: "stale_ref" }),
@@ -6960,8 +7011,8 @@ describe("retry-safe mutation outbox integration", () => {
     await seedPinnedIntent("ref_a", "mutation-a");
     // The scan is held open by a deferred rather than by timing luck. It is a
     // real IndexedDB read either way - the outbox's own startup scan is the
-    // first one, and handleReady's is the second, issued only once that startup
-    // resolves - so this removes the race's variance, not its existence.
+    // first one, and handleReady's is the second, issued after the runtime
+    // initializes - so this removes the race's variance, not its existence.
     const storage = new MutationOutboxIndexedDB();
     const discovery = deferred<string[]>();
     const realListTargetRefs = storage.listTargetRefs.bind(storage);
@@ -6978,8 +7029,7 @@ describe("retry-safe mutation outbox integration", () => {
 
     // handleReady's own scan being ISSUED is the observable that puts this
     // generation inside the window: its tracked-ref fan-out is empty here and
-    // settles in microtasks, while the scan cannot be issued until the outbox
-    // startup's IndexedDB read has resolved a task or more later.
+    // settles in microtasks, while the scan remains outstanding.
     fake.emitReady();
     await flushIndexedDBUntil(() => scans >= 2);
     expect(scans).toBe(2);

--- a/cmd/evener-hub/frontend/src/stores/threads.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.test.ts
@@ -1972,6 +1972,60 @@ describe("useThreadsStore.ensureThread", () => {
     expect(threadsStore.getState().threads.has("ref_a")).toBe(false);
   });
 
+  test.each([true, false])(
+    "a released read cannot resume on a replacement connection (release first: %s)",
+    async (releaseFirst) => {
+      const original = connectFakeClient();
+      let rejectRead: ((error: Error) => void) | undefined;
+      const started = nextHandledRequest(
+        original,
+        "thread/read",
+        () =>
+          new Promise<ThreadReadResponse>((_resolve, reject) => {
+            rejectRead = reject;
+          }),
+      );
+      const ensuring = threadsStore.getState().ensureThread("ref_a");
+      await started;
+      if (releaseFirst) threadsStore.getState().releaseThread("ref_a");
+
+      const replacement = new FakeClient("connecting");
+      replacement.on("thread/read", () => readResponse("ref_a"));
+      connectionStore.getState().connect(replacement);
+      rejectRead?.(new Error("old connection failed"));
+      if (!releaseFirst) {
+        await settleCallerContinuations();
+        threadsStore.getState().releaseThread("ref_a");
+      }
+      replacement.emitReady();
+      await ensuring;
+
+      expect(replacement.calls.filter((call) => call.method === "thread/read")).toHaveLength(0);
+      expect(threadsStore.getState().threads.has("ref_a")).toBe(false);
+    },
+  );
+
+  test("a released retry owner cannot resume after replacement readiness", async () => {
+    const original = connectFakeClient();
+    const started = nextHandledRequest(original, "thread/read", () => {
+      throw new RequestTimeoutError("initial read failed");
+    });
+    const ensuring = threadsStore.getState().ensureThread("ref_a");
+    await started;
+    await settleCallerContinuations();
+
+    const replacement = new FakeClient("connecting");
+    replacement.on("thread/read", () => readResponse("ref_a"));
+    connectionStore.getState().connect(replacement);
+    await settleCallerContinuations();
+    threadsStore.getState().releaseThread("ref_a");
+    replacement.emitReady();
+    await ensuring;
+
+    expect(replacement.calls.filter((call) => call.method === "thread/read")).toHaveLength(0);
+    expect(threadsStore.getState().threads.has("ref_a")).toBe(false);
+  });
+
   test("last release retires a pending hydrate before an immediate re-ensure starts a new lifecycle", async () => {
     const fake = connectFakeClient();
     const reads: Array<(response: ThreadReadResponse) => void> = [];

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -102,6 +102,7 @@ export class ConflictError extends Error {
 
 export interface ThreadsStoreState {
   threads: Map<string, ThreadModel>;
+  mutationWriteStalled: boolean;
   // Per-ref ring of live-notification arrival timestamps, for
   // widgets/cadence's Cadence trace - see appendFrameTime below. Deliberately
   // NOT part of ThreadModel/the reducer: it is display-liveness bookkeeping
@@ -688,8 +689,14 @@ function getMutationRuntime(): MutationRuntime | null {
   if (mutationRuntime) return mutationRuntime;
   if (!globalThis.indexedDB) return null;
 
-  const storage = mutationStorageForTests ?? new MutationOutboxIndexedDB();
   let runtime: MutationRuntime | null = null;
+  const storage =
+    mutationStorageForTests ??
+    new MutationOutboxIndexedDB({
+      onWriteStalled: (waiting) => {
+        if (isCurrentMutationRuntime(runtime)) threadsStore.setState({ mutationWriteStalled: waiting });
+      },
+    });
   const dispatcher = new MutationDispatcher(storage, {
     getClient: (targetRef) => (isCurrentMutationRuntime(runtime) ? currentDispatchClient(targetRef) : null),
     onStorageChange: (targetRefs) => {
@@ -2039,6 +2046,7 @@ function replaceThread(
 
 export const threadsStore = createStore<ThreadsStoreState>(() => ({
   threads: new Map(),
+  mutationWriteStalled: false,
   frameTimes: new Map(),
   hydrations: new Map(),
   watchedThreads: new Map(),

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -570,15 +570,28 @@ interface MutationRuntime {
 let mutationRuntime: MutationRuntime | null = null;
 let mutationStorageForTests: MutationOutboxIndexedDB | null = null;
 let createMutationBroadcastChannelForTests: NonNullable<MutationOutboxOptions["createBroadcastChannel"]> | undefined;
-const mutationPersistenceListeners = new Set<(targetRefs: string[]) => void>();
+interface MutationCommit {
+  record: MutationOutboxRecord;
+  recoveryId?: string;
+}
+
+type MutationPersistenceListener = (targetRefs: string[], committed?: MutationCommit) => void;
+const mutationPersistenceListeners = new Set<MutationPersistenceListener>();
 
 function isCurrentMutationRuntime(runtime: MutationRuntime | null): runtime is MutationRuntime {
   return runtime?.active === true && mutationRuntime === runtime;
 }
 
-function notifyMutationPersistence(targetRefs: Iterable<string>): void {
+function notifyMutationPersistence(targetRefs: Iterable<string>, committed?: MutationCommit): void {
   const refs = [...new Set(targetRefs)];
-  for (const listener of mutationPersistenceListeners) listener(refs);
+  for (const listener of mutationPersistenceListeners) {
+    try {
+      listener(refs, committed);
+    } catch (error) {
+      // A projection listener cannot change the result of a durable write.
+      console.error("Mutation persistence listener failed", error);
+    }
+  }
 }
 
 function applyClearResponse(targetRef: string, response: ThreadClearResponse): void {
@@ -736,7 +749,7 @@ export interface MutationPersistenceSnapshot {
   recovery: MutationRecoveryRecord[];
 }
 
-export function subscribeMutationPersistence(listener: (targetRefs: string[]) => void): () => void {
+export function subscribeMutationPersistence(listener: MutationPersistenceListener): () => void {
   mutationPersistenceListeners.add(listener);
   return () => mutationPersistenceListeners.delete(listener);
 }
@@ -808,7 +821,7 @@ export async function resendRecoveryMutation(
   const record = await runtime.storage.resendRecovery(clientMutationId, intent);
   if (!record) return undefined;
   pinnedMutationRefs.add(targetRef);
-  notifyMutationPersistence([targetRef]);
+  notifyMutationPersistence([targetRef], { record, recoveryId: clientMutationId });
   handleDiscoveredMutations(runtime, [targetRef]);
   return record;
 }
@@ -1130,8 +1143,8 @@ async function enqueueMutationIntent(intent: MutationIntent): Promise<void> {
   if (pending?.client !== wiredClient || pending.epoch !== readyEpoch) {
     dispatchableMutationRefs.add(ref);
   }
-  await runtime.outbox.enqueueIntent(intent);
-  notifyMutationPersistence([ref]);
+  const record = await runtime.outbox.enqueueIntent(intent);
+  notifyMutationPersistence([ref], { record });
 }
 
 async function enqueueMutation(

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -2124,6 +2124,9 @@ export const threadsStore = createStore<ThreadsStoreState>(() => ({
             continue;
           }
           if (lifecycleActive && threadsStore.getState().threads.has(ref)) return;
+          // Release is terminal even when the failed read belongs to an old
+          // connection. A reconnect cannot re-arm a pane that no longer exists.
+          if (!lifecycleActive) return;
           if (wiredClient !== inflightClient || readyEpoch !== inflightEpoch) {
             if (threadsStore.getState().threads.has(ref)) return;
             // requireReadyClient re-reads the CURRENT client on the way out,
@@ -2131,12 +2134,10 @@ export const threadsStore = createStore<ThreadsStoreState>(() => ({
             // hydration that outlived it. Same shape as the re-arm below and
             // as both of watchThread's.
             client = await requireReadyClient();
+            if (ensureGenerations.get(ref) !== generation || (refCounts.get(ref) ?? 0) <= 0) return;
             inflight = inflightHydrates.get(ref) ?? startHydration(client);
             continue;
           }
-          // Release is terminal for this owner generation: this call's claim is
-          // already gone, so there is nothing left to retry or to report.
-          if (!lifecycleActive) return;
           // Same client, same ready epoch: the read failed in transport, not
           // because this pane lost the ref. The failed attempt owns one
           // scheduled retry for this owner generation, and every concurrent
@@ -2153,6 +2154,7 @@ export const threadsStore = createStore<ThreadsStoreState>(() => ({
         if (threadsStore.getState().threads.has(ref)) return;
 
         client = await requireReadyClient();
+        if ((refCounts.get(ref) ?? 0) <= 0) return;
         inflight = inflightHydrates.get(ref);
         if (!inflight) inflight = startHydration(client);
       }

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -1138,12 +1138,20 @@ async function enqueueMutationIntent(intent: MutationIntent): Promise<void> {
   if (client.state !== "ready") throw new Error(`threads store: cannot enqueue mutation while ${client.state}`);
   const runtime = requireMutationRuntime();
   await runtime.start;
-  pinnedMutationRefs.add(ref);
+  // Enqueue schedules discovery before returning; preserve the hydrated replay
+  // gate now, but only a durable commit may pin this ref after its pane closes.
   const pending = pendingThreadHydrations.get(ref);
   if (pending?.client !== wiredClient || pending.epoch !== readyEpoch) {
     dispatchableMutationRefs.add(ref);
   }
-  const record = await runtime.outbox.enqueueIntent(intent);
+  let record: MutationOutboxRecord;
+  try {
+    record = await runtime.outbox.enqueueIntent(intent);
+  } catch (error) {
+    if (!pinnedMutationRefs.has(ref)) dispatchableMutationRefs.delete(ref);
+    throw error;
+  }
+  pinnedMutationRefs.add(ref);
   notifyMutationPersistence([ref], { record });
 }
 

--- a/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
+++ b/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
@@ -757,6 +757,20 @@ restores the submitted payload into the main composer because the durable
 outbox or recovery tray already owns it. Clicking Send again therefore cannot
 create a second mutation merely because the first response was lost.
 
+Browser storage waits have a bounded watchdog. A stalled open or read retires
+its connection; a late open cannot replace the recovered connection. For a
+write, the watchdog attempts transaction abort. Only successful cancellation
+permits reporting a local failure and leaving the draft available to retry.
+If the browser refuses abort because the transaction is committing or finished,
+the original submission remains pending until its complete or abort event arrives.
+The composer displays that uncertainty without offering a fresh submission of
+the same draft. The watchdog never deletes the database or bypasses the outbox.
+
+Discovery and projection refresh are background work after a successful commit.
+Their delays or failures cannot turn a saved message into a failed submission.
+A failed startup scan remains retryable, and repeated lifecycle scans of the
+same kind share outstanding work rather than accumulating behind stalled storage.
+
 An outbox record moves through:
 
 1. `submitting`: locally recorded, no authoritative outcome observed;

--- a/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
+++ b/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
@@ -787,9 +787,13 @@ send of the same pending draft. Successful completion clears sticky text only if
 its revision and text still match the submitted draft. Edits advance the revision
 even when they produce identical text or reuse image markers; remounts preserve
 it. A retired composer cannot clear a newer mount's draft or attachments.
-Mounted composers also capture an edit revision for both text and attachment
-cleanup, including recovery drafts. Persistence updates and commit display
-notifications do not count as edits; editing away and back to identical text does.
+Mounted composers also capture an edit revision for text cleanup, including
+recovery drafts. Submitted attachments are removed independently of text edits;
+newly staged items and explicit replacements survive even if they reuse markers.
+Recovery completion carries its consumed recovery ID to the current mount, which
+exits that recovery owner and preserves newer text as an ordinary draft.
+Persistence updates, recovery restoration, and commit display notifications do
+not count as shared draft edits; editing away and back to identical text does.
 
 This page-lifetime guard is not a durable draft-to-mutation identity. Sticky
 composer drafts currently persist text separately from the outbox; a full reload

--- a/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
+++ b/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
@@ -764,7 +764,8 @@ permits reporting a local failure and leaving the draft available to retry.
 If the browser refuses abort because the transaction is committing or finished,
 the original submission remains pending until its complete or abort event arrives.
 The composer displays that uncertainty without offering a fresh submission of
-the same draft. The watchdog never deletes the database or bypasses the outbox.
+the same draft. Storage-status listener failures cannot change the write outcome.
+The watchdog never deletes the database or bypasses the outbox.
 
 Discovery and projection refresh are background work after a successful commit.
 Their delays or failures cannot turn a saved message into a failed submission.
@@ -775,7 +776,10 @@ without waiting for the scan. A new submission can commit while that read stalls
 
 Local commits publish their record and provenance before releasing the composer.
 Projection reads, whether for one target or all targets, cannot overwrite a newer
-commit with an older snapshot. Recovery resend also publishes the atomic handoff
+commit with an older snapshot. A newer read fences older snapshots when it starts,
+even if it fails; failure retains the current projection for a later retry.
+Only durable mutations pin a thread after its pane closes; failed enqueues do not
+retain models or subscriptions. Recovery resend also publishes the atomic handoff
 from its recovery record to its new outbox record directly.
 Recovery edits remain serialized through write completion, without waiting for
 display refresh. Notification listener failures are reported separately and

--- a/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
+++ b/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
@@ -782,8 +782,9 @@ cannot change a committed submission into a failed send.
 Within a page, pending composer submission ownership is shared per target from
 the initial click through completion. Switching dock tabs cannot create a fresh
 send of the same pending draft. Successful completion clears sticky text only if
-it still matches the submitted text, and a retired composer cannot clear a newer
-mount's draft or attachments.
+its revision and text still match the submitted draft. Edits advance the revision
+even when they produce identical text or reuse image markers; remounts preserve
+it. A retired composer cannot clear a newer mount's draft or attachments.
 
 This page-lifetime guard is not a durable draft-to-mutation identity. Sticky
 composer drafts currently persist text separately from the outbox; a full reload

--- a/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
+++ b/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
@@ -771,6 +771,27 @@ Their delays or failures cannot turn a saved message into a failed submission.
 A failed startup scan remains retryable, and repeated lifecycle scans of the
 same kind share outstanding work rather than accumulating behind stalled storage.
 
+Local commits publish their record and provenance before releasing the composer.
+Projection reads, whether for one target or all targets, cannot overwrite a newer
+commit with an older snapshot. Recovery resend also publishes the atomic handoff
+from its recovery record to its new outbox record directly.
+Recovery edits remain serialized through write completion, without waiting for
+display refresh. Notification listener failures are reported separately and
+cannot change a committed submission into a failed send.
+
+Within a page, pending composer submission ownership is shared per target from
+the initial click through completion. Switching dock tabs cannot create a fresh
+send of the same pending draft. Successful completion clears sticky text only if
+it still matches the submitted text, and a retired composer cannot clear a newer
+mount's draft or attachments.
+
+This page-lifetime guard is not a durable draft-to-mutation identity. Sticky
+composer drafts currently persist text separately from the outbox; a full reload
+can recover a committed outbox record while also restoring that text. Strict
+duplicate prevention for resubmitting the restored draft requires an atomic or
+otherwise recoverable draft-to-mutation handoff. That architectural work is
+separate from the storage watchdog; matching text cannot safely identify a send.
+
 An outbox record moves through:
 
 1. `submitting`: locally recorded, no authoritative outcome observed;

--- a/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
+++ b/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
@@ -770,6 +770,8 @@ Discovery and projection refresh are background work after a successful commit.
 Their delays or failures cannot turn a saved message into a failed submission.
 A failed startup scan remains retryable, and repeated lifecycle scans of the
 same kind share outstanding work rather than accumulating behind stalled storage.
+Runtime initialization registers its listeners and schedules startup discovery
+without waiting for the scan. A new submission can commit while that read stalls.
 
 Local commits publish their record and provenance before releasing the composer.
 Projection reads, whether for one target or all targets, cannot overwrite a newer

--- a/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
+++ b/docs/superpowers/specs/2026-07-28-appwire-retry-safe-mutations-and-atomic-rejoin-design.md
@@ -785,6 +785,9 @@ send of the same pending draft. Successful completion clears sticky text only if
 its revision and text still match the submitted draft. Edits advance the revision
 even when they produce identical text or reuse image markers; remounts preserve
 it. A retired composer cannot clear a newer mount's draft or attachments.
+Mounted composers also capture an edit revision for both text and attachment
+cleanup, including recovery drafts. Persistence updates and commit display
+notifications do not count as edits; editing away and back to identical text does.
 
 This page-lifetime guard is not a durable draft-to-mutation identity. Sticky
 composer drafts currently persist text separately from the outbox; a full reload


### PR DESCRIPTION
Safari could leave Send and Steer disabled indefinitely when IndexedDB stopped completing operations. Add a storage watchdog that preserves the submission's durable outcome: a successfully cancelled write leaves the draft available to retry; a write that cannot be cancelled remains pending and displays a storage status until its original outcome is known.

Timed-out schema upgrades are aborted to release the database open lock; already-completed upgrades retain the late-connection cleanup path.

Runtime startup registers listeners and schedules discovery in the background, so a stalled initial scan cannot delay a new durable submission. Committed submissions release the composer without awaiting discovery or display reads. Publish the committed record immediately so stalled or older projections cannot hide a pending start and misroute the next message. Apply the same commit boundary to recovery edits and resend.

Share pending submission ownership across dock tab remounts. Repeated clicks cannot enqueue another submission while the original is unresolved, and late completion cannot erase a newer draft. Clear submitted attachments independently of text edits while preserving new or explicitly replaced items, including after recovery merges. Queue-strip drains atomically consume active recovery ownership. Submission cleanup clears this mount's sent content while preserving a newer shared draft edited in another composer, including attachment cleanup. Recovery completion releases the consumed recovery ID across mounts and preserves newer text as an ordinary draft; internal recovery persistence does not count as a user edit. Isolate notification and storage-status listener failures from write outcomes. Failed enqueues retain no phantom thread pin. Fence projection reads when newer reads start, including when those newer reads fail, so stale snapshots cannot resurrect settled work.

Also fixes a thread cleanup race exposed by the full test run: a released pane's failed read could resume after reconnecting. Recheck ownership before and after readiness waits, with deterministic coverage for all three release windows.

The directory-picker browser guard now awaits its existing focus condition alongside creation readiness. This fixes a CI scheduling race exposed after merging main; a negative check confirms missing focus restoration still fails.

Validation:

- `make merge-approval-gate` passed after merging current main; the final frontend corrections were rechecked with both frontend gates at `d906f60a4`.
- `make test-web` passed: type checking, frontend tests, and Biome.
- `make test-web-browser` passed all five browser guards.
- Regressions exercise real stores and Composer controls with fake IndexedDB callback stalls, cancelled and uncertain writes, stale projections, remounts, simultaneous composers, atomic recovery drains, recovery resend, and throwing subscribers.
- Independent review has no remaining actionable findings.

Limit: this protects submission ownership within a page lifetime. A full browser reload still requires a separate durable draft-to-mutation handoff to prevent resubmitting restored text as a new message. The tests simulate storage callback stalls; they do not establish the underlying WebKit trigger or prove this fixes Safari's storage engine.
