### PR TITLE
Add optional parent-history forks for delegates

### DIFF
--- a/agent/delegate_fork_context.go
+++ b/agent/delegate_fork_context.go
@@ -29,10 +29,14 @@ func (s *Session) snapshotDelegateContext() ([]transcript.Entry, error) {
 		// parent's delivery receipts, client mutation IDs, usage, or server
 		// continuation handles. Those belong to its execution, not the child.
 		entry.Turn = schema.Turn{
-			Kind: t.Kind, Message: t.Message, Timestamp: t.Timestamp,
-			SteeringSource:   t.SteeringSource,
-			ResponseProvider: t.ResponseProvider, ResponseModel: t.ResponseModel,
-			ResponseRequestModel: t.ResponseRequestModel, ResponseProtocol: t.ResponseProtocol,
+			Kind:                 t.Kind,
+			Message:              t.Message,
+			Timestamp:            t.Timestamp,
+			SteeringSource:       t.SteeringSource,
+			ResponseProvider:     t.ResponseProvider,
+			ResponseModel:        t.ResponseModel,
+			ResponseRequestModel: t.ResponseRequestModel,
+			ResponseProtocol:     t.ResponseProtocol,
 		}
 		out = append(out, entry)
 	}

--- a/agent/delegate_fork_context.go
+++ b/agent/delegate_fork_context.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"fmt"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+)
+
+// snapshotDelegateContext takes an independent, durable conversation snapshot.
+// attentionMu excludes both appends and compaction publication while we read;
+// decoding the transcript gives the child its own message and content objects.
+func (s *Session) snapshotDelegateContext() ([]transcript.Entry, error) {
+	s.attentionMu.Lock()
+	defer s.attentionMu.Unlock()
+	data, err := readStrictChildTranscript(transcriptPath(s.stateDir, s.id), s.id, s.strictTranscriptMaxLineBytes)
+	if err != nil {
+		return nil, fmt.Errorf("fork delegate context: %w", err)
+	}
+	entries := completedDelegateContext(data.Entries)
+	out := make([]transcript.Entry, 0, len(entries))
+	for _, entry := range entries {
+		t := entry.Turn
+		switch t.Kind {
+		case schema.TurnHookCompleted, schema.TurnAttentionResolution, schema.TurnModelSwitch, schema.TurnFailure:
+			continue
+		}
+		// Copy conversation and content provenance, without adopting the
+		// parent's delivery receipts, client mutation IDs, usage, or server
+		// continuation handles. Those belong to its execution, not the child.
+		entry.Turn = schema.Turn{
+			Kind: t.Kind, Message: t.Message, Timestamp: t.Timestamp,
+			SteeringSource:   t.SteeringSource,
+			ResponseProvider: t.ResponseProvider, ResponseModel: t.ResponseModel,
+			ResponseRequestModel: t.ResponseRequestModel, ResponseProtocol: t.ResponseProtocol,
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// completedDelegateContext cuts before an unfinished assistant tool round.
+// In particular the call creating this delegate has no result yet, and cannot
+// be inherited as a pending action for the child to resume or repair.
+func completedDelegateContext(entries []transcript.Entry) []transcript.Entry {
+	pending := make(map[string]bool)
+	roundStart := 0
+	for i, entry := range entries {
+		t := entry.Turn
+		switch t.Kind {
+		case schema.TurnAssistant:
+			clear(pending)
+			roundStart = i
+			for _, call := range assistantToolCalls(t.Message) {
+				pending[call.ID] = true
+			}
+		case schema.TurnTool, schema.TurnToolResults:
+			for _, part := range t.Message.Content {
+				if part.ToolResult != nil {
+					delete(pending, part.ToolResult.ToolCallID)
+				}
+			}
+		case schema.TurnSteering, schema.TurnHookCompleted, schema.TurnAttentionResolution:
+		default:
+			clear(pending)
+		}
+	}
+	if len(pending) != 0 {
+		return entries[:roundStart]
+	}
+	return entries
+}

--- a/agent/delegate_fork_context.go
+++ b/agent/delegate_fork_context.go
@@ -64,7 +64,8 @@ func completedDelegateContext(entries []transcript.Entry) []transcript.Entry {
 					delete(pending, part.ToolResult.ToolCallID)
 				}
 			}
-		case schema.TurnSteering, schema.TurnHookCompleted, schema.TurnAttentionResolution:
+		case schema.TurnSteering, schema.TurnHookCompleted, schema.TurnAttentionResolution, schema.TurnModelSwitch:
+			// Settings and telemetry can change while tools are executing.
 		default:
 			clear(pending)
 		}

--- a/agent/delegate_fork_context_test.go
+++ b/agent/delegate_fork_context_test.go
@@ -247,6 +247,39 @@ func TestDelegateForkContext_RejectsDifferentModelBeforeCreation(t *testing.T) {
 	}
 }
 
+// A direct resume has no live parent spawn config. It must still identify the
+// delegate by its assignment rather than the first inherited user message.
+func TestDelegateForkContext_DirectResumeKeepsAssignment(t *testing.T) {
+	meta, client, profile, stateDir, workspace, _ := closedDelegateResourceBootstrapFixture(t)
+	meta.IsSubagent = true
+	meta.ParentSessionID = identifier.MustNewSessionID()
+	meta.DivergenceTurn = 2
+	meta.OriginalPrompt = "assigned-unit-sentinel"
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := transcript.NewWriter(transcriptPath(stateDir, meta.ID), transcript.Header{SessionID: meta.ID, ParentSessionID: meta.ParentSessionID, Task: meta.OriginalPrompt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, input := range []string{"parent-request-sentinel", "assigned-unit-sentinel"} {
+		if err := writer.Append(schema.NewTurn(schema.TurnUserInput, llm.User(input))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := restoreDelegateResourceBootstrapSession(client, profile, workspace, meta, stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restored.Close()
+	if got := restored.Meta(); !got.IsSubagent || got.OriginalPrompt != "assigned-unit-sentinel" {
+		t.Fatalf("directly resumed delegate identity = %+v", got)
+	}
+}
+
 func TestDelegateForkContext_SchemaOffersOptionalBoolean(t *testing.T) {
 	root, _, _ := newDelegateResourceBootstrapSession(t)
 	definition := root.delegateToolDefinition()

--- a/agent/delegate_fork_context_test.go
+++ b/agent/delegate_fork_context_test.go
@@ -35,6 +35,8 @@ func TestDelegateForkContext_OptInHistory(t *testing.T) {
 			root.appendTurn(schema.TurnTool, llm.ToolResult("completed", "parent-result-sentinel", true))
 			root.appendTurn(schema.TurnUserInput, llm.User("current-input-sentinel"))
 			root.appendTurn(schema.TurnAssistant, forkContextToolCall("pending-spawn", "delegate"))
+			// A model setting can change while a tool is still executing.
+			root.appendTurn(schema.TurnModelSwitch, llm.System("model-marker-sentinel"))
 
 			params := map[string]any{"prompt": "child-assignment-sentinel", "delegation_allowance": float64(0)}
 			if option != nil {

--- a/agent/delegate_fork_context_test.go
+++ b/agent/delegate_fork_context_test.go
@@ -1,0 +1,277 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/identifier"
+	"primeradiant.com/evener/llm"
+)
+
+// Only an explicit opt-in may send the parent's conversation to a delegate.
+// Completed tool exchanges must survive, while the in-flight spawn must not.
+func TestDelegateForkContext_OptInHistory(t *testing.T) {
+	for _, option := range []any{nil, false, true} {
+		name := "default"
+		if option != nil {
+			name = map[bool]string{false: "clean", true: "fork"}[option.(bool)]
+		}
+		t.Run(name, func(t *testing.T) {
+			root, client, _ := newDelegateResourceBootstrapSession(t)
+			adapter := newTask6FrozenDescriptorAdapter()
+			client.Register(adapter)
+			t.Cleanup(adapter.releaseRun)
+			root.appendTurn(schema.TurnUserInput, llm.User("parent-context-sentinel"))
+			root.appendTurn(schema.TurnUserInput, llm.Message{Role: llm.RoleUser, Content: []llm.ContentPart{{Kind: llm.ContentImage, Image: &llm.ImageData{Data: []byte("image-sentinel"), MediaType: "image/png"}}}})
+			completed := schema.NewTurn(schema.TurnAssistant, forkContextToolCall("completed", "read_file"))
+			completed.ResponseID = "parent-response-anchor"
+			completed.Usage = llm.Usage{TotalTokens: 999}
+			root.recordTurn(completed, completed)
+			root.appendTurn(schema.TurnTool, llm.ToolResult("completed", "parent-result-sentinel", true))
+			root.appendTurn(schema.TurnUserInput, llm.User("current-input-sentinel"))
+			root.appendTurn(schema.TurnAssistant, forkContextToolCall("pending-spawn", "delegate"))
+
+			params := map[string]any{"prompt": "child-assignment-sentinel", "delegation_allowance": float64(0)}
+			if option != nil {
+				params["fork_context"] = option
+			}
+			args, err := decodeDelegateArgs(params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := root.createDelegate(context.Background(), args)
+			if result.Err != nil {
+				t.Fatal(result.Err)
+			}
+			var request llm.Request
+			select {
+			case request = <-adapter.entered:
+			case <-time.After(10 * time.Second): // TRIPWIRE: the scripted provider signals the first request.
+				t.Fatal("child did not issue a request")
+			}
+			wantHistory := option == true
+			for _, marker := range []string{"parent-context-sentinel", "current-input-sentinel"} {
+				if got := requestContainsText(request, marker); got != wantHistory {
+					t.Errorf("inherited %s = %v, want %v", marker, got, wantHistory)
+				}
+			}
+			if !requestContainsText(request, "child-assignment-sentinel") {
+				t.Error("child assignment missing")
+			}
+			foundToolResult := false
+			foundImage := false
+			for _, message := range request.Messages {
+				for _, part := range message.Content {
+					if part.Image != nil && string(part.Image.Data) == "image-sentinel" {
+						foundImage = true
+					}
+					if part.ToolResult != nil && part.ToolResult.ToolCallID == "completed" && part.ToolResult.Content == "parent-result-sentinel" {
+						foundToolResult = true
+					}
+					if part.ToolCall != nil && part.ToolCall.ID == "pending-spawn" {
+						t.Error("unfinished spawn call reached the child")
+					}
+				}
+			}
+			if foundToolResult != wantHistory {
+				t.Errorf("inherited completed tool result = %v, want %v", foundToolResult, wantHistory)
+			}
+			if foundImage != wantHistory {
+				t.Errorf("inherited image = %v, want %v", foundImage, wantHistory)
+			}
+			child := root.getSub(result.ChildSessionID).sess
+			meta := child.Meta()
+			if !meta.IsSubagent || meta.OriginalPrompt != "child-assignment-sentinel" || meta.CumulativeUsage.TotalTokens != 0 {
+				t.Errorf("child identity or accounting inherited: %+v", meta)
+			}
+			if child.reg.Get("ask_user") != nil || child.reg.Get("delegate") != nil {
+				t.Error("leaf child gained parent tools")
+			}
+			if failures, measured := child.FailedToolCallsSnapshot(); !measured || failures != 0 {
+				t.Errorf("child charged for parent's tool failure: %d, measured=%v", failures, measured)
+			}
+			data, err := readTranscriptFull(transcriptPath(root.stateDir, child.id))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, entry := range data.Entries {
+				if entry.Turn.ResponseID == "parent-response-anchor" {
+					t.Error("parent continuation anchor copied into child")
+				}
+			}
+		})
+	}
+}
+
+func TestDelegateForkContext_DescendantsStartClean(t *testing.T) {
+	root, _, _ := newDelegateResourceBootstrapSession(t)
+	root.appendTurn(schema.TurnUserInput, llm.User("ancestor-context-sentinel"))
+	grandchild := newTask6FrozenDescriptorAdapter()
+	t.Cleanup(grandchild.releaseRun)
+	var constructed atomic.Int32
+	root.cfg.testOnly.childClientFactory = func() *llm.Client {
+		client := llm.NewClient()
+		if constructed.Add(1) == 1 {
+			client.Register(&fakeAdapter{name: "openai", steps: []func(llm.Request) llm.Response{
+				func(llm.Request) llm.Response {
+					message := forkContextToolCall("nested-spawn", "delegate")
+					message.Content[0].ToolCall.Arguments = []byte(`{"prompt":"grandchild-unit-sentinel","delegation_allowance":0}`)
+					return llm.Response{Message: message}
+				},
+				func(llm.Request) llm.Response { return finalResponse("child finished") },
+			}})
+		} else {
+			client.Register(grandchild)
+		}
+		return client
+	}
+	result := root.createDelegate(context.Background(), delegateArgs{Task: "middle-assignment-sentinel", ForkContext: true, DelegationAllowance: new(1)})
+	if result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	select {
+	case req := <-grandchild.entered:
+		if requestContainsText(req, "ancestor-context-sentinel") || requestContainsText(req, "middle-assignment-sentinel") || !requestContainsText(req, "grandchild-unit-sentinel") {
+			t.Fatal("grandchild inherited context without opting in")
+		}
+	case <-time.After(10 * time.Second): // TRIPWIRE: real delegate dispatch must reach the scripted grandchild provider.
+		t.Fatal("grandchild did not issue a request")
+	}
+}
+
+func TestDelegateForkContext_RejectsMismatchedSourceTranscript(t *testing.T) {
+	root, _, _ := newDelegateResourceBootstrapSession(t)
+	if err := root.closeAttachedTranscript(); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := transcript.NewWriter(transcriptPath(root.stateDir, root.id), transcript.Header{SessionID: identifier.MustNewSessionID()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := root.snapshotDelegateContext(); err == nil {
+		t.Fatal("fork accepted another session's transcript")
+	}
+}
+
+// A cold delegate resumes from its own saved snapshot, even after its parent
+// has continued. Parent compaction controls the working context but must not
+// erase the earlier conversation from the child's transcript.
+func TestDelegateForkContext_ColdResumePreservesSnapshot(t *testing.T) {
+	root, client, _ := newDelegateResourceBootstrapSession(t)
+	root.appendTurn(schema.TurnUserInput, llm.User("archived-parent-sentinel"))
+	root.appendTurn(schema.TurnCheckpoint, llm.User("parent-summary-sentinel"))
+	root.appendTurn(schema.TurnUserInput, llm.User("recent-parent-sentinel"))
+	adapter := &fakeAdapter{name: "openai", steps: []func(llm.Request) llm.Response{
+		func(llm.Request) llm.Response { return finalResponse("child-result-sentinel") },
+	}}
+	client.Register(adapter)
+	result := root.createDelegate(context.Background(), delegateArgs{Task: "child-unit-sentinel", ForkContext: true, DelegationAllowance: new(0)})
+	if result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	sub := root.getSub(result.ChildSessionID)
+	sub.mu.Lock()
+	done := sub.done
+	sub.mu.Unlock()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second): // TRIPWIRE: scripted completion; synchronization is the closed run channel.
+		t.Fatal("child did not complete")
+	}
+	root.delegateController.mu.Lock()
+	root.delegateController.maxRetainedTerminal = 1
+	root.delegateController.mu.Unlock()
+	if err := root.reclaimDelegateRuntimeCapacity(1); err != nil {
+		t.Fatal(err)
+	}
+	if root.getSub(result.ChildSessionID) != nil {
+		t.Fatal("child runtime was not reclaimed")
+	}
+	root.appendTurn(schema.TurnUserInput, llm.User("after-fork-sentinel"))
+	resumedAdapter := newTask6FrozenDescriptorAdapter()
+	client.Register(resumedAdapter)
+	t.Cleanup(resumedAdapter.releaseRun)
+	outcome := (delegateRuntime{owner: root}).send(context.Background(), result.DelegateID, "followup-sentinel", 0)
+	if outcome.result.Err != nil {
+		t.Fatal(outcome.result.Err)
+	}
+	var req llm.Request
+	select {
+	case req = <-resumedAdapter.entered:
+	case <-time.After(10 * time.Second): // TRIPWIRE: the restored runtime must reach the scripted provider.
+		t.Fatal("resumed child did not issue a request")
+	}
+	for _, marker := range []string{"parent-summary-sentinel", "recent-parent-sentinel", "child-unit-sentinel", "followup-sentinel"} {
+		if !requestContainsText(req, marker) {
+			t.Errorf("missing resumed context %s", marker)
+		}
+	}
+	for _, marker := range []string{"archived-parent-sentinel", "after-fork-sentinel"} {
+		if requestContainsText(req, marker) {
+			t.Errorf("unexpected context %s", marker)
+		}
+	}
+	child := root.getSub(result.ChildSessionID).sess
+	meta := child.Meta()
+	if !meta.IsSubagent || meta.DivergenceTurn == 0 || meta.OriginalPrompt != "child-unit-sentinel" || child.reg.Get("ask_user") != nil {
+		t.Fatalf("restored delegate lost identity or gained permissions: %+v", meta)
+	}
+	data, err := readTranscriptFull(transcriptPath(root.stateDir, child.id))
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundArchive := false
+	for _, entry := range data.Entries {
+		if entry.Turn.Message.Text() == "archived-parent-sentinel" {
+			foundArchive = true
+		}
+	}
+	if !foundArchive {
+		t.Fatal("fork discarded the parent's archived conversation")
+	}
+}
+
+func TestDelegateForkContext_RejectsDifferentModelBeforeCreation(t *testing.T) {
+	root, _, _ := newDelegateResourceBootstrapSession(t)
+	result := root.createDelegate(context.Background(), delegateArgs{Task: "unit", ForkContext: true, Model: "gpt-5.5"})
+	if result.Err == nil || !strings.Contains(result.Err.Error(), "fork_context") || result.DelegateID != "" {
+		t.Fatalf("different-model fork = %+v", result)
+	}
+}
+
+func TestDelegateForkContext_SchemaOffersOptionalBoolean(t *testing.T) {
+	root, _, _ := newDelegateResourceBootstrapSession(t)
+	definition := root.delegateToolDefinition()
+	property, ok := definition.Parameters["properties"].(map[string]any)["fork_context"].(map[string]any)
+	if !ok || property["type"] != "boolean" || property["default"] != false {
+		t.Fatalf("fork_context schema = %#v", property)
+	}
+	for _, required := range definition.Parameters["required"].([]string) {
+		if required == "fork_context" {
+			t.Fatal("clean-session callers must not need to supply fork_context")
+		}
+	}
+}
+
+func TestDelegateForkContext_RejectsMalformedOption(t *testing.T) {
+	for _, option := range []any{"true", 1, nil, []any{true}} {
+		if _, err := decodeDelegateArgs(map[string]any{"prompt": "unit", "fork_context": option}); err == nil {
+			t.Errorf("accepted fork_context=%#v", option)
+		}
+	}
+}
+
+func forkContextToolCall(id, name string) llm.Message {
+	return llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{{
+		Kind:     llm.ContentToolCall,
+		ToolCall: &llm.ToolCallData{ID: id, Name: name, Arguments: []byte(`{}`), Type: "function"},
+	}}}
+}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1162,6 +1162,12 @@ func (runtime delegateRuntime) create(ctx context.Context, args delegateArgs) de
 	if err != nil {
 		return delegateStartFailed(err)
 	}
+	if args.ForkContext {
+		parent := s.currentProfile()
+		if selection.profile.ID() != parent.ID() || selection.profile.Model() != parent.Model() {
+			return delegateStartFailed(errors.New("invalid_request: fork_context requires the parent's model and provider; use a clean session with a self-contained prompt for a different model"))
+		}
+	}
 	if selection.warning != nil {
 		s.emitDiagnosticWarning(*selection.warning)
 	}
@@ -1526,7 +1532,15 @@ func (runtime delegateRuntime) construct(_ context.Context, args delegateArgs, s
 	if started.descriptor.ParentWatchGranted {
 		ctx = context.WithValue(ctx, ctxWatchParent, true)
 	}
-	prepared, err := s.prepareStableDelegateRun(ctx, started.descriptor, started.descriptor.ParentWatchGranted, selection)
+	var inheritedContext []transcript.Entry
+	if args.ForkContext {
+		var err error
+		inheritedContext, err = s.snapshotDelegateContext()
+		if err != nil {
+			return nil, err
+		}
+	}
+	prepared, err := s.prepareStableDelegateRun(ctx, started.descriptor, started.descriptor.ParentWatchGranted, selection, inheritedContext)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/internal/tool/definitions.go
+++ b/agent/internal/tool/definitions.go
@@ -177,11 +177,11 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 			"properties": map[string]any{
 				"prompt": map[string]any{
 					"type":        "string",
-					"description": "The brief: the delegate's only top-level input (task_list adds the ordered step prompts). None of your conversation, the user's message, or what you have learned reaches it. State the user's request for this unit (quote it), the facts it needs that you already know (environment, tools present or missing, paths, formats), exactly which files or paths it owns and must not touch, the acceptance check (the exact command(s) and the expected result), and the evidence to report back (paths, diffs, the check's output). For a unit with more than one step, put the steps in task_list rather than here.",
+					"description": "The delegate's assignment (task_list adds ordered step prompts). By default the delegate starts a clean session with no parent conversation. State the user's request for this unit (quote it), the facts it needs that you already know (environment, tools present or missing, paths, formats), exactly which files or paths it owns and must not touch, the acceptance check (the exact command(s) and the expected result), and the evidence to report back (paths, diffs, the check's output). With fork_context=true, inherited history supplies background but this prompt must still define the assignment, ownership, acceptance check, and report. For a unit with more than one step, put the steps in task_list rather than here.",
 				},
 				"task_list": map[string]any{
 					"type":        "array",
-					"description": "Seed the delegate's task list, one item per step, in order. Items fill the role's parent_tasks slot when its default task list has one and follow the role's default tasks otherwise. The first task auto-starts and its prompt is injected into the delegate; the delegate works the list in order and marks each task done. Each item's prompt must stand alone: the delegate sees no other context.",
+					"description": "Seed the delegate's task list, one item per step, in order. Items fill the role's parent_tasks slot when its default task list has one and follow the role's default tasks otherwise. The first task auto-starts and its prompt is injected into the delegate; the delegate works the list in order and marks each task done. Each item's prompt must define a self-contained step.",
 					"items": map[string]any{
 						"type":                 "object",
 						"additionalProperties": false,
@@ -199,6 +199,10 @@ func DefDelegateWithSandbox(agentTypes []string, sandboxSchema DelegateSandboxSc
 				"reasoning_effort":     map[string]any{"type": "string", "description": "Reasoning effort for this delegate (low, medium, or high). Default inherits from parent.", "enum": []string{"low", "medium", "high"}},
 				"delegation_allowance": map[string]any{"type": "integer", "description": "Absent (default): the delegate gets an allowance one below yours and may delegate in turn. 0: a leaf delegate that cannot itself delegate. >0: the delegate may delegate, granting onward allowances strictly smaller than this; must be strictly less than your own allowance. The allowance only takes effect if the chosen agent_type carries the `delegate` tool (the built-in `default` and `subagent` roles do; `explorer` does not)."},
 				"watch_parent":         map[string]any{"type": "boolean", "description": "Grant this child permission to observe your session with job_watch(source=\"parent\"). This does not grant delegation or any transitive watch permission."},
+				"fork_context": map[string]any{
+					"type": "boolean", "default": false,
+					"description": "Copy the parent's full conversation history into this delegate. Use only when the assignment requires that full context and history. Defaults to false. When selected facts, decisions, or excerpts are sufficient, include them in the prompt and start a clean session. The snapshot excludes the unfinished tool round; the child keeps its own role and permissions. Requires the parent's model and provider.",
+				},
 				"isolation": map[string]any{
 					"type":        "string",
 					"enum":        []string{"worktree"},

--- a/agent/job_delegate.go
+++ b/agent/job_delegate.go
@@ -32,6 +32,7 @@ type delegateArgs struct {
 	ReasoningEffort     string
 	DelegationAllowance *int
 	WatchParent         bool
+	ForkContext         bool
 	Isolation           string
 	Sandbox             string
 	SandboxNet          *bool

--- a/agent/prompts/sections/delegation.md
+++ b/agent/prompts/sections/delegation.md
@@ -18,10 +18,10 @@ delegate's session `transcript_ref` to read its conversation. `job_list` present
 delegates and shell jobs together, but their identities remain typed: `dlg_...`
 for delegates and `job_...` for shell work.
 
-Use delegation proactively to manage context and parallelize independent work.
-For broad, ambiguous, or multi-part tasks, decompose the work into bounded
-subtasks and assign subagents when they can investigate, implement, verify,
-review, or report with a smaller working set than the parent session.
+Delegate whenever doing so could save time, improve quality, or provide a
+useful independent perspective. This applies to both root agents and delegates.
+Give each delegate a clear assignment. Work can benefit from delegation even
+when it is sequential or does not reduce the parent's working context.
 
 Before running data-heavy work concurrently, price it against these CPU and memory caps, treating your own context and transcript heap as an invisible co-tenant.
 
@@ -46,9 +46,14 @@ sense together, delegate one coordinator that fans them out and reports once.
 Prefer several subagents in parallel when the questions are genuinely
 independent.
 
-A delegate sees only your brief and its role prompt: none of your
-conversation, not the user's message, not what you have learned. Every brief
-therefore carries, in this order:
+Prefer clean sessions. By default a delegate sees only your brief and its role
+prompt. Put the relevant facts, decisions, and excerpts in the brief whenever
+that provides enough context. Set `fork_context=true` only when the assignment
+requires the parent's full context and conversation history. It takes a fixed
+snapshot, excluding the unfinished tool round, and requires the same model and
+provider. The child keeps its own role, tools, permissions, and assignment.
+
+Every brief carries, in this order:
 
 1. The user's request for this unit, quoted, plus the facts it needs that
    you already know: environment, tools present or missing, paths, formats.
@@ -61,6 +66,11 @@ therefore carries, in this order:
 
 A brief missing any of these is not ready to send. Do not delegate an
 underspecified unit; specify it first.
+
+With `fork_context=true`, inherited history can supply the background facts;
+the brief must still define the unit's assignment, ownership, acceptance check,
+and report. A few useful earlier facts are a reason to write a better brief,
+not to copy the full history.
 
 When the unit has more than one step, pass the steps as `task_list`, one item
 per step with a self-contained prompt: the delegate works them in order, marks

--- a/agent/session.go
+++ b/agent/session.go
@@ -1518,8 +1518,8 @@ func (s *Session) acceptCommunicateTerminal(ctx context.Context, message, reply,
 	return true
 }
 
-// extractOriginalPrompt returns the text of the first user input in the session history.
-// If compaction removed it, falls back to the SubagentTask from config.
+// extractOriginalPrompt returns a delegate's assignment or the first user
+// input of a root session. Inherited conversation does not redefine the task.
 func (s *Session) extractOriginalPrompt() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/agent/session.go
+++ b/agent/session.go
@@ -1523,6 +1523,9 @@ func (s *Session) acceptCommunicateTerminal(ctx context.Context, message, reply,
 func (s *Session) extractOriginalPrompt() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.isSubagentSession() && s.cfg.spawn.subagentTask != "" {
+		return s.cfg.spawn.subagentTask
+	}
 	for _, t := range s.history {
 		if t.Kind == schema.TurnUserInput {
 			return t.Message.Text()

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -601,6 +601,10 @@ type spawnConfig struct {
 	// subagentTask is the task description passed to delegate.
 	subagentTask string
 
+	// inheritedContext seeds a delegate's transcript once, at construction.
+	// NewSession consumes it; descendants start clean unless they also opt in.
+	inheritedContext []transcript.Entry
+
 	// depth is the sub-agent nesting depth (0 for root sessions).
 	depth int
 

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -269,6 +269,8 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 			return nil, fmt.Errorf("acquire session ownership: %w", err)
 		}
 	}
+	inheritedContext := cfg.spawn.inheritedContext
+	cfg.spawn.inheritedContext = nil
 	s := &Session{
 		id:                            sessionID,
 		cfg:                           cfg,
@@ -296,6 +298,13 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 		artifactStore:                 store,
 		ownsArtifactStore:             ownsArtifactStore,
 		subscriberCountFn:             cfg.spawn.subscriberCount,
+	}
+	if inheritedContext != nil {
+		s.fork = forkInfo{parentID: cfg.spawn.parentSessionID, divergence: len(inheritedContext) + 1}
+		s.history = ResumeHistory(inheritedContext)
+		boundary := schema.NewTurn(schema.TurnSteering, llm.User("The conversation above is inherited context from your parent. You are a separate delegate. Use that history as background for the assignment that follows; your own role, tools, permissions, and working directory govern this session."))
+		s.history = append(s.history, boundary)
+		s.pendingTranscriptTurns = append(s.pendingTranscriptTurns, boundary)
 	}
 	s.captureModelAvailability(selectedModels)
 	s.createdAt = s.sclock().Now().UTC()
@@ -433,10 +442,20 @@ func NewSession(client *llm.Client, profile *provider.Profile, env execenv.Execu
 		}
 		if tw != nil {
 			tw.SyncInterval = 1 * time.Second
-			// A fresh session starts from an empty transcript, so the running
-			// failure count starts at a MEASURED zero rather than at "unknown"
-			// (FailedToolCallsSnapshot).
-			tw.TrackFailures(nil, 0)
+			// Only this session's own turns count as failures; a forked
+			// delegate's inherited prefix belongs to its parent.
+			tw.TrackFailures(nil, s.fork.divergence)
+		}
+	}
+	if inheritedContext != nil {
+		if tw == nil {
+			return nil, errors.New("fork delegate context requires a writable child transcript")
+		}
+		for _, entry := range inheritedContext {
+			if err := tw.Append(entry.Turn); err != nil {
+				_ = tw.Close()
+				return nil, fmt.Errorf("persist inherited delegate context: %w", err)
+			}
 		}
 	}
 	s.attachTranscript(tw)

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -696,6 +696,11 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	if restoreCfg.spawn.parentSessionID != "" {
 		cfg.spawn = restoreCfg.spawn
 	}
+	if meta.IsSubagent && meta.DivergenceTurn > 0 && cfg.spawn.subagentTask == "" {
+		// A direct resume has no live parent carrier. The assignment in meta
+		// belongs to this delegate; the first inherited input belongs to its parent.
+		cfg.spawn.subagentTask = meta.OriginalPrompt
+	}
 	if restoreCfg.ModelFallbacks != nil {
 		cfg.ModelFallbacks = append([]string(nil), restoreCfg.ModelFallbacks...)
 	}

--- a/agent/session_state.go
+++ b/agent/session_state.go
@@ -119,7 +119,6 @@ func (s *Session) Meta() schema.SessionMeta {
 	if s.fork.divergence > 0 {
 		parentID = s.fork.parentID
 		divergence = s.fork.divergence
-		isSubagent = false
 	} else if parentID == "" {
 		// A live spawn wins; the persisted parent covers the resume that left the
 		// carrier empty, so the delegate keeps the parent row the hub nests it

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -472,6 +472,13 @@ func decodeDelegateArgs(args map[string]any) (delegateArgs, error) {
 		Isolation:       stringArg(args, "isolation"),
 		Sandbox:         stringArg(args, "sandbox"), // may carry "+nonet" suffix or be "nonet" alone
 	}
+	if raw, exists := args["fork_context"]; exists {
+		var ok bool
+		a.ForkContext, ok = raw.(bool)
+		if !ok {
+			return delegateArgs{}, errors.New("invalid_request: fork_context must be a JSON boolean")
+		}
+	}
 	// The sandbox field now encodes both mode and an optional network override
 	// in a single enum value. Values like "read-only+nonet" split into mode=
 	// "read-only" and sandbox_net=false. "nonet" alone means inherit the
@@ -523,8 +530,8 @@ func decodeDelegateArgs(args map[string]any) (delegateArgs, error) {
 }
 
 // delegateTaskListArg decodes the delegate tool's task_list items into task
-// templates. Every item needs a title and a prompt; the delegate sees nothing
-// but these strings, so an empty prompt is an error rather than a blank task.
+// templates. Every item needs a title and a prompt that defines its own step,
+// so an empty prompt is an error rather than a blank task.
 func delegateTaskListArg(args map[string]any) ([]taskpkg.TaskTemplate, error) {
 	raw, ok := args["task_list"]
 	if !ok || raw == nil {

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -23,6 +23,7 @@ import (
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/skill"
 	taskpkg "primeradiant.com/evener/agent/task"
+	"primeradiant.com/evener/agent/transcript"
 )
 
 const delegateSalvagedDraftNote = "partial draft salvaged in the child transcript — resume it with delegate_send rather than re-dispatching"
@@ -622,11 +623,11 @@ func (s *Session) prepareSubagentRunWithModelSelection(
 ) (*preparedSubagentRun, error) {
 	return s.prepareSubagentRunFromSelection(
 		ctx, task, workingDir, maxTurns, agentType, reasoningEffort,
-		parentTasks, grantTools, selection, nil,
+		parentTasks, grantTools, selection, nil, nil,
 	)
 }
 
-func (s *Session) prepareStableDelegateRun(ctx context.Context, descriptor delegatestore.Descriptor, watchParent bool, selection subagentModelSelection) (*preparedSubagentRun, error) {
+func (s *Session) prepareStableDelegateRun(ctx context.Context, descriptor delegatestore.Descriptor, watchParent bool, selection subagentModelSelection, inheritedContext []transcript.Entry) (*preparedSubagentRun, error) {
 	if selection.profile == nil || selection.profile.ID() != descriptor.ResolvedProfileID || selection.profile.Model() != descriptor.ResolvedModel {
 		actual := "<nil>"
 		if selection.profile != nil {
@@ -649,7 +650,7 @@ func (s *Session) prepareStableDelegateRun(ctx context.Context, descriptor deleg
 	selection.agent = nil
 	return s.prepareSubagentRunFromSelection(
 		ctx, descriptor.Task, descriptor.WorkingDir, 0, descriptor.AgentType, descriptor.Config.ReasoningEffort,
-		nil, nil, selection, &descriptor,
+		nil, nil, selection, &descriptor, inheritedContext,
 	)
 }
 
@@ -691,6 +692,7 @@ func (s *Session) prepareSubagentRunFromSelection(
 	grantTools []string,
 	selection subagentModelSelection,
 	frozen *delegatestore.Descriptor,
+	inheritedContext []transcript.Entry,
 ) (*preparedSubagentRun, error) {
 	s.mu.Lock()
 	depth := s.depth
@@ -728,6 +730,7 @@ func (s *Session) prepareSubagentRunFromSelection(
 	}
 	subCfg.spawn.parentSessionID = s.id
 	subCfg.spawn.subagentTask = task
+	subCfg.spawn.inheritedContext = inheritedContext
 	subCfg.spawn.depth = depth + 1
 	subCfg.spawn.parentSteer = s.SteerWithProvenance
 	subCfg.spawn.parentSystemNotification = s.routeSystemNotification

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -359,6 +359,24 @@ with the returned `delegate_id`. To start an observer sidecar, set
 `watch_parent:true`; the child can then observe its immediate parent with
 `job_watch(source="parent")` and report through `communicate(end_turn=true)`.
 
+Delegates start with a **clean session** by default. Put the relevant facts,
+decisions, and excerpts in the assignment whenever that gives the child enough
+context. Use `fork_context:true` only for work that requires the parent's **full
+context and conversation history**. The option requires the same model and
+provider, including the model selected by an agent role.
+
+A fork takes a fixed copy of the recorded conversation before the unfinished
+tool round. Completed tool exchanges and images remain available; compaction
+summaries determine the working context just as they do in the parent, while
+the earlier conversation remains in the child's transcript. Later parent
+messages are not added to that snapshot. Resuming the delegate uses its own
+saved transcript.
+
+The child keeps its own assignment, role, tools, sandbox, and delegation
+allowance. Parent usage, pending deliveries, client mutation IDs, and server
+continuation handles are not adopted. The assignment must still state what
+the child owns, how to verify the result, and what to report back.
+
 Canonical background shape:
 
 ```json
@@ -383,6 +401,7 @@ Full target shape (no `max_wait_ms`):
   "model": "openai/gpt-5.5",
   "reasoning_effort": "high",
   "watch_parent": false,
+  "fork_context": false,
   "result_schema": {
     "type": "object",
     "properties": {

--- a/docs/job-control.md
+++ b/docs/job-control.md
@@ -50,8 +50,9 @@ This reference contract is not itself the runtime system prompt, but the followi
 - Delegate creation returns after one stable `delegate_id` and its initial input
   are durable. It does not accept `max_wait_ms` and does not expose a run handle.
 - Use `delegate` to start a new delegate conversation: `prompt` is the brief
-  (the only input the delegate receives) and `task_list` seeds its task list,
-  one item per step. It returns `dlg_...`,
+  and `task_list` seeds its task list, one item per step. Sessions start clean
+  by default; use `fork_context=true` only when the assignment requires the
+  parent's full context and history. It returns `dlg_...`,
   child/session transcript metadata, status, and resumability—never `job_...`.
 - Use `delegate_send` for follow-up: a running delegate is steered; an idle,
   resumable delegate starts its next private run through the same call.


### PR DESCRIPTION
Adds optional `fork_context: true` to `delegate`. Clean sessions remain the default and preferred path: put selected facts, decisions, and excerpts in a self-contained brief. Copy the parent's full context and history only when the assignment requires it.

Broadens runtime guidance to delegate whenever it could save time, improve quality, or provide a useful independent perspective, including sequential work.

- Forks require the parent's model and provider. They copy a fixed conversation snapshot, preserve compacted archives, and exclude the unfinished tool round and parent response-continuation handles.
- Children retain their own assignment, role, tools, sandbox, delegation allowance, and accounting. Descendants start clean unless they also opt in; resumed children use their saved snapshot rather than later parent history.
- Scripted-provider regressions exercise opt-in/default behavior, images and completed tool results, model-switch markers inside unfinished rounds, nested delegation, cold/direct resume, and malformed or incompatible requests.

## Validation

- `make merge-approval-gate` — passed on `439a5d1bc`, rebased onto main's Astra changes.
- `make vet` — passed.
- `go test -race ./agent -run '^TestDelegateForkContext' -count=1` — passed.
- `make test-web-browser` — all five guards passed; frontend sources are unchanged by the rebase.

The regression tests use scripted providers to verify Evener behavior. Live-model delegation behavior was not evaluated.
