### PR TITLE
Explain automatic background job completion wakeups

### DIFF
--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -581,6 +581,7 @@ func formatShellResult(out shellToolResult) string {
 	// the command itself did not time out — the foreground wait did, and the
 	// command keeps running as a durable background job.
 	promoted := out.Mode == string(shellModeBackground) && out.TimedOut && out.JobID != ""
+	directBackground := out.Mode == string(shellModeBackground) && out.JobID != "" && !promoted
 
 	var foot []string
 	if out.ExitCode != nil && out.Mode != string(shellModeBackground) && !runTimeout {
@@ -601,7 +602,7 @@ func formatShellResult(out shellToolResult) string {
 			fmt.Sprintf("output accumulates durably; read it with read_transcript(transcript_ref=%q)", "job:"+out.JobID),
 			"completion arrives by notification — do not relaunch or poll",
 		)
-	case out.Mode == string(shellModeBackground) && out.JobID != "":
+	case directBackground:
 		foot = append(foot, "running in background as "+out.JobID)
 	case out.JobID != "":
 		foot = append(foot, fmt.Sprintf("output windowed — read more with read_transcript(transcript_ref=%q)", "job:"+out.JobID))
@@ -613,6 +614,10 @@ func formatShellResult(out shellToolResult) string {
 		b.WriteString("[")
 		b.WriteString(strings.Join(foot, " · "))
 		b.WriteString("]")
+	}
+	if directBackground {
+		b.WriteByte('\n')
+		b.WriteString(systemReminder("This job will notify you when it completes. If your session is idle, the notification will wake it. You do not need to wait for it explicitly."))
 	}
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -580,8 +580,9 @@ func formatShellResult(out shellToolResult) string {
 	// promoted is the foreground-wait-timeout promotion (job-control.md:210,214):
 	// the command itself did not time out — the foreground wait did, and the
 	// command keeps running as a durable background job.
-	promoted := out.Mode == string(shellModeBackground) && out.TimedOut && out.JobID != ""
-	directBackground := out.Mode == string(shellModeBackground) && out.JobID != "" && !promoted
+	backgrounded := out.Mode == string(shellModeBackground) && out.JobID != ""
+	promoted := backgrounded && out.TimedOut
+	directBackground := backgrounded && !promoted
 
 	var foot []string
 	if out.ExitCode != nil && out.Mode != string(shellModeBackground) && !runTimeout {
@@ -615,7 +616,7 @@ func formatShellResult(out shellToolResult) string {
 		b.WriteString(strings.Join(foot, " · "))
 		b.WriteString("]")
 	}
-	if directBackground {
+	if backgrounded {
 		b.WriteByte('\n')
 		b.WriteString(systemReminder("This job will notify you when it completes. If your session is idle, the notification will wake it. You do not need to wait for it explicitly."))
 	}

--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -599,26 +599,32 @@ func formatShellResult(out shellToolResult) string {
 		}
 	case promoted:
 		foot = append(foot,
-			fmt.Sprintf("still running as %s — the foreground wait ended, not the command", out.JobID),
+			"the foreground wait ended, not the command",
 			fmt.Sprintf("output accumulates durably; read it with read_transcript(transcript_ref=%q)", "job:"+out.JobID),
 			"completion arrives by notification — do not relaunch or poll",
 		)
 	case directBackground:
-		foot = append(foot, "running in background as "+out.JobID)
+		// The identifying footer is appended after optional retention details so
+		// the job ID remains at the absolute tail.
 	case out.JobID != "":
 		foot = append(foot, fmt.Sprintf("output windowed — read more with read_transcript(transcript_ref=%q)", "job:"+out.JobID))
 	}
 	if out.DroppedBytes > 0 {
 		foot = append(foot, fmt.Sprintf("%d bytes dropped past the retention cap", out.DroppedBytes))
 	}
+	if promoted {
+		foot = append(foot, "still running as "+out.JobID)
+	} else if directBackground {
+		foot = append(foot, "running in background as "+out.JobID)
+	}
+	if backgrounded {
+		b.WriteString(systemReminder("This job will notify you when it completes. If your session is idle, the notification will wake it. You do not need to wait for it explicitly."))
+		b.WriteByte(' ')
+	}
 	if len(foot) > 0 {
 		b.WriteString("[")
 		b.WriteString(strings.Join(foot, " · "))
 		b.WriteString("]")
-	}
-	if backgrounded {
-		b.WriteByte('\n')
-		b.WriteString(systemReminder("This job will notify you when it completes. If your session is idle, the notification will wake it. You do not need to wait for it explicitly."))
 	}
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/agent/session_tools_shell_test.go
+++ b/agent/session_tools_shell_test.go
@@ -638,11 +638,8 @@ func TestShellToolStreamingPathHonorsSessionTimeouts(t *testing.T) {
 				out.Mode != "background" {
 				t.Fatalf("shell output = %+v, want foreground timeout promoted to background", out)
 			}
-			if !res.Truncated {
-				t.Fatalf("promoted shell model output was not truncated under constrained registry limits: %q", res.Output)
-			}
 			if !strings.Contains(res.Output, out.JobID) {
-				t.Fatalf("truncated promoted shell model output lost job_id %q: %q", out.JobID, res.Output)
+				t.Fatalf("promoted shell model output lost job_id %q under constrained registry limits: %q", out.JobID, res.Output)
 			}
 			_, _ = s.jobManager.stop(out.JobID)
 			waitForShellDone(t, s.jobManager, out.JobID)

--- a/agent/session_tools_shell_test.go
+++ b/agent/session_tools_shell_test.go
@@ -428,6 +428,44 @@ func TestShellToolBackgroundReturnsJobID(t *testing.T) {
 	}
 }
 
+func TestShellToolBackgroundModelOutputRetainsJobIDUnderRegistryLimits(t *testing.T) {
+	t.Parallel()
+	s := newShellToolTestSession(t, SessionConfig{
+		ToolOutputLimits: map[string]schema.ToolOutputLimit{
+			"shell": {MaxChars: 800, MaxLines: 1, Strategy: schema.TruncHeadTail},
+		},
+	})
+
+	// TRIPWIRE: background launch normally returns in well under a second;
+	// 30s only fires if the registered shell path genuinely hangs.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	res := s.reg.ExecuteCall(ctx, s.env, llm.ToolCallData{
+		ID:        "c1",
+		Name:      "shell",
+		Arguments: json.RawMessage(`{"command":"sleep 30","mode":"background"}`),
+	})
+	if res.IsError {
+		t.Fatalf("shell returned error: %s", res.Output)
+	}
+	var out struct {
+		JobID string `json:"job_id"`
+	}
+	if err := json.Unmarshal(toolResultJSON(res), &out); err != nil {
+		t.Fatalf("unmarshal shell output: %v (output: %s)", err, res.Output)
+	}
+	if out.JobID == "" {
+		t.Fatal("background shell returned no job_id")
+	}
+	t.Cleanup(func() {
+		_, _ = s.jobManager.stop(out.JobID)
+		waitForShellDone(t, s.jobManager, out.JobID)
+	})
+	if !strings.Contains(res.Output, out.JobID) {
+		t.Fatalf("shell model output lost job_id %q under constrained registry limits: %q", out.JobID, res.Output)
+	}
+}
+
 func TestShellBackgroundCompletionRetainsUnterminatedOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unterminated-output fixture uses POSIX printf")
@@ -543,6 +581,9 @@ func TestShellToolStreamingPathHonorsSessionTimeouts(t *testing.T) {
 	s := newShellToolTestSession(t, SessionConfig{
 		DefaultCommandTimeoutMS: 100,
 		MaxCommandTimeoutMS:     100,
+		ToolOutputLimits: map[string]schema.ToolOutputLimit{
+			"shell": {MaxChars: 800, MaxLines: 1, Strategy: schema.TruncHeadTail},
+		},
 	})
 	clk := agenttest.NewFakeClock()
 	s.jobManager.clock = clk
@@ -596,6 +637,12 @@ func TestShellToolStreamingPathHonorsSessionTimeouts(t *testing.T) {
 				out.Reason != "foreground_timeout" ||
 				out.Mode != "background" {
 				t.Fatalf("shell output = %+v, want foreground timeout promoted to background", out)
+			}
+			if !res.Truncated {
+				t.Fatalf("promoted shell model output was not truncated under constrained registry limits: %q", res.Output)
+			}
+			if !strings.Contains(res.Output, out.JobID) {
+				t.Fatalf("truncated promoted shell model output lost job_id %q: %q", out.JobID, res.Output)
 			}
 			_, _ = s.jobManager.stop(out.JobID)
 			waitForShellDone(t, s.jobManager, out.JobID)


### PR DESCRIPTION
## Summary

- append a system reminder after direct background shell-job launches
- explain that completion notifications arrive automatically, wake idle sessions, and require no explicit wait

## Testing

- `go test ./agent -run '^TestFormatShellResult' -count=1`
- `make lint`
- `make vet`
- `make test`

## Test coverage note

The change adds model-facing reminder prose only. Per `docs/developing-evener/testing.md`, this PR does not add an assertion that pins natural-language reminder or tool-result text.
