### PR TITLE
feat(web,hub): consolidated keybindings system (dispatcher, persistence, navigation, cheatsheet, editor)

### DIFF
--- a/appwire/errors.go
+++ b/appwire/errors.go
@@ -24,6 +24,10 @@ const (
 	ErrorQueuedDrainPartial     ErrorInfo = "queuedDrainPartial"
 	ErrorMutationOutcomeUnknown ErrorInfo = "mutationOutcomeUnknown"
 	ErrorInternal               ErrorInfo = "internal"
+	// ErrorKeybindingsPostRename marks a keybindings patch that APPLIED (the
+	// rename published the new revision) before a follow-up durable step
+	// failed; the error's data carries the applied canonical state.
+	ErrorKeybindingsPostRename ErrorInfo = "keybindingsPostRename"
 )
 
 type MutationOutcome string

--- a/appwire/keybindings.go
+++ b/appwire/keybindings.go
@@ -1,0 +1,193 @@
+package appwire
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	MethodEvenerSettingsKeybindingsGet   = "evener/settings/keybindings/get"
+	MethodEvenerSettingsKeybindingsPatch = "evener/settings/keybindings/patch"
+
+	NotifyEvenerSettingsKeybindingsChanged = "evener/settings/keybindings/changed"
+)
+
+// KeybindingsRule is one user override: a non-nil Chord rebinds the action, a
+// nil Chord (JSON null) unbinds it. The server stores rules verbatim; last
+// rule wins on conflict, resolved by the frontend.
+type KeybindingsRule struct {
+	Action string  `json:"action"`
+	Chord  *string `json:"chord"`
+}
+
+// KeybindingsConfig is the user-controlled part of the keybindings overrides:
+// the payload contract minus the store-owned revision.
+type KeybindingsConfig struct {
+	Version int               `json:"version"`
+	Rules   []KeybindingsRule `json:"rules"`
+}
+
+// KeybindingsOverrides is the canonical payload returned by the get method and
+// broadcast on change: {version, revision, rules}.
+type KeybindingsOverrides struct {
+	Version  int               `json:"version"`
+	Revision uint64            `json:"revision"`
+	Rules    []KeybindingsRule `json:"rules"`
+	// LoadError is set only by GET when the persisted state failed to load:
+	// Rules then carries the shipped-default fallback (what is actually in
+	// effect) while the diagnostic tells the client to keep editing read-only
+	// - PATCH rejects in this state, so a client that treated the fallback as
+	// writable would fail every save (roborev PR #884 round 6). Absent from
+	// broadcasts and patch responses, which only exist post-load.
+	LoadError string `json:"loadError,omitempty"`
+}
+
+// KeybindingsGetResponse is kept as an operation-oriented name for callers;
+// the wire result's underlying named type is KeybindingsOverrides.
+type KeybindingsGetResponse = KeybindingsOverrides
+
+type KeybindingsPatchParams struct {
+	ExpectedRevision uint64            `json:"expectedRevision"`
+	Config           KeybindingsConfig `json:"config"`
+}
+
+type KeybindingsPatchResponse = KeybindingsOverrides
+
+type KeybindingsChangedParams = KeybindingsOverrides
+
+type KeybindingsChangedNotification = KeybindingsOverrides
+
+type KeybindingsConflictData struct {
+	EvenerErrorInfo ErrorInfo            `json:"evenerErrorInfo"`
+	Current         KeybindingsOverrides `json:"current"`
+}
+
+// KeybindingsPostRenameData is the WireError.Data payload for
+// ErrorKeybindingsPostRename: the patch APPLIED (Applied carries the
+// canonical applied state) but a follow-up durable step failed. Clients
+// should reconcile from Applied instead of treating the write as rejected.
+type KeybindingsPostRenameData struct {
+	EvenerErrorInfo ErrorInfo            `json:"evenerErrorInfo"`
+	Applied         KeybindingsOverrides `json:"applied"`
+}
+
+const keybindingsConfigVersion = 1
+
+// KeybindingsShippedDefaults is the payload when nothing is persisted: empty
+// overrides (all default bindings) at revision 0.
+func KeybindingsShippedDefaults() KeybindingsOverrides {
+	return KeybindingsOverrides{Version: keybindingsConfigVersion, Rules: []KeybindingsRule{}}
+}
+
+// ValidateKeybindingsConfig checks the structural contract only: the version
+// and rule-field sanity. Semantic validation (action ids, reserved chords,
+// conflicts) is the frontend's job; the server does not know the action
+// registry.
+func ValidateKeybindingsConfig(config KeybindingsConfig) error {
+	if config.Version != keybindingsConfigVersion {
+		return fmt.Errorf("unsupported keybindings config version %d", config.Version)
+	}
+	for i, rule := range config.Rules {
+		if strings.TrimSpace(rule.Action) == "" {
+			return fmt.Errorf("rule %d: action must be a non-empty string", i)
+		}
+		if rule.Chord != nil && strings.TrimSpace(*rule.Chord) == "" {
+			return fmt.Errorf("rule %d (%s): chord must be null or a non-empty string", i, rule.Action)
+		}
+	}
+	return nil
+}
+
+func DecodeKeybindingsPatchParams(raw json.RawMessage) (KeybindingsPatchParams, error) {
+	var params KeybindingsPatchParams
+	if err := decodeKeybindingsStrictJSON(raw, &params); err != nil {
+		return KeybindingsPatchParams{}, err
+	}
+
+	top, err := keybindingsObjectFields(raw)
+	if err != nil {
+		return KeybindingsPatchParams{}, err
+	}
+	if err := requireKeybindingsFields(top, "expectedRevision", "config"); err != nil {
+		return KeybindingsPatchParams{}, err
+	}
+	if string(bytes.TrimSpace(top["expectedRevision"])) == "null" {
+		return KeybindingsPatchParams{}, errors.New("expectedRevision must be an unsigned integer")
+	}
+
+	configFields, err := keybindingsObjectFields(top["config"])
+	if err != nil {
+		return KeybindingsPatchParams{}, fmt.Errorf("config: %w", err)
+	}
+	if err := requireKeybindingsFields(configFields, "version", "rules"); err != nil {
+		return KeybindingsPatchParams{}, fmt.Errorf("config: %w", err)
+	}
+	if string(bytes.TrimSpace(configFields["version"])) == "null" {
+		return KeybindingsPatchParams{}, errors.New("config: version must be an integer")
+	}
+	if string(bytes.TrimSpace(configFields["rules"])) == "null" {
+		return KeybindingsPatchParams{}, errors.New("config: rules must be an array")
+	}
+
+	var rules []json.RawMessage
+	if err := json.Unmarshal(configFields["rules"], &rules); err != nil {
+		return KeybindingsPatchParams{}, fmt.Errorf("config: rules: %w", err)
+	}
+	for i, rawRule := range rules {
+		ruleFields, err := keybindingsObjectFields(rawRule)
+		if err != nil {
+			return KeybindingsPatchParams{}, fmt.Errorf("rule %d: %w", i, err)
+		}
+		if err := requireKeybindingsFields(ruleFields, "action", "chord"); err != nil {
+			return KeybindingsPatchParams{}, fmt.Errorf("rule %d: %w", i, err)
+		}
+		if string(bytes.TrimSpace(ruleFields["action"])) == "null" {
+			return KeybindingsPatchParams{}, fmt.Errorf("rule %d: action must be a string", i)
+		}
+	}
+
+	if err := ValidateKeybindingsConfig(params.Config); err != nil {
+		return KeybindingsPatchParams{}, err
+	}
+	return params, nil
+}
+
+func decodeKeybindingsStrictJSON(raw []byte, dst any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dst); err != nil {
+		return fmt.Errorf("invalid keybindings patch: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return errors.New("invalid keybindings patch: trailing JSON value")
+		}
+		return fmt.Errorf("invalid keybindings patch: trailing JSON: %w", err)
+	}
+	return nil
+}
+
+func keybindingsObjectFields(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	if fields == nil {
+		return nil, errors.New("expected JSON object")
+	}
+	return fields, nil
+}
+
+func requireKeybindingsFields(fields map[string]json.RawMessage, names ...string) error {
+	for _, name := range names {
+		if _, ok := fields[name]; !ok {
+			return fmt.Errorf("missing required field %q", name)
+		}
+	}
+	return nil
+}

--- a/appwire/keybindings_test.go
+++ b/appwire/keybindings_test.go
@@ -1,0 +1,150 @@
+package appwire
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestKeybindingsShippedDefaults(t *testing.T) {
+	got := KeybindingsShippedDefaults()
+	if got.Version != 1 {
+		t.Errorf("defaults version = %d, want 1", got.Version)
+	}
+	if got.Revision != 0 {
+		t.Errorf("defaults revision = %d, want 0", got.Revision)
+	}
+	if got.Rules == nil || len(got.Rules) != 0 {
+		t.Errorf("defaults rules = %#v, want empty non-nil slice", got.Rules)
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `{"version":1,"revision":0,"rules":[]}`; string(encoded) != want {
+		t.Fatalf("defaults JSON = %s, want %s", encoded, want)
+	}
+}
+
+func TestDecodeKeybindingsPatchAcceptsRebindAndUnbind(t *testing.T) {
+	raw := json.RawMessage(`{"expectedRevision":3,"config":{"version":1,"rules":[{"action":"thread.new","chord":"ctrl+n"},{"action":"thread.close","chord":null}]}}`)
+	got, err := DecodeKeybindingsPatchParams(raw)
+	if err != nil {
+		t.Fatalf("valid patch rejected: %v", err)
+	}
+	if got.ExpectedRevision != 3 || got.Config.Version != 1 || len(got.Config.Rules) != 2 {
+		t.Fatalf("decoded = %#v", got)
+	}
+	rebind := got.Config.Rules[0]
+	if rebind.Action != "thread.new" || rebind.Chord == nil || *rebind.Chord != "ctrl+n" {
+		t.Fatalf("rebind rule = %#v", rebind)
+	}
+	unbind := got.Config.Rules[1]
+	if unbind.Action != "thread.close" || unbind.Chord != nil {
+		t.Fatalf("unbind rule = %#v", unbind)
+	}
+}
+
+func TestDecodeKeybindingsPatchAcceptsEmptyRules(t *testing.T) {
+	raw := json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[]}}`)
+	got, err := DecodeKeybindingsPatchParams(raw)
+	if err != nil {
+		t.Fatalf("empty rules rejected: %v", err)
+	}
+	if got.Config.Rules == nil || len(got.Config.Rules) != 0 {
+		t.Fatalf("decoded rules = %#v, want empty non-nil slice", got.Config.Rules)
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsUnknownFields(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"top level": json.RawMessage(`{"expectedRevision":0,"unexpected":true,"config":{"version":1,"rules":[]}}`),
+		"config":    json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[],"unexpected":true}}`),
+		"rule":      json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"thread.new","chord":"ctrl+n","unexpected":true}]}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+				t.Fatal("unknown field accepted")
+			}
+		})
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsMissingFields(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"expectedRevision": json.RawMessage(`{"config":{"version":1,"rules":[]}}`),
+		"config":           json.RawMessage(`{"expectedRevision":0}`),
+		"version":          json.RawMessage(`{"expectedRevision":0,"config":{"rules":[]}}`),
+		"rules":            json.RawMessage(`{"expectedRevision":0,"config":{"version":1}}`),
+		"rule action":      json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"chord":"ctrl+n"}]}}`),
+		"rule chord":       json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"thread.new"}]}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+				t.Fatal("missing field accepted")
+			}
+		})
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsNullScalars(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"expectedRevision": json.RawMessage(`{"expectedRevision":null,"config":{"version":1,"rules":[]}}`),
+		"version":          json.RawMessage(`{"expectedRevision":0,"config":{"version":null,"rules":[]}}`),
+		"rules":            json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":null}}`),
+		"rule action":      json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":null,"chord":"ctrl+n"}]}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+				t.Fatal("null scalar accepted")
+			}
+		})
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsTrailingJSON(t *testing.T) {
+	raw := json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[]}} {}`)
+	if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+		t.Fatal("trailing JSON accepted")
+	}
+}
+
+func TestDecodeKeybindingsPatchRejectsInvalidValues(t *testing.T) {
+	for name, raw := range map[string]json.RawMessage{
+		"version":           json.RawMessage(`{"expectedRevision":0,"config":{"version":2,"rules":[]}}`),
+		"empty action":      json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"","chord":"ctrl+n"}]}}`),
+		"whitespace action": json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"  ","chord":"ctrl+n"}]}}`),
+		"empty chord":       json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"thread.new","chord":""}]}}`),
+		"whitespace chord":  json.RawMessage(`{"expectedRevision":0,"config":{"version":1,"rules":[{"action":"thread.new","chord":" \t "}]}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeKeybindingsPatchParams(raw); err == nil {
+				t.Fatal("invalid value accepted")
+			}
+		})
+	}
+}
+
+func TestValidateKeybindingsConfigRejectsInvalidShapes(t *testing.T) {
+	chord := "ctrl+n"
+	empty := ""
+	tests := []struct {
+		name   string
+		config KeybindingsConfig
+	}{
+		{name: "version", config: KeybindingsConfig{Version: 2, Rules: []KeybindingsRule{}}},
+		{name: "empty action", config: KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: "", Chord: &chord}}}},
+		{name: "whitespace action", config: KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: " ", Chord: &chord}}}},
+		{name: "empty chord", config: KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: "thread.new", Chord: &empty}}}},
+		{name: "whitespace chord", config: KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: "thread.new", Chord: &[]string{"\n"}[0]}}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := ValidateKeybindingsConfig(tc.config); err == nil {
+				t.Fatal("invalid config accepted")
+			}
+		})
+	}
+	if err := ValidateKeybindingsConfig(KeybindingsConfig{Version: 1, Rules: []KeybindingsRule{{Action: "thread.new", Chord: &chord}, {Action: "thread.close"}}}); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+}

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -197,6 +197,8 @@ var Methods = []MethodSpec{
 	{MethodEvenerSettingsOverview, EmptyParams{}, SettingsOverviewResponse{}, ScopeHub, "Returns the settings overview field bag: hub/runtime, storage, agent roster, codex launch configs, and probed MCP servers — the six template-only settings sections' data."},
 	{MethodEvenerSettingsTranscriptDisplayGet, EmptyParams{}, TranscriptDisplayDefaults{}, ScopeHub, "Reads the canonical Desktop and Mobile transcript-display defaults."},
 	{MethodEvenerSettingsTranscriptDisplayPatch, TranscriptDisplayDefaultsPatchParams{}, TranscriptDisplayPatchResponse{}, ScopeHub, "Updates one transcript-display default using an expected revision and returns the canonical value."},
+	{MethodEvenerSettingsKeybindingsGet, EmptyParams{}, KeybindingsOverrides{}, ScopeHub, "Reads the canonical user keybinding overrides (version, revision, rules)."},
+	{MethodEvenerSettingsKeybindingsPatch, KeybindingsPatchParams{}, KeybindingsOverrides{}, ScopeHub, "Replaces the user keybinding overrides using an expected revision and returns the canonical value."},
 	{MethodEvenerSandboxEscalationResolve, SandboxEscalationResolveParams{}, EmptyResponse{}, ScopeBoth, "Delivers a human's approve/deny decision for a pending sandbox-exemption escalation (M7); the daemon unblocks the waiting tool-exec goroutine, the hub relays."},
 }
 
@@ -289,4 +291,5 @@ var Notifications = []NotificationSpec{
 	{NotifyEvenerSandboxEscalationRequested, SandboxEscalationRequested{}, "A harness-raised, human-gated sandbox-exemption approval card (M7); the tool-exec goroutine blocks until answered via evener/sandbox/escalation/resolve."},
 	{NotifyEvenerSandboxEscalationResolved, SandboxEscalationResolved{}, "A previously-raised sandbox escalation left the pending set — resolved, turn-interrupted, or cleared by session close (M7); every OTHER subscribed client clears its now-stale copy of the card."},
 	{NotifyEvenerSettingsTranscriptDisplayChanged, TranscriptDisplayChangedParams{}, "Broadcast after a transcript-display default changes; carries the layout, revision, and canonical configuration."},
+	{NotifyEvenerSettingsKeybindingsChanged, KeybindingsOverrides{}, "Broadcast after the user keybinding overrides change; carries the revision and canonical rules."},
 }

--- a/appwire/protocol_test.go
+++ b/appwire/protocol_test.go
@@ -246,6 +246,63 @@ func TestTranscriptDisplayCatalog(t *testing.T) {
 	}
 }
 
+func TestKeybindingsCatalog(t *testing.T) {
+	methods := map[string]MethodSpec{}
+	for _, method := range Methods {
+		methods[method.Name] = method
+	}
+	for _, name := range []string{
+		MethodEvenerSettingsKeybindingsGet,
+		MethodEvenerSettingsKeybindingsPatch,
+	} {
+		method, ok := methods[name]
+		if !ok {
+			t.Fatalf("method catalog missing %s", name)
+		}
+		if method.Scope != ScopeHub {
+			t.Errorf("method %s scope = %q, want %q", name, method.Scope, ScopeHub)
+		}
+	}
+	var changed *NotificationSpec
+	for i := range Notifications {
+		if Notifications[i].Name == NotifyEvenerSettingsKeybindingsChanged {
+			changed = &Notifications[i]
+			break
+		}
+	}
+	if changed == nil {
+		t.Fatalf("notification catalog missing %s", NotifyEvenerSettingsKeybindingsChanged)
+	}
+	if reflect.TypeOf(changed.Payload) != reflect.TypeFor[KeybindingsOverrides]() {
+		t.Fatalf("changed payload type = %T, want %T", changed.Payload, KeybindingsOverrides{})
+	}
+}
+
+func TestFeatureSetKeybindingsJSONField(t *testing.T) {
+	encoded, err := json.Marshal(FeatureSet{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(encoded, []byte(`"keybindingsSettings"`)) {
+		t.Fatalf("false feature must be omitted: %s", encoded)
+	}
+	encoded, err = json.Marshal(FeatureSet{KeybindingsSettings: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(encoded, []byte(`"keybindingsSettings":true`)) {
+		t.Fatalf("true feature missing from JSON: %s", encoded)
+	}
+
+	generated, err := os.ReadFile("../cmd/evener-hub/frontend/src/protocol/types.gen.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(generated, []byte("keybindingsSettings?: boolean;")) {
+		t.Fatal("generated TypeScript feature field is not optional")
+	}
+}
+
 func TestFeatureSetTranscriptDisplayJSONField(t *testing.T) {
 	encoded, err := json.Marshal(FeatureSet{})
 	if err != nil {
@@ -397,6 +454,7 @@ func TestThreadNotificationsRequireAuthoritativeRoutingIdentity(t *testing.T) {
 		NotifyEvenerPluginUpdated:                    true,
 		NotifyEvenerNavigationInvalidated:            true,
 		NotifyEvenerSettingsTranscriptDisplayChanged: true,
+		NotifyEvenerSettingsKeybindingsChanged:       true,
 	}
 	for _, notification := range Notifications {
 		if global[notification.Name] {

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -527,6 +527,7 @@ type FeatureSet struct {
 	DirectoryComplete         bool `json:"directoryComplete"`
 	Auth                      bool `json:"auth"`
 	TranscriptDisplaySettings bool `json:"transcriptDisplaySettings,omitempty"`
+	KeybindingsSettings       bool `json:"keybindingsSettings,omitempty"`
 }
 
 type Thread struct {

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -176,6 +176,7 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 			DirectoryComplete:         true,
 			Auth:                      true,
 			TranscriptDisplaySettings: true,
+			KeybindingsSettings:       true,
 		},
 	})
 	hubStateRoot := cfg.HubStateRoot
@@ -220,6 +221,7 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 	registerMiscHandlers(server, cfg, sources)
 	registerPluginAutoUpgradeHandlers(server, plugins.NewManager(cfg.PluginRoot))
 	registerTranscriptDisplayHandlers(server, cfg.TranscriptDisplayStore)
+	registerKeybindingsHandlers(server, cfg.KeybindingsStore)
 	return server
 }
 

--- a/cmd/evener-hub/app_rpc_keybindings.go
+++ b/cmd/evener-hub/app_rpc_keybindings.go
@@ -1,0 +1,62 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/appserver"
+)
+
+func registerKeybindingsHandlers(server *appserver.Server, store *hubcore.KeybindingsStore) {
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsKeybindingsGet,
+		func(context.Context, appwire.EmptyParams) (appwire.KeybindingsOverrides, error) {
+			overrides := store.Snapshot()
+			// A malformed persisted state loads as the shipped-default fallback
+			// and PATCH rejects - surface the diagnostic so clients keep the
+			// editor read-only with an explanation instead of failing every
+			// save (roborev PR #884 round 6). Same wording as Patch's rejection.
+			if loadErr := store.LoadErr(); loadErr != nil {
+				overrides.LoadError = fmt.Sprintf("keybindings state is unavailable: %v", loadErr)
+			}
+			return overrides, nil
+		})
+	server.Router().Handle(appwire.MethodEvenerSettingsKeybindingsPatch,
+		func(_ context.Context, raw json.RawMessage) (any, error) {
+			params, err := appwire.DecodeKeybindingsPatchParams(raw)
+			if err != nil {
+				return nil, appwire.InvalidParams(err.Error())
+			}
+			result, err := store.Patch(params)
+			if err != nil {
+				// A post-rename durable error means the patch APPLIED: the
+				// store already published the new revision. Returning the
+				// error without broadcasting would leave every other client
+				// on the pre-patch revision, so fan out the canonical
+				// snapshot before surfacing the failure - and carry that same
+				// snapshot in the error itself so the REQUESTING client can
+				// reconcile from it instead of treating its write as rejected
+				// (roborev PR #884 round 2).
+				if _, postRename := errors.AsType[*hubcore.KeybindingsPostRenameError](err); postRename {
+					snapshot := store.Snapshot()
+					server.BroadcastAll(appwire.NotifyEvenerSettingsKeybindingsChanged, snapshot)
+					return nil, appwire.WireError{
+						Code:    appwire.CodeInternalError,
+						Message: err.Error(),
+						Data: appwire.KeybindingsPostRenameData{
+							EvenerErrorInfo: appwire.ErrorKeybindingsPostRename,
+							Applied:         snapshot,
+						},
+					}
+				}
+				return nil, err
+			}
+			if result.Revision != params.ExpectedRevision {
+				server.BroadcastAll(appwire.NotifyEvenerSettingsKeybindingsChanged, result)
+			}
+			return result, nil
+		})
+}

--- a/cmd/evener-hub/app_rpc_keybindings_test.go
+++ b/cmd/evener-hub/app_rpc_keybindings_test.go
@@ -1,0 +1,434 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestHubRPCKeybindingsGetReturnsCanonicalShippedDefaults(t *testing.T) {
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: t.TempDir()})
+	defer hub.Close()
+
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	init, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion})
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if !init.Features.KeybindingsSettings {
+		t.Fatalf("keybindings capability is false: %+v", init.Features)
+	}
+
+	var got appwire.KeybindingsOverrides
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	if want := appwire.KeybindingsShippedDefaults(); !equalKeybindingsOverrides(got, want) {
+		t.Fatalf("GET defaults = %#v, want %#v", got, want)
+	}
+}
+
+func TestHubRPCKeybindingsPatchBroadcastsCanonicalValue(t *testing.T) {
+	store, err := hubcore.NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{KeybindingsStore: store})
+	defer hub.Close()
+
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+		{Action: "thread.close", Chord: nil},
+	}}
+	var result appwire.KeybindingsPatchResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 0,
+			Config:           config,
+		}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Revision != 1 || result.Version != 1 || !equalKeybindingsRules(result.Rules, config.Rules) {
+		t.Fatalf("PATCH result = %#v, want revision 1 and canonical rules", result)
+	}
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		notification := receiveKeybindingsChanged(t, client)
+		if notification.Revision != result.Revision || notification.Version != result.Version || !equalKeybindingsRules(notification.Rules, result.Rules) {
+			t.Fatalf("notification = %#v, result = %#v", notification, result)
+		}
+	}
+}
+
+func TestHubRPCKeybindingsPatchPostRenameErrorStillBroadcasts(t *testing.T) {
+	// A durable failure AFTER the rename means the patch applied: the store
+	// published the new revision, and the error the patching client gets back
+	// must not leave every OTHER client stale. The hub therefore broadcasts
+	// the canonical snapshot before surfacing the failure.
+	wantFailure := errors.New("after rename failed")
+	store, err := hubcore.NewKeybindingsStoreForTest(t.TempDir(), func() error { return wantFailure })
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{KeybindingsStore: store})
+	defer hub.Close()
+
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	var result appwire.KeybindingsPatchResponse
+	err = clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{ExpectedRevision: 0, Config: config}, &result)
+	if err == nil {
+		t.Fatal("PATCH with a post-rename fault returned no error")
+	}
+	// The error must carry the APPLIED canonical state so the requesting
+	// client reconciles from it rather than treating its write as rejected.
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInternalError {
+		t.Fatalf("error = %T %v, want wire code %d", err, err, appwire.CodeInternalError)
+	}
+	dataJSON, merr := json.Marshal(wire.Data)
+	if merr != nil {
+		t.Fatal(merr)
+	}
+	var data appwire.KeybindingsPostRenameData
+	if err := json.Unmarshal(dataJSON, &data); err != nil {
+		t.Fatalf("decode post-rename error data: %v", err)
+	}
+	if data.EvenerErrorInfo != appwire.ErrorKeybindingsPostRename {
+		t.Fatalf("evenerErrorInfo = %q, want %q", data.EvenerErrorInfo, appwire.ErrorKeybindingsPostRename)
+	}
+	if data.Applied.Revision != 1 || !equalKeybindingsRules(data.Applied.Rules, config.Rules) {
+		t.Fatalf("applied = %#v, want revision 1 and the canonical rules", data.Applied)
+	}
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		notification := receiveKeybindingsChanged(t, client)
+		if notification.Revision != 1 || notification.Version != 1 || !equalKeybindingsRules(notification.Rules, config.Rules) {
+			t.Fatalf("notification = %#v, want revision 1 and the canonical rules", notification)
+		}
+	}
+}
+
+func TestHubRPCKeybindingsPatchRawUnknownFieldRejectedWithoutNotification(t *testing.T) {
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: t.TempDir()})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := json.Marshal(map[string]any{
+		"expectedRevision": 0,
+		"config": map[string]any{
+			"version": 1,
+			"rules":   []any{},
+		},
+		"unknown": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result appwire.KeybindingsPatchResponse
+	err = client.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch, json.RawMessage(raw), &result)
+	assertKeybindingsWireCode(t, err, appwire.CodeInvalidParams)
+	assertNoKeybindingsNotification(t, client)
+}
+
+func TestHubRPCKeybindingsPatchFailuresDoNotNotify(t *testing.T) {
+	root := t.TempDir()
+	store, err := hubcore.NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{KeybindingsStore: store})
+	defer hub.Close()
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	defaults := appwire.KeybindingsShippedDefaults()
+	var noOp appwire.KeybindingsPatchResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 0,
+			Config:           appwire.KeybindingsConfig{Version: defaults.Version, Rules: defaults.Rules},
+		}, &noOp); err != nil {
+		t.Fatalf("no-op PATCH: %v", err)
+	}
+	if noOp.Revision != 0 {
+		t.Fatalf("no-op revision = %d, want 0", noOp.Revision)
+	}
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+
+	invalidRaw, err := json.Marshal(map[string]any{
+		"expectedRevision": 0,
+		"config": map[string]any{
+			"version": 99,
+			"rules":   []any{},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var invalidResult appwire.KeybindingsPatchResponse
+	err = clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch, json.RawMessage(invalidRaw), &invalidResult)
+	assertKeybindingsWireCode(t, err, appwire.CodeInvalidParams)
+	if !containsKeybindingsError(err, "unsupported keybindings config version") {
+		t.Fatalf("structural validation error = %v, want unsupported-version diagnostic", err)
+	}
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+
+	changed := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	var first appwire.KeybindingsPatchResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 0,
+			Config:           changed,
+		}, &first); err != nil {
+		t.Fatalf("first PATCH: %v", err)
+	}
+	_ = receiveKeybindingsChanged(t, clientA)
+	_ = receiveKeybindingsChanged(t, clientB)
+
+	var staleResult appwire.KeybindingsPatchResponse
+	err = clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 0,
+			Config:           appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{}},
+		}, &staleResult)
+	var conflict appwire.WireError
+	if !errors.As(err, &conflict) || conflict.Code != appwire.CodeConflict {
+		t.Fatalf("stale PATCH error = %T %v, want conflict", err, err)
+	}
+	var conflictData appwire.KeybindingsConflictData
+	conflictJSON, err := json.Marshal(conflict.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(conflictJSON, &conflictData); err != nil {
+		t.Fatalf("decode conflict data: %v", err)
+	}
+	if conflictData.EvenerErrorInfo != appwire.ErrorConflict || conflictData.Current.Revision != 1 || !equalKeybindingsRules(conflictData.Current.Rules, changed.Rules) {
+		t.Fatalf("conflict data = %#v, want current revision 1 with canonical rules", conflictData)
+	}
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+
+	if err := os.RemoveAll(filepath.Join(root, "keybindings")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "keybindings"), []byte("blocked"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	failedConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+alt+n")},
+	}}
+	var failedResult appwire.KeybindingsPatchResponse
+	err = clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{
+			ExpectedRevision: 1,
+			Config:           failedConfig,
+		}, &failedResult)
+	assertKeybindingsWireCode(t, err, appwire.CodeInternalError)
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+}
+
+func TestHubRPCKeybindingsPatchPersistsAcrossRestart(t *testing.T) {
+	root := t.TempDir()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: root})
+	client := dialHubRPC(t, hub)
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+		{Action: "thread.close", Chord: nil},
+	}}
+	var result appwire.KeybindingsPatchResponse
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{Config: config}, &result); err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	_ = receiveKeybindingsChanged(t, client)
+	client.Close()
+	hub.Close()
+
+	hub = newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: root})
+	defer hub.Close()
+	client = dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	var got appwire.KeybindingsOverrides
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("GET after restart: %v", err)
+	}
+	if got.Revision != 1 || got.Version != 1 || !equalKeybindingsRules(got.Rules, config.Rules) {
+		t.Fatalf("GET after restart = %#v, want revision 1 and canonical rules", got)
+	}
+}
+
+func TestHubRPCKeybindingsMalformedStateUsesFallbackAndRemainsReadOnly(t *testing.T) {
+	root := t.TempDir()
+	statePath := filepath.Join(root, "keybindings", "state.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	malformed := []byte(`{"version":1,"revision":`)
+	if err := os.WriteFile(statePath, malformed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	hub, web := newHubRPCTestServerWithWeb(t, hubcore.WebConfig{HubStateRoot: root})
+	defer hub.Close()
+	if web.cfg.KeybindingsStore == nil || web.keybindingsStoreErr == nil {
+		t.Fatalf("malformed startup store=%p loadErr=%v, want non-nil fallback and diagnostic", web.cfg.KeybindingsStore, web.keybindingsStoreErr)
+	}
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var got appwire.KeybindingsOverrides
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("GET malformed state: %v", err)
+	}
+	if want := appwire.KeybindingsShippedDefaults(); !equalKeybindingsOverrides(got, want) {
+		t.Fatalf("GET malformed state = %#v, want fallback %#v", got, want)
+	}
+	// The fallback alone would read as writable while PATCH rejects every
+	// save; the diagnostic rides the GET so clients stay read-only with the
+	// reason showing (roborev PR #884 round 6).
+	if !strings.Contains(got.LoadError, "decode keybindings state") {
+		t.Fatalf("GET malformed state loadError = %q, want the load diagnostic", got.LoadError)
+	}
+	var result appwire.KeybindingsPatchResponse
+	err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.KeybindingsPatchParams{Config: appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+			{Action: "thread.new", Chord: new("ctrl+n")},
+		}}}, &result)
+	assertKeybindingsWireCode(t, err, appwire.CodeInternalError)
+	if !containsKeybindingsError(err, "decode keybindings state") {
+		t.Fatalf("malformed-state PATCH error = %v, want load diagnostic", err)
+	}
+	assertNoKeybindingsNotification(t, clientA)
+	assertNoKeybindingsNotification(t, clientB)
+	unchanged, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(unchanged, malformed) {
+		t.Fatalf("malformed state was overwritten: %q", unchanged)
+	}
+}
+
+func receiveKeybindingsChanged(t *testing.T, client *appwire.Client) appwire.KeybindingsChangedParams {
+	t.Helper()
+	select {
+	case notification := <-client.Notifications():
+		if notification.Method != appwire.NotifyEvenerSettingsKeybindingsChanged {
+			t.Fatalf("notification method = %q, want %q", notification.Method, appwire.NotifyEvenerSettingsKeybindingsChanged)
+		}
+		var params appwire.KeybindingsChangedParams
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode notification: %v", err)
+		}
+		return params
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for keybindings notification")
+		return appwire.KeybindingsChangedParams{}
+	}
+}
+
+func assertNoKeybindingsNotification(t *testing.T, client *appwire.Client) {
+	t.Helper()
+	select {
+	case notification := <-client.Notifications():
+		t.Fatalf("unexpected notification %q", notification.Method)
+	default:
+	}
+}
+
+func assertKeybindingsWireCode(t *testing.T, err error, code int) {
+	t.Helper()
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != code {
+		t.Fatalf("error = %T %v, want wire code %d", err, err, code)
+	}
+}
+
+func containsKeybindingsError(err error, want string) bool {
+	return err != nil && strings.Contains(err.Error(), want)
+}
+
+func equalKeybindingsOverrides(a, b appwire.KeybindingsOverrides) bool {
+	return a.Version == b.Version && a.Revision == b.Revision && equalKeybindingsRules(a.Rules, b.Rules)
+}
+
+func equalKeybindingsRules(a, b []appwire.KeybindingsRule) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	for i := range a {
+		if a[i].Action != b[i].Action {
+			return false
+		}
+		if (a[i].Chord == nil) != (b[i].Chord == nil) {
+			return false
+		}
+		if a[i].Chord != nil && *a[i].Chord != *b[i].Chord {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11132,6 +11132,8 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodEvenerSettingsOverview,
 		appwire.MethodEvenerSettingsTranscriptDisplayGet,
 		appwire.MethodEvenerSettingsTranscriptDisplayPatch,
+		appwire.MethodEvenerSettingsKeybindingsGet,
+		appwire.MethodEvenerSettingsKeybindingsPatch,
 		appwire.MethodEvenerMarketplaceList,
 		appwire.MethodEvenerMarketplaceAdd,
 		appwire.MethodEvenerMarketplaceRemove,

--- a/cmd/evener-hub/frontend/package-lock.json
+++ b/cmd/evener-hub/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router": "^8.3.0",
+        "tinykeys": "^4.0.0",
         "zustand": "^5.0.14"
       },
       "devDependencies": {
@@ -2412,6 +2413,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinykeys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tinykeys/-/tinykeys-4.0.0.tgz",
+      "integrity": "sha512-z5bQRQHL1PSx3lGOZEAMM2oKp0EBtn5T5f7HJnaKPOzk6vEH0wUPvdHLeQ7F4tmkek8AgoTQISUFmn/5SNF2xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/tinyrainbow": {

--- a/cmd/evener-hub/frontend/package.json
+++ b/cmd/evener-hub/frontend/package.json
@@ -33,6 +33,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router": "^8.3.0",
+    "tinykeys": "^4.0.0",
     "zustand": "^5.0.14"
   },
   "devDependencies": {

--- a/cmd/evener-hub/frontend/src/keybindings/actions.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/actions.ts
@@ -9,6 +9,17 @@ export const ACTIONS = {
   composerFocus: "composer.focus",
   nextNeedsYou: "next-needs-you",
   selectionQuote: "selection.quote",
+  sessionNext: "session.next",
+  sessionPrevious: "session.previous",
+  transcriptLineUp: "transcript.lineUp",
+  transcriptLineDown: "transcript.lineDown",
+  transcriptPageUp: "transcript.pageUp",
+  transcriptPageDown: "transcript.pageDown",
+  // No DEFAULT_BINDINGS entries for these two: their handlers exist (the
+  // session transcript registers them per pane) but the Phase 4 keymap
+  // decides whether they get a chord at all.
+  transcriptScrollTop: "transcript.scrollTop",
+  transcriptScrollBottom: "transcript.scrollBottom",
   settingsClose: "settings.close",
 } as const;
 

--- a/cmd/evener-hub/frontend/src/keybindings/actions.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/actions.ts
@@ -1,0 +1,15 @@
+// Canonical shell action ids. Where a palette command already owns the
+// behavior, the action id IS the palette command id (see
+// shell/palette/commands.ts: "next-needs-you"); the rest are shell action ids.
+// Task 2 registers each id's real run function against the registry.
+
+export const ACTIONS = {
+  paletteOpen: "palette.open",
+  railToggle: "rail.toggle",
+  composerFocus: "composer.focus",
+  nextNeedsYou: "next-needs-you",
+  selectionQuote: "selection.quote",
+  settingsClose: "settings.close",
+} as const;
+
+export type ActionId = (typeof ACTIONS)[keyof typeof ACTIONS];

--- a/cmd/evener-hub/frontend/src/keybindings/actions.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/actions.ts
@@ -1,7 +1,9 @@
 // Canonical shell action ids. Where a palette command already owns the
 // behavior, the action id IS the palette command id (see
-// shell/palette/commands.ts: "next-needs-you"); the rest are shell action ids.
-// Task 2 registers each id's real run function against the registry.
+// shell/palette/commands.ts: "next-needs-you" and "settings"); the rest are
+// shell action ids. The components that own each behavior register its run
+// function against the registry (AppShell, RailHost, Settings,
+// SelectionQuote, the session transcript's useTranscriptScrollKeys).
 
 export const ACTIONS = {
   paletteOpen: "palette.open",
@@ -15,12 +17,18 @@ export const ACTIONS = {
   transcriptLineDown: "transcript.lineDown",
   transcriptPageUp: "transcript.pageUp",
   transcriptPageDown: "transcript.pageDown",
-  // No DEFAULT_BINDINGS entries for these two: their handlers exist (the
-  // session transcript registers them per pane) but the Phase 4 keymap
-  // decides whether they get a chord at all.
   transcriptScrollTop: "transcript.scrollTop",
   transcriptScrollBottom: "transcript.scrollBottom",
+  // Reuses the palette's "settings" command id: that command's run owns the
+  // behavior (navigate("/settings")), exactly the next-needs-you precedent
+  // above.
+  settingsOpen: "settings",
   settingsClose: "settings.close",
+  // Phase 4a (the p4 plan's Design decision 3): the cheatsheet overlay's
+  // open/toggle and close. toggle's handler lives in the CheatsheetOverlay
+  // component (shell/cheatsheet/), close's next to it, scope-gated.
+  cheatsheetToggle: "cheatsheet.toggle",
+  cheatsheetClose: "cheatsheet.close",
 } as const;
 
 export type ActionId = (typeof ACTIONS)[keyof typeof ACTIONS];

--- a/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+import { type Chord, formatChord, formatSequence, parseChord, serializeChord } from "./chord";
+
+function singleChord(input: string): Chord {
+  const sequence = parseChord(input);
+  if (sequence.length !== 1) throw new Error(`expected exactly one press in "${input}"`);
+  return sequence[0]!;
+}
+
+// jsdom's navigator.platform is "" on every host, so tinykeys resolves the
+// "$mod" alias to "Control" here regardless of the machine running the suite.
+// Tests that want the Meta spelling parse "Meta+..." explicitly.
+describe("parseChord", () => {
+  test("parses a single press with a modifier", () => {
+    expect(parseChord("$mod+K")).toEqual([{ modifiers: ["Control"], optionalModifiers: [], key: "K" }]);
+  });
+
+  test("parses a bare key with no modifiers", () => {
+    expect(parseChord("Escape")).toEqual([{ modifiers: [], optionalModifiers: [], key: "Escape" }]);
+  });
+
+  test("parses a sequence of presses", () => {
+    expect(parseChord("Shift+A b")).toEqual([
+      { modifiers: ["Shift"], optionalModifiers: [], key: "A" },
+      { modifiers: [], optionalModifiers: [], key: "b" },
+    ]);
+  });
+
+  test("parses optional modifiers", () => {
+    expect(parseChord("$mod+[Alt]+K")).toEqual([{ modifiers: ["Control"], optionalModifiers: ["Alt"], key: "K" }]);
+  });
+
+  test("canonicalizes modifier order", () => {
+    expect(parseChord("Shift+Control+K")).toEqual([
+      { modifiers: ["Control", "Shift"], optionalModifiers: [], key: "K" },
+    ]);
+  });
+
+  test("parses a regex key", () => {
+    const chord = singleChord("(a|b)");
+    expect(chord.modifiers).toEqual([]);
+    expect(chord.key).toBeInstanceOf(RegExp);
+  });
+
+  test("rejects a blank keybinding string", () => {
+    expect(() => parseChord("")).toThrow();
+    expect(() => parseChord("   ")).toThrow();
+  });
+});
+
+describe("serializeChord round-trips", () => {
+  const CASES = ["$mod+K", "$mod+B", "$mod+'", "Escape", "Shift+A b", "$mod+[Alt]+K", "Control+Shift+Home"];
+
+  test.each(CASES)("parse -> serialize -> parse is stable: %s", (input) => {
+    const ast = parseChord(input);
+    expect(parseChord(serializeChord(ast))).toEqual(ast);
+  });
+
+  test.each(CASES)("serialization is idempotent: %s", (input) => {
+    const once = serializeChord(parseChord(input));
+    expect(serializeChord(parseChord(once))).toBe(once);
+  });
+
+  test("serializes modifiers in canonical order", () => {
+    expect(serializeChord(parseChord("Shift+Control+K"))).toBe("Control+Shift+K");
+  });
+
+  test("serializes optional modifiers with bracket syntax", () => {
+    expect(serializeChord(parseChord("$mod+[Alt]+K"))).toBe("Control+[Alt]+K");
+  });
+
+  test("serializes a sequence as space-separated presses", () => {
+    expect(serializeChord(parseChord("Shift+A b"))).toBe("Shift+A b");
+  });
+});
+
+describe("formatChord", () => {
+  // The Mod platform-split concept from widgets/keyhint: the primary modifier
+  // reads "Ctrl" off Apple platforms and "⌘" on them. tinykeys has already
+  // resolved "$mod" by parse time, so formatting maps the resolved modifier.
+  test("formats Control with the Ctrl label", () => {
+    expect(formatChord(singleChord("Control+K"))).toBe("Ctrl+K");
+  });
+
+  test("formats Meta with the Apple command glyph", () => {
+    expect(formatChord(singleChord("Meta+K"))).toBe("⌘+K");
+  });
+
+  test("leaves non-split keys verbatim", () => {
+    expect(formatChord(singleChord("Shift+Enter"))).toBe("Shift+Enter");
+  });
+
+  test("formats a bare key", () => {
+    expect(formatChord(singleChord("Escape"))).toBe("Escape");
+  });
+});
+
+describe("formatSequence", () => {
+  test("joins presses with a space", () => {
+    expect(formatSequence(parseChord("Shift+A b"))).toBe("Shift+A b");
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
@@ -112,10 +112,10 @@ describe("chordsOverlap", () => {
 
   test("an exact-required chord overlaps a chord that lists the rest as OPTIONAL", () => {
     // The dispatch-time shadowing the whole-branch review flagged: Control+K
-    // matches palette.open's Control+[Meta]+[Shift]+[Alt]+K default.
-    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+[Meta]+[Shift]+[Alt]+K"))).toBe(true);
+    // matches palette.open's Control+[Meta]+K default.
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+[Meta]+K"))).toBe(true);
     // Symmetrically, the fully-loaded press also overlaps the plain one.
-    expect(chordsOverlap(parseChord("Control+[Meta]+[Shift]+[Alt]+K"), parseChord("Control+K"))).toBe(true);
+    expect(chordsOverlap(parseChord("Control+[Meta]+K"), parseChord("Control+K"))).toBe(true);
   });
 
   test("an extra REQUIRED modifier escapes the overlap when the other side does not allow it", () => {

--- a/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { type Chord, formatChord, formatSequence, parseChord, serializeChord } from "./chord";
+import { type Chord, chordsOverlap, formatChord, formatSequence, parseChord, serializeChord } from "./chord";
 
 function singleChord(input: string): Chord {
   const sequence = parseChord(input);
@@ -98,5 +98,113 @@ describe("formatChord", () => {
 describe("formatSequence", () => {
   test("joins presses with a space", () => {
     expect(formatSequence(parseChord("Shift+A b"))).toBe("Shift+A b");
+  });
+});
+
+describe("chordsOverlap", () => {
+  test("identical single-press chords overlap", () => {
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+K"))).toBe(true);
+  });
+
+  test("keys match case-insensitively", () => {
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+k"))).toBe(true);
+  });
+
+  test("an exact-required chord overlaps a chord that lists the rest as OPTIONAL", () => {
+    // The dispatch-time shadowing the whole-branch review flagged: Control+K
+    // matches palette.open's Control+[Meta]+[Shift]+[Alt]+K default.
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+[Meta]+[Shift]+[Alt]+K"))).toBe(true);
+    // Symmetrically, the fully-loaded press also overlaps the plain one.
+    expect(chordsOverlap(parseChord("Control+[Meta]+[Shift]+[Alt]+K"), parseChord("Control+K"))).toBe(true);
+  });
+
+  test("an extra REQUIRED modifier escapes the overlap when the other side does not allow it", () => {
+    expect(chordsOverlap(parseChord("Control+Alt+B"), parseChord("Control+B"))).toBe(false);
+    expect(chordsOverlap(parseChord("Control+B"), parseChord("Control+Alt+B"))).toBe(false);
+  });
+
+  test("an extra required modifier still overlaps when the other side lists it as optional", () => {
+    expect(chordsOverlap(parseChord("Control+Alt+K"), parseChord("Control+[Alt]+K"))).toBe(true);
+  });
+
+  test("different keys never overlap", () => {
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+J"))).toBe(false);
+  });
+
+  test("multi-press sequences conflict when one is a press-overlapping prefix of the other", () => {
+    // tinykeys defers a completing binding while another holds a pending
+    // partial: "Control+K" pressed with "Control+K Control+W" registered
+    // leaves the sequence pending, so the single-press binding never fires
+    // (roborev PR #884 round 12).
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Control+K Control+W"))).toBe(true);
+    expect(chordsOverlap(parseChord("Control+K Control+W"), parseChord("Control+K"))).toBe(true);
+    expect(chordsOverlap(parseChord("Control+K Control+W"), parseChord("Control+K Control+W"))).toBe(true);
+  });
+
+  test("multi-press sequences that diverge at a shared position never shadow", () => {
+    expect(chordsOverlap(parseChord("Control+K Control+W"), parseChord("Control+K Control+V"))).toBe(false);
+    expect(chordsOverlap(parseChord("a b"), parseChord("x b"))).toBe(false);
+    // Prefix positions must overlap with modifiers too, not just keys.
+    expect(chordsOverlap(parseChord("Control+K"), parseChord("Shift+K Control+W"))).toBe(false);
+  });
+
+  test("a regex key overlaps a literal it matches, on key OR code spellings", () => {
+    // tinykeys tests a regex against event.key AND event.code (roborev PR
+    // #884 round 12).
+    expect(chordsOverlap(parseChord("(K|X)"), parseChord("K"))).toBe(true);
+    expect(chordsOverlap(parseChord("K"), parseChord("(K|X)"))).toBe(true);
+    // The literal's code-name form matches too: "(KeyK)" shares the event
+    // with the "K" spelling via event.code.
+    expect(chordsOverlap(parseChord("(KeyK)"), parseChord("K"))).toBe(true);
+    expect(chordsOverlap(parseChord("(K|X)"), parseChord("J"))).toBe(false);
+  });
+
+  test("regex-vs-literal honors the literal's spelling class (round 14)", () => {
+    // A code-spelled literal matches only its own code's events: "(7)" and
+    // "Numpad7" share the numpad event, but "(Numpad7)" and "Digit7" never
+    // share one (the Digit7 event's code is not Numpad7).
+    expect(chordsOverlap(parseChord("(7)"), parseChord("Numpad7"))).toBe(true);
+    expect(chordsOverlap(parseChord("(Numpad7)"), parseChord("Digit7"))).toBe(false);
+    expect(chordsOverlap(parseChord("(Numpad7)"), parseChord("Numpad7"))).toBe(true);
+    // A key-spelled literal matches every event carrying the key, so "(7)"
+    // overlaps "7" (whose events include the numpad one).
+    expect(chordsOverlap(parseChord("(7)"), parseChord("7"))).toBe(true);
+  });
+
+  test("two regex chords ALWAYS overlap - fail closed (regex intersection is undecidable here)", () => {
+    // A false non-overlap lets dispatch order silently shadow one binding
+    // (roborev PR #884 round 14); only hand-authored hub payloads can carry
+    // regex chords, so the conservative block has no shipped cost.
+    expect(chordsOverlap(parseChord("(K|X)"), parseChord("(K|X)"))).toBe(true);
+    expect(chordsOverlap(parseChord("(K|X)"), parseChord("(K|Y)"))).toBe(true);
+    expect(chordsOverlap(parseChord("([A-Z])"), parseChord("([0-9])"))).toBe(true);
+  });
+
+  // tinykeys matches a string key against event.key OR event.code, so a
+  // code-named chord and a key-named chord claim the same physical press.
+  // Overlap must fold the aliases or validation passes a shadowing override
+  // (roborev PR #884 round 8).
+  test("code-name spellings overlap their key spellings", () => {
+    expect(chordsOverlap(parseChord("Control+Slash"), parseChord("Control+/"))).toBe(true);
+    expect(chordsOverlap(parseChord("Meta+KeyW"), parseChord("Meta+W"))).toBe(true);
+    expect(chordsOverlap(parseChord("Control+Digit7"), parseChord("Control+7"))).toBe(true);
+    expect(chordsOverlap(parseChord("Meta+Comma"), parseChord("Meta+,"))).toBe(true);
+  });
+
+  test("physically distinct numpad codes do NOT fold onto the top-row key", () => {
+    // A numpad-7 event matches a "7" binding via event.key, but a top-row 7
+    // never matches a Numpad7 binding - folding them would invent a conflict.
+    expect(chordsOverlap(parseChord("Control+Numpad7"), parseChord("Control+Digit7"))).toBe(false);
+  });
+
+  // The containment the fold cannot express (roborev PR #884 round 9): a
+  // NumLock-on numpad event is {key: "7", code: "Numpad7"}, so the plain "7"
+  // spelling matches it via key AND the code-named spelling matches it via
+  // code. Both bindings matching one event means registration order silently
+  // shadows one - validation must call it a conflict.
+  test("a plain key spelling overlaps the numpad code name for the same physical value", () => {
+    expect(chordsOverlap(parseChord("Control+7"), parseChord("Control+Numpad7"))).toBe(true);
+    expect(chordsOverlap(parseChord("Control+Numpad7"), parseChord("Control+7"))).toBe(true);
+    expect(chordsOverlap(parseChord("Enter"), parseChord("NumpadEnter"))).toBe(true);
   });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -1,0 +1,92 @@
+// Canonical chord AST for the keybinding module: a Chord is one key press
+// (required modifiers + optional modifiers + key), a KeySequence is a list of
+// presses (tinykeys' space-separated multi-press bindings). Parsing delegates
+// to tinykeys' parseKeybinding, which also resolves the "$mod" alias to "Meta"
+// on Apple platforms and "Control" everywhere else at parse time - so an AST
+// captured at runtime is already platform-resolved.
+//
+// This module is deliberately React-free: the Mod ⌘/Ctrl platform-split
+// CONCEPT comes from widgets/keyhint (see keyhint/index.tsx:24-37), but no
+// widget code is imported here.
+
+import { parseKeybinding } from "tinykeys";
+
+export interface Chord {
+  /** Required modifiers, canonical KeyboardEvent modifier names, in canonical order. */
+  modifiers: string[];
+  /** Optional modifiers (tinykeys' [Alt] bracket syntax): match with or without. */
+  optionalModifiers: string[];
+  /** KeyboardEvent.key (matched case-insensitively by tinykeys) or a regex against key/code. */
+  key: string | RegExp;
+}
+
+export type KeySequence = Chord[];
+
+// Fixed display/serialization order for modifiers, so a chord's canonical
+// form never depends on the order its source string happened to list them in.
+const MODIFIER_ORDER = ["Control", "Alt", "Shift", "Meta"];
+
+function byCanonicalOrder(a: string, b: string): number {
+  return MODIFIER_ORDER.indexOf(a) - MODIFIER_ORDER.indexOf(b);
+}
+
+/** Parses a tinykeys keybinding string ("$mod+K", "Shift+A b") into the canonical AST. */
+export function parseChord(input: string): KeySequence {
+  if (input.trim() === "") throw new Error("cannot parse an empty keybinding");
+  return parseKeybinding(input).map(([required, optional, key]) => ({
+    modifiers: [...required].sort(byCanonicalOrder),
+    optionalModifiers: [...optional].sort(byCanonicalOrder),
+    key,
+  }));
+}
+
+/** Returns a copy of the sequence with `modifier` added as an OPTIONAL
+ * modifier on every press that neither requires nor already optionally
+ * lists it, preserving canonical modifier order. Used by the default map to
+ * express the legacy "either or both of Meta/Ctrl" chords. */
+export function withOptionalModifier(sequence: KeySequence, modifier: string): KeySequence {
+  return sequence.map((press) => {
+    if (press.modifiers.includes(modifier) || press.optionalModifiers.includes(modifier)) return press;
+    return { ...press, optionalModifiers: [...press.optionalModifiers, modifier].sort(byCanonicalOrder) };
+  });
+}
+
+/** Serializes the AST back to a tinykeys keybinding string: parseChord(serializeChord(ast)) deep-equals ast. */
+export function serializeChord(sequence: KeySequence): string {
+  return sequence.map(serializePress).join(" ");
+}
+
+function serializePress(chord: Chord): string {
+  const mods = [...chord.modifiers, ...chord.optionalModifiers.map((m) => `[${m}]`)];
+  return [...mods, serializeKey(chord.key)].join("+");
+}
+
+function serializeKey(key: string | RegExp): string {
+  if (!(key instanceof RegExp)) return key;
+  // parseKeybinding wraps a (regex) key as /^(?:regex)$/iv; unwrap that exact
+  // anchor so a parsed regex serializes back to its source form and the
+  // round-trip stays stable instead of nesting anchors on every pass.
+  const anchored = key.source.match(/^\^\(\?:(.*)\)\$$/);
+  return `(${anchored?.[1] ?? key.source})`;
+}
+
+// Display labels, reusing keyhint's platform-split concept: "$mod" has already
+// been resolved by parse time, so Meta reads as the Apple command glyph and
+// Control as the cross-platform "Ctrl". Every other name renders verbatim,
+// exactly as keyhint treats non-Mod keys.
+const MODIFIER_DISPLAY: Record<string, string> = {
+  Control: "Ctrl",
+  Meta: "⌘",
+};
+
+/** One press as speakable words: "⌘+K" on Apple platforms, "Ctrl+K" elsewhere. */
+export function formatChord(chord: Chord): string {
+  const mods = chord.modifiers.map((m) => MODIFIER_DISPLAY[m] ?? m);
+  const key = chord.key instanceof RegExp ? chord.key.source : chord.key;
+  return [...mods, key].join("+");
+}
+
+/** A whole sequence as words, presses space-separated: "Shift+A b". */
+export function formatSequence(sequence: KeySequence): string {
+  return sequence.map(formatChord).join(" ");
+}

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -251,6 +251,13 @@ export function chordDisplayKeys(chord: Chord): string[] {
   return [...chord.modifiers.map((m) => MODIFIER_DISPLAY[m] ?? m), key];
 }
 
+/** One modifier's display label (Ctrl / ⌘ / verbatim) - the chordDisplayKeys
+ * mapping for the capture editor's modifier-only live preview, which has no
+ * key yet. */
+export function modifierDisplayKey(modifier: string): string {
+  return MODIFIER_DISPLAY[modifier] ?? modifier;
+}
+
 /** One press as speakable words: "⌘+K" on Apple platforms, "Ctrl+K" elsewhere. */
 export function formatChord(chord: Chord): string {
   return chordDisplayKeys(chord).join("+");

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -56,6 +56,169 @@ export function serializeChord(sequence: KeySequence): string {
   return sequence.map(serializePress).join(" ");
 }
 
+/** Do two chords share a matching key event? The conflict predicate for
+ * validation and rebind, built from tinykeys' actual dispatch loop:
+ *
+ * SINGLE-press chords overlap when their keys share an event
+ * (keysShareAnEvent) AND each side's required-modifier set is a subset of the
+ * other side's required ∪ optional set - the exact condition for one
+ * KeyboardEvent's modifier state to satisfy both. (Serialization equality
+ * alone misses e.g. Control+K vs a default's Control+[Meta]+K, which the same
+ * event matches; the earlier-registered binding shadows the later one.)
+ *
+ * MULTI-press sequences: tinykeys advances every binding whose next expected
+ * press matches each keydown, and a COMPLETING binding does not fire while
+ * any other binding holds a pending partial (its loop's `conflicts` list).
+ * So two sequences conflict exactly when every shared position overlaps:
+ * equal length means one event stream completes both (map order decides), and
+ * unequal length means the shorter is a prefix - when its last press lands,
+ * the longer is pending, so the shorter is deferred and never fires
+ * (roborev PR #884 round 12). A mismatch at any shared position ends any
+ * shared stream, so those pairs never shadow.
+ *
+ * Regex keys (tinykeys' "(...)" syntax): two regexes ALWAYS overlap (regex
+ * intersection is undecidable here, and a false non-overlap shadows one
+ * binding at dispatch - fail closed); a regex vs a literal tests the regex
+ * against the exact event spellings the literal's spelling class can match
+ * (its key value and/or code-name forms). */
+export function chordsOverlap(a: KeySequence, b: KeySequence): boolean {
+  if (a.length !== 1 || b.length !== 1) {
+    const shared = Math.min(a.length, b.length);
+    for (let i = 0; i < shared; i++) {
+      const pressA = a[i];
+      const pressB = b[i];
+      if (pressA === undefined || pressB === undefined || !pressesOverlap(pressA, pressB)) return false;
+    }
+    return true;
+  }
+  const pressA = a[0];
+  const pressB = b[0];
+  if (pressA === undefined || pressB === undefined) return false;
+  return pressesOverlap(pressA, pressB);
+}
+
+function pressesOverlap(pressA: Chord, pressB: Chord): boolean {
+  if (!keysShareAnEvent(pressA.key, pressB.key)) return false;
+  const allowedA = [...pressA.modifiers, ...pressA.optionalModifiers];
+  const allowedB = [...pressB.modifiers, ...pressB.optionalModifiers];
+  return pressA.modifiers.every((m) => allowedB.includes(m)) && pressB.modifiers.every((m) => allowedA.includes(m));
+}
+
+/** Does a regex press key match any event spelling carrying this key value
+ * (the value itself, or the code name of any physical key producing it)?
+ * Shared by chordsOverlap's literal-vs-regex branch and validation.ts's
+ * reserved-chord check (roborev PR #884 round 14). */
+export function regexMatchesKeyValue(regex: RegExp, keyValue: string): boolean {
+  const candidates = [keyValue, ...(KEY_TO_CODE_NAMES[keyValue] ?? [])];
+  return candidates.some((candidate) => regex.test(candidate));
+}
+
+/** Do two spellings share even ONE matching event? A string spelling matches
+ * via event.key (case-insensitive) OR event.code (exact). Same-physical-key
+ * aliases fold through keyComparisonIdentity ("KeyW" and "W", "Slash" and
+ * "/"). The case a pure fold cannot express is ASYMMETRIC containment
+ * (roborev PR #884 round 9): a NumLock-on numpad event is {key: "7", code:
+ * "Numpad7"}, so the plain "7" spelling matches it via key AND the "Numpad7"
+ * spelling matches it via code - they collide - while "Digit7" and "Numpad7"
+ * never share an event (disjoint code domains, and neither spelling matches
+ * anything via key). */
+function keysShareAnEvent(a: string | RegExp, b: string | RegExp): boolean {
+  if (a instanceof RegExp || b instanceof RegExp) {
+    // Regex vs regex: regex intersection is not decidable here, and a false
+    // NON-overlap lets dispatch order silently shadow one of them - fail
+    // closed instead (roborev PR #884 round 14). Only hand-authored hub
+    // payloads can carry regex chords (nothing shipped uses one, capture
+    // records literals), so the conservative block has no shipped cost.
+    if (a instanceof RegExp && b instanceof RegExp) return true;
+    // Literal vs regex: tinykeys tests the regex against event.key AND
+    // event.code. Which event spellings the LITERAL can produce depends on
+    // its spelling class (round 14): a code-spelled literal ("Numpad7")
+    // matches only its own code's events, so its candidates are the code
+    // name and that event's key value; a key-spelled literal ("7") matches
+    // every event carrying the key regardless of code, so its candidates are
+    // the key value and every code name for it (top-row AND numpad).
+    const regex = (a instanceof RegExp ? a : b) as RegExp;
+    const literal = (a instanceof RegExp ? b : a) as string;
+    const literalLower = literal.toLowerCase();
+    const asCodeKeyValue = CODE_PHYSICAL_KEY[literalLower];
+    const candidates =
+      asCodeKeyValue !== undefined
+        ? [literal, asCodeKeyValue]
+        : [literal, literalLower, ...(KEY_TO_CODE_NAMES[literalLower] ?? [])];
+    return candidates.some((candidate) => regex.test(candidate));
+  }
+  if (keyComparisonIdentity(a) === keyComparisonIdentity(b)) return true;
+  const ka = a.toLowerCase();
+  const kb = b.toLowerCase();
+  return CODE_PHYSICAL_KEY[ka] === kb || CODE_PHYSICAL_KEY[kb] === ka;
+}
+
+// tinykeys matches a string key against KeyboardEvent.key (case-insensitive)
+// OR KeyboardEvent.code (exact) - so a chord spelled with a CODE name
+// ("Control+Slash") and one spelled with the key ("Control+/") match the same
+// physical keypress, while a literal-string comparison calls them distinct
+// and lets one silently shadow the other at dispatch (roborev PR #884 round
+// 8). This table is the single source of truth: canonical KeyboardEvent.code
+// name -> the physical key's (unmodified, lowercased) key value.
+const CODE_TO_KEY_CANONICAL: Record<string, string> = {
+  ...Object.fromEntries(
+    Array.from({ length: 26 }, (_, i) => [`Key${String.fromCharCode(65 + i)}`, String.fromCharCode(97 + i)]),
+  ),
+  ...Object.fromEntries(Array.from({ length: 10 }, (_, i) => [`Digit${i}`, String(i)])),
+  Minus: "-",
+  Equal: "=",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Backslash: "\\",
+  Semicolon: ";",
+  Quote: "'",
+  Comma: ",",
+  Period: ".",
+  Slash: "/",
+  Backquote: "`",
+  ...Object.fromEntries(Array.from({ length: 10 }, (_, i) => [`Numpad${i}`, String(i)])),
+  NumpadDecimal: ".",
+  NumpadAdd: "+",
+  NumpadSubtract: "-",
+  NumpadMultiply: "*",
+  NumpadDivide: "/",
+  NumpadEnter: "enter",
+};
+
+// Lowercase-code lookup views of the canonical table. CODE_NAME_TO_KEY
+// EXCLUDES the numpad: the reserved-chord check (the fold's other consumer)
+// names top-row keys, and numpad-vs-top-row collision handling lives in the
+// overlap predicate's own containment check (CODE_PHYSICAL_KEY), not in a
+// shared identity. CODE_PHYSICAL_KEY includes it because the EVENTS are
+// shared.
+const CODE_NAME_TO_KEY: Record<string, string> = Object.fromEntries(
+  Object.entries(CODE_TO_KEY_CANONICAL)
+    .filter(([code]) => !code.startsWith("Numpad"))
+    .map(([code, key]) => [code.toLowerCase(), key]),
+);
+const CODE_PHYSICAL_KEY: Record<string, string> = Object.fromEntries(
+  Object.entries(CODE_TO_KEY_CANONICAL).map(([code, key]) => [code.toLowerCase(), key]),
+);
+
+// Key value -> the canonical code names of every physical key carrying it
+// (top-row AND numpad): the candidate event.code spellings for the regex-vs-
+// literal overlap check (tinykeys tests a regex against event.code too).
+const KEY_TO_CODE_NAMES: Record<string, string[]> = {};
+for (const [code, key] of Object.entries(CODE_TO_KEY_CANONICAL)) {
+  const names = KEY_TO_CODE_NAMES[key];
+  if (names === undefined) KEY_TO_CODE_NAMES[key] = [code];
+  else names.push(code);
+}
+
+/** The comparison identity of one press's key: regex keys by source, string
+ * keys lowercased with code-name aliases folded to their key value. Shared by
+ * chord.ts's overlap predicate and validation.ts's reserved check. */
+export function keyComparisonIdentity(key: string | RegExp): string {
+  if (key instanceof RegExp) return key.source;
+  const lowered = key.toLowerCase();
+  return CODE_NAME_TO_KEY[lowered] ?? lowered;
+}
+
 function serializePress(chord: Chord): string {
   const mods = [...chord.modifiers, ...chord.optionalModifiers.map((m) => `[${m}]`)];
   return [...mods, serializeKey(chord.key)].join("+");
@@ -79,11 +242,18 @@ const MODIFIER_DISPLAY: Record<string, string> = {
   Meta: "⌘",
 };
 
+/** One press as display tokens, in KeyHint's `keys` shape: ["⌘","K"] on Apple
+ * platforms (the AST was `$mod`-resolved at parse time), ["Ctrl","K"]
+ * elsewhere. Optional modifiers are NOT included - they describe match
+ * permissiveness, not the key the user presses. */
+export function chordDisplayKeys(chord: Chord): string[] {
+  const key = chord.key instanceof RegExp ? chord.key.source : chord.key;
+  return [...chord.modifiers.map((m) => MODIFIER_DISPLAY[m] ?? m), key];
+}
+
 /** One press as speakable words: "⌘+K" on Apple platforms, "Ctrl+K" elsewhere. */
 export function formatChord(chord: Chord): string {
-  const mods = chord.modifiers.map((m) => MODIFIER_DISPLAY[m] ?? m);
-  const key = chord.key instanceof RegExp ? chord.key.source : chord.key;
-  return [...mods, key].join("+");
+  return chordDisplayKeys(chord).join("+");
 }
 
 /** A whole sequence as words, presses space-separated: "Shift+A b". */

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -5,7 +5,9 @@ import {
   CHARACTER_KEY_TRIGGER_BINDING_ID,
   CHEATSHEET_SCOPE,
   DEFAULT_BINDINGS,
+  defaultBindingShapesForAction,
   registerDefaultBindings,
+  registerDefaultBindingsForAction,
   SETTINGS_SCOPE,
 } from "./defaults";
 import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
@@ -374,5 +376,25 @@ describe("default bindings through the dispatcher", () => {
       ACTIONS.selectionQuote,
       ACTIONS.settingsOpen,
     ]);
+  });
+});
+
+describe("register vs shapes agreement", () => {
+  // The preflight (defaultBindingShapesForAction) and the mutation
+  // (registerDefaultBindingsForAction) share one predicate for the
+  // conditional "?" entry; if they ever diverge the validation can accept a
+  // restore that then throws, or reject one that would succeed.
+  test("both paths include or exclude the ? trigger for the SAME pref value", () => {
+    for (const pref of [true, false]) {
+      const registry = createKeybindingsRegistry();
+      const registered = registerDefaultBindingsForAction(registry, ACTIONS.cheatsheetToggle, {
+        characterKeyTriggers: pref,
+      }).map((b) => b.id);
+      const shaped = defaultBindingShapesForAction(ACTIONS.cheatsheetToggle, {
+        characterKeyTriggers: pref,
+      }).map((s) => s.id);
+      expect(registered).toEqual(shaped);
+      expect(registered.includes(CHARACTER_KEY_TRIGGER_BINDING_ID)).toBe(pref);
+    }
   });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { ACTIONS } from "./actions";
 import { formatSequence, parseChord, serializeChord } from "./chord";
-import { DEFAULT_BINDINGS, registerDefaultBindings, SETTINGS_SCOPE } from "./defaults";
+import {
+  CHARACTER_KEY_TRIGGER_BINDING_ID,
+  CHEATSHEET_SCOPE,
+  DEFAULT_BINDINGS,
+  registerDefaultBindings,
+  SETTINGS_SCOPE,
+} from "./defaults";
 import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
 import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
@@ -17,36 +23,38 @@ describe("default binding map", () => {
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.settingsOpen,
       ACTIONS.sessionNext,
       ACTIONS.sessionPrevious,
       ACTIONS.transcriptLineUp,
       ACTIONS.transcriptLineDown,
       ACTIONS.transcriptPageUp,
       ACTIONS.transcriptPageDown,
+      ACTIONS.transcriptScrollTop,
+      ACTIONS.transcriptScrollBottom,
       ACTIONS.settingsClose,
+      ACTIONS.cheatsheetToggle,
+      ACTIONS.cheatsheetToggle, // the "?" character-key trigger is a second entry for the same action
+      ACTIONS.cheatsheetClose,
     ]);
-  });
-
-  // Phase 3 registers the scrollTop/scrollBottom ACTIONS (their handlers are
-  // the session transcript's) but deliberately ships no default chord for
-  // them - the Phase 4 keymap decides whether they get one.
-  test("transcript.scrollTop/scrollBottom ship with no default chord", () => {
-    expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollTop)).toBe(false);
-    expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollBottom)).toBe(false);
   });
 
   // Chords are compared through parse+serialize so the assertion is
   // platform-independent ("$mod" resolves per host platform at parse time).
-  // The optional modifiers are the legacy-faithful semantics: the AppShell
-  // K/I/J listener had no shift/alt guard, SelectionQuote guarded only
-  // AltGr (alt), rail.toggle guarded both, and the Settings Escape listener
-  // had no modifier guard at all.
+  // palette.open / composer.focus / next-needs-you are STRICT single-press
+  // chords since Phase 4a - docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md
+  // (Design decision 1) is the authority for dropping the 2a map's OPTIONAL
+  // Shift/Alt, which hijacked the browser's DevTools chords (⌘⌥I,
+  // Ctrl+Shift+J). The remaining optional modifiers are the legacy-faithful
+  // semantics: SelectionQuote guarded only AltGr (alt), rail.toggle guarded
+  // both, and the Settings Escape listener had no modifier guard at all.
   test.each([
-    [ACTIONS.paletteOpen, "$mod+[Shift]+[Alt]+K"],
+    [ACTIONS.paletteOpen, "$mod+K"],
     [ACTIONS.railToggle, "$mod+B"],
-    [ACTIONS.composerFocus, "$mod+[Shift]+[Alt]+I"],
-    [ACTIONS.nextNeedsYou, "$mod+[Shift]+[Alt]+J"],
+    [ACTIONS.composerFocus, "$mod+I"],
+    [ACTIONS.nextNeedsYou, "$mod+J"],
     [ACTIONS.selectionQuote, "$mod+[Shift]+'"],
+    [ACTIONS.settingsOpen, "$mod+,"],
     [ACTIONS.settingsClose, "[Control]+[Alt]+[Shift]+[Meta]+Escape"],
     [ACTIONS.sessionNext, "Alt+ArrowRight"],
     [ACTIONS.sessionPrevious, "Alt+ArrowLeft"],
@@ -54,10 +62,20 @@ describe("default binding map", () => {
     [ACTIONS.transcriptLineDown, "Alt+ArrowDown"],
     [ACTIONS.transcriptPageUp, "Alt+Shift+ArrowUp"],
     [ACTIONS.transcriptPageDown, "Alt+Shift+ArrowDown"],
+    [ACTIONS.transcriptScrollTop, "Alt+Home"],
+    [ACTIONS.transcriptScrollBottom, "Alt+End"],
+    [ACTIONS.cheatsheetToggle, "$mod+/"],
+    [ACTIONS.cheatsheetClose, "[Control]+[Alt]+[Shift]+[Meta]+Escape"],
   ])("%s is bound to %s", (actionId, chord) => {
     const binding = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
     expect(binding).toBeDefined();
     expect(serializeChord(parseChord(String(binding?.chord)))).toBe(serializeChord(parseChord(chord)));
+  });
+
+  test('the "?" trigger lists Shift as OPTIONAL (every common layout types ? with Shift held; a bare binding would never fire)', () => {
+    const binding = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+    expect(binding?.actionId).toBe(ACTIONS.cheatsheetToggle);
+    expect(serializeChord(parseChord(String(binding?.chord)))).toBe(serializeChord(parseChord("[Shift]+?")));
   });
 
   test("editable-target policy matches today's per-chord behavior", () => {
@@ -67,21 +85,40 @@ describe("default binding map", () => {
     expect(policy.get(ACTIONS.nextNeedsYou)).toBe(true);
     expect(policy.get(ACTIONS.selectionQuote)).toBe(true);
     expect(policy.get(ACTIONS.railToggle)).toBe(false);
-    // The Phase 3 navigation chords all suppress in editable targets: plain
-    // Alt+Arrow and Alt+Shift+Arrow keep their native text-editing meanings
-    // (word/selection movement) inside inputs and the composer.
+    // settings.open fires from editable targets (the p4 plan, Design
+    // decision 2): ⌘, never collides with typing.
+    expect(policy.get(ACTIONS.settingsOpen)).toBe(true);
+    // The Phase 3/4 navigation chords all suppress in editable targets:
+    // plain Alt+Arrow, Alt+Shift+Arrow and Alt+Home/End keep their native
+    // text-editing meanings (word/selection movement, caret to line
+    // start/end) inside inputs and the composer.
     expect(policy.get(ACTIONS.sessionNext)).toBe(false);
     expect(policy.get(ACTIONS.sessionPrevious)).toBe(false);
     expect(policy.get(ACTIONS.transcriptLineUp)).toBe(false);
     expect(policy.get(ACTIONS.transcriptLineDown)).toBe(false);
     expect(policy.get(ACTIONS.transcriptPageUp)).toBe(false);
     expect(policy.get(ACTIONS.transcriptPageDown)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptScrollTop)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptScrollBottom)).toBe(false);
+    // cheatsheet.toggle's $mod+/ fires from editable targets (never collides
+    // with typing); the "?" character-key trigger does NOT (it is itself a
+    // printable character). cheatsheet.close mirrors settings.close.
+    // (Asserted per-entry, not via the policy map: the two toggle entries
+    // share one action id.)
+    const toggleBase = DEFAULT_BINDINGS.find((b) => b.id === ACTIONS.cheatsheetToggle);
+    const toggleQuestion = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+    const close = DEFAULT_BINDINGS.find((b) => b.id === ACTIONS.cheatsheetClose);
+    expect(toggleBase?.allowInEditable).toBe(true);
+    expect(toggleQuestion?.allowInEditable).toBe(false);
+    expect(close?.allowInEditable).toBe(true);
   });
 
-  test("settings.close is scope-gated, not global", () => {
-    const binding = DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.settingsClose);
-    expect(binding?.scope).toBe(SETTINGS_SCOPE);
-    for (const other of DEFAULT_BINDINGS.filter((b) => b.actionId !== ACTIONS.settingsClose)) {
+  test("settings.close and cheatsheet.close are scope-gated, not global", () => {
+    expect(DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.settingsClose)?.scope).toBe(SETTINGS_SCOPE);
+    expect(DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.cheatsheetClose)?.scope).toBe(CHEATSHEET_SCOPE);
+    for (const other of DEFAULT_BINDINGS.filter(
+      (b) => b.actionId !== ACTIONS.settingsClose && b.actionId !== ACTIONS.cheatsheetClose,
+    )) {
       expect(other.scope ?? GLOBAL_SCOPE).toBe(GLOBAL_SCOPE);
     }
   });
@@ -112,6 +149,19 @@ describe("default binding map", () => {
     expect(policy.get(ACTIONS.composerFocus)).toBe(false);
     expect(policy.get(ACTIONS.nextNeedsYou)).toBe(false);
     expect(policy.get(ACTIONS.settingsClose)).toBe(false);
+    // settings.open keeps the default suppression too (the p4 plan, Design
+    // decision 2: allowInModal: false).
+    expect(policy.get(ACTIONS.settingsOpen)).toBe(false);
+    // cheatsheet.toggle's $mod+/ is exempt so the same chord toggles the
+    // overlay CLOSED while it (or another modal) is open; the "?" trigger
+    // and cheatsheet.close keep the default suppression (the OverlayPanel's
+    // own Escape handler owns close while focus is inside the dialog).
+    const toggleBase = DEFAULT_BINDINGS.find((b) => b.id === ACTIONS.cheatsheetToggle);
+    const toggleQuestion = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+    const close = DEFAULT_BINDINGS.find((b) => b.id === ACTIONS.cheatsheetClose);
+    expect(toggleBase?.allowInModal).toBe(true);
+    expect(toggleQuestion?.allowInModal ?? false).toBe(false);
+    expect(close?.allowInModal ?? false).toBe(false);
   });
 });
 
@@ -147,35 +197,51 @@ describe("default bindings through the dispatcher", () => {
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "'", code: "Quote", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: ",", code: "Comma", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowRight", code: "ArrowRight", altKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowLeft", code: "ArrowLeft", altKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true, shiftKey: true }));
     window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "Home", code: "Home", altKey: true }));
+    window.dispatchEvent(keydown({ key: "End", code: "End", altKey: true }));
     expect(calls).toEqual([
       ACTIONS.paletteOpen,
       ACTIONS.railToggle,
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.settingsOpen,
       ACTIONS.sessionNext,
       ACTIONS.sessionPrevious,
       ACTIONS.transcriptLineUp,
       ACTIONS.transcriptLineDown,
       ACTIONS.transcriptPageUp,
       ACTIONS.transcriptPageDown,
+      ACTIONS.transcriptScrollTop,
+      ACTIONS.transcriptScrollBottom,
     ]);
   });
 
-  test("the Alt+Arrow chords are suppressed in an editable target", () => {
+  test("the Alt+Arrow and Alt+Home/End chords are suppressed in an editable target", () => {
     setup();
     const input = document.createElement("input");
     document.body.appendChild(input);
     input.dispatchEvent(keydown({ key: "ArrowRight", code: "ArrowRight", altKey: true }));
     input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
     input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+    input.dispatchEvent(keydown({ key: "Home", code: "Home", altKey: true }));
+    input.dispatchEvent(keydown({ key: "End", code: "End", altKey: true }));
     expect(calls).toEqual([]);
+  });
+
+  test("⌘, fires settings.open from an editable target (it never collides with typing)", () => {
+    setup();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(keydown({ key: ",", code: "Comma", ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.settingsOpen]);
   });
 
   test("Escape only closes settings while the settings scope is pushed", () => {
@@ -185,6 +251,27 @@ describe("default bindings through the dispatcher", () => {
     registry.getState().pushScope(SETTINGS_SCOPE);
     window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
     expect(calls).toEqual([ACTIONS.settingsClose]);
+  });
+
+  test('the "?" trigger fires with or without Shift held, and is suppressed in an editable target', () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "?", code: "Slash", shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "?", code: "Slash" }));
+    expect(calls).toEqual([ACTIONS.cheatsheetToggle, ACTIONS.cheatsheetToggle]);
+    calls = [];
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(keydown({ key: "?", code: "Slash", shiftKey: true }));
+    expect(calls).toEqual([]);
+  });
+
+  test("Escape only closes the cheatsheet while the cheatsheet scope is pushed", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
+    expect(calls).toEqual([]);
+    registry.getState().pushScope(CHEATSHEET_SCOPE);
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
+    expect(calls).toEqual([ACTIONS.cheatsheetClose]);
   });
 
   test("Mod+B is suppressed in an editable target while Mod+K still fires", () => {
@@ -197,18 +284,23 @@ describe("default bindings through the dispatcher", () => {
     expect(calls).toEqual([ACTIONS.paletteOpen]);
   });
 
-  // Extra-modifier variants: the legacy AppShell ⌘K/⌘I/⌘J listener checked
-  // only metaKey||ctrlKey + key (NO shift/alt guard), and the legacy
-  // Settings Escape listener checked only key === "Escape" - so these all
-  // fired legacy and must still fire.
-  test("⌘⇧K and ⌘⌥K fire palette.open (legacy had no shift/alt guard)", () => {
+  // STRICT extra-modifier contract (Phase 4a): the 2a map listed Shift/Alt
+  // as OPTIONAL on palette.open/composer.focus/next-needs-you because the
+  // legacy AppShell ⌘K/⌘I/⌘J listener checked only metaKey||ctrlKey + key
+  // with NO shift/alt guard - which hijacked the browser's DevTools chords
+  // (⌘⌥I, Ctrl+Shift+J). docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md
+  // (Design decision 1) is the authority for the deliberate change: these
+  // extra-modifier presses must NOT fire, so the browser gets its chords
+  // back. legacyEitherMod is retained - Meta+Ctrl together still fires
+  // (pinned below).
+  test("⌘⇧K and ⌘⌥K do NOT fire palette.open (strict per the p4 plan)", () => {
     setup();
     window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, shiftKey: true }));
     window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, altKey: true }));
-    expect(calls).toEqual([ACTIONS.paletteOpen, ACTIONS.paletteOpen]);
+    expect(calls).toEqual([]);
   });
 
-  test("Meta+Ctrl+K fires palette.open (legacy accepted either or both modifiers)", () => {
+  test("Meta+Ctrl+K fires palette.open (legacyEitherMod kept: either or both modifiers)", () => {
     setup();
     window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, ctrlKey: true }));
     expect(calls).toEqual([ACTIONS.paletteOpen]);
@@ -226,16 +318,18 @@ describe("default bindings through the dispatcher", () => {
     expect(calls).toEqual([ACTIONS.selectionQuote]);
   });
 
-  test("⌘⇧I fires composer.focus", () => {
+  test("⌘⌥I does NOT fire composer.focus (the browser's DevTools chord reverts to the browser)", () => {
     setup();
+    window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true, altKey: true }));
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true, shiftKey: true }));
-    expect(calls).toEqual([ACTIONS.composerFocus]);
+    expect(calls).toEqual([]);
   });
 
-  test("Ctrl+Shift+J fires next-needs-you", () => {
+  test("Ctrl+Shift+J and ⌘⇧J do NOT fire next-needs-you (DevTools/downloads chords revert to the browser)", () => {
     setup();
     window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true, shiftKey: true }));
-    expect(calls).toEqual([ACTIONS.nextNeedsYou]);
+    window.dispatchEvent(keydown({ key: "j", code: "KeyJ", metaKey: true, shiftKey: true }));
+    expect(calls).toEqual([]);
   });
 
   test("Shift+Escape closes settings while the settings scope is pushed (legacy had no modifier guard)", () => {
@@ -271,12 +365,14 @@ describe("default bindings through the dispatcher", () => {
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true }));
     window.dispatchEvent(keydown({ key: "j", code: "KeyJ", metaKey: true }));
     window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true }));
+    window.dispatchEvent(keydown({ key: ",", code: "Comma", metaKey: true }));
     expect(calls).toEqual([
       ACTIONS.paletteOpen,
       ACTIONS.railToggle,
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.settingsOpen,
     ]);
   });
 });

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -10,15 +10,29 @@ function keydown(init: KeyboardEventInit): KeyboardEvent {
 }
 
 describe("default binding map", () => {
-  test("is exactly the six shell chords", () => {
+  test("is exactly the shell chords", () => {
     expect(DEFAULT_BINDINGS.map((b) => b.actionId)).toEqual([
       ACTIONS.paletteOpen,
       ACTIONS.railToggle,
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.sessionNext,
+      ACTIONS.sessionPrevious,
+      ACTIONS.transcriptLineUp,
+      ACTIONS.transcriptLineDown,
+      ACTIONS.transcriptPageUp,
+      ACTIONS.transcriptPageDown,
       ACTIONS.settingsClose,
     ]);
+  });
+
+  // Phase 3 registers the scrollTop/scrollBottom ACTIONS (their handlers are
+  // the session transcript's) but deliberately ships no default chord for
+  // them - the Phase 4 keymap decides whether they get one.
+  test("transcript.scrollTop/scrollBottom ship with no default chord", () => {
+    expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollTop)).toBe(false);
+    expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollBottom)).toBe(false);
   });
 
   // Chords are compared through parse+serialize so the assertion is
@@ -34,6 +48,12 @@ describe("default binding map", () => {
     [ACTIONS.nextNeedsYou, "$mod+[Shift]+[Alt]+J"],
     [ACTIONS.selectionQuote, "$mod+[Shift]+'"],
     [ACTIONS.settingsClose, "[Control]+[Alt]+[Shift]+[Meta]+Escape"],
+    [ACTIONS.sessionNext, "Alt+ArrowRight"],
+    [ACTIONS.sessionPrevious, "Alt+ArrowLeft"],
+    [ACTIONS.transcriptLineUp, "Alt+ArrowUp"],
+    [ACTIONS.transcriptLineDown, "Alt+ArrowDown"],
+    [ACTIONS.transcriptPageUp, "Alt+Shift+ArrowUp"],
+    [ACTIONS.transcriptPageDown, "Alt+Shift+ArrowDown"],
   ])("%s is bound to %s", (actionId, chord) => {
     const binding = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
     expect(binding).toBeDefined();
@@ -47,6 +67,15 @@ describe("default binding map", () => {
     expect(policy.get(ACTIONS.nextNeedsYou)).toBe(true);
     expect(policy.get(ACTIONS.selectionQuote)).toBe(true);
     expect(policy.get(ACTIONS.railToggle)).toBe(false);
+    // The Phase 3 navigation chords all suppress in editable targets: plain
+    // Alt+Arrow and Alt+Shift+Arrow keep their native text-editing meanings
+    // (word/selection movement) inside inputs and the composer.
+    expect(policy.get(ACTIONS.sessionNext)).toBe(false);
+    expect(policy.get(ACTIONS.sessionPrevious)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptLineUp)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptLineDown)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptPageUp)).toBe(false);
+    expect(policy.get(ACTIONS.transcriptPageDown)).toBe(false);
   });
 
   test("settings.close is scope-gated, not global", () => {
@@ -118,13 +147,35 @@ describe("default bindings through the dispatcher", () => {
     window.dispatchEvent(keydown({ key: "i", code: "KeyI", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true }));
     window.dispatchEvent(keydown({ key: "'", code: "Quote", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowRight", code: "ArrowRight", altKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowLeft", code: "ArrowLeft", altKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
     expect(calls).toEqual([
       ACTIONS.paletteOpen,
       ACTIONS.railToggle,
       ACTIONS.composerFocus,
       ACTIONS.nextNeedsYou,
       ACTIONS.selectionQuote,
+      ACTIONS.sessionNext,
+      ACTIONS.sessionPrevious,
+      ACTIONS.transcriptLineUp,
+      ACTIONS.transcriptLineDown,
+      ACTIONS.transcriptPageUp,
+      ACTIONS.transcriptPageDown,
     ]);
+  });
+
+  test("the Alt+Arrow chords are suppressed in an editable target", () => {
+    setup();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(keydown({ key: "ArrowRight", code: "ArrowRight", altKey: true }));
+    input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+    input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+    expect(calls).toEqual([]);
   });
 
   test("Escape only closes settings while the settings scope is pushed", () => {

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { ACTIONS } from "./actions";
+import { formatSequence, parseChord, serializeChord } from "./chord";
+import { DEFAULT_BINDINGS, registerDefaultBindings, SETTINGS_SCOPE } from "./defaults";
+import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
+import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+describe("default binding map", () => {
+  test("is exactly the six shell chords", () => {
+    expect(DEFAULT_BINDINGS.map((b) => b.actionId)).toEqual([
+      ACTIONS.paletteOpen,
+      ACTIONS.railToggle,
+      ACTIONS.composerFocus,
+      ACTIONS.nextNeedsYou,
+      ACTIONS.selectionQuote,
+      ACTIONS.settingsClose,
+    ]);
+  });
+
+  // Chords are compared through parse+serialize so the assertion is
+  // platform-independent ("$mod" resolves per host platform at parse time).
+  // The optional modifiers are the legacy-faithful semantics: the AppShell
+  // K/I/J listener had no shift/alt guard, SelectionQuote guarded only
+  // AltGr (alt), rail.toggle guarded both, and the Settings Escape listener
+  // had no modifier guard at all.
+  test.each([
+    [ACTIONS.paletteOpen, "$mod+[Shift]+[Alt]+K"],
+    [ACTIONS.railToggle, "$mod+B"],
+    [ACTIONS.composerFocus, "$mod+[Shift]+[Alt]+I"],
+    [ACTIONS.nextNeedsYou, "$mod+[Shift]+[Alt]+J"],
+    [ACTIONS.selectionQuote, "$mod+[Shift]+'"],
+    [ACTIONS.settingsClose, "[Control]+[Alt]+[Shift]+[Meta]+Escape"],
+  ])("%s is bound to %s", (actionId, chord) => {
+    const binding = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
+    expect(binding).toBeDefined();
+    expect(serializeChord(parseChord(String(binding?.chord)))).toBe(serializeChord(parseChord(chord)));
+  });
+
+  test("editable-target policy matches today's per-chord behavior", () => {
+    const policy = new Map(DEFAULT_BINDINGS.map((b) => [b.actionId, b.allowInEditable ?? false]));
+    expect(policy.get(ACTIONS.paletteOpen)).toBe(true);
+    expect(policy.get(ACTIONS.composerFocus)).toBe(true);
+    expect(policy.get(ACTIONS.nextNeedsYou)).toBe(true);
+    expect(policy.get(ACTIONS.selectionQuote)).toBe(true);
+    expect(policy.get(ACTIONS.railToggle)).toBe(false);
+  });
+
+  test("settings.close is scope-gated, not global", () => {
+    const binding = DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.settingsClose);
+    expect(binding?.scope).toBe(SETTINGS_SCOPE);
+    for (const other of DEFAULT_BINDINGS.filter((b) => b.actionId !== ACTIONS.settingsClose)) {
+      expect(other.scope ?? GLOBAL_SCOPE).toBe(GLOBAL_SCOPE);
+    }
+  });
+
+  test("display formatting renders every default chord (optional modifiers are dropped from display - parked L22 minor, but it must not crash)", () => {
+    for (const binding of DEFAULT_BINDINGS) {
+      const rendered = formatSequence(parseChord(String(binding.chord)));
+      expect(rendered.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("only rail.toggle opts out of the defaultPrevented gate (RailHost.tsx:59-66 has no such check)", () => {
+    for (const binding of DEFAULT_BINDINGS) {
+      const expected = binding.actionId !== ACTIONS.railToggle;
+      expect(binding.ignoreIfDefaultPrevented ?? true).toBe(expected);
+    }
+  });
+
+  test("modal policy matches today's per-site modal guards", () => {
+    // palette.open (AppShell's deliberate ⌘K exemption), rail.toggle and
+    // selection.quote (their listeners have no modal check at all) are exempt;
+    // composer.focus / next-needs-you (AppShell's blockedByOpenModal) and
+    // settings.close keep the default suppression.
+    const policy = new Map(DEFAULT_BINDINGS.map((b) => [b.actionId, b.allowInModal ?? false]));
+    expect(policy.get(ACTIONS.paletteOpen)).toBe(true);
+    expect(policy.get(ACTIONS.railToggle)).toBe(true);
+    expect(policy.get(ACTIONS.selectionQuote)).toBe(true);
+    expect(policy.get(ACTIONS.composerFocus)).toBe(false);
+    expect(policy.get(ACTIONS.nextNeedsYou)).toBe(false);
+    expect(policy.get(ACTIONS.settingsClose)).toBe(false);
+  });
+});
+
+describe("default bindings through the dispatcher", () => {
+  let registry: KeybindingsRegistry;
+  let dispatcher: KeybindingDispatcher;
+  let detach: () => void;
+  let calls: string[];
+
+  afterEach(() => {
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+
+  function setup() {
+    registry = createKeybindingsRegistry();
+    calls = [];
+    for (const actionId of Object.values(ACTIONS)) {
+      registry.getState().registerAction(actionId, () => {
+        calls.push(actionId);
+      });
+    }
+    registerDefaultBindings(registry);
+    dispatcher = createKeybindingDispatcher({ registry });
+    detach = dispatcher.attach(window);
+  }
+
+  test("each chord runs its own action", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "i", code: "KeyI", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true }));
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", ctrlKey: true }));
+    expect(calls).toEqual([
+      ACTIONS.paletteOpen,
+      ACTIONS.railToggle,
+      ACTIONS.composerFocus,
+      ACTIONS.nextNeedsYou,
+      ACTIONS.selectionQuote,
+    ]);
+  });
+
+  test("Escape only closes settings while the settings scope is pushed", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
+    expect(calls).toEqual([]);
+    registry.getState().pushScope(SETTINGS_SCOPE);
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape" }));
+    expect(calls).toEqual([ACTIONS.settingsClose]);
+  });
+
+  test("Mod+B is suppressed in an editable target while Mod+K still fires", () => {
+    setup();
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(keydown({ key: "b", code: "KeyB", ctrlKey: true }));
+    expect(calls).toEqual([]);
+    input.dispatchEvent(keydown({ key: "k", code: "KeyK", ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.paletteOpen]);
+  });
+
+  // Extra-modifier variants: the legacy AppShell ⌘K/⌘I/⌘J listener checked
+  // only metaKey||ctrlKey + key (NO shift/alt guard), and the legacy
+  // Settings Escape listener checked only key === "Escape" - so these all
+  // fired legacy and must still fire.
+  test("⌘⇧K and ⌘⌥K fire palette.open (legacy had no shift/alt guard)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, altKey: true }));
+    expect(calls).toEqual([ACTIONS.paletteOpen, ACTIONS.paletteOpen]);
+  });
+
+  test("Meta+Ctrl+K fires palette.open (legacy accepted either or both modifiers)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true, ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.paletteOpen]);
+  });
+
+  test("Meta+Ctrl+B fires rail.toggle (legacy accepted either or both; only Alt/Shift stay strict)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", metaKey: true, ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.railToggle]);
+  });
+
+  test("Meta+Ctrl+' fires selection.quote (legacy accepted either or both; only Alt stays strict)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true, ctrlKey: true }));
+    expect(calls).toEqual([ACTIONS.selectionQuote]);
+  });
+
+  test("⌘⇧I fires composer.focus", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true, shiftKey: true }));
+    expect(calls).toEqual([ACTIONS.composerFocus]);
+  });
+
+  test("Ctrl+Shift+J fires next-needs-you", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "j", code: "KeyJ", ctrlKey: true, shiftKey: true }));
+    expect(calls).toEqual([ACTIONS.nextNeedsYou]);
+  });
+
+  test("Shift+Escape closes settings while the settings scope is pushed (legacy had no modifier guard)", () => {
+    setup();
+    registry.getState().pushScope(SETTINGS_SCOPE);
+    window.dispatchEvent(keydown({ key: "Escape", code: "Escape", shiftKey: true }));
+    expect(calls).toEqual([ACTIONS.settingsClose]);
+  });
+
+  test("⌘⇧' fires selection.quote but ⌘⌥' does NOT (the legacy AltGr guard)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true, shiftKey: true }));
+    expect(calls).toEqual([ACTIONS.selectionQuote]);
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true, altKey: true }));
+    expect(calls).toEqual([ACTIONS.selectionQuote]);
+  });
+
+  test("⌘⇧B and ⌘⌥B do NOT fire rail.toggle (the legacy listener guarded both)", () => {
+    setup();
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", metaKey: true, shiftKey: true }));
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", metaKey: true, altKey: true }));
+    expect(calls).toEqual([]);
+  });
+
+  test("every $mod chord also fires under Meta (today's listeners accept metaKey||ctrlKey)", () => {
+    // jsdom resolves tinykeys' $mod to Control, but the shell's pre-dispatcher
+    // listeners (and Mac users hitting Ctrl+K) accept either modifier on every
+    // platform, so registerDefaultBindings registers the cross-platform twin
+    // of each $mod chord as well.
+    setup();
+    window.dispatchEvent(keydown({ key: "k", code: "KeyK", metaKey: true }));
+    window.dispatchEvent(keydown({ key: "b", code: "KeyB", metaKey: true }));
+    window.dispatchEvent(keydown({ key: "i", code: "KeyI", metaKey: true }));
+    window.dispatchEvent(keydown({ key: "j", code: "KeyJ", metaKey: true }));
+    window.dispatchEvent(keydown({ key: "'", code: "Quote", metaKey: true }));
+    expect(calls).toEqual([
+      ACTIONS.paletteOpen,
+      ACTIONS.railToggle,
+      ACTIONS.composerFocus,
+      ACTIONS.nextNeedsYou,
+      ACTIONS.selectionQuote,
+    ]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -323,16 +323,39 @@ export function registerDefaultBindings(registry: KeybindingsRegistry): Binding[
   return registered;
 }
 
+/** The one CONDITIONAL default-map entry's inclusion test, shared by the
+ * registration path here and the simulation path
+ * (defaultBindingShapesForAction) so the actual restore and the validation
+ * simulation can never disagree (finding 27): the "?" character-key
+ * trigger exists only while the characterKeyTriggers pref is on. */
+function includeDefaultEntry(entryId: string, options?: { characterKeyTriggers?: boolean }): boolean {
+  return !(options?.characterKeyTriggers === false && entryId === CHARACTER_KEY_TRIGGER_BINDING_ID);
+}
+
 /** Registers only the given action's default entries (plus the $mod twin),
  * the per-action equivalent of registerDefaultBindings the overrides store
- * uses to restore one action's defaults. Throws on an unknown action id. */
-export function registerDefaultBindingsForAction(registry: KeybindingsRegistry, actionId: string): Binding[] {
+ * uses to restore one action's defaults. Throws on an unknown action id.
+ *
+ * `characterKeyTriggers: false` mirrors the live registry when the
+ * cheatsheet character-key pref is off (the cheatsheetController has no
+ * "?" binding registered then): the restore skips the conditional entry,
+ * so it cannot collide with a user rule claiming exactly [Shift]+? -
+ * registerBinding throws on an exact same-scope serialization match, and
+ * the reconcile's strip runs AFTER this mutation (the ordering contract),
+ * so the collision would precede the cleanup. The controller re-registers
+ * the entry itself when the pref turns back on. */
+export function registerDefaultBindingsForAction(
+  registry: KeybindingsRegistry,
+  actionId: string,
+  options?: { characterKeyTriggers?: boolean },
+): Binding[] {
   const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
   if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
   const registered: Binding[] = [];
   for (const input of inputs) {
     const pair = modPair(input);
     for (const entry of pair ?? [input]) {
+      if (!includeDefaultEntry(entry.id, options)) continue;
       registered.push(registry.getState().registerBinding(entry));
     }
   }
@@ -348,14 +371,24 @@ export interface DefaultBindingShape {
 /** The (scope, parsed chord) pairs registerDefaultBindingsForAction would
  * register for the action, WITHOUT registering them: the validation layer
  * simulates dropped-override restorations against these. Throws on an
- * unknown action id. */
-export function defaultBindingShapesForAction(actionId: string): DefaultBindingShape[] {
+ * unknown action id.
+ *
+ * `characterKeyTriggers: false` mirrors the live registry when the
+ * cheatsheet character-key pref is off (the cheatsheetController
+ * unregisters the "?" entry while the pref is off): the restored set then
+ * excludes the character-key trigger binding, so the simulation cannot
+ * report a conflict against a binding that will not exist. */
+export function defaultBindingShapesForAction(
+  actionId: string,
+  options?: { characterKeyTriggers?: boolean },
+): DefaultBindingShape[] {
   const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
   if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
   const shapes: DefaultBindingShape[] = [];
   for (const input of inputs) {
     const pair = modPair(input);
     for (const entry of pair ?? [input]) {
+      if (!includeDefaultEntry(entry.id, options)) continue;
       shapes.push({
         id: entry.id,
         scope: entry.scope ?? GLOBAL_SCOPE,

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -1,6 +1,8 @@
-// The default binding map: exactly the six shell chords that today live in six
+// The default binding map: the six legacy shell chords that lived in six
 // independent keydown listeners (AppShell, RailHost, SelectionQuote,
-// Settings). Per-binding policy per chord matches today's behavior:
+// Settings), plus the Phase 3 navigation chords (session-pane cycling and
+// transcript scroll). For the legacy six, per-binding policy per chord
+// matches the pre-dispatcher behavior:
 //
 //   - ⌘K / ⌘I / ⌘J / ⌘' fire from editable targets (allowInEditable: true):
 //     none of today's listeners for these chords guards on the target.
@@ -116,6 +118,56 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     allowInEditable: true,
     allowInModal: true,
     legacyEitherMod: true,
+  },
+  // Phase 3 navigation chords (the webui-keybindings-p3 approved map). All
+  // six are strict single-modifier-family Alt chords with NO optional
+  // modifiers: Alt+ArrowUp and Alt+Shift+ArrowUp must stay distinct bindings
+  // (line vs page scroll), which forbids a [Shift] on the plain chord. All
+  // keep the default allowInEditable: false - plain Alt+Arrow keeps its
+  // native text-editing meaning inside inputs and the composer - and the
+  // default allowInModal/ignoreIfDefaultPrevented policy. None is a $mod
+  // chord, so modPair registers no cross-platform twin.
+  //
+  // The session-cycling pair acts even when the focused pane is NOT a
+  // session (focusing the first/last open session then); the transcript
+  // scroll actions are per-pane multi-instance registrations whose handlers
+  // decline unless their pane is the focused one - see
+  // panes/session/transcript/flow/useTranscriptScrollKeys.ts.
+  {
+    id: ACTIONS.sessionNext,
+    actionId: ACTIONS.sessionNext,
+    title: "Focus the next session pane",
+    chord: "Alt+ArrowRight",
+  },
+  {
+    id: ACTIONS.sessionPrevious,
+    actionId: ACTIONS.sessionPrevious,
+    title: "Focus the previous session pane",
+    chord: "Alt+ArrowLeft",
+  },
+  {
+    id: ACTIONS.transcriptLineUp,
+    actionId: ACTIONS.transcriptLineUp,
+    title: "Scroll the transcript up one line",
+    chord: "Alt+ArrowUp",
+  },
+  {
+    id: ACTIONS.transcriptLineDown,
+    actionId: ACTIONS.transcriptLineDown,
+    title: "Scroll the transcript down one line",
+    chord: "Alt+ArrowDown",
+  },
+  {
+    id: ACTIONS.transcriptPageUp,
+    actionId: ACTIONS.transcriptPageUp,
+    title: "Scroll the transcript up one page",
+    chord: "Alt+Shift+ArrowUp",
+  },
+  {
+    id: ACTIONS.transcriptPageDown,
+    actionId: ACTIONS.transcriptPageDown,
+    title: "Scroll the transcript down one page",
+    chord: "Alt+Shift+ArrowDown",
   },
   {
     id: ACTIONS.settingsClose,

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -1,8 +1,10 @@
 // The default binding map: the six legacy shell chords that lived in six
 // independent keydown listeners (AppShell, RailHost, SelectionQuote,
 // Settings), plus the Phase 3 navigation chords (session-pane cycling and
-// transcript scroll). For the legacy six, per-binding policy per chord
-// matches the pre-dispatcher behavior:
+// transcript scroll) and the Phase 4a additions (settings.open and
+// transcript.scrollTop/scrollBottom - the p4 plan's Design decision 2). For
+// the legacy six, per-binding policy per chord matches the pre-dispatcher
+// behavior:
 //
 //   - ⌘K / ⌘I / ⌘J / ⌘' fire from editable targets (allowInEditable: true):
 //     none of today's listeners for these chords guards on the target.
@@ -21,19 +23,19 @@
 //     handler, which the dispatcher's per-binding defaultPrevented gate
 //     reproduces.
 //
-// Extra-modifier semantics are equally legacy-faithful (tinykeys matches
-// strictly, so each chord lists as OPTIONAL exactly the modifiers the legacy
-// listener ignored):
+// Extra-modifier semantics (tinykeys matches strictly, so each chord lists as
+// OPTIONAL exactly the modifiers it should tolerate):
 //
-//   - ⌘K / ⌘I / ⌘J: the legacy AppShell listener checked only
-//     metaKey||ctrlKey + key - NO shift/alt guard - so ⌘⇧K, ⌘⌥I,
-//     Ctrl+Shift+J etc. all fired, on either OR BOTH of Meta/Ctrl. Chords
-//     are $mod+[Shift]+[Alt]+… plus legacyEitherMod (the other of
-//     Meta/Ctrl also optional on the entry and its twin). RATIONALE: this
-//     permissiveness means these chords keep hijacking the browser's
-//     DevTools shortcuts (⌘⌥I, Ctrl+Shift+J) exactly like the legacy
-//     listeners did - deliberately revisiting THAT is Phase 3 policy, not
-//     this PR.
+//   - ⌘K / ⌘I / ⌘J: STRICT single-press chords since Phase 4a. The 2a map
+//     kept the legacy AppShell listener's missing shift/alt guard as
+//     OPTIONAL Shift/Alt - so ⌘⌥I fired composer.focus and Ctrl+Shift+J
+//     fired next-needs-you, hijacking the browser's DevTools chords.
+//     docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md
+//     (Design decision 1) is the authority for dropping that optionality;
+//     ⌘⌥I, Ctrl+Shift+J and ⌘⇧J now revert to the browser. legacyEitherMod
+//     STAYS (the other of Meta/Ctrl optional on the entry and its twin):
+//     every legacy listener accepted metaKey||ctrlKey on every platform,
+//     and no browser-reserved chord collides with Meta+Ctrl.
 //   - ⌘': extra Shift allowed ([Shift] - the legacy listener had no shift
 //     guard), extra Alt NOT (the legacy !event.altKey AltGr guard).
 //   - ⌘B: strict - the legacy listener guarded !event.altKey &&
@@ -49,6 +51,14 @@ import { type KeySequence, parseChord, serializeChord, withOptionalModifier } fr
 import { type Binding, type BindingInput, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
 export const SETTINGS_SCOPE = "settings";
+export const CHEATSHEET_SCOPE = "cheatsheet";
+
+/** The default-map id of the "?" character-key trigger for the cheatsheet
+ * overlay. It is the one CONDITIONAL entry in the map: registered only while
+ * the characterKeyTriggers pref (stores/prefs.ts) is on - the WCAG 2.1.4
+ * character-key turn-off. shell/cheatsheet/cheatsheetController.ts's
+ * reconcile owns that invariant; this module only names the entry. */
+export const CHARACTER_KEY_TRIGGER_BINDING_ID = "cheatsheet.toggle#question";
 
 /** A default-map entry: a BindingInput plus the module-internal
  * legacyEitherMod marker (stripped before registerBinding - see modPair). */
@@ -73,7 +83,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     id: ACTIONS.paletteOpen,
     actionId: ACTIONS.paletteOpen,
     title: "Open the command palette",
-    chord: "$mod+[Shift]+[Alt]+K",
+    chord: "$mod+K",
     allowInEditable: true,
     allowInModal: true,
     legacyEitherMod: true,
@@ -95,7 +105,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     id: ACTIONS.composerFocus,
     actionId: ACTIONS.composerFocus,
     title: "Focus the composer",
-    chord: "$mod+[Shift]+[Alt]+I",
+    chord: "$mod+I",
     allowInEditable: true,
     legacyEitherMod: true,
   },
@@ -103,7 +113,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     id: ACTIONS.nextNeedsYou,
     actionId: ACTIONS.nextNeedsYou,
     title: "Go to the next session needing you",
-    chord: "$mod+[Shift]+[Alt]+J",
+    chord: "$mod+J",
     allowInEditable: true,
     legacyEitherMod: true,
   },
@@ -118,6 +128,19 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     allowInEditable: true,
     allowInModal: true,
     legacyEitherMod: true,
+  },
+  // Phase 4a (the p4 plan's Design decision 2): settings.open's action id IS
+  // the palette's "settings" command id, whose run owns the behavior
+  // (shell/palette/commands.ts; AppShell registers the action against the
+  // registry). Strict $mod chord - NO legacyEitherMod, only the plain
+  // cross-platform modPair twin. allowInEditable: ⌘, never collides with
+  // typing; the default modal suppression stays.
+  {
+    id: ACTIONS.settingsOpen,
+    actionId: ACTIONS.settingsOpen,
+    title: "Open settings",
+    chord: "$mod+,",
+    allowInEditable: true,
   },
   // Phase 3 navigation chords (the webui-keybindings-p3 approved map). All
   // six are strict single-modifier-family Alt chords with NO optional
@@ -169,12 +192,77 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
     title: "Scroll the transcript down one page",
     chord: "Alt+Shift+ArrowDown",
   },
+  // Phase 4a completes the Alt-scroll family (Alt = transcript, Shift =
+  // bigger step, Home/End = the ends) with the SAME plain policy as the
+  // Alt-arrow entries above: suppressed in editable targets so Home/End keep
+  // their native caret meaning there. The per-pane handlers were registered
+  // in Phase 3 (panes/session/transcript/flow/useTranscriptScrollKeys.ts);
+  // these entries only assign the chords.
+  {
+    id: ACTIONS.transcriptScrollTop,
+    actionId: ACTIONS.transcriptScrollTop,
+    title: "Scroll the transcript to the top",
+    chord: "Alt+Home",
+  },
+  {
+    id: ACTIONS.transcriptScrollBottom,
+    actionId: ACTIONS.transcriptScrollBottom,
+    title: "Scroll the transcript to the bottom",
+    chord: "Alt+End",
+  },
   {
     id: ACTIONS.settingsClose,
     actionId: ACTIONS.settingsClose,
     title: "Close settings",
     chord: "[Control]+[Alt]+[Shift]+[Meta]+Escape",
     scope: SETTINGS_SCOPE,
+    allowInEditable: true,
+  },
+  // Phase 4a (the p4 plan's Design decision 3): the cheatsheet overlay's
+  // triggers. $mod+/ is the primary (Slack precedent): not a printable
+  // character, so it fires from editable targets, and allowInModal so the
+  // same chord toggles the overlay CLOSED while it is open (the dialog's
+  // aria-modal would otherwise suppress it). Strict chord, NO
+  // legacyEitherMod - a new binding with no legacy listener to match.
+  {
+    id: ACTIONS.cheatsheetToggle,
+    actionId: ACTIONS.cheatsheetToggle,
+    title: "Show the keyboard shortcuts overlay",
+    chord: "$mod+/",
+    allowInEditable: true,
+    allowInModal: true,
+  },
+  // "?" is the secondary trigger (Design decision 3). It IS a printable
+  // character, so it never fires from an editable target (allowInEditable
+  // stays false) or over a modal. The chord lists Shift as OPTIONAL because
+  // tinykeys rejects an event carrying any modifier the binding does not
+  // name, and every common layout types "?" WITH Shift held - a bare "?"
+  // binding would never fire. Display drops optional modifiers
+  // (chordDisplayKeys), so the row still reads "?". The entry is
+  // CONDITIONAL: shell/cheatsheet/cheatsheetController.ts keeps it
+  // registered only while the characterKeyTriggers pref is on.
+  // Listed SECOND for the action so defaultInputFor (overrides.ts) keeps
+  // the $mod+/ entry's policy flags for overrides.
+  {
+    id: CHARACTER_KEY_TRIGGER_BINDING_ID,
+    actionId: ACTIONS.cheatsheetToggle,
+    title: "Show the keyboard shortcuts overlay",
+    chord: "[Shift]+?",
+    allowInEditable: false,
+  },
+  // The overlay's own Escape, scope-gated exactly like settings.close: the
+  // CheatsheetOverlay component pushes CHEATSHEET_SCOPE while it is open.
+  // In practice the OverlayPanel's own Escape handler claims the key first
+  // (it preventDefaults, which this binding's default
+  // ignoreIfDefaultPrevented gate then honors); this binding is the
+  // window-level backstop for a keydown whose target sits outside the
+  // dialog, and makes the close chord remappable like every other.
+  {
+    id: ACTIONS.cheatsheetClose,
+    actionId: ACTIONS.cheatsheetClose,
+    title: "Close the keyboard shortcuts overlay",
+    chord: "[Control]+[Alt]+[Shift]+[Meta]+Escape",
+    scope: CHEATSHEET_SCOPE,
     allowInEditable: true,
   },
 ];
@@ -252,6 +340,7 @@ export function registerDefaultBindingsForAction(registry: KeybindingsRegistry, 
 }
 
 export interface DefaultBindingShape {
+  id: string;
   scope: string;
   sequence: KeySequence;
 }
@@ -268,6 +357,7 @@ export function defaultBindingShapesForAction(actionId: string): DefaultBindingS
     const pair = modPair(input);
     for (const entry of pair ?? [input]) {
       shapes.push({
+        id: entry.id,
         scope: entry.scope ?? GLOBAL_SCOPE,
         sequence: typeof entry.chord === "string" ? parseChord(entry.chord) : entry.chord,
       });
@@ -277,6 +367,7 @@ export function defaultBindingShapesForAction(actionId: string): DefaultBindingS
 }
 
 export interface DefaultChordInfo {
+  id: string;
   scope: string;
   serialized: string;
 }
@@ -286,6 +377,7 @@ export interface DefaultChordInfo {
  * customized-marker comparison. */
 export function defaultBindingChordsForAction(actionId: string): DefaultChordInfo[] {
   return defaultBindingShapesForAction(actionId).map((shape) => ({
+    id: shape.id,
     scope: shape.scope,
     serialized: serializeChord(shape.sequence),
   }));

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -1,0 +1,172 @@
+// The default binding map: exactly the six shell chords that today live in six
+// independent keydown listeners (AppShell, RailHost, SelectionQuote,
+// Settings). Per-binding policy per chord matches today's behavior:
+//
+//   - ⌘K / ⌘I / ⌘J / ⌘' fire from editable targets (allowInEditable: true):
+//     none of today's listeners for these chords guards on the target.
+//   - ⌘B suppresses in editable targets (allowInEditable: false):
+//     RailHost guards so Ctrl+B keeps its emacs "cursor back" meaning in
+//     native text fields.
+//   - settings.close fires from editable targets too: today's Settings Escape
+//     listener is document-level with no editable guard.
+//   - ⌘K, ⌘B and ⌘' fire while a modal is open (allowInModal: true):
+//     AppShell deliberately exempts ⌘K from its blockedByOpenModal guard
+//     ("opening the palette while it's already open is a harmless no-op
+//     reset"), and RailHost's ⌘B / SelectionQuote's ⌘' listeners have no
+//     modal check at all. ⌘I / ⌘J keep the default suppression (AppShell's
+//     blockedByOpenModal covered exactly them), and so does settings.close -
+//     today a modal dialog claims Escape first via its FocusScope/OverlayPanel
+//     handler, which the dispatcher's per-binding defaultPrevented gate
+//     reproduces.
+//
+// Extra-modifier semantics are equally legacy-faithful (tinykeys matches
+// strictly, so each chord lists as OPTIONAL exactly the modifiers the legacy
+// listener ignored):
+//
+//   - ⌘K / ⌘I / ⌘J: the legacy AppShell listener checked only
+//     metaKey||ctrlKey + key - NO shift/alt guard - so ⌘⇧K, ⌘⌥I,
+//     Ctrl+Shift+J etc. all fired, on either OR BOTH of Meta/Ctrl. Chords
+//     are $mod+[Shift]+[Alt]+… plus legacyEitherMod (the other of
+//     Meta/Ctrl also optional on the entry and its twin). RATIONALE: this
+//     permissiveness means these chords keep hijacking the browser's
+//     DevTools shortcuts (⌘⌥I, Ctrl+Shift+J) exactly like the legacy
+//     listeners did - deliberately revisiting THAT is Phase 3 policy, not
+//     this PR.
+//   - ⌘': extra Shift allowed ([Shift] - the legacy listener had no shift
+//     guard), extra Alt NOT (the legacy !event.altKey AltGr guard).
+//   - ⌘B: strict - the legacy listener guarded !event.altKey &&
+//     !event.shiftKey.
+//   - Escape (settings.close): every modifier optional - the legacy
+//     listener checked only event.key === "Escape".
+//
+// settings.close is scope-gated: it lives in the settings scope, NOT global.
+// The Settings pane pushes that scope while it is open.
+
+import { ACTIONS } from "./actions";
+import { type KeySequence, parseChord, serializeChord, withOptionalModifier } from "./chord";
+import type { Binding, BindingInput, KeybindingsRegistry } from "./registry";
+
+export const SETTINGS_SCOPE = "settings";
+
+/** A default-map entry: a BindingInput plus the module-internal
+ * legacyEitherMod marker (stripped before registerBinding - see modPair). */
+interface DefaultBindingInput extends BindingInput {
+  /** Legacy "either or both of Meta/Ctrl" permissiveness: the AppShell
+   * ⌘K/⌘I/⌘J, RailHost ⌘B and SelectionQuote ⌘' listeners all checked
+   * metaKey||ctrlKey with no regard for the OTHER modifier's state (their
+   * guards rejected only Alt/Shift), so Meta+Ctrl+<key> fired. The
+   * complement of $mod is added as an OPTIONAL modifier on both this entry
+   * and its twin. Alt/Shift strictness is unaffected. */
+  legacyEitherMod?: boolean;
+}
+
+export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
+  {
+    id: ACTIONS.paletteOpen,
+    actionId: ACTIONS.paletteOpen,
+    chord: "$mod+[Shift]+[Alt]+K",
+    allowInEditable: true,
+    allowInModal: true,
+    legacyEitherMod: true,
+  },
+  // ignoreIfDefaultPrevented: false - RailHost's ⌘B listener guards only the
+  // editable target; it has no defaultPrevented check and toggles the rail
+  // even when an inner handler already claimed the keydown.
+  {
+    id: ACTIONS.railToggle,
+    actionId: ACTIONS.railToggle,
+    chord: "$mod+B",
+    allowInEditable: false,
+    allowInModal: true,
+    ignoreIfDefaultPrevented: false,
+    legacyEitherMod: true,
+  },
+  {
+    id: ACTIONS.composerFocus,
+    actionId: ACTIONS.composerFocus,
+    chord: "$mod+[Shift]+[Alt]+I",
+    allowInEditable: true,
+    legacyEitherMod: true,
+  },
+  {
+    id: ACTIONS.nextNeedsYou,
+    actionId: ACTIONS.nextNeedsYou,
+    chord: "$mod+[Shift]+[Alt]+J",
+    allowInEditable: true,
+    legacyEitherMod: true,
+  },
+  // The dispatcher preventDefaults when a handler accepts this chord; the
+  // legacy ⌘' listener never preventDefault'd. That superset is deliberate
+  // and harmless: nothing meaningful defaults on Ctrl/⌘+'.
+  {
+    id: ACTIONS.selectionQuote,
+    actionId: ACTIONS.selectionQuote,
+    chord: "$mod+[Shift]+'",
+    allowInEditable: true,
+    allowInModal: true,
+    legacyEitherMod: true,
+  },
+  {
+    id: ACTIONS.settingsClose,
+    actionId: ACTIONS.settingsClose,
+    chord: "[Control]+[Alt]+[Shift]+[Meta]+Escape",
+    scope: SETTINGS_SCOPE,
+    allowInEditable: true,
+  },
+];
+
+// tinykeys resolves "$mod" to Meta on Apple platforms and Control everywhere
+// else AT PARSE TIME, but every pre-dispatcher listener these bindings replace
+// accepted `event.metaKey || event.ctrlKey` on EVERY platform (a Mac user's
+// Ctrl+K opened the palette exactly like ⌘K). Registering the cross-platform
+// twin of each $mod chord preserves that. It also keeps the shell's jsdom
+// suites - where $mod resolves to Control but userEvent/fireEvent press Meta
+// chords - exercising the same code path production does.
+//
+// Returns the two entries to register for a $mod-sourced binding (platform
+// base + twin), or null when the chord has no $mod. With legacyEitherMod the
+// complement of $mod is added as an OPTIONAL modifier on both entries, so
+// pressing Meta and Ctrl together also fires - legacy accepted either or
+// both regardless of the other modifier's state.
+function modPair(input: DefaultBindingInput): [BindingInput, BindingInput] | null {
+  if (typeof input.chord !== "string" || !input.chord.includes("$mod")) return null;
+  const resolved = serializeChord(parseChord(input.chord));
+  let twinString: string | null = null;
+  for (const mod of ["Meta", "Control"] as const) {
+    const candidate = input.chord.replaceAll("$mod", mod);
+    if (serializeChord(parseChord(candidate)) !== resolved) twinString = candidate;
+  }
+  if (twinString === null) return null;
+  const { legacyEitherMod: _legacyEitherMod, ...base } = input;
+  const twin: BindingInput = { ...base, id: `${base.id}#mod-twin`, chord: twinString };
+  if (!input.legacyEitherMod) return [base, twin];
+  return [
+    { ...base, chord: withComplementOptional(parseChord(input.chord as string)) },
+    { ...twin, chord: withComplementOptional(parseChord(twinString)) },
+  ];
+}
+
+// Adds the OTHER of Meta/Ctrl as an optional modifier to every press that
+// requires one of them.
+function withComplementOptional(sequence: KeySequence): KeySequence {
+  let complement: string | null = null;
+  for (const press of sequence) {
+    if (press.modifiers.includes("Meta")) complement = "Control";
+    else if (press.modifiers.includes("Control")) complement = "Meta";
+  }
+  if (complement === null) return sequence;
+  return withOptionalModifier(sequence, complement);
+}
+
+/** Registers the full default map (plus each $mod chord's cross-platform
+ * twin); returns the registered entries. */
+export function registerDefaultBindings(registry: KeybindingsRegistry): Binding[] {
+  const registered: Binding[] = [];
+  for (const input of DEFAULT_BINDINGS) {
+    const pair = modPair(input);
+    for (const entry of pair ?? [input]) {
+      registered.push(registry.getState().registerBinding(entry));
+    }
+  }
+  return registered;
+}

--- a/cmd/evener-hub/frontend/src/keybindings/defaults.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/defaults.ts
@@ -44,13 +44,19 @@
 
 import { ACTIONS } from "./actions";
 import { type KeySequence, parseChord, serializeChord, withOptionalModifier } from "./chord";
-import type { Binding, BindingInput, KeybindingsRegistry } from "./registry";
+import { type Binding, type BindingInput, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
 export const SETTINGS_SCOPE = "settings";
 
 /** A default-map entry: a BindingInput plus the module-internal
  * legacyEitherMod marker (stripped before registerBinding - see modPair). */
 interface DefaultBindingInput extends BindingInput {
+  /** The action's user-facing title, shown by the Settings keybindings
+   * section. Kept on the default-map entry itself so the section's action
+   * list is sourced live from this map - a new action appears there
+   * automatically, and no second hand-maintained list can go stale (the
+   * survey's stale-HELP_ROWS lesson). */
+  title: string;
   /** Legacy "either or both of Meta/Ctrl" permissiveness: the AppShell
    * ⌘K/⌘I/⌘J, RailHost ⌘B and SelectionQuote ⌘' listeners all checked
    * metaKey||ctrlKey with no regard for the OTHER modifier's state (their
@@ -64,6 +70,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.paletteOpen,
     actionId: ACTIONS.paletteOpen,
+    title: "Open the command palette",
     chord: "$mod+[Shift]+[Alt]+K",
     allowInEditable: true,
     allowInModal: true,
@@ -75,6 +82,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.railToggle,
     actionId: ACTIONS.railToggle,
+    title: "Toggle the sidebar",
     chord: "$mod+B",
     allowInEditable: false,
     allowInModal: true,
@@ -84,6 +92,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.composerFocus,
     actionId: ACTIONS.composerFocus,
+    title: "Focus the composer",
     chord: "$mod+[Shift]+[Alt]+I",
     allowInEditable: true,
     legacyEitherMod: true,
@@ -91,6 +100,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.nextNeedsYou,
     actionId: ACTIONS.nextNeedsYou,
+    title: "Go to the next session needing you",
     chord: "$mod+[Shift]+[Alt]+J",
     allowInEditable: true,
     legacyEitherMod: true,
@@ -101,6 +111,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.selectionQuote,
     actionId: ACTIONS.selectionQuote,
+    title: "Quote the selection into the composer",
     chord: "$mod+[Shift]+'",
     allowInEditable: true,
     allowInModal: true,
@@ -109,6 +120,7 @@ export const DEFAULT_BINDINGS: readonly DefaultBindingInput[] = [
   {
     id: ACTIONS.settingsClose,
     actionId: ACTIONS.settingsClose,
+    title: "Close settings",
     chord: "[Control]+[Alt]+[Shift]+[Meta]+Escape",
     scope: SETTINGS_SCOPE,
     allowInEditable: true,
@@ -137,7 +149,7 @@ function modPair(input: DefaultBindingInput): [BindingInput, BindingInput] | nul
     if (serializeChord(parseChord(candidate)) !== resolved) twinString = candidate;
   }
   if (twinString === null) return null;
-  const { legacyEitherMod: _legacyEitherMod, ...base } = input;
+  const { legacyEitherMod: _legacyEitherMod, title: _title, ...base } = input;
   const twin: BindingInput = { ...base, id: `${base.id}#mod-twin`, chord: twinString };
   if (!input.legacyEitherMod) return [base, twin];
   return [
@@ -169,4 +181,60 @@ export function registerDefaultBindings(registry: KeybindingsRegistry): Binding[
     }
   }
   return registered;
+}
+
+/** Registers only the given action's default entries (plus the $mod twin),
+ * the per-action equivalent of registerDefaultBindings the overrides store
+ * uses to restore one action's defaults. Throws on an unknown action id. */
+export function registerDefaultBindingsForAction(registry: KeybindingsRegistry, actionId: string): Binding[] {
+  const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
+  if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
+  const registered: Binding[] = [];
+  for (const input of inputs) {
+    const pair = modPair(input);
+    for (const entry of pair ?? [input]) {
+      registered.push(registry.getState().registerBinding(entry));
+    }
+  }
+  return registered;
+}
+
+export interface DefaultBindingShape {
+  scope: string;
+  sequence: KeySequence;
+}
+
+/** The (scope, parsed chord) pairs registerDefaultBindingsForAction would
+ * register for the action, WITHOUT registering them: the validation layer
+ * simulates dropped-override restorations against these. Throws on an
+ * unknown action id. */
+export function defaultBindingShapesForAction(actionId: string): DefaultBindingShape[] {
+  const inputs = DEFAULT_BINDINGS.filter((input) => input.actionId === actionId);
+  if (inputs.length === 0) throw new Error(`unknown keybinding action "${actionId}"`);
+  const shapes: DefaultBindingShape[] = [];
+  for (const input of inputs) {
+    const pair = modPair(input);
+    for (const entry of pair ?? [input]) {
+      shapes.push({
+        scope: entry.scope ?? GLOBAL_SCOPE,
+        sequence: typeof entry.chord === "string" ? parseChord(entry.chord) : entry.chord,
+      });
+    }
+  }
+  return shapes;
+}
+
+export interface DefaultChordInfo {
+  scope: string;
+  serialized: string;
+}
+
+/** The display-oriented (scope, serialized chord) form of
+ * defaultBindingShapesForAction, for the read-only settings section's
+ * customized-marker comparison. */
+export function defaultBindingChordsForAction(actionId: string): DefaultChordInfo[] {
+  return defaultBindingShapesForAction(actionId).map((shape) => ({
+    scope: shape.scope,
+    serialized: serializeChord(shape.sequence),
+  }));
 }

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createKeybindingDispatcher, type KeybindingDispatcher } from "./dispatcher";
+import { createKeybindingsRegistry, type KeybindingsRegistry } from "./registry";
+
+// jsdom resolves tinykeys' "$mod" to "Control" on every host, so every Mod
+// chord in this file is pressed with ctrlKey and the tests stay
+// platform-deterministic.
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+function pressOn(target: Window | Element, init: KeyboardEventInit): KeyboardEvent {
+  const event = keydown(init);
+  target.dispatchEvent(event);
+  return event;
+}
+
+const MOD_K: KeyboardEventInit = { key: "k", code: "KeyK", ctrlKey: true };
+
+describe("dispatcher", () => {
+  let registry: KeybindingsRegistry;
+  let dispatcher: KeybindingDispatcher;
+  let detach: () => void;
+
+  afterEach(() => {
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+
+  function setup(options: { isModalOpen?: (event: KeyboardEvent) => boolean } = {}) {
+    registry = createKeybindingsRegistry();
+    dispatcher = createKeybindingDispatcher({ registry, ...options });
+    detach = dispatcher.attach(window);
+    return registry.getState();
+  }
+
+  test("runs the action bound to a matching chord and preventDefaults", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("palette.open", run);
+    state.registerBinding({ id: "b1", actionId: "palette.open", chord: "$mod+K" });
+    const event = pressOn(window, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("numpad and top-row aliases at dispatch: code-named bindings match only their physical key, plain spellings match both", () => {
+    // The tinykeys behavior the overlap predicate models (roborev PR #884
+    // round 9): a NumLock-on numpad-7 event is {key: "7", code: "Numpad7"},
+    // so a "Control+7" binding fires on BOTH rows' 7 (via key) while
+    // "Control+Numpad7" fires only on the numpad one (via code).
+    const state = setup();
+    const plain = vi.fn();
+    const numpad = vi.fn();
+    state.registerAction("plain", plain);
+    state.registerAction("numpad", numpad);
+    state.registerBinding({ id: "b1", actionId: "plain", chord: "Control+7" });
+    state.registerBinding({ id: "b2", actionId: "numpad", chord: "Control+Numpad7" });
+
+    pressOn(window, { key: "7", code: "Digit7", ctrlKey: true });
+    expect(plain).toHaveBeenCalledTimes(1);
+    expect(numpad).not.toHaveBeenCalled();
+
+    pressOn(window, { key: "7", code: "Numpad7", ctrlKey: true });
+    // Both match this event; the earlier-registered binding claims it - the
+    // silent shadowing the overlap check must catch BEFORE registration.
+    expect(plain).toHaveBeenCalledTimes(2);
+    expect(numpad).not.toHaveBeenCalled();
+  });
+
+  test("ignores IME composition keydowns (isComposing / keyCode 229)", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    pressOn(window, { ...MOD_K, isComposing: true });
+    pressOn(window, { ...MOD_K, keyCode: 229 });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  test("yields to a keydown another handler already claimed", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const inner = document.createElement("div");
+    inner.addEventListener("keydown", (event) => event.preventDefault());
+    document.body.appendChild(inner);
+    pressOn(inner, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  test("ignoreIfDefaultPrevented: false fires on a keydown another handler claimed", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    // RailHost's ⌘B listener has no defaultPrevented check (RailHost.tsx:59-66)
+    // and toggles even when an inner handler claimed the keydown; the flag
+    // exists so the module can express exactly that.
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+B", ignoreIfDefaultPrevented: false });
+    const inner = document.createElement("div");
+    inner.addEventListener("keydown", (event) => event.preventDefault());
+    document.body.appendChild(inner);
+    pressOn(inner, { key: "b", code: "KeyB", ctrlKey: true });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("suppresses bindings in editable targets by default", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    const event = pressOn(input, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("allowInEditable bindings fire from editable targets", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K", allowInEditable: true });
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    pressOn(input, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("the modal predicate suppresses bindings by default", () => {
+    const state = setup({ isModalOpen: () => true });
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K", allowInEditable: true });
+    const event = pressOn(window, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("allowInModal: true fires while the modal predicate reports open", () => {
+    // Today's ⌘K handler deliberately exempts palette.open from the modal
+    // guard (and RailHost's ⌘B / SelectionQuote's ⌘' listeners have no modal
+    // check at all), so the modal layer is per-binding, not blanket.
+    const state = setup({ isModalOpen: () => true });
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K", allowInModal: true });
+    pressOn(window, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("the default modal check sees an [aria-modal] ancestor of the target", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const modal = document.createElement("div");
+    modal.setAttribute("aria-modal", "true");
+    const inner = document.createElement("button");
+    modal.appendChild(inner);
+    document.body.appendChild(modal);
+    pressOn(inner, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    pressOn(window, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("scope stack top-down shadows the global scope for the same chord", () => {
+    const state = setup();
+    const globalRun = vi.fn();
+    const scopedRun = vi.fn();
+    state.registerAction("global.action", globalRun);
+    state.registerAction("scoped.action", scopedRun);
+    state.registerBinding({ id: "b1", actionId: "global.action", chord: "$mod+K" });
+    state.registerBinding({ id: "b2", actionId: "scoped.action", chord: "$mod+K", scope: "settings" });
+    pressOn(window, MOD_K);
+    expect(globalRun).toHaveBeenCalledTimes(1);
+    expect(scopedRun).not.toHaveBeenCalled();
+    state.pushScope("settings");
+    pressOn(window, MOD_K);
+    expect(scopedRun).toHaveBeenCalledTimes(1);
+    expect(globalRun).toHaveBeenCalledTimes(1);
+    state.popScope("settings");
+    pressOn(window, MOD_K);
+    expect(globalRun).toHaveBeenCalledTimes(2);
+  });
+
+  test("a scope without a matching binding falls through to global", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    state.pushScope("settings");
+    pressOn(window, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  test("a binding whose action is not registered does not fire or preventDefault", () => {
+    const state = setup();
+    state.registerBinding({ id: "b1", actionId: "missing", chord: "$mod+K" });
+    const event = pressOn(window, MOD_K);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("action handlers run in registration order until one handles the event", () => {
+    const state = setup();
+    const calls: string[] = [];
+    state.registerAction("a", () => {
+      calls.push("first");
+      return false; // declines: try the next handler
+    });
+    state.registerAction("a", () => {
+      calls.push("second");
+    });
+    state.registerAction("a", () => {
+      calls.push("third");
+    });
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const event = pressOn(window, MOD_K);
+    expect(calls).toEqual(["first", "second"]);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("an event every handler declines is not preventDefault'd", () => {
+    const state = setup();
+    state.registerAction("a", () => false);
+    state.registerAction("a", () => false);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const event = pressOn(window, MOD_K);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test("matches a synthetic keydown with no code (fireEvent-style), running the real event", () => {
+    // The pre-dispatcher listeners never looked at event.code, and the app's
+    // existing suites (and any app code dispatching a bare KeyboardEvent)
+    // construct codeless events that tinykeys' isKeyboardEvent gate would
+    // otherwise drop.
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const event = pressOn(window, { key: "k", ctrlKey: true });
+    expect(event.code).toBe("");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("matches a multi-press sequence", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "x y" });
+    pressOn(window, { key: "x", code: "KeyX" });
+    expect(run).not.toHaveBeenCalled();
+    const event = pressOn(window, { key: "y", code: "KeyY" });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test("a binding stops matching once unregistered", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    state.unregisterBinding("b1");
+    pressOn(window, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  test("detach removes the listener", () => {
+    const state = setup();
+    const run = vi.fn();
+    state.registerAction("a", run);
+    state.registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    detach();
+    pressOn(window, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    detach = () => undefined;
+  });
+});
+
+describe("default editable-target detection", () => {
+  test.each(["input", "textarea", "select"])("treats <%s> as editable", (tagName) => {
+    const registry = createKeybindingsRegistry();
+    const dispatcher = createKeybindingDispatcher({ registry });
+    const detach = dispatcher.attach(window);
+    const run = vi.fn();
+    registry.getState().registerAction("a", run);
+    registry.getState().registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const element = document.createElement(tagName);
+    document.body.appendChild(element);
+    pressOn(element, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+
+  test("treats a contenteditable element as editable", () => {
+    const registry = createKeybindingsRegistry();
+    const dispatcher = createKeybindingDispatcher({ registry });
+    const detach = dispatcher.attach(window);
+    const run = vi.fn();
+    registry.getState().registerAction("a", run);
+    registry.getState().registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    // jsdom does not implement the contentEditable/isContentEditable IDL
+    // properties, so the test sets the content attribute the dispatcher's
+    // [contenteditable] check (and tinykeys' own default ignore) matches.
+    const element = document.createElement("div");
+    element.setAttribute("contenteditable", "true");
+    document.body.appendChild(element);
+    pressOn(element, MOD_K);
+    expect(run).not.toHaveBeenCalled();
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+
+  test("an element inside a contenteditable=false island inside an editor is NOT editable", () => {
+    // The nearest contenteditable ancestor's VALUE decides: an explicitly
+    // non-editable control nested in an editor must not suppress bindings
+    // (e.g. Ctrl+B inside a toolbar embedded in a rich-text editor).
+    const registry = createKeybindingsRegistry();
+    const dispatcher = createKeybindingDispatcher({ registry });
+    const detach = dispatcher.attach(window);
+    const run = vi.fn();
+    registry.getState().registerAction("a", run);
+    registry.getState().registerBinding({ id: "b1", actionId: "a", chord: "$mod+K" });
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "true");
+    const island = document.createElement("div");
+    island.setAttribute("contenteditable", "false");
+    const button = document.createElement("button");
+    editor.appendChild(island);
+    island.appendChild(button);
+    document.body.appendChild(editor);
+    pressOn(button, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+    // ...while a plain descendant of the same editor still suppresses.
+    const plain = document.createElement("span");
+    editor.appendChild(plain);
+    pressOn(plain, MOD_K);
+    expect(run).toHaveBeenCalledTimes(1);
+    detach();
+    dispatcher.dispose();
+    document.body.innerHTML = "";
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/dispatcher.ts
@@ -1,0 +1,197 @@
+// The single window-level keydown dispatcher. Matching is tinykeys
+// (createKeybindingsHandler over the active scope set); precedence, in order:
+//
+//   1. IME composition keydowns (event.isComposing / keyCode 229) are ignored.
+//   2. The scope stack, top-down, then the global scope, decide WHICH binding
+//      a chord resolves to (the first/highest-precedence binding claims it).
+//   3. Per-binding policy on the matched binding, each flag reproducing one
+//      of the pre-dispatcher listeners' own guards:
+//      - ignoreIfDefaultPrevented (default true): an already-claimed keydown
+//        is ignored.
+//      - allowInModal (default false): an open modal suppresses the binding -
+//        [aria-modal="true"] ancestor of the event target by default, plus
+//        whatever store check the caller's injected predicate adds (the app
+//        wiring adds paletteStore.open there).
+//      - allowInEditable (default false): an editable event target suppresses
+//        the binding.
+//
+// The first (highest-precedence) binding for a chord claims it outright: a
+// firing binding preventDefaults and stops evaluation, and a shadowed or
+// policy-blocked binding never falls through to a lower-precedence twin.
+//
+// An event another handler already claimed (event.defaultPrevented) is
+// ignored per binding: ignoreIfDefaultPrevented defaults to true, matching
+// the pre-dispatcher AppShell ⌘K/⌘I/⌘J, Settings Escape, and SelectionQuote
+// ⌘' listeners - but NOT RailHost's ⌘B listener, which had no
+// defaultPrevented check and so binds with ignoreIfDefaultPrevented: false
+// in defaults.ts.
+
+import { createKeybindingsHandler, type KeybindingsMap } from "tinykeys";
+import { serializeChord } from "./chord";
+import { GLOBAL_SCOPE, type KeybindingsRegistry, type KeybindingsState, keybindingsRegistry } from "./registry";
+
+export type ModalOpenPredicate = (event: KeyboardEvent) => boolean;
+export type EditableTargetPredicate = (target: EventTarget | null) => boolean;
+
+/** Walks up from the target; the FIRST element bearing a contenteditable
+ * attribute decides - editable unless its value is "false" (empty string,
+ * "true" and "plaintext-only" are all editable), which is how the
+ * contentEditable IDL property inherits in a real browser. A
+ * contenteditable="false" island inside an editor (a toolbar, an embedded
+ * control) is therefore NOT editable. */
+function hasEditableContentEditableAncestor(target: HTMLElement): boolean {
+  for (let element: HTMLElement | null = target; element !== null; element = element.parentElement) {
+    const value = element.getAttribute("contenteditable");
+    if (value !== null) return value.toLowerCase() !== "false";
+  }
+  return false;
+}
+
+/** The ONE IME guard every keyboard handler in the app shares (the
+ * dispatcher below, the settings capture editor, AskDock's batch handlers):
+ * during composition, keydowns arrive with isComposing set, and some browsers
+ * report an IME COMMIT keydown (Enter that confirms text, not a submit) only
+ * through the legacy keyCode 229 fallback - both are text input, never a
+ * chord or an activation. */
+export function isIMECompositionKeydown(event: KeyboardEvent): boolean {
+  return event.isComposing || event.keyCode === 229;
+}
+
+/** shell/rail/RailHost.tsx's isEditableTarget, plus the contenteditable
+ * attribute walk above: isContentEditable alone already covers descendants
+ * of an editable ancestor in a real browser, but jsdom does not implement
+ * the property at all (it is undefined there), so the attribute walk stands
+ * in for it. Everything else doesn't count. */
+export const isEditableTarget: EditableTargetPredicate = (target) => {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.isContentEditable ||
+    hasEditableContentEditableAncestor(target) ||
+    target.tagName === "INPUT" ||
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "SELECT"
+  );
+};
+
+/** The DOM half of the shell's old blockedByOpenModal check. The palette is
+ * not an [aria-modal] element, so the app wiring (shell/installKeybindings.ts)
+ * composes this with a paletteStore.open store check. */
+export const isModalOpenTarget: ModalOpenPredicate = (event) => {
+  const target = event.target;
+  return target instanceof Element && target.closest('[aria-modal="true"]') !== null;
+};
+
+export interface DispatcherOptions {
+  /** Defaults to the app-wide registry singleton. */
+  registry?: KeybindingsRegistry;
+  isModalOpen?: ModalOpenPredicate;
+  isEditableTarget?: EditableTargetPredicate;
+}
+
+export interface KeybindingDispatcher {
+  handleKeyDown(event: KeyboardEvent): void;
+  /** Adds the keydown listener; returns the detach function. */
+  attach(target: Window): () => void;
+  /** Stops tracking the registry. Always pair with the attach disposer. */
+  dispose(): void;
+}
+
+export function createKeybindingDispatcher(options: DispatcherOptions = {}): KeybindingDispatcher {
+  const registry = options.registry ?? keybindingsRegistry;
+  const isModalOpen = options.isModalOpen ?? isModalOpenTarget;
+  const isEditable = options.isEditableTarget ?? isEditableTarget;
+
+  function buildHandler(state: KeybindingsState): EventListener {
+    const map: KeybindingsMap = {};
+    const claimed = new Set<string>();
+    const scopes = [...state.scopeStack].reverse();
+    scopes.push(GLOBAL_SCOPE);
+    for (const scope of scopes) {
+      for (const binding of state.bindings) {
+        if (binding.scope !== scope) continue;
+        const chordKey = serializeChord(binding.chord);
+        if (claimed.has(chordKey)) continue;
+        claimed.add(chordKey);
+        map[chordKey] = (event) => {
+          const real = realEvent ?? event;
+          if (binding.ignoreIfDefaultPrevented && real.defaultPrevented) return;
+          if (!binding.allowInModal && isModalOpen(real)) return;
+          if (!binding.allowInEditable && isEditable(real.target)) return;
+          const handlers = registry.getState().actions.get(binding.actionId);
+          if (!handlers || handlers.length === 0) return;
+          // Registration order, until one handler accepts (returns
+          // true/undefined); a handler returning false declines and the next
+          // is tried - the multi-instance equivalent of the per-component
+          // listeners this module replaced (one SelectionQuote per session
+          // pane; only the instance holding a selection acts). An event
+          // every handler declines is not preventDefault'd.
+          for (const run of handlers) {
+            if (run(real) === false) continue;
+            real.preventDefault();
+            return;
+          }
+        };
+      }
+    }
+    // ignore: () => false - the precedence layers above replace tinykeys'
+    // default ignore wholesale; the default would suppress EVERY binding from
+    // an editable target, which several shell chords explicitly allow.
+    return createKeybindingsHandler(map, { ignore: () => false });
+  }
+
+  let current = buildHandler(registry.getState());
+  const unsubscribe = registry.subscribe((state) => {
+    current = buildHandler(state);
+  });
+
+  // The binding handler tinykeys invokes receives whatever event object the
+  // handler was called with; when matching ran against a code-fallback view
+  // (see handleKeyDown), the REAL event is what's run through the binding.
+  // Single-threaded dispatch makes the stash safe: current() runs
+  // synchronously to completion inside the try.
+  let realEvent: KeyboardEvent | null = null;
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (isIMECompositionKeydown(event)) return;
+    // tinykeys' isKeyboardEvent gate drops any event with an empty `code`.
+    // Real browsers always set one, but synthetic keydowns (fireEvent-style
+    // tests, and any app code dispatching a bare KeyboardEvent) routinely
+    // omit it - and the pre-dispatcher listeners this module replaced never
+    // looked at `code`. Match against a view whose code falls back to the
+    // key: matching consults code only as a fallback for string keys
+    // (already case-insensitively matched on `key`) and as a second target
+    // for regex keys (where code===key can never add a match the key itself
+    // didn't already produce), so the fallback is semantically invisible.
+    const view =
+      event.code === "" && event.key !== ""
+        ? new KeyboardEvent("keydown", {
+            key: event.key,
+            code: event.key,
+            ctrlKey: event.ctrlKey,
+            altKey: event.altKey,
+            shiftKey: event.shiftKey,
+            metaKey: event.metaKey,
+          })
+        : event;
+    realEvent = event;
+    try {
+      current(view);
+    } finally {
+      realEvent = null;
+    }
+  }
+
+  return {
+    handleKeyDown,
+    attach(target) {
+      const listener = (event: Event) => {
+        if (event instanceof KeyboardEvent) handleKeyDown(event);
+      };
+      target.addEventListener("keydown", listener);
+      return () => target.removeEventListener("keydown", listener);
+    },
+    dispose() {
+      unsubscribe();
+    },
+  };
+}

--- a/cmd/evener-hub/frontend/src/keybindings/display.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/display.ts
@@ -1,0 +1,76 @@
+// Display sourcing for the two binding-list UIs (the Settings keybindings
+// section and the cheatsheet overlay): WHICH actions to list, in what order,
+// and which of an action's registered bindings is the one to show. Both
+// consumers read this module so the list can never drift into two
+// hand-maintained copies - the survey's stale-HELP_ROWS lesson, named as a
+// binding constraint in docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md.
+//
+// Deliberately React-free and store-free like the rest of src/keybindings/:
+// the registry's bindings array and the characterKeyTriggers pref value are
+// passed in by the caller.
+
+import { serializeChord } from "./chord";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS, defaultBindingChordsForAction } from "./defaults";
+import type { Binding } from "./registry";
+
+export interface ActionDisplayRow {
+  actionId: string;
+  title: string;
+}
+
+/** One row per action, in default-map order. Module-level because it derives
+ * entirely from the compiled-in default map; the effective chord each row
+ * shows is read from the live registry at render. */
+export const ACTION_DISPLAY_ROWS: readonly ActionDisplayRow[] = (() => {
+  const seen = new Set<string>();
+  const rows: ActionDisplayRow[] = [];
+  for (const input of DEFAULT_BINDINGS) {
+    if (seen.has(input.actionId)) continue;
+    seen.add(input.actionId);
+    rows.push({ actionId: input.actionId, title: input.title });
+  }
+  return rows;
+})();
+
+/** The bindings to display for an action, as the effective chord list: the
+ * override alone when one is applied (it replaces the action's whole chord
+ * set), else every non-twin default entry - the platform base entry plus any
+ * extra default chords of the same action (cheatsheet.toggle's "?" alongside
+ * "$mod+/"). The `#mod-twin` entries are the same chord's cross-platform
+ * spelling, never shown. Empty when the action is unbound. */
+export function displayBindingsFor(bindings: readonly Binding[], actionId: string): Binding[] {
+  const owned = bindings.filter((b) => b.actionId === actionId);
+  const override = owned.find((b) => b.id === `${actionId}#override`);
+  if (override !== undefined) return [override];
+  const nonTwin = owned.filter((b) => !b.id.endsWith("#mod-twin"));
+  return nonTwin.length > 0 ? nonTwin : owned;
+}
+
+/** The single-binding form of displayBindingsFor (the Settings section shows
+ * one chord per row): the override when present, else the platform base
+ * entry, else whatever binding the action has left. */
+export function displayBindingFor(bindings: readonly Binding[], actionId: string): Binding | undefined {
+  return displayBindingsFor(bindings, actionId)[0];
+}
+
+/** Whether the action's effective bindings differ from its default map
+ * entries - including the unbound (override `chord: null`) case, where the
+ * effective set is empty. The comparison is pref-aware about the ONE
+ * conditional default entry: the "?" character-key trigger is part of the
+ * default map only while characterKeyTriggers is on, so turning the pref off
+ * (which unregisters that binding) is not itself a customization. */
+export function isActionCustomized(
+  bindings: readonly Binding[],
+  actionId: string,
+  characterKeyTriggers: boolean,
+): boolean {
+  const effective = bindings
+    .filter((b) => b.actionId === actionId)
+    .map((b) => `${b.scope} ${serializeChord(b.chord)}`)
+    .sort();
+  const defaults = defaultBindingChordsForAction(actionId)
+    .filter((info) => characterKeyTriggers || info.id !== CHARACTER_KEY_TRIGGER_BINDING_ID)
+    .map((info) => `${info.scope} ${info.serialized}`)
+    .sort();
+  return effective.length !== defaults.length || effective.some((entry, i) => entry !== defaults[i]);
+}

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "vitest";
+import { ACTIONS } from "./actions";
+import { serializeChord } from "./chord";
+import { registerDefaultBindings } from "./defaults";
+import { rebindAction, restoreDefaultBinding } from "./overrides";
+import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
+
+function withDefaults(): KeybindingsRegistry {
+  const registry = createKeybindingsRegistry();
+  registerDefaultBindings(registry);
+  return registry;
+}
+
+function bindingsFor(registry: KeybindingsRegistry, actionId: string) {
+  return registry.getState().bindings.filter((b) => b.actionId === actionId);
+}
+
+describe("rebindAction", () => {
+  test("replaces the default binding AND its mod-twin with a single override entry", () => {
+    const registry = withDefaults();
+    expect(bindingsFor(registry, ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+
+    const bindings = bindingsFor(registry, ACTIONS.paletteOpen);
+    expect(bindings).toHaveLength(1);
+    const override = bindings[0];
+    expect(override?.id).toBe(`${ACTIONS.paletteOpen}#override`);
+    expect(serializeChord(override?.chord ?? [])).toBe("Control+P");
+  });
+
+  test("keeps the default's scope and policy flags - a rebind changes the chord, not the guards", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.railToggle, "Control+Alt+B");
+    const override = bindingsFor(registry, ACTIONS.railToggle)[0];
+    expect(override?.scope).toBe(GLOBAL_SCOPE);
+    expect(override?.allowInEditable).toBe(false);
+    expect(override?.allowInModal).toBe(true);
+    expect(override?.ignoreIfDefaultPrevented).toBe(false);
+  });
+
+  test("keeps a non-global default's scope (settings.close stays in the settings scope)", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.settingsClose, "Control+Shift+Escape");
+    const override = bindingsFor(registry, ACTIONS.settingsClose)[0];
+    expect(override?.scope).toBe("settings");
+    expect(override?.allowInEditable).toBe(true);
+  });
+
+  test("does not twin-expand the override chord: the user chord binds exactly what was written", () => {
+    const registry = withDefaults();
+    // "$mod" resolves to Control under jsdom; a twin would add a Meta entry.
+    rebindAction(registry, ACTIONS.paletteOpen, "$mod+P");
+    expect(bindingsFor(registry, ACTIONS.paletteOpen)).toHaveLength(1);
+  });
+
+  test("a null chord unbinds the action entirely", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, null);
+    expect(bindingsFor(registry, ACTIONS.paletteOpen)).toHaveLength(0);
+    // Other actions are untouched.
+    expect(bindingsFor(registry, ACTIONS.railToggle)).toHaveLength(2);
+  });
+
+  test("re-applying the same override is idempotent", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+    const first = bindingsFor(registry, ACTIONS.paletteOpen);
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+    const second = bindingsFor(registry, ACTIONS.paletteOpen);
+    expect(second).toHaveLength(1);
+    expect(serializeChord(second[0]?.chord ?? [])).toBe(serializeChord(first[0]?.chord ?? []));
+  });
+
+  test("a later override replaces an earlier one (last rule wins)", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+U");
+    const bindings = bindingsFor(registry, ACTIONS.paletteOpen);
+    expect(bindings).toHaveLength(1);
+    expect(serializeChord(bindings[0]?.chord ?? [])).toBe("Control+U");
+  });
+
+  test("throws on an unknown action id and leaves the registry unchanged", () => {
+    const registry = withDefaults();
+    const before = registry.getState().bindings;
+    expect(() => rebindAction(registry, "no.such.action", "Control+P")).toThrow(/unknown/);
+    expect(registry.getState().bindings).toEqual(before);
+  });
+
+  test("throws on an unparseable chord and leaves the registry unchanged", () => {
+    const registry = withDefaults();
+    const before = registry.getState().bindings;
+    expect(() => rebindAction(registry, ACTIONS.paletteOpen, "")).toThrow();
+    expect(registry.getState().bindings).toEqual(before);
+  });
+
+  test("throws on a conflict with another action's effective binding, atomically", () => {
+    const registry = withDefaults();
+    registry.getState().registerBinding({ id: "other", actionId: "other.action", chord: "Control+X" });
+    const before = registry.getState().bindings;
+    expect(() => rebindAction(registry, ACTIONS.paletteOpen, "Control+X")).toThrow(/conflict/);
+    // The failure is atomic: palette.open's default + twin survive intact.
+    expect(registry.getState().bindings).toEqual(before);
+  });
+
+  test("no conflict when the same chord lives in a different scope", () => {
+    const registry = withDefaults();
+    registry
+      .getState()
+      .registerBinding({ id: "other", actionId: "other.action", chord: "Control+X", scope: "settings" });
+    expect(() => rebindAction(registry, ACTIONS.paletteOpen, "Control+X")).not.toThrow();
+  });
+});
+
+describe("restoreDefaultBinding", () => {
+  test("restores the default and its mod-twin after an override", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+P");
+    restoreDefaultBinding(registry, ACTIONS.paletteOpen);
+    expect(bindingsFor(registry, ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("restores the default after an unbind", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, null);
+    restoreDefaultBinding(registry, ACTIONS.paletteOpen);
+    expect(bindingsFor(registry, ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  test("is a no-op equivalent on an action that was never overridden", () => {
+    const registry = withDefaults();
+    restoreDefaultBinding(registry, ACTIONS.paletteOpen);
+    expect(bindingsFor(registry, ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("throws on an unknown action id", () => {
+    const registry = withDefaults();
+    expect(() => restoreDefaultBinding(registry, "no.such.action")).toThrow(/unknown/);
+  });
+});
+
+describe("rebindAction overlap conflicts", () => {
+  test("throws when the chord only overlaps another action's OPTIONAL modifiers, atomically", () => {
+    // Control+K matches palette.open's Control+[Meta]+[Shift]+[Alt]+K at
+    // dispatch time; the earlier-registered default would shadow the override.
+    const registry = withDefaults();
+    const before = registry.getState().bindings;
+    expect(() => rebindAction(registry, ACTIONS.composerFocus, "Control+K")).toThrow(/conflict/);
+    expect(registry.getState().bindings).toEqual(before);
+  });
+
+  test("accepts a genuinely non-overlapping chord (extra required modifier nothing allows)", () => {
+    const registry = withDefaults();
+    expect(() => rebindAction(registry, ACTIONS.composerFocus, "Control+Alt+B")).not.toThrow();
+    const override = bindingsFor(registry, ACTIONS.composerFocus)[0];
+    expect(serializeChord(override?.chord ?? [])).toBe("Control+Alt+B");
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { ACTIONS } from "./actions";
 import { serializeChord } from "./chord";
-import { registerDefaultBindings } from "./defaults";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, registerDefaultBindings } from "./defaults";
 import { rebindAction, restoreDefaultBinding } from "./overrides";
 import { createKeybindingsRegistry, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
@@ -124,6 +124,32 @@ describe("restoreDefaultBinding", () => {
     expect(bindingsFor(registry, ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
       ACTIONS.paletteOpen,
       `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("with the character-key pref off, the restore does not re-register the ? trigger", () => {
+    const registry = withDefaults();
+    // What the cheatsheetController does while the pref is off: the live
+    // registry has no "?" entry. A restore that re-registered it would
+    // resurrect a binding the user turned off (and could exact-match a
+    // surviving "Shift+?" override elsewhere).
+    registry.getState().unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+    rebindAction(registry, ACTIONS.cheatsheetToggle, "Control+Shift+/");
+    restoreDefaultBinding(registry, ACTIONS.cheatsheetToggle, { characterKeyTriggers: false });
+    expect(bindingsFor(registry, ACTIONS.cheatsheetToggle).map((b) => b.id)).toEqual([
+      ACTIONS.cheatsheetToggle,
+      `${ACTIONS.cheatsheetToggle}#mod-twin`,
+    ]);
+  });
+
+  test("without the pref option the restore still registers the ? trigger (pref-on default)", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.cheatsheetToggle, "Control+Shift+/");
+    restoreDefaultBinding(registry, ACTIONS.cheatsheetToggle);
+    expect(bindingsFor(registry, ACTIONS.cheatsheetToggle).map((b) => b.id)).toEqual([
+      ACTIONS.cheatsheetToggle,
+      `${ACTIONS.cheatsheetToggle}#mod-twin`,
+      CHARACTER_KEY_TRIGGER_BINDING_ID,
     ]);
   });
 

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.test.ts
@@ -151,8 +151,8 @@ describe("restoreDefaultBinding", () => {
 
 describe("rebindAction overlap conflicts", () => {
   test("throws when the chord only overlaps another action's OPTIONAL modifiers, atomically", () => {
-    // Control+K matches palette.open's Control+[Meta]+[Shift]+[Alt]+K at
-    // dispatch time; the earlier-registered default would shadow the override.
+    // Control+K matches palette.open's Control+[Meta]+K at dispatch time;
+    // the earlier-registered default would shadow the override.
     const registry = withDefaults();
     const before = registry.getState().bindings;
     expect(() => rebindAction(registry, ACTIONS.composerFocus, "Control+K")).toThrow(/conflict/);

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.ts
@@ -68,9 +68,20 @@ export function rebindAction(registry: KeybindingsRegistry, actionId: string, ch
 
 /** Restores the action's default binding(s) (plus the `$mod` twin), removing
  * any override or unbind. Idempotent on an action that was never overridden.
- * Throws on an unknown action id. */
-export function restoreDefaultBinding(registry: KeybindingsRegistry, actionId: string): void {
+ * Throws on an unknown action id.
+ *
+ * `characterKeyTriggers: false` mirrors the character-key pref into the
+ * restore (finding 27): with the pref off the conditional "?" entry is not
+ * re-registered - the cheatsheetController owns it and re-adds it when the
+ * pref turns on. The caller (the overrides store) knows the pref; the
+ * simulation (validation.ts via defaultBindingShapesForAction) consults the
+ * SAME inclusion test, so restore and simulation stay in lockstep. */
+export function restoreDefaultBinding(
+  registry: KeybindingsRegistry,
+  actionId: string,
+  options?: { characterKeyTriggers?: boolean },
+): void {
   defaultInputFor(actionId);
   removeActionBindings(registry, actionId);
-  registerDefaultBindingsForAction(registry, actionId);
+  registerDefaultBindingsForAction(registry, actionId, options);
 }

--- a/cmd/evener-hub/frontend/src/keybindings/overrides.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/overrides.ts
@@ -1,0 +1,76 @@
+// User override application for the keybinding registry: rebindAction is the
+// one primitive the overrides store (src/stores/keybindings.ts) applies each
+// validated rule through. A rebind replaces the action's CURRENT binding(s) -
+// the default entry and its cross-platform `#mod-twin`, or an earlier
+// `#override` - with a single binding that keeps the default's scope and
+// policy flags (allowInEditable/allowInModal/ignoreIfDefaultPrevented): a
+// rebind changes the chord, never the action's guards. The override chord
+// binds exactly what the user wrote - no twin expansion, because user chords
+// are platform-explicit (a `$mod` spelling resolves at parse time).
+//
+// Every throwing path (unknown action, unparseable chord, conflict with
+// another action's effective binding) throws BEFORE mutating the registry, so
+// a failed rebind never leaves the action half-unbound. The store's semantic
+// validation layer (validation.ts) pre-checks the same conditions and skips
+// bad rules with warnings, so these throws should never reach startup; they
+// exist so a direct caller cannot corrupt the registry either.
+
+import { chordsOverlap, parseChord, serializeChord } from "./chord";
+import { DEFAULT_BINDINGS, registerDefaultBindingsForAction } from "./defaults";
+import { type BindingInput, GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
+
+function defaultInputFor(actionId: string): BindingInput {
+  const input = DEFAULT_BINDINGS.find((b) => b.actionId === actionId);
+  if (input === undefined) throw new Error(`unknown keybinding action "${actionId}"`);
+  return input;
+}
+
+/** Removes every binding the action currently has (default, `#mod-twin`,
+ * `#override`); the registry-equivalent of an unbound action. */
+export function removeActionBindings(registry: KeybindingsRegistry, actionId: string): void {
+  const state = registry.getState();
+  for (const binding of state.bindings) {
+    if (binding.actionId === actionId) state.unregisterBinding(binding.id);
+  }
+}
+
+/** Applies one override rule: `chord` rebinds the action, null unbinds it.
+ * Re-applying the same override is idempotent; a later override replaces an
+ * earlier one (last rule wins, matching the wire payload). Throws - without
+ * mutating the registry - on an unknown action id, an unparseable chord, or a
+ * conflict with another action's effective binding in the same scope. */
+export function rebindAction(registry: KeybindingsRegistry, actionId: string, chord: string | null): void {
+  const defaultInput = defaultInputFor(actionId);
+  if (chord === null) {
+    removeActionBindings(registry, actionId);
+    return;
+  }
+  const sequence = parseChord(chord);
+  const serialized = serializeChord(sequence);
+  const scope = defaultInput.scope ?? GLOBAL_SCOPE;
+  for (const existing of registry.getState().bindings) {
+    if (existing.actionId === actionId) continue;
+    if (existing.scope === scope && chordsOverlap(existing.chord, sequence)) {
+      throw new Error(`keybinding conflict: "${serialized}" in scope "${scope}" is already bound by "${existing.id}"`);
+    }
+  }
+  removeActionBindings(registry, actionId);
+  registry.getState().registerBinding({
+    id: `${defaultInput.id}#override`,
+    actionId,
+    chord: sequence,
+    ...(defaultInput.scope === undefined ? {} : { scope: defaultInput.scope }),
+    allowInEditable: defaultInput.allowInEditable,
+    allowInModal: defaultInput.allowInModal,
+    ignoreIfDefaultPrevented: defaultInput.ignoreIfDefaultPrevented,
+  });
+}
+
+/** Restores the action's default binding(s) (plus the `$mod` twin), removing
+ * any override or unbind. Idempotent on an action that was never overridden.
+ * Throws on an unknown action id. */
+export function restoreDefaultBinding(registry: KeybindingsRegistry, actionId: string): void {
+  defaultInputFor(actionId);
+  removeActionBindings(registry, actionId);
+  registerDefaultBindingsForAction(registry, actionId);
+}

--- a/cmd/evener-hub/frontend/src/keybindings/registry.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test, vi } from "vitest";
+import { createKeybindingsRegistry, GLOBAL_SCOPE } from "./registry";
+
+describe("action registration", () => {
+  test("registers and unregisters an action", () => {
+    const registry = createKeybindingsRegistry();
+    const run = vi.fn();
+    const unregister = registry.getState().registerAction("palette.open", run);
+    expect(registry.getState().actions.get("palette.open")).toEqual([run]);
+    unregister();
+    expect(registry.getState().actions.has("palette.open")).toBe(false);
+  });
+
+  test("multiple handlers coexist per action id; a disposer removes only its own registration", () => {
+    // SelectionQuote mounts one instance per session pane, each registering
+    // selection.quote - the multi-instance equivalent of the old per-instance
+    // document listeners. Overwriting or clobbering across instances breaks
+    // ⌘' in multi-pane workspaces.
+    const registry = createKeybindingsRegistry();
+    const first = vi.fn();
+    const second = vi.fn();
+    registry.getState().registerAction("a", first);
+    const unregisterSecond = registry.getState().registerAction("a", second);
+    unregisterSecond();
+    expect(registry.getState().actions.get("a")).toEqual([first]);
+  });
+
+  test("a stale disposer cannot remove a later registration of the same id", () => {
+    const registry = createKeybindingsRegistry();
+    const first = vi.fn();
+    const second = vi.fn();
+    const unregisterFirst = registry.getState().registerAction("a", first);
+    unregisterFirst();
+    registry.getState().registerAction("a", second);
+    unregisterFirst(); // stale: must not clobber the second registration
+    expect(registry.getState().actions.get("a")).toEqual([second]);
+  });
+});
+
+describe("binding registration", () => {
+  test("applies defaults: global scope, editable targets suppressed", () => {
+    const registry = createKeybindingsRegistry();
+    const binding = registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(binding.scope).toBe(GLOBAL_SCOPE);
+    expect(binding.allowInEditable).toBe(false);
+    expect(registry.getState().bindings).toHaveLength(1);
+  });
+
+  test("allowInModal defaults to false and is stored verbatim when set", () => {
+    const registry = createKeybindingsRegistry();
+    const plain = registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(plain.allowInModal).toBe(false);
+    const exempt = registry
+      .getState()
+      .registerBinding({ id: "b2", actionId: "a1", chord: "$mod+J", allowInModal: true });
+    expect(exempt.allowInModal).toBe(true);
+  });
+
+  test("accepts a pre-parsed chord sequence", () => {
+    const registry = createKeybindingsRegistry();
+    const parsed = registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    const fromAst = registry.getState().registerBinding({ id: "b2", actionId: "a1", chord: parsed.chord, scope: "s" });
+    expect(fromAst.chord).toEqual(parsed.chord);
+  });
+
+  test("rejects the same chord twice in the same scope", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(() => registry.getState().registerBinding({ id: "b2", actionId: "a2", chord: "$mod+K" })).toThrow(
+      /conflict/i,
+    );
+    expect(registry.getState().bindings).toHaveLength(1);
+  });
+
+  test("allows the same chord in different scopes (stack order shadows)", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "Escape" });
+    expect(() =>
+      registry.getState().registerBinding({ id: "b2", actionId: "a2", chord: "Escape", scope: "settings" }),
+    ).not.toThrow();
+  });
+
+  test("rejects a duplicate binding id even across scopes", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(() =>
+      registry.getState().registerBinding({ id: "b1", actionId: "a2", chord: "$mod+J", scope: "settings" }),
+    ).toThrow(/b1/);
+  });
+
+  test("unregisterBinding removes the entry", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K" });
+    expect(registry.getState().unregisterBinding("b1")).toBe(true);
+    expect(registry.getState().bindings).toHaveLength(0);
+    expect(registry.getState().unregisterBinding("b1")).toBe(false);
+  });
+
+  test("carries an optional structured when clause without evaluating it", () => {
+    const registry = createKeybindingsRegistry();
+    const binding = registry
+      .getState()
+      .registerBinding({ id: "b1", actionId: "a1", chord: "$mod+K", when: { pane: "settings" } });
+    expect(binding.when).toEqual({ pane: "settings" });
+  });
+});
+
+describe("scope stack", () => {
+  test("push appends, pop removes the topmost matching scope", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().pushScope("a");
+    registry.getState().pushScope("b");
+    registry.getState().pushScope("a");
+    expect(registry.getState().scopeStack).toEqual(["a", "b", "a"]);
+    expect(registry.getState().popScope("a")).toBe(true);
+    expect(registry.getState().scopeStack).toEqual(["a", "b"]);
+    expect(registry.getState().popScope("missing")).toBe(false);
+    expect(registry.getState().scopeStack).toEqual(["a", "b"]);
+  });
+
+  test("the pushScope disposer removes its own entry and is idempotent", () => {
+    const registry = createKeybindingsRegistry();
+    registry.getState().pushScope("a");
+    const dispose = registry.getState().pushScope("b");
+    dispose();
+    expect(registry.getState().scopeStack).toEqual(["a"]);
+    dispose();
+    expect(registry.getState().scopeStack).toEqual(["a"]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/registry.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/registry.ts
@@ -1,0 +1,169 @@
+// The keybinding registry: a vanilla zustand store (same pattern as
+// shell/palette/paletteController.ts) holding the action registry (action id
+// -> run function), the binding entries, and the scope stack the dispatcher
+// evaluates top-down. Pure logic - no DOM, no React.
+
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { type KeySequence, parseChord, serializeChord } from "./chord";
+
+/** The implicit bottom of every scope stack: bindings with no `scope` land here. */
+export const GLOBAL_SCOPE = "global";
+
+/** Structured when-clause, carried for Phase 2b. Task 1 stores it verbatim and
+ * never evaluates it: scope-stack membership is the only gating the dispatcher
+ * applies. */
+export type WhenClause = Readonly<Record<string, string | boolean>>;
+
+/** An action handler. Returning false DECLINES the event - the dispatcher
+ * tries the action's next handler (multi-instance components like
+ * SelectionQuote register one handler per mounted instance, and only the
+ * instance holding state that can act accepts). Returning true or undefined
+ * reports the event handled and stops iteration. */
+// biome-ignore lint/suspicious/noConfusingVoidType: "false declines, anything else (including a void fall-through) accepts" IS the contract; boolean|undefined would reject the existing void-bodied handlers
+export type ActionRunner = (event: KeyboardEvent) => boolean | void;
+
+export interface Binding {
+  id: string;
+  actionId: string;
+  chord: KeySequence;
+  scope: string;
+  when?: WhenClause;
+  allowInEditable: boolean;
+  /** When true, an open modal does NOT suppress this binding. Default false.
+   * Three of the shell's pre-dispatcher listeners had no modal guard at all
+   * (AppShell's deliberate ⌘K exemption, RailHost's ⌘B, SelectionQuote's ⌘'),
+   * so modal suppression is per-binding rather than a blanket layer. */
+  allowInModal: boolean;
+  /** When true (the default), a keydown another handler already claimed
+   * (event.defaultPrevented) suppresses this binding. RailHost's ⌘B listener
+   * has no such check, so rail.toggle sets this to false. */
+  ignoreIfDefaultPrevented: boolean;
+}
+
+export interface BindingInput {
+  id: string;
+  actionId: string;
+  /** A tinykeys keybinding string ("$mod+K") or an already-parsed sequence. */
+  chord: string | KeySequence;
+  /** Defaults to the global scope. */
+  scope?: string;
+  when?: WhenClause;
+  /** Defaults to false: bindings are suppressed while an editable target has focus. */
+  allowInEditable?: boolean;
+  /** Defaults to false: bindings are suppressed while a modal is open. */
+  allowInModal?: boolean;
+  /** Defaults to true. */
+  ignoreIfDefaultPrevented?: boolean;
+}
+
+export interface KeybindingsState {
+  /** Action id -> its handlers, in registration order. */
+  actions: ReadonlyMap<string, readonly ActionRunner[]>;
+  bindings: readonly Binding[];
+  /** Bottom-to-top; the dispatcher evaluates it top-down before the global scope. */
+  scopeStack: readonly string[];
+  /** Appends a handler for the action; the returned disposer removes ONLY
+   * this registration (by identity), never another instance's handler for
+   * the same action, and is idempotent. */
+  registerAction(id: string, run: ActionRunner): () => void;
+  /**
+   * Throws on a duplicate binding id, or on a chord conflict: the same chord
+   * already bound in the SAME scope. The same chord in a DIFFERENT scope is
+   * not a conflict - scope-stack order shadows it deterministically.
+   */
+  registerBinding(input: BindingInput): Binding;
+  unregisterBinding(id: string): boolean;
+  /** Returns an idempotent disposer that pops this entry. */
+  pushScope(scope: string): () => void;
+  /** Removes the topmost matching scope; false when the scope is not on the stack. */
+  popScope(scope: string): boolean;
+}
+
+export type KeybindingsRegistry = StoreApi<KeybindingsState>;
+
+export function createKeybindingsRegistry(): KeybindingsRegistry {
+  return createStore<KeybindingsState>()((set, get) => ({
+    actions: new Map(),
+    bindings: [],
+    scopeStack: [],
+
+    registerAction(id, run) {
+      set((s) => {
+        const actions = new Map(s.actions);
+        actions.set(id, [...(actions.get(id) ?? []), run]);
+        return { actions };
+      });
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        set((s) => {
+          const list = s.actions.get(id);
+          if (!list) return {};
+          const index = list.indexOf(run);
+          if (index === -1) return {};
+          const actions = new Map(s.actions);
+          const next = [...list.slice(0, index), ...list.slice(index + 1)];
+          if (next.length === 0) actions.delete(id);
+          else actions.set(id, next);
+          return { actions };
+        });
+      };
+    },
+
+    registerBinding(input) {
+      const chord = typeof input.chord === "string" ? parseChord(input.chord) : input.chord;
+      const binding: Binding = {
+        id: input.id,
+        actionId: input.actionId,
+        chord,
+        scope: input.scope ?? GLOBAL_SCOPE,
+        ...(input.when === undefined ? {} : { when: input.when }),
+        allowInEditable: input.allowInEditable ?? false,
+        allowInModal: input.allowInModal ?? false,
+        ignoreIfDefaultPrevented: input.ignoreIfDefaultPrevented ?? true,
+      };
+      const serialized = serializeChord(chord);
+      for (const existing of get().bindings) {
+        if (existing.id === binding.id) {
+          throw new Error(`keybinding id "${binding.id}" is already registered`);
+        }
+        if (existing.scope === binding.scope && serializeChord(existing.chord) === serialized) {
+          throw new Error(
+            `keybinding conflict: "${serialized}" in scope "${binding.scope}" is already bound by "${existing.id}"`,
+          );
+        }
+      }
+      set((s) => ({ bindings: [...s.bindings, binding] }));
+      return binding;
+    },
+
+    unregisterBinding(id) {
+      const found = get().bindings.some((b) => b.id === id);
+      if (found) set((s) => ({ bindings: s.bindings.filter((b) => b.id !== id) }));
+      return found;
+    },
+
+    pushScope(scope) {
+      set((s) => ({ scopeStack: [...s.scopeStack, scope] }));
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        get().popScope(scope);
+      };
+    },
+
+    popScope(scope) {
+      const stack = get().scopeStack;
+      const index = stack.lastIndexOf(scope);
+      if (index === -1) return false;
+      set({ scopeStack: [...stack.slice(0, index), ...stack.slice(index + 1)] });
+      return true;
+    },
+  }));
+}
+
+/** The app-wide registry. Task 2 wires it to AppShell; tests build their own
+ * with createKeybindingsRegistry(). */
+export const keybindingsRegistry = createKeybindingsRegistry();

--- a/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
@@ -281,9 +281,9 @@ describe("validateOverrideRules dropped-override restorations", () => {
 
 describe("validateOverrideRules overlap conflicts", () => {
   test("flags an override whose exact chord overlaps a default's OPTIONAL modifiers (dispatch would shadow it)", () => {
-    // palette.open's default is Control+[Meta]+[Shift]+[Alt]+K: a plain
-    // Control+K matches it at dispatch time, and the earlier-registered
-    // default would win - so this is a conflict, not a valid remap.
+    // palette.open's default is Control+[Meta]+K: a plain Control+K matches
+    // it at dispatch time, and the earlier-registered default would win -
+    // so this is a conflict, not a valid remap.
     const registry = withDefaults();
     const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: "Control+K" }], registry);
     expect(result.rules).toHaveLength(0);

--- a/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, test } from "vitest";
+import { ACTIONS } from "./actions";
+import { serializeChord } from "./chord";
+import { registerDefaultBindings } from "./defaults";
+import { rebindAction } from "./overrides";
+import { createKeybindingsRegistry, type KeybindingsRegistry } from "./registry";
+import { validateOverrideRules } from "./validation";
+
+function withDefaults(): KeybindingsRegistry {
+  const registry = createKeybindingsRegistry();
+  registerDefaultBindings(registry);
+  return registry;
+}
+
+function defaultChord(registry: KeybindingsRegistry, bindingId: string): string {
+  const binding = registry.getState().bindings.find((b) => b.id === bindingId);
+  if (binding === undefined) throw new Error(`test setup: no binding ${bindingId}`);
+  return serializeChord(binding.chord);
+}
+
+describe("validateOverrideRules", () => {
+  test("accepts a well-formed rebind and unbind", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+        { action: ACTIONS.railToggle, chord: null },
+      ],
+      registry,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(2);
+    expect(result.rules[0]?.action).toBe(ACTIONS.paletteOpen);
+    expect(serializeChord(result.rules[0]?.chord ?? [])).toBe("Control+P");
+    expect(result.rules[1]?.chord).toBeNull();
+  });
+
+  test("collects a warning and skips an unknown action without throwing", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+      ],
+      registry,
+    );
+    expect(result.rules).toHaveLength(1);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("unknown-action");
+    expect(result.warnings[0]?.rule.action).toBe("no.such.action");
+  });
+
+  test("collects a warning and skips an unparseable chord", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "" }], registry);
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings[0]?.reason).toBe("unparseable-chord");
+  });
+
+  test("last rule wins for repeated rules on the same action", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        { action: ACTIONS.paletteOpen, chord: "Control+U" },
+      ],
+      registry,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+    expect(serializeChord(result.rules[0]?.chord ?? [])).toBe("Control+U");
+  });
+
+  test("flags a chord two rules in the same payload try to claim", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+        { action: ACTIONS.railToggle, chord: "Control+P" },
+      ],
+      registry,
+    );
+    expect(result.rules).toHaveLength(1);
+    expect(result.rules[0]?.action).toBe(ACTIONS.paletteOpen);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("conflict");
+    expect(result.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+  });
+
+  test("flags a rule that lands on another action's current effective binding", () => {
+    const registry = withDefaults();
+    const taken = defaultChord(registry, ACTIONS.paletteOpen);
+    const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: taken }], registry);
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings[0]?.reason).toBe("conflict");
+    expect(result.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+  });
+
+  test("a chord freed by the same payload can be claimed by a later rule", () => {
+    const registry = withDefaults();
+    const freed = defaultChord(registry, ACTIONS.paletteOpen);
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        { action: ACTIONS.railToggle, chord: freed },
+      ],
+      registry,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(2);
+  });
+
+  test("an unbind frees the action's chord for a later rule", () => {
+    const registry = withDefaults();
+    const freed = defaultChord(registry, ACTIONS.paletteOpen);
+    const result = validateOverrideRules(
+      [
+        { action: ACTIONS.paletteOpen, chord: null },
+        { action: ACTIONS.railToggle, chord: freed },
+      ],
+      registry,
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(2);
+  });
+
+  test("a chord taken in a different scope does not conflict", () => {
+    const registry = withDefaults();
+    // settings.close lives in the settings scope; a global-scope rule may
+    // reuse its chord (stack order shadows deterministically).
+    const settingsChord = defaultChord(registry, ACTIONS.settingsClose);
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: settingsChord }], registry);
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+});
+
+describe("validateOverrideRules reserved chords", () => {
+  test("Control+W/N/T/Tab, Ctrl+digits, F11 are reserved on non-Apple platforms", () => {
+    const registry = withDefaults();
+    for (const chord of ["Control+W", "Control+N", "Control+T", "Control+Tab", "Control+5", "F11"]) {
+      const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord }], registry, "other");
+      expect(result.rules, chord).toHaveLength(0);
+      expect(result.warnings[0]?.reason, chord).toBe("reserved-chord");
+    }
+  });
+
+  test("Meta+W is NOT reserved on non-Apple platforms", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Meta+W" }], registry, "other");
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test("the macOS family (Cmd+W/N/T/Q, Cmd+digits, Cmd+Shift+N/T) is reserved on Apple platforms", () => {
+    const registry = withDefaults();
+    for (const chord of ["Meta+W", "Meta+N", "Meta+T", "Meta+Q", "Meta+5", "Meta+Shift+N", "Meta+Shift+T"]) {
+      const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord }], registry, "apple");
+      expect(result.rules, chord).toHaveLength(0);
+      expect(result.warnings[0]?.reason, chord).toBe("reserved-chord");
+    }
+  });
+
+  test("the Control family stays reserved on Apple platforms too (the survey lists it unqualified)", () => {
+    const registry = withDefaults();
+    for (const chord of ["Control+W", "Control+Tab", "Control+5"]) {
+      const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord }], registry, "apple");
+      expect(result.rules, chord).toHaveLength(0);
+      expect(result.warnings[0]?.reason, chord).toBe("reserved-chord");
+    }
+  });
+
+  test("a code-SPELLED reserved chord (Control+KeyW) is still reserved - the browser reserves the physical key", () => {
+    // tinykeys matches the code name against the same Ctrl+W event the
+    // browser never delivers; the string-literal check would miss it
+    // (roborev PR #884 round 8).
+    const registry = withDefaults();
+    for (const chord of ["Control+KeyW", "Meta+KeyT"]) {
+      const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord }], registry, "apple");
+      expect(result.rules, chord).toHaveLength(0);
+      expect(result.warnings[0]?.reason, chord).toBe("reserved-chord");
+    }
+  });
+
+  test("a regex chord matching a reserved event is reserved too (Control+(W)), conservatively", () => {
+    // The regex never string-matches the canonical reserved set, but it
+    // matches the same browser-reserved event (roborev PR #884 round 14).
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Control+(W)" }], registry, "other");
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings[0]?.reason).toBe("reserved-chord");
+    // A regex that matches no reserved event is fine.
+    const ok = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Control+(X)" }], registry, "other");
+    expect(ok.warnings).toEqual([]);
+    expect(ok.rules).toHaveLength(1);
+  });
+
+  test("Alt+F4 is reserved on non-Apple platforms but not on Apple", () => {
+    const registry = withDefaults();
+    const other = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Alt+F4" }], registry, "other");
+    expect(other.warnings[0]?.reason).toBe("reserved-chord");
+    const apple = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Alt+F4" }], registry, "apple");
+    expect(apple.warnings).toEqual([]);
+  });
+
+  test("Ctrl+Shift+P is NOT reserved: the survey's caveat is Firefox-private-window specific", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [{ action: ACTIONS.paletteOpen, chord: "Control+Shift+P" }],
+      registry,
+      "other",
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test("an optional extra modifier does not rescue a reserved chord (the no-modifier case is undeliverable)", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [{ action: ACTIONS.paletteOpen, chord: "[Shift]+Control+W" }],
+      registry,
+      "other",
+    );
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings[0]?.reason).toBe("reserved-chord");
+  });
+
+  test("extra REQUIRED modifiers escape the reserved list (Cmd+Shift+W is not the survey's Cmd+W)", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.paletteOpen, chord: "Meta+Shift+W" }], registry, "apple");
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test("multi-press sequences are never reserved", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules(
+      [{ action: ACTIONS.paletteOpen, chord: "Control+K Control+W" }],
+      registry,
+      "other",
+    );
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+});
+
+describe("validateOverrideRules dropped-override restorations", () => {
+  test("a rule claiming a chord a dropped override's restored default needs is skipped with a warning", () => {
+    const registry = withDefaults();
+    const reclaimed = defaultChord(registry, ACTIONS.paletteOpen);
+    // The live state the reviewer's payload 1 produces: palette.open moved
+    // away, rail.toggle claimed its freed default chord.
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+Y");
+    rebindAction(registry, ACTIONS.railToggle, reclaimed);
+
+    // Payload 2 drops palette.open (its defaults must be restored) and keeps
+    // rail.toggle's claim on the chord the restore needs. The restore wins:
+    // the rule is skipped with a conflict warning so every action stays bound.
+    const result = validateOverrideRules(
+      [{ action: ACTIONS.railToggle, chord: reclaimed }],
+      registry,
+      "other",
+      new Set([ACTIONS.paletteOpen, ACTIONS.railToggle]),
+    );
+
+    expect(result.rules).toEqual([]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("conflict");
+    expect(result.warnings[0]?.rule).toEqual({ action: ACTIONS.railToggle, chord: reclaimed });
+    expect(result.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+  });
+
+  test("a dropped override restores cleanly when its default chord was not reclaimed", () => {
+    const registry = withDefaults();
+    rebindAction(registry, ACTIONS.paletteOpen, "Control+Y");
+    const result = validateOverrideRules([], registry, "other", new Set([ACTIONS.paletteOpen]));
+    expect(result.rules).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+});
+
+describe("validateOverrideRules overlap conflicts", () => {
+  test("flags an override whose exact chord overlaps a default's OPTIONAL modifiers (dispatch would shadow it)", () => {
+    // palette.open's default is Control+[Meta]+[Shift]+[Alt]+K: a plain
+    // Control+K matches it at dispatch time, and the earlier-registered
+    // default would win - so this is a conflict, not a valid remap.
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: "Control+K" }], registry);
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("conflict");
+    expect(result.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+    expect(result.warnings[0]?.message).toContain('scope "global"');
+  });
+
+  test("a genuinely non-overlapping chord (extra required modifier nothing allows) still validates", () => {
+    const registry = withDefaults();
+    const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: "Control+Alt+B" }], registry);
+    expect(result.warnings).toEqual([]);
+    expect(result.rules).toHaveLength(1);
+  });
+
+  test("the reserved-chord check runs before conflict detection: a reserved chord reports only reserved-chord", () => {
+    const registry = withDefaults();
+    // A foreign live binding holds Control+W, so the chord is BOTH reserved
+    // and conflicting; check order must surface only the reserved warning.
+    registry.getState().registerBinding({ id: "foreign", actionId: "foreign.action", chord: "Control+W" });
+    const result = validateOverrideRules([{ action: ACTIONS.composerFocus, chord: "Control+W" }], registry, "other");
+    expect(result.rules).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]?.reason).toBe("reserved-chord");
+  });
+});

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -13,8 +13,16 @@
 // the offending rule is skipped, so persisted data can degrade to defaults
 // but can never crash the shell.
 
-import { chordsOverlap, type KeySequence, keyComparisonIdentity, parseChord, regexMatchesKeyValue } from "./chord";
-import { DEFAULT_BINDINGS, defaultBindingShapesForAction } from "./defaults";
+import { ACTIONS } from "./actions";
+import {
+  chordsOverlap,
+  type KeySequence,
+  keyComparisonIdentity,
+  parseChord,
+  regexMatchesKeyValue,
+  serializeChord,
+} from "./chord";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS, defaultBindingShapesForAction } from "./defaults";
 import { GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
 
 export type KeybindingsPlatform = "apple" | "other";
@@ -25,6 +33,19 @@ export type KeybindingsPlatform = "apple" | "other";
 export function currentKeybindingsPlatform(): KeybindingsPlatform {
   if (typeof window === "undefined") return "other";
   return /Mac|iPhone|iPad|iPod/.test(window.navigator.platform) ? "apple" : "other";
+}
+
+/** User-facing label for an action id in conflict messages: the default
+ * map's title plus the id when the action is known
+ * ("Open the command palette" (palette.open)); the bare id otherwise (a
+ * binding registered outside the default map - e.g. a test double or a
+ * conditional entry - has no title here). A conflict message names the
+ * HOLDER of the chord the user tried to claim; a bare action id meant
+ * nothing in the editor's inline error or the skipped-overrides warnings
+ * list, where the rows themselves are titled. */
+export function actionDisplayLabel(actionId: string): string {
+  const title = DEFAULT_BINDINGS.find((b) => b.actionId === actionId)?.title;
+  return title === undefined ? `"${actionId}"` : `"${title}" (${actionId})`;
 }
 
 // The survey's verified never-use list ("not interceptable by pages"),
@@ -128,7 +149,17 @@ export interface OverrideRule {
   chord: string | null;
 }
 
-export type ValidationWarningReason = "unknown-action" | "unparseable-chord" | "reserved-chord" | "conflict";
+export type ValidationWarningReason =
+  | "unknown-action"
+  | "unparseable-chord"
+  | "reserved-chord"
+  | "conflict"
+  /** Not a validation outcome: the cheatsheetController's conditional "?"
+   * entry skipped registration because a live binding of ANOTHER action
+   * overlaps it (the chord was claimed while the character-key pref kept
+   * the entry unregistered, so nothing conflicted at bind time). Surfaces
+   * through the same store warnings channel as skipped override rules. */
+  | "character-key-conflict";
 
 export interface ValidationWarning {
   rule: OverrideRule;
@@ -170,12 +201,17 @@ interface EffectiveBinding {
  * alternative (deferring the restore) would strand the dropped action on an
  * override the hub payload no longer contains, diverging the registry from
  * the payload indefinitely. Defaults never conflict with each other, so a
- * conflict always has a rule claim to blame. */
+ * conflict always has a rule claim to blame.
+ *
+ * `characterKeyTriggers: false` mirrors the cheatsheet character-key pref:
+ * the live registry has no "?" cheatsheet binding while the pref is off, so
+ * the dropped-restore simulation must not claim one either. */
 export function validateOverrideRules(
   rules: readonly OverrideRule[],
   registry: KeybindingsRegistry,
   platform: KeybindingsPlatform = currentKeybindingsPlatform(),
   appliedActionIds: ReadonlySet<string> = new Set(),
+  characterKeyTriggers = true,
 ): ValidatedOverrides {
   const warnings: ValidationWarning[] = [];
   const reserved = RESERVED_BY_PLATFORM[platform];
@@ -255,6 +291,37 @@ export function validateOverrideRules(
     list.push({ scope: binding.scope, sequence: binding.chord });
     live.set(binding.actionId, list);
   }
+  // The pref is authoritative over the live registry for the conditional
+  // "?" entry: a pref-flip re-apply (stores/keybindings.ts's prefs
+  // subscription) runs in the flip instant, BEFORE the cheatsheetController's
+  // reconcile has unregistered or re-registered "?", and must simulate the
+  // map the reconcile is about to establish - otherwise a pref-off re-apply
+  // would keep skipping a claim that is now valid, and a pref-on re-apply
+  // would leave a now-conflicting claim applied. Steady state (registry
+  // already mirrors the pref) is untouched. Only the default-map shape is
+  // adjusted: a cheatsheet.toggle override candidate or a dropped restore
+  // overwrites the action's whole final entry below anyway.
+  const questionShape = defaultBindingShapesForAction(ACTIONS.cheatsheetToggle, {
+    characterKeyTriggers: true,
+  }).find((shape) => shape.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+  if (questionShape !== undefined) {
+    const questionSerialized = serializeChord(questionShape.sequence);
+    const isQuestion = (binding: EffectiveBinding) =>
+      binding.scope === questionShape.scope && serializeChord(binding.sequence) === questionSerialized;
+    const toggleLive = live.get(ACTIONS.cheatsheetToggle) ?? [];
+    const liveHasQuestion = toggleLive.some(isQuestion);
+    if (characterKeyTriggers && !liveHasQuestion) {
+      live.set(ACTIONS.cheatsheetToggle, [
+        ...toggleLive,
+        { scope: questionShape.scope, sequence: questionShape.sequence },
+      ]);
+    } else if (!characterKeyTriggers && liveHasQuestion) {
+      live.set(
+        ACTIONS.cheatsheetToggle,
+        toggleLive.filter((binding) => !isQuestion(binding)),
+      );
+    }
+  }
   const dropped = new Set<string>();
   for (const action of appliedActionIds) {
     if (!candidates.some((c) => c.rule.action === action)) dropped.add(action);
@@ -273,7 +340,10 @@ export function validateOverrideRules(
     for (const action of dropped) {
       final.set(
         action,
-        defaultBindingShapesForAction(action).map((shape) => ({ scope: shape.scope, sequence: shape.sequence })),
+        defaultBindingShapesForAction(action, { characterKeyTriggers }).map((shape) => ({
+          scope: shape.scope,
+          sequence: shape.sequence,
+        })),
       );
     }
     for (const candidate of candidates) {
@@ -327,7 +397,7 @@ export function validateOverrideRules(
         rule: removed.rule,
         reason: "conflict",
         conflictWith,
-        message: `chord "${removed.rule.chord ?? ""}" in scope "${scope}" is already bound by "${conflictWith}"`,
+        message: `chord "${removed.rule.chord ?? ""}" in scope "${scope}" is already bound by ${actionDisplayLabel(conflictWith)}`,
       });
       if (appliedActionIds.has(removed.rule.action)) dropped.add(removed.rule.action);
       skipped = true;

--- a/cmd/evener-hub/frontend/src/keybindings/validation.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/validation.ts
@@ -1,0 +1,342 @@
+// Semantic validation for user keybinding overrides. The server validates
+// STRUCTURE only (it does not know the frontend action registry); everything
+// that requires knowing the live bindings happens here, at load and at patch:
+//
+//   - action ids against the default map (unknown or stale rules are skipped),
+//   - chord parseability,
+//   - the survey's per-platform never-use list (docs/web-ui/specs/
+//     2026-09-03-keybinding-system-survey.md "Reserved-chord landscape") -
+//     chords the browser will never deliver to the page,
+//   - conflicts against the effective map the payload would produce.
+//
+// Validation NEVER throws into startup: every problem becomes a warning and
+// the offending rule is skipped, so persisted data can degrade to defaults
+// but can never crash the shell.
+
+import { chordsOverlap, type KeySequence, keyComparisonIdentity, parseChord, regexMatchesKeyValue } from "./chord";
+import { DEFAULT_BINDINGS, defaultBindingShapesForAction } from "./defaults";
+import { GLOBAL_SCOPE, type KeybindingsRegistry } from "./registry";
+
+export type KeybindingsPlatform = "apple" | "other";
+
+/** Same platform split tinykeys applies for `$mod` (and keyhint for display):
+ * navigator.platform's Apple tokens. jsdom reports "", so tests default to
+ * "other" regardless of the host running them. */
+export function currentKeybindingsPlatform(): KeybindingsPlatform {
+  if (typeof window === "undefined") return "other";
+  return /Mac|iPhone|iPad|iPod/.test(window.navigator.platform) ? "apple" : "other";
+}
+
+// The survey's verified never-use list ("not interceptable by pages"),
+// platform-split. The Control family is listed unqualified in the survey, so
+// it is reserved on every platform. Two survey entries are deliberately NOT
+// encoded: "Escape in fullscreen" is context-dependent (Escape is
+// settings.close's own default chord), and "Ctrl+Shift+P in Firefox" is a
+// private-window-only caveat in one browser, not a platform rule.
+const COMMON_RESERVED = [
+  "Control+W",
+  "Control+N",
+  "Control+T",
+  "Control+Tab",
+  "Control+Shift+Tab",
+  "Control+1",
+  "Control+2",
+  "Control+3",
+  "Control+4",
+  "Control+5",
+  "Control+6",
+  "Control+7",
+  "Control+8",
+  "Control+9",
+  "F11",
+];
+const APPLE_RESERVED = [
+  "Meta+W",
+  "Meta+N",
+  "Meta+T",
+  "Meta+Q",
+  "Meta+Shift+N",
+  "Meta+Shift+T",
+  "Meta+1",
+  "Meta+2",
+  "Meta+3",
+  "Meta+4",
+  "Meta+5",
+  "Meta+6",
+  "Meta+7",
+  "Meta+8",
+  "Meta+9",
+];
+const OTHER_RESERVED = ["Alt+F4", "Control+Alt+Delete"];
+
+// A reserved match compares REQUIRED modifiers + key only (case-insensitive
+// on the key): a user chord that lists extra OPTIONAL modifiers still has a
+// no-modifier match the browser will never deliver, so it stays reserved.
+// Extra REQUIRED modifiers escape the list (Meta+Shift+W is not the survey's
+// Meta+W), and multi-press sequences are never reserved - the browser
+// delivers every press after the first to the page.
+function canonicalPress(sequence: KeySequence): string | null {
+  if (sequence.length !== 1) return null;
+  const press = sequence[0];
+  if (press === undefined) return null;
+  // keyComparisonIdentity folds code-name spellings (Control+KeyW) onto the
+  // key spelling (Control+W) so a code-named rule cannot slip a
+  // browser-reserved chord past the check (roborev PR #884 round 8).
+  return `${press.modifiers.join("+")}+${keyComparisonIdentity(press.key)}`;
+}
+
+const RESERVED_BY_PLATFORM: Record<KeybindingsPlatform, ReadonlySet<string>> = {
+  apple: new Set(
+    [...COMMON_RESERVED, ...APPLE_RESERVED].map((chord) => {
+      const canonical = canonicalPress(parseChord(chord));
+      if (canonical === null) throw new Error(`bad reserved chord "${chord}"`);
+      return canonical;
+    }),
+  ),
+  other: new Set(
+    [...COMMON_RESERVED, ...OTHER_RESERVED].map((chord) => {
+      const canonical = canonicalPress(parseChord(chord));
+      if (canonical === null) throw new Error(`bad reserved chord "${chord}"`);
+      return canonical;
+    }),
+  ),
+};
+
+// The same reserved chords as modifier-set + key-value pairs, for the REGEX
+// path: a regex chord like Control+(W) never string-matches the canonical
+// set, but it matches the reserved event, so it must be flagged the same way
+// (roborev PR #884 round 14) - the browser delivers it to the page never or
+// unreliably either way.
+interface ReservedPress {
+  modifiers: string;
+  keyValue: string;
+}
+function reservedPresses(chords: string[]): ReservedPress[] {
+  return chords.map((chord) => {
+    const press = parseChord(chord)[0];
+    if (press === undefined || press.key instanceof RegExp) throw new Error(`bad reserved chord "${chord}"`);
+    return { modifiers: press.modifiers.join("+"), keyValue: keyComparisonIdentity(press.key) };
+  });
+}
+const RESERVED_PRESSES_BY_PLATFORM: Record<KeybindingsPlatform, readonly ReservedPress[]> = {
+  apple: reservedPresses([...COMMON_RESERVED, ...APPLE_RESERVED]),
+  other: reservedPresses([...COMMON_RESERVED, ...OTHER_RESERVED]),
+};
+
+export interface OverrideRule {
+  action: string;
+  chord: string | null;
+}
+
+export type ValidationWarningReason = "unknown-action" | "unparseable-chord" | "reserved-chord" | "conflict";
+
+export interface ValidationWarning {
+  rule: OverrideRule;
+  reason: ValidationWarningReason;
+  message: string;
+  /** For "conflict": the other action holding the chord. */
+  conflictWith?: string;
+}
+
+export interface ValidatedRule {
+  action: string;
+  chord: KeySequence | null;
+}
+
+export interface ValidatedOverrides {
+  /** The payload's effective rules: valid, deduped last-rule-wins, in order. */
+  rules: ValidatedRule[];
+  warnings: ValidationWarning[];
+}
+
+interface EffectiveBinding {
+  scope: string;
+  sequence: KeySequence;
+}
+
+/** Validates a rules payload against the live registry. Conflict detection
+ * simulates the FINAL effective map the payload would produce: untouched
+ * actions keep their live bindings, every currently-overridden action the
+ * payload does not (validly) name gets its defaults restored, and each
+ * candidate rule claims its new chord. A chord freed by an earlier rule
+ * (rebind-away or unbind) can therefore be claimed by a later one.
+ * Conflicts are OVERLAPS (chordsOverlap), not serialization equality: an
+ * override whose exact chord overlaps a default's optional modifiers would
+ * be shadowed by the earlier-registered default at dispatch time.
+ *
+ * When a restored default and a rule claim collide, THE RESTORE WINS: the
+ * rule is skipped with a conflict warning and its action falls back to its
+ * own defaults. This is the choice that leaves every action bound - the
+ * alternative (deferring the restore) would strand the dropped action on an
+ * override the hub payload no longer contains, diverging the registry from
+ * the payload indefinitely. Defaults never conflict with each other, so a
+ * conflict always has a rule claim to blame. */
+export function validateOverrideRules(
+  rules: readonly OverrideRule[],
+  registry: KeybindingsRegistry,
+  platform: KeybindingsPlatform = currentKeybindingsPlatform(),
+  appliedActionIds: ReadonlySet<string> = new Set(),
+): ValidatedOverrides {
+  const warnings: ValidationWarning[] = [];
+  const reserved = RESERVED_BY_PLATFORM[platform];
+
+  interface Candidate {
+    rule: OverrideRule;
+    chord: KeySequence | null;
+  }
+  const candidates: Candidate[] = [];
+  // The payload resolves same-action repeats last-rule-wins; the candidate
+  // list keeps only the winning rule.
+  const pushCandidate = (candidate: Candidate): void => {
+    const prior = candidates.findIndex((c) => c.rule.action === candidate.rule.action);
+    if (prior !== -1) candidates.splice(prior, 1);
+    candidates.push(candidate);
+  };
+
+  for (const rule of rules) {
+    const defaultInput = DEFAULT_BINDINGS.find((b) => b.actionId === rule.action);
+    if (defaultInput === undefined) {
+      warnings.push({
+        rule,
+        reason: "unknown-action",
+        message: `unknown keybinding action "${rule.action}"`,
+      });
+      continue;
+    }
+    if (rule.chord === null) {
+      pushCandidate({ rule, chord: null });
+      continue;
+    }
+    let sequence: KeySequence;
+    try {
+      sequence = parseChord(rule.chord);
+    } catch (error) {
+      warnings.push({
+        rule,
+        reason: "unparseable-chord",
+        message: `cannot parse chord "${rule.chord}": ${error instanceof Error ? error.message : String(error)}`,
+      });
+      continue;
+    }
+    const canonical = canonicalPress(sequence);
+    if (canonical !== null && reserved.has(canonical)) {
+      warnings.push({
+        rule,
+        reason: "reserved-chord",
+        message: `chord "${rule.chord}" is reserved by the browser/OS on this platform and would never reach the page`,
+      });
+      continue;
+    }
+    // Regex keys never string-match the canonical set: check them against
+    // each reserved chord's event spellings instead (same required-modifier
+    // comparison as the canonical path).
+    const onlyPress = sequence.length === 1 ? sequence[0] : undefined;
+    if (onlyPress !== undefined && onlyPress.key instanceof RegExp) {
+      const modifiers = onlyPress.modifiers.join("+");
+      const regex = onlyPress.key;
+      const reservedHit = RESERVED_PRESSES_BY_PLATFORM[platform].some(
+        (entry) => entry.modifiers === modifiers && regexMatchesKeyValue(regex, entry.keyValue),
+      );
+      if (reservedHit) {
+        warnings.push({
+          rule,
+          reason: "reserved-chord",
+          message: `chord "${rule.chord}" is reserved by the browser/OS on this platform and would never reach the page`,
+        });
+        continue;
+      }
+    }
+    pushCandidate({ rule, chord: sequence });
+  }
+
+  const live = new Map<string, EffectiveBinding[]>();
+  for (const binding of registry.getState().bindings) {
+    const list = live.get(binding.actionId) ?? [];
+    list.push({ scope: binding.scope, sequence: binding.chord });
+    live.set(binding.actionId, list);
+  }
+  const dropped = new Set<string>();
+  for (const action of appliedActionIds) {
+    if (!candidates.some((c) => c.rule.action === action)) dropped.add(action);
+  }
+
+  // Conflict resolution on the final simulated map, iterated to a fixpoint:
+  // skipping a rule converts its action to a dropped restore (when it was
+  // overridden), which can surface a further conflict. Each pass skips at
+  // least one rule, so the loop is bounded by the candidate count; the guard
+  // break covers the production-unreachable restore-vs-foreign-binding
+  // collision, which reconcile's rollback + notification containment handle.
+  let guard = candidates.length + 1;
+  for (;;) {
+    const final = new Map<string, EffectiveBinding[]>();
+    for (const [action, bindings] of live) final.set(action, [...bindings]);
+    for (const action of dropped) {
+      final.set(
+        action,
+        defaultBindingShapesForAction(action).map((shape) => ({ scope: shape.scope, sequence: shape.sequence })),
+      );
+    }
+    for (const candidate of candidates) {
+      const defaultInput = DEFAULT_BINDINGS.find((b) => b.actionId === candidate.rule.action);
+      if (defaultInput === undefined) continue;
+      final.set(
+        candidate.rule.action,
+        candidate.chord === null ? [] : [{ scope: defaultInput.scope ?? GLOBAL_SCOPE, sequence: candidate.chord }],
+      );
+    }
+    // Each binding's first overlapping claimant in final-map order, so
+    // conflict pairs always name the earliest claimant first.
+    const claimants: { action: string; binding: EffectiveBinding }[] = [];
+    const conflicts: [string, string][] = [];
+    for (const [action, bindings] of final) {
+      for (const binding of bindings) {
+        const overlapping = claimants.find(
+          (c) =>
+            c.action !== action &&
+            c.binding.scope === binding.scope &&
+            chordsOverlap(c.binding.sequence, binding.sequence),
+        );
+        if (overlapping === undefined) claimants.push({ action, binding });
+        else conflicts.push([overlapping.action, action]);
+      }
+    }
+    if (conflicts.length === 0 || guard-- <= 0) break;
+    let skipped = false;
+    for (const [first, second] of conflicts) {
+      const indexFirst = candidates.findIndex((c) => c.rule.action === first);
+      const indexSecond = candidates.findIndex((c) => c.rule.action === second);
+      let skip = -1;
+      let conflictWith = "";
+      if (indexFirst !== -1 && indexSecond !== -1) {
+        // Both rules claim the chord: the later rule loses.
+        skip = Math.max(indexFirst, indexSecond);
+        conflictWith = skip === indexFirst ? second : first;
+      } else if (indexFirst !== -1) {
+        skip = indexFirst;
+        conflictWith = second;
+      } else if (indexSecond !== -1) {
+        skip = indexSecond;
+        conflictWith = first;
+      }
+      if (skip === -1) continue;
+      const removed = candidates.splice(skip, 1)[0];
+      if (removed === undefined) continue;
+      const removedDefault = DEFAULT_BINDINGS.find((b) => b.actionId === removed.rule.action);
+      const scope = removedDefault?.scope ?? GLOBAL_SCOPE;
+      warnings.push({
+        rule: removed.rule,
+        reason: "conflict",
+        conflictWith,
+        message: `chord "${removed.rule.chord ?? ""}" in scope "${scope}" is already bound by "${conflictWith}"`,
+      });
+      if (appliedActionIds.has(removed.rule.action)) dropped.add(removed.rule.action);
+      skipped = true;
+    }
+    if (!skipped) break;
+  }
+
+  return {
+    rules: candidates.map((candidate) => ({ action: candidate.rule.action, chord: candidate.chord })),
+    warnings,
+  };
+}

--- a/cmd/evener-hub/frontend/src/panes/session/Session.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.tsx
@@ -47,6 +47,7 @@ import { LoadOlderRow } from "./transcript/flow/LoadOlderRow";
 import { NewContentPill } from "./transcript/flow/NewContentPill";
 import { useSeenDivider } from "./transcript/flow/useSeenDivider";
 import { useTranscriptScroll } from "./transcript/flow/useTranscriptScroll";
+import { useTranscriptScrollKeys } from "./transcript/flow/useTranscriptScrollKeys";
 import { SelectionQuote } from "./transcript/SelectionQuote";
 import { formatQuoteBlock } from "./transcript/selectionQuoteLogic";
 import {
@@ -233,6 +234,10 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
     askDockPending: askPending,
     askDockActivationEpoch: askEpoch,
   });
+  // The transcript's keyboard scroll (Alt+Arrow/Alt+Shift+Arrow, Phase 3):
+  // per-pane handlers against the shared registry that decline unless THIS
+  // pane is the workspace's focused one. Nothing registers on mobile.
+  useTranscriptScrollKeys({ paneId, listRef: virtualListRef, jumpToBottom: flow.jumpToBottom });
   const showColdStartSkeleton = useColdStartSkeleton(ref, model);
   // kata g2ez: names the one turn (if any) that starts what's arrived since
   // this pane was last open, so a reopened session shows where to pick up.

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.test.tsx
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { act, cleanup, render, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createElement, useState } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -610,6 +610,30 @@ describe("ActivityTree", () => {
     await user.keyboard("{Enter}");
     expect(onToggleFold).toHaveBeenCalledWith(FOLD_ID);
     expect(openTranscript).not.toHaveBeenCalled();
+  });
+
+  test("keyboard: Alt/Ctrl/Meta arrows fall through to the global chords - no move, no preventDefault", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(NOW);
+    setupUser();
+    render(<ActivityTree tree={TREE} expandedFoldIDs={[]} onToggleFold={vi.fn()} />);
+
+    // Alt+ArrowUp/Down and Alt+Home/End are the global transcript scroll/jump
+    // chords; a tree row is not an editable, so the dispatcher would honor
+    // them - unless the row's own handler swallowed the key first (roborev PR
+    // #884 round 3). Modified arrows must neither move row focus nor be
+    // preventDefaulted here.
+    const shellRow = screen.getByRole("treeitem", { name: "run tests" });
+    shellRow.focus();
+    for (const event of [
+      { key: "ArrowDown", altKey: true },
+      { key: "ArrowUp", ctrlKey: true },
+      { key: "ArrowRight", altKey: true },
+      { key: "ArrowLeft", metaKey: true },
+    ]) {
+      expect(fireEvent.keyDown(shellRow, event)).toBe(true);
+      expect(document.activeElement).toBe(shellRow);
+    }
   });
 
   test("keyboard: arrows still navigate rows when focus sits on a row chevron button", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
@@ -341,6 +341,13 @@ export const ActivityTree = forwardRef<ActivityTreeHandle, ActivityTreeProps>(fu
   function handleKeyDown(event: KeyboardEvent<HTMLDivElement>, row: ActivityRow): void {
     const index = indexByID.get(row.id);
     if (index === undefined) return;
+    // Alt/Ctrl/Meta mean the key belongs elsewhere: Alt+ArrowUp/Down and
+    // Alt+Home/End are the global transcript scroll/jump chords, and the
+    // dispatcher's editable test does not shield them from these row divs -
+    // a blanket preventDefault here would swallow them (roborev PR #884
+    // round 3). Shift stays: coarse-step and range conventions aside, the
+    // tree's own behavior is unchanged by it.
+    if (event.altKey || event.ctrlKey || event.metaKey) return;
     switch (event.key) {
       case "ArrowDown": {
         event.preventDefault();

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -1312,7 +1312,11 @@ export function Composer({ ref }: ComposerProps) {
         </ConfirmDialog>
       )}
       {(!ended || showFollowUpCard) && (
-        <div className={CLASS.formAnchor}>
+        // data-composer is the hold-hints overlay's anchor (shell/holdhints):
+        // the composer.focus chip positions itself above this wrapper. The
+        // value carries this pane's session ref so the overlay can anchor to
+        // the FOCUSED pane's composer when several are mounted.
+        <div className={CLASS.formAnchor} data-composer={ref}>
           {/* Anchored above the control row inside the card below, opening
               upward the same way GoalControl's own popover does - see
               slashcompletionmenu.module.css's header comment. Mounted only

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
@@ -17,6 +17,7 @@ import {
   subscribeMutationPersistence,
   threadsStore,
 } from "../../../../stores/threads";
+import { resetComposerFocusStoreForTests, useComposerFocusRequest } from "../composerFocus";
 import { AskDock, AskDockAnnouncements } from "./AskDock";
 import { askDockStore, resetAskDockStoreForTests } from "./askDockStore";
 
@@ -149,6 +150,7 @@ beforeEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   resetThreadsStoreForTests();
   resetAskDockStoreForTests();
+  resetComposerFocusStoreForTests();
 });
 
 test("renders nothing when there is no pending ask for this ref", async () => {
@@ -281,6 +283,12 @@ test("clicking Send composes and submits through the plain send() path, then the
   expect(screen.queryByText("Deploy?")).toBeNull();
 });
 
+// Escape is a documented NO-OP on the ask dock, not a missing feature:
+// parity-m5-composer.md:120 ("the dock is the one canonical response surface
+// and there is no alternate 'collapse' state to escape to") and
+// contracts-composer-queue-pending.md's test-ask-card.js row both record it
+// as deliberate. AskDock installs no Escape handler at all - this test and
+// the one at the end of this file pin the no-op so it stays deliberate.
 test("Escape does not dismiss the dock or clear any in-progress selection", async () => {
   const user = userEvent.setup();
   const fake = connectFakeClient();
@@ -678,6 +686,113 @@ test("Mod+Enter advances rather than sends when another question is still unansw
   expect(fake.calls.some((c) => c.method === "turn/start")).toBe(false);
 });
 
+test("Mod+Enter on the last question with the walk unfinished does not bypass the disabled Send button", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  await hydrateWithTwoAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(<AskDock ref="ref_a" />);
+
+  // Answer q1, advance to q2. q2 is the LAST question and still unanswered:
+  // the footer Send button is disabled in this state, so the keyboard chord
+  // must be too (roborev PR #884) - submitting here would send the batch
+  // with q2 implicitly skipped.
+  await user.click(screen.getByRole("radio", { name: /something else/i }));
+  await user.type(screen.getByPlaceholderText(/type your answer/i), "custom answer");
+  fireEvent.keyDown(screen.getByPlaceholderText(/type your answer/i), { key: "Enter", metaKey: true });
+  expect(screen.getByText("q2")).toBeTruthy();
+
+  const sendButton = screen.getByRole("button", { name: /send/i });
+  expect(sendButton).toHaveProperty("disabled", true);
+  fireEvent.keyDown(sendButton, { key: "Enter", metaKey: true });
+
+  expect(fake.calls.some((c) => c.method === "turn/start")).toBe(false);
+});
+
+test("Alt+Enter in the free-text answer input does not invoke the primary action", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(<AskDock ref="ref_a" />);
+
+  // Bare Enter in this input is a submit chord; Alt+Enter is NOT - the
+  // bare-Enter path requires every modifier clear (roborev PR #884 round 2).
+  await user.click(screen.getByRole("radio", { name: /something else/i }));
+  await user.type(screen.getByPlaceholderText(/type your answer/i), "custom answer");
+  fireEvent.keyDown(screen.getByPlaceholderText(/type your answer/i), { key: "Enter", altKey: true });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(fake.calls.some((c) => c.method === "turn/start")).toBe(false);
+});
+
+test("modified arrows in the tab strip keep their global meaning - no tab move, no preventDefault", async () => {
+  const fake = connectFakeClient();
+  await hydrateWithTwoAsk(fake);
+  render(<AskDock ref="ref_a" />);
+
+  // Alt+Arrow* and Alt+Home/End are the global transcript scroll/jump chords;
+  // from a tab BUTTON the dispatcher's editable test does not shield them, so
+  // the walk must leave modified events alone entirely (roborev PR #884).
+  const firstTab = screen.getByRole("tab", { name: /1\. First/ });
+  firstTab.focus();
+  const notPrevented = fireEvent.keyDown(firstTab, { key: "ArrowRight", altKey: true });
+
+  expect(notPrevented).toBe(true);
+  expect(firstTab.getAttribute("aria-selected")).toBe("true");
+  expect(screen.getByText("q1")).toBeTruthy();
+  expect(screen.queryByText("q2")).toBeNull();
+});
+
+test("Shift+Arrow still moves tabs - no global binding claims it (the round-2 guard's regression)", async () => {
+  const fake = connectFakeClient();
+  await hydrateWithTwoAsk(fake);
+  render(<AskDock ref="ref_a" />);
+
+  const firstTab = screen.getByRole("tab", { name: /1\. First/ });
+  firstTab.focus();
+  const prevented = fireEvent.keyDown(firstTab, { key: "ArrowRight", shiftKey: true });
+
+  expect(prevented).toBe(false); // the walk consumed it
+  expect(screen.getByRole("tab", { name: /2\. Second/ }).getAttribute("aria-selected")).toBe("true");
+  expect(screen.getByText("q2")).toBeTruthy();
+});
+
+test("a consumed Mod+Enter does not propagate to window-level listeners", async () => {
+  const fake = connectFakeClient();
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(<AskDock ref="ref_a" />);
+
+  // The dock consumes the chord; a window-level binding that ignores
+  // defaultPrevented (rail.toggle) remapped onto Mod+Enter must not also
+  // fire. stopPropagation, not just preventDefault (roborev PR #884).
+  const seen: string[] = [];
+  const listener = (event: KeyboardEvent) => seen.push(event.key);
+  window.addEventListener("keydown", listener);
+  try {
+    fireEvent.keyDown(screen.getByRole("radio", { name: "Yes" }), { key: "Enter", metaKey: true });
+    expect(seen).toEqual([]);
+  } finally {
+    window.removeEventListener("keydown", listener);
+  }
+});
+
+test("a consumed batch-jump chord does not propagate to window-level listeners", async () => {
+  const fake = connectFakeClient();
+  await renderTwoBatches(fake); // renders the dock itself
+
+  const seen: string[] = [];
+  const listener = (event: KeyboardEvent) => seen.push(event.key);
+  window.addEventListener("keydown", listener);
+  try {
+    fireEvent.keyDown(screen.getAllByRole("radio", { name: "Yes" })[0]!, { key: "PageDown", altKey: true });
+    expect(seen).toEqual([]);
+  } finally {
+    window.removeEventListener("keydown", listener);
+  }
+});
+
 test("plain Enter in the free-text answer input invokes the primary action", async () => {
   const user = userEvent.setup();
   const fake = connectFakeClient();
@@ -715,6 +830,23 @@ test("Mod+Enter is ignored while an IME composition is in progress", async () =>
   render(<AskDock ref="ref_a" />);
 
   fireEvent.keyDown(screen.getByRole("radio", { name: "Yes" }), { key: "Enter", metaKey: true, isComposing: true });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(fake.calls.some((c) => c.method === "turn/start")).toBe(false);
+});
+
+test("an IME commit reported only through keyCode 229 (no isComposing) does not submit", async () => {
+  // Some browsers report the composition-confirm keydown solely through the
+  // legacy keyCode 229: without that fallback the commit Enter would submit
+  // or advance the batch (roborev PR #884 round 7). The dock shares the
+  // dispatcher's isIMECompositionKeydown guard.
+  const fake = connectFakeClient();
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(<AskDock ref="ref_a" />);
+
+  const radio = screen.getByRole("radio", { name: "Yes" });
+  fireEvent.keyDown(radio, { key: "Enter", keyCode: 229, metaKey: true });
 
   await new Promise((resolve) => setTimeout(resolve, 0));
   expect(fake.calls.some((c) => c.method === "turn/start")).toBe(false);
@@ -1001,4 +1133,258 @@ test("an atomic pending-set replacement with an identical count re-announces the
 
   await waitFor(() => expect(region.textContent).toBe("Answer the agent’s questions."));
   expect(region.firstChild).not.toBe(firstNode);
+});
+
+// --- Phase 3 keyboard operation -------------------------------------------
+//
+// Three pins on top of the walk/submit keys above:
+//
+// - Escape STAYS a no-op (parity-m5-composer.md:120 documents the no-dismiss
+//   behavior as deliberate) - and pressing it inside the dock must not leak
+//   into anything else either (no send, no cleared answer/note). The only
+//   window-level Escape consumers are SelectionQuote's selection clear (which
+//   reads no dock state) and the settings scope's close (pushed only while
+//   Settings is open); the composer has no Escape-to-clear at all.
+// - Alt+PageDown/Alt+PageUp jump focus between question BATCHES directly
+//   (the tab strip's ArrowLeft/Right walk only moves within one batch).
+//   Alt+Page* is chosen over Alt+Arrow* because the Phase 3 transcript
+//   scroll bindings own Alt+ArrowUp/Down with allowInEditable: false - and
+//   the dispatcher's editable test only covers INPUT/TEXTAREA/SELECT, so
+//   from the dock's tab/send BUTTONS those chords would scroll the
+//   transcript. Bare PageUp/PageDown keep their native meaning (the dock is
+//   its own overflow-y scroller). No registered chord or native text-editing
+//   meaning uses Alt+PageUp/Down.
+// - A send that empties the dock requests composer focus through
+//   composerFocus.ts's requestComposerFocus seam (the same one ⌘I drives);
+//   a send with batches still pending moves focus to the next batch's entry
+//   control instead, because the composer input row is still hidden/inert.
+
+const SECOND_ASK = [{ header: "Later", question: "q_later", options: [{ label: "later-opt", detail: "d" }] }];
+
+// renderTwoBatches drives the REAL two-batch route (reconcileBatches.ts: a
+// batch mid-send is frozen, so the late ask_user call mints a sibling batch
+// instead of joining the open one). Determinism lives in the ordering, not
+// in any timing: the click and the ack run in ONE synchronous block (act's
+// callback executes synchronously), and send() can only resolve after its
+// durable outbox write - an IndexedDB round trip that cannot complete inside
+// a synchronous block - so the ack is guaranteed to land while batch 1 is
+// still sending. turn/start stays parked so nothing else settles the batch.
+async function renderTwoBatches(
+  fake: FakeClient,
+  secondQuestions: Array<Record<string, unknown>> = SECOND_ASK,
+): Promise<void> {
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(<AskDock ref="ref_a" />);
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /send answers/i }));
+    ackAskUserCall(fake, "ref_a", "turn_1", "item_2", "call_2", secondQuestions);
+  });
+  expect(askDockStore.getState().byRef.get("ref_a")?.batches.length).toBe(2);
+}
+
+test("Escape inside the dock sends nothing and preserves both the answer and a typed note", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(<AskDock ref="ref_a" />);
+
+  await user.click(screen.getByRole("radio", { name: "Yes" }));
+  const note = screen.getByPlaceholderText(/note \(optional\)/i);
+  await user.type(note, "keep me");
+  await user.keyboard("{Escape}");
+
+  expect(screen.getByText("Deploy?")).toBeTruthy();
+  expect(screen.getByRole("radio", { name: "Yes" })).toHaveProperty("checked", true);
+  expect((note as HTMLInputElement).value).toBe("keep me");
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(fake.calls.some((c) => c.method === "turn/start")).toBe(false);
+});
+
+test("Alt+PageDown/Alt+PageUp jump focus between batches, wrapping at both ends", async () => {
+  const fake = connectFakeClient();
+  await renderTwoBatches(fake);
+
+  // Batch 1 is mid-send, so its editing controls are disabled (roborev PR
+  // #884 round 10): the jump into it lands on the batch CONTAINER
+  // (focusBatchEntry's fallback) rather than a dead disabled radio.
+  const openRadio = screen.getByRole("radio", { name: "later-opt" });
+  const sendingContainer = document.querySelector('[data-ask-batch="ask-batch-1"]');
+  if (!(sendingContainer instanceof HTMLElement)) throw new Error("batch 1 container missing");
+
+  openRadio.focus();
+  // Past the last batch: wrap to the first - the mid-send one.
+  fireEvent.keyDown(openRadio, { key: "PageDown", altKey: true });
+  expect(document.activeElement).toBe(sendingContainer);
+
+  // Before the first batch: wrap back to the last - the open one.
+  fireEvent.keyDown(sendingContainer, { key: "PageUp", altKey: true });
+  expect(document.activeElement).toBe(openRadio);
+});
+
+test("batch jump lands on the target batch's selected tab when it has a tab strip", async () => {
+  const fake = connectFakeClient();
+  await renderTwoBatches(fake, [
+    { header: "Alpha", question: "q_alpha", options: [{ label: "alpha-opt", detail: "" }] },
+    { header: "Beta", question: "q_beta", options: [{ label: "beta-opt", detail: "" }] },
+  ]);
+
+  const batch1Radio = screen.getByRole("radio", { name: "Yes" });
+  batch1Radio.focus();
+  fireEvent.keyDown(batch1Radio, { key: "PageDown", altKey: true });
+
+  const selectedTab = screen.getByRole("tab", { name: /1\. Alpha/ });
+  expect(selectedTab.getAttribute("aria-selected")).toBe("true");
+  expect(document.activeElement).toBe(selectedTab);
+});
+
+test("a mid-send batch's editing controls are disabled while the open batch stays editable", async () => {
+  const fake = connectFakeClient();
+  await renderTwoBatches(fake);
+
+  // The successful send REMOVES the batch, so an edit made mid-flight would
+  // be silently discarded - every editing control of the sending batch
+  // disables until the send settles (roborev PR #884 round 10).
+  const sending = document.querySelector('[data-ask-batch="ask-batch-1"]');
+  const open = document.querySelector('[data-ask-batch="ask-batch-2"]');
+  if (!(sending instanceof HTMLElement) || !(open instanceof HTMLElement)) throw new Error("batch containers missing");
+  for (const control of sending.querySelectorAll("input, button")) {
+    // The footer's Send is long-since disabled mid-send; the new part is the
+    // answer controls.
+    expect(control).toHaveProperty("disabled", true);
+  }
+  expect(open.querySelector('input[type="radio"]')).toHaveProperty("disabled", false);
+
+  // The store boundary refuses the same writes (the UI is not the contract).
+  const sendingKey = askDockStore.getState().byRef.get("ref_a")?.batches[0]?.questions[0]?.key;
+  const openKey = askDockStore.getState().byRef.get("ref_a")?.batches[1]?.questions[0]?.key;
+  if (sendingKey === undefined || openKey === undefined) throw new Error("question keys missing");
+  askDockStore.getState().setAnswer("ref_a", sendingKey, { kind: "option", labels: ["Yes"] });
+  askDockStore.getState().setNote("ref_a", sendingKey, "mid-flight edit");
+  expect(askDockStore.getState().byRef.get("ref_a")?.answers[sendingKey]?.resolution ?? null).toBeNull();
+  expect(askDockStore.getState().byRef.get("ref_a")?.answers[sendingKey]?.note ?? "").toBe("");
+  askDockStore.getState().setNote("ref_a", openKey, "fine here");
+  expect(askDockStore.getState().byRef.get("ref_a")?.answers[openKey]?.note).toBe("fine here");
+});
+
+test("plain PageUp/PageDown keep their native meaning - no batch jump without Alt", async () => {
+  const fake = connectFakeClient();
+  await renderTwoBatches(fake);
+
+  const batch1Radio = screen.getByRole("radio", { name: "Yes" });
+  batch1Radio.focus();
+  fireEvent.keyDown(batch1Radio, { key: "PageDown" });
+  expect(document.activeElement).toBe(batch1Radio);
+  fireEvent.keyDown(batch1Radio, { key: "PageUp" });
+  expect(document.activeElement).toBe(batch1Radio);
+});
+
+test("a send that empties the dock requests composer focus", async () => {
+  const user = userEvent.setup();
+  const fake = connectFakeClient();
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", (params) => ({
+    receipt: {
+      clientMutationId: params.clientMutationId,
+      disposition: "applied",
+      threadId: "thread_a",
+      projectionState: "reflected",
+    },
+    turn: { id: "turn_2", status: "inProgress", itemsView: "" },
+  }));
+  // The composerFocus store's only read seam is its hook (composerFocus.ts),
+  // so the assertion renders a probe over it rather than reaching into the
+  // module's private store.
+  function Probe() {
+    return <span>{useComposerFocusRequest("ref_a") ? "requested" : "none"}</span>;
+  }
+  render(
+    <>
+      <AskDock ref="ref_a" />
+      <Probe />
+    </>,
+  );
+
+  const persisted = nextMutationPersistence("ref_a");
+  await user.click(screen.getByRole("button", { name: /send answers/i }));
+  await persisted;
+
+  await waitFor(() => expect(screen.getByText("requested")).toBeTruthy());
+});
+
+test("post-send focus lands on the first NON-sending remaining batch when several sends are in flight", async () => {
+  // Two batches mid-send with an open batch behind them: batch 1's send
+  // resolving must move focus to batch 3 (editable), not batch 2 (disabled
+  // mid-flight controls) (roborev PR #884 round 13). Settlement timing is
+  // controlled by stubbing threadsStore.send with parked promises.
+  const fake = connectFakeClient();
+  await hydrateWithOneAsk(fake);
+  render(<AskDock ref="ref_a" />);
+  const sendResolvers: Array<() => void> = [];
+  const realSend = threadsStore.getState().send;
+  threadsStore.setState({ send: () => new Promise<void>((resolve) => sendResolvers.push(resolve)) });
+  onTestFinished(() => threadsStore.setState({ send: realSend }));
+
+  // Batch 1 sends; the late ask mints batch 2 beside it.
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /send answers/i }));
+    ackAskUserCall(fake, "ref_a", "turn_1", "item_2", "call_2", SECOND_ASK);
+  });
+  expect(askDockStore.getState().byRef.get("ref_a")?.batches.length).toBe(2);
+
+  // Answer and send batch 2; the next late ask mints batch 3.
+  const THIRD_ASK = [{ header: "Third", question: "q_third", options: [{ label: "third-opt", detail: "d" }] }];
+  await act(async () => {
+    fireEvent.click(screen.getByRole("radio", { name: "later-opt" }));
+  });
+  await act(async () => {
+    fireEvent.click(screen.getAllByRole("button", { name: /send answers/i })[1]!);
+    ackAskUserCall(fake, "ref_a", "turn_1", "item_3", "call_3", THIRD_ASK);
+  });
+  expect(askDockStore.getState().byRef.get("ref_a")?.batches.length).toBe(3);
+
+  // Batch 1's send resolves with batch 2 still in flight and batch 3 open.
+  const settle = sendResolvers[0];
+  if (settle === undefined) throw new Error("batch 1's send never started");
+  await act(async () => {
+    settle();
+  });
+
+  await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("radio", { name: "third-opt" })));
+});
+
+test("a send with another batch still pending moves focus to the remaining batch, not the composer", async () => {
+  const fake = connectFakeClient();
+  function Probe() {
+    return <span>{useComposerFocusRequest("ref_a") ? "requested" : "none"}</span>;
+  }
+  await hydrateWithOneAsk(fake);
+  fake.on("turn/start", () => new Promise(() => {}));
+  render(
+    <>
+      <AskDock ref="ref_a" />
+      <Probe />
+    </>,
+  );
+  // Focus lives in batch 1; its send starts (parked turn/start) and the
+  // late ask mints batch 2 while batch 1 is genuinely mid-send - one
+  // synchronous block, so the send cannot settle first (renderTwoBatches's
+  // own comment has the determinism argument).
+  screen.getByRole("radio", { name: "Yes" }).focus();
+  const persisted = nextMutationPersistence("ref_a");
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /send answers/i }));
+    ackAskUserCall(fake, "ref_a", "turn_1", "item_2", "call_2", SECOND_ASK);
+  });
+  expect(askDockStore.getState().byRef.get("ref_a")?.batches.length).toBe(2);
+
+  await persisted;
+  await waitFor(() => expect(askDockStore.getState().byRef.get("ref_a")?.batches.length).toBe(1));
+
+  // Batch 1 unmounted with the focus in it; focus lands on the remaining
+  // batch's first answer control, and the still-hidden composer is NOT
+  // asked for focus.
+  await waitFor(() => expect(document.activeElement).toBe(screen.getByRole("radio", { name: "later-opt" })));
+  expect(screen.getByText("none")).toBeTruthy();
 });

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.tsx
@@ -50,9 +50,29 @@
 //   - Failure feedback for a local durable-enqueue error is a toast (the
 //     wave's decided convention, T1's loadOlder reference implementation);
 //     network outcomes are rendered by recovery state, not an inline banner.
+//
+// Phase 3 keyboard operation (webui-keybindings-p3): on top of the per-batch
+// keys above, Alt+PageDown/Alt+PageUp jump focus between BATCHES directly,
+// wrapping at both ends (landing on the target batch's selected tab when it
+// has a tab strip, else its first answer control). Alt+Page* rather than
+// Alt+Arrow* because the Phase 3 transcript-scroll bindings own
+// Alt+ArrowUp/Down with allowInEditable: false - and the dispatcher's
+// editable test only covers INPUT/TEXTAREA/SELECT, so from the dock's tab
+// and send BUTTONS those chords would still scroll the transcript - and
+// rather than bare PageUp/PageDown, which keep their native meaning (the
+// dock is its own overflow-y scroller). Escape stays a deliberate NO-OP:
+// parity-m5-composer.md:120 documents that the dock is the one canonical
+// response surface with no collapse state to escape to, so this component
+// installs no Escape handler at all (AskDock.test.tsx pins both halves). A
+// send returns focus: to the composer via composerFocus.ts's
+// requestComposerFocus seam when the dock just emptied, or to the next
+// still-pending batch's entry control when it has not (the composer input
+// row is hidden/inert until the last batch resolves - Composer.tsx).
 import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { isIMECompositionKeydown } from "../../../../keybindings/dispatcher";
 import { Button, useToasts } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
+import { requestComposerFocus } from "../composerFocus";
 import { AskQuestionCard } from "./AskQuestionCard";
 import type { AskResolution } from "./askCompose";
 import { type AskAnswerState, askDockStore, nextUnansweredKey, useAskDockStore } from "./askDockStore";
@@ -78,6 +98,32 @@ export interface AskDockProps {
 const NO_BATCHES: AskBatch[] = [];
 const NO_ANSWERS: Record<string, AskAnswerState> = {};
 const UNTOUCHED_ANSWER: AskAnswerState = { resolution: null, note: "" };
+
+// FIRST_CONTROL_SELECTOR names a batch's first answer control. Two callers:
+// the activation auto-focus effect (scoped to [data-ask-question] so a
+// multi-question batch's TAB BUTTONS - which sit before the card in DOM
+// order, kata 99yf - never win over the first actual answer control) and
+// focusBatchEntry's no-tab-strip fallback below.
+const FIRST_CONTROL_SELECTOR =
+  '[data-ask-question] input[type="radio"], [data-ask-question] input[type="checkbox"], [data-ask-question] input[type="text"], [data-ask-question] button';
+
+// focusBatchEntry moves focus into a batch at its orientation point: the
+// selected tab when the batch has a tab strip (the tab announces where in
+// the walk the reader is - "2. Second, tab, selected"), else the first
+// answer control, matching the dock-activation auto-focus below. A batch
+// mid-send has its editing controls DISABLED (they must not take focus -
+// jsdom and browsers both refuse focus() on a disabled control), so the
+// fallback chain ends at the batch's own container, which the card makes
+// focusable exactly while sending (roborev PR #884 round 10).
+function focusBatchEntry(batchEl: HTMLElement): void {
+  const entry =
+    batchEl.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]') ??
+    batchEl.querySelector<HTMLElement>(
+      '[data-ask-question] input[type="radio"]:not(:disabled), [data-ask-question] input[type="checkbox"]:not(:disabled), [data-ask-question] input[type="text"]:not(:disabled), [data-ask-question] button:not(:disabled)',
+    ) ??
+    (batchEl.tabIndex >= 0 || batchEl.hasAttribute("tabindex") ? batchEl : null);
+  entry?.focus();
+}
 
 // useAskDockPending is the seam T2 (or any other composer-surface owner)
 // reads to decide whether to hide/inert the plain composer for `ref` -
@@ -156,6 +202,11 @@ function AskBatchCard({ sessionRef, batch, answers, onSend }: AskBatchCardProps)
   }
 
   function handlePrimaryAction() {
+    // The keyboard path honors the SAME disabled state as the footer button:
+    // on the last question with the walk unfinished (or with a send in
+    // flight) the button is disabled, and Mod+Enter must not bypass that and
+    // submit the batch with the question on screen implicitly skipped.
+    if (sendDisabled) return;
     if (advanceTarget !== undefined) {
       askDockStore.getState().setActive(sessionRef, batch.id, advanceTarget);
       return;
@@ -171,17 +222,28 @@ function AskBatchCard({ sessionRef, batch, answers, onSend }: AskBatchCardProps)
   // (data-ask-free-input, AskQuestionCard.tsx's own doc comment on that
   // attribute) - it is a plain <input>, not a <textarea>, so there is no
   // newline for a bare Enter to otherwise insert, unlike the main
-  // composer's own Shift+Enter-newlines contract. Guarded on isComposing
+  // composer's own Shift+Enter-newlines contract. Guarded against IME input
   // both ways: an IME composition's own confirm keystroke also fires as
-  // "Enter", and must never be read as a submit (same guard Composer.tsx's
-  // own handleKeyDown applies to its Enter-to-send path).
+  // "Enter", and must never be read as a submit - the shared
+  // isIMECompositionKeydown guard (keybindings/dispatcher.ts) pairs
+  // isComposing with the keyCode 229 fallback, which some browsers report an
+  // IME commit through WITHOUT isComposing (roborev PR #884 round 7).
   function handleBatchKeyDown(event: React.KeyboardEvent) {
-    if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
+    if (event.key !== "Enter" || isIMECompositionKeydown(event.nativeEvent)) return;
     const isPrimaryChord = event.metaKey || event.ctrlKey;
     const isFreeTextInputEnter =
-      !isPrimaryChord && !event.shiftKey && (event.target as HTMLElement).dataset.askFreeInput === "true";
+      !isPrimaryChord &&
+      !event.altKey &&
+      !event.shiftKey &&
+      (event.target as HTMLElement).dataset.askFreeInput === "true";
     if (!isPrimaryChord && !isFreeTextInputEnter) return;
     event.preventDefault();
+    // The dock CONSUMED this chord: keep it from the window-level dispatcher
+    // too. preventDefault alone only reaches bindings that honor
+    // defaultPrevented - a binding that deliberately ignores it (rail.toggle)
+    // remapped onto one of these chords would otherwise fire alongside the
+    // send (roborev PR #884 round 2).
+    event.stopPropagation();
     handlePrimaryAction();
   }
 
@@ -189,6 +251,13 @@ function AskBatchCard({ sessionRef, batch, answers, onSend }: AskBatchCardProps)
   // the panel is right there on the same surface, so there is no expensive
   // switch to defer behind a second Enter press). Home/End jump the ends.
   function handleTabsKeyDown(event: React.KeyboardEvent) {
+    // Alt/Ctrl/Meta mean the key belongs elsewhere: Alt+ArrowUp/Down and
+    // Alt+Home/End are the global transcript scroll/jump chords, and from a
+    // tab BUTTON the dispatcher's editable test does not shield them - the
+    // walk must not eat them (roborev PR #884 round 2). Shift stays LOCAL:
+    // no global binding claims Shift+Arrow/Home/End, and the walk moved tabs
+    // on those chords before the guard existed (round 5).
+    if (event.altKey || event.ctrlKey || event.metaKey) return;
     const current = activeIndex >= 0 ? activeIndex : 0;
     let next = -1;
     if (event.key === "ArrowRight") next = (current + 1) % total;
@@ -207,6 +276,7 @@ function AskBatchCard({ sessionRef, batch, answers, onSend }: AskBatchCardProps)
         question={question}
         number={index + 1}
         answer={answerFor(answers, question.key)}
+        disabled={batch.sending}
         onResolutionChange={(resolution: AskResolution | null) =>
           askDockStore.getState().setAnswer(sessionRef, question.key, resolution)
         }
@@ -216,8 +286,19 @@ function AskBatchCard({ sessionRef, batch, answers, onSend }: AskBatchCardProps)
   }
 
   return (
+    // data-ask-batch lets the dock-level batch jump (Alt+PageUp/Down) and the
+    // post-send focus move locate each batch's card without depending on the
+    // CSS-module class name. While sending, every editing control inside is
+    // disabled, so the container itself takes tabIndex -1 as the jump's
+    // focus-landing fallback (focusBatchEntry's last resort - the card is
+    // otherwise never in the tab order).
     // biome-ignore lint/a11y/noStaticElementInteractions: catches Mod+Enter/Enter bubbling up from the batch's own controls (radios, the free-text input) - the div is a layout container, not itself interactive, same precedent as Settings.tsx's own Escape-catching wrapper
-    <div className={CLASS.batch} onKeyDown={handleBatchKeyDown}>
+    <div
+      className={CLASS.batch}
+      onKeyDown={handleBatchKeyDown}
+      data-ask-batch={batch.id}
+      tabIndex={batch.sending ? -1 : undefined}
+    >
       {total > 1 && (
         // key="tabs"/key="panel" on both siblings: when a late ask_user call
         // grows a single-question batch past one question, the tab strip
@@ -410,11 +491,7 @@ export function AskDock({ ref: sessionRef }: AskDockProps) {
     if (!dock) return;
     const focusFirst = () => {
       askDockStore.getState().markPendingGreeted(sessionRef);
-      dock
-        .querySelector<HTMLElement>(
-          '[data-ask-question] input[type="radio"], [data-ask-question] input[type="checkbox"], [data-ask-question] input[type="text"], [data-ask-question] button',
-        )
-        ?.focus();
+      dock.querySelector<HTMLElement>(FIRST_CONTROL_SELECTOR)?.focus();
     };
     if (typeof IntersectionObserver !== "function") {
       focusFirst();
@@ -438,14 +515,69 @@ export function AskDock({ ref: sessionRef }: AskDockProps) {
       // that can still tell a failed send from the failed session resume
       // behind it (askDockStore's SendBatchOutcome).
       toasts.push("error", outcome.message);
+      return;
     }
-    // "sent"/"stale": nothing further to do here - a successful send's own
-    // batch removal, and a stale click's own no-op, are both already
-    // reflected by askDockStore's reactive state.
+    // "stale": nothing further to do here - the dock re-checked and found
+    // nothing left to send, and that no-op is already reflected by
+    // askDockStore's reactive state.
+    if (outcome.outcome !== "sent") return;
+    // Focus return (Phase 3): the sent batch's card - including whichever
+    // control had focus - unmounts with it, and without an explicit move
+    // keyboard focus drops to <body>. removeBatch has already run inside
+    // sendBatch, so the store (not the not-yet-flushed DOM) says what
+    // remains. Dock empty: ask the composer to take focus back through the
+    // composerFocus.ts seam (the request survives until the input row's
+    // hidden/inert lifts - exactly the transition this send just caused).
+    // Batches remain: the composer input row is still hidden/inert, so move
+    // focus to the next pending batch's entry control instead. That
+    // batch's DOM element still exists pre-flush and survives it (keyed),
+    // so the query is safe at either flush ordering.
+    const remaining = askDockStore.getState().byRef.get(sessionRef)?.batches ?? [];
+    // Several batches can be mid-send at once (each send freezes its own
+    // batch; a later send starts from the still-open one). Landing on a
+    // sending batch strands focus on disabled controls while an EDITABLE
+    // batch waits behind it - take the first non-sending one, falling back
+    // to the first only when every remaining batch is in flight (roborev PR
+    // #884 round 13).
+    const nextBatch = remaining.find((b) => !b.sending) ?? remaining[0];
+    if (nextBatch === undefined) {
+      requestComposerFocus(sessionRef);
+      return;
+    }
+    const nextEl = dockRef.current?.querySelector<HTMLElement>(`[data-ask-batch="${nextBatch.id}"]`);
+    if (nextEl) focusBatchEntry(nextEl);
+  }
+
+  // Batch jump (Phase 3): Alt+PageDown/Alt+PageUp move focus between batch
+  // cards directly, wrapping at both ends - the tab strip's ArrowLeft/Right
+  // walk only moves within ONE batch. Strict Alt-only chord (an extra
+  // modifier or an IME composition lets the key keep whatever other meaning
+  // it has). Fewer than two batches: nothing to jump to, and the event is
+  // left alone rather than claimed.
+  function handleDockKeyDown(event: React.KeyboardEvent) {
+    if (isIMECompositionKeydown(event.nativeEvent)) return;
+    if (!event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+    const delta = event.key === "PageDown" ? 1 : event.key === "PageUp" ? -1 : 0;
+    if (delta === 0) return;
+    const root = dockRef.current;
+    if (!root) return;
+    const batchEls = Array.from(root.querySelectorAll<HTMLElement>("[data-ask-batch]"));
+    if (batchEls.length < 2) return;
+    event.preventDefault();
+    // Consumed: stop propagation as well so a remapped window-level binding
+    // that ignores defaultPrevented cannot fire alongside the jump (same
+    // contract as the batch Enter handler above).
+    event.stopPropagation();
+    const current = batchEls.findIndex((el) => event.target instanceof Node && el.contains(event.target));
+    const next =
+      current === -1 ? (delta === 1 ? 0 : batchEls.length - 1) : (current + delta + batchEls.length) % batchEls.length;
+    const target = batchEls[next];
+    if (target) focusBatchEntry(target);
   }
 
   return (
-    <div className={CLASS.dock} ref={dockRef} data-ask-response-dock>
+    // biome-ignore lint/a11y/noStaticElementInteractions: catches Alt+PageUp/Down bubbling up from any control inside any batch - the div is a layout container, not itself interactive, same precedent as the batch-level Enter handler above
+    <div className={CLASS.dock} ref={dockRef} data-ask-response-dock onKeyDown={handleDockKeyDown}>
       {/* Visual caption only - NOT a live region. The row is virtualized, so
           an aria-live region here would re-insert and re-announce on every
           scroll-away/scroll-back remount; the one live region for this

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskQuestionCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskQuestionCard.test.tsx
@@ -46,6 +46,7 @@ function Harness({ q, initial = UNTOUCHED }: { q: AskQuestionRef; initial?: AskA
   const [answer, setAnswer] = useState<AskAnswerState>(initial);
   return (
     <AskQuestionCard
+      disabled={false}
       question={q}
       number={1}
       answer={answer}
@@ -160,6 +161,7 @@ test("clicking a regular option (single-select) resolves to that option alone", 
   const onResolutionChange = vi.fn();
   render(
     <AskQuestionCard
+      disabled={false}
       question={question()}
       number={1}
       answer={UNTOUCHED}
@@ -223,6 +225,7 @@ test("while Something else is active, the shared text field edits the free resol
   const onNoteChange = vi.fn();
   render(
     <AskQuestionCard
+      disabled={false}
       question={question()}
       number={1}
       answer={{ resolution: { kind: "free", text: "" }, note: "" }}
@@ -264,6 +267,7 @@ test("the note field is visible with no disclosure toggle and calls onNoteChange
   const onNoteChange = vi.fn();
   render(
     <AskQuestionCard
+      disabled={false}
       question={question()}
       number={1}
       answer={UNTOUCHED}

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskQuestionCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskQuestionCard.tsx
@@ -54,6 +54,12 @@ export interface AskQuestionCardProps {
   // [answers] reply's own numbering (askCompose.ts).
   number: number;
   answer: AskAnswerState;
+  // True while the batch's send is in flight (AskBatch.sending): the
+  // successful send removes the batch, so an edit made mid-flight would be
+  // silently discarded - every editing control disables until the send
+  // settles (roborev PR #884 round 10). askDockStore's setAnswer/setNote
+  // refuse the same writes at the store boundary.
+  disabled: boolean;
   onResolutionChange(resolution: AskResolution | null): void;
   onNoteChange(note: string): void;
 }
@@ -73,7 +79,14 @@ function orderedOptions(options: AskQuestionRef["options"]) {
     .map(({ opt }) => opt);
 }
 
-export function AskQuestionCard({ question, number, answer, onResolutionChange, onNoteChange }: AskQuestionCardProps) {
+export function AskQuestionCard({
+  question,
+  number,
+  answer,
+  disabled,
+  onResolutionChange,
+  onNoteChange,
+}: AskQuestionCardProps) {
   const id = useId();
   const headerId = `${id}-header`;
   const textId = `${id}-text`;
@@ -141,6 +154,7 @@ export function AskQuestionCard({ question, number, answer, onResolutionChange, 
             type={multiSelect ? "checkbox" : "radio"}
             name={radioName}
             aria-label={opt.label}
+            disabled={disabled}
             checked={
               multiSelect
                 ? checkedLabels.has(opt.label)
@@ -166,6 +180,7 @@ export function AskQuestionCard({ question, number, answer, onResolutionChange, 
             type="radio"
             name={radioName}
             aria-label="Something else…"
+            disabled={disabled}
             checked={freeActive}
             onClick={(e) => {
               if (freeActive) {
@@ -221,6 +236,7 @@ export function AskQuestionCard({ question, number, answer, onResolutionChange, 
           ref={noteInputRef}
           type="text"
           className={CLASS.textInput}
+          disabled={disabled}
           placeholder={freeActive ? "type your answer" : "note (optional)"}
           aria-labelledby={freeActive ? `${freeLabelId} ${headerId} ${textId}` : `${headerId} ${textId} ${noteLabelId}`}
           data-ask-free-input={freeActive ? "true" : undefined}

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askDockStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askDockStore.ts
@@ -212,12 +212,23 @@ function advancesOnAnswer(questionMultiSelect: boolean, resolution: AskResolutio
   return resolution.kind === "option" && !questionMultiSelect;
 }
 
+// isSendingQuestion answers whether the question key belongs to a batch
+// mid-send. setAnswer/setNote refuse those writes: the card's editing
+// controls are already disabled (AskQuestionCard's disabled prop), and this
+// is the store-level half of the same contract - an edit landing mid-flight
+// would be silently discarded when the send resolves and removes the batch
+// (roborev PR #884 round 10).
+function isSendingQuestion(refState: AskDockRefState, key: string): boolean {
+  return refState.batches.some((b) => b.sending && b.questions.some((q) => q.key === key));
+}
+
 export const askDockStore = createStore<AskDockState>(() => ({
   byRef: new Map(),
 
   setAnswer(ref, key, resolution) {
     askDockStore.setState((s) => {
       const refState = s.byRef.get(ref) ?? EMPTY_REF_STATE;
+      if (isSendingQuestion(refState, key)) return s;
       const nextAnswers = { ...refState.answers, [key]: { resolution, note: answerFor(refState, key).note } };
       // Auto-advance (kata 99yf): a one-click resolution landing on the tab
       // the reader is currently on moves the dock to the next unanswered
@@ -256,6 +267,7 @@ export const askDockStore = createStore<AskDockState>(() => ({
   setNote(ref, key, note) {
     askDockStore.setState((s) => {
       const refState = s.byRef.get(ref) ?? EMPTY_REF_STATE;
+      if (isSendingQuestion(refState, key)) return s;
       const nextByRef = new Map(s.byRef);
       nextByRef.set(ref, {
         ...refState,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.test.tsx
@@ -279,3 +279,58 @@ test("mousedown on the bar is prevented, so clicking its action never collapses 
   const event = fireEvent.mouseDown(screen.getByRole("toolbar", { name: "Selection actions" }));
   expect(event).toBe(false); // fireEvent returns false when preventDefault() was called
 });
+
+// Multi-pane workspaces mount one SelectionQuote per session pane
+// (Session.tsx), and each instance registers the selection.quote action.
+// These two tests pin the multi-instance contract against the two ways a
+// shared registry can break it: the LAST-registered instance clobbering the
+// one holding the selection, and an instance's unmount deadening the chord
+// for every remaining instance.
+function renderInstance(label: string, onInvoke: (text: string) => void) {
+  const containerRef = createRef<HTMLDivElement>();
+  const rendered = render(
+    <div ref={containerRef} data-testid={`${label}-container`}>
+      <div data-view-anchor-message="true" data-testid={`${label}-message`}>
+        selectable message prose
+      </div>
+      <SelectionQuote containerRef={containerRef} actions={[{ label: "Quote in reply", onInvoke }]} />
+    </div>,
+  );
+  return {
+    containerRef,
+    unmount: rendered.unmount,
+    messageNode: screen.getByTestId(`${label}-message`).firstChild as Text,
+  };
+}
+
+test("two mounted instances: the one holding the selection handles Mod+', not the last-registered", () => {
+  const onInvokeA = vi.fn();
+  const onInvokeB = vi.fn();
+  const a = renderInstance("a", onInvokeA);
+  renderInstance("b", onInvokeB);
+  installFakeSelection({ text: "quoted prose", anchorNode: a.messageNode });
+  act(() => {
+    a.containerRef.current?.dispatchEvent(new Event("pointerup", { bubbles: true }));
+  });
+
+  fireEvent.keyDown(document, { key: "'", metaKey: true });
+
+  expect(onInvokeA).toHaveBeenCalledExactlyOnceWith("quoted prose");
+  expect(onInvokeB).not.toHaveBeenCalled();
+});
+
+test("unmounting the last-registered instance does not deaden Mod+' for the remaining ones", () => {
+  const onInvokeA = vi.fn();
+  const onInvokeB = vi.fn();
+  const a = renderInstance("a", onInvokeA);
+  const b = renderInstance("b", onInvokeB);
+  b.unmount();
+  installFakeSelection({ text: "quoted prose", anchorNode: a.messageNode });
+  act(() => {
+    a.containerRef.current?.dispatchEvent(new Event("pointerup", { bubbles: true }));
+  });
+
+  fireEvent.keyDown(document, { key: "'", metaKey: true });
+
+  expect(onInvokeA).toHaveBeenCalledExactlyOnceWith("quoted prose");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/SelectionQuote.tsx
@@ -32,6 +32,9 @@
 // scroller, anywhere) rather than leaving it floating over content it no
 // longer points at.
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { ACTIONS } from "../../../keybindings/actions";
+import { keybindingsRegistry } from "../../../keybindings/registry";
+import { installKeybindings } from "../../../shell/installKeybindings";
 import { Button } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import { clampToBounds, messageContentElement } from "./selectionQuoteLogic";
@@ -71,19 +74,58 @@ export function SelectionQuote({ containerRef, actions }: SelectionQuoteProps) {
   const [selection, setSelection] = useState<CapturedSelection | null>(null);
   const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
   const barRef = useRef<HTMLDivElement>(null);
-  // Read by the Mod+' handler inside the effect below without making
-  // `actions` an effect dependency - every caller (Session.tsx included)
-  // passes a fresh array literal each render, and re-subscribing the whole
-  // listener set on every render for that reason alone would be wasteful
-  // (same idiom as Composer.tsx's own textRef, kept live without being a
-  // dependency).
+  // Read by the selection.quote action below without making `actions` an
+  // effect dependency - every caller (Session.tsx included) passes a fresh
+  // array literal each render, and re-registering the action on every render
+  // for that reason alone would be wasteful (same idiom as Composer.tsx's
+  // own textRef, kept live without being a dependency).
   const actionsRef = useRef(actions);
   actionsRef.current = actions;
-  // Mirrors `selection` state, read (never written) by the Mod+' handler -
-  // see that handler's own comment for why it reads this ref instead of
-  // the setSelection updater's own current-value argument.
+  // Mirrors `selection` state, read (never written) by the selection.quote
+  // action - see that registration's own comment for why it reads this ref
+  // instead of the setSelection updater's own current-value argument.
   const selectionRef = useRef(selection);
   selectionRef.current = selection;
+
+  // Mod+' invokes the bar's first (and today, only) action directly against
+  // the currently captured selection - the same code path a click on the
+  // bar's own button takes (actions[0].onInvoke below), just reachable
+  // without a pointer. A no-op with nothing captured. The chord is the
+  // keybindings dispatcher's; its binding (keybindings/defaults.ts's
+  // selection.quote) carries this listener's old policy: strict modifiers
+  // (AltGr, reported as ctrlKey+altKey, does not misfire the chord - see
+  // MDN's own note on AltGr), no editable-target or modal guard (the old
+  // listener had neither), and still yields to a keydown another handler
+  // already claimed (defaultPrevented - see OverlayPanel.tsx's own Escape
+  // precedent).
+  //
+  // BLOCKER fix (preserved): onInvoke must NOT run inside a setSelection
+  // updater. A setState updater must be a pure function - React calls it
+  // twice under StrictMode (see shell/rail/Rail.tsx:323-325's own comment on
+  // this exact rule) - so a real double-invoke there ran onInvoke (and so
+  // requestQuoteInsert) twice per keypress, silently double-inserting the
+  // quote. Reading the current selection from selectionRef (written every
+  // render, never inside a state updater) and invoking OUTSIDE setSelection
+  // keeps the updater the pure `() => null` it always should have been.
+  useEffect(() => {
+    installKeybindings();
+    // One SelectionQuote mounts per session pane (Session.tsx), so several
+    // instances register selection.quote at once. The registry invokes an
+    // action's handlers in registration order until one ACCEPTS; returning
+    // false when THIS instance holds no captured selection passes the chord
+    // to the instance that does - exactly the old per-instance document
+    // listeners' semantics (every instance saw the keydown; only the one
+    // holding the selection acted). The disposer removes only this
+    // instance's registration, so unmounting one pane never deadens ⌘' for
+    // the rest.
+    return keybindingsRegistry.getState().registerAction(ACTIONS.selectionQuote, () => {
+      const current = selectionRef.current;
+      if (!current) return false;
+      actionsRef.current[0]?.onInvoke(current.text);
+      setSelection(null);
+      return true;
+    });
+  }, []);
 
   const evaluate = useCallback(() => {
     const container = containerRef.current;
@@ -121,36 +163,6 @@ export function SelectionQuote({ containerRef, actions }: SelectionQuoteProps) {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setSelection(null);
-        return;
-      }
-      // Mod+' invokes the bar's first (and today, only) action directly
-      // against the currently captured selection - the same code path a
-      // click on the bar's own button takes (actions[0].onInvoke below),
-      // just reachable without a pointer. A no-op with nothing captured.
-      //
-      // !event.altKey: AltGr (used to type "'" directly on some non-US
-      // keyboard layouts) is reported as ctrlKey+altKey by browsers - see
-      // MDN's own note on AltGr - so without this guard, typing a literal
-      // "'" via AltGr on those layouts would misfire this chord.
-      // !event.defaultPrevented: some other handler (e.g. an ancestor
-      // overlay) already claimed this keydown - see OverlayPanel.tsx's own
-      // Escape precedent for the same idea.
-      //
-      // BLOCKER fix: onInvoke used to run INSIDE the setSelection updater
-      // function. A setState updater must be a pure function - React calls
-      // it twice under StrictMode (see shell/rail/Rail.tsx:323-325's own
-      // comment on this exact rule) - so a real double-invoke there ran
-      // onInvoke (and so requestQuoteInsert) twice per keypress, silently
-      // double-inserting the quote. Reading the current selection from
-      // selectionRef (written every render, never inside a state updater)
-      // and invoking OUTSIDE setSelection fixes that: the updater itself is
-      // now the pure `() => null` it always should have been.
-      if (event.key === "'" && (event.metaKey || event.ctrlKey) && !event.altKey && !event.defaultPrevented) {
-        const current = selectionRef.current;
-        if (current) {
-          actionsRef.current[0]?.onInvoke(current.text);
-          setSelection(null);
-        }
       }
     };
     const handleScroll = () => setSelection(null);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.test.tsx
@@ -1,0 +1,203 @@
+// Tests for useTranscriptScrollKeys (webui-keybindings-p3 Task 1): the
+// session transcript's keyboard scroll seam. Each mounted Session pane
+// registers its own transcript.* handlers against the shared keybindings
+// registry; the multi-instance rule (a handler returns false when its pane
+// is not workspaceStore.focusedPaneId) is the SelectionQuote clobber class
+// from Phase 2a, pinned here with a two-pane test. Chord dispatch goes
+// through the REAL dispatcher/defaults (installKeybindings) so these tests
+// also pin the Alt+Arrow chords themselves, the editable-target suppression,
+// and mobile inertness (rail.toggle's no-registration pattern).
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { ACTIONS } from "../../../../keybindings/actions";
+import { DEFAULT_BINDINGS } from "../../../../keybindings/defaults";
+import { keybindingsRegistry } from "../../../../keybindings/registry";
+import { installKeybindings } from "../../../../shell/installKeybindings";
+import { resetMobileViewportForTests } from "../../../../shell/useIsMobile";
+import { resetWorkspaceStoreForTests, workspaceStore } from "../../../../shell/workspace";
+import type { VirtualListHandle } from "../../../../widgets/virtuallist";
+import { TRANSCRIPT_LINE_SCROLL_PX, useTranscriptScrollKeys } from "./useTranscriptScrollKeys";
+
+function keydown(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, ...init });
+}
+
+// A VirtualListHandle double whose scroll element is a real (layout-free)
+// jsdom div: scrollTop assignment sticks in jsdom, and clientHeight is
+// defined explicitly (500px) so the page-scroll step has geometry to read.
+function renderPaneKeys(paneId: string, { mounted = true }: { mounted?: boolean } = {}) {
+  const el = document.createElement("div");
+  Object.defineProperty(el, "clientHeight", { value: 500, configurable: true });
+  document.body.appendChild(el);
+  const scrollToIndex = vi.fn();
+  const listRef = {
+    current: {
+      scrollToIndex,
+      getScrollElement: () => (mounted ? el : null),
+      getVisibleRange: () => null,
+    } as VirtualListHandle,
+  };
+  const jumpToBottom = vi.fn();
+  const hook = renderHook(() => useTranscriptScrollKeys({ paneId, listRef, jumpToBottom }));
+  return { el, scrollToIndex, jumpToBottom, unmount: hook.unmount };
+}
+
+beforeEach(() => {
+  resetWorkspaceStoreForTests();
+  installKeybindings();
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+  resetMobileViewportForTests();
+});
+
+test("Alt+ArrowDown scrolls only the focused pane's transcript (two-pane multi-instance pin)", () => {
+  const a = renderPaneKeys("pane_a");
+  const b = renderPaneKeys("pane_b");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+  expect(b.el.scrollTop).toBe(0);
+
+  workspaceStore.setState({ focusedPaneId: "pane_b" });
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+  expect(b.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+});
+
+test("Alt+ArrowUp scrolls the focused transcript up one line step", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  a.el.scrollTop = 100;
+
+  window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true }));
+  expect(a.el.scrollTop).toBe(100 - TRANSCRIPT_LINE_SCROLL_PX);
+});
+
+test("Alt+Shift+ArrowDown/Up page the focused transcript by ~0.9 of the viewport", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+  expect(a.el.scrollTop).toBe(450);
+
+  window.dispatchEvent(keydown({ key: "ArrowUp", code: "ArrowUp", altKey: true, shiftKey: true }));
+  expect(a.el.scrollTop).toBe(0);
+});
+
+test("the Alt+Shift page chords do NOT also fire the plain line-scroll bindings", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true, shiftKey: true }));
+  // Exactly the page step, not page+line (the line binding requires Shift to
+  // be absent).
+  expect(a.el.scrollTop).toBe(450);
+});
+
+test("Alt+Arrow scroll chords are suppressed from editable targets", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+
+  input.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(0);
+
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+});
+
+test("a keydown no pane accepts is not preventDefaulted (unfocused panes decline, unmounted lists decline)", () => {
+  const a = renderPaneKeys("pane_a");
+  // pane_b registers handlers too, but its VirtualList has no scroll element.
+  renderPaneKeys("pane_b", { mounted: false });
+  // Nobody focused: both handlers decline.
+  const unfocused = keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+  window.dispatchEvent(unfocused);
+  expect(unfocused.defaultPrevented).toBe(false);
+  expect(a.el.scrollTop).toBe(0);
+
+  // Focused but the transcript's VirtualList has not mounted a scroll
+  // element yet (a dormant session renders EmptyTranscript, no list).
+  workspaceStore.setState({ focusedPaneId: "pane_b" });
+  const unmounted = keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+  window.dispatchEvent(unmounted);
+  expect(unmounted.defaultPrevented).toBe(false);
+});
+
+test("unmounting a pane unregisters only that pane's handlers", () => {
+  const a = renderPaneKeys("pane_a");
+  const b = renderPaneKeys("pane_b");
+  workspaceStore.setState({ focusedPaneId: "pane_b" });
+  b.unmount();
+
+  const event = keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+  window.dispatchEvent(event);
+  expect(event.defaultPrevented).toBe(false);
+  expect(a.el.scrollTop).toBe(0);
+
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  window.dispatchEvent(keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true }));
+  expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
+});
+
+test("transcript.scrollTop/scrollBottom ship with NO default chord (Phase 4's map decides)", () => {
+  expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollTop)).toBe(false);
+  expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollBottom)).toBe(false);
+});
+
+test("scrollTop/scrollBottom drive the focused pane's virtualizer (bound to test chords here)", () => {
+  const a = renderPaneKeys("pane_a");
+  const b = renderPaneKeys("pane_b");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  const registry = keybindingsRegistry.getState();
+  registry.registerBinding({ id: "test.transcript.scrollTop", actionId: ACTIONS.transcriptScrollTop, chord: "F8" });
+  registry.registerBinding({
+    id: "test.transcript.scrollBottom",
+    actionId: ACTIONS.transcriptScrollBottom,
+    chord: "F9",
+  });
+  try {
+    window.dispatchEvent(keydown({ key: "F8", code: "F8" }));
+    expect(a.scrollToIndex).toHaveBeenCalledWith(0, { align: "start" });
+    expect(b.scrollToIndex).not.toHaveBeenCalled();
+
+    window.dispatchEvent(keydown({ key: "F9", code: "F9" }));
+    expect(a.jumpToBottom).toHaveBeenCalledOnce();
+    expect(b.jumpToBottom).not.toHaveBeenCalled();
+  } finally {
+    registry.unregisterBinding("test.transcript.scrollTop");
+    registry.unregisterBinding("test.transcript.scrollBottom");
+  }
+});
+
+// jsdom has no matchMedia at all (useIsMobile.test.ts's header documents the
+// probe); a matching stub puts every useIsMobile consumer on mobile.
+function installMobileViewport(): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      media,
+      matches: media === "(max-width: 899px)",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })),
+  );
+}
+
+test("mobile: no transcript scroll handlers register at all (the rail.toggle inertness pattern)", () => {
+  installMobileViewport();
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+
+  expect(keybindingsRegistry.getState().actions.get(ACTIONS.transcriptLineDown)).toBeUndefined();
+  const event = keydown({ key: "ArrowDown", code: "ArrowDown", altKey: true });
+  window.dispatchEvent(event);
+  expect(a.el.scrollTop).toBe(0);
+  expect(event.defaultPrevented).toBe(false);
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.test.tsx
@@ -146,34 +146,37 @@ test("unmounting a pane unregisters only that pane's handlers", () => {
   expect(a.el.scrollTop).toBe(TRANSCRIPT_LINE_SCROLL_PX);
 });
 
-test("transcript.scrollTop/scrollBottom ship with NO default chord (Phase 4's map decides)", () => {
-  expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollTop)).toBe(false);
-  expect(DEFAULT_BINDINGS.some((b) => b.actionId === ACTIONS.transcriptScrollBottom)).toBe(false);
+// Phase 4a assigned the default chords (the p4 plan's Design decision 2):
+// Alt+Home/Alt+End complete the Alt-arrow scroll family, same plain policy.
+test("transcript.scrollTop/scrollBottom default to Alt+Home/Alt+End", () => {
+  expect(DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.transcriptScrollTop)?.chord).toBe("Alt+Home");
+  expect(DEFAULT_BINDINGS.find((b) => b.actionId === ACTIONS.transcriptScrollBottom)?.chord).toBe("Alt+End");
 });
 
-test("scrollTop/scrollBottom drive the focused pane's virtualizer (bound to test chords here)", () => {
+test("Alt+Home/Alt+End drive the focused pane's virtualizer (the real default chords)", () => {
   const a = renderPaneKeys("pane_a");
   const b = renderPaneKeys("pane_b");
   workspaceStore.setState({ focusedPaneId: "pane_a" });
-  const registry = keybindingsRegistry.getState();
-  registry.registerBinding({ id: "test.transcript.scrollTop", actionId: ACTIONS.transcriptScrollTop, chord: "F8" });
-  registry.registerBinding({
-    id: "test.transcript.scrollBottom",
-    actionId: ACTIONS.transcriptScrollBottom,
-    chord: "F9",
-  });
-  try {
-    window.dispatchEvent(keydown({ key: "F8", code: "F8" }));
-    expect(a.scrollToIndex).toHaveBeenCalledWith(0, { align: "start" });
-    expect(b.scrollToIndex).not.toHaveBeenCalled();
 
-    window.dispatchEvent(keydown({ key: "F9", code: "F9" }));
-    expect(a.jumpToBottom).toHaveBeenCalledOnce();
-    expect(b.jumpToBottom).not.toHaveBeenCalled();
-  } finally {
-    registry.unregisterBinding("test.transcript.scrollTop");
-    registry.unregisterBinding("test.transcript.scrollBottom");
-  }
+  window.dispatchEvent(keydown({ key: "Home", code: "Home", altKey: true }));
+  expect(a.scrollToIndex).toHaveBeenCalledWith(0, { align: "start" });
+  expect(b.scrollToIndex).not.toHaveBeenCalled();
+
+  window.dispatchEvent(keydown({ key: "End", code: "End", altKey: true }));
+  expect(a.jumpToBottom).toHaveBeenCalledOnce();
+  expect(b.jumpToBottom).not.toHaveBeenCalled();
+});
+
+test("Alt+Home/Alt+End are suppressed from editable targets (Home/End keep their caret meaning)", () => {
+  const a = renderPaneKeys("pane_a");
+  workspaceStore.setState({ focusedPaneId: "pane_a" });
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+
+  input.dispatchEvent(keydown({ key: "Home", code: "Home", altKey: true }));
+  input.dispatchEvent(keydown({ key: "End", code: "End", altKey: true }));
+  expect(a.scrollToIndex).not.toHaveBeenCalled();
+  expect(a.jumpToBottom).not.toHaveBeenCalled();
 });
 
 // jsdom has no matchMedia at all (useIsMobile.test.ts's header documents the

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScrollKeys.ts
@@ -1,0 +1,105 @@
+// useTranscriptScrollKeys: the session transcript's keyboard scroll seam
+// (webui-keybindings-p3 Task 1). Every mounted Session pane registers its own
+// handlers for the transcript.* actions against the shared keybindings
+// registry, using the registry's multi-instance support (registry.ts's
+// ActionRunner contract): a handler returns false - DECLINES - when its pane
+// is not workspaceStore.focusedPaneId, so only the focused pane's transcript
+// scrolls. This is the SelectionQuote clobber class from Phase 2a, pinned by
+// this hook's own two-pane test.
+//
+// The scroll mechanisms are the ones the transcript's own flow stack already
+// exposes - no new scroll math:
+//   - line/page steps write the scroll element's scrollTop directly, the
+//     same adjustment useTranscriptScroll's own anchor-restore paths use
+//     (el.scrollTop += delta). The native scroll listener that hook attaches
+//     keeps wasAtBottom/the new-content pill in step afterward.
+//   - scrollTop uses the virtualizer's scrollToIndex(0, { align: "start" }).
+//   - scrollBottom is the hook's own jumpToBottom (error-anchor aware, pill
+//     clearing) - the exact action NewContentPill's click target runs.
+//
+// Mobile: nothing registers at all (rail.toggle's no-registration pattern);
+// with no handler the bindings are inert there.
+
+import { type RefObject, useEffect, useRef } from "react";
+import { ACTIONS } from "../../../../keybindings/actions";
+import { keybindingsRegistry } from "../../../../keybindings/registry";
+import { installKeybindings } from "../../../../shell/installKeybindings";
+import { useIsMobile } from "../../../../shell/useIsMobile";
+import { workspaceStore } from "../../../../shell/workspace";
+import type { VirtualListHandle } from "../../../../widgets/virtuallist";
+
+/** One line-scroll step in pixels (≈ one transcript row's text line). */
+export const TRANSCRIPT_LINE_SCROLL_PX = 40;
+
+/** One page-scroll step as a fraction of the scroll viewport's height. */
+export const TRANSCRIPT_PAGE_SCROLL_RATIO = 0.9;
+
+export interface UseTranscriptScrollKeysOptions {
+  /** The workspace pane this Session instance is mounted as. */
+  paneId: string;
+  listRef: RefObject<VirtualListHandle | null>;
+  /** useTranscriptScroll's jumpToBottom (error-anchor aware, pill clearing). */
+  jumpToBottom: () => void;
+}
+
+export function useTranscriptScrollKeys({ paneId, listRef, jumpToBottom }: UseTranscriptScrollKeysOptions): void {
+  const isMobile = useIsMobile();
+  // jumpToBottom's identity tracks useTranscriptScroll's renders; the ref
+  // keeps the registered handler stable across them (SelectionQuote's
+  // actionsRef idiom).
+  const jumpToBottomRef = useRef(jumpToBottom);
+  jumpToBottomRef.current = jumpToBottom;
+
+  useEffect(() => {
+    if (isMobile) return undefined;
+    installKeybindings();
+    const registry = keybindingsRegistry.getState();
+    const focused = () => workspaceStore.getState().focusedPaneId === paneId;
+    const scrollElement = () => listRef.current?.getScrollElement() ?? null;
+    const unregister = [
+      registry.registerAction(ACTIONS.transcriptLineUp, () => {
+        if (!focused()) return false;
+        const el = scrollElement();
+        if (!el) return false;
+        el.scrollTop -= TRANSCRIPT_LINE_SCROLL_PX;
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptLineDown, () => {
+        if (!focused()) return false;
+        const el = scrollElement();
+        if (!el) return false;
+        el.scrollTop += TRANSCRIPT_LINE_SCROLL_PX;
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptPageUp, () => {
+        if (!focused()) return false;
+        const el = scrollElement();
+        if (!el) return false;
+        el.scrollTop -= el.clientHeight * TRANSCRIPT_PAGE_SCROLL_RATIO;
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptPageDown, () => {
+        if (!focused()) return false;
+        const el = scrollElement();
+        if (!el) return false;
+        el.scrollTop += el.clientHeight * TRANSCRIPT_PAGE_SCROLL_RATIO;
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptScrollTop, () => {
+        if (!focused()) return false;
+        const list = listRef.current;
+        if (!list) return false;
+        list.scrollToIndex(0, { align: "start" });
+        return true;
+      }),
+      registry.registerAction(ACTIONS.transcriptScrollBottom, () => {
+        if (!focused()) return false;
+        jumpToBottomRef.current();
+        return true;
+      }),
+    ];
+    return () => {
+      for (const dispose of unregister) dispose();
+    };
+  }, [isMobile, paneId, listRef]);
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.test.tsx
@@ -1,12 +1,38 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, expect, test, vi } from "vitest";
+import { afterEach, beforeAll, expect, test, vi } from "vitest";
 import { FakeClient } from "../../protocol/testing/fakeClient";
 import { chromeStore, resetChromeStoreForTests } from "../../shell/chromeStore";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../../shell/workspace";
 import { connectionStore } from "../../stores/connection";
 import { resetCredentialsStoreForTests } from "../../stores/credentials";
+import { prefsStore, resetPrefsStoreForTests } from "../../stores/prefs";
 import Settings from "./Settings";
+
+// Node 26 shadows jsdom's real window.localStorage with its own
+// (non-functional under vitest) global - the same MemoryStorage stand-in
+// stores/prefs.test.ts's own comment documents, needed here because the
+// last-visited-section memory persists through localStorage.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeAll(() => {
+  // @ts-expect-error see MemoryStorage's own comment for why this is needed
+  globalThis.localStorage = new MemoryStorage();
+});
 
 // jsdom does not implement window.matchMedia at all - useIsMobile.test.ts's
 // own header comment documents this; every test file that drives mobile
@@ -27,6 +53,8 @@ afterEach(() => {
   window.history.pushState({}, "", "/");
   // @ts-expect-error restores jsdom's own honest default between tests.
   delete window.matchMedia;
+  localStorage.clear();
+  resetPrefsStoreForTests();
   resetWorkspaceStoreForTests();
   resetChromeStoreForTests();
   connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
@@ -244,4 +272,90 @@ test("the pane title reflects the focused section", () => {
   stubMatchMedia(false);
   render(<Settings params={{ section: "credentials" }} paneId="settings-1" focused={true} />);
   expect(screen.getByRole("heading", { name: "Providers & credentials" })).toBeTruthy();
+});
+
+// Reopening Settings returns to the section the user last visited
+// (prefs.ts's lastSettingsSection), not always the first nav entry. The
+// memory is prefs-backed, so it survives a full reload; the bare URL stays
+// bare (the mobile list depends on that shape).
+test("a bare /settings reopens on the last visited section", async () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  const first = render(<Settings params={{ section: "keybindings" }} paneId="settings-1" focused={true} />);
+  // The visit is recorded - and persisted - while the section is shown.
+  expect(prefsStore.getState().lastSettingsSection).toBe("keybindings");
+  expect(localStorage.getItem("evener.prefs.lastSettingsSection")).toBe("keybindings");
+  first.unmount();
+
+  render(<Settings params={{}} paneId="settings-1" focused={true} />);
+
+  expect(await screen.findByRole("heading", { name: "Keybindings" })).toBeTruthy();
+  expect(screen.getByRole("button", { name: "Keybindings" }).getAttribute("aria-current")).toBe("page");
+});
+
+test("a bare /settings opens on General when no section has been visited", () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  render(<Settings params={{}} paneId="settings-1" focused={true} />);
+
+  expect(screen.getByRole("heading", { name: "General" })).toBeTruthy();
+});
+
+test("the pane tab title follows the remembered section too - no General tab over Keybindings content", async () => {
+  // The registry's title() is the DOCK TAB label (DockHost); it must resolve
+  // a bare /settings through the same remembered-section fallback the content
+  // uses (roborev PR #884 round 8).
+  const { paneFor } = await import("../../shell/paneRegistry");
+  await import("./index");
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  localStorage.setItem("evener.prefs.lastSettingsSection", "keybindings");
+  resetPrefsStoreForTests();
+
+  expect(paneFor("settings").title({}, {})).toBe("Keybindings");
+  // An explicit section always wins over the memory.
+  expect(paneFor("settings").title({ section: "theme" }, {})).toBe("Theme");
+  // And a stale remembered id falls back to General, like the content does.
+  localStorage.setItem("evener.prefs.lastSettingsSection", "retired.section");
+  resetPrefsStoreForTests();
+  expect(paneFor("settings").title({}, {})).toBe("General");
+});
+
+test("a remembered section that is no longer a known section falls back to General", () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  localStorage.setItem("evener.prefs.lastSettingsSection", "retired.section");
+  resetPrefsStoreForTests();
+  render(<Settings params={{}} paneId="settings-1" focused={true} />);
+
+  expect(screen.getByRole("heading", { name: "General" })).toBeTruthy();
+});
+
+test("the project section is not remembered (it has no nav row and needs its ?cwd= context)", () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  render(<Settings params={{ section: "project" }} paneId="settings-1" focused={true} />);
+
+  expect(prefsStore.getState().lastSettingsSection).toBeNull();
+});
+
+// The flow that motivated the memory: open Keybindings, leave, reopen, and
+// the character-key toggle is right there - one click, pref flipped, no
+// re-navigation.
+test("the remembered section carries the character-key toggle flow", async () => {
+  stubMatchMedia(false);
+  seedOpenSettingsPane();
+  const first = render(<Settings params={{ section: "keybindings" }} paneId="settings-1" focused={true} />);
+  first.unmount();
+
+  render(<Settings params={{}} paneId="settings-1" focused={true} />);
+  const toggle = await screen.findByRole("switch", { name: "Character-key shortcuts" });
+  // Default ON (the WCAG 2.1.4 turn-off exists, per the p4 plan's Design
+  // decision 3).
+  expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+  await userEvent.setup().click(toggle);
+
+  expect(prefsStore.getState().characterKeyTriggers).toBe(false);
+  expect(localStorage.getItem("evener.prefs.characterKeyTriggers")).toBe("0");
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
@@ -9,12 +9,13 @@ import type { PaneProps } from "../../shell/paneRegistry";
 import { navigate, paneToURL } from "../../shell/routing";
 import { useIsMobile } from "../../shell/useIsMobile";
 import { workspaceStore } from "../../shell/workspace";
+import { prefsStore, usePrefsStore } from "../../stores/prefs";
 import { useSettingsOverviewStore } from "../../stores/settingsOverview";
 import { IconButton, PaneScaffold } from "../../widgets";
 import { CloseIcon } from "../../widgets/dialog/CloseIcon";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { SettingsNav } from "./SettingsNav";
-import { DEFAULT_SECTION_ID, settingsSectionLabel } from "./sections";
+import { DEFAULT_SECTION_ID, isKnownSettingsSection, settingsSectionLabel } from "./sections";
 import { AboutSection } from "./sections/about";
 import { AgentsSection } from "./sections/agents";
 import { CredentialsSection } from "./sections/credentials/CredentialsSection";
@@ -111,8 +112,12 @@ function showSettingsList(): void {
  * each level is addressable (routing.ts already resolves both forms;
  * AppShell's replacePrimary glue updates this singleton pane's params in
  * place on every popstate). Desktop is unchanged: nav and content sit side
- * by side, and a bare /settings still resolves its content to
- * DEFAULT_SECTION_ID.
+ * by side, and a bare /settings resolves its content to the section the
+ * user last visited (prefs.ts's lastSettingsSection), falling back to
+ * DEFAULT_SECTION_ID when there is no remembered section or the remembered
+ * id is no longer a known section. Mobile keeps the bare URL as the section
+ * LIST (the drill-down root) - the remembered section only picks the
+ * desktop content, never the mobile view.
  *
  * Back on mobile lives in the shell's top bar, not in the content: a
  * focused section publishes showSettingsList to the chrome store's paneBack
@@ -130,7 +135,10 @@ function showSettingsList(): void {
  * text and scroll position survive the drill-down round trip.
  */
 export default function Settings({ params, paneId }: PaneProps<SettingsPaneParams>) {
-  const activeId = params.section ?? DEFAULT_SECTION_ID;
+  const rememberedSection = usePrefsStore((s) => s.lastSettingsSection);
+  const activeId =
+    params.section ??
+    (rememberedSection !== null && isKnownSettingsSection(rememberedSection) ? rememberedSection : DEFAULT_SECTION_ID);
   const isMobile = useIsMobile();
   const SectionComponent = SECTION_COMPONENTS[activeId] ?? PlaceholderSection;
   // Mobile list view: bare /settings on a phone. No row is "active" - there
@@ -142,6 +150,16 @@ export default function Settings({ params, paneId }: PaneProps<SettingsPaneParam
     const url = paneToURL("settings", { section: sectionId });
     if (url !== null) navigate(url);
   }
+
+  // Record the visited section so the next bare /settings reopens here.
+  // Only KNOWN nav sections are remembered: "project" is a valid dispatch
+  // target (SECTION_COMPONENTS) but no nav row and needs its ?cwd= context,
+  // so restoring it would land on a meaningless page.
+  useEffect(() => {
+    if (params.section !== undefined && isKnownSettingsSection(params.section)) {
+      prefsStore.getState().setLastSettingsSection(params.section);
+    }
+  }, [params.section]);
 
   // paneBack is published whenever a section is focused, in EITHER host -
   // host-agnostic like the title channel. The effect (not render) owns the

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
@@ -1,6 +1,10 @@
 import type { ComponentType } from "react";
-import { useEffect } from "react";
+import { useCallback, useEffect } from "react";
+import { ACTIONS } from "../../keybindings/actions";
+import { SETTINGS_SCOPE } from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
 import { chromeStore } from "../../shell/chromeStore";
+import { installKeybindings } from "../../shell/installKeybindings";
 import type { PaneProps } from "../../shell/paneRegistry";
 import { navigate, paneToURL } from "../../shell/routing";
 import { useIsMobile } from "../../shell/useIsMobile";
@@ -168,29 +172,34 @@ export default function Settings({ params, paneId }: PaneProps<SettingsPaneParam
   // in a real browser: Escape/close did nothing). Routing through
   // paneToURL/navigate keeps the URL and the workspace in agreement, so
   // there is nothing left for reconciliation to "fix".
-  function handleClose() {
+  const handleClose = useCallback(() => {
     const url = paneToURL("welcome", {});
     if (url !== null) navigate(url);
     workspaceStore.getState().closePane(paneId);
-  }
+  }, [paneId]);
 
-  // Escape closes the pane. A React onKeyDown on the pane's own div only
-  // fires when focus is INSIDE it — and the common open path (clicking the
-  // rail's gear) leaves focus on the gear button, so in a real browser the
-  // pane-scoped handler never saw the key (live-verified regression). A
-  // document-level bubble-phase listener sees Escape regardless of where
-  // focus sits, and still yields to anything inside settings that claimed
-  // the key first: a Dialog/Menu preventDefaults its own Escape (see
-  // OverlayPanel/Menu), which this checks before closing.
+  // Escape closes the pane, via the keybindings dispatcher: the pane pushes
+  // the settings scope while it is open and registers the settings.close
+  // action (Escape, scope-gated - keybindings/defaults.ts), so the chord is
+  // live exactly while this pane exists. A React onKeyDown on the pane's own
+  // div only fires when focus is INSIDE it — and the common open path
+  // (clicking the rail's gear) leaves focus on the gear button, so in a real
+  // browser the pane-scoped handler never saw the key (live-verified
+  // regression). The dispatcher's window-level listener sees Escape
+  // regardless of where focus sits, and still yields to anything inside
+  // settings that claimed the key first: a Dialog/Menu preventDefaults its
+  // own Escape (see OverlayPanel/Menu), which the binding's
+  // ignoreIfDefaultPrevented gate (default true) checks before closing.
   useEffect(() => {
-    function onDocumentKeyDown(event: globalThis.KeyboardEvent) {
-      if (event.key !== "Escape") return;
-      if (event.defaultPrevented) return;
-      handleClose();
-    }
-    document.addEventListener("keydown", onDocumentKeyDown);
-    return () => document.removeEventListener("keydown", onDocumentKeyDown);
-  });
+    installKeybindings();
+    const registry = keybindingsRegistry.getState();
+    const popScope = registry.pushScope(SETTINGS_SCOPE);
+    const unregister = registry.registerAction(ACTIONS.settingsClose, () => handleClose());
+    return () => {
+      unregister();
+      popScope();
+    };
+  }, [handleClose]);
 
   return (
     <PaneScaffold

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
@@ -22,6 +22,7 @@ import { DisplaySection } from "./sections/display";
 import { GeneralSection } from "./sections/general";
 import { HubSection } from "./sections/hub";
 import { InRepoSection } from "./sections/inrepo";
+import { KeybindingsSection } from "./sections/keybindings";
 import { CodexLaunchSection } from "./sections/launchCodex";
 import { LaunchServerSection } from "./sections/launchServer";
 import { MarketplacesPluginsSection } from "./sections/marketplacesPlugins";
@@ -81,6 +82,7 @@ const SECTION_COMPONENTS: Record<string, ComponentType<{ sectionId: string }>> =
   transcript: TranscriptSection,
   display: DisplaySection,
   notifications: NotificationsSection,
+  keybindings: KeybindingsSection,
   hub: HubSection,
   mobile: MobileSection,
   storage: StorageSection,

--- a/cmd/evener-hub/frontend/src/panes/settings/index.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/index.tsx
@@ -7,8 +7,20 @@
 // eager; Settings.tsx is the lazy-loaded chunk.
 import { lazy } from "react";
 import { registerPane } from "../../shell/paneRegistry";
+import { prefsStore } from "../../stores/prefs";
 import type { SettingsPaneParams } from "./Settings";
-import { DEFAULT_SECTION_ID, settingsSectionLabel } from "./sections";
+import { DEFAULT_SECTION_ID, isKnownSettingsSection, settingsSectionLabel } from "./sections";
+
+// A bare /settings tab title follows the same remembered-section fallback
+// the CONTENT resolves (Settings.tsx's activeId), or the tab reads "General"
+// beside a Keybindings detail (roborev PR #884 round 8). The prefs read is
+// non-reactive, but DockHost recomputes the title on every params change and
+// the remembered section only ever changes WITH a section navigation (which
+// sets params.section), so the tab cannot lag the content.
+function rememberedSettingsSection(): string {
+  const remembered = prefsStore.getState().lastSettingsSection;
+  return remembered !== null && isKnownSettingsSection(remembered) ? remembered : DEFAULT_SECTION_ID;
+}
 
 registerPane<SettingsPaneParams>({
   id: "settings",
@@ -16,7 +28,7 @@ registerPane<SettingsPaneParams>({
   // credentials") - no "Settings:" prefix, matching Welcome/Session's own
   // tab-title precedent of showing just the one thing this pane instance
   // is currently about, not a generic pane-type name.
-  title: (params) => settingsSectionLabel(params.section ?? DEFAULT_SECTION_ID),
+  title: (params) => settingsSectionLabel(params.section ?? rememberedSettingsSection()),
   component: lazy(() => import("./Settings")),
   // Every settings section lives in ONE pane instance (nav + content) -
   // navigating between sections updates this same pane's params in place

--- a/cmd/evener-hub/frontend/src/panes/settings/sections.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections.test.ts
@@ -13,8 +13,8 @@ import {
 // two sections with no legacy counterpart, "about" and "mobile" (see
 // sections.ts's own doc comment).
 
-test("has exactly 18 sections", () => {
-  expect(SETTINGS_SECTIONS).toHaveLength(18);
+test("has exactly 19 sections", () => {
+  expect(SETTINGS_SECTIONS).toHaveLength(19);
 });
 
 test("every section id is unique", () => {
@@ -22,10 +22,17 @@ test("every section id is unique", () => {
   expect(new Set(ids).size).toBe(ids.length);
 });
 
-test("the 5 ungrouped sections are General/Theme/Transcript display/Display/Notifications, in this order, first", () => {
+test("the 6 ungrouped sections are General/Theme/Transcript display/Display/Notifications/Keybindings, in this order, first", () => {
   const ungrouped = SETTINGS_SECTIONS.filter((s) => s.cluster === undefined);
-  expect(ungrouped.map((s) => s.label)).toEqual(["General", "Theme", "Transcript display", "Display", "Notifications"]);
-  expect(SETTINGS_SECTIONS.slice(0, 5)).toEqual(ungrouped);
+  expect(ungrouped.map((s) => s.label)).toEqual([
+    "General",
+    "Theme",
+    "Transcript display",
+    "Display",
+    "Notifications",
+    "Keybindings",
+  ]);
+  expect(SETTINGS_SECTIONS.slice(0, 6)).toEqual(ungrouped);
 });
 
 test('the "Agents & models" cluster has exactly these 5 sections, in order, right after the ungrouped ones', () => {
@@ -37,19 +44,19 @@ test('the "Agents & models" cluster has exactly these 5 sections, in order, righ
     "Codex launch",
     "In-repo config",
   ]);
-  expect(SETTINGS_SECTIONS.slice(5, 10)).toEqual(cluster);
+  expect(SETTINGS_SECTIONS.slice(6, 11)).toEqual(cluster);
 });
 
 test('the "Extensions" cluster has exactly these 4 sections, in order, right after "Agents & models"', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "extensions");
   expect(cluster.map((s) => s.label)).toEqual(["Marketplaces & Plugins", "Plugins", "Skills", "MCP servers"]);
-  expect(SETTINGS_SECTIONS.slice(10, 14)).toEqual(cluster);
+  expect(SETTINGS_SECTIONS.slice(11, 15)).toEqual(cluster);
 });
 
 test('the "Daemon" cluster has exactly these 4 sections, in order, last', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "daemon");
   expect(cluster.map((s) => s.label)).toEqual(["Hub", "Mobile app", "Storage", "About"]);
-  expect(SETTINGS_SECTIONS.slice(14, 18)).toEqual(cluster);
+  expect(SETTINGS_SECTIONS.slice(15, 19)).toEqual(cluster);
 });
 
 test('"About" is the very last section overall', () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections.ts
@@ -2,9 +2,11 @@
 // SettingsNav's link list/grouping, the pane's own title() (paneRegistry),
 // and (via DEFAULT_SECTION_ID) what a bare /settings resolves to. Verified
 // against templates/partials/settings.html:13-31 (16 exact - "16 nav
-// sections" per the wave-7 plan's own Goal line) PLUS one section with no
-// legacy counterpart: "about" (design-language credits) and "mobile"
-// (browser-only dedicated-app pairing), added after that
+// sections" per the wave-7 plan's own Goal line) PLUS three sections with no
+// legacy counterpart: "keybindings" (the Phase 2b read-only effective-
+// shortcuts list, appended to the ungrouped top links), "about"
+// (design-language credits) and "mobile"
+// (browser-only dedicated-app pairing), the latter two added after that
 // baseline and deliberately placed last, in the Daemon cluster. The 16
 // legacy-parity sections are 5 ungrouped top links (General/Theme/
 // Transcript display/Display/Notifications) plus 3 labeled clusters ("Agents &
@@ -42,6 +44,7 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
   { id: "transcript", label: "Transcript display" },
   { id: "display", label: "Display" },
   { id: "notifications", label: "Notifications" },
+  { id: "keybindings", label: "Keybindings" },
   // --- Agents & models -----------------------------------------------
   { id: "credentials", label: "Providers & credentials", cluster: "agents-models" },
   { id: "agents", label: "Agents", cluster: "agents-models" },

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
@@ -1,0 +1,84 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+.intro {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+  line-height: var(--line-height-body);
+}
+
+.status {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+.status p {
+  margin: 0;
+}
+
+.warningList {
+  margin: var(--space-1) 0 0;
+  padding-left: var(--space-4);
+}
+
+.error {
+  margin: 0;
+  background: var(--surface-inset);
+  padding: var(--space-2) var(--space-3);
+  color: var(--ink-hi);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+  line-height: var(--line-height-body);
+}
+
+.marker {
+  background: var(--surface-inset);
+  border-radius: var(--radius-chip);
+  padding: 0 var(--space-2);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+.unbound {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+.chord {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.module.css
@@ -12,6 +12,19 @@
   line-height: var(--line-height-body);
 }
 
+.toggle {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.help {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
 .status {
   margin: 0;
   color: var(--ink-mid);
@@ -52,6 +65,9 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
+  /* The read-only note and the inline error sit UNDER the label/controls
+     line, full width. */
+  flex-wrap: wrap;
 }
 
 .label {
@@ -81,4 +97,127 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
+}
+
+.controls {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* The chord cell made clickable: same look as the read-only chord run, plus
+   a hover/focus affordance. */
+.chordButton {
+  appearance: none;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-chip);
+  padding: var(--space-1) var(--space-2);
+  margin: calc(-1 * var(--space-1)) calc(-1 * var(--space-2));
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.chordButton:hover {
+  border-color: var(--edge);
+}
+
+.chordButton:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 1px;
+}
+
+/* The row's small text-level actions (Unbind / Reset). */
+.actionButton {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: var(--space-1) var(--space-2);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+  cursor: pointer;
+  border-radius: var(--radius-chip);
+}
+
+.actionButton:hover {
+  color: var(--ink-hi);
+  background: var(--surface-inset);
+}
+
+.actionButton:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.note {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.rowError {
+  flex-basis: 100%;
+  margin: 0;
+  color: var(--danger-ink);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+/* The capture widget plus its inline error, stacked under the row label. */
+.captureWrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+/* The capture widget: an inset box that replaces the row's controls while a
+   chord is being recorded. */
+.capture {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--surface-inset);
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-chip);
+  padding: var(--space-1) var(--space-2);
+  min-width: 0;
+}
+
+.capture:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.capturePrompt {
+  color: var(--ink-hi);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+}
+
+.captureHint {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
+  white-space: nowrap;
+}
+
+.captureError {
+  margin: 0;
+  color: var(--danger-ink);
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
 }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1,13 +1,46 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
-import { afterEach, beforeEach, expect, test } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { ACTIONS } from "../../../keybindings/actions";
-import { DEFAULT_BINDINGS, registerDefaultBindings } from "../../../keybindings/defaults";
+import {
+  CHARACTER_KEY_TRIGGER_BINDING_ID,
+  DEFAULT_BINDINGS,
+  registerDefaultBindings,
+  SETTINGS_SCOPE,
+} from "../../../keybindings/defaults";
+import { createKeybindingDispatcher } from "../../../keybindings/dispatcher";
 import { keybindingsRegistry } from "../../../keybindings/registry";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import type { KeybindingsOverrides, KeybindingsRule } from "../../../protocol/types.gen";
 import { connectionStore } from "../../../stores/connection";
 import { keybindingsStore, resetKeybindingsStoreForTests } from "../../../stores/keybindings";
+import { prefsStore, resetPrefsStoreForTests } from "../../../stores/prefs";
 import { KeybindingsSection } from "./keybindings";
+
+// Node 26 shadows jsdom's real window.localStorage with its own
+// (non-functional under vitest) global, so every test file that touches
+// localStorage (the prefs store does) needs this same small in-memory
+// stand-in - see stores/prefs.test.ts's own comment.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeAll(() => {
+  // @ts-expect-error see MemoryStorage's own comment for why this is needed
+  globalThis.localStorage = new MemoryStorage();
+});
 
 function resetRegistryToDefaults(): void {
   for (const binding of keybindingsRegistry.getState().bindings) {
@@ -32,6 +65,8 @@ beforeEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
   resetKeybindingsStoreForTests();
   resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
 });
 
 afterEach(() => {
@@ -39,6 +74,8 @@ afterEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
   resetKeybindingsStoreForTests();
   resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
 });
 
 function rowFor(title: string): HTMLElement {
@@ -52,22 +89,28 @@ test("lists every default action with its title and effective chord, none custom
   render(<KeybindingsSection />);
 
   // The row list is sourced live from the keybindings module's default map,
-  // never a hand-maintained copy: one row per action, in default-map order.
+  // never a hand-maintained copy: one row per ACTION (the cheatsheet's two
+  // trigger entries share one action id), in default-map order.
   const rows = screen.getAllByRole("listitem");
-  expect(rows).toHaveLength(DEFAULT_BINDINGS.length);
+  expect(rows).toHaveLength(new Set(DEFAULT_BINDINGS.map((b) => b.actionId)).size);
   expect(rows.map((row) => row.textContent)).toEqual([
     expect.stringContaining("Open the command palette"),
     expect.stringContaining("Toggle the sidebar"),
     expect.stringContaining("Focus the composer"),
     expect.stringContaining("Go to the next session needing you"),
     expect.stringContaining("Quote the selection into the composer"),
+    expect.stringContaining("Open settings"),
     expect.stringContaining("Focus the next session pane"),
     expect.stringContaining("Focus the previous session pane"),
     expect.stringContaining("Scroll the transcript up one line"),
     expect.stringContaining("Scroll the transcript down one line"),
     expect.stringContaining("Scroll the transcript up one page"),
     expect.stringContaining("Scroll the transcript down one page"),
+    expect.stringContaining("Scroll the transcript to the top"),
+    expect.stringContaining("Scroll the transcript to the bottom"),
     expect.stringContaining("Close settings"),
+    expect.stringContaining("Show the keyboard shortcuts overlay"),
+    expect.stringContaining("Close the keyboard shortcuts overlay"),
   ]);
   expect(screen.queryByText("Customized")).toBeNull();
 
@@ -80,6 +123,31 @@ test("lists every default action with its title and effective chord, none custom
   // the Escape key renders.
   const settingsRow = rowFor("Close settings");
   expect(within(settingsRow).getByText("Escape")).toBeTruthy();
+});
+
+test("the cheatsheet row shows the platform $mod chord (its ? trigger is a second entry of the same action)", () => {
+  render(<KeybindingsSection />);
+  const row = rowFor("Show the keyboard shortcuts overlay");
+  // jsdom resolves $mod to Control; the section's single-chord display shows
+  // the base entry (keybindings/display.ts's displayBindingFor).
+  expect(within(row).getByText("Ctrl")).toBeTruthy();
+  expect(within(row).getByText("/")).toBeTruthy();
+});
+
+test("the character-key toggle persists through the prefs store", async () => {
+  render(<KeybindingsSection />);
+  const toggle = screen.getByRole("switch", { name: "Character-key shortcuts" });
+  // Default ON (the WCAG 2.1.4 turn-off exists, per the p4 plan's Design
+  // decision 3).
+  expect(toggle.getAttribute("aria-checked")).toBe("true");
+
+  await userEvent.setup().click(toggle);
+  expect(prefsStore.getState().characterKeyTriggers).toBe(false);
+  expect(localStorage.getItem("evener.prefs.characterKeyTriggers")).toBe("0");
+
+  // A fresh hydration (what the next page load does) reads it back.
+  resetPrefsStoreForTests();
+  expect(prefsStore.getState().characterKeyTriggers).toBe(false);
 });
 
 test("with no hub connection the section waits quietly and still shows the defaults", () => {
@@ -158,4 +226,330 @@ test("validation warnings from the applied payload are listed quietly", async ()
   expect(status.textContent).toContain('chord "Control+W" is reserved');
   // Both bad rules were skipped: every action stays on its default.
   expect(screen.queryByText("Customized")).toBeNull();
+});
+
+// --- Phase 4b: the capture-based editor ------------------------------------
+
+/** A supported hub whose patch echoes the requested rules back at the next
+ * revision - the hub's real apply-and-confirm behavior, minimal. */
+async function wireEditableClient(initial: KeybindingsRule[] = []): Promise<FakeClient> {
+  const client = new FakeClient("ready");
+  let revision = 1;
+  client.on("evener/settings/keybindings/get", () => overridesPayload(revision, initial));
+  client.on("evener/settings/keybindings/patch", (params) => {
+    revision += 1;
+    return overridesPayload(revision, params.config.rules);
+  });
+  await wireClient(client, true);
+  return client;
+}
+
+function patchCallsOf(client: FakeClient) {
+  return client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+}
+
+function captureBox(): HTMLElement {
+  return screen.getByRole("textbox", { name: /Press the new shortcut/ });
+}
+
+async function enterCapture(title: string): Promise<HTMLElement> {
+  await userEvent.setup().click(screen.getByRole("button", { name: `Change the shortcut for ${title}` }));
+  return captureBox();
+}
+
+test("an unsupported hub keeps every row read-only (no editing affordances)", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  await wireClient(client, false);
+  render(<KeybindingsSection />);
+
+  expect(screen.getByRole("status").textContent).toContain("does not support synced keybinding overrides");
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  expect(screen.queryByRole("button", { name: "Unbind" })).toBeNull();
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
+test("a hub with unknown support keeps every row read-only", () => {
+  render(<KeybindingsSection />);
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
+test("clicking a chord enters capture mode with the prompt focused", async () => {
+  await wireEditableClient();
+  render(<KeybindingsSection />);
+
+  const box = await enterCapture("Open the command palette");
+
+  expect(box.textContent).toContain("Press new shortcut…");
+  expect(box.textContent).toContain("Enter to save");
+  expect(document.activeElement).toBe(box);
+});
+
+test("held modifiers render live while capturing, before any key is recorded", async () => {
+  await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "Control", ctrlKey: true });
+  expect(within(box).getByText("Ctrl")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Shift", ctrlKey: true, shiftKey: true });
+  expect(within(box).getByText("Shift")).toBeTruthy();
+  // Releasing keeps the preview in step.
+  fireEvent.keyUp(box, { key: "Shift", ctrlKey: true });
+  expect(within(box).queryByText("Shift")).toBeNull();
+  // No chord recorded yet, and no hub write.
+  expect(box.textContent).toContain("Enter to save");
+});
+
+test("Enter saves the captured chord through patchOverrides and the row shows the new chord", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  expect(within(box).getByText("P")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.paletteOpen, chord: "Control+P" }] },
+  });
+  // The confirmed payload reconciled: capture closed, row shows the override.
+  await waitFor(() => expect(within(rowFor("Open the command palette")).getByText("P")).toBeTruthy());
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(within(rowFor("Open the command palette")).getByText("Customized")).toBeTruthy();
+});
+
+test("Escape cancels the capture without a hub write and leaves the chord unchanged", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Escape" });
+
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(0);
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("K")).toBeTruthy();
+  expect(within(row).queryByText("Customized")).toBeNull();
+  // A keyboard-ended capture returns focus to the chord button it started
+  // from (a click-away cancel does not - focus went where the user put it).
+  expect(document.activeElement).toBe(
+    within(row).getByRole("button", { name: "Change the shortcut for Open the command palette" }),
+  );
+});
+
+test("a plain Enter with nothing captured neither saves nor cancels", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  expect(screen.getByText("Press new shortcut…")).toBeTruthy();
+  expect(patchCallsOf(client)).toHaveLength(0);
+});
+
+test("a conflicting chord is rejected pre-flight: inline message, no hub write, capture stays open", async () => {
+  const client = await wireEditableClient([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain(
+    `chord "Control+P" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`,
+  );
+  expect(patchCallsOf(client)).toHaveLength(0);
+  // The capture stays open so the user can try another chord or cancel...
+  expect(captureBox()).toBeTruthy();
+  // ...and composer.focus's registry bindings never moved off the default
+  // (the row itself shows the capture box while capturing, so assert the
+  // registry, not the render).
+  expect(
+    keybindingsRegistry
+      .getState()
+      .bindings.filter((b) => b.actionId === ACTIONS.composerFocus)
+      .map((b) => b.id),
+  ).toEqual([ACTIONS.composerFocus, `${ACTIONS.composerFocus}#mod-twin`]);
+  // A subsequent valid chord still saves from the same capture.
+  fireEvent.keyDown(captureBox(), { key: "m", ctrlKey: true });
+  fireEvent.keyDown(captureBox(), { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+});
+
+test("a platform-reserved chord is rejected pre-flight with the validation message", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "w", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain('chord "Control+W" is reserved');
+  expect(patchCallsOf(client)).toHaveLength(0);
+});
+
+test("Unbind writes a chord:null rule and the row renders Unbound and Customized", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.paletteOpen, chord: null }] },
+  });
+  const row = rowFor("Open the command palette");
+  await waitFor(() => expect(within(row).getByText("Unbound")).toBeTruthy());
+  expect(within(row).getByText("Customized")).toBeTruthy();
+  // An unbound action offers capture (to set a new chord) but not Unbind.
+  expect(within(row).getByRole("button", { name: "Set a shortcut for Open the command palette" })).toBeTruthy();
+  expect(within(row).queryByRole("button", { name: "Unbind" })).toBeNull();
+});
+
+test("Reset removes the action's rule and restores the default chord", async () => {
+  const client = await wireEditableClient([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+  render(<KeybindingsSection />);
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("P")).toBeTruthy();
+  expect(within(row).getByText("Customized")).toBeTruthy();
+
+  await userEvent.setup().click(within(row).getByRole("button", { name: "Reset" }));
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  // The patch drops the action's rule entirely (the payload is the whole
+  // desired rule set).
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [] },
+  });
+  await waitFor(() => expect(within(row).getByText("K")).toBeTruthy());
+  expect(within(row).queryByText("Customized")).toBeNull();
+  expect(within(row).queryByRole("button", { name: "Reset" })).toBeNull();
+});
+
+test("a failed Unbind surfaces the hub error inline on the row", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  client.on("evener/settings/keybindings/patch", () => {
+    throw new Error("socket went away");
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+
+  const row = rowFor("Open the command palette");
+  await waitFor(() => expect(within(row).getByRole("alert").textContent).toContain("socket went away"));
+  expect(within(row).getByText("K")).toBeTruthy();
+});
+
+// The cheatsheet.toggle row is the one multi-entry action: the editor edits
+// the base ($mod+/) chord only; the conditional "?" trigger is the
+// character-key setting's own entry, shown read-only with a note.
+test("the cheatsheet row shows the conditional ? trigger as a read-only note", async () => {
+  await wireEditableClient();
+  render(<KeybindingsSection />);
+
+  const row = rowFor("Show the keyboard shortcuts overlay");
+  // One editable chord button (the base entry)...
+  expect(
+    within(row).getByRole("button", { name: "Change the shortcut for Show the keyboard shortcuts overlay" }),
+  ).toBeTruthy();
+  expect(within(row).getAllByRole("button", { name: /shortcut for/ })).toHaveLength(1);
+  // ...and the "?" entry as a note, not a second editable chord.
+  const note = row.querySelector("p");
+  expect(note?.textContent).toContain("character-key setting");
+  expect(within(row).getByText("?")).toBeTruthy();
+});
+
+test("the ? note disappears with the conditional binding (character-key setting off)", async () => {
+  await wireEditableClient();
+  keybindingsRegistry.getState().unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+  render(<KeybindingsSection />);
+
+  const row = rowFor("Show the keyboard shortcuts overlay");
+  expect(row.textContent).not.toContain("character-key setting");
+});
+
+test("an override on cheatsheet.toggle owns the whole chord set: no ? note", async () => {
+  await wireEditableClient([{ action: ACTIONS.cheatsheetToggle, chord: "Control+Slash" }]);
+  render(<KeybindingsSection />);
+
+  const row = rowFor("Show the keyboard shortcuts overlay");
+  expect(row.textContent).not.toContain("character-key setting");
+  expect(within(row).getByText("Customized")).toBeTruthy();
+});
+
+// While capture is active the window-level dispatcher must not act: the
+// capture box consumes every keydown (preventDefault + stopPropagation).
+// These tests wire the REAL dispatcher and settings scope, the same way
+// Settings.tsx does for the live pane.
+async function withDispatcher(run: () => Promise<void>): Promise<void> {
+  const dispatcher = createKeybindingDispatcher();
+  const detach = dispatcher.attach(window);
+  try {
+    await run();
+  } finally {
+    detach();
+    dispatcher.dispose();
+  }
+}
+
+test("a captured chord never reaches the dispatcher (rail.toggle opts out of defaultPrevented)", async () => {
+  await wireEditableClient();
+  const railSpy = vi.fn();
+  const unregister = keybindingsRegistry.getState().registerAction(ACTIONS.railToggle, railSpy);
+  try {
+    await withDispatcher(async () => {
+      render(<KeybindingsSection />);
+      const box = await enterCapture("Open the command palette");
+
+      // Control+B is rail.toggle's live default chord; capturing it must not
+      // toggle the rail - rail.toggle's binding even opts OUT of the
+      // defaultPrevented gate, so only the capture box's stopPropagation
+      // keeps the press from the dispatcher.
+      fireEvent.keyDown(box, { key: "b", ctrlKey: true });
+
+      expect(railSpy).not.toHaveBeenCalled();
+      expect(within(box).getByText("Ctrl")).toBeTruthy();
+      expect(within(box).getByText("B")).toBeTruthy();
+    });
+  } finally {
+    unregister();
+  }
+});
+
+test("Escape cancels the capture and does NOT fire settings.close; outside capture it closes", async () => {
+  await wireEditableClient();
+  const closeSpy = vi.fn();
+  const popScope = keybindingsRegistry.getState().pushScope(SETTINGS_SCOPE);
+  const unregister = keybindingsRegistry.getState().registerAction(ACTIONS.settingsClose, closeSpy);
+  try {
+    await withDispatcher(async () => {
+      render(<KeybindingsSection />);
+      const box = await enterCapture("Open the command palette");
+
+      fireEvent.keyDown(box, { key: "Escape" });
+
+      // Capture cancelled, pane still open.
+      expect(screen.queryByText("Press new shortcut…")).toBeNull();
+      expect(closeSpy).not.toHaveBeenCalled();
+
+      // Not capturing: Escape reaches the settings scope's close binding.
+      fireEvent.keyDown(document.body, { key: "Escape" });
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    });
+  } finally {
+    unregister();
+    popScope();
+  }
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-li
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { ACTIONS } from "../../../keybindings/actions";
+import { parseChord, serializeChord } from "../../../keybindings/chord";
 import {
   CHARACTER_KEY_TRIGGER_BINDING_ID,
   DEFAULT_BINDINGS,
@@ -269,6 +270,59 @@ test("an unsupported hub keeps every row read-only (no editing affordances)", as
   expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
 });
 
+// The stale-hub window: a supported hub whose override state has not landed
+// (or failed to) for the CURRENT client must not offer editing - a PATCH
+// composed there would carry the previous hub's revision and payload.
+test("the section is read-only while the hub's overrides are still loading, then editing unlocks", async () => {
+  const client = new FakeClient("ready");
+  let resolveGet: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/get",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolveGet = resolve;
+      }),
+  );
+  client.on("evener/settings/keybindings/patch", (params) => overridesPayload(2, params.config.rules));
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: true },
+  });
+  render(<KeybindingsSection />);
+
+  // hubSupport is "supported" but nothing is loaded for THIS hub yet: no
+  // editing affordances, and a status line says why.
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  expect(screen.getByRole("status").textContent).toContain("read-only until they arrive");
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+
+  // The refresh lands: editing unlocks and a save round-trips.
+  // (FakeClient defers the handler to a microtask, like a real RPC.)
+  await waitFor(() => expect(resolveGet).toBeDefined());
+  resolveGet?.(overridesPayload(1, []));
+  const chordButton = await screen.findByRole("button", {
+    name: "Change the shortcut for Open the command palette",
+  });
+  await userEvent.setup().click(chordButton);
+  fireEvent.keyDown(captureBox(), { key: "p", ctrlKey: true });
+  fireEvent.keyDown(captureBox(), { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+});
+
+test("a refresh error leaves the section read-only with a truthful status", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => {
+    throw new Error("socket went away");
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  expect(screen.getByRole("alert").textContent).toContain("socket went away");
+  expect(screen.getByRole("status").textContent).toContain("Editing is unavailable");
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
 test("a hub with unknown support keeps every row read-only", () => {
   render(<KeybindingsSection />);
   expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
@@ -342,6 +396,203 @@ test("Escape cancels the capture without a hub write and leaves the chord unchan
   );
 });
 
+test("a second non-modifier key does NOT overwrite the captured chord; Enter saves the FIRST", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  expect(within(box).getByText("P")).toBeTruthy();
+  // The stray press before Enter: the recorded chord stands (cancel and
+  // re-capture to change it) - the box keeps showing P and W never appears.
+  fireEvent.keyDown(box, { key: "w" });
+  expect(within(box).getByText("P")).toBeTruthy();
+  expect(within(box).queryByText("W")).toBeNull();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.paletteOpen, chord: "Control+P" }] },
+  });
+});
+
+test("after capture, modifier presses do not replace the preview and Escape still cancels", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  expect(within(box).getByText("P")).toBeTruthy();
+  // The held-modifier echo still updates internally, but the recorded chord
+  // owns the preview.
+  fireEvent.keyDown(box, { key: "Shift" });
+  expect(within(box).getByText("P")).toBeTruthy();
+  fireEvent.keyUp(box, { key: "Shift" });
+  fireEvent.keyDown(box, { key: "Escape" });
+
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(0);
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("K")).toBeTruthy();
+  expect(within(row).queryByText("Customized")).toBeNull();
+});
+
+// Plain Escape is cancel, permanently: it cannot be assigned through the
+// editor (the VS Code keybinding-editor convention), so the built-in Escape
+// bindings come back via Reset, never via capture. Escape WITH a modifier is
+// a normal chord and records. settings.close's own default is Escape with
+// every modifier optional, so overriding THAT action with Shift+Escape
+// conflicts with nothing.
+test("plain Escape cancels but Shift+Escape records as a chord", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  let box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "Escape" });
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(0);
+
+  box = await enterCapture("Close settings");
+  fireEvent.keyDown(box, { key: "Escape", shiftKey: true });
+  expect(within(box).getByText("Shift")).toBeTruthy();
+  expect(within(box).getByText("Escape")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.settingsClose, chord: "Shift+Escape" }] },
+  });
+});
+
+// Uppercase normalization is ASCII-only: String.toUpperCase can change
+// LENGTH on non-ASCII input ("ß" -> "SS"), which would corrupt the chord.
+test("a non-ASCII character records verbatim; ASCII letters still normalize to uppercase", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  let box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "ß" });
+  expect(within(box).getByText("ß")).toBeTruthy();
+  expect(within(box).queryByText("SS")).toBeNull();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "ß" }] },
+  });
+
+  box = await enterCapture("Quote the selection into the composer");
+  fireEvent.keyDown(box, { key: "a" });
+  expect(within(box).getByText("A")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(2));
+  expect(patchCallsOf(client)[1]?.params).toEqual({
+    expectedRevision: 2,
+    config: {
+      version: 1,
+      rules: [
+        { action: ACTIONS.composerFocus, chord: "ß" },
+        { action: ACTIONS.selectionQuote, chord: "A" },
+      ],
+    },
+  });
+});
+
+// Click-away cancels even when the click target cannot take focus: onBlur
+// alone only fires when focus MOVES, so a document-level pointerdown listener
+// (capture phase) covers non-focusable clicks while the capture is live.
+test("pointerdown outside the capture box cancels without refocusing the chord button", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.pointerDown(document.body);
+
+  expect(screen.queryByText("Press new shortcut…")).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(0);
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("K")).toBeTruthy();
+  // refocus:false - a click-away cancel leaves focus where the user put it,
+  // unlike the keyboard cancel which returns focus to the chord button.
+  expect(document.activeElement).not.toBe(
+    within(row).getByRole("button", { name: "Change the shortcut for Open the command palette" }),
+  );
+});
+
+test("pointerdown INSIDE the capture box does not cancel", async () => {
+  await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Open the command palette");
+
+  fireEvent.pointerDown(box);
+
+  expect(captureBox()).toBeTruthy();
+  expect(screen.getByText("Press new shortcut…")).toBeTruthy();
+});
+
+test("the outside-pointerdown listener is removed when the capture closes", async () => {
+  const addSpy = vi.spyOn(document, "addEventListener");
+  const removeSpy = vi.spyOn(document, "removeEventListener");
+  try {
+    await wireEditableClient();
+    render(<KeybindingsSection />);
+    await enterCapture("Open the command palette");
+
+    // The capture box's listener is the pointerdown one in the capture phase.
+    const added = addSpy.mock.calls.filter((call) => call[0] === "pointerdown" && call[2] === true);
+    expect(added).not.toHaveLength(0);
+    const listener = added[added.length - 1]?.[1];
+
+    fireEvent.keyDown(captureBox(), { key: "Escape" });
+    expect(screen.queryByText("Press new shortcut…")).toBeNull();
+
+    expect(
+      removeSpy.mock.calls.some((call) => call[0] === "pointerdown" && call[1] === listener && call[2] === true),
+    ).toBe(true);
+  } finally {
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  }
+});
+
+// Whole-payload PATCHes are composed from the hub's RAW rules: a rule
+// validation skipped (here: an action this client does not know, written by
+// a newer one) is still the hub's state and must survive an unrelated edit.
+test("an unrelated edit preserves a hub rule validation skips (unknown action survives in the PATCH payload)", async () => {
+  const client = await wireEditableClient([{ action: "future.new.action", chord: "Control+Alt+9" }]);
+  render(<KeybindingsSection />);
+
+  // The skipped rule stays a quiet warning; nothing is customized.
+  expect(screen.getByRole("status").textContent).toContain('unknown keybinding action "future.new.action"');
+  expect(screen.queryByText("Customized")).toBeNull();
+
+  const box = await enterCapture("Open the command palette");
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  // The unknown-action rule passes through untouched, alongside the edit.
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: {
+      version: 1,
+      rules: [
+        { action: "future.new.action", chord: "Control+Alt+9" },
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+      ],
+    },
+  });
+  // The preserved rule's pre-existing warning did not block the save, and
+  // the confirmed payload still lists it as a (skipped) warning.
+  await waitFor(() => expect(within(rowFor("Open the command palette")).getByText("P")).toBeTruthy());
+  expect(screen.getByRole("status").textContent).toContain('unknown keybinding action "future.new.action"');
+});
+
 test("a plain Enter with nothing captured neither saves nor cancels", async () => {
   const client = await wireEditableClient();
   render(<KeybindingsSection />);
@@ -351,6 +602,270 @@ test("a plain Enter with nothing captured neither saves nor cancels", async () =
 
   expect(screen.getByText("Press new shortcut…")).toBeTruthy();
   expect(patchCallsOf(client)).toHaveLength(0);
+});
+
+// The spacebar's event.key is a literal " " - the tinykeys grammar's press
+// SEPARATOR - so capture maps it to the canonical, matchable name "Space"
+// (tinykeys' matcher also compares event.code, which IS "Space"). A literal
+// " " would not survive parseChord at all.
+test("capturing Space records the canonical name and the chord round-trips through the grammar", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: " " });
+  expect(within(box).getByText("Space")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Space" }] },
+  });
+  // The saved chord parses back to the same press (it would throw on " ").
+  expect(serializeChord(parseChord("Space"))).toBe("Space");
+  // The confirmed payload reconciled onto the registry with the same chord.
+  await waitFor(() => expect(within(rowFor("Focus the composer")).getByText("Space")).toBeTruthy());
+});
+
+// IME composition keydowns (isComposing, key "Process"/"Unidentified") are
+// not presses: they record nothing and an IME commit Enter must not save.
+test("IME composition events neither record nor save; a non-composing press still works", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  // Mid-composition keydowns: no chord recorded.
+  fireEvent.keyDown(box, { key: "Process", isComposing: true });
+  fireEvent.keyDown(box, { key: "a", isComposing: true });
+  expect(box.textContent).toContain("Press new shortcut…");
+  // A composition-commit Enter does NOT save...
+  fireEvent.keyDown(box, { key: "Enter", isComposing: true });
+  fireEvent.keyDown(box, { key: "Unidentified" });
+  expect(patchCallsOf(client)).toHaveLength(0);
+  expect(captureBox()).toBeTruthy();
+
+  // ...and a real press afterwards still records and saves.
+  fireEvent.keyDown(box, { key: "m", ctrlKey: true });
+  expect(within(box).getByText("M")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
+  });
+});
+
+// Browsers that signal IME input ONLY through keyCode 229 (no isComposing,
+// an ordinary-looking key) hit the dispatcher's second guard; capture must
+// run the same one or composition input / a commit Enter records as a chord.
+test("a keydown reported only via keyCode 229 records nothing and does not save", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+  const box = await enterCapture("Focus the composer");
+
+  fireEvent.keyDown(box, { key: "a", keyCode: 229 });
+  expect(box.textContent).toContain("Press new shortcut…");
+  fireEvent.keyDown(box, { key: "Enter", keyCode: 229 });
+  expect(patchCallsOf(client)).toHaveLength(0);
+  expect(captureBox()).toBeTruthy();
+
+  // A real press afterwards still records and saves.
+  fireEvent.keyDown(box, { key: "m", ctrlKey: true });
+  expect(within(box).getByText("M")).toBeTruthy();
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+});
+
+// A save is a hub round trip; a click-away cancel closes the box while the
+// PATCH is in flight. The per-capture generation token keeps the stale
+// continuation from closing or repainting a capture it did not start.
+test("a save resolving after a click-away cancel does not clobber a reopened capture", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/patch",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolvePatch = resolve;
+      }),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // Open a capture and start a save; the PATCH hangs.
+  const box = await enterCapture("Open the command palette");
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+
+  // Click away: the capture cancels while the save is in flight...
+  fireEvent.pointerDown(document.body);
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+
+  // ...and the user reopens the same row's capture.
+  const reopened = await enterCapture("Open the command palette");
+  expect(reopened.textContent).toContain("Press new shortcut…");
+
+  // The stale save resolves: the reopened capture stays open and untouched.
+  resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+  await waitFor(() => expect(keybindingsStore.getState().revision).toBe(2));
+  expect(screen.getByRole("textbox", { name: /Press the new shortcut/ })).toBe(reopened);
+  expect(reopened.textContent).toContain("Press new shortcut…");
+});
+
+test("a stale save's error does not surface into a reopened capture", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  let rejectPatch: ((error: Error) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/patch",
+    () =>
+      new Promise<KeybindingsOverrides>((_resolve, reject) => {
+        rejectPatch = reject;
+      }),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  const box = await enterCapture("Open the command palette");
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+
+  fireEvent.pointerDown(document.body);
+  const reopened = await enterCapture("Open the command palette");
+  expect(reopened.textContent).toContain("Press new shortcut…");
+
+  // The old save FAILS: its error belongs to the cancelled capture and must
+  // not surface on the ROW. (The store still records the failed patch as
+  // hubError - the section-level alert is the store's contract for any
+  // failed patch, capture or not; what the generation token guards is the
+  // row/capture continuation.)
+  rejectPatch?.(new Error("hub exploded"));
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  expect(within(rowFor("Open the command palette")).queryByRole("alert")).toBeNull();
+  // hubError also makes the whole section read-only (editable includes
+  // hubError === null), so the reopened capture CLOSES: an interactive box
+  // must not strand in a section whose controls have all gone read-only.
+  // The finding-13 guarantee this test pins is the error's containment, not
+  // the capture's survival across an editability loss.
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+});
+
+// Writes serialize at the store: an edit made while ANOTHER row's write is
+// in flight queues behind it (no controls are disabled - the queue absorbs
+// the concurrency), composes its expectedRevision and payload from the
+// first write's confirmed state, and - via the finding-13 generation token
+// - still cannot touch a capture that was cancelled while it queued.
+test("a save queued behind another row's in-flight write lands in order and ignores its cancelled capture", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  let firstExpectedRevision: number | undefined;
+  let resolveFirstPatch: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on("evener/settings/keybindings/patch", (params) => {
+    if (firstExpectedRevision === undefined) {
+      firstExpectedRevision = params.expectedRevision;
+      return new Promise<KeybindingsOverrides>((resolve) => {
+        resolveFirstPatch = resolve;
+      });
+    }
+    return overridesPayload(params.expectedRevision + 1, params.config.rules);
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // Row B (command palette) Reset starts PATCH #1, which hangs in flight.
+  const resetButton = within(rowFor("Open the command palette")).getByRole("button", { name: "Reset" });
+  await userEvent.setup().click(resetButton);
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+
+  // While it hangs, the composer row's controls stay ENABLED (the queue
+  // absorbs the concurrency - nothing is disabled during a write)...
+  const chordButton = screen.getByRole("button", { name: "Change the shortcut for Focus the composer" });
+  expect((chordButton as HTMLButtonElement).disabled).toBe(false);
+  await userEvent.setup().click(chordButton);
+  const box = captureBox();
+  fireEvent.keyDown(box, { key: "m", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+  // ...and the save QUEUES: no second PATCH has hit the wire yet.
+  expect(patchCallsOf(client)).toHaveLength(1);
+
+  // The capture is cancelled before its save executes.
+  fireEvent.pointerDown(document.body);
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+
+  // PATCH #1 lands: the queued save composes against the post-Reset state
+  // (expectedRevision 2, rules WITHOUT the dropped palette override) and
+  // applies to the store...
+  resolveFirstPatch?.(overridesPayload((firstExpectedRevision ?? 0) + 1, []));
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(2));
+  expect(patchCallsOf(client)[1]?.params).toEqual({
+    expectedRevision: 2,
+    config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
+  });
+  await waitFor(() => expect(keybindingsStore.getState().revision).toBe(3));
+
+  // ...but the cancelled capture is never touched: it stays closed, no row
+  // error appears, focus is not stolen back to the chord button.
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+  expect(within(rowFor("Focus the composer")).queryByRole("alert")).toBeNull();
+  expect(document.activeElement).not.toBe(
+    screen.getByRole("button", { name: "Change the shortcut for Focus the composer" }),
+  );
+});
+
+// "+" is tinykeys' modifier DELIMITER, so a naive read says a captured "+"
+// chord ("Shift++", "Control++") cannot parse. The installed tinykeys splits
+// modifiers with a lookbehind (/(?<=\w|\])\+/), so a trailing "+" parses as
+// the key, and capture records the modifiers actually held - the chord
+// matches the very keydown that produced it. This test pins that end-to-end
+// through the REAL dispatcher so a tinykeys regression turns red here.
+test("capturing + saves a chord that round-trips and fires on a real + keydown", async () => {
+  const client = await wireEditableClient();
+  const focusSpy = vi.fn();
+  const unregister = keybindingsRegistry.getState().registerAction(ACTIONS.composerFocus, focusSpy);
+  try {
+    await withDispatcher(async () => {
+      render(<KeybindingsSection />);
+      const box = await enterCapture("Focus the composer");
+
+      // US layout: "+" is Shift+=, so the keydown carries Shift.
+      fireEvent.keyDown(box, { key: "+", shiftKey: true });
+      // KeyHint renders "+" SEPARATORS between kbds, so assert the kbd run
+      // itself rather than a bare text match.
+      expect([...box.querySelectorAll("kbd")].map((kbd) => kbd.textContent)).toEqual(["Shift", "+"]);
+      fireEvent.keyDown(box, { key: "Enter" });
+
+      await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+      expect(patchCallsOf(client)[0]?.params).toEqual({
+        expectedRevision: 1,
+        config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Shift++" }] },
+      });
+      // The serialized chord parses back to itself (a delimiter collision
+      // would throw or misparse the key).
+      expect(serializeChord(parseChord("Shift++"))).toBe("Shift++");
+      expect(serializeChord(parseChord("Control++"))).toBe("Control++");
+
+      // The confirmed payload reconciled, and the REAL dispatcher's matcher
+      // fires the action on the + keydown.
+      await waitFor(() =>
+        expect([...rowFor("Focus the composer").querySelectorAll("kbd")].map((kbd) => kbd.textContent)).toEqual([
+          "Shift",
+          "+",
+        ]),
+      );
+      fireEvent.keyDown(document.body, { key: "+", shiftKey: true });
+      expect(focusSpy).toHaveBeenCalledTimes(1);
+    });
+  } finally {
+    unregister();
+  }
 });
 
 test("a conflicting chord is rejected pre-flight: inline message, no hub write, capture stays open", async () => {
@@ -363,7 +878,7 @@ test("a conflicting chord is rejected pre-flight: inline message, no hub write, 
 
   const alert = await screen.findByRole("alert");
   expect(alert.textContent).toContain(
-    `chord "Control+P" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`,
+    `chord "Control+P" in scope "global" is already bound by "Open the command palette" (${ACTIONS.paletteOpen})`,
   );
   expect(patchCallsOf(client)).toHaveLength(0);
   // The capture stays open so the user can try another chord or cancel...
@@ -377,9 +892,15 @@ test("a conflicting chord is rejected pre-flight: inline message, no hub write, 
       .bindings.filter((b) => b.actionId === ACTIONS.composerFocus)
       .map((b) => b.id),
   ).toEqual([ACTIONS.composerFocus, `${ACTIONS.composerFocus}#mod-twin`]);
-  // A subsequent valid chord still saves from the same capture.
+  // The recorded (conflicting) chord stands while this capture lives
+  // (finding 30): the way to another chord is cancel and RE-CAPTURE, and
+  // the fresh capture then saves clean.
   fireEvent.keyDown(captureBox(), { key: "m", ctrlKey: true });
-  fireEvent.keyDown(captureBox(), { key: "Enter" });
+  expect(within(captureBox()).getByText("P")).toBeTruthy();
+  fireEvent.keyDown(captureBox(), { key: "Escape" });
+  const box2 = await enterCapture("Focus the composer");
+  fireEvent.keyDown(box2, { key: "m", ctrlKey: true });
+  fireEvent.keyDown(box2, { key: "Enter" });
   await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
 });
 
@@ -450,6 +971,47 @@ test("a failed Unbind surfaces the hub error inline on the row", async () => {
   const row = rowFor("Open the command palette");
   await waitFor(() => expect(within(row).getByRole("alert").textContent).toContain("socket went away"));
   expect(within(row).getByText("K")).toBeTruthy();
+});
+
+test("a confirmed hub payload clears a stale row error - and leaves an unrelated capture alone", async () => {
+  // The hub rejects writes while it recovers; the failed PATCH never
+  // confirmed, so the GET stays at revision 1 and the refresh re-confirms
+  // the SAME payload (the stale guard is `<`: an equal-revision refresh
+  // still applies and clears hubError).
+  let failPatch = true;
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  client.on("evener/settings/keybindings/patch", (params) => {
+    if (failPatch) throw new Error("state unavailable");
+    return overridesPayload(2, params.config.rules);
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+  const row = rowFor("Open the command palette");
+  await waitFor(() => expect(within(row).getByRole("alert").textContent).toContain("state unavailable"));
+  expect(keybindingsStore.getState().hubError).not.toBeNull();
+
+  // The hub answers a refresh again: hubError clears, and the row's stale
+  // inline error clears WITH it - the bindings it described are no longer
+  // the truth (the palette was never unbound).
+  failPatch = false;
+  await keybindingsStore.getState().refreshOverrides();
+  expect(keybindingsStore.getState().hubError).toBeNull();
+  await waitFor(() => expect(within(row).queryByRole("alert")).toBeNull());
+
+  // The clearing is scoped to the stale error: a capture open on another
+  // row rides through a later confirmed payload untouched. A NOTIFICATION,
+  // not a refresh: a refresh flips hubLoading, which makes the section
+  // read-only for the flight and cancels captures by design (finding 18) -
+  // the notification path confirms a payload without the loading gate.
+  const box = await enterCapture("Focus the composer");
+  client.emitNotification({
+    method: "evener/settings/keybindings/changed",
+    params: overridesPayload(1, []),
+  });
+  expect(screen.getByRole("textbox", { name: /Press the new shortcut/ })).toBe(box);
 });
 
 // The cheatsheet.toggle row is the one multi-entry action: the editor edits
@@ -552,4 +1114,358 @@ test("Escape cancels the capture and does NOT fire settings.close; outside captu
     unregister();
     popScope();
   }
+});
+
+// Editability is a per-render prop driven by hub support; a capture is row
+// state with a save in flight on the wire. Support loss mid-capture must
+// cancel the capture like a click-away (generation bumped, no refocus):
+// otherwise the interactive box strands in a read-only section and the
+// resolving save's continuation would repaint it.
+test("editable flipping false mid-capture closes the box and a resolving in-flight save does not touch the row", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+  let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/patch",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolvePatch = resolve;
+      }),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // Open a capture and start a save; the PATCH hangs.
+  const box = await enterCapture("Open the command palette");
+  fireEvent.keyDown(box, { key: "p", ctrlKey: true });
+  fireEvent.keyDown(box, { key: "Enter" });
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+
+  // Support drops while the save is in flight: the row goes read-only and
+  // the capture must close with it.
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+  await waitFor(() => expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull());
+  expect(screen.queryByRole("button", { name: /shortcut for Open the command palette/ })).toBeNull();
+
+  // The stale save resolves: no capture reopens, no row-level error.
+  resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
+  expect(within(rowFor("Open the command palette")).queryByRole("alert")).toBeNull();
+});
+
+test("editable true → false → true leaves the row read-only then editable again, and a fresh capture opens", async () => {
+  const client = await wireEditableClient();
+  render(<KeybindingsSection />);
+
+  await enterCapture("Open the command palette");
+
+  // Support drops: capture cancelled, editing affordance gone.
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+  await waitFor(() => expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull());
+  expect(screen.queryByRole("button", { name: /shortcut for Open the command palette/ })).toBeNull();
+
+  // Support returns (the store re-refreshes the hub payload on its own):
+  // the chord button comes back and opens a NEW capture.
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: true },
+  });
+  const chordButton = await screen.findByRole("button", { name: "Change the shortcut for Open the command palette" });
+  await userEvent.setup().click(chordButton);
+  expect(captureBox().textContent).toContain("Press new shortcut…");
+});
+
+// Reset availability derives from the hub's RAW rules: a persisted rule
+// validation skips (reserved here) never reaches the validated set, but
+// dropping it is exactly the meaningful action - so the row must offer
+// Reset even though the effective bindings never changed.
+// A conflict-skip warning names the holder the way the rows do - by TITLE
+// (with the action id alongside) - not by bare action id: this list is what
+// the user reads to understand why a saved rule did not apply.
+test("a persisted rule skipped for conflicting with a default names the holder by title in the warnings list", async () => {
+  // composerFocus claiming Control+K collides with palette.open's default.
+  await wireEditableClient([{ action: ACTIONS.composerFocus, chord: "Control+K" }]);
+  render(<KeybindingsSection />);
+
+  await waitFor(() =>
+    expect(screen.getByRole("status").textContent).toContain(
+      `chord "Control+K" in scope "global" is already bound by "Open the command palette" (${ACTIONS.paletteOpen})`,
+    ),
+  );
+  // The skipped rule changed nothing: composer stays on its default.
+  expect(within(rowFor("Focus the composer")).queryByText("Customized")).toBeNull();
+});
+
+test("a persisted rule skipped by validation shows Reset, and clicking it drops the rule from the hub payload", async () => {
+  // Control+W is reserved on every platform: the rule is skipped with a
+  // warning and never applies.
+  const client = await wireEditableClient([{ action: ACTIONS.railToggle, chord: "Control+W" }]);
+  render(<KeybindingsSection />);
+
+  const row = rowFor("Toggle the sidebar");
+  const reset = within(row).getByRole("button", { name: "Reset" });
+  // An action with no raw rule shows no Reset (regression).
+  expect(within(rowFor("Open the command palette")).queryByRole("button", { name: "Reset" })).toBeNull();
+  // The Customized marker stays on the effective bindings: the skipped rule
+  // changed nothing, so no marker.
+  expect(within(row).queryByText("Customized")).toBeNull();
+
+  await userEvent.setup().click(reset);
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  // The PATCH drops the rule: the full replacement rule set without it.
+  expect(patchCallsOf(client)[0]?.params).toEqual({
+    expectedRevision: 1,
+    config: { version: 1, rules: [] },
+  });
+  await waitFor(() => expect(within(rowFor("Toggle the sidebar")).queryByRole("button", { name: "Reset" })).toBeNull());
+});
+
+// Finding 33: a preflight rejection (a Reset that would re-conflict a
+// restored default) sets ONLY the row error - hubError stays null by design,
+// so the hubError transition cannot clear it. The next confirmed hub payload
+// (here a `changed` notification from an edit made elsewhere) supersedes the
+// bindings the error described, and the apply-serial bump clears the row error.
+test("a Reset preflight rejection's row error clears on the next confirmed payload", async () => {
+  const client = await wireEditableClient([
+    { action: ACTIONS.composerFocus, chord: "Control+K" },
+    { action: ACTIONS.paletteOpen, chord: "Control+P" },
+  ]);
+  render(<KeybindingsSection />);
+
+  // Reset on the palette row drops the palette override: the simulation
+  // restores palette.open's default Control+K, which composer's override
+  // still claims - an introduced conflict the hub write never sees.
+  const row = rowFor("Open the command palette");
+  await userEvent.setup().click(within(row).getByRole("button", { name: "Reset" }));
+  const alert = await within(row).findByRole("alert");
+  expect(alert.textContent).toContain(`already bound by "Open the command palette" (${ACTIONS.paletteOpen})`);
+  expect(patchCallsOf(client)).toHaveLength(0);
+  expect(keybindingsStore.getState().hubError).toBeNull();
+
+  // Nothing hub-sourced follows on its own: the error persists until a
+  // confirmed payload lands (the composer rule was removed through another
+  // client), then clears with the apply.
+  client.emitNotification({
+    method: "evener/settings/keybindings/changed",
+    params: overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  });
+  await waitFor(() => expect(within(row).queryByRole("alert")).toBeNull());
+  expect(keybindingsStore.getState().hubError).toBeNull();
+});
+
+// Finding 33, fence half: a write QUEUED in a ready generation that a
+// support flap ends rejects at the call-time fence - throw-only, hubError
+// stays null by design (finding 22) - leaving a row error no hubError
+// transition can clear. The next confirmed payload clears it.
+test("a generation-fenced queued write's row error clears on the next confirmed payload", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+  client.on(
+    "evener/settings/keybindings/patch",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolvePatch = resolve;
+      }),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // Write 1 (palette Unbind) hangs in flight; write 2 (composer Unbind)
+  // queues behind it in the same generation.
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+  await waitFor(() => expect(patchCallsOf(client)).toHaveLength(1));
+  await userEvent.setup().click(within(rowFor("Focus the composer")).getByRole("button", { name: "Unbind" }));
+
+  // A support flap ends the ready generation: the flap-back begins a NEW
+  // generation and re-refreshes (revision 3 again), confirming state - that
+  // apply-serial bump happens BEFORE either row error exists.
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: true },
+  });
+  await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+  // Write 1's response lands in the DEAD generation (dropped, synthesized
+  // resolution); write 2 then executes and the call-time fence throws - the
+  // composer row shows the error while hubError stays null.
+  resolvePatch?.(overridesPayload(4, []));
+  const composerRow = rowFor("Focus the composer");
+  const alert = await within(composerRow).findByRole("alert");
+  expect(alert.textContent).toContain("unavailable");
+  expect(keybindingsStore.getState().hubError).toBeNull();
+  expect(patchCallsOf(client)).toHaveLength(1);
+
+  // A confirmed payload for the NEW generation supersedes the bindings the
+  // error described: the row error clears.
+  client.emitNotification({
+    method: "evener/settings/keybindings/changed",
+    params: overridesPayload(5, []),
+  });
+  await waitFor(() => expect(within(composerRow).queryByRole("alert")).toBeNull());
+});
+
+// Finding 35: after an un-apply ROLLBACK on support loss the hubError alert
+// reports the old overrides still in effect; the status line must not
+// contradict it by claiming the built-in defaults. (Clean unsupported keeps
+// the defaults wording - pinned by the pre-existing "does not support synced
+// keybinding overrides" test.)
+test("a wedged support loss keeps the overrides firing and the status does not claim the defaults are in effect", async () => {
+  const client = await wireEditableClient([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+  render(<KeybindingsSection />);
+
+  // The wedge: a foreign binding squatting palette.open's DEFAULT chord, so
+  // the support drop's un-apply restore exact-matches, throws, and rolls
+  // back. palette.open's default is $mod+K with legacyEitherMod, so the
+  // restored base serializes "Control+[Meta]+K" (Meta OPTIONAL).
+  keybindingsRegistry.getState().registerBinding({
+    id: "foreign.squatter",
+    actionId: "foreign.action",
+    chord: "Control+[Meta]+K",
+  });
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain("still in effect");
+  const status = screen.getByRole("status");
+  expect(status.textContent).not.toContain("built-in defaults are in effect");
+  expect(status.textContent).toContain("still in effect");
+  // ...and the listing backs it up: the palette override is still firing
+  // and still marked Customized.
+  const row = rowFor("Open the command palette");
+  expect(within(row).getByText("Customized")).toBeTruthy();
+  expect(within(row).getByText("P")).toBeTruthy();
+});
+
+// Finding 37: the round-3 gate locks editing while hubError is set, and a
+// successful refresh clears it - the error block offers a Retry control that
+// re-drives the refresh. The control unmounts the moment the refresh starts
+// (refreshFor's entry clears hubError), so a double-click has no second
+// target; the in-flight window with a PRESERVED rollback error disables it
+// instead (separate test).
+test("a failed patch locks editing and shows a Retry that re-drives the refresh and restores editability (finding 37)", async () => {
+  const client = new FakeClient("ready");
+  let pending: Promise<KeybindingsOverrides> | undefined;
+  client.on("evener/settings/keybindings/get", () => pending ?? overridesPayload(1, []));
+  let failPatch = true;
+  client.on("evener/settings/keybindings/patch", (params) => {
+    if (failPatch) throw new Error("hub exploded");
+    return overridesPayload(2, params.config.rules);
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  // A transient server error: the PATCH rejects on the live generation, so
+  // hubError surfaces and editing locks behind the round-3 gate.
+  await userEvent.setup().click(within(rowFor("Open the command palette")).getByRole("button", { name: "Unbind" }));
+  await waitFor(() => expect(keybindingsStore.getState().hubError).toBe("hub exploded"));
+  expect(screen.queryByRole("button", { name: /shortcut for/ })).toBeNull();
+  const retry = screen.getByRole("button", { name: "Retry" });
+
+  // The hub recovers. Arm a hanging get so the in-flight window is
+  // observable: clicking Retry starts the refresh, which clears hubError at
+  // entry - the alert and the Retry control unmount, leaving no second
+  // click target (the double-fire guard on this path).
+  failPatch = false;
+  let resolveGet: ((p: KeybindingsOverrides) => void) | undefined;
+  pending = new Promise<KeybindingsOverrides>((resolve) => {
+    resolveGet = resolve;
+  });
+  const getCalls = () => client.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+  const before = getCalls();
+  await userEvent.setup().click(retry);
+  await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+  expect(getCalls()).toBe(before + 1);
+  expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+
+  // The refresh lands: hubError clears and editability returns.
+  resolveGet?.(overridesPayload(1, []));
+  await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
+  await screen.findByRole("button", { name: "Change the shortcut for Open the command palette" });
+});
+
+// Finding 37: on an unsupported hub a refresh cannot help (refreshFor's
+// entry guard refuses it) - no Retry, even when the rollback alert is
+// showing (that state's retry is connection-change-driven, findings 31/35).
+test("Retry does not appear on an unsupported hub, even with the rollback alert (finding 37)", async () => {
+  const client = await wireEditableClient([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+  render(<KeybindingsSection />);
+  // The wedge rolls the support drop's un-apply back (finding-35 staging):
+  // the rollback alert shows, but the hub is unsupported - no Retry.
+  keybindingsRegistry.getState().registerBinding({
+    id: "foreign.squatter",
+    actionId: "foreign.action",
+    chord: "Control+[Meta]+K",
+  });
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  });
+  const alert = await screen.findByRole("alert");
+  expect(alert.textContent).toContain("still in effect");
+  expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+});
+
+// Finding 37, in-flight window: through a rewire rollback the hubError is
+// PRESERVED while the new hub's refresh is in flight (unapplyRolledBack), so
+// the Retry control stays mounted - disabled while hubLoading, making a
+// double-click a no-op. When the refresh lands and clears the error, the
+// control unmounts.
+test("Retry is disabled while a refresh is in flight through the rollback window (finding 37)", async () => {
+  const clientA = new FakeClient("ready");
+  clientA.on("evener/settings/keybindings/get", () =>
+    overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  await wireClient(clientA, true);
+  render(<KeybindingsSection />);
+
+  // The wedge: a foreign binding squatting palette.open's default chord, so
+  // the rewire's un-apply restore throws and rolls back.
+  keybindingsRegistry.getState().registerBinding({
+    id: "foreign.squatter",
+    actionId: "foreign.action",
+    chord: "Control+[Meta]+K",
+  });
+  const clientB = new FakeClient("ready");
+  let resolveGet: ((p: KeybindingsOverrides) => void) | undefined;
+  clientB.on(
+    "evener/settings/keybindings/get",
+    () =>
+      new Promise<KeybindingsOverrides>((resolve) => {
+        resolveGet = resolve;
+      }),
+  );
+  connectionStore.getState().connect(clientB);
+  connectionStore.setState({
+    features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+  });
+  await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+  expect(keybindingsStore.getState().hubError).toContain("still in effect");
+
+  // Retry is mounted (supported hub, hubError present) but disabled for the
+  // flight: clicking it fires no second get.
+  const retry = screen.getByRole("button", { name: "Retry" });
+  expect((retry as HTMLButtonElement).disabled).toBe(true);
+  const getCalls = () => clientB.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+  const before = getCalls();
+  await userEvent.setup().click(retry);
+  expect(getCalls()).toBe(before);
+
+  // Unwedge; the refresh lands, clears the rollback error, and the control
+  // unmounts.
+  keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+  resolveGet?.(overridesPayload(1, []));
+  await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
+  expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -61,6 +61,12 @@ test("lists every default action with its title and effective chord, none custom
     expect.stringContaining("Focus the composer"),
     expect.stringContaining("Go to the next session needing you"),
     expect.stringContaining("Quote the selection into the composer"),
+    expect.stringContaining("Focus the next session pane"),
+    expect.stringContaining("Focus the previous session pane"),
+    expect.stringContaining("Scroll the transcript up one line"),
+    expect.stringContaining("Scroll the transcript down one line"),
+    expect.stringContaining("Scroll the transcript up one page"),
+    expect.stringContaining("Scroll the transcript down one page"),
     expect.stringContaining("Close settings"),
   ]);
   expect(screen.queryByText("Customized")).toBeNull();

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { ACTIONS } from "../../../keybindings/actions";
+import { DEFAULT_BINDINGS, registerDefaultBindings } from "../../../keybindings/defaults";
+import { keybindingsRegistry } from "../../../keybindings/registry";
+import { FakeClient } from "../../../protocol/testing/fakeClient";
+import type { KeybindingsOverrides, KeybindingsRule } from "../../../protocol/types.gen";
+import { connectionStore } from "../../../stores/connection";
+import { keybindingsStore, resetKeybindingsStoreForTests } from "../../../stores/keybindings";
+import { KeybindingsSection } from "./keybindings";
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+function overridesPayload(revision: number, rules: KeybindingsRule[]): KeybindingsOverrides {
+  return { version: 1, revision, rules };
+}
+
+async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  });
+  await keybindingsStore.getState().refreshOverrides();
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+});
+
+afterEach(() => {
+  cleanup();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+});
+
+function rowFor(title: string): HTMLElement {
+  const label = screen.getByText(title);
+  const row = label.closest("li");
+  if (row === null) throw new Error(`no row for "${title}"`);
+  return row;
+}
+
+test("lists every default action with its title and effective chord, none customized", () => {
+  render(<KeybindingsSection />);
+
+  // The row list is sourced live from the keybindings module's default map,
+  // never a hand-maintained copy: one row per action, in default-map order.
+  const rows = screen.getAllByRole("listitem");
+  expect(rows).toHaveLength(DEFAULT_BINDINGS.length);
+  expect(rows.map((row) => row.textContent)).toEqual([
+    expect.stringContaining("Open the command palette"),
+    expect.stringContaining("Toggle the sidebar"),
+    expect.stringContaining("Focus the composer"),
+    expect.stringContaining("Go to the next session needing you"),
+    expect.stringContaining("Quote the selection into the composer"),
+    expect.stringContaining("Close settings"),
+  ]);
+  expect(screen.queryByText("Customized")).toBeNull();
+
+  // jsdom resolves $mod to Control, so palette.open's effective chord renders
+  // as the Ctrl + K kbd pair via the KeyHint widget.
+  const paletteRow = rowFor("Open the command palette");
+  expect(within(paletteRow).getByText("Ctrl")).toBeTruthy();
+  expect(within(paletteRow).getByText("K")).toBeTruthy();
+  // settings.close's default chord lists every modifier as optional, so only
+  // the Escape key renders.
+  const settingsRow = rowFor("Close settings");
+  expect(within(settingsRow).getByText("Escape")).toBeTruthy();
+});
+
+test("with no hub connection the section waits quietly and still shows the defaults", () => {
+  render(<KeybindingsSection />);
+  expect(screen.getByRole("status").textContent).toContain("Waiting for the hub");
+  expect(rowFor("Open the command palette").textContent).toContain("K");
+});
+
+test("an applied override marks the action customized and shows the override chord", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  const paletteRow = rowFor("Open the command palette");
+  expect(within(paletteRow).getByText("Customized")).toBeTruthy();
+  expect(within(paletteRow).getByText("P")).toBeTruthy();
+  expect(within(paletteRow).queryByText("K")).toBeNull();
+  // Untouched actions keep their default chords and no marker.
+  const railRow = rowFor("Toggle the sidebar");
+  expect(within(railRow).queryByText("Customized")).toBeNull();
+  expect(within(railRow).getByText("B")).toBeTruthy();
+});
+
+test("an unbound action renders Unbound and counts as customized", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: null }]),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  const paletteRow = rowFor("Open the command palette");
+  expect(within(paletteRow).getByText("Unbound")).toBeTruthy();
+  expect(within(paletteRow).getByText("Customized")).toBeTruthy();
+});
+
+test("a hub that predates the feature shows a quiet unsupported status and the defaults", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+  await wireClient(client, false);
+  render(<KeybindingsSection />);
+
+  expect(screen.getByRole("status").textContent).toContain("does not support synced keybinding overrides");
+  expect(screen.queryByRole("alert")).toBeNull();
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
+test("a hub load failure surfaces the error honestly and keeps the defaults visible", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => {
+    throw new Error("socket went away");
+  });
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  expect(screen.getByRole("alert").textContent).toContain("socket went away");
+  expect(within(rowFor("Open the command palette")).getByText("K")).toBeTruthy();
+});
+
+test("validation warnings from the applied payload are listed quietly", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(2, [
+      { action: "no.such.action", chord: "Control+P" },
+      { action: ACTIONS.railToggle, chord: "Control+W" }, // reserved on every platform
+    ]),
+  );
+  await wireClient(client, true);
+  render(<KeybindingsSection />);
+
+  const status = screen.getByRole("status");
+  expect(status.textContent).toContain('unknown keybinding action "no.such.action"');
+  expect(status.textContent).toContain('chord "Control+W" is reserved');
+  // Both bad rules were skipped: every action stays on its default.
+  expect(screen.queryByText("Customized")).toBeNull();
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -9,9 +9,12 @@
 // keybindings/display.ts - the same module the cheatsheet overlay reads -
 // never a hand-maintained copy (the survey's stale-HELP_ROWS lesson).
 //
-// Editing requires a hub with synced-override support (hubSupport ===
-// "supported"): the overrides layer is hub-only by design, so unknown and
-// unsupported hubs get the read-only listing with the existing status text.
+// Editing requires a hub with synced-override support whose override state
+// is CURRENT: hubSupport === "supported" plus the store's `loaded` flag (set
+// only by a confirmed apply in the current ready generation, cleared on
+// rewire/disconnect), no in-flight refresh, and no hub error. Anything less
+// gets the read-only listing with a truthful status line - a PATCH composed
+// in the stale window would carry the previous hub's revision and payload.
 //
 // The overrides model owns an action's WHOLE chord set, so the editor edits
 // each action's base chord only; cheatsheet.toggle's conditional "?" entry
@@ -22,6 +25,7 @@ import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState }
 import { useStore } from "zustand";
 import { type Chord, chordDisplayKeys, modifierDisplayKey, serializeChord } from "../../../keybindings/chord";
 import { CHARACTER_KEY_TRIGGER_BINDING_ID } from "../../../keybindings/defaults";
+import { isIMECompositionKeydown } from "../../../keybindings/dispatcher";
 import {
   ACTION_DISPLAY_ROWS,
   displayBindingFor,
@@ -66,6 +70,18 @@ const CLASS = {
 // preview but never records a chord.
 const MODIFIER_KEYS = new Set(["Control", "Alt", "Shift", "Meta"]);
 
+// Browser key values that collide with the tinykeys GRAMMAR need the
+// grammar's canonical, matchable spelling. The spacebar is the one case:
+// its event.key is a literal " ", which is the grammar's press SEPARATOR -
+// parseChord(" ") throws on the empty string and "Control+ " parses to an
+// empty key, so a saved " " binding is dead on the next reconcile.
+// tinykeys' matcher (matchKeybindingPress) accepts event.code as well as
+// event.key, and the spacebar's code is "Space", so "Space" both survives
+// the grammar and matches the key. Every other whitespace-adjacent key
+// already arrives grammar-safe (Tab -> "Tab", Enter -> "Enter"). Kept at
+// the capture seam on purpose: chord.ts's parser stays grammar-pure.
+const CAPTURE_KEY_NAMES: Record<string, string> = { " ": "Space" };
+
 /** The held modifiers of a key event, in the chord module's canonical order
  * (chord.ts's MODIFIER_ORDER), so a recorded chord serializes canonically. */
 function eventModifiers(event: ReactKeyboardEvent): string[] {
@@ -84,9 +100,13 @@ function errorMessage(error: unknown): string {
 /** The full replacement rule set a single-action edit produces: the store's
  * patch semantics are whole-payload (an action the payload drops gets its
  * defaults restored), so every edit re-sends the current overrides with this
- * action's rule swapped - or REMOVED (chord undefined) for reset-to-default. */
+ * action's rule swapped - or REMOVED (chord undefined) for reset-to-default.
+ * Composition is from the hub's RAW rules (rawOverrides), NOT the validated
+ * `overrides`: a rule validation skipped (an unknown action from a newer
+ * client, an unparseable chord) is still the hub's state and passes through
+ * untouched - composing from the validated set would silently delete it. */
 function replacementRules(actionId: string, chord: string | null | undefined): OverrideRule[] {
-  const current = keybindingsStore.getState().overrides;
+  const current = keybindingsStore.getState().rawOverrides;
   const rest = current.filter((rule) => rule.action !== actionId);
   if (chord === undefined) return [...rest];
   return [...rest, { action: actionId, chord }];
@@ -114,7 +134,10 @@ interface CaptureBoxProps {
  * Single-press chords only: the default map is single-press throughout and
  * multi-press overlap checking is deliberately coarser (chord.ts's
  * chordsOverlap), so the editor does not author sequences. Plain Enter saves
- * and plain Escape cancels; either key WITH a modifier records as a chord. */
+ * and plain Escape cancels; either key WITH a modifier records as a chord.
+ * The FIRST non-modifier press records the chord; later presses are ignored
+ * (a stray key before Enter must not silently replace what is saved) - to
+ * change the chord, cancel and re-capture. */
 function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
   const [held, setHeld] = useState<string[]>([]);
   const [captured, setCaptured] = useState<Chord | null>(null);
@@ -128,7 +151,34 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
     boxRef.current?.focus();
   }, []);
 
+  // Click-away cancels even when the click target is not focusable: onBlur
+  // alone only fires when focus MOVES (to another control), so clicking
+  // non-focusable text or empty space would leave the capture live. A
+  // document-level pointerdown in the capture phase sees every press,
+  // wherever it lands; a press outside the box cancels with refocus:false
+  // (focus goes where the user put it - or stays, for a non-focusable
+  // target). The listener dies with the box (unmount on cancel/save).
+  useEffect(() => {
+    function onPointerDown(event: PointerEvent): void {
+      const box = boxRef.current;
+      if (box !== null && event.target instanceof Node && !box.contains(event.target)) {
+        onCancel(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [onCancel]);
+
   function handleKeyDown(event: ReactKeyboardEvent<HTMLDivElement>): void {
+    // IME composition keydowns are not presses: during composition events
+    // arrive with isComposing set and key "Process"/"Unidentified", and an
+    // IME COMMIT Enter would otherwise hit the save branch below. The shared
+    // guard (keybindings/dispatcher.ts's isIMECompositionKeydown, with its
+    // keyCode 229 fallback for browsers that report IME input only through
+    // it) precedes preventDefault/stopPropagation, and the dispatcher's own
+    // guard covers the propagation we let through. "Process"/"Unidentified"
+    // stay local to capture: they must never be RECORDED as a chord.
+    if (isIMECompositionKeydown(event.nativeEvent) || event.key === "Process" || event.key === "Unidentified") return;
     event.preventDefault();
     event.stopPropagation();
     if (savingRef.current) return;
@@ -153,16 +203,22 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
       });
       return;
     }
+    // The recorded chord stands: further non-modifier presses are consumed
+    // (preventDefault/stopPropagation above) but do NOT overwrite it.
+    if (captured !== null) return;
     setError(null);
-    // Single-character keys normalize to uppercase: KeyboardEvent.key for a
+    // ASCII letters normalize to uppercase: KeyboardEvent.key for a
     // mod chord arrives lowercase ("p" for Ctrl+P) while the default map
     // writes letters uppercase, and tinykeys matches case-insensitively, so
     // normalizing keeps display and serialization consistent with the
-    // existing rows without changing what matches.
+    // existing rows without changing what matches. The test is ASCII-only on
+    // purpose: String.toUpperCase can CHANGE LENGTH on non-ASCII input
+    // ("ß".toUpperCase() === "SS"), which would corrupt the chord.
+    const key = /^[a-z]$/.test(event.key) ? event.key.toUpperCase() : event.key;
     setCaptured({
       modifiers,
       optionalModifiers: [],
-      key: event.key.length === 1 ? event.key.toUpperCase() : event.key,
+      key: CAPTURE_KEY_NAMES[key] ?? key,
     });
   }
 
@@ -173,7 +229,9 @@ function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
   return (
     <div className={CLASS.captureWrap}>
       {/* Clicking away cancels: the box is modal-ish, and focus leaving it
-          (another row's chord button, the toggle) ends the capture. The
+          (another row's chord button, the toggle) ends the capture via
+          onBlur; the pointerdown listener above covers clicks that never
+          move focus (non-focusable text, empty space). The
           textbox role names what it is - a keyboard-capture surface in the
           spirit of HotkeyRecorder's input; aria-readonly because every key
           is intercepted rather than typed. */}
@@ -219,13 +277,46 @@ interface KeybindingRowProps {
 function KeybindingRow({ actionId, title, editable, bindings, characterKeyTriggers }: KeybindingRowProps) {
   const [capturing, setCapturing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const hasOverride = useKeybindingsStore((s) => s.overrides.some((rule) => rule.action === actionId));
+  // A failed save leaves this row's inline error AND the store's hubError
+  // set. When a later confirmed hub payload (refresh or notification) clears
+  // hubError, the row's stale error clears with it - the bindings it
+  // described are no longer the truth, and the store's isEditable gate
+  // already reopens. Local state only: an unrelated capture is untouched.
+  const hubError = useKeybindingsStore((s) => s.hubError);
+  useEffect(() => {
+    if (hubError === null) setError(null);
+  }, [hubError]);
+  // Finding 33: preflight and generation-fence rejections deliberately never
+  // set hubError, so the hubError transition above cannot clear a row error
+  // they left behind. Every confirmed hub payload (refresh, notification, or
+  // a later successful patch) supersedes the bindings that error described,
+  // so clear on the apply serial instead.
+  const appliedSerial = useKeybindingsStore((s) => s.appliedSerial);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: appliedSerial is a deliberate trigger-only dep - the effect's whole job is to re-run on the serial bump
+  useEffect(() => {
+    setError(null);
+  }, [appliedSerial]);
+  // Reset availability derives from the hub's RAW rules, not the validated
+  // set: a persisted rule validation skips (reserved/malformed/conflicting)
+  // never reaches `overrides`, but dropping it is exactly the meaningful
+  // action - replacementRules composes from rawOverrides for the same
+  // reason. The Customized marker stays on the effective bindings.
+  const hasOverride = useKeybindingsStore((s) => s.rawOverrides.some((rule) => rule.action === actionId));
   const chordButtonRef = useRef<HTMLButtonElement>(null);
   // Set when a capture ends from the keyboard (Escape cancel, Enter save):
   // focus returns to the chord button so the keyboard flow continues where
   // it started. A click-away cancel does NOT set it - focus already went
   // where the user put it.
   const refocusOnCloseRef = useRef(false);
+  // A save is a hub round trip and OUTLIVES the capture that started it: a
+  // click-away cancel closes the box while the PATCH is in flight, and the
+  // user can open a NEW capture before the old save resolves. Every capture
+  // open/cancel bumps this generation; a resolving save applies its result
+  // (closing the box, clearing the row error, refocusing) only while its
+  // generation is still current, so a stale continuation cannot close or
+  // repaint a capture it did not start. Same role as CaptureBox's
+  // savingRef, one level up.
+  const captureGenerationRef = useRef(0);
 
   useEffect(() => {
     if (!capturing && refocusOnCloseRef.current) {
@@ -233,6 +324,20 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
       chordButtonRef.current?.focus();
     }
   }, [capturing]);
+
+  // A capture must not outlive editability: a disconnect, support loss, or
+  // hub replacement mid-capture would strand an interactive box in a
+  // read-only section (the store side already rejects the save). Cancel
+  // like a click-away: bump the generation so an in-flight save's
+  // continuation no-ops, and do NOT refocus - the controls focus would
+  // return to are going away with editability.
+  useEffect(() => {
+    if (!editable && capturing) {
+      captureGenerationRef.current += 1;
+      refocusOnCloseRef.current = false;
+      setCapturing(false);
+    }
+  }, [editable, capturing]);
 
   const binding = displayBindingFor(bindings, actionId);
   const customized = isActionCustomized(bindings, actionId, characterKeyTriggers);
@@ -245,11 +350,20 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
   );
 
   async function saveCapture(chord: Chord): Promise<string | null> {
+    const generation = captureGenerationRef.current;
     try {
-      await keybindingsStore.getState().patchOverrides(replacementRules(actionId, serializeChord([chord])));
+      // A THUNK: the store serializes writes, so this composition must run
+      // when the write executes (against the raw set the previous write left
+      // behind), not now - composing at call time would race an in-flight
+      // edit from another row with a stale expectedRevision and payload.
+      await keybindingsStore.getState().patchOverrides(() => replacementRules(actionId, serializeChord([chord])));
     } catch (saveError) {
       return errorMessage(saveError);
     }
+    // Cancelled (or cancelled-and-reopened) while the PATCH was in flight:
+    // the capture this save belongs to is gone; its resolution must not
+    // touch the row's current capture state.
+    if (captureGenerationRef.current !== generation) return null;
     refocusOnCloseRef.current = true;
     setCapturing(false);
     setError(null);
@@ -257,11 +371,12 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
   }
 
   function cancelCapture(refocus: boolean): void {
+    captureGenerationRef.current += 1;
     refocusOnCloseRef.current = refocus;
     setCapturing(false);
   }
 
-  async function applyRules(rules: OverrideRule[]): Promise<void> {
+  async function applyRules(rules: readonly OverrideRule[] | (() => readonly OverrideRule[])): Promise<void> {
     try {
       await keybindingsStore.getState().patchOverrides(rules);
       setError(null);
@@ -275,8 +390,9 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
       <span className={CLASS.unbound}>Unbound</span>
     ) : (
       <span className={CLASS.chord}>
-        {binding.chord.map((press) => (
-          <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
+        {binding.chord.map((press, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: repeated presses in a multi-press sequence ("g g") are content-identical, position is identity, and the list is static per binding
+          <KeyHint key={`${i}:${serializeChord([press])}`} keys={chordDisplayKeys(press)} />
         ))}
       </span>
     );
@@ -297,6 +413,7 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
             className={CLASS.chordButton}
             aria-label={binding === undefined ? `Set a shortcut for ${title}` : `Change the shortcut for ${title}`}
             onClick={() => {
+              captureGenerationRef.current += 1;
               setError(null);
               setCapturing(true);
             }}
@@ -307,7 +424,7 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
             <button
               type="button"
               className={CLASS.actionButton}
-              onClick={() => void applyRules(replacementRules(actionId, null))}
+              onClick={() => void applyRules(() => replacementRules(actionId, null))}
             >
               Unbind
             </button>
@@ -316,7 +433,7 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
             <button
               type="button"
               className={CLASS.actionButton}
-              onClick={() => void applyRules(replacementRules(actionId, undefined))}
+              onClick={() => void applyRules(() => replacementRules(actionId, undefined))}
             >
               Reset
             </button>
@@ -346,17 +463,38 @@ function KeybindingRow({ actionId, title, editable, bindings, characterKeyTrigge
 
 export function KeybindingsSection() {
   const hubSupport = useKeybindingsStore((s) => s.hubSupport);
+  const hubLoading = useKeybindingsStore((s) => s.hubLoading);
   const hubError = useKeybindingsStore((s) => s.hubError);
+  const loaded = useKeybindingsStore((s) => s.loaded);
   const warnings = useKeybindingsStore((s) => s.warnings);
   const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
   const characterKeyTriggers = usePrefsStore((s) => s.characterKeyTriggers);
-  const editable = hubSupport === "supported";
+  const editable = hubSupport === "supported" && hubError === null && !hubLoading && loaded;
 
   let status: string | undefined;
   if (hubSupport === "unknown") {
     status = "Waiting for the hub connection to report keybindings support.";
   } else if (hubSupport === "unsupported") {
-    status = "This hub does not support synced keybinding overrides. The built-in defaults are in effect.";
+    // Finding 35: after an un-apply ROLLBACK the hubError alert says the
+    // old overrides are still in effect - the status must not contradict it
+    // by claiming the built-in defaults.
+    status =
+      hubError === null
+        ? "This hub does not support synced keybinding overrides. The built-in defaults are in effect."
+        : "This hub does not support synced keybinding overrides. The previously synced overrides are still in effect; restoring the built-in defaults is retried on the next connection change.";
+  } else if (hubLoading || !loaded) {
+    // The stale-hub window: a client replacement reset the loaded state and
+    // the new hub's refresh has not landed (or failed - the alert below
+    // carries that message). Read-only until the overrides are current.
+    status =
+      hubError === null
+        ? "Loading this hub's synced keybinding overrides; the shortcuts shown are read-only until they arrive."
+        : "Editing is unavailable until this hub's synced keybinding overrides load cleanly.";
+  } else if (hubError !== null) {
+    // A patch or re-refresh failed AFTER a successful load: the listing is
+    // current, but editing waits for a clean reload (the alert carries the
+    // failure itself).
+    status = "Editing is unavailable until this hub's synced keybinding overrides load cleanly.";
   }
 
   return (
@@ -391,11 +529,32 @@ export function KeybindingsSection() {
       {hubError !== null && (
         <p className={CLASS.error} role="alert">
           Could not load keybinding overrides: {hubError}
+          {hubSupport === "supported" && (
+            // Finding 37: the round-3 gate locks editing while hubError is
+            // set, and a successful refresh clears it - offer the recovery
+            // inline. Supported hubs only: on an unsupported hub a refresh
+            // cannot help (refreshFor's entry guard refuses it), and the
+            // rollback message's own retry is connection-change-driven.
+            // Disabled while hubLoading so a double-click cannot double-fire
+            // the refresh.
+            <button
+              type="button"
+              className={CLASS.actionButton}
+              disabled={hubLoading}
+              onClick={() => void keybindingsStore.getState().refreshOverrides()}
+            >
+              Retry
+            </button>
+          )}
         </p>
       )}
       {warnings.length > 0 && (
         <div className={CLASS.status} role="status">
-          <p>Some saved overrides were skipped:</p>
+          <p>
+            {warnings.some((warning) => warning.reason === "character-key-conflict")
+              ? "Keybinding warnings:"
+              : "Some saved overrides were skipped:"}
+          </p>
           <ul className={CLASS.warningList}>
             {warnings.map((warning) => (
               <li key={warning.message}>{warning.message}</li>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -1,23 +1,46 @@
-// Settings -> Keybindings: a READ-ONLY listing of the effective bindings.
-// The action list is sourced live from the keybindings module's default map
-// (DEFAULT_BINDINGS is also the validator's action universe), never a
-// hand-maintained copy - the survey's stale-HELP_ROWS lesson. The chords come
-// from the live registry, so hub overrides applied by the keybindings store
-// show up the moment they reconcile. Editing affordances are deliberately
-// absent; the shortcuts editor is a later phase.
+// Settings -> Keybindings: the capture-based binding editor (Phase 4b).
+// Clicking a row's chord enters capture mode (HotkeyRecorder-style: the
+// prompt shows held modifiers live, the first non-modifier press records the
+// chord, Enter saves, Escape cancels); per-action Unbind and Reset affordances
+// sit beside it. Writes go through the keybindings store's patchOverrides,
+// whose pre-flight validation rejects a conflicting (or reserved, or
+// unparseable) chord BEFORE the hub write - that message renders inline on
+// the row. The action list and per-action display bindings are sourced from
+// keybindings/display.ts - the same module the cheatsheet overlay reads -
+// never a hand-maintained copy (the survey's stale-HELP_ROWS lesson).
+//
+// Editing requires a hub with synced-override support (hubSupport ===
+// "supported"): the overrides layer is hub-only by design, so unknown and
+// unsupported hubs get the read-only listing with the existing status text.
+//
+// The overrides model owns an action's WHOLE chord set, so the editor edits
+// each action's base chord only; cheatsheet.toggle's conditional "?" entry
+// (managed by the character-key setting, per shell/cheatsheet/
+// cheatsheetController.ts) renders read-only with a note.
 
+import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from "react";
 import { useStore } from "zustand";
-import { chordDisplayKeys, serializeChord } from "../../../keybindings/chord";
-import { DEFAULT_BINDINGS, defaultBindingChordsForAction } from "../../../keybindings/defaults";
+import { type Chord, chordDisplayKeys, modifierDisplayKey, serializeChord } from "../../../keybindings/chord";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID } from "../../../keybindings/defaults";
+import {
+  ACTION_DISPLAY_ROWS,
+  displayBindingFor,
+  displayBindingsFor,
+  isActionCustomized,
+} from "../../../keybindings/display";
 import { type Binding, keybindingsRegistry } from "../../../keybindings/registry";
-import { useKeybindingsStore } from "../../../stores/keybindings";
-import { KeyHint } from "../../../widgets";
+import type { OverrideRule } from "../../../keybindings/validation";
+import { keybindingsStore, useKeybindingsStore } from "../../../stores/keybindings";
+import { prefsStore, usePrefsStore } from "../../../stores/prefs";
+import { KeyHint, Switch } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import styles from "./keybindings.module.css";
 
 const CLASS = {
   root: requireClass(styles.root, "keybindings.module.css", "root"),
   intro: requireClass(styles.intro, "keybindings.module.css", "intro"),
+  toggle: requireClass(styles.toggle, "keybindings.module.css", "toggle"),
+  help: requireClass(styles.help, "keybindings.module.css", "help"),
   status: requireClass(styles.status, "keybindings.module.css", "status"),
   warningList: requireClass(styles.warningList, "keybindings.module.css", "warningList"),
   error: requireClass(styles.error, "keybindings.module.css", "error"),
@@ -27,47 +50,298 @@ const CLASS = {
   marker: requireClass(styles.marker, "keybindings.module.css", "marker"),
   unbound: requireClass(styles.unbound, "keybindings.module.css", "unbound"),
   chord: requireClass(styles.chord, "keybindings.module.css", "chord"),
+  chordButton: requireClass(styles.chordButton, "keybindings.module.css", "chordButton"),
+  controls: requireClass(styles.controls, "keybindings.module.css", "controls"),
+  rowError: requireClass(styles.rowError, "keybindings.module.css", "rowError"),
+  note: requireClass(styles.note, "keybindings.module.css", "note"),
+  actionButton: requireClass(styles.actionButton, "keybindings.module.css", "actionButton"),
+  captureWrap: requireClass(styles.captureWrap, "keybindings.module.css", "captureWrap"),
+  capture: requireClass(styles.capture, "keybindings.module.css", "capture"),
+  capturePrompt: requireClass(styles.capturePrompt, "keybindings.module.css", "capturePrompt"),
+  captureHint: requireClass(styles.captureHint, "keybindings.module.css", "captureHint"),
+  captureError: requireClass(styles.captureError, "keybindings.module.css", "captureError"),
 };
 
-interface ActionRow {
+// The keys that are modifiers themselves: holding one updates the live
+// preview but never records a chord.
+const MODIFIER_KEYS = new Set(["Control", "Alt", "Shift", "Meta"]);
+
+/** The held modifiers of a key event, in the chord module's canonical order
+ * (chord.ts's MODIFIER_ORDER), so a recorded chord serializes canonically. */
+function eventModifiers(event: ReactKeyboardEvent): string[] {
+  const modifiers: string[] = [];
+  if (event.ctrlKey) modifiers.push("Control");
+  if (event.altKey) modifiers.push("Alt");
+  if (event.shiftKey) modifiers.push("Shift");
+  if (event.metaKey) modifiers.push("Meta");
+  return modifiers;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** The full replacement rule set a single-action edit produces: the store's
+ * patch semantics are whole-payload (an action the payload drops gets its
+ * defaults restored), so every edit re-sends the current overrides with this
+ * action's rule swapped - or REMOVED (chord undefined) for reset-to-default. */
+function replacementRules(actionId: string, chord: string | null | undefined): OverrideRule[] {
+  const current = keybindingsStore.getState().overrides;
+  const rest = current.filter((rule) => rule.action !== actionId);
+  if (chord === undefined) return [...rest];
+  return [...rest, { action: actionId, chord }];
+}
+
+interface CaptureBoxProps {
+  title: string;
+  /** Returns null on success (the box unmounts) or the message to show. */
+  onSave: (chord: Chord) => Promise<string | null>;
+  /** `refocus` is true when the capture ended from the keyboard (Escape) -
+   * the row returns focus to its chord button - and false when it ended by
+   * clicking away (focus already went where the user put it). */
+  onCancel: (refocus: boolean) => void;
+}
+
+/** The capture widget: a focusable box that consumes EVERY keydown while it
+ * is alive. preventDefault + stopPropagation keep each press from the
+ * window-level dispatcher - a captured chord must never fire the action it
+ * would replace, and rail.toggle's binding opts out of the
+ * defaultPrevented gate, so stopping propagation is the load-bearing half -
+ * and from the settings scope's own Escape (settings.close's
+ * ignoreIfDefaultPrevented gate is the backstop there, so capture's Escape
+ * cancels the capture instead of closing the pane).
+ *
+ * Single-press chords only: the default map is single-press throughout and
+ * multi-press overlap checking is deliberately coarser (chord.ts's
+ * chordsOverlap), so the editor does not author sequences. Plain Enter saves
+ * and plain Escape cancels; either key WITH a modifier records as a chord. */
+function CaptureBox({ title, onSave, onCancel }: CaptureBoxProps) {
+  const [held, setHeld] = useState<string[]>([]);
+  const [captured, setCaptured] = useState<Chord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+  // A save is a hub round trip; keypresses that land while it is in flight
+  // are ignored rather than queued into a second patch.
+  const savingRef = useRef(false);
+
+  useEffect(() => {
+    boxRef.current?.focus();
+  }, []);
+
+  function handleKeyDown(event: ReactKeyboardEvent<HTMLDivElement>): void {
+    event.preventDefault();
+    event.stopPropagation();
+    if (savingRef.current) return;
+    const modifiers = eventModifiers(event);
+    if (MODIFIER_KEYS.has(event.key)) {
+      setHeld(modifiers);
+      return;
+    }
+    if (event.key === "Escape" && modifiers.length === 0) {
+      onCancel(true);
+      return;
+    }
+    if (event.key === "Enter" && modifiers.length === 0) {
+      if (captured === null) return;
+      savingRef.current = true;
+      const chord = captured;
+      void onSave(chord).then((saveError) => {
+        savingRef.current = false;
+        // On success the parent unmounted this box; only a failure needs
+        // the state write.
+        if (saveError !== null) setError(saveError);
+      });
+      return;
+    }
+    setError(null);
+    // Single-character keys normalize to uppercase: KeyboardEvent.key for a
+    // mod chord arrives lowercase ("p" for Ctrl+P) while the default map
+    // writes letters uppercase, and tinykeys matches case-insensitively, so
+    // normalizing keeps display and serialization consistent with the
+    // existing rows without changing what matches.
+    setCaptured({
+      modifiers,
+      optionalModifiers: [],
+      key: event.key.length === 1 ? event.key.toUpperCase() : event.key,
+    });
+  }
+
+  function handleKeyUp(event: ReactKeyboardEvent<HTMLDivElement>): void {
+    if (MODIFIER_KEYS.has(event.key)) setHeld(eventModifiers(event));
+  }
+
+  return (
+    <div className={CLASS.captureWrap}>
+      {/* Clicking away cancels: the box is modal-ish, and focus leaving it
+          (another row's chord button, the toggle) ends the capture. The
+          textbox role names what it is - a keyboard-capture surface in the
+          spirit of HotkeyRecorder's input; aria-readonly because every key
+          is intercepted rather than typed. */}
+      {/* biome-ignore lint/a11y/useSemanticElements: a real <input> cannot hold the KeyHint kbd rendering or the save/cancel hint - only its role is wanted */}
+      <div
+        ref={boxRef}
+        className={CLASS.capture}
+        role="textbox"
+        aria-readonly="true"
+        tabIndex={-1}
+        aria-label={`Press the new shortcut for ${title}. Enter saves, Escape cancels.`}
+        onKeyDown={handleKeyDown}
+        onKeyUp={handleKeyUp}
+        onBlur={() => onCancel(false)}
+      >
+        {captured !== null ? (
+          <KeyHint keys={chordDisplayKeys(captured)} />
+        ) : held.length > 0 ? (
+          <KeyHint keys={held.map(modifierDisplayKey)} />
+        ) : (
+          <span className={CLASS.capturePrompt}>Press new shortcut…</span>
+        )}
+        <span className={CLASS.captureHint}>Enter to save · Esc to cancel</span>
+      </div>
+      {error !== null && (
+        <p className={CLASS.captureError} role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface KeybindingRowProps {
   actionId: string;
   title: string;
+  /** False on hubs without synced-override support: the row renders read-only. */
+  editable: boolean;
+  bindings: readonly Binding[];
+  characterKeyTriggers: boolean;
 }
 
-// One row per action, in default-map order. Module-level because it derives
-// entirely from the compiled-in default map; the effective chord each row
-// shows is read from the live registry at render.
-const ACTION_ROWS: readonly ActionRow[] = (() => {
-  const seen = new Set<string>();
-  const rows: ActionRow[] = [];
-  for (const input of DEFAULT_BINDINGS) {
-    if (seen.has(input.actionId)) continue;
-    seen.add(input.actionId);
-    rows.push({ actionId: input.actionId, title: input.title });
+function KeybindingRow({ actionId, title, editable, bindings, characterKeyTriggers }: KeybindingRowProps) {
+  const [capturing, setCapturing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const hasOverride = useKeybindingsStore((s) => s.overrides.some((rule) => rule.action === actionId));
+  const chordButtonRef = useRef<HTMLButtonElement>(null);
+  // Set when a capture ends from the keyboard (Escape cancel, Enter save):
+  // focus returns to the chord button so the keyboard flow continues where
+  // it started. A click-away cancel does NOT set it - focus already went
+  // where the user put it.
+  const refocusOnCloseRef = useRef(false);
+
+  useEffect(() => {
+    if (!capturing && refocusOnCloseRef.current) {
+      refocusOnCloseRef.current = false;
+      chordButtonRef.current?.focus();
+    }
+  }, [capturing]);
+
+  const binding = displayBindingFor(bindings, actionId);
+  const customized = isActionCustomized(bindings, actionId, characterKeyTriggers);
+  // Extra default entries beyond the platform base entry - in practice
+  // exactly cheatsheet.toggle's conditional "?" trigger. The overrides model
+  // owns an action's whole chord set, so these are the setting's to manage,
+  // not the editor's: read-only, with the consequence spelled out.
+  const conditionalEntries = displayBindingsFor(bindings, actionId).filter(
+    (entry) => entry.id === CHARACTER_KEY_TRIGGER_BINDING_ID,
+  );
+
+  async function saveCapture(chord: Chord): Promise<string | null> {
+    try {
+      await keybindingsStore.getState().patchOverrides(replacementRules(actionId, serializeChord([chord])));
+    } catch (saveError) {
+      return errorMessage(saveError);
+    }
+    refocusOnCloseRef.current = true;
+    setCapturing(false);
+    setError(null);
+    return null;
   }
-  return rows;
-})();
 
-/** The binding to display for an action: the override when present, else the
- * platform base entry (its `#mod-twin` shows the same chord on this
- * platform), else whatever binding the action has left. */
-function displayBindingFor(bindings: readonly Binding[], actionId: string): Binding | undefined {
-  const owned = bindings.filter((b) => b.actionId === actionId);
-  return owned.find((b) => b.id === `${actionId}#override`) ?? owned.find((b) => b.id === actionId) ?? owned[0];
-}
+  function cancelCapture(refocus: boolean): void {
+    refocusOnCloseRef.current = refocus;
+    setCapturing(false);
+  }
 
-/** Whether the action's effective bindings differ from its default map
- * entries - including the unbound (override `chord: null`) case, where the
- * effective set is empty. */
-function isCustomized(bindings: readonly Binding[], actionId: string): boolean {
-  const effective = bindings
-    .filter((b) => b.actionId === actionId)
-    .map((b) => `${b.scope} ${serializeChord(b.chord)}`)
-    .sort();
-  const defaults = defaultBindingChordsForAction(actionId)
-    .map((d) => `${d.scope} ${d.serialized}`)
-    .sort();
-  return effective.length !== defaults.length || effective.some((entry, i) => entry !== defaults[i]);
+  async function applyRules(rules: OverrideRule[]): Promise<void> {
+    try {
+      await keybindingsStore.getState().patchOverrides(rules);
+      setError(null);
+    } catch (patchError) {
+      setError(errorMessage(patchError));
+    }
+  }
+
+  const chordCell =
+    binding === undefined ? (
+      <span className={CLASS.unbound}>Unbound</span>
+    ) : (
+      <span className={CLASS.chord}>
+        {binding.chord.map((press) => (
+          <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
+        ))}
+      </span>
+    );
+
+  return (
+    <li className={CLASS.row}>
+      <span className={CLASS.label}>
+        {title}
+        {customized && <span className={CLASS.marker}>Customized</span>}
+      </span>
+      {capturing ? (
+        <CaptureBox title={title} onSave={saveCapture} onCancel={cancelCapture} />
+      ) : editable ? (
+        <span className={CLASS.controls}>
+          <button
+            ref={chordButtonRef}
+            type="button"
+            className={CLASS.chordButton}
+            aria-label={binding === undefined ? `Set a shortcut for ${title}` : `Change the shortcut for ${title}`}
+            onClick={() => {
+              setError(null);
+              setCapturing(true);
+            }}
+          >
+            {binding === undefined ? <span className={CLASS.unbound}>Unbound</span> : chordCell}
+          </button>
+          {binding !== undefined && (
+            <button
+              type="button"
+              className={CLASS.actionButton}
+              onClick={() => void applyRules(replacementRules(actionId, null))}
+            >
+              Unbind
+            </button>
+          )}
+          {hasOverride && (
+            <button
+              type="button"
+              className={CLASS.actionButton}
+              onClick={() => void applyRules(replacementRules(actionId, undefined))}
+            >
+              Reset
+            </button>
+          )}
+        </span>
+      ) : (
+        chordCell
+      )}
+      {conditionalEntries.length > 0 && (
+        <p className={CLASS.note}>
+          Also opens on{" "}
+          {conditionalEntries.map((entry) =>
+            entry.chord.map((press) => <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />),
+          )}{" "}
+          while the character-key setting above is on. That entry follows the setting, not this editor; changing or
+          unbinding this shortcut replaces it too.
+        </p>
+      )}
+      {error !== null && (
+        <p className={CLASS.rowError} role="alert">
+          {error}
+        </p>
+      )}
+    </li>
+  );
 }
 
 export function KeybindingsSection() {
@@ -75,6 +349,8 @@ export function KeybindingsSection() {
   const hubError = useKeybindingsStore((s) => s.hubError);
   const warnings = useKeybindingsStore((s) => s.warnings);
   const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
+  const characterKeyTriggers = usePrefsStore((s) => s.characterKeyTriggers);
+  const editable = hubSupport === "supported";
 
   let status: string | undefined;
   if (hubSupport === "unknown") {
@@ -86,8 +362,26 @@ export function KeybindingsSection() {
   return (
     <div className={CLASS.root}>
       <p className={CLASS.intro}>
-        The keyboard shortcuts currently in effect. Bindings marked Customized come from this hub's synced overrides.
+        {editable
+          ? "Click a shortcut to change it; Enter saves and Escape cancels. Changes sync to this hub. Bindings marked Customized come from this hub's synced overrides."
+          : "The keyboard shortcuts currently in effect. Bindings marked Customized come from this hub's synced overrides."}
       </p>
+
+      {/* The WCAG 2.1.4 character-key turn-off (the p4 plan's Design
+          decision 3): off unregisters the "?" cheatsheet trigger, leaving
+          every shortcut on a modifier chord. Browser-local (prefs store),
+          by controller ruling. */}
+      <div className={CLASS.toggle}>
+        <Switch
+          label="Character-key shortcuts"
+          checked={characterKeyTriggers}
+          onChange={(value) => prefsStore.getState().setCharacterKeyTriggers(value)}
+        />
+        <p className={CLASS.help}>
+          When on, pressing ? outside a text field opens the keyboard shortcuts overlay. Turn off to keep every shortcut
+          on a modifier chord.
+        </p>
+      </div>
 
       {status !== undefined && (
         <p className={CLASS.status} role="status">
@@ -111,26 +405,16 @@ export function KeybindingsSection() {
       )}
 
       <ul className={CLASS.list}>
-        {ACTION_ROWS.map((row) => {
-          const binding = displayBindingFor(bindings, row.actionId);
-          return (
-            <li className={CLASS.row} key={row.actionId}>
-              <span className={CLASS.label}>
-                {row.title}
-                {isCustomized(bindings, row.actionId) && <span className={CLASS.marker}>Customized</span>}
-              </span>
-              {binding === undefined ? (
-                <span className={CLASS.unbound}>Unbound</span>
-              ) : (
-                <span className={CLASS.chord}>
-                  {binding.chord.map((press) => (
-                    <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
-                  ))}
-                </span>
-              )}
-            </li>
-          );
-        })}
+        {ACTION_DISPLAY_ROWS.map((row) => (
+          <KeybindingRow
+            key={row.actionId}
+            actionId={row.actionId}
+            title={row.title}
+            editable={editable}
+            bindings={bindings}
+            characterKeyTriggers={characterKeyTriggers}
+          />
+        ))}
       </ul>
     </div>
   );

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.tsx
@@ -1,0 +1,137 @@
+// Settings -> Keybindings: a READ-ONLY listing of the effective bindings.
+// The action list is sourced live from the keybindings module's default map
+// (DEFAULT_BINDINGS is also the validator's action universe), never a
+// hand-maintained copy - the survey's stale-HELP_ROWS lesson. The chords come
+// from the live registry, so hub overrides applied by the keybindings store
+// show up the moment they reconcile. Editing affordances are deliberately
+// absent; the shortcuts editor is a later phase.
+
+import { useStore } from "zustand";
+import { chordDisplayKeys, serializeChord } from "../../../keybindings/chord";
+import { DEFAULT_BINDINGS, defaultBindingChordsForAction } from "../../../keybindings/defaults";
+import { type Binding, keybindingsRegistry } from "../../../keybindings/registry";
+import { useKeybindingsStore } from "../../../stores/keybindings";
+import { KeyHint } from "../../../widgets";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import styles from "./keybindings.module.css";
+
+const CLASS = {
+  root: requireClass(styles.root, "keybindings.module.css", "root"),
+  intro: requireClass(styles.intro, "keybindings.module.css", "intro"),
+  status: requireClass(styles.status, "keybindings.module.css", "status"),
+  warningList: requireClass(styles.warningList, "keybindings.module.css", "warningList"),
+  error: requireClass(styles.error, "keybindings.module.css", "error"),
+  list: requireClass(styles.list, "keybindings.module.css", "list"),
+  row: requireClass(styles.row, "keybindings.module.css", "row"),
+  label: requireClass(styles.label, "keybindings.module.css", "label"),
+  marker: requireClass(styles.marker, "keybindings.module.css", "marker"),
+  unbound: requireClass(styles.unbound, "keybindings.module.css", "unbound"),
+  chord: requireClass(styles.chord, "keybindings.module.css", "chord"),
+};
+
+interface ActionRow {
+  actionId: string;
+  title: string;
+}
+
+// One row per action, in default-map order. Module-level because it derives
+// entirely from the compiled-in default map; the effective chord each row
+// shows is read from the live registry at render.
+const ACTION_ROWS: readonly ActionRow[] = (() => {
+  const seen = new Set<string>();
+  const rows: ActionRow[] = [];
+  for (const input of DEFAULT_BINDINGS) {
+    if (seen.has(input.actionId)) continue;
+    seen.add(input.actionId);
+    rows.push({ actionId: input.actionId, title: input.title });
+  }
+  return rows;
+})();
+
+/** The binding to display for an action: the override when present, else the
+ * platform base entry (its `#mod-twin` shows the same chord on this
+ * platform), else whatever binding the action has left. */
+function displayBindingFor(bindings: readonly Binding[], actionId: string): Binding | undefined {
+  const owned = bindings.filter((b) => b.actionId === actionId);
+  return owned.find((b) => b.id === `${actionId}#override`) ?? owned.find((b) => b.id === actionId) ?? owned[0];
+}
+
+/** Whether the action's effective bindings differ from its default map
+ * entries - including the unbound (override `chord: null`) case, where the
+ * effective set is empty. */
+function isCustomized(bindings: readonly Binding[], actionId: string): boolean {
+  const effective = bindings
+    .filter((b) => b.actionId === actionId)
+    .map((b) => `${b.scope} ${serializeChord(b.chord)}`)
+    .sort();
+  const defaults = defaultBindingChordsForAction(actionId)
+    .map((d) => `${d.scope} ${d.serialized}`)
+    .sort();
+  return effective.length !== defaults.length || effective.some((entry, i) => entry !== defaults[i]);
+}
+
+export function KeybindingsSection() {
+  const hubSupport = useKeybindingsStore((s) => s.hubSupport);
+  const hubError = useKeybindingsStore((s) => s.hubError);
+  const warnings = useKeybindingsStore((s) => s.warnings);
+  const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
+
+  let status: string | undefined;
+  if (hubSupport === "unknown") {
+    status = "Waiting for the hub connection to report keybindings support.";
+  } else if (hubSupport === "unsupported") {
+    status = "This hub does not support synced keybinding overrides. The built-in defaults are in effect.";
+  }
+
+  return (
+    <div className={CLASS.root}>
+      <p className={CLASS.intro}>
+        The keyboard shortcuts currently in effect. Bindings marked Customized come from this hub's synced overrides.
+      </p>
+
+      {status !== undefined && (
+        <p className={CLASS.status} role="status">
+          {status}
+        </p>
+      )}
+      {hubError !== null && (
+        <p className={CLASS.error} role="alert">
+          Could not load keybinding overrides: {hubError}
+        </p>
+      )}
+      {warnings.length > 0 && (
+        <div className={CLASS.status} role="status">
+          <p>Some saved overrides were skipped:</p>
+          <ul className={CLASS.warningList}>
+            {warnings.map((warning) => (
+              <li key={warning.message}>{warning.message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <ul className={CLASS.list}>
+        {ACTION_ROWS.map((row) => {
+          const binding = displayBindingFor(bindings, row.actionId);
+          return (
+            <li className={CLASS.row} key={row.actionId}>
+              <span className={CLASS.label}>
+                {row.title}
+                {isCustomized(bindings, row.actionId) && <span className={CLASS.marker}>Customized</span>}
+              </span>
+              {binding === undefined ? (
+                <span className={CLASS.unbound}>Unbound</span>
+              ) : (
+                <span className={CLASS.chord}>
+                  {binding.chord.map((press) => (
+                    <KeyHint key={serializeChord([press])} keys={chordDisplayKeys(press)} />
+                  ))}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -428,6 +428,7 @@ export interface FeatureSet {
   directoryComplete: boolean;
   auth: boolean;
   transcriptDisplaySettings?: boolean;
+  keybindingsSettings?: boolean;
 }
 
 export interface GitHeadParams {
@@ -715,6 +716,28 @@ export interface JobsTreeUpdatedParams {
   threadId: string;
   ref: string;
   revision: number;
+}
+
+export interface KeybindingsConfig {
+  version: number;
+  rules: KeybindingsRule[];
+}
+
+export interface KeybindingsOverrides {
+  version: number;
+  revision: number;
+  rules: KeybindingsRule[];
+  loadError?: string;
+}
+
+export interface KeybindingsPatchParams {
+  expectedRevision: number;
+  config: KeybindingsConfig;
+}
+
+export interface KeybindingsRule {
+  action: string;
+  chord: string | null;
 }
 
 export interface LaunchConfigDiagnostic {
@@ -2161,6 +2184,8 @@ export const METHOD_NAMES = [
   "evener/settings/overview",
   "evener/settings/transcriptDisplay/get",
   "evener/settings/transcriptDisplay/patch",
+  "evener/settings/keybindings/get",
+  "evener/settings/keybindings/patch",
   "evener/sandbox/escalation/resolve",
 ] as const;
 
@@ -2202,6 +2227,7 @@ export const NOTIFICATION_NAMES = [
   "evener/sandbox/escalation/requested",
   "evener/sandbox/escalation/resolved",
   "evener/settings/transcriptDisplay/changed",
+  "evener/settings/keybindings/changed",
 ] as const;
 
 export type NotificationName = (typeof NOTIFICATION_NAMES)[number];
@@ -2338,6 +2364,8 @@ export interface MethodTypes {
   "evener/settings/overview": { params: EmptyParams; result: SettingsOverviewResponse };
   "evener/settings/transcriptDisplay/get": { params: EmptyParams; result: TranscriptDisplayDefaults };
   "evener/settings/transcriptDisplay/patch": { params: TranscriptDisplayDefaultsPatchParams; result: TranscriptDisplayPatchResponse };
+  "evener/settings/keybindings/get": { params: EmptyParams; result: KeybindingsOverrides };
+  "evener/settings/keybindings/patch": { params: KeybindingsPatchParams; result: KeybindingsOverrides };
   "evener/sandbox/escalation/resolve": { params: SandboxEscalationResolveParams; result: EmptyResponse };
 }
 
@@ -2377,6 +2405,7 @@ export interface NotificationTypes {
   "evener/sandbox/escalation/requested": SandboxEscalationRequested;
   "evener/sandbox/escalation/resolved": SandboxEscalationResolved;
   "evener/settings/transcriptDisplay/changed": TranscriptDisplayChangedParams;
+  "evener/settings/keybindings/changed": KeybindingsOverrides;
 }
 
 export type AnyNotification = { [K in NotificationName]: { method: K; params: NotificationTypes[K] } }[NotificationName];

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -26,6 +26,7 @@ import {
 } from "../stores/navigation/store";
 import { wireV2 } from "../stores/navigation/testing";
 import { keyID } from "../stores/navigation/types";
+import { resetPrefsStoreForTests } from "../stores/prefs";
 import { resetSettingsOverviewStoreForTests } from "../stores/settingsOverview";
 import { AppShell } from "./AppShell";
 import { DockHost } from "./DockHost";
@@ -438,6 +439,11 @@ beforeEach(() => {
   // @ts-expect-error MemoryStorage implements the subset used by DockHost.
   globalThis.localStorage = new MemoryStorage();
   localStorage.clear();
+  // The settings pane's last-visited-section memory (prefs.ts's
+  // lastSettingsSection) is a module-singleton field backed by this same
+  // storage: rehydrate against the cleared storage, or one test's settings
+  // visit picks the next test's bare-/settings landing section.
+  resetPrefsStoreForTests();
 });
 
 afterEach(() => {

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -2579,3 +2579,96 @@ test("Escape in Settings exits to welcome and the URL stays there, not reinstate
   });
   expect(screen.queryByRole("navigation", { name: "Settings sections" })).toBeNull();
 });
+
+// --- Alt+ArrowLeft/Right session-pane cycling (webui-keybindings-p3 Task 1)
+//
+// AppShell registers session.next/session.previous against the keybindings
+// registry (desktop only - the rail.toggle inertness pattern); the actions
+// drive workspaceStore.focusPane through shell/sessionCycle.ts. These tests
+// pin the WIRING (real dispatcher, real defaults, real shell); the cycling
+// order/wrap/no-op semantics themselves are sessionCycle.test.ts's.
+
+test("Alt+ArrowRight/Left cycle the open session panes through the shell, wrapping", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  let a = "";
+  let b = "";
+  act(() => {
+    a = workspaceStore.getState().openPane("session", { ref: "local:cycle-a" });
+    b = workspaceStore.getState().openPane("session", { ref: "local:cycle-b" });
+    workspaceStore.getState().focusPane(a);
+  });
+  await waitFor(() => expect(workspaceStore.getState().panes).toHaveLength(2));
+
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+
+  // Wrap: the last session pane's next is the first.
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+
+  await user.keyboard("{Alt>}{ArrowLeft}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+});
+
+test("Alt+Arrow cycling is a no-op with a single session pane open", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  let only = "";
+  act(() => {
+    only = workspaceStore.getState().openPane("session", { ref: "local:cycle-only" });
+  });
+  await waitFor(() => expect(workspaceStore.getState().panes).toHaveLength(1));
+
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(only);
+  await user.keyboard("{Alt>}{ArrowLeft}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(only);
+});
+
+test("Alt+Arrow cycling is suppressed from an editable target", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  let a = "";
+  act(() => {
+    a = workspaceStore.getState().openPane("session", { ref: "local:cycle-a" });
+    workspaceStore.getState().openPane("session", { ref: "local:cycle-b" });
+    workspaceStore.getState().focusPane(a);
+  });
+  await waitFor(() => expect(workspaceStore.getState().panes).toHaveLength(2));
+
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  try {
+    await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+    expect(workspaceStore.getState().focusedPaneId).toBe(a);
+  } finally {
+    input.remove();
+  }
+});
+
+test("mobile: Alt+Arrow cycling registers nothing and is inert", async () => {
+  installMobileViewport();
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  let a = "";
+  act(() => {
+    a = workspaceStore.getState().openPane("session", { ref: "local:cycle-a" });
+    workspaceStore.getState().openPane("session", { ref: "local:cycle-b" });
+    workspaceStore.getState().focusPane(a);
+  });
+  await waitFor(() => expect(workspaceStore.getState().panes).toHaveLength(2));
+
+  await user.keyboard("{Alt>}{ArrowRight}{/Alt}");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+  vi.unstubAllGlobals();
+});

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -22,9 +22,11 @@ import { navigationStore, useNavigationStore } from "../stores/navigation/store"
 import { isNavigationUnavailable, isSettledGone, keyID } from "../stores/navigation/types";
 import { initTranscriptDisplay } from "../stores/transcriptDisplay";
 import { ConnectionBanner } from "./ConnectionBanner";
+import { CheatsheetOverlay } from "./cheatsheet/CheatsheetOverlay";
 import { ToastRegion } from "./chrome/ToastRegion";
 import { ClientProvider } from "./clientContext";
 import { DockRegion } from "./DockRegion";
+import { HoldHints } from "./holdhints/HoldHints";
 import { installKeybindings } from "./installKeybindings";
 import { StackHost } from "./mobile/StackHost";
 import { NotFound } from "./NotFound";
@@ -32,7 +34,7 @@ import { CommandPalette } from "./palette/CommandPalette";
 import { openPalette, paletteStore } from "./palette/paletteController";
 import { RailHost } from "./rail";
 import { needsYouRefs, nextNeedsYouRef, openNeedsYouSession } from "./rail/needsYouCycle";
-import { urlToPane } from "./routing";
+import { navigate, urlToPane } from "./routing";
 import { cycleSessionPane } from "./sessionCycle";
 import { openNestedSessionWithOwner, openTopLevelSession } from "./sessionPlacement";
 import { isSinglePaneRoute } from "./singlePane";
@@ -516,6 +518,13 @@ export function AppShell({ client: injectedClient, bannerDelayMs, bannerCreateCl
   // cycling no-ops (fewer than two session panes): Alt+ArrowLeft is the
   // browser's Back shortcut, and declining would navigate the SPA's history
   // underneath a user who has one session open.
+  //
+  // ⌘, (settings.open, Phase 4a) joins this desktop-only group per the p4
+  // plan's mobile-inert constraint. Its behavior IS the palette "settings"
+  // command's - the action id reuses that command's id (keybindings/
+  // actions.ts), and navigate("/settings") is exactly its run body
+  // (shell/palette/commands.ts); same shared-seam precedent as
+  // next-needs-you above.
   useEffect(() => {
     if (isMobile) return undefined;
     installKeybindings();
@@ -523,6 +532,7 @@ export function AppShell({ client: injectedClient, bannerDelayMs, bannerCreateCl
     const unregister = [
       registry.registerAction(ACTIONS.sessionNext, () => cycleSessionPane("next")),
       registry.registerAction(ACTIONS.sessionPrevious, () => cycleSessionPane("previous")),
+      registry.registerAction(ACTIONS.settingsOpen, () => navigate("/settings")),
     ];
     return () => {
       for (const dispose of unregister) dispose();
@@ -684,6 +694,13 @@ export function AppShell({ client: injectedClient, bannerDelayMs, bannerCreateCl
         />
         <ToastRegion />
         <CommandPalette />
+        {/* The cheatsheet overlay and the hold-modifier hints (Phase 4a):
+            desktop-only, so on a touch viewport no cheatsheet action is ever
+            registered and its trigger chords stay inert - RailHost's
+            rail.toggle no-registration pattern - and no hold-hint listener
+            is ever installed. */}
+        {!isMobile && <CheatsheetOverlay />}
+        {!isMobile && <HoldHints />}
         <div className={styles.content}>
           {/* Desktop: the rail sits as a flex sibling of DockHost and
               collapses itself. Mobile (<900px): StackHost owns the whole

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -33,6 +33,7 @@ import { openPalette, paletteStore } from "./palette/paletteController";
 import { RailHost } from "./rail";
 import { needsYouRefs, nextNeedsYouRef, openNeedsYouSession } from "./rail/needsYouCycle";
 import { urlToPane } from "./routing";
+import { cycleSessionPane } from "./sessionCycle";
 import { openNestedSessionWithOwner, openTopLevelSession } from "./sessionPlacement";
 import { isSinglePaneRoute } from "./singlePane";
 import { useIsMobile } from "./useIsMobile";
@@ -508,6 +509,25 @@ export function AppShell({ client: injectedClient, bannerDelayMs, bannerCreateCl
       .catch(() => undefined);
   }, [locationFailed, locationGone, locationRef, locationResource, navigationMode]);
   const isMobile = useIsMobile();
+  // Alt+ArrowLeft/Right cycle focus through the open session panes (Phase 3;
+  // cycling semantics live in sessionCycle.ts). Desktop only, following
+  // RailHost's rail.toggle pattern: with no action registered on mobile the
+  // bindings are inert there. The handlers CLAIM their chord even when
+  // cycling no-ops (fewer than two session panes): Alt+ArrowLeft is the
+  // browser's Back shortcut, and declining would navigate the SPA's history
+  // underneath a user who has one session open.
+  useEffect(() => {
+    if (isMobile) return undefined;
+    installKeybindings();
+    const registry = keybindingsRegistry.getState();
+    const unregister = [
+      registry.registerAction(ACTIONS.sessionNext, () => cycleSessionPane("next")),
+      registry.registerAction(ACTIONS.sessionPrevious, () => cycleSessionPane("previous")),
+    ];
+    return () => {
+      for (const dispose of unregister) dispose();
+    };
+  }, [isMobile]);
   // Keeps --keyboard-inset current for the mobile .shell rule; see
   // useKeyboardInset.ts's header for the why.
   useKeyboardInset();

--- a/cmd/evener-hub/frontend/src/shell/AppShell.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.tsx
@@ -3,6 +3,8 @@
 // workspace - DockHost (dockview) on desktop; renders NotFound in its
 // place for a path urlToPane() can't resolve at all.
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { ACTIONS } from "../keybindings/actions";
+import { keybindingsRegistry } from "../keybindings/registry";
 import { initNotifications } from "../notifications";
 import { requestComposerFocus } from "../panes/session/composer/composerFocus";
 import { AppwireClient } from "../protocol/client";
@@ -23,6 +25,7 @@ import { ConnectionBanner } from "./ConnectionBanner";
 import { ToastRegion } from "./chrome/ToastRegion";
 import { ClientProvider } from "./clientContext";
 import { DockRegion } from "./DockRegion";
+import { installKeybindings } from "./installKeybindings";
 import { StackHost } from "./mobile/StackHost";
 import { NotFound } from "./NotFound";
 import { CommandPalette } from "./palette/CommandPalette";
@@ -325,36 +328,34 @@ export function AppShell({ client: injectedClient, bannerDelayMs, bannerCreateCl
     return () => owned?.close();
   }, [client, owned]);
 
-  // Global command-palette entry points (floor §2.1): ⌘K / Ctrl-K from
-  // anywhere in the app, and a click on any [data-search-trigger] element.
-  // Both open the palette through the one openPalette() the whole app shares
-  // (Composer's leading-"/"-on-empty hook is the third). ⌘B (sidebar cycle,
-  // T5) is a separate, disjoint listener and is never added here (PIN-D).
+  // Global chord wiring (floor §2.1 + the UX-fix chords), now driven by the
+  // keybindings dispatcher (src/keybindings/, installed app-wide by
+  // installKeybindings): this effect registers the three actions AppShell
+  // owns - palette.open (⌘K / Ctrl-K from anywhere, through the one
+  // openPalette() the whole app shares; Composer's leading-"/"-on-empty hook
+  // and the [data-search-trigger] click listener below are the other entry
+  // points), composer.focus (⌘I: focuses the focused session pane's composer
+  // via composerFocus.ts's per-ref seam - a no-op when the focused pane isn't
+  // a session), and next-needs-you (⌘J: cycles the needs-you sessions, tree
+  // order, wrapping from whichever session is currently focused, opening a
+  // hit through the same top-level/nested seams the rail itself uses -
+  // needsYouCycle.ts). ⌘B (sidebar cycle) is RailHost's action, never
+  // registered here (PIN-D).
   //
-  // ⌘I / Ctrl-I (UX fix) focuses the focused session pane's composer
-  // (composerFocus.ts's per-ref seam) - a no-op when the focused pane isn't a
-  // session. ⌘J / Ctrl-J (UX fix) cycles the needs-you sessions (tree order,
-  // wrapping from whichever session is currently focused), opening a hit
-  // through the same top-level/nested seams the rail itself uses
-  // (needsYouCycle.ts). Both are Mod-chords, like ⌘K, so they fire
-  // everywhere - including while typing in an input/textarea - matching how
-  // ⌘K already behaves; only event.defaultPrevented (another handler already
-  // claimed this keystroke) suppresses them.
-  //
-  // BLOCKER fix: I/J used to fire straight through an open modal (the
-  // command palette itself, or a Dialog/Sheet like Settings' credential
-  // editors) - ⌘I stealing focus into a session composer, or ⌘J navigating
-  // the tree, out from under a modal the user is still looking at. Guarded
-  // two ways: paletteStore's own `open` flag (the palette isn't a
-  // [role=dialog] - it's CommandPalette's own overlay, so the DOM check
-  // below wouldn't catch it) and event.target sitting inside any
-  // [aria-modal="true"] element (every OverlayPanel-based Dialog/Sheet sets
-  // this - see widgets/dialog/OverlayPanel.tsx - and it needs no per-modal
-  // wiring here to keep catching new ones). ⌘K is deliberately exempt:
-  // opening the palette while it's already open is a harmless no-op reset,
-  // not a focus hijack, and ⌘K from inside a Dialog is the same "open the
-  // palette" intent as anywhere else.
+  // The chords' shared guards live on the bindings (keybindings/defaults.ts),
+  // not in these runners: all three fire from editable targets
+  // (allowInEditable) and yield to a keydown another handler already claimed
+  // (defaultPrevented). The modal guard (the old blockedByOpenModal:
+  // paletteStore.open, plus the event target sitting inside any
+  // [aria-modal="true"] element - every OverlayPanel Dialog/Sheet) is the
+  // dispatcher's injected isModalOpen predicate; it suppresses ⌘I/⌘J (the
+  // BLOCKER fix: ⌘I stealing composer focus, or ⌘J navigating the tree, out
+  // from under a modal the user is still looking at) while ⌘K stays
+  // deliberately exempt via its binding's allowInModal - opening the palette
+  // while it's already open is a harmless no-op reset, and ⌘K from inside a
+  // Dialog is the same "open the palette" intent as anywhere else.
   useEffect(() => {
+    installKeybindings();
     const requestedPages = new Set<string>();
     let generation = navigationStore.getState().clientGenerationID;
     let mounted = true;
@@ -409,30 +410,14 @@ export function AppShell({ client: injectedClient, bannerDelayMs, bannerCreateCl
         })
         .catch(() => undefined);
     };
-    function blockedByOpenModal(event: KeyboardEvent): boolean {
-      if (paletteStore.getState().open) return true;
-      const target = event.target;
-      return target instanceof Element && target.closest('[aria-modal="true"]') !== null;
-    }
-    function onKeyDown(event: KeyboardEvent): void {
-      if (event.defaultPrevented) return;
-      if (!(event.metaKey || event.ctrlKey)) return;
-      const key = event.key.toLowerCase();
-      if (key === "k") {
-        event.preventDefault();
-        openPalette();
-        return;
-      }
-      if (key === "i") {
-        if (blockedByOpenModal(event)) return;
-        event.preventDefault();
+    const registry = keybindingsRegistry.getState();
+    const unregisterActions = [
+      registry.registerAction(ACTIONS.paletteOpen, () => openPalette()),
+      registry.registerAction(ACTIONS.composerFocus, () => {
         const ref = focusedSessionRef();
         if (ref !== null) requestComposerFocus(ref);
-        return;
-      }
-      if (key === "j") {
-        if (blockedByOpenModal(event)) return;
-        event.preventDefault();
+      }),
+      registry.registerAction(ACTIONS.nextNeedsYou, () => {
         const state = navigationStore.getState();
         if (state.clientGenerationID !== generation) {
           generation = state.clientGenerationID;
@@ -475,8 +460,8 @@ export function AppShell({ client: injectedClient, bannerDelayMs, bannerCreateCl
         }
         const next = nextNeedsYouRef(refs, current);
         if (next !== null) openNeedsYouSession(next);
-      }
-    }
+      }),
+    ];
     function onClick(event: MouseEvent): void {
       const target = event.target as Element | null;
       if (target?.closest("[data-search-trigger]")) {
@@ -484,12 +469,11 @@ export function AppShell({ client: injectedClient, bannerDelayMs, bannerCreateCl
         openPalette();
       }
     }
-    window.addEventListener("keydown", onKeyDown);
     document.addEventListener("click", onClick);
     return () => {
       mounted = false;
       intent++;
-      window.removeEventListener("keydown", onKeyDown);
+      for (const unregister of unregisterActions) unregister();
       document.removeEventListener("click", onClick);
     };
   }, []);

--- a/cmd/evener-hub/frontend/src/shell/PaneTab.tsx
+++ b/cmd/evener-hub/frontend/src/shell/PaneTab.tsx
@@ -45,7 +45,9 @@ export function PaneTab(props: IDockviewPanelHeaderProps<PanePanelParams>) {
   const statusType = useThreadsStore((s) => (ref === undefined ? undefined : s.threads.get(ref)?.status.type));
   const state = statusType === undefined ? undefined : cadenceStateForStatus(statusType);
   return (
-    <span className={styles.tab}>
+    // data-session-tab is the hold-hints overlay's anchor (shell/holdhints):
+    // the session-cycling chip positions itself over the first session tab.
+    <span className={styles.tab} data-session-tab={ref !== undefined ? "" : undefined}>
       <DockviewDefaultTab {...props} />
       {state !== undefined && DOT_STATES.has(state) && (
         <span className={styles.dot}>

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.test.tsx
@@ -1,0 +1,376 @@
+// Tests for the cheatsheet overlay (Phase 4a, the p4 plan's Design
+// decision 3): trigger chords (⌘/ primary, "?" secondary and
+// pref-conditional), editable-target policy, Escape/⌘/ toggle-close,
+// registry-sourced rows (an applied override shows its own chord), the
+// prefs-persisted character-key toggle, and mobile inertness (AppShell
+// mounts the overlay only off mobile, so no action registers and the chords
+// stay inert - the rail.toggle no-registration pattern).
+//
+// The AppShell render/warm-up/store-reset scaffolding below mirrors
+// shell/keybindingsMigration.test.tsx's own (helpers duplicated, not
+// shared - this project has no cross-test-file test-utils module; see that
+// file's and AppShell.test.tsx's notes on the convention).
+
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { ACTIONS } from "../../keybindings/actions";
+import {
+  CHARACTER_KEY_TRIGGER_BINDING_ID,
+  CHEATSHEET_SCOPE,
+  DEFAULT_BINDINGS,
+  registerDefaultBindings,
+} from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { initNotifications, resetNotificationsForTests } from "../../notifications";
+import { FakeClient } from "../../protocol/testing/fakeClient";
+import type { KeybindingsOverrides, KeybindingsRule } from "../../protocol/types.gen";
+import { connectionStore } from "../../stores/connection";
+import { keybindingsStore, resetKeybindingsStoreForTests } from "../../stores/keybindings";
+import { resetNavigationStoreForTests } from "../../stores/navigation/store";
+import { prefsStore, resetPrefsStoreForTests } from "../../stores/prefs";
+import { AppShell } from "../AppShell";
+import { paletteStore } from "../palette/paletteController";
+import { resetMobileViewportForTests } from "../useIsMobile";
+import { resetWorkspaceStoreForTests } from "../workspace";
+import { CheatsheetOverlay } from "./CheatsheetOverlay";
+import { cheatsheetStore, closeCheatsheet, openCheatsheet } from "./cheatsheetController";
+
+// See AppShell.test.tsx for why both stubs are needed (jsdom has no
+// ResizeObserver; Node 26 shadows jsdom's localStorage accessor).
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+// jsdom implements no matchMedia at all (useIsMobile.test.ts documents the
+// probe), so the mobile test installs one: the mobile query matches, every
+// other query does not - AppShell.test.tsx's installMobileViewport, verbatim.
+function installMobileViewport(): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      media,
+      matches: media === "(max-width: 899px)",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })),
+  );
+}
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+function overridesPayload(revision: number, rules: KeybindingsRule[]): KeybindingsOverrides {
+  return { version: 1, revision, rules };
+}
+
+async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  });
+  await keybindingsStore.getState().refreshOverrides();
+}
+
+function questionTriggerRegistered(): boolean {
+  return keybindingsRegistry.getState().bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+}
+
+async function openDialog(): Promise<HTMLElement> {
+  return screen.findByRole("dialog", { name: "Keyboard shortcuts" });
+}
+
+beforeAll(async () => {
+  globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver;
+  // @ts-expect-error MemoryStorage deliberately implements only the Storage
+  // methods the stores actually call - see AppShell.test.tsx's own stub.
+  globalThis.localStorage = new MemoryStorage();
+  // Await the lazy pane/dock modules once up front, then pay react-dom's
+  // per-boundary fallback throttle in one warm render - see
+  // keybindingsMigration.test.tsx's beforeAll for the full reasoning.
+  await import("../../panes/welcome/Welcome");
+  await import("../DockHost");
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+});
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetWorkspaceStoreForTests();
+  resetNavigationStoreForTests();
+  resetKeybindingsStoreForTests();
+  // @ts-expect-error see the beforeAll stub.
+  globalThis.localStorage = new MemoryStorage();
+  localStorage.clear();
+  resetPrefsStoreForTests();
+  resetRegistryToDefaults();
+  closeCheatsheet();
+});
+
+afterEach(() => {
+  cleanup();
+  window.history.pushState({}, "", "/");
+  paletteStore.setState({ open: false, query: "" });
+  closeCheatsheet();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetNavigationStoreForTests();
+  resetKeybindingsStoreForTests();
+  resetNotificationsForTests();
+  initNotifications();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test("opens on ⌘/ and lists every action with its effective chord, grouped", async () => {
+  render(<CheatsheetOverlay />);
+  fireEvent.keyDown(document.body, { key: "/", code: "Slash", ctrlKey: true });
+
+  const dialog = await openDialog();
+  for (const group of ["Sessions", "Transcript", "Composer", "General"]) {
+    expect(within(dialog).getByText(group)).toBeTruthy();
+  }
+  // One row per action (the overlay's two trigger entries share one action
+  // id), sourced live from the default map via keybindings/display.ts.
+  const rows = within(dialog).getAllByRole("listitem");
+  expect(rows).toHaveLength(new Set(DEFAULT_BINDINGS.map((b) => b.actionId)).size);
+  // jsdom resolves $mod to Control: palette.open's row shows Ctrl + K, and
+  // the cheatsheet row shows Ctrl + / with the "?" trigger alongside.
+  const paletteRow = within(dialog).getByText("Open the command palette").closest("li");
+  if (paletteRow === null) throw new Error("no palette row");
+  expect(within(paletteRow).getByText("Ctrl")).toBeTruthy();
+  expect(within(paletteRow).getByText("K")).toBeTruthy();
+  const cheatsheetRow = within(dialog).getByText("Show the keyboard shortcuts overlay").closest("li");
+  if (cheatsheetRow === null) throw new Error("no cheatsheet row");
+  expect(within(cheatsheetRow).getByText("/")).toBeTruthy();
+  expect(within(cheatsheetRow).getByText("?")).toBeTruthy();
+  // The hold-hints footer line (the feature itself is the next task).
+  expect(within(dialog).getByText(/to see hints/)).toBeTruthy();
+});
+
+test("opens on ? outside editable targets", async () => {
+  render(<CheatsheetOverlay />);
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  await openDialog();
+});
+
+test("? does NOT fire inside an editable target (it is a printable character)", () => {
+  render(<CheatsheetOverlay />);
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  fireEvent.keyDown(input, { key: "?", code: "Slash", shiftKey: true });
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(cheatsheetStore.getState().open).toBe(false);
+  input.remove();
+});
+
+test("⌘/ fires inside an editable target (it never collides with typing)", async () => {
+  render(<CheatsheetOverlay />);
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  fireEvent.keyDown(input, { key: "/", code: "Slash", ctrlKey: true });
+  await openDialog();
+  input.remove();
+});
+
+test("? does NOT fire while the character-key toggle is off, and comes back when it returns", async () => {
+  render(<CheatsheetOverlay />);
+  act(() => prefsStore.getState().setCharacterKeyTriggers(false));
+
+  // The binding is unregistered, not merely suppressed - and the open
+  // overlay's row stops offering "?".
+  expect(questionTriggerRegistered()).toBe(false);
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  expect(screen.queryByRole("dialog")).toBeNull();
+
+  // ⌘/ is unaffected (it is not a character-key trigger).
+  fireEvent.keyDown(document.body, { key: "/", code: "Slash", ctrlKey: true });
+  const dialog = await openDialog();
+  const row = within(dialog).getByText("Show the keyboard shortcuts overlay").closest("li");
+  if (row === null) throw new Error("no cheatsheet row");
+  expect(within(row).queryByText("?")).toBeNull();
+  expect(within(row).getByText("/")).toBeTruthy();
+  act(() => closeCheatsheet());
+
+  act(() => prefsStore.getState().setCharacterKeyTriggers(true));
+  expect(questionTriggerRegistered()).toBe(true);
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  await openDialog();
+});
+
+test("a pref seeded off before mount never registers the ? trigger", () => {
+  localStorage.setItem("evener.prefs.characterKeyTriggers", "0");
+  resetPrefsStoreForTests();
+  render(<CheatsheetOverlay />);
+  expect(questionTriggerRegistered()).toBe(false);
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+test("Escape closes the overlay (and the cheatsheet scope is live only while open)", async () => {
+  render(<CheatsheetOverlay />);
+  expect(keybindingsRegistry.getState().scopeStack).not.toContain(CHEATSHEET_SCOPE);
+  act(() => openCheatsheet());
+  const dialog = await openDialog();
+  expect(keybindingsRegistry.getState().scopeStack).toContain(CHEATSHEET_SCOPE);
+
+  // The OverlayPanel's own Escape handler owns the close (focus is trapped
+  // inside the dialog); it preventDefaults, which the scope-gated
+  // cheatsheet.close binding then honors via ignoreIfDefaultPrevented.
+  const target = document.activeElement ?? dialog;
+  fireEvent.keyDown(target, { key: "Escape", code: "Escape" });
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  expect(keybindingsRegistry.getState().scopeStack).not.toContain(CHEATSHEET_SCOPE);
+});
+
+test("⌘/ toggles the overlay closed while it is open", async () => {
+  render(<CheatsheetOverlay />);
+  act(() => openCheatsheet());
+  const dialog = await openDialog();
+  // Fired from inside the dialog (an aria-modal target): the binding's
+  // allowInModal is what lets the same chord close what it opened.
+  const target = document.activeElement ?? dialog;
+  fireEvent.keyDown(target, { key: "/", code: "Slash", ctrlKey: true });
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+});
+
+test("unmounting (the mobile breakpoint swap) resets the open state - a remount does not reopen", async () => {
+  // AppShell gates this component on !isMobile, so crossing the breakpoint
+  // unmounts it while the singleton store lives on: an overlay open on the
+  // way to mobile must not reappear on the way back (roborev PR #884 round 4).
+  const first = render(<CheatsheetOverlay />);
+  act(() => openCheatsheet());
+  await openDialog();
+
+  first.unmount();
+  expect(cheatsheetStore.getState().open).toBe(false);
+
+  render(<CheatsheetOverlay />);
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+test("rows reflect an applied hub override (registry-sourced, not hardcoded)", async () => {
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () =>
+    overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  );
+  await wireClient(client, true);
+  render(<CheatsheetOverlay />);
+  act(() => openCheatsheet());
+
+  const dialog = await openDialog();
+  const paletteRow = within(dialog).getByText("Open the command palette").closest("li");
+  if (paletteRow === null) throw new Error("no palette row");
+  expect(within(paletteRow).getByText("P")).toBeTruthy();
+  expect(within(paletteRow).queryByText("K")).toBeNull();
+});
+
+// The override-restore half of the character-key reconcile (the stated
+// reason for its keybindingsStore subscription): removing an override on
+// cheatsheet.toggle re-registers EVERY default entry for the action - "?"
+// included - through registerDefaultBindingsForAction, and the reconcile
+// must then strip "?" again when the pref is off. A regression here is
+// silent, so the invariant is pinned at the registry level in both pref
+// states.
+test("override removal with the pref OFF restores the defaults and strips the ? trigger again", async () => {
+  render(<CheatsheetOverlay />);
+  act(() => prefsStore.getState().setCharacterKeyTriggers(false));
+  expect(questionTriggerRegistered()).toBe(false);
+
+  let payload = overridesPayload(3, [{ action: ACTIONS.cheatsheetToggle, chord: "Control+P" }]);
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => payload);
+  await wireClient(client, true);
+
+  // Overridden: the override owns the action's whole chord set ("?" does not
+  // come back while the override is applied).
+  expect(
+    keybindingsRegistry
+      .getState()
+      .bindings.filter((b) => b.actionId === ACTIONS.cheatsheetToggle)
+      .map((b) => b.id),
+  ).toEqual([`${ACTIONS.cheatsheetToggle}#override`]);
+
+  // Removing the override restores the default map - which re-registers "?"
+  // with no knowledge of the pref - and the reconcile strips it again
+  // without throwing (a rollback would surface as hubError).
+  payload = overridesPayload(4, []);
+  await keybindingsStore.getState().refreshOverrides();
+  expect(keybindingsStore.getState().hubError).toBeNull();
+  expect(questionTriggerRegistered()).toBe(false);
+  expect(
+    keybindingsRegistry
+      .getState()
+      .bindings.filter((b) => b.actionId === ACTIONS.cheatsheetToggle)
+      .map((b) => b.id)
+      .sort(),
+  ).toEqual([ACTIONS.cheatsheetToggle, `${ACTIONS.cheatsheetToggle}#mod-twin`]);
+});
+
+test("override removal with the pref ON restores the defaults with exactly one ? binding (no duplicate-id throw)", async () => {
+  render(<CheatsheetOverlay />);
+  expect(questionTriggerRegistered()).toBe(true);
+
+  let payload = overridesPayload(3, [{ action: ACTIONS.cheatsheetToggle, chord: "Control+P" }]);
+  const client = new FakeClient("ready");
+  client.on("evener/settings/keybindings/get", () => payload);
+  await wireClient(client, true);
+  expect(questionTriggerRegistered()).toBe(false);
+
+  // The restore re-registers "?" itself; the reconcile must be a no-op here -
+  // re-registering the same id would throw into the store's rollback path.
+  payload = overridesPayload(4, []);
+  await keybindingsStore.getState().refreshOverrides();
+  expect(keybindingsStore.getState().hubError).toBeNull();
+  expect(keybindingsRegistry.getState().bindings.filter((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID)).toHaveLength(
+    1,
+  );
+  expect(
+    keybindingsRegistry
+      .getState()
+      .bindings.filter((b) => b.actionId === ACTIONS.cheatsheetToggle)
+      .map((b) => b.id)
+      .sort(),
+  ).toEqual([ACTIONS.cheatsheetToggle, `${ACTIONS.cheatsheetToggle}#mod-twin`, CHARACTER_KEY_TRIGGER_BINDING_ID]);
+});
+
+test("mobile: nothing mounts, registers, or intercepts on a touch viewport", async () => {
+  installMobileViewport();
+  resetMobileViewportForTests();
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+
+  // No overlay mounted, no action registered - the trigger chords are inert.
+  expect(keybindingsRegistry.getState().actions.get(ACTIONS.cheatsheetToggle)).toBeUndefined();
+  fireEvent.keyDown(document.body, { key: "/", code: "Slash", ctrlKey: true });
+  fireEvent.keyDown(document.body, { key: "?", code: "Slash", shiftKey: true });
+  // (StackHost's own "Sessions" drawer is a role=dialog too - the assertion
+  // is specifically that the CHEATSHEET never appears.)
+  expect(screen.queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull();
+  expect(cheatsheetStore.getState().open).toBe(false);
+});

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.tsx
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.tsx
@@ -1,0 +1,162 @@
+// The cheatsheet overlay (Phase 4a, the p4 plan's Design decision 3): a
+// modal listing every keybinding action with its EFFECTIVE chord, grouped
+// into Sessions / Transcript / Composer / General. The action list and the
+// chords are sourced live - ACTION_DISPLAY_ROWS derives from the default
+// map, and each row's chord comes from the registry at render via
+// keybindings/display.ts, the same source the Settings keybindings section
+// reads - so hub-synced overrides and unbound actions render truthfully and
+// no hand-maintained copy can go stale (the survey's stale-HELP_ROWS
+// lesson).
+//
+// Triggers live in the default map (keybindings/defaults.ts): ⌘/ (the $mod
+// chord, allowInEditable + allowInModal so it also toggles the overlay
+// closed while open) and the pref-conditional "?" (cheatsheetController.ts's
+// reconcile). Escape closes through the OverlayPanel's own handler, with the
+// scope-gated cheatsheet.close binding as the window-level backstop - the
+// Settings pane's SETTINGS_SCOPE precedent.
+//
+// Desktop-only: AppShell mounts this component only off mobile, so no action
+// is ever registered on a touch viewport and the trigger chords stay inert
+// there (RailHost's rail.toggle no-registration pattern).
+
+import { Fragment, useEffect } from "react";
+import { useStore } from "zustand";
+import { ACTIONS } from "../../keybindings/actions";
+import { chordDisplayKeys, serializeChord } from "../../keybindings/chord";
+import { CHEATSHEET_SCOPE } from "../../keybindings/defaults";
+import { ACTION_DISPLAY_ROWS, displayBindingsFor } from "../../keybindings/display";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { Dialog, KeyHint } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
+import { installKeybindings } from "../installKeybindings";
+import styles from "./cheatsheet.module.css";
+import { closeCheatsheet, toggleCheatsheet, useCheatsheetStore } from "./cheatsheetController";
+
+const CLASS = {
+  groups: requireClass(styles.groups, "cheatsheet.module.css", "groups"),
+  groupTitle: requireClass(styles.groupTitle, "cheatsheet.module.css", "groupTitle"),
+  list: requireClass(styles.list, "cheatsheet.module.css", "list"),
+  row: requireClass(styles.row, "cheatsheet.module.css", "row"),
+  label: requireClass(styles.label, "cheatsheet.module.css", "label"),
+  chord: requireClass(styles.chord, "cheatsheet.module.css", "chord"),
+  or: requireClass(styles.or, "cheatsheet.module.css", "or"),
+  unbound: requireClass(styles.unbound, "cheatsheet.module.css", "unbound"),
+  footerHint: requireClass(styles.footerHint, "cheatsheet.module.css", "footerHint"),
+};
+
+type GroupId = "sessions" | "transcript" | "composer" | "general";
+
+const GROUPS: readonly { id: GroupId; title: string }[] = [
+  { id: "sessions", title: "Sessions" },
+  { id: "transcript", title: "Transcript" },
+  { id: "composer", title: "Composer" },
+  { id: "general", title: "General" },
+];
+
+// Presentation-only grouping (Design decision 3). Anything not named here -
+// including any action a future phase adds to the default map - lands in
+// General, so a new action can never silently vanish from the overlay.
+const GROUP_BY_ACTION: Readonly<Record<string, GroupId>> = {
+  [ACTIONS.sessionNext]: "sessions",
+  [ACTIONS.sessionPrevious]: "sessions",
+  [ACTIONS.nextNeedsYou]: "sessions",
+  [ACTIONS.transcriptLineUp]: "transcript",
+  [ACTIONS.transcriptLineDown]: "transcript",
+  [ACTIONS.transcriptPageUp]: "transcript",
+  [ACTIONS.transcriptPageDown]: "transcript",
+  [ACTIONS.transcriptScrollTop]: "transcript",
+  [ACTIONS.transcriptScrollBottom]: "transcript",
+  [ACTIONS.composerFocus]: "composer",
+  [ACTIONS.selectionQuote]: "composer",
+};
+
+function groupOf(actionId: string): GroupId {
+  return GROUP_BY_ACTION[actionId] ?? "general";
+}
+
+export function CheatsheetOverlay() {
+  const open = useCheatsheetStore((s) => s.open);
+  const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
+
+  // Registers the toggle action (the chord→handler half; the chords
+  // themselves are the default map's, registered by installKeybindings).
+  // Desktop-only by virtue of the mount site, per this file's header.
+  useEffect(() => {
+    installKeybindings();
+    const unregister = keybindingsRegistry
+      .getState()
+      .registerAction(ACTIONS.cheatsheetToggle, () => toggleCheatsheet());
+    return () => {
+      unregister();
+      // Unmount is the mobile/desktop breakpoint swap (AppShell gates this
+      // component on !isMobile), and the store is a singleton: an overlay
+      // left open on the way to mobile would otherwise REAPPEAR already open
+      // on the way back to desktop (roborev PR #884 round 4).
+      closeCheatsheet();
+    };
+  }, []);
+
+  // While open, push the cheatsheet scope and register the close action -
+  // the scope-gated Escape backstop (the OverlayPanel's own Escape handler
+  // claims the key first whenever focus is inside the dialog; this covers a
+  // keydown whose target sits outside it, and keeps the chord remappable).
+  useEffect(() => {
+    if (!open) return undefined;
+    const registry = keybindingsRegistry.getState();
+    const popScope = registry.pushScope(CHEATSHEET_SCOPE);
+    const unregister = registry.registerAction(ACTIONS.cheatsheetClose, () => closeCheatsheet());
+    return () => {
+      unregister();
+      popScope();
+    };
+  }, [open]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={closeCheatsheet}
+      title="Keyboard shortcuts"
+      footer={
+        // The hold-hints feature itself is Phase 4a's next task; this line
+        // is its discoverability hook (Design decision 4). "Mod" renders ⌘
+        // on Apple platforms and Ctrl elsewhere (widgets/keyhint).
+        <span className={CLASS.footerHint}>
+          Hold <KeyHint keys={["Mod"]} /> to see hints
+        </span>
+      }
+    >
+      <div className={CLASS.groups}>
+        {GROUPS.map((group) => (
+          <section key={group.id}>
+            <h3 className={CLASS.groupTitle}>{group.title}</h3>
+            <ul className={CLASS.list}>
+              {ACTION_DISPLAY_ROWS.filter((row) => groupOf(row.actionId) === group.id).map((row) => {
+                const displayed = displayBindingsFor(bindings, row.actionId);
+                return (
+                  <li className={CLASS.row} key={row.actionId}>
+                    <span className={CLASS.label}>{row.title}</span>
+                    {displayed.length === 0 ? (
+                      <span className={CLASS.unbound}>Unbound</span>
+                    ) : (
+                      <span className={CLASS.chord}>
+                        {displayed.map((binding, i) => (
+                          <Fragment key={binding.id}>
+                            {i > 0 && <span className={CLASS.or}>or</span>}
+                            {binding.chord.map((press, i) => (
+                              // biome-ignore lint/suspicious/noArrayIndexKey: repeated presses in a multi-press sequence ("g g") are content-identical, position is identity, and the list is static per binding
+                              <KeyHint key={`${i}:${serializeChord([press])}`} keys={chordDisplayKeys(press)} />
+                            ))}
+                          </Fragment>
+                        ))}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </Dialog>
+  );
+}

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheet.module.css
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheet.module.css
@@ -1,0 +1,63 @@
+.groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 22rem;
+}
+
+.groupTitle {
+  margin: 0 0 var(--space-2);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-display);
+  text-transform: uppercase;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.label {
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+  line-height: var(--line-height-body);
+}
+
+.chord {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.or {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  padding: 0 var(--space-1);
+}
+
+.unbound {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+.footerHint {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { ACTIONS } from "../../keybindings/actions";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, registerDefaultBindings } from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { FakeClient } from "../../protocol/testing/fakeClient";
+import type { KeybindingsOverrides, KeybindingsRule } from "../../protocol/types.gen";
+import { connectionStore } from "../../stores/connection";
+import { keybindingsStore, resetKeybindingsStoreForTests } from "../../stores/keybindings";
+import { prefsStore, resetPrefsStoreForTests } from "../../stores/prefs";
+import { installCharacterKeyTriggerReconcile, reconcileCharacterKeyTrigger } from "./cheatsheetController";
+
+// Node 26 shadows jsdom's real window.localStorage with its own
+// (non-functional under vitest) global - the same in-memory stand-in
+// stores/keybindings.test.ts carries, needed here because the prefs store
+// (the characterKeyTriggers pref this controller reconciles against) reads
+// and writes localStorage.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeAll(() => {
+  // @ts-expect-error see MemoryStorage's own comment for why this is needed
+  globalThis.localStorage = new MemoryStorage();
+});
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+function overridesPayload(revision: number, rules: KeybindingsRule[]): KeybindingsOverrides {
+  return { version: 1, revision, rules };
+}
+
+async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  });
+  await keybindingsStore.getState().refreshOverrides();
+}
+
+function questionTriggerRegistered(): boolean {
+  return keybindingsRegistry.getState().bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+}
+
+function characterKeyWarnings() {
+  return keybindingsStore.getState().warnings.filter((w) => w.reason === "character-key-conflict");
+}
+
+// A leaked reconcile subscription would keep firing into later tests (the
+// store resets above do not remove subscriptions), so every install is
+// tracked and disposed here.
+const disposers: Array<() => void> = [];
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
+});
+
+afterEach(() => {
+  while (disposers.length > 0) disposers.pop()?.();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
+});
+
+describe("cheatsheet controller: character-key trigger reconcile", () => {
+  test("pref off then on registers and unregisters the ? trigger with no warning (regression)", () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+    expect(questionTriggerRegistered()).toBe(true);
+
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(questionTriggerRegistered()).toBe(false);
+    expect(characterKeyWarnings()).toEqual([]);
+
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(characterKeyWarnings()).toEqual([]);
+  });
+
+  // The pref-flip flow is owned by the STORE's re-apply (finding 20): the
+  // simulation treats "?" as pref-authoritative, so a flip ON un-applies an
+  // overlapping override through the validation layer's restore-wins rule -
+  // the reconcile's own overlap skip (the next test) is the guard for
+  // overlaps validation does not manage (a foreign binding squatting the
+  // chord).
+  test("pref flip ON un-applies a conflicting Shift+? override (restore wins), registers ?, and clearing the rule clears the warning", async () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+
+    // Pref off: "?" unregisters, so a Shift+? claim by another action
+    // conflicts with NOTHING and must apply clean.
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(questionTriggerRegistered()).toBe(false);
+
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.composerFocus, chord: "Shift+?" }]),
+    );
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+    expect(keybindingsRegistry.getState().bindings.some((b) => b.id === `${ACTIONS.composerFocus}#override`)).toBe(
+      true,
+    );
+
+    // Pref back on: the store's re-apply simulates "?" as present (the
+    // pref is authoritative over the flip-instant registry), so the
+    // composer claim conflicts, the restore wins, and the override is
+    // UN-APPLIED with a validation conflict warning - then the reconcile
+    // registers "?" against a clean map.
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(keybindingsRegistry.getState().bindings.some((b) => b.id === `${ACTIONS.composerFocus}#override`)).toBe(
+      false,
+    );
+    expect(questionTriggerRegistered()).toBe(true);
+    const warnings = keybindingsStore.getState().warnings;
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.reason).toBe("conflict");
+    expect(warnings[0]?.rule).toEqual({ action: ACTIONS.composerFocus, chord: "Shift+?" });
+    expect(warnings[0]?.conflictWith).toBe(ACTIONS.cheatsheetToggle);
+
+    // The hub dropping the rule re-validates clean: the warning clears and
+    // nothing else moves.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, []),
+    });
+    expect(keybindingsStore.getState().revision).toBe(2);
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+  });
+
+  // The reconcile's own overlap guard (finding 17): an overlap validation
+  // does not manage - a FOREIGN binding squatting the "?" chord - skips the
+  // registration with a character-key-conflict warning, and clearing the
+  // squatter lets the next reconcile register "?" and clear the warning.
+  test("a foreign binding overlapping ? skips the registration with a character-key-conflict warning until it clears", () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(questionTriggerRegistered()).toBe(false);
+    // A bare "?" squatter: chordsOverlap treats the entry's Shift as
+    // OPTIONAL, so the bare form overlaps - but its serialization differs
+    // from "[Shift]+?", so the registry's exact-match registration allows it.
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "?",
+    });
+
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(questionTriggerRegistered()).toBe(false);
+    const warnings = characterKeyWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.rule).toEqual({ action: ACTIONS.cheatsheetToggle, chord: "[Shift]+?" });
+    expect(warnings[0]?.conflictWith).toBe("foreign.action");
+    expect(warnings[0]?.message).toBe(
+      'the "?" cheatsheet trigger was not registered: chord "[Shift]+?" in scope "global" is already bound by "foreign.action"',
+    );
+
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    reconcileCharacterKeyTrigger();
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(characterKeyWarnings()).toEqual([]);
+  });
+
+  // Finding 29: present no longer implies checked. A foreign binding that
+  // lands AFTER "?" registered (a direct registration bypasses the overrides
+  // store's validation, and registerBinding's exact-match gate allows bare
+  // "?" against "[Shift]+?") must not co-fire with the built-in: the next
+  // reconcile unregisters "?" and warns, the foreign binding wins - and its
+  // removal re-registers "?" and clears the warning (total both ways).
+  test("a foreign binding landing AFTER ? was registered unregisters it with the warning until it clears", () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+    expect(questionTriggerRegistered()).toBe(true);
+
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "?",
+    });
+    reconcileCharacterKeyTrigger();
+    expect(questionTriggerRegistered()).toBe(false);
+    const warnings = characterKeyWarnings();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.rule).toEqual({ action: ACTIONS.cheatsheetToggle, chord: "[Shift]+?" });
+    expect(warnings[0]?.conflictWith).toBe("foreign.action");
+
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    reconcileCharacterKeyTrigger();
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(characterKeyWarnings()).toEqual([]);
+  });
+
+  test("present without overlap stays quiet across repeated reconciles (regression)", () => {
+    disposers.push(installCharacterKeyTriggerReconcile());
+    expect(questionTriggerRegistered()).toBe(true);
+
+    // The present-path re-check must not churn: no warning, and the entry
+    // stays registered no matter how often the reconcile runs.
+    reconcileCharacterKeyTrigger();
+    reconcileCharacterKeyTrigger();
+    reconcileCharacterKeyTrigger();
+    expect(questionTriggerRegistered()).toBe(true);
+    expect(characterKeyWarnings()).toEqual([]);
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
@@ -26,8 +26,10 @@
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 import { ACTIONS } from "../../keybindings/actions";
+import { chordsOverlap, parseChord } from "../../keybindings/chord";
 import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS } from "../../keybindings/defaults";
-import { keybindingsRegistry } from "../../keybindings/registry";
+import { GLOBAL_SCOPE, keybindingsRegistry } from "../../keybindings/registry";
+import { actionDisplayLabel, type ValidationWarning } from "../../keybindings/validation";
 import { keybindingsStore } from "../../stores/keybindings";
 import { prefsStore } from "../../stores/prefs";
 
@@ -57,26 +59,94 @@ export function useCheatsheetStore<T>(selector: (state: CheatsheetState) => T): 
   return useStore(cheatsheetStore, selector);
 }
 
+/** The store's warnings channel doubles as the surface for the conditional
+ * entry's overlap skip (the same list skipped override rules render in).
+ * The controller's warning is identified by its reason so the reconcile can
+ * replace or clear exactly its own entry. setState fires only on a CHANGE:
+ * the reconcile is subscribed to the keybindings store, and a redundant
+ * write would re-enter it. */
+function setCharacterKeyWarning(conflictWith: string | null): void {
+  const state = keybindingsStore.getState();
+  const rest = state.warnings.filter((warning) => warning.reason !== "character-key-conflict");
+  if (conflictWith === null) {
+    if (rest.length !== state.warnings.length) keybindingsStore.setState({ warnings: rest });
+    return;
+  }
+  const message = `the "?" cheatsheet trigger was not registered: chord "[Shift]+?" in scope "global" is already bound by ${actionDisplayLabel(conflictWith)}`;
+  if (state.warnings.some((warning) => warning.reason === "character-key-conflict" && warning.message === message))
+    return;
+  const warning: ValidationWarning = {
+    rule: { action: ACTIONS.cheatsheetToggle, chord: "[Shift]+?" },
+    reason: "character-key-conflict",
+    conflictWith,
+    message,
+  };
+  keybindingsStore.setState({ warnings: [...rest, warning] });
+}
+
 /** Enforces "the ? binding is registered exactly while characterKeyTriggers
- * is on AND cheatsheet.toggle is on its default map". An applied override
- * (or unbind) owns the action's whole chord set, so "?" never comes back
- * there - the override is the user's own replacement for both triggers.
- * Idempotent and total: safe to run after any pref or override change. */
+ * is on AND cheatsheet.toggle is on its default map AND no foreign binding
+ * overlaps the chord". An applied override (or unbind) owns the action's
+ * whole chord set, so "?" never comes back there - the override is the
+ * user's own replacement for both triggers. Idempotent and total: safe to
+ * run after any pref or override change. */
 export function reconcileCharacterKeyTrigger(): void {
   const registry = keybindingsRegistry.getState();
   const present = registry.bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
   if (!prefsStore.getState().characterKeyTriggers) {
     if (present) registry.unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+    setCharacterKeyWarning(null);
     return;
   }
-  if (present) return;
   const input = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
   if (input === undefined) return;
+  // The entry registers with NO validation layer: a chord claimed while the
+  // pref was off (the entry was not registered, so nothing conflicted at
+  // bind time) must not end up shadowing or shadowed by the built-in. The
+  // entry's Shift is OPTIONAL, and chordsOverlap's modifier check treats
+  // optionals as allowed on both sides, so this one predicate covers both
+  // the bare "?" and the Shift+"?" forms. Only bindings of OTHER actions
+  // count - cheatsheet.toggle's own base chord never overlaps "?".
+  const sequence = typeof input.chord === "string" ? parseChord(input.chord) : input.chord;
+  const scope = input.scope ?? GLOBAL_SCOPE;
+  const overlapping = registry.bindings.find(
+    (binding) =>
+      binding.actionId !== ACTIONS.cheatsheetToggle &&
+      binding.scope === scope &&
+      chordsOverlap(binding.chord, sequence),
+  );
+  if (present) {
+    // Present does NOT imply checked: a foreign binding registered AFTER
+    // "?" (registerBinding's exact-match gate allows bare "?" against
+    // "[Shift]+?", and a direct registration bypasses the overrides store's
+    // validation) would co-fire with the built-in forever. The foreign
+    // binding wins - same precedence as the not-present path - so the entry
+    // unregisters and the warning surfaces; the foreign binding's removal
+    // re-registers "?" on a later pass and clears the warning.
+    if (overlapping !== undefined) {
+      registry.unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+      setCharacterKeyWarning(overlapping.actionId);
+      return;
+    }
+    setCharacterKeyWarning(null);
+    return;
+  }
   const onDefaultMap =
     registry.bindings.some((b) => b.id === ACTIONS.cheatsheetToggle) &&
     !registry.bindings.some((b) => b.actionId === ACTIONS.cheatsheetToggle && b.id.endsWith("#override"));
-  if (!onDefaultMap) return;
+  if (!onDefaultMap) {
+    setCharacterKeyWarning(null);
+    return;
+  }
+  if (overlapping !== undefined) {
+    // Do not register; surface the skip. The reconcile is total and
+    // subscribed to the overrides store, so removing the overlapping
+    // override registers "?" on the next pass and clears the warning.
+    setCharacterKeyWarning(overlapping.actionId);
+    return;
+  }
   registry.registerBinding(input);
+  setCharacterKeyWarning(null);
 }
 
 /** Installs the reconcile: runs it once against the current state, then on

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheetController.ts
@@ -1,0 +1,92 @@
+// The cheatsheet overlay's open state and its one piece of registry
+// bookkeeping. The store mirrors shell/palette/paletteController.ts: a
+// vanilla store the mounted <CheatsheetOverlay/> subscribes to, toggled by
+// the cheatsheet.toggle action's handler.
+//
+// The character-key trigger ("?", the default map's one CONDITIONAL entry -
+// keybindings/defaults.ts's CHARACTER_KEY_TRIGGER_BINDING_ID) is live only
+// while the characterKeyTriggers pref (stores/prefs.ts, the WCAG 2.1.4
+// turn-off, default ON) is on. reconcileCharacterKeyTrigger enforces that as
+// an invariant and is subscribed to BOTH sources that can break it:
+//
+//   - the prefs store (the user flips the toggle), and
+//   - the keybindings overrides store (an override restore re-registers
+//     EVERY default entry for the action - "?" included - through
+//     registerDefaultBindingsForAction, with no knowledge of the pref).
+//
+// The registry itself is deliberately NOT subscribed: override application
+// mutates the registry binding-by-binding, and a synchronous registry
+// subscription would observe the half-restored state (base entry present,
+// "?" not yet re-registered) and register "?" itself - making the restore's
+// own re-registration of the same id throw a duplicate-id error into the
+// store's rollback path. Both stores above set their state only after the
+// registry mutation is complete, so the reconcile always sees the final
+// shape.
+
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+import { ACTIONS } from "../../keybindings/actions";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, DEFAULT_BINDINGS } from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { keybindingsStore } from "../../stores/keybindings";
+import { prefsStore } from "../../stores/prefs";
+
+export interface CheatsheetState {
+  open: boolean;
+}
+
+export const cheatsheetStore = createStore<CheatsheetState>(() => ({ open: false }));
+
+export function openCheatsheet(): void {
+  cheatsheetStore.setState({ open: true });
+}
+
+export function closeCheatsheet(): void {
+  cheatsheetStore.setState({ open: false });
+}
+
+/** The cheatsheet.toggle action's handler: ⌘/ opens the overlay and - the
+ * binding carries allowInModal so the same chord keeps firing while the
+ * dialog is open - toggles it closed again (the p4 plan's "Escape/⌘/
+ * toggles closed"). */
+export function toggleCheatsheet(): void {
+  cheatsheetStore.setState((s) => ({ open: !s.open }));
+}
+
+export function useCheatsheetStore<T>(selector: (state: CheatsheetState) => T): T {
+  return useStore(cheatsheetStore, selector);
+}
+
+/** Enforces "the ? binding is registered exactly while characterKeyTriggers
+ * is on AND cheatsheet.toggle is on its default map". An applied override
+ * (or unbind) owns the action's whole chord set, so "?" never comes back
+ * there - the override is the user's own replacement for both triggers.
+ * Idempotent and total: safe to run after any pref or override change. */
+export function reconcileCharacterKeyTrigger(): void {
+  const registry = keybindingsRegistry.getState();
+  const present = registry.bindings.some((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+  if (!prefsStore.getState().characterKeyTriggers) {
+    if (present) registry.unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+    return;
+  }
+  if (present) return;
+  const input = DEFAULT_BINDINGS.find((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID);
+  if (input === undefined) return;
+  const onDefaultMap =
+    registry.bindings.some((b) => b.id === ACTIONS.cheatsheetToggle) &&
+    !registry.bindings.some((b) => b.actionId === ACTIONS.cheatsheetToggle && b.id.endsWith("#override"));
+  if (!onDefaultMap) return;
+  registry.registerBinding(input);
+}
+
+/** Installs the reconcile: runs it once against the current state, then on
+ * every pref or applied-override change. Returns the disposer. */
+export function installCharacterKeyTriggerReconcile(): () => void {
+  reconcileCharacterKeyTrigger();
+  const unsubPrefs = prefsStore.subscribe(reconcileCharacterKeyTrigger);
+  const unsubOverrides = keybindingsStore.subscribe(reconcileCharacterKeyTrigger);
+  return () => {
+    unsubPrefs();
+    unsubOverrides();
+  };
+}

--- a/cmd/evener-hub/frontend/src/shell/holdhints/HoldHints.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/HoldHints.test.tsx
@@ -1,0 +1,439 @@
+// Tests for the hold-modifier hints (Phase 4a, the p4 plan's Design
+// decision 4): the ~400ms modifier-alone hold shows the chips, every cleanup
+// path hides them (modifier keyup, window blur, visibilitychange, any
+// non-modifier keydown, and the hard-timeout backstop), the listeners are
+// observers only (no preventDefault, no propagation interference), the
+// reduced-motion instant path, registry-sourced effective chords (an applied
+// override shows its own chord), and mobile inertness (AppShell mounts the
+// component only off mobile - the CheatsheetOverlay pattern, so no listener
+// is ever installed on touch).
+//
+// jsdom's navigator.platform is "" (keybindings/chord.test.ts documents it),
+// so currentKeybindingsPlatform() resolves "other" and the tracked modifier
+// is Control.
+//
+// The AppShell render/warm-up/store-reset scaffolding for the mobile test
+// mirrors CheatsheetOverlay.test.tsx's own (helpers duplicated, not shared -
+// this project has no cross-test-file test-utils module; see that file's
+// header note on the convention).
+
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { ACTIONS } from "../../keybindings/actions";
+import { registerDefaultBindings } from "../../keybindings/defaults";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { resetNotificationsForTests } from "../../notifications";
+import { FakeClient } from "../../protocol/testing/fakeClient";
+import { connectionStore } from "../../stores/connection";
+import { resetKeybindingsStoreForTests } from "../../stores/keybindings";
+import { resetNavigationStoreForTests } from "../../stores/navigation/store";
+import { resetPrefsStoreForTests } from "../../stores/prefs";
+import { AppShell } from "../AppShell";
+import { paletteStore } from "../palette/paletteController";
+import { resetMobileViewportForTests } from "../useIsMobile";
+import { resetWorkspaceStoreForTests, workspaceStore } from "../workspace";
+import { HoldHints } from "./HoldHints";
+import { HARD_TIMEOUT_MS, HOLD_THRESHOLD_MS, holdHintsStore, resetHoldHintsForTests } from "./holdHintsController";
+
+// See AppShell.test.tsx for why both stubs are needed (jsdom has no
+// ResizeObserver; Node 26 shadows jsdom's localStorage accessor).
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+// CheatsheetOverlay.test.tsx's installMobileViewport, verbatim: the mobile
+// query matches, every other query (the reduced-motion read included) does
+// not.
+function installMobileViewport(): void {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      media,
+      matches: media === "(max-width: 899px)",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })),
+  );
+}
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+/** The live affordances the chips anchor to (their data attributes are the
+ * contract - shell/holdhints/HoldHints.tsx's ANCHORS). */
+function addAnchors(): void {
+  for (const attr of ["data-search-trigger", "data-rail-toggle", "data-session-tab", "data-composer"]) {
+    const element = document.createElement("div");
+    element.setAttribute(attr, "");
+    document.body.appendChild(element);
+  }
+}
+
+function removeAnchors(): void {
+  for (const attr of ["data-search-trigger", "data-rail-toggle", "data-session-tab", "data-composer"]) {
+    document.querySelector(`[${attr}]`)?.remove();
+  }
+}
+
+function hintRoot(): HTMLElement | null {
+  return document.querySelector("[data-hold-hints]");
+}
+
+function holdModifier(): void {
+  fireEvent.keyDown(document.body, { key: "Control", code: "ControlLeft", ctrlKey: true });
+}
+
+function showHints(): void {
+  holdModifier();
+  act(() => vi.advanceTimersByTime(HOLD_THRESHOLD_MS));
+}
+
+beforeAll(async () => {
+  globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver;
+  // @ts-expect-error MemoryStorage deliberately implements only the Storage
+  // methods the stores actually call - see AppShell.test.tsx's own stub.
+  globalThis.localStorage = new MemoryStorage();
+  // Await the lazy pane/dock modules once up front, then pay react-dom's
+  // per-boundary fallback throttle in one warm render - see
+  // keybindingsMigration.test.tsx's beforeAll for the full reasoning.
+  await import("../../panes/welcome/Welcome");
+  await import("../DockHost");
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+});
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetWorkspaceStoreForTests();
+  resetNavigationStoreForTests();
+  resetKeybindingsStoreForTests();
+  // @ts-expect-error see the beforeAll stub.
+  globalThis.localStorage = new MemoryStorage();
+  localStorage.clear();
+  resetPrefsStoreForTests();
+  resetRegistryToDefaults();
+  resetHoldHintsForTests();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  removeAnchors();
+  window.history.pushState({}, "", "/");
+  paletteStore.setState({ open: false, query: "" });
+  resetHoldHintsForTests();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetNavigationStoreForTests();
+  resetKeybindingsStoreForTests();
+  resetNotificationsForTests();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+test("hints appear after the hold threshold with the modifier held - not before", () => {
+  addAnchors();
+  render(<HoldHints />);
+  expect(hintRoot()).toBeNull();
+
+  holdModifier();
+  act(() => vi.advanceTimersByTime(HOLD_THRESHOLD_MS - 1));
+  expect(hintRoot()).toBeNull();
+
+  act(() => vi.advanceTimersByTime(1));
+  const root = hintRoot();
+  if (root === null) throw new Error("hints did not appear at the threshold");
+  // One chip per mounted anchor; jsdom resolves $mod to Control.
+  const palette = within(root).getByText("K").closest("[data-hint]");
+  expect(palette?.getAttribute("data-hint")).toBe("palette");
+  expect(within(root).getByText("B").closest("[data-hint]")?.getAttribute("data-hint")).toBe("rail-toggle");
+  expect(within(root).getByText("I").closest("[data-hint]")?.getAttribute("data-hint")).toBe("composer");
+  const tabs = root.querySelector('[data-hint="session-tabs"]');
+  if (tabs === null) throw new Error("no session-tabs chip");
+  // The tab chip carries BOTH cycling chords.
+  expect(within(tabs as HTMLElement).getByText("ArrowLeft")).toBeTruthy();
+  expect(within(tabs as HTMLElement).getByText("ArrowRight")).toBeTruthy();
+});
+
+test("modifier keyup hides the hints (and a release before the threshold never shows them)", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  // Released early: no chips.
+  holdModifier();
+  act(() => vi.advanceTimersByTime(HOLD_THRESHOLD_MS - 100));
+  fireEvent.keyUp(document.body, { key: "Control", code: "ControlLeft" });
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+
+  // Shown, then released: gone.
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  fireEvent.keyUp(document.body, { key: "Control", code: "ControlLeft" });
+  expect(hintRoot()).toBeNull();
+  expect(holdHintsStore.getState().visible).toBe(false);
+});
+
+test("window blur hides the hints and cancels a pending hold", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  fireEvent(window, new Event("blur"));
+  expect(hintRoot()).toBeNull();
+
+  holdModifier();
+  fireEvent(window, new Event("blur"));
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("visibilitychange hides the hints and cancels a pending hold", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  fireEvent(document, new Event("visibilitychange"));
+  expect(hintRoot()).toBeNull();
+
+  holdModifier();
+  fireEvent(document, new Event("visibilitychange"));
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("any non-modifier keydown hides the hints and cancels a pending hold", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  // A chord starting while visible hides them (on macOS this keydown may be
+  // the ONLY event the chord ever delivers - the keyup is not delivered).
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  fireEvent.keyDown(document.body, { key: "k", code: "KeyK", ctrlKey: true });
+  expect(hintRoot()).toBeNull();
+
+  // A key pressed during the pending window cancels the hold outright.
+  holdModifier();
+  act(() => vi.advanceTimersByTime(100));
+  fireEvent.keyDown(document.body, { key: "x", code: "KeyX", ctrlKey: true });
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("the hard timeout hides the hints even when every event-based cleanup missed", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  showHints();
+  expect(hintRoot()).not.toBeNull();
+  // No keyup, no blur, nothing - the backstop alone must end it.
+  act(() => vi.advanceTimersByTime(HARD_TIMEOUT_MS - 1));
+  expect(hintRoot()).not.toBeNull();
+  act(() => vi.advanceTimersByTime(1));
+  expect(hintRoot()).toBeNull();
+  // And the lapsed hold does not re-arm itself from modifier auto-repeat.
+  fireEvent.keyDown(document.body, { key: "Control", code: "ControlLeft", ctrlKey: true, repeat: true });
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("the hold counts only with the modifier held ALONE", () => {
+  addAnchors();
+  render(<HoldHints />);
+
+  fireEvent.keyDown(document.body, { key: "Control", code: "ControlLeft", ctrlKey: true, shiftKey: true });
+  act(() => vi.advanceTimersByTime(2 * HOLD_THRESHOLD_MS));
+  expect(hintRoot()).toBeNull();
+});
+
+test("the listeners are observers only: no preventDefault, no propagation interference", () => {
+  addAnchors();
+  const seen: KeyboardEvent[] = [];
+  // Attached BEFORE <HoldHints/> mounts, on a different target (document
+  // sits earlier in the bubble path than window): any stopPropagation or
+  // stopImmediatePropagation from the hold listeners would show here.
+  const recorder = (event: KeyboardEvent) => seen.push(event);
+  document.addEventListener("keydown", recorder);
+  render(<HoldHints />);
+
+  fireEvent.keyDown(document.body, { key: "Control", code: "ControlLeft", ctrlKey: true });
+  act(() => vi.advanceTimersByTime(HOLD_THRESHOLD_MS));
+  expect(hintRoot()).not.toBeNull();
+
+  for (const event of seen) {
+    expect(event.defaultPrevented).toBe(false);
+  }
+  expect(seen.some((event) => event.key === "Control")).toBe(true);
+
+  // And the dispatcher still owns its chords while the hints are visible:
+  // ⌘K reaches it untouched (the hints' own keydown observer hides them).
+  const openPalette = vi.fn();
+  const unregister = keybindingsRegistry.getState().registerAction(ACTIONS.paletteOpen, () => {
+    openPalette();
+  });
+  fireEvent.keyDown(document.body, { key: "k", code: "KeyK", ctrlKey: true });
+  expect(openPalette).toHaveBeenCalledTimes(1);
+  unregister();
+  document.removeEventListener("keydown", recorder);
+});
+
+test("chips show the EFFECTIVE chord: an applied override replaces the default", () => {
+  addAnchors();
+  const registry = keybindingsRegistry.getState();
+  registry.unregisterBinding(ACTIONS.paletteOpen);
+  registry.unregisterBinding(`${ACTIONS.paletteOpen}#mod-twin`);
+  registry.registerBinding({
+    id: `${ACTIONS.paletteOpen}#override`,
+    actionId: ACTIONS.paletteOpen,
+    chord: "Control+P",
+  });
+  render(<HoldHints />);
+
+  showHints();
+  const root = hintRoot();
+  if (root === null) throw new Error("hints did not appear");
+  const chip = root.querySelector('[data-hint="palette"]');
+  if (chip === null) throw new Error("no palette chip");
+  expect(within(chip as HTMLElement).getByText("P")).toBeTruthy();
+  expect(within(chip as HTMLElement).queryByText("K")).toBeNull();
+});
+
+test("an unbound action renders no chip, and a missing anchor renders none either", () => {
+  addAnchors();
+  const registry = keybindingsRegistry.getState();
+  // Unbound-by-override: palette.open's effective binding set is empty.
+  for (const binding of registry.bindings.filter((b) => b.actionId === ACTIONS.paletteOpen)) {
+    registry.unregisterBinding(binding.id);
+  }
+  registry.registerBinding({ id: `${ACTIONS.paletteOpen}#override`, actionId: ACTIONS.paletteOpen, chord: [] });
+  // The composer's anchor is not mounted at all in this test.
+  document.querySelector("[data-composer]")?.remove();
+  render(<HoldHints />);
+
+  showHints();
+  const root = hintRoot();
+  if (root === null) throw new Error("hints did not appear");
+  expect(root.querySelector('[data-hint="palette"]')).toBeNull();
+  expect(root.querySelector('[data-hint="composer"]')).toBeNull();
+  expect(root.querySelector('[data-hint="rail-toggle"]')).not.toBeNull();
+});
+
+test("the composer chip anchors to the FOCUSED pane's composer when several are mounted", () => {
+  // Split workspace: two composers are mounted. composer.focus targets the
+  // focused session pane's ref (AppShell's registerAction), so the chip must
+  // sit over THAT composer, not the first in DOM order (roborev PR #884).
+  const rectFor = (left: number): DOMRect =>
+    ({
+      left,
+      top: 600,
+      width: 200,
+      height: 40,
+      right: left + 200,
+      bottom: 640,
+      x: left,
+      y: 600,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  const first = document.createElement("div");
+  first.setAttribute("data-composer", "ref_a");
+  first.getBoundingClientRect = () => rectFor(100);
+  const second = document.createElement("div");
+  second.setAttribute("data-composer", "ref_b");
+  second.getBoundingClientRect = () => rectFor(500);
+  document.body.append(first, second);
+  workspaceStore.setState({
+    panes: [
+      { id: "pane_a", type: "session", params: { ref: "ref_a" }, slot: "main" },
+      { id: "pane_b", type: "session", params: { ref: "ref_b" }, slot: "main" },
+    ],
+    focusedPaneId: "pane_b",
+  });
+  try {
+    render(<HoldHints />);
+    showHints();
+
+    const root = hintRoot();
+    if (root === null) throw new Error("hints did not appear");
+    const chip = root.querySelector('[data-hint="composer"]');
+    if (!(chip instanceof HTMLElement)) throw new Error("composer chip missing");
+    // 500 + 200/2 - the SECOND composer's center, not the first's (350px).
+    expect(chip.style.left).toBe("600px");
+  } finally {
+    first.remove();
+    second.remove();
+  }
+});
+
+test("prefers-reduced-motion marks the root for the instant (no-fade) path", () => {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((media: string) => ({
+      media,
+      matches: media === "(prefers-reduced-motion: reduce)",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    })),
+  );
+  addAnchors();
+  render(<HoldHints />);
+  showHints();
+  expect(hintRoot()?.hasAttribute("data-reduced-motion")).toBe(true);
+});
+
+test("without the reduced-motion preference the root is unmarked", () => {
+  // jsdom has no matchMedia at all: the guarded read degrades to false.
+  addAnchors();
+  render(<HoldHints />);
+  showHints();
+  expect(hintRoot()?.hasAttribute("data-reduced-motion")).toBe(false);
+});
+
+test("mobile: no listeners installed, no chips on a touch viewport", async () => {
+  // Real timers: RTL's findByText cannot advance vitest's fake ones, and
+  // with no listeners installed there is no pending hold timer to advance.
+  vi.useRealTimers();
+  installMobileViewport();
+  resetMobileViewportForTests();
+  addAnchors();
+  const addListener = vi.spyOn(window, "addEventListener");
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+
+  // The component never mounted: nothing subscribed to key/keyup/blur.
+  const watchedTypes = new Set(addListener.mock.calls.map(([type]) => type));
+  expect(watchedTypes.has("keyup")).toBe(false);
+  expect(watchedTypes.has("blur")).toBe(false);
+
+  // And the hold does nothing.
+  holdModifier();
+  expect(holdHintsStore.getState().visible).toBe(false);
+  expect(hintRoot()).toBeNull();
+});

--- a/cmd/evener-hub/frontend/src/shell/holdhints/HoldHints.tsx
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/HoldHints.tsx
@@ -1,0 +1,172 @@
+// The hold-modifier hint chips (Phase 4a, the p4 plan's Design decision 4):
+// hold ⌘ (Apple) / Ctrl (elsewhere) alone for ~400ms and a small chip fades
+// in over each bound affordance, showing the EFFECTIVE chord for the action
+// that affordance triggers. Release - or any of the cleanup paths in
+// holdHintsController.ts - hides them.
+//
+// The chords are registry-sourced through keybindings/display.ts's
+// displayBindingFor - the same read the cheatsheet overlay and the Settings
+// section make - so a hub-synced override (or an unbound action, whose chip
+// then does not render) shows truthfully, and no hand-maintained copy can go
+// stale (the survey's stale-HELP_ROWS lesson).
+//
+// Desktop-only by mount site: AppShell renders this component behind its
+// {!isMobile && ...} gate (the CheatsheetOverlay precedent), so a touch
+// viewport installs no listeners and renders no chips. The detection
+// listeners are observers only (holdHintsController.ts's header).
+//
+// The chips anchor to REAL elements by the data attributes those components
+// carry, queried live at show time - never absolutely-positioned guesses:
+// an affordance that is not mounted (the rail's toggle exists in exactly one
+// of its two states) simply renders no chip.
+
+import { Fragment, type ReactNode, useEffect } from "react";
+import { createPortal } from "react-dom";
+import { useStore } from "zustand";
+import { ACTIONS } from "../../keybindings/actions";
+import { chordDisplayKeys, type KeySequence, serializeChord } from "../../keybindings/chord";
+import { displayBindingFor } from "../../keybindings/display";
+import { keybindingsRegistry } from "../../keybindings/registry";
+import { KeyHint } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
+import { workspaceStore } from "../workspace";
+import { installHoldHints, useHoldHintsStore } from "./holdHintsController";
+import styles from "./holdhints.module.css";
+import { usePrefersReducedMotion } from "./usePrefersReducedMotion";
+
+const CLASS = {
+  root: requireClass(styles.root, "holdhints.module.css", "root"),
+  chip: requireClass(styles.chip, "holdhints.module.css", "chip"),
+  below: requireClass(styles.below, "holdhints.module.css", "below"),
+  above: requireClass(styles.above, "holdhints.module.css", "above"),
+  or: requireClass(styles.or, "holdhints.module.css", "or"),
+};
+
+interface AnchorSpec {
+  /** The chip's data-hint value (its stable hook for tests). */
+  id: string;
+  /** Selects the live affordance element the chip anchors to. */
+  selector: string;
+  /** The actions whose effective chords the chip shows (a chip for an
+   * action with NO effective binding - unbound by override - is skipped). */
+  actionIds: readonly string[];
+  /** Chips sit BELOW the top-edge affordances (rail header, tab strip) and
+   * ABOVE the bottom-edge one (the composer). */
+  placement: "above" | "below";
+  /** Optional resolver overriding the bare selector query, for affordances
+   * whose action targets one of SEVERAL matching elements (the composer). */
+  resolve?: () => HTMLElement | null;
+}
+
+// resolveFocusedComposer mirrors composer.focus's own target choice
+// (AppShell.tsx's registerAction: the FOCUSED session pane's ref): in a
+// split workspace several [data-composer] anchors are mounted, and the chip
+// must sit over the one the chord would actually focus (roborev PR #884).
+// Falls back to the first anchor when no session pane is focused (the chord
+// no-ops then, and the pre-change single-composer behavior holds).
+function resolveFocusedComposer(): HTMLElement | null {
+  const state = workspaceStore.getState();
+  const pane = state.panes.find((p) => p.id === state.focusedPaneId);
+  const ref = pane?.type === "session" ? (pane.params as { ref?: unknown } | undefined)?.ref : undefined;
+  if (typeof ref === "string" && ref !== "") {
+    // Dataset equality, not a selector-interpolated ref: no CSS.escape
+    // dependency (jsdom has none) and no quoting hazard for odd ref values.
+    const targeted = Array.from(document.querySelectorAll<HTMLElement>("[data-composer]")).find(
+      (el) => el.dataset.composer === ref,
+    );
+    if (targeted !== undefined) return targeted;
+  }
+  return document.querySelector("[data-composer]");
+}
+
+// The bound affordances (Design decision 4): the palette trigger (the rail's
+// search button - data-search-trigger pre-exists as AppShell's click-to-open
+// hook), the rail toggle (Rail's "Hide sidebar" button and RailHost's
+// hidden-state ☰ chip, exactly one of which is mounted), the session tabs
+// (PaneTab's session wrapper - one chip over the first tab carrying BOTH
+// cycling chords), and the composer (Composer's form wrapper).
+const ANCHORS: readonly AnchorSpec[] = [
+  {
+    id: "palette",
+    selector: "[data-search-trigger]",
+    actionIds: [ACTIONS.paletteOpen],
+    placement: "below",
+  },
+  {
+    id: "rail-toggle",
+    selector: "[data-rail-toggle]",
+    actionIds: [ACTIONS.railToggle],
+    placement: "below",
+  },
+  {
+    id: "session-tabs",
+    selector: "[data-session-tab]",
+    actionIds: [ACTIONS.sessionPrevious, ACTIONS.sessionNext],
+    placement: "below",
+  },
+  {
+    id: "composer",
+    selector: "[data-composer]",
+    actionIds: [ACTIONS.composerFocus],
+    placement: "above",
+    resolve: resolveFocusedComposer,
+  },
+];
+
+export function HoldHints() {
+  const visible = useHoldHintsStore((s) => s.visible);
+  const bindings = useStore(keybindingsRegistry, (s) => s.bindings);
+  const reducedMotion = usePrefersReducedMotion();
+
+  // The detection listeners' whole lifetime is this mount (desktop-only, per
+  // the file header), so a touch viewport never installs one.
+  useEffect(() => installHoldHints(), []);
+
+  if (!visible) return null;
+
+  const chips: ReactNode[] = [];
+  for (const spec of ANCHORS) {
+    const anchor = spec.resolve ? spec.resolve() : document.querySelector(spec.selector);
+    if (!(anchor instanceof HTMLElement)) continue;
+    // The WHOLE effective sequence per action (an override can be
+    // multi-press); an action with no effective binding contributes nothing.
+    const sequences: KeySequence[] = [];
+    for (const actionId of spec.actionIds) {
+      const sequence = displayBindingFor(bindings, actionId)?.chord;
+      if (sequence !== undefined && sequence.length > 0) sequences.push(sequence);
+    }
+    if (sequences.length === 0) continue;
+    const rect = anchor.getBoundingClientRect();
+    chips.push(
+      <span
+        key={spec.id}
+        data-hint={spec.id}
+        className={`${CLASS.chip} ${spec.placement === "above" ? CLASS.above : CLASS.below}`}
+        style={{ left: rect.left + rect.width / 2, top: spec.placement === "above" ? rect.top : rect.bottom }}
+      >
+        {sequences.map((sequence, i) => (
+          <Fragment key={serializeChord(sequence)}>
+            {i > 0 && <span className={CLASS.or}>/</span>}
+            {sequence.map((press, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: repeated presses in a multi-press sequence ("g g") are content-identical, position is identity, and the list is static per binding
+              <KeyHint key={`${i}:${serializeChord([press])}`} keys={chordDisplayKeys(press)} />
+            ))}
+          </Fragment>
+        ))}
+      </span>,
+    );
+  }
+  if (chips.length === 0) return null;
+
+  return createPortal(
+    <div
+      className={CLASS.root}
+      data-hold-hints=""
+      data-reduced-motion={reducedMotion ? "" : undefined}
+      aria-hidden="true"
+    >
+      {chips}
+    </div>,
+    document.body,
+  );
+}

--- a/cmd/evener-hub/frontend/src/shell/holdhints/holdHintsController.ts
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/holdHintsController.ts
@@ -1,0 +1,136 @@
+// Hold-modifier hint detection (Phase 4a, the p4 plan's Design decision 4):
+// holding the primary modifier ALONE - Meta on Apple platforms, Control
+// elsewhere, the same platform split as keybindings/validation.ts's
+// currentKeybindingsPlatform (and keyhint's Mod glyph) - for
+// HOLD_THRESHOLD_MS shows the hint chips; any cleanup path hides them. The
+// store mirrors cheatsheetController.ts: a vanilla store the mounted
+// <HoldHints/> subscribes to.
+//
+// The listeners installed here are OBSERVERS ONLY - they never preventDefault
+// and never stopPropagation, so the keybindings dispatcher (and every other
+// keydown consumer) sees exactly the events it would see without this module.
+// That is pinned by HoldHints.test.tsx.
+//
+// The cleanup set comes from the feasibility research (docs/web-ui/specs/
+// 2026-09-03-keybinding-system-survey.md): the modifier's keyup IS delivered
+// even on macOS, but a non-modifier keyup while the modifier is held is NOT -
+// so release alone cannot be trusted to end every hold. Every one of these
+// hides the chips, and each is pinned by a test:
+//
+//   - the tracked modifier's keyup (the normal path),
+//   - window blur (⌘-Tab away mid-hold),
+//   - document visibilitychange (tab switch mid-hold),
+//   - ANY keydown that is not the tracked modifier (a chord starting - its
+//     keyup may never arrive on macOS, so the keydown itself is the hide),
+//   - a hard timeout (HARD_TIMEOUT_MS) as the final backstop.
+//
+// A stuck visible state must be impossible.
+
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+import { currentKeybindingsPlatform } from "../../keybindings/validation";
+
+/** How long the modifier must be held alone before the chips appear. */
+export const HOLD_THRESHOLD_MS = 400;
+
+/** The backstop: the chips can never stay up longer than this, even if every
+ * event-based cleanup path missed (a keyup swallowed by an OS-level chord,
+ * a blur that never fired). */
+export const HARD_TIMEOUT_MS = 10_000;
+
+export interface HoldHintsState {
+  visible: boolean;
+}
+
+export const holdHintsStore = createStore<HoldHintsState>(() => ({ visible: false }));
+
+export function useHoldHintsStore<T>(selector: (state: HoldHintsState) => T): T {
+  return useStore(holdHintsStore, selector);
+}
+
+/** Test-only: clears the visible flag between tests. The timers belong to
+ * the install disposer, which the component's unmount runs. */
+export function resetHoldHintsForTests(): void {
+  holdHintsStore.setState({ visible: false });
+}
+
+/** Installs the observer listeners; returns the disposer (which also hides
+ * and clears every pending timer). Per-mount lifetime: <HoldHints/>'s one
+ * effect owns it, and AppShell mounts that component only on desktop, so a
+ * touch viewport never installs a listener. */
+export function installHoldHints(target: Window = window): () => void {
+  const modifierKey = currentKeybindingsPlatform() === "apple" ? "Meta" : "Control";
+  // The OTHER modifier flags: the hold counts only while the tracked modifier
+  // is held ALONE. A keydown arriving with Shift/Alt (or the other of
+  // Meta/Ctrl) already down is the start of a chord, not of a hint hold.
+  // (The tracked modifier's own flag is already true on its keydown, so it
+  // must not be in this list.)
+  const otherFlags: readonly ("ctrlKey" | "metaKey" | "altKey" | "shiftKey")[] =
+    modifierKey === "Meta" ? ["ctrlKey", "altKey", "shiftKey"] : ["metaKey", "altKey", "shiftKey"];
+
+  let holdTimer: ReturnType<typeof setTimeout> | null = null;
+  let hardTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimers(): void {
+    if (holdTimer !== null) {
+      clearTimeout(holdTimer);
+      holdTimer = null;
+    }
+    if (hardTimer !== null) {
+      clearTimeout(hardTimer);
+      hardTimer = null;
+    }
+  }
+
+  function hide(): void {
+    clearTimers();
+    if (holdHintsStore.getState().visible) holdHintsStore.setState({ visible: false });
+  }
+
+  function show(): void {
+    holdTimer = null;
+    holdHintsStore.setState({ visible: true });
+    hardTimer = setTimeout(hide, HARD_TIMEOUT_MS);
+  }
+
+  function onKeyDown(event: KeyboardEvent): void {
+    // Any other key - printable, navigation, or another modifier - ends the
+    // hold (and clears a pending one): the hold is "modifier alone", and on
+    // macOS this keydown may be the ONLY event the chord ever delivers.
+    if (event.key !== modifierKey) {
+      hide();
+      return;
+    }
+    // Held-down modifiers auto-repeat on some platforms; the first keydown
+    // already armed the timer.
+    if (event.repeat) return;
+    if (otherFlags.some((flag) => event[flag])) return;
+    if (holdTimer !== null || holdHintsStore.getState().visible) return;
+    holdTimer = setTimeout(show, HOLD_THRESHOLD_MS);
+  }
+
+  function onKeyUp(event: KeyboardEvent): void {
+    if (event.key === modifierKey) hide();
+  }
+
+  function onBlur(): void {
+    hide();
+  }
+
+  function onVisibilityChange(): void {
+    hide();
+  }
+
+  target.addEventListener("keydown", onKeyDown);
+  target.addEventListener("keyup", onKeyUp);
+  target.addEventListener("blur", onBlur);
+  target.document.addEventListener("visibilitychange", onVisibilityChange);
+
+  return () => {
+    target.removeEventListener("keydown", onKeyDown);
+    target.removeEventListener("keyup", onKeyUp);
+    target.removeEventListener("blur", onBlur);
+    target.document.removeEventListener("visibilitychange", onVisibilityChange);
+    hide();
+  };
+}

--- a/cmd/evener-hub/frontend/src/shell/holdhints/holdhints.module.css
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/holdhints.module.css
@@ -1,0 +1,67 @@
+/* Hold-modifier hint chips (Phase 4a, Design decision 4). The root is a
+ * fixed, pointer-events-none layer portaled to document.body (the popover
+ * pattern): chips get their top/left inline from the anchor's
+ * getBoundingClientRect(), so showing never reflows page content and no
+ * clipping ancestor can cut a chip off. The layer itself is aria-hidden
+ * decoration - the same chords live in the cheatsheet overlay and the
+ * controls' own tooltips. */
+
+.root {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-menu);
+  pointer-events: none;
+  animation: holdHintsIn var(--motion-duration-overlay) var(--motion-easing-standard);
+}
+
+@keyframes holdHintsIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.chip {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px;
+  border-radius: var(--radius-pane);
+  background: var(--surface-2);
+  box-shadow: var(--shadow-overlay);
+}
+
+/* Horizontal centering on the anchor is shared; placement differs only along
+ * the vertical axis - rail/palette/tab affordances sit at the top edge of the
+ * shell (chip BELOW), the composer at the bottom (chip ABOVE its card). */
+.below {
+  transform: translate(-50%, 6px);
+}
+
+.above {
+  transform: translate(-50%, calc(-100% - 6px));
+}
+
+.or {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+/* prefers-reduced-motion: the chips appear/disappear instantly - no fade.
+ * The @media rule is the first-paint source of truth (the house pattern -
+ * widgets/popover et al.); the [data-reduced-motion] mirror is the same
+ * preference read JS-side (usePrefersReducedMotion) so the instant path is
+ * observable where media queries are not evaluated (jsdom tests). */
+@media (prefers-reduced-motion: reduce) {
+  .root {
+    animation: none;
+  }
+}
+
+.root[data-reduced-motion] {
+  animation: none;
+}

--- a/cmd/evener-hub/frontend/src/shell/holdhints/usePrefersReducedMotion.ts
+++ b/cmd/evener-hub/frontend/src/shell/holdhints/usePrefersReducedMotion.ts
@@ -1,0 +1,32 @@
+// The one JS-side read of the reduced-motion preference. Every other consumer
+// in the app is a CSS module's @media (prefers-reduced-motion: reduce) rule
+// (widgets/popover, widgets/sheet, ...), which jsdom cannot evaluate - the
+// hold-hints overlay mirrors the same preference into a data attribute so its
+// instant (no-fade) path is observable and pinned in tests
+// (HoldHints.test.tsx). The CSS @media rule stays the first paint's source of
+// truth; this hook keeps the attribute in sync, including later changes.
+
+import { useEffect, useState } from "react";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function readPreference(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(readPreference);
+  useEffect(() => {
+    // Guarded like stores/prefs.ts's own matchMedia reads: this project's
+    // jsdom has no matchMedia at all, and the no-op path degrades to the
+    // initial (false) value.
+    if (typeof window.matchMedia !== "function") return undefined;
+    const list = window.matchMedia(REDUCED_MOTION_QUERY);
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+    onChange({ matches: list.matches } as MediaQueryListEvent);
+    list.addEventListener("change", onChange);
+    return () => list.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}

--- a/cmd/evener-hub/frontend/src/shell/installKeybindings.ts
+++ b/cmd/evener-hub/frontend/src/shell/installKeybindings.ts
@@ -1,0 +1,37 @@
+// The one app-startup wiring point between the React-free keybindings module
+// (src/keybindings/) and the live app: registers the default binding map and
+// attaches the single window-level dispatcher, with the modal predicate
+// composed from the real stores - paletteStore.open (the palette is
+// CommandPalette's own overlay, not an [aria-modal] element, so the DOM check
+// alone can't see it) OR an [aria-modal="true"] ancestor of the event target
+// (every OverlayPanel-based Dialog/Sheet). This is exactly the old AppShell
+// blockedByOpenModal check, kept blanket - with per-binding allowInModal
+// exemptions living on the bindings themselves (keybindings/defaults.ts),
+// the predicate never sniffs which chord was pressed.
+//
+// Idempotent per window: AppShell installs it at mount, and every component
+// that registers a chord action (RailHost, Settings, SelectionQuote) calls it
+// too so the chord also works when the component is mounted WITHOUT the shell
+// - those components' own unit tests render them standalone, and a chord that
+// silently did nothing there would be worse than this belt-and-braces call.
+// Per-window lifetime by design: the dispatcher and the (actionless on their
+// own) default bindings stay attached until the page unloads; actions and
+// scopes come and go with their components. Vitest file isolation gives each
+// test file a fresh module registry, so the singleton never crosses files.
+
+import { registerDefaultBindings } from "../keybindings/defaults";
+import { createKeybindingDispatcher, isModalOpenTarget } from "../keybindings/dispatcher";
+import { keybindingsRegistry } from "../keybindings/registry";
+import { paletteStore } from "./palette/paletteController";
+
+let installed = false;
+
+export function installKeybindings(): void {
+  if (installed) return;
+  installed = true;
+  registerDefaultBindings(keybindingsRegistry);
+  const dispatcher = createKeybindingDispatcher({
+    isModalOpen: (event) => paletteStore.getState().open || isModalOpenTarget(event),
+  });
+  dispatcher.attach(window);
+}

--- a/cmd/evener-hub/frontend/src/shell/installKeybindings.ts
+++ b/cmd/evener-hub/frontend/src/shell/installKeybindings.ts
@@ -22,6 +22,7 @@
 import { registerDefaultBindings } from "../keybindings/defaults";
 import { createKeybindingDispatcher, isModalOpenTarget } from "../keybindings/dispatcher";
 import { keybindingsRegistry } from "../keybindings/registry";
+import { installCharacterKeyTriggerReconcile } from "./cheatsheet/cheatsheetController";
 import { paletteStore } from "./palette/paletteController";
 
 let installed = false;
@@ -30,6 +31,12 @@ export function installKeybindings(): void {
   if (installed) return;
   installed = true;
   registerDefaultBindings(keybindingsRegistry);
+  // The "?" character-key trigger's pref-conditional registration (the WCAG
+  // 2.1.4 turn-off). Installed here, not by the overlay component, so the
+  // invariant holds on mobile too - where the overlay never mounts and the
+  // binding is inert for lack of an action - keeping the settings section's
+  // customized-marker comparison truthful there as well.
+  installCharacterKeyTriggerReconcile();
   const dispatcher = createKeybindingDispatcher({
     isModalOpen: (event) => paletteStore.getState().open || isModalOpenTarget(event),
   });

--- a/cmd/evener-hub/frontend/src/shell/keybindingsMigration.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/keybindingsMigration.test.tsx
@@ -282,6 +282,21 @@ test("Mod+J fires while an input is focused", async () => {
   remove();
 });
 
+// settings.open (Phase 4a, the p4 plan's Design decision 2): ⌘, runs exactly
+// what the palette's "settings" command runs - navigate("/settings") - and
+// fires from editable targets (⌘, never collides with typing).
+test("Mod+, opens the Settings pane while an input is focused", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { input, remove } = focusedInput();
+
+  fireEvent.keyDown(input, { key: ",", metaKey: true });
+
+  await waitFor(() => expect(workspaceStore.getState().mainPane()?.type).toBe("settings"));
+  expect(window.location.pathname).toBe("/settings");
+  remove();
+});
+
 test("Mod+B is suppressed from editable targets (Ctrl+B keeps its emacs meaning)", async () => {
   render(<AppShell client={new FakeClient("ready")} />);
   await screen.findByText("No session open");
@@ -351,6 +366,18 @@ test("Mod+I and Mod+J are suppressed while an [aria-modal] dialog is open", asyn
 
   expect(focusSpy).not.toHaveBeenCalled();
   expect(workspaceStore.getState().mainPane()?.params).toMatchObject({ ref: "local:ref_abc123" });
+  close();
+});
+
+test("Mod+, is suppressed while an [aria-modal] dialog is open (allowInModal: false)", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { inside, close } = openFakeModal();
+
+  fireEvent.keyDown(inside, { key: ",", metaKey: true });
+
+  expect(workspaceStore.getState().mainPane()?.type).not.toBe("settings");
+  expect(window.location.pathname).not.toBe("/settings");
   close();
 });
 

--- a/cmd/evener-hub/frontend/src/shell/keybindingsMigration.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/keybindingsMigration.test.tsx
@@ -1,0 +1,412 @@
+// Migration tests for the keybindings dispatcher wiring (Task 2 of the
+// webui-keybindings-p2a plan): the six shell chords moved from six ad-hoc
+// keydown listeners (AppShell, RailHost, Settings, SelectionQuote) onto the
+// single window-level dispatcher (src/keybindings/, installed by
+// shell/installKeybindings.ts). These tests pin the chord-policy contract
+// that the pre-existing suites do NOT already cover: firing-or-not from
+// editable targets, from open modals (per-binding allowInModal), while the
+// palette itself is open, on IME composition keydowns, and against a keydown
+// another handler already claimed - plus the one deliberate non-migration
+// (FocusScope's Tab trap is untouched).
+//
+// The AppShell render/warm-up/store-reset scaffolding below mirrors
+// AppShell.test.tsx's own (helpers duplicated, not shared - this project has
+// no cross-test-file test-utils module; see that file's and
+// stores/threads.test.ts's own notes on the convention).
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { initNotifications, resetNotificationsForTests } from "../notifications";
+import * as composerFocus from "../panes/session/composer/composerFocus";
+import { FakeClient } from "../protocol/testing/fakeClient";
+import type { NavigationReadParams, NavigationReadResponse, NavigationSessionLocation } from "../protocol/types.gen";
+import { connectionStore } from "../stores/connection";
+import { navigationStore, resetNavigationStoreForTests } from "../stores/navigation/store";
+import { keyID } from "../stores/navigation/types";
+import { prefsStore, resetPrefsStoreForTests } from "../stores/prefs";
+import { resetSettingsOverviewStoreForTests } from "../stores/settingsOverview";
+import { FocusScope } from "../widgets/focusscope";
+import { AppShell } from "./AppShell";
+import { closePalette, paletteStore } from "./palette/paletteController";
+import { resetWorkspaceStoreForTests, workspaceStore } from "./workspace";
+
+// See AppShell.test.tsx for why both stubs are needed (jsdom has no
+// ResizeObserver; Node 26 shadows jsdom's localStorage accessor).
+class StubResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const TREE_SESSION = {
+  row_id: "project:proj1:local:s1",
+  ref: "local:s1",
+  host_id: "local",
+  session_id: "s1",
+  title: "Session one",
+  project: "prime-radiant",
+  state: "idle",
+  kind: "session",
+  live: true,
+  children: [],
+};
+
+function navigationRead(params: NavigationReadParams): NavigationReadResponse {
+  const envelope = (data: unknown): NavigationReadResponse => ({
+    status: "ok",
+    generationId: "generation_test",
+    revision: 1,
+    etag: '"test"',
+    data,
+  });
+  if (params.resource === "location") {
+    return envelope({
+      generation_id: "generation_test",
+      revision: 1,
+      ref: params.ref,
+      top_level_ref: params.ref,
+      top_level: true,
+      session: { ...TREE_SESSION, ref: params.ref, session_id: params.ref },
+    });
+  }
+  throw new Error(`unsupported navigation resource: ${params.resource}`);
+}
+
+// A FakeClient whose connect() advertises v1 navigation with v2 read support
+// (the entity-deltas capability split, navigation #846) - see AppShell.
+// test.tsx's own navClient comment for why a bare FakeClient("ready") leaves
+// the navigation store in "error" mode instead.
+function navClient(): FakeClient {
+  const client = new FakeClient("ready");
+  client.on("evener/navigation/read", navigationRead);
+  client.scriptConnect(() => ({
+    serverInfo: { name: "fake", version: "1" },
+    protocolVersion: "evener-appwire-v3",
+    sourceId: "fake",
+    features: {} as never,
+    navigation: { version: 1, generationId: "generation_test", sequence: 0, readVersions: [2] },
+  }));
+  return client;
+}
+
+function installLocationForRoute(ref: string): void {
+  const location: NavigationSessionLocation = {
+    generation_id: "generation_test",
+    revision: 1,
+    ref,
+    top_level_ref: ref,
+    top_level: true,
+    session: {
+      ref,
+      host_id: "local",
+      session_id: ref,
+      title: ref,
+      project: "test-project",
+      state: "idle",
+      kind: "session",
+      live: false,
+      children: [],
+    },
+  };
+  const key = { kind: "location", ref } as const;
+  const resources = new Map(navigationStore.getState().resources);
+  resources.set(keyID(key), {
+    key,
+    data: location,
+    loadedRevision: location.revision,
+    targetRevision: null,
+    forceToken: 0,
+    etag: '"test"',
+    loading: false,
+    stale: false,
+    error: null,
+    generationID: location.generation_id,
+  });
+  navigationStore.setState({ mode: "v2", clientGenerationID: location.generation_id, resources });
+}
+
+function installNeedsYouRows(): void {
+  const key = { kind: "section", section: "needs_you", offset: 0, limit: 50 } as const;
+  const rows = [
+    { ...TREE_SESSION, ref: "local:ny1", session_id: "ny1", title: "Needs you one", state: "awaiting" },
+    { ...TREE_SESSION, ref: "local:ny2", session_id: "ny2", title: "Needs you two", state: "awaiting" },
+  ];
+  const resources = new Map(navigationStore.getState().resources);
+  resources.set(keyID(key), {
+    key,
+    data: { generation_id: "generation_test", revision: 1, sessions: rows, remaining: 0, truncated: false },
+    loadedRevision: 1,
+    targetRevision: null,
+    forceToken: 0,
+    etag: '"test"',
+    loading: false,
+    stale: false,
+    error: null,
+    generationID: "generation_test",
+  });
+  navigationStore.setState({ mode: "v2", resources });
+}
+
+// A focused plain <input> appended beside the shell: the editable target the
+// editable-policy tests fire their chords from. Returns a cleanup.
+function focusedInput(): { input: HTMLInputElement; remove: () => void } {
+  const input = document.createElement("input");
+  document.body.appendChild(input);
+  input.focus();
+  return { input, remove: () => input.remove() };
+}
+
+// An [aria-modal="true"] stand-in for an OverlayPanel Dialog/Sheet, with a
+// focusable element inside so chords can be fired from within it.
+function openFakeModal(): { modal: HTMLElement; inside: HTMLButtonElement; close: () => void } {
+  const modal = document.createElement("div");
+  modal.setAttribute("aria-modal", "true");
+  const inside = document.createElement("button");
+  modal.appendChild(inside);
+  document.body.appendChild(modal);
+  inside.focus();
+  return { modal, inside, close: () => modal.remove() };
+}
+
+beforeAll(async () => {
+  globalThis.ResizeObserver = StubResizeObserver as unknown as typeof ResizeObserver;
+  // @ts-expect-error MemoryStorage deliberately implements only the Storage
+  // methods the stores actually call - see AppShell.test.tsx's own stub.
+  globalThis.localStorage = new MemoryStorage();
+  // Await the lazy pane/dock modules once up front, then pay react-dom's
+  // per-boundary fallback throttle in one warm render per route shape - see
+  // AppShell.test.tsx's warmRoute for the full reasoning (the cost is real
+  // and awaitable here; inside a test it would eat the assertion window).
+  await import("../panes/welcome/Welcome");
+  await import("../panes/session/Session");
+  await import("../panes/settings/Settings");
+  await import("./DockHost");
+  window.history.pushState({}, "", "/");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open", undefined, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+  window.history.pushState({}, "", "/settings");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByRole("navigation", { name: "Settings sections" }, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+  resetSettingsOverviewStoreForTests();
+  window.history.pushState({}, "", "/s/local:warm");
+  installLocationForRoute("local:warm");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText(/loading transcript/i, undefined, { timeout: 10_000 });
+  cleanup();
+  resetWorkspaceStoreForTests();
+  window.history.pushState({}, "", "/");
+});
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetWorkspaceStoreForTests();
+  resetNavigationStoreForTests();
+  navigationStore.setState({ mode: "v2" });
+  resetPrefsStoreForTests();
+  // @ts-expect-error see the beforeAll stub.
+  globalThis.localStorage = new MemoryStorage();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  window.history.pushState({}, "", "/");
+  paletteStore.setState({ open: false, query: "" });
+  resetSettingsOverviewStoreForTests();
+  // Same module-singleton reasoning as AppShell.test.tsx's afterEach: the
+  // notifications engine's reconnect detector must not carry one test's
+  // ready-client into the next.
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetNavigationStoreForTests();
+  resetNotificationsForTests();
+  initNotifications();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// --- editable targets -------------------------------------------------------
+
+test("Mod+K fires while an input is focused", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { input, remove } = focusedInput();
+
+  fireEvent.keyDown(input, { key: "k", metaKey: true });
+
+  expect(await screen.findByRole("dialog", { name: "Command palette" })).toBeTruthy();
+  remove();
+});
+
+test("Mod+I fires while an input is focused", async () => {
+  const focusSpy = vi.spyOn(composerFocus, "requestComposerFocus");
+  window.history.pushState({}, "", "/s/local:ref_abc123");
+  installLocationForRoute("local:ref_abc123");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText(/loading transcript/i);
+  const { input, remove } = focusedInput();
+
+  fireEvent.keyDown(input, { key: "i", metaKey: true });
+
+  expect(focusSpy).toHaveBeenCalledWith("local:ref_abc123");
+  remove();
+});
+
+test("Mod+J fires while an input is focused", async () => {
+  installNeedsYouRows();
+  render(<AppShell client={navClient()} />);
+  await screen.findByText("No session open");
+  const { input, remove } = focusedInput();
+
+  fireEvent.keyDown(input, { key: "j", metaKey: true });
+
+  await waitFor(() => expect(workspaceStore.getState().mainPane()?.params).toMatchObject({ ref: "local:ny1" }));
+  remove();
+});
+
+test("Mod+B is suppressed from editable targets (Ctrl+B keeps its emacs meaning)", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { input, remove } = focusedInput();
+
+  const metaEvent = new KeyboardEvent("keydown", { key: "b", metaKey: true, bubbles: true, cancelable: true });
+  act(() => {
+    input.dispatchEvent(metaEvent);
+  });
+  const ctrlEvent = new KeyboardEvent("keydown", { key: "b", ctrlKey: true, bubbles: true, cancelable: true });
+  act(() => {
+    input.dispatchEvent(ctrlEvent);
+  });
+
+  expect(prefsStore.getState().sidebarHidden).toBe(false);
+  // A suppressed binding claims nothing: the text field's own Ctrl+B behavior
+  // (cursor back) must not be preventDefault'd either.
+  expect(metaEvent.defaultPrevented).toBe(false);
+  expect(ctrlEvent.defaultPrevented).toBe(false);
+  remove();
+});
+
+// --- open modals (per-binding allowInModal) ---------------------------------
+
+test("Mod+K fired while the palette is already open re-opens it (the deliberate exemption)", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  await user.keyboard("{Meta>}k{/Meta}");
+  await screen.findByRole("dialog", { name: "Command palette" });
+  const openSeq = paletteStore.getState().openSeq;
+
+  await user.keyboard("{Meta>}k{/Meta}");
+
+  // Every openPalette() call bumps openSeq - the remount-on-open contract the
+  // exemption exists to preserve (paletteController.ts's own comment).
+  expect(paletteStore.getState().openSeq).toBe(openSeq + 1);
+  expect(screen.getByRole("dialog", { name: "Command palette" })).toBeTruthy();
+});
+
+test("Mod+K and Mod+B still fire while an [aria-modal] dialog is open", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  const { inside, close } = openFakeModal();
+
+  fireEvent.keyDown(inside, { key: "k", metaKey: true });
+  expect(await screen.findByRole("dialog", { name: "Command palette" })).toBeTruthy();
+
+  act(() => closePalette());
+  inside.focus();
+  fireEvent.keyDown(inside, { key: "b", metaKey: true });
+  expect(prefsStore.getState().sidebarHidden).toBe(true);
+  close();
+});
+
+test("Mod+I and Mod+J are suppressed while an [aria-modal] dialog is open", async () => {
+  const focusSpy = vi.spyOn(composerFocus, "requestComposerFocus");
+  installNeedsYouRows();
+  window.history.pushState({}, "", "/s/local:ref_abc123");
+  installLocationForRoute("local:ref_abc123");
+  render(<AppShell client={navClient()} />);
+  await screen.findByText(/loading transcript/i);
+  const { inside, close } = openFakeModal();
+
+  fireEvent.keyDown(inside, { key: "i", metaKey: true });
+  fireEvent.keyDown(inside, { key: "j", metaKey: true });
+
+  expect(focusSpy).not.toHaveBeenCalled();
+  expect(workspaceStore.getState().mainPane()?.params).toMatchObject({ ref: "local:ref_abc123" });
+  close();
+});
+
+// --- claimed events / IME composition ----------------------------------------
+
+test("an isComposing keydown is ignored (IME input never triggers a chord)", async () => {
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+
+  fireEvent.keyDown(window, { key: "k", metaKey: true, isComposing: true });
+
+  expect(screen.queryByRole("dialog")).toBeNull();
+  expect(paletteStore.getState().open).toBe(false);
+});
+
+test("Escape claimed by an earlier handler (defaultPrevented) does not close Settings", async () => {
+  window.history.pushState({}, "", "/settings");
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByRole("navigation", { name: "Settings sections" });
+  const claimEscape = (event: globalThis.KeyboardEvent) => {
+    if (event.key === "Escape") event.preventDefault();
+  };
+  document.addEventListener("keydown", claimEscape, true);
+
+  try {
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(workspaceStore.getState().mainPane()?.type).toBe("settings");
+  } finally {
+    document.removeEventListener("keydown", claimEscape, true);
+  }
+
+  // Mechanism check: with the claiming handler gone, the same Escape DOES
+  // close the pane - the suppression above was the gate, not a dead chord.
+  fireEvent.keyDown(document.body, { key: "Escape" });
+  await screen.findByText("No session open");
+  expect(workspaceStore.getState().mainPane()?.type).not.toBe("settings");
+});
+
+// --- deliberately not migrated ----------------------------------------------
+
+test("FocusScope Tab cycling from a text field is unaffected by the dispatcher", async () => {
+  const user = userEvent.setup();
+  render(<AppShell client={new FakeClient("ready")} />);
+  await screen.findByText("No session open");
+  render(
+    <FocusScope trap>
+      <input aria-label="Field" />
+      <button type="button">After</button>
+    </FocusScope>,
+  );
+
+  const field = screen.getByRole("textbox", { name: "Field" });
+  field.focus();
+  await user.tab();
+  expect(document.activeElement).toBe(screen.getByRole("button", { name: "After" }));
+  // Trapped: Tabbing past the last tabbable loops back to the first.
+  await user.tab();
+  expect(document.activeElement).toBe(field);
+});

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -1422,6 +1422,7 @@ function NavigationRail({
           </Tooltip>
           {onHide && (
             <IconButton
+              data-rail-toggle=""
               label="Hide sidebar"
               icon={<span aria-hidden="true">☰</span>}
               variant="quiet"

--- a/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
@@ -77,6 +77,7 @@ export function RailHost(_props: { railSlot?: never } = {}): JSX.Element {
         <button
           type="button"
           className={CLASS.chip}
+          data-rail-toggle=""
           aria-label={label}
           onClick={() => prefsStore.getState().setSidebarHidden(false)}
         >

--- a/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailHost.tsx
@@ -14,11 +14,14 @@
 // (railController) hands it a session ref; if the rail is hidden, revealing
 // docks it first so there's a mounted Rail to expand + scroll.
 import { type JSX, useCallback, useEffect, useState } from "react";
+import { ACTIONS } from "../../keybindings/actions";
+import { keybindingsRegistry } from "../../keybindings/registry";
 import { selectNeedsYouCount } from "../../stores/navigation/selectors";
 import { useNavigationStore } from "../../stores/navigation/store";
 import { prefsStore, usePrefsStore } from "../../stores/prefs";
 import { Badge } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
+import { installKeybindings } from "../installKeybindings";
 import { useIsMobile } from "../useIsMobile";
 import { Rail } from "./Rail";
 import styles from "./RailHost.module.css";
@@ -28,20 +31,6 @@ const CLASS = {
   chipBar: requireClass(styles.chipBar, "RailHost.module.css", "chipBar"),
   chip: requireClass(styles.chip, "RailHost.module.css", "chip"),
 };
-
-// Ctrl+B is the macOS emacs-style "move cursor back one character" binding
-// native text fields honor while focused; without this guard, the ⌘B
-// listener below would hijack it mid-typing (it accepts ctrl as well as
-// meta for the cross-platform chord).
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  return (
-    target.isContentEditable ||
-    target.tagName === "INPUT" ||
-    target.tagName === "TEXTAREA" ||
-    target.tagName === "SELECT"
-  );
-}
 
 export function RailHost(_props: { railSlot?: never } = {}): JSX.Element {
   const isMobile = useIsMobile();
@@ -53,19 +42,20 @@ export function RailHost(_props: { railSlot?: never } = {}): JSX.Element {
   const clearReveal = useCallback(() => setRevealTarget(null), []);
 
   // ⌘B toggles the sidebar (desktop only — mobile's drawer is its own
-  // show/hide). PIN-D: ⌘B is the rail's; ⌘K (palette) is AppShell's.
+  // show/hide, and with no action registered the binding is inert there).
+  // PIN-D: ⌘B is the rail's; ⌘K (palette) is AppShell's. The chord itself is
+  // the keybindings dispatcher's (keybindings/defaults.ts's rail.toggle
+  // binding carries this listener's old policy verbatim: suppressed from
+  // editable targets so Ctrl+B keeps its emacs "cursor back" meaning in
+  // native text fields, and NO defaultPrevented check -
+  // ignoreIfDefaultPrevented: false).
   useEffect(() => {
     if (isMobile) return undefined;
-    function onKeyDown(event: KeyboardEvent): void {
-      if (isEditableTarget(event.target)) return;
-      if ((event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey && event.key.toLowerCase() === "b") {
-        event.preventDefault();
-        const prefs = prefsStore.getState();
-        prefs.setSidebarHidden(!prefs.sidebarHidden);
-      }
-    }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    installKeybindings();
+    return keybindingsRegistry.getState().registerAction(ACTIONS.railToggle, () => {
+      const prefs = prefsStore.getState();
+      prefs.setSidebarHidden(!prefs.sidebarHidden);
+    });
   }, [isMobile]);
 
   // Reveal seam (railController /project, PIN-A). Reveal-first when hidden:

--- a/cmd/evener-hub/frontend/src/shell/rail/RailResizeHandle.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailResizeHandle.test.tsx
@@ -229,6 +229,23 @@ describe("keyboard operation", () => {
     expect(committedWidth()).toBe(SIDEBAR_WIDTH_DEFAULT);
   });
 
+  test("Alt/Ctrl/Meta arrows and Home/End belong to the global chords - no resize, no preventDefault", () => {
+    render(<Harness />);
+    // Alt+Arrow/Alt+Home/End are the global session-cycling and transcript
+    // jump chords; the handle must leave modified keys entirely alone so the
+    // dispatcher's defaultPrevented check never sees them swallowed here
+    // (roborev PR #884 round 3). Shift stays the coarse-step modifier.
+    for (const event of [
+      { key: "ArrowLeft", altKey: true },
+      { key: "ArrowRight", ctrlKey: true },
+      { key: "Home", altKey: true },
+      { key: "End", metaKey: true },
+    ]) {
+      expect(fireEvent.keyDown(handle(), event)).toBe(true);
+    }
+    expect(committedWidth()).toBe(SIDEBAR_WIDTH_DEFAULT);
+  });
+
   test("a resizing key is preventDefaulted so the page never scrolls instead", () => {
     render(<Harness />);
     expect(fireEvent.keyDown(handle(), { key: "ArrowRight" })).toBe(false);

--- a/cmd/evener-hub/frontend/src/shell/rail/RailResizeHandle.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailResizeHandle.tsx
@@ -91,6 +91,11 @@ export function RailResizeHandle({ width, onCommit, railRef }: RailResizeHandleP
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
+    // Alt/Ctrl/Meta mean the key belongs elsewhere (Alt+Arrow/Alt+Home/End are
+    // the global session/transcript chords); a blanket preventDefault here
+    // would swallow them while the handle has focus (roborev PR #884 round
+    // 3). Shift stays: it selects the coarse step below.
+    if (event.altKey || event.ctrlKey || event.metaKey) return;
     const coarse = event.shiftKey ? KEY_STEP_COARSE : KEY_STEP;
     switch (event.key) {
       case "ArrowLeft":

--- a/cmd/evener-hub/frontend/src/shell/sessionCycle.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/sessionCycle.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment node
+
+// Unit tests for sessionCycle.ts (webui-keybindings-p3 Task 1): the
+// session.next/session.previous actions cycle the workspace's SESSION panes
+// in workspace (workspaceStore.panes) order, wrapping at both ends, skipping
+// every non-session pane, and no-op with fewer than two session panes open.
+// Pane-registration scaffolding mirrors workspace.test.ts's own (fixture
+// descriptors over the shared paneRegistry singleton).
+import { lazy } from "react";
+import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
+import { type PaneDescriptor, type PaneProps, registerPaneForTests } from "./paneRegistry";
+import { cycleSessionPane } from "./sessionCycle";
+import { resetWorkspaceStoreForTests, workspaceStore } from "./workspace";
+
+function fixtureDescriptor<P>(
+  id: PaneDescriptor<P>["id"],
+  overrides: Partial<PaneDescriptor<P>> = {},
+): PaneDescriptor<P> {
+  return {
+    id,
+    title: () => `title for ${id}`,
+    component: lazy(() => new Promise<{ default: React.ComponentType<PaneProps<P>> }>(() => {})),
+    ...overrides,
+  };
+}
+
+const restorePaneFixtures: Array<() => void> = [];
+
+beforeAll(() => {
+  restorePaneFixtures.push(registerPaneForTests(fixtureDescriptor("session")));
+  restorePaneFixtures.push(registerPaneForTests(fixtureDescriptor("settings", { singleton: true })));
+  restorePaneFixtures.push(registerPaneForTests(fixtureDescriptor("doc")));
+});
+
+afterAll(() => {
+  for (const restore of restorePaneFixtures) restore();
+});
+
+beforeEach(() => {
+  resetWorkspaceStoreForTests();
+});
+
+function openSessions(...refs: string[]): string[] {
+  return refs.map((ref) => workspaceStore.getState().openPane("session", { ref }));
+}
+
+test("next cycles through the session panes in workspace order", () => {
+  // The tuple casts: noUncheckedIndexedAccess types destructured elements string|undefined.
+  const [a, b, c] = openSessions("local:a", "local:b", "local:c") as [string, string, string];
+  workspaceStore.getState().focusPane(a);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(c);
+});
+
+test("next wraps from the last session pane back to the first", () => {
+  const [a, , c] = openSessions("local:a", "local:b", "local:c") as [string, string, string];
+  workspaceStore.getState().focusPane(c);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+});
+
+test("previous cycles backward and wraps from the first to the last", () => {
+  // The tuple casts: noUncheckedIndexedAccess types destructured elements string|undefined.
+  const [a, b, c] = openSessions("local:a", "local:b", "local:c") as [string, string, string];
+  workspaceStore.getState().focusPane(a);
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(c);
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+});
+
+test("non-session panes in the workspace are skipped", () => {
+  const a = workspaceStore.getState().openPane("session", { ref: "local:a" });
+  workspaceStore.getState().openPane("settings", {});
+  workspaceStore.getState().openPane("doc", { session: "local:a", path: "README.md" });
+  const b = workspaceStore.getState().openPane("session", { ref: "local:b" });
+  workspaceStore.getState().focusPane(a);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(b);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+});
+
+test("no-op when no session pane is open", () => {
+  const settings = workspaceStore.getState().openPane("settings", {});
+  workspaceStore.getState().focusPane(settings);
+  cycleSessionPane("next");
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(settings);
+});
+
+test("no-op when only one session pane is open", () => {
+  const [only] = openSessions("local:only") as [string];
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(only);
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(only);
+});
+
+test("with focus on a non-session pane, next focuses the first session and previous the last", () => {
+  const [a, , c] = openSessions("local:a", "local:b", "local:c") as [string, string, string];
+  const settings = workspaceStore.getState().openPane("settings", {});
+  workspaceStore.getState().focusPane(settings);
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+  workspaceStore.getState().focusPane(settings);
+  cycleSessionPane("previous");
+  expect(workspaceStore.getState().focusedPaneId).toBe(c);
+});
+
+test("no focused pane at all still lands on a session pane rather than throwing", () => {
+  const [a] = openSessions("local:a", "local:b") as [string];
+  workspaceStore.setState({ focusedPaneId: null });
+  cycleSessionPane("next");
+  expect(workspaceStore.getState().focusedPaneId).toBe(a);
+});

--- a/cmd/evener-hub/frontend/src/shell/sessionCycle.ts
+++ b/cmd/evener-hub/frontend/src/shell/sessionCycle.ts
@@ -1,0 +1,33 @@
+// Session-pane cycling for the session.next/session.previous keybinding
+// actions (webui-keybindings-p3 Task 1): Alt+ArrowRight/Left move focus
+// through the workspace's SESSION panes in workspaceStore.panes order,
+// wrapping at both ends. The action handlers (AppShell) call
+// cycleSessionPane; the semantics live here, against the store, so the
+// handler is one line and the policy is unit-testable without the shell.
+//
+// Only panes of type "session" participate - the transcript/doc/tasks/etc.
+// panels beside a session are not cycling targets. Fewer than two session
+// panes open is a no-op (cycling one pane onto itself would be motion
+// without movement). When the focused pane is not a session (settings, a
+// doc, nothing focused at all), next lands on the FIRST session pane and
+// previous on the LAST - needsYouCycle.ts's nextNeedsYouRef precedent for
+// "current not in the cycle list".
+
+import { workspaceStore } from "./workspace";
+
+export type SessionCycleDirection = "next" | "previous";
+
+export function cycleSessionPane(direction: SessionCycleDirection): void {
+  const state = workspaceStore.getState();
+  const sessions = state.panes.filter((pane) => pane.type === "session");
+  if (sessions.length < 2) return;
+  const index = sessions.findIndex((pane) => pane.id === state.focusedPaneId);
+  let target: (typeof sessions)[number] | undefined;
+  if (index < 0) {
+    target = direction === "next" ? sessions[0] : sessions[sessions.length - 1];
+  } else {
+    const step = direction === "next" ? 1 : -1;
+    target = sessions[(index + step + sessions.length) % sessions.length];
+  }
+  if (target) state.focusPane(target.id);
+}

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1,13 +1,41 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { ACTIONS } from "../keybindings/actions";
 import { serializeChord } from "../keybindings/chord";
-import { registerDefaultBindings } from "../keybindings/defaults";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID, registerDefaultBindings } from "../keybindings/defaults";
 import { type Binding, keybindingsRegistry } from "../keybindings/registry";
 import { WireError } from "../protocol/errors";
 import { FakeClient } from "../protocol/testing/fakeClient";
 import type { KeybindingsOverrides, KeybindingsRule } from "../protocol/types.gen";
 import { connectionStore } from "./connection";
 import { keybindingsStore, resetKeybindingsStoreForTests } from "./keybindings";
+import { prefsStore, resetPrefsStoreForTests } from "./prefs";
+
+// Node 26 shadows jsdom's real window.localStorage with its own
+// (non-functional under vitest) global, so every test file that touches
+// localStorage (the prefs store does, and keybindings.ts now reads the
+// character-key pref through it) needs this same small in-memory stand-in -
+// see stores/prefs.test.ts's own comment.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) ?? null) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+beforeAll(() => {
+  // @ts-expect-error see MemoryStorage's own comment for why this is needed
+  globalThis.localStorage = new MemoryStorage();
+});
 
 function resetRegistryToDefaults(): void {
   for (const binding of keybindingsRegistry.getState().bindings) {
@@ -42,12 +70,16 @@ beforeEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
   resetKeybindingsStoreForTests();
   resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
 });
 
 afterEach(() => {
   connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
   resetKeybindingsStoreForTests();
   resetRegistryToDefaults();
+  localStorage.clear();
+  resetPrefsStoreForTests();
   vi.restoreAllMocks();
 });
 
@@ -336,7 +368,9 @@ describe("keybindings store: patch", () => {
     // strict Control+K claim by another action.
     await expect(
       keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+K" }]),
-    ).rejects.toThrow(`chord "Control+K" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`);
+    ).rejects.toThrow(
+      `chord "Control+K" in scope "global" is already bound by "Open the command palette" (${ACTIONS.paletteOpen})`,
+    );
 
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
     // A client-side authoring error is not hub-sourced: neither hubError nor
@@ -392,6 +426,206 @@ describe("keybindings store: patch", () => {
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
     expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
     expect(bindingsFor(ACTIONS.nextNeedsYou)).toHaveLength(2);
+  });
+
+  // The store retains the hub's RAW rules (rawOverrides) so a PATCH composed
+  // from them preserves rules validation skips; pre-flight then tolerates
+  // warnings the current raw set already produces (baseline), rejecting only
+  // what the edit itself introduced.
+  test("the raw rule set is retained verbatim while the validated set drives application", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]),
+    );
+    await wireClient(client, true);
+
+    const state = keybindingsStore.getState();
+    expect(state.rawOverrides).toEqual([
+      { action: "no.such.action", chord: "Control+P" },
+      { action: ACTIONS.composerFocus, chord: "Control+M" },
+    ]);
+    // Application/display still see only the validated rule.
+    expect(state.overrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(state.warnings.map((w) => w.message)).toEqual(['unknown keybinding action "no.such.action"']);
+  });
+
+  test("a patch carrying a preserved invalid rule passes pre-flight and the rule reaches the hub verbatim", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: "no.such.action", chord: "Control+P" }]),
+    );
+    client.on("evener/settings/keybindings/patch", (params) => overridesPayload(4, params.config.rules));
+    await wireClient(client, true);
+
+    // Composed the way the editor composes: raw rules with one swapped. The
+    // unknown-action warning is baseline (the current raw set already
+    // produces it), so it must NOT reject the edit.
+    const result = await keybindingsStore.getState().patchOverrides([
+      { action: "no.such.action", chord: "Control+P" },
+      { action: ACTIONS.composerFocus, chord: "Control+M" },
+    ]);
+
+    expect(result.revision).toBe(4);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 3,
+      config: {
+        version: 1,
+        rules: [
+          { action: "no.such.action", chord: "Control+P" },
+          { action: ACTIONS.composerFocus, chord: "Control+M" },
+        ],
+      },
+    });
+    // The preserved rule is still skipped (never applied) after the confirm.
+    expect(keybindingsStore.getState().rawOverrides).toEqual([
+      { action: "no.such.action", chord: "Control+P" },
+      { action: ACTIONS.composerFocus, chord: "Control+M" },
+    ]);
+    expect(keybindingsStore.getState().overrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+  });
+
+  test("baseline tolerance does NOT mask a conflict the edit itself introduces", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: "no.such.action", chord: "Control+P" }]),
+    );
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    // palette.open's default overlaps a strict Control+K claim: a NEW
+    // warning, not one the raw set already produces.
+    await expect(
+      keybindingsStore.getState().patchOverrides([
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.composerFocus, chord: "Control+K" },
+      ]),
+    ).rejects.toThrow(
+      `chord "Control+K" in scope "global" is already bound by "Open the command palette" (${ACTIONS.paletteOpen})`,
+    );
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+  });
+
+  test("the edited action's own invalid chord still rejects pre-flight alongside a preserved invalid rule", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: "no.such.action", chord: "Control+P" }]),
+    );
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.railToggle, chord: "Control+W" }, // reserved on this platform
+      ]),
+    ).rejects.toThrow('chord "Control+W" is reserved');
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: "no.such.action", chord: "Control+P" }]);
+  });
+});
+
+// The stale-hub window: replacing the client must not let the previous
+// hub's payload present as current (a PATCH composed from it would carry
+// the old expectedRevision and rules to the NEW hub), and the registry must
+// not keep firing the old hub's overrides one layer down.
+describe("keybindings store: client replacement (stale-hub window)", () => {
+  /** Replaces the wired client with one whose get never resolves: the
+   * refresh starts (hubLoading) but never lands, holding the store in the
+   * stale window. */
+  async function rewireToHangingClient(): Promise<FakeClient> {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => new Promise<KeybindingsOverrides>(() => {}));
+    connectionStore.getState().connect(client);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    return client;
+  }
+
+  async function wireClientAWithPaletteOverride(): Promise<FakeClient> {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(7, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(keybindingsStore.getState().revision).toBe(7);
+    expect(keybindingsStore.getState().loaded).toBe(true);
+    return client;
+  }
+
+  test("client replacement un-applies the old hub's overrides from the registry and resets the hub state", async () => {
+    await wireClientAWithPaletteOverride();
+
+    await rewireToHangingClient();
+
+    // Immediately - hub B's refresh is still in flight - the registry is
+    // back on defaults and the store carries none of hub A's payload.
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    const state = keybindingsStore.getState();
+    expect(state.revision).toBe(0);
+    expect(state.overrides).toEqual([]);
+    expect(state.rawOverrides).toEqual([]);
+    expect(state.warnings).toEqual([]);
+    expect(state.loaded).toBe(false);
+  });
+
+  test("a patch attempted in the stale window throws before any wire request", async () => {
+    await wireClientAWithPaletteOverride();
+    const clientB = await rewireToHangingClient();
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    ).rejects.toThrow(/unavailable/);
+
+    expect(clientB.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    // Hub A's override stays un-applied: the rejected patch changed nothing.
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("after the new hub's refresh lands, patching works with the NEW hub's revision and rules", async () => {
+    const clientA = await wireClientAWithPaletteOverride();
+
+    // Hub B holds its own state at a COLLIDING revision (the overwrite the
+    // stale window would have caused): the patch must compose from B's
+    // (empty) rule set with B's expectedRevision, never A's payload.
+    const clientB = new FakeClient("ready");
+    clientB.on("evener/settings/keybindings/get", () => overridesPayload(7, []));
+    clientB.on("evener/settings/keybindings/patch", (params) => overridesPayload(8, params.config.rules));
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+    await keybindingsStore.getState().refreshOverrides();
+
+    expect(keybindingsStore.getState().loaded).toBe(true);
+    const result = await keybindingsStore
+      .getState()
+      .patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(result.revision).toBe(8);
+    const patchCalls = clientB.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 7,
+      config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
+    });
+    // Hub A never saw a patch.
+    expect(clientA.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
   });
 });
 
@@ -571,5 +805,1345 @@ describe("keybindings store: hubError/conflict clear symmetry", () => {
 
     expect(keybindingsStore.getState().conflict).toBe("revision conflict");
     expect(keybindingsStore.getState().hubError).toBe("revision conflict");
+  });
+});
+
+describe("keybindings store: atomic un-apply", () => {
+  /** Replaces the wired client with one whose get never resolves: the
+   * refresh starts (hubLoading) but never lands. Same shape as the
+   * stale-window describe's helper. */
+  async function rewireToHangingClient(): Promise<FakeClient> {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => new Promise<KeybindingsOverrides>(() => {}));
+    connectionStore.getState().connect(client);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    return client;
+  }
+
+  test("client replacement un-applies a reclaimed-chord pair atomically", async () => {
+    // Payload 1 is legal via freed-chord reclaim: palette.open moves away,
+    // rail.toggle claims palette.open's default chord. Restoring BOTH on
+    // un-apply needs the two-phase unwind: restoring palette.open while
+    // rail.toggle's override still squats its default chord throws.
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        { action: ACTIONS.railToggle, chord: paletteDefault },
+      ]),
+    );
+    await wireClient(clientA, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+
+    await rewireToHangingClient();
+
+    // BOTH actions are back at their defaults: no orphaned override binding.
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([
+      ACTIONS.railToggle,
+      `${ACTIONS.railToggle}#mod-twin`,
+    ]);
+  });
+
+  test("a wedged unwind rolls the registry back, keeps the applied map, and never throws", async () => {
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    );
+    await wireClient(clientA, true);
+
+    // Out-of-band wedge: free the override binding and squat palette.open's
+    // default chord with a foreign binding, so restoring the default throws.
+    keybindingsRegistry.getState().unregisterBinding(`${ACTIONS.paletteOpen}#override`);
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: paletteDefault,
+    });
+
+    // Client replacement's un-apply must NOT throw and must roll back: the
+    // registry keeps the wedged shape exactly.
+    const clientB = new FakeClient("ready");
+    let resolveGet: ((payload: KeybindingsOverrides) => void) | undefined;
+    clientB.on(
+      "evener/settings/keybindings/get",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolveGet = resolve;
+        }),
+    );
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen)).toEqual([]);
+    expect(keybindingsRegistry.getState().bindings.some((b) => b.id === "foreign.squatter")).toBe(true);
+
+    // Hub B's refresh lands an EMPTY payload. Because the applied map
+    // survived the rolled-back unwind, the reconcile RETRIES the restore of
+    // palette.open, hits the same wedge, rolls back, and surfaces hubError -
+    // the revision does not advance and the state never presents as loaded.
+    // (Had the unwind cleared the map, the empty payload would apply clean
+    // against the wedged registry and confirm revision 1.)
+    await waitFor(() => expect(resolveGet).toBeDefined());
+    resolveGet?.(overridesPayload(1, []));
+    await waitFor(() => expect(keybindingsStore.getState().hubError).not.toBeNull());
+
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().loaded).toBe(false);
+    expect(bindingsFor(ACTIONS.paletteOpen)).toEqual([]);
+    expect(keybindingsRegistry.getState().bindings.some((b) => b.id === "foreign.squatter")).toBe(true);
+  });
+});
+
+describe("keybindings store: patch gating", () => {
+  test("a patch attempted while a refresh is in flight throws before any wire request", async () => {
+    let pending: Promise<KeybindingsOverrides> | undefined;
+    let resolvePending: ((payload: KeybindingsOverrides) => void) | undefined;
+    const client = new FakeClient("ready");
+    client.on(
+      "evener/settings/keybindings/get",
+      () => pending ?? overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    client.on("evener/settings/keybindings/patch", (params) => overridesPayload(2, params.config.rules));
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().loaded).toBe(true);
+
+    // A refresh is in flight (hubLoading): its payload can land at ANY
+    // revision, so a concurrent PATCH's expectedRevision would race it.
+    pending = new Promise<KeybindingsOverrides>((resolve) => {
+      resolvePending = resolve;
+    });
+    const refresh = keybindingsStore.getState().refreshOverrides();
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    ).rejects.toThrow(/unavailable/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    // The rejection applies to the CURRENT generation (the loading-window
+    // race), so hubError still surfaces: the fence's throw-only posture is
+    // only for writes whose generation has ended (finding 22).
+    expect(keybindingsStore.getState().hubError).toBe("Hub keybindings settings are unavailable.");
+
+    resolvePending?.(overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await refresh;
+    expect(keybindingsStore.getState().hubLoading).toBe(false);
+  });
+});
+
+describe("keybindings store: character-key pref in the restore simulation", () => {
+  /** What the cheatsheetController does while the pref is off. */
+  function turnCharacterKeyPrefOff(): void {
+    prefsStore.setState({ characterKeyTriggers: false });
+    keybindingsRegistry.getState().unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+  }
+
+  function wireCharacterKeyPayload(): Promise<FakeClient> {
+    // composer.focus takes "Shift+?" (the character-key chord with a
+    // REQUIRED shift); cheatsheet.toggle moves to Control+Slash. With the
+    // pref OFF there is no "?" binding to conflict with, so this payload
+    // must apply clean.
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [
+        { action: ACTIONS.composerFocus, chord: "Shift+?" },
+        { action: ACTIONS.cheatsheetToggle, chord: "Control+Slash" },
+      ]),
+    );
+    client.on("evener/settings/keybindings/patch", (params) => overridesPayload(2, params.config.rules));
+    return wireClient(client, true).then(() => client);
+  }
+
+  test("with the pref off, resetting cheatsheet.toggle past a composer Shift+? override is accepted", async () => {
+    turnCharacterKeyPrefOff();
+    const client = await wireCharacterKeyPayload();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(1);
+
+    // The Reset: the PATCH payload drops cheatsheet.toggle's override, so
+    // its defaults restore. The restore simulation must mirror the pref -
+    // with the "?" trigger absent from the live registry, the restored set
+    // must not claim it either, so it cannot phantom-conflict with the
+    // composer override that survives the patch.
+    const result = await keybindingsStore
+      .getState()
+      .patchOverrides([{ action: ACTIONS.composerFocus, chord: "Shift+?" }]);
+    expect(result.revision).toBe(2);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1);
+    expect(serializeChord(bindingsFor(ACTIONS.cheatsheetToggle)[0]?.chord ?? [])).toBe("Control+/");
+  });
+
+  test("with the pref on, the same reset still rejects: the restored ? binding would conflict", async () => {
+    const client = await wireCharacterKeyPayload();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+
+    // Pref ON: the restore legitimately reclaims "?", which overlaps the
+    // surviving composer Shift+? - the preflight must still reject.
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Shift+?" }]),
+    ).rejects.toThrow(/already bound by/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+
+  test("with the pref off, a hub notification that drops an override restores defaults WITHOUT reclaiming the ? trigger", async () => {
+    // Pref off BEFORE the initial load: railToggle holds "Shift+?" (the
+    // character-key chord with a required shift), cheatsheet.toggle is
+    // overridden away. Both validate clean because the "?" entry is absent.
+    turnCharacterKeyPrefOff();
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [
+        { action: ACTIONS.cheatsheetToggle, chord: "Control+Shift+/" },
+        { action: ACTIONS.railToggle, chord: "Shift+?" },
+      ]),
+    );
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+
+    // The notification drops cheatsheet.toggle's override, so its defaults
+    // restore. The restore MUTATION must mirror the pref just like the
+    // preflight does: re-registering "?" would exact-match railToggle's
+    // surviving "Shift+?" override ("[Shift]+?" and "Shift+?" both serialize
+    // "Shift+?") and registerBinding would throw, surfacing a hubError from
+    // a payload the preflight already accepted.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, [{ action: ACTIONS.railToggle, chord: "Shift+?" }]),
+    });
+
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(2);
+    expect(bindingsFor(ACTIONS.cheatsheetToggle).map((b) => b.id)).toEqual([
+      ACTIONS.cheatsheetToggle,
+      `${ACTIONS.cheatsheetToggle}#mod-twin`,
+    ]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+  });
+});
+
+describe("keybindings store: support loss", () => {
+  test("support resolving to UNSUPPORTED un-applies the hub's overrides from the registry", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The feature set is KNOWN and no longer advertises keybindings: the
+    // section claims "the built-in defaults are in effect", so the registry
+    // must stop firing the override.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+
+    expect(keybindingsStore.getState().hubSupport).toBe("unsupported");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("support loss against a WEDGED registry RETAINS the hub state with a retryable hubError, and the retry after unwedging resets", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The wedge: a foreign binding squatting palette.open's DEFAULT chord,
+    // so the un-apply's restore exact-matches, throws, and rolls back - the
+    // registry keeps firing the override. palette.open's default is $mod+K
+    // with legacyEitherMod, so the restored base serializes
+    // "Control+[Meta]+K" (Meta OPTIONAL) - the squatter must hold exactly
+    // that, not bare "Control+K".
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+
+    expect(keybindingsStore.getState().hubSupport).toBe("unsupported");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    // The store must not claim "defaults in effect" against live user
+    // behavior: the hub payload is RETAINED (it re-drives reconciliation
+    // once the wedge clears) and the error says so, retryably.
+    const retained = keybindingsStore.getState();
+    // loaded drops even on the rollback (finding 36): the retained payload
+    // is retained-but-UNCONFIRMED, so a changed-notification landing
+    // between a flap-back and its refresh must take the finding-25
+    // dirty-flag path instead of applying against the pre-flap state.
+    expect(retained.loaded).toBe(false);
+    // revision RESETS to 0 even on the rollback (finding 34): revision
+    // numbering is hub-scoped, and a retained old-hub revision would let
+    // the stale guard discard a flap-back refresh carrying a LOWER
+    // revision, stranding the rollback state. The raw set stays retained -
+    // it is what re-drives the retry.
+    expect(retained.revision).toBe(0);
+    expect(retained.rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(retained.hubError).toContain("still in effect");
+
+    // Unwedge; the next connection change re-runs the unsupported branch,
+    // the restore succeeds, and the drop proceeds exactly as on the clean
+    // path (the regression test above).
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+
+    const reset = keybindingsStore.getState();
+    expect(reset.hubError).toBeNull();
+    expect(reset.loaded).toBe(false);
+    expect(reset.revision).toBe(0);
+    expect(reset.rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a same-client reconnect serving a LOWER revision (hub restarted, state reset) applies authoritatively", async () => {
+    let payload = overridesPayload(5, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => payload);
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(keybindingsStore.getState().revision).toBe(5);
+
+    // The hub restarted behind the SAME client connection: its state file is
+    // fresh, so the reconnect's refresh legitimately serves revision 0. The
+    // ready flap invalidates the generation, and the revision baseline must
+    // reset with it - otherwise applyHubOverrides' stale guard rejects the
+    // authoritative payload on every refresh, the old shortcut stays live,
+    // and editing stays silently disabled (roborev PR #884 round 11). This
+    // is the finding-34 reset extended to the plain ready flap.
+    payload = overridesPayload(0, []);
+    client.emitStateChange("idle");
+    client.emitStateChange("ready");
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a support-loss rollback resets revision, so a LOWER-revision flap-back refresh applies and reconciles (finding 34)", async () => {
+    let payload = overridesPayload(5, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => payload);
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The wedge (a foreign binding squatting palette.open's default chord)
+    // rolls the support drop's un-apply back: the override keeps firing.
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    const rolled = keybindingsStore.getState();
+    expect(rolled.hubSupport).toBe("unsupported");
+    expect(rolled.hubError).toContain("still in effect");
+    expect(rolled.rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(rolled.revision).toBe(0);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // Unwedge, then flap back: the hub's state was reset elsewhere, so the
+    // refresh carries a LOWER revision than the pre-drop state. It must
+    // APPLY (not be eaten by the stale guard against the retained
+    // revision), clearing the rollback error and reconciling the registry.
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    payload = overridesPayload(2, []);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
+    expect(keybindingsStore.getState().revision).toBe(2);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a flap-back refresh with a HIGHER revision still applies after a support-loss rollback (regression)", async () => {
+    let payload = overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => payload);
+    await wireClient(client, true);
+
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(keybindingsStore.getState().hubError).toContain("still in effect");
+
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    payload = overridesPayload(7, []);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().revision).toBe(7));
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a notification landing between flap-back and its refresh is dropped to the dirty-flag path, and the refresh converges to the hub's truth (finding 36)", async () => {
+    let payload = overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    let pending: Promise<KeybindingsOverrides> | undefined;
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => pending ?? payload);
+    await wireClient(client, true);
+
+    // Wedge + support drop: the un-apply rolls back, retaining the payload
+    // UNCONFIRMED (loaded false) with revision reset.
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(keybindingsStore.getState().hubError).toContain("still in effect");
+    expect(keybindingsStore.getState().loaded).toBe(false);
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+
+    // Support returns; the flap-back refresh hangs in flight.
+    let resolveGet: ((p: KeybindingsOverrides) => void) | undefined;
+    pending = new Promise<KeybindingsOverrides>((resolve) => {
+      resolveGet = resolve;
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    // The hub changes the override to Control+Y (revision 4); the
+    // notification arrives BEFORE the refresh lands. With loaded false it
+    // must NOT apply against the pre-flap state - it marks the generation
+    // dirty instead.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    });
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The in-flight get's response PREDATES the change (revision 3): it
+    // confirms the state (loaded flips true) and the dirty flag fires ONE
+    // follow-up fetch, which lands the hub's truth (revision 4).
+    payload = overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]);
+    const getCalls = () => client.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+    resolveGet?.(overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    pending = undefined;
+    await waitFor(() => expect(keybindingsStore.getState().revision).toBe(4));
+    // wireClient's connect refresh + its explicit refreshOverrides, the
+    // flap-back refresh, and the dirty-flag follow-up. Without the finding-36
+    // gate the notification applies and no follow-up fires (3 calls).
+    expect(getCalls()).toBe(4);
+    expect(keybindingsStore.getState().loaded).toBe(true);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => serializeChord(b.chord))).toEqual(["Control+Y"]);
+  });
+
+  test("a notification landing AFTER the confirmed flap-back refresh applies normally (regression)", async () => {
+    let payload = overridesPayload(5, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => payload);
+    await wireClient(client, true);
+
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(keybindingsStore.getState().loaded).toBe(false);
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+
+    // Flap back; the refresh confirms revision 6, flipping loaded back.
+    payload = overridesPayload(6, []);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+    expect(keybindingsStore.getState().hubError).toBeNull();
+
+    // A notification on the CONFIRMED state applies directly.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(7, [{ action: ACTIONS.paletteOpen, chord: "Control+M" }]),
+    });
+    await waitFor(() => expect(keybindingsStore.getState().revision).toBe(7));
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+M" }]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => serializeChord(b.chord))).toEqual(["Control+M"]);
+  });
+
+  test("a transient disconnect of a SUPPORTED hub keeps the overrides applied", async () => {
+    // The ruled behavior, pinned: while a supported hub is temporarily
+    // unreachable the feature set is unknown, not contradicted - the rows
+    // show the overrides read-only and the chords keep firing.
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    connectionStore.setState({ state: "idle", features: undefined });
+
+    expect(keybindingsStore.getState().hubSupport).toBe("unknown");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(serializeChord(bindingsFor(ACTIONS.paletteOpen)[0]?.chord ?? [])).toBe("Control+P");
+  });
+});
+
+describe("keybindings store: support flap discards hub state", () => {
+  test("a lower-revision refresh after an unsupported flap is ACCEPTED, and edits compose from the new payload", async () => {
+    const client = new FakeClient("ready");
+    let current = overridesPayload(7, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    client.on("evener/settings/keybindings/get", () => current);
+    client.on("evener/settings/keybindings/patch", (params) =>
+      overridesPayload(params.expectedRevision + 1, params.config.rules),
+    );
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().revision).toBe(7);
+
+    // Support drops: the registry un-applies AND the hub payload state
+    // resets - a retained revision 7 would eat the returning hub's
+    // lower-revision refresh via the stale guard.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    const dropped = keybindingsStore.getState();
+    expect(dropped.hubSupport).toBe("unsupported");
+    expect(dropped.loaded).toBe(false);
+    expect(dropped.revision).toBe(0);
+    expect(dropped.overrides).toEqual([]);
+    expect(dropped.rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+
+    // The same hub returns at a LOWER revision (restored backup, reset
+    // state file): the refresh must not be discarded as stale.
+    current = overridesPayload(3, [{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+    expect(keybindingsStore.getState().revision).toBe(3);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+
+    // An edit composes from the NEW hub's payload with the NEW revision.
+    await keybindingsStore
+      .getState()
+      .patchOverrides([
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+      ]);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 3,
+      config: {
+        version: 1,
+        rules: [
+          { action: ACTIONS.composerFocus, chord: "Control+M" },
+          { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        ],
+      },
+    });
+  });
+
+  test("a changed notification arriving while UNSUPPORTED does not touch the registry or the store", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+
+    // A late notification from before the support drop must not re-install
+    // overrides into the registry that was just un-applied.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(9, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]),
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    const state = keybindingsStore.getState();
+    expect(state.revision).toBe(0);
+    expect(state.loaded).toBe(false);
+    expect(state.hubError).toBeNull();
+  });
+
+  test("a patch response landing after support loss does not apply", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const patch = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() => expect(resolvePatch).toBeDefined());
+
+    // Support drops while the PATCH is in flight: the response must not
+    // re-apply over the un-applied registry and reset hub state.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    const result = await patch;
+
+    expect(result.revision).toBe(0);
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a refresh rejecting after support loss leaves the state clean (no hubError)", async () => {
+    // The FIRST get lands normally; the second hangs so support can drop
+    // while the refresh is in flight.
+    const client = new FakeClient("ready");
+    let rejectGet: ((error: Error) => void) | undefined;
+    let hang = false;
+    client.on("evener/settings/keybindings/get", () => {
+      if (!hang) return overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+      return new Promise<KeybindingsOverrides>((_, reject) => {
+        rejectGet = reject;
+      });
+    });
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().loaded).toBe(true);
+
+    hang = true;
+    const refresh = keybindingsStore.getState().refreshOverrides();
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    // Support drops mid-flight: the cleanup un-applies and resets the hub
+    // state (hubLoading false, hubError null).
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    expect(keybindingsStore.getState().hubSupport).toBe("unsupported");
+    expect(keybindingsStore.getState().hubLoading).toBe(false);
+
+    // The in-flight refresh now rejects: the catch/finally must not
+    // overwrite the support-drop cleanup with a stale "could not load"
+    // hubError - the section claims the built-in defaults are in effect
+    // (finding 23).
+    rejectGet?.(new Error("socket went away"));
+    await refresh;
+
+    const state = keybindingsStore.getState();
+    expect(state.hubError).toBeNull();
+    expect(state.hubLoading).toBe(false);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+});
+
+// A support flap (supported -> unsupported -> supported, SAME client) begins
+// a new ready generation on the flap-BACK (finding 24): every token captured
+// under the pre-flap generation dies with it, while the new generation's own
+// refresh - fired after the bump - applies normally.
+describe("keybindings store: support flap generation fence", () => {
+  test("a patch response landing after a support flap is dropped, leaving the refreshed state", async () => {
+    const client = new FakeClient("ready");
+    let current = overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    client.on("evener/settings/keybindings/get", () => current);
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const patch = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]);
+    await waitFor(() => expect(resolvePatch).toBeDefined());
+
+    // The flap: down (un-apply + reset), then back - the hub now serves
+    // revision 5 with a DIFFERENT override, and the flap-back refresh lands
+    // it under the new generation.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    current = overridesPayload(5, [{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+    expect(keybindingsStore.getState().revision).toBe(5);
+
+    // The pre-flap patch's response lands now: composed against the pre-flap
+    // revision, it must not re-apply over the refreshed state.
+    resolvePatch?.(overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]));
+    const result = await patch;
+
+    expect(result.revision).toBe(5);
+    const state = keybindingsStore.getState();
+    expect(state.revision).toBe(5);
+    expect(state.rawOverrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("a write queued pre-flap rejects after the flap with no wire request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() =>
+      expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1),
+    );
+    // Write #2 queues behind the in-flight write, created under the pre-flap
+    // generation.
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    // The flap: the same client loses and regains support; the flap-back
+    // refresh (revision 1, empty) lands under the new generation.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+    // The first write's response is dropped (pre-flap generation); write #2
+    // must REJECT at the call-time fence - its generation ended with the
+    // flap - having sent no request, and (finding 22) without stamping
+    // hubError onto the refreshed state.
+    resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await first;
+    await expect(second).rejects.toThrow(/unavailable/);
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(1);
+  });
+
+  test("a notification landing in the post-flap pre-refresh window is dropped; the refresh and later notifications apply", async () => {
+    // The first get lands; the flap-back get hangs so a notification can
+    // arrive inside the post-flap pre-refresh window.
+    const client = new FakeClient("ready");
+    let resolveGet: ((value: KeybindingsOverrides) => void) | undefined;
+    let hang = false;
+    client.on("evener/settings/keybindings/get", () => {
+      if (!hang) return overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+      return new Promise<KeybindingsOverrides>((resolve) => {
+        resolveGet = resolve;
+      });
+    });
+    await wireClient(client, true);
+
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    hang = true;
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    // Pre-flap cargo (revision 9, higher than anything the returning hub
+    // will serve) lands before the new generation's refresh has confirmed
+    // state: dropped. Applied, it would also eat the refresh's lower-but-
+    // current revision 5 via the stale guard.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(9, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+    });
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().loaded).toBe(false);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([
+      ACTIONS.railToggle,
+      `${ACTIONS.railToggle}#mod-twin`,
+    ]);
+
+    // The new generation's own refresh is NOT fenced out by the transition
+    // bump: revision 5 applies ...
+    resolveGet?.(overridesPayload(5, [{ action: ACTIONS.composerFocus, chord: "Control+M" }]));
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+    expect(keybindingsStore.getState().revision).toBe(5);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+
+    // ... and post-refresh notifications apply normally.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(6, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+    });
+    expect(keybindingsStore.getState().revision).toBe(6);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+  });
+
+  test("a same-value support re-notification does NOT fence in-flight work", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const patch = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]);
+    await waitFor(() => expect(resolvePatch).toBeDefined());
+
+    // The features object is re-set with the SAME supported value: not a
+    // transition, so no generation bump - the in-flight patch's response
+    // must still apply.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    resolvePatch?.(overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+Y" }]));
+    const result = await patch;
+
+    expect(result.revision).toBe(4);
+    expect(keybindingsStore.getState().revision).toBe(4);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+  });
+});
+
+describe("keybindings store: write serialization", () => {
+  test("concurrent patches serialize: each composes expectedRevision and payload after the previous lands", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    client.on("evener/settings/keybindings/patch", (params) =>
+      overridesPayload(params.expectedRevision + 1, params.config.rules),
+    );
+    await wireClient(client, true);
+
+    // Two edits in the SAME tick. Both thunks compose against the raw set,
+    // but the second runs only after the first has fully landed, so it
+    // folds the first edit's confirmed payload in instead of racing it with
+    // the same expectedRevision (a self-inflicted conflict).
+    const first = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.paletteOpen, chord: "Control+P" },
+      ]);
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult.revision).toBe(2);
+    expect(secondResult.revision).toBe(3);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 1,
+      config: { version: 1, rules: [{ action: ACTIONS.paletteOpen, chord: "Control+P" }] },
+    });
+    expect(patchCalls[1]?.params).toEqual({
+      expectedRevision: 2,
+      config: {
+        version: 1,
+        rules: [
+          { action: ACTIONS.paletteOpen, chord: "Control+P" },
+          { action: ACTIONS.composerFocus, chord: "Control+M" },
+        ],
+      },
+    });
+    expect(keybindingsStore.getState().revision).toBe(3);
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+  });
+
+  test("a failed write does not block the queue: the next write runs against the post-failure state", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let failFirst = true;
+    client.on("evener/settings/keybindings/patch", (params) => {
+      if (failFirst) {
+        failFirst = false;
+        throw new Error("socket went away");
+      }
+      return overridesPayload(params.expectedRevision + 1, params.config.rules);
+    });
+    await wireClient(client, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    await expect(first).rejects.toThrow("socket went away");
+    // The first write failed WITHOUT touching the hub: the second still
+    // composes from revision 1 and lands.
+    const secondResult = await second;
+    expect(secondResult.revision).toBe(2);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(2);
+    expect(patchCalls[1]?.params).toEqual({
+      expectedRevision: 1,
+      config: { version: 1, rules: [{ action: ACTIONS.composerFocus, chord: "Control+M" }] },
+    });
+  });
+});
+
+// A queued write is fenced to the ready generation it was CREATED under:
+// compose-at-execution (finding 16) is right within one generation, but a
+// write whose generation ended while it queued carries edit intent made
+// against the hub the user was looking at - it must die with that
+// generation, never land on the new hub.
+describe("keybindings store: write generation fence", () => {
+  test("a write queued behind an in-flight write rejects after a mid-flight client replacement, with no wire request to the new hub", async () => {
+    // Hub A: get lands immediately; the PATCH hangs so a second write queues.
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatchA: ((value: KeybindingsOverrides) => void) | undefined;
+    clientA.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatchA = resolve;
+        }),
+    );
+    await wireClient(clientA, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() =>
+      expect(clientA.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1),
+    );
+    // Write #2 queues behind the in-flight write, created while hub A's
+    // state is the displayed state.
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    // The client is replaced mid-flight: hub B loads cleanly at revision 1.
+    const clientB = new FakeClient("ready");
+    clientB.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    clientB.on("evener/settings/keybindings/patch", (params) =>
+      overridesPayload(params.expectedRevision + 1, params.config.rules),
+    );
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+    // A's hanging PATCH resolves: its response must not apply (the
+    // post-response staleness branch), and write #2 - created under A's
+    // generation - must REJECT with the unavailable-class error having sent
+    // NO request to B. Without the call-time fence, run #2 would recompute
+    // against B's now-loaded state, pass every execution-time guard, and
+    // land the A-era edit on B.
+    resolvePatchA?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await first;
+    await expect(second).rejects.toThrow(/unavailable/);
+
+    expect(clientB.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    expect(keybindingsStore.getState().revision).toBe(1);
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  test("the fence rejection leaves the NEW hub's clean state untouched: no hubError, still editable", async () => {
+    // Same setup as the fence test: write #2 queues behind A's hanging
+    // PATCH, the client is replaced mid-flight, hub B loads cleanly.
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatchA: ((value: KeybindingsOverrides) => void) | undefined;
+    clientA.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatchA = resolve;
+        }),
+    );
+    await wireClient(clientA, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() =>
+      expect(clientA.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1),
+    );
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    const clientB = new FakeClient("ready");
+    clientB.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    clientB.on("evener/settings/keybindings/patch", (params) =>
+      overridesPayload(params.expectedRevision + 1, params.config.rules),
+    );
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
+
+    resolvePatchA?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await first;
+    await expect(second).rejects.toThrow(/unavailable/);
+
+    // The rejection belonged to the DEAD generation: setting hubError would
+    // land "settings are unavailable" on hub B's freshly-loaded state, and
+    // the round-3 editing gate would read the clean new hub read-only until
+    // something cleared it (finding 22). hubError stays null ...
+    const state = keybindingsStore.getState();
+    expect(state.hubError).toBeNull();
+    expect(state.loaded).toBe(true);
+    // ... and the new hub stays editable: a fresh write under B's generation
+    // composes and lands.
+    const result = await keybindingsStore
+      .getState()
+      .patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(result.revision).toBe(2);
+  });
+
+  // The same-generation half is pinned by "concurrent patches serialize"
+  // (write serialization describe): two writes created in one tick under one
+  // generation both land in order - the fence must not reject them.
+});
+
+// A characterKeyTriggers flip re-validates the persisted rules against the
+// new pref: the simulation treats the "?" entry as pref-authoritative (the
+// re-apply runs in the flip instant, before the controller's reconcile has
+// re-registered/unregistered it), so a rule skipped under one pref applies
+// under the other - and vice versa - with the warnings list following.
+describe("keybindings store: pref flips re-validate persisted overrides", () => {
+  test("a Shift+? override skipped while the pref is on applies when the pref flips off, and is skipped again when it flips back on", async () => {
+    // Pref ON (default), "?" live: the claim conflicts with the built-in
+    // trigger and is skipped with a conflict warning.
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.composerFocus, chord: "Shift+?" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([
+      ACTIONS.composerFocus,
+      `${ACTIONS.composerFocus}#mod-twin`,
+    ]);
+    const skipped = keybindingsStore.getState().warnings;
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.reason).toBe("conflict");
+    expect(skipped[0]?.conflictWith).toBe(ACTIONS.cheatsheetToggle);
+    // The RAW set retains the skipped rule - it is still the hub's state.
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Shift+?" }]);
+
+    // Pref OFF: the re-apply simulates "?" as absent (it is still live in
+    // the registry for this instant - the controller's reconcile has not
+    // unregistered it yet, and in this test file no reconcile is installed
+    // at all), so the claim validates clean and APPLIES; the warning clears.
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Shift+?" }]);
+
+    // Pref ON again: symmetric - the claim stops validating (the simulated
+    // map claims "?" again), the restore wins, and the warning returns.
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([
+      ACTIONS.composerFocus,
+      `${ACTIONS.composerFocus}#mod-twin`,
+    ]);
+    const reskipped = keybindingsStore.getState().warnings;
+    expect(reskipped).toHaveLength(1);
+    expect(reskipped[0]?.reason).toBe("conflict");
+    expect(reskipped[0]?.conflictWith).toBe(ACTIONS.cheatsheetToggle);
+  });
+
+  test("a pref flip with no ?-related overrides changes nothing", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    const before = bindingsFor(ACTIONS.paletteOpen);
+    expect(before.map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    prefsStore.getState().setCharacterKeyTriggers(true);
+
+    // Same effective map - same binding OBJECTS, nothing torn down - and no
+    // warnings appeared.
+    expect(bindingsFor(ACTIONS.paletteOpen)).toEqual(before);
+    expect(bindingsFor(ACTIONS.paletteOpen)[0]).toBe(before[0]);
+    expect(keybindingsStore.getState().warnings).toEqual([]);
+    expect(keybindingsStore.getState().overrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(keybindingsStore.getState().revision).toBe(1);
+  });
+});
+
+// A changed-notification dropped by the loaded gate during the INITIAL load
+// must not be lost (finding 25): the in-flight get's response may predate
+// the change, so the drop marks the generation dirty and the refresh that
+// confirms its state fires ONE follow-up fetch.
+describe("keybindings store: notifications during the initial load", () => {
+  test("a notification dropped mid-initial-refresh is converged by one follow-up refresh", async () => {
+    // The FIRST get hangs so the notification lands inside the initial-load
+    // window; its resolved response (revision 3) PREDATES the change
+    // (revision 4) the notification announced. Follow-up gets serve the
+    // latest.
+    const client = new FakeClient("ready");
+    let resolveGet: ((value: KeybindingsOverrides) => void) | undefined;
+    let hang = true;
+    const current = overridesPayload(4, [{ action: ACTIONS.railToggle, chord: "Control+R" }]);
+    client.on("evener/settings/keybindings/get", () => {
+      if (hang)
+        return new Promise<KeybindingsOverrides>((resolve) => {
+          resolveGet = resolve;
+        });
+      return current;
+    });
+    connectionStore.getState().connect(client);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
+    await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
+
+    // The change arrives mid-load: dropped by the loaded gate (finding 24),
+    // marked dirty.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: current,
+    });
+
+    // The get's response predates the change: the store settles on revision
+    // 3 momentarily, then the follow-up fetch converges to revision 4.
+    // Delta-based: the wiring fires its own refresh(es) before this point,
+    // so the pin is exactly ONE additional get (the dirty-flag refetch).
+    const getsBefore = client.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+    hang = false;
+    resolveGet?.(overridesPayload(3, []));
+    await waitFor(() => expect(keybindingsStore.getState().revision).toBe(4));
+
+    const state = keybindingsStore.getState();
+    expect(state.loaded).toBe(true);
+    expect(state.hubLoading).toBe(false);
+    expect(state.rawOverrides).toEqual([{ action: ACTIONS.railToggle, chord: "Control+R" }]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/get")).toHaveLength(getsBefore + 1);
+  });
+
+  test("a notification arriving when loaded applies once, with no follow-up refresh", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    await wireClient(client, true);
+    const getsBefore = client.calls.filter((c) => c.method === "evener/settings/keybindings/get").length;
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+    });
+
+    expect(keybindingsStore.getState().revision).toBe(4);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+    // No drop, no dirty flag, no refetch: the new path must not double-apply.
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/get")).toHaveLength(getsBefore);
+  });
+});
+
+// A write rejected because support resolved to UNSUPPORTED throws WITHOUT
+// setting hubError (finding 26): the unsupported state is deliberately
+// clean - the section says the built-in defaults are in effect - and the
+// write no longer owns it. Both orderings: queued while supported and
+// executing after the drop, and composed while unsupported.
+describe("keybindings store: unsupported write rejection", () => {
+  test("rejection due to unsupported support leaves hubError null, whether queued across the drop or composed in it", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
+    client.on(
+      "evener/settings/keybindings/patch",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolvePatch = resolve;
+        }),
+    );
+    await wireClient(client, true);
+
+    const first = keybindingsStore.getState().patchOverrides([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    await waitFor(() =>
+      expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1),
+    );
+    // Write #2 queues behind the in-flight write, created while supported.
+    const second = keybindingsStore
+      .getState()
+      .patchOverrides(() => [
+        ...keybindingsStore.getState().rawOverrides,
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]);
+
+    // Support drops (no flap-back): a plain unsupported transition does not
+    // bump the generation, so write #2 reaches the guard - and rejects via
+    // the unsupported branch, throwing without hubError.
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
+    resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await first;
+    await expect(second).rejects.toThrow(/unavailable/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+
+    // Composed while unsupported: the same clean rejection.
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow(/unavailable/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(1);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+  });
+});
+
+describe("keybindings store: rewire rollback retention (finding 32)", () => {
+  test("a wedged un-apply on client replacement retains the old hub's payload, resets revision, and reconciles after the wedge clears", async () => {
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const clientA = new FakeClient("ready");
+    clientA.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(clientA, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // Out-of-band wedge: squat palette.open's default chord with a foreign
+    // binding, so restoring the default during the rewire's un-apply throws
+    // and the unwind rolls back - the OLD hub's override keeps firing.
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: paletteDefault,
+    });
+
+    // Client B's refresh hangs, so the ONLY hubError in the first phase is
+    // the rewire's own rollback signal.
+    const clientB = new FakeClient("ready");
+    let resolveGet: ((payload: KeybindingsOverrides) => void) | undefined;
+    clientB.on(
+      "evener/settings/keybindings/get",
+      () =>
+        new Promise<KeybindingsOverrides>((resolve) => {
+          resolveGet = resolve;
+        }),
+    );
+    connectionStore.getState().connect(clientB);
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
+
+    const retained = keybindingsStore.getState();
+    // The display stays truthful: the payload that is STILL FIRING is the
+    // one shown (rawOverrides/overrides/warnings retained). revision resets
+    // to 0 regardless: revision sequences are per-hub, and carrying the old
+    // hub's revision would eat the new hub's lower revisions via
+    // applyHubOverrides' stale guard.
+    expect(retained.revision).toBe(0);
+    expect(retained.rawOverrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    // loaded still drops (invalidateReadyGeneration, pinned by the round-15
+    // wedged-unwind test): the retained payload is the OLD hub's, so editing
+    // must wait for the NEW hub's own confirmation - but the retained raw
+    // set keeps the display truthful about what is still firing.
+    expect(retained.loaded).toBe(false);
+    expect(retained.hubError).toContain("still in effect");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+
+    // The wedge clears; hub B's refresh lands an EMPTY payload. The intact
+    // applied map lets the reconcile restore palette.open's default.
+    keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+    await waitFor(() => expect(resolveGet).toBeDefined());
+    resolveGet?.(overridesPayload(1, []));
+    await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
+
+    expect(keybindingsStore.getState().revision).toBe(1);
+    expect(keybindingsStore.getState().rawOverrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
   });
 });

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -322,6 +322,77 @@ describe("keybindings store: patch", () => {
     ).rejects.toThrow(/unavailable/);
     expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
   });
+
+  // Pre-flight semantic validation (the parked 2b minor, made live by the
+  // settings editor): a rule the reconcile would skip is rejected BEFORE the
+  // hub write, with the validation layer's message.
+  test("a chord conflicting with a live binding is rejected pre-flight, without any hub request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    // palette.open's default (Control+[Meta]+K with its twin) overlaps a
+    // strict Control+K claim by another action.
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+K" }]),
+    ).rejects.toThrow(`chord "Control+K" in scope "global" is already bound by "${ACTIONS.paletteOpen}"`);
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    // A client-side authoring error is not hub-sourced: neither hubError nor
+    // conflict moves, and the registry is untouched.
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+  });
+
+  test("a platform-reserved chord is rejected pre-flight, without any hub request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    // Control+W is on the every-platform reserved list (the browser never
+    // delivers it to the page).
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+W" }]),
+    ).rejects.toThrow('chord "Control+W" is reserved');
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+
+  test("an unknown action is rejected pre-flight, without any hub request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: "no.such.action", chord: "Control+M" }]),
+    ).rejects.toThrow('unknown keybinding action "no.such.action"');
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+
+  test("a conflicting rule inside a larger payload rejects the whole patch pre-flight", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, true);
+
+    // The editor submits the FULL desired rule set; two rules claiming the
+    // same chord must not reach the hub at all.
+    await expect(
+      keybindingsStore.getState().patchOverrides([
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+        { action: ACTIONS.nextNeedsYou, chord: "Control+M" },
+      ]),
+    ).rejects.toThrow("already bound by");
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+    expect(bindingsFor(ACTIONS.nextNeedsYou)).toHaveLength(2);
+  });
 });
 
 describe("keybindings store: reconcile resilience", () => {
@@ -429,5 +500,76 @@ describe("keybindings store: reconcile resilience", () => {
     expect(() => resetKeybindingsStoreForTests()).not.toThrow();
     expect(keybindingsStore.getState().revision).toBe(0);
     expect(keybindingsStore.getState().overrides).toEqual([]);
+  });
+});
+
+describe("keybindings store: hubError/conflict clear symmetry", () => {
+  // The parked 2b asymmetry: conflict was cleared ONLY by a successful patch
+  // while hubError cleared on any successful apply, so a revision-race notice
+  // outlived the state it described. Both now clear together.
+  async function stageConflict(client: FakeClient): Promise<void> {
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => {
+      throw new WireError("revision conflict", -32013, {
+        evenerErrorInfo: "conflict",
+        current: overridesPayload(6, []),
+      });
+    });
+    await wireClient(client, true);
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow("revision conflict");
+    expect(keybindingsStore.getState().conflict).toBe("revision conflict");
+    expect(keybindingsStore.getState().hubError).toBe("revision conflict");
+  }
+
+  test("a successful changed notification after a conflict clears BOTH conflict and hubError", async () => {
+    const client = new FakeClient("ready");
+    await stageConflict(client);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(7, []),
+    });
+
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(7);
+  });
+
+  test("a successful refresh after a conflict clears BOTH conflict and hubError", async () => {
+    const client = new FakeClient("ready");
+    await stageConflict(client);
+    client.on("evener/settings/keybindings/get", () => overridesPayload(7, []));
+
+    await keybindingsStore.getState().refreshOverrides();
+
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+  });
+
+  test("a support drop after a conflict clears BOTH conflict and hubError", async () => {
+    const client = new FakeClient("ready");
+    await stageConflict(client);
+
+    // The connection losing its feature set (disconnect/reconnect without
+    // the feature) makes the conflict notice as stale as hubError.
+    connectionStore.setState({ features: undefined });
+
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(keybindingsStore.getState().hubError).toBeNull();
+  });
+
+  test("a stale changed notification (older revision) clears NEITHER conflict nor hubError", async () => {
+    const client = new FakeClient("ready");
+    await stageConflict(client);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, []),
+    });
+
+    expect(keybindingsStore.getState().conflict).toBe("revision conflict");
+    expect(keybindingsStore.getState().hubError).toBe("revision conflict");
   });
 });

--- a/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.test.ts
@@ -1,0 +1,433 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { ACTIONS } from "../keybindings/actions";
+import { serializeChord } from "../keybindings/chord";
+import { registerDefaultBindings } from "../keybindings/defaults";
+import { type Binding, keybindingsRegistry } from "../keybindings/registry";
+import { WireError } from "../protocol/errors";
+import { FakeClient } from "../protocol/testing/fakeClient";
+import type { KeybindingsOverrides, KeybindingsRule } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+import { keybindingsStore, resetKeybindingsStoreForTests } from "./keybindings";
+
+function resetRegistryToDefaults(): void {
+  for (const binding of keybindingsRegistry.getState().bindings) {
+    keybindingsRegistry.getState().unregisterBinding(binding.id);
+  }
+  registerDefaultBindings(keybindingsRegistry);
+}
+
+function bindingsFor(actionId: string): Binding[] {
+  return keybindingsRegistry.getState().bindings.filter((b) => b.actionId === actionId);
+}
+
+function overridesPayload(revision: number, rules: KeybindingsRule[]): KeybindingsOverrides {
+  return { version: 1, revision, rules };
+}
+
+function defaultChordOf(bindingId: string): string {
+  const binding = keybindingsRegistry.getState().bindings.find((b) => b.id === bindingId);
+  if (binding === undefined) throw new Error(`test setup: no binding ${bindingId}`);
+  return serializeChord(binding.chord);
+}
+
+async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
+  connectionStore.getState().connect(client);
+  connectionStore.setState({
+    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  });
+  await keybindingsStore.getState().refreshOverrides();
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+});
+
+afterEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, features: undefined, client: null });
+  resetKeybindingsStoreForTests();
+  resetRegistryToDefaults();
+  vi.restoreAllMocks();
+});
+
+describe("keybindings store: startup", () => {
+  test("a GET carrying loadError applies the fallback rules but lands hubError so editing stays read-only", async () => {
+    // The hub's persisted state failed to load: rules are the shipped-default
+    // fallback (what is actually in effect), loadError is the diagnostic. The
+    // store must show the fallback AND keep the editing gate closed - PATCH
+    // rejects in this state, so a writable editor would fail every save
+    // (roborev PR #884 round 6).
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => ({
+      ...overridesPayload(0, []),
+      loadError: "keybindings state is unavailable: decode keybindings state: unexpected end",
+    }));
+    await wireClient(client, true);
+
+    expect(keybindingsStore.getState().loaded).toBe(true);
+    expect(keybindingsStore.getState().hubError).toBe(
+      "keybindings state is unavailable: decode keybindings state: unexpected end",
+    );
+    // A repeat refresh re-carries the diagnostic: no flap back to writable.
+    await keybindingsStore.getState().refreshOverrides();
+    expect(keybindingsStore.getState().hubError).not.toBeNull();
+  });
+
+  test("applies the hub overrides to the registry on connect", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+
+    const bindings = bindingsFor(ACTIONS.paletteOpen);
+    expect(bindings).toHaveLength(1);
+    expect(bindings[0]?.id).toBe(`${ACTIONS.paletteOpen}#override`);
+    expect(serializeChord(bindings[0]?.chord ?? [])).toBe("Control+P");
+
+    const state = keybindingsStore.getState();
+    expect(state.hubSupport).toBe("supported");
+    expect(state.revision).toBe(3);
+    expect(state.overrides).toEqual([{ action: ACTIONS.paletteOpen, chord: "Control+P" }]);
+    expect(state.warnings).toEqual([]);
+    expect(state.hubError).toBeNull();
+  });
+
+  test("defaults only when the server predates the feature: no request, unsupported state, no crash", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    await wireClient(client, false);
+
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/get")).toHaveLength(0);
+    expect(keybindingsStore.getState().hubSupport).toBe("unsupported");
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("an unreachable hub surfaces hubError and leaves defaults in place", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => {
+      throw new Error("socket went away");
+    });
+    await wireClient(client, true);
+
+    expect(keybindingsStore.getState().hubError).toBe("socket went away");
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  test("malformed get payloads surface hubError and leave defaults in place", async () => {
+    const client = new FakeClient("ready");
+    client.on(
+      "evener/settings/keybindings/get",
+      () => ({ version: 2, revision: "three", rules: "nope" }) as unknown as KeybindingsOverrides,
+    );
+    await wireClient(client, true);
+
+    expect(keybindingsStore.getState().hubError).not.toBeNull();
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(2);
+  });
+
+  test("semantically invalid rules are skipped with warnings; valid rules still apply", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(2, [
+        { action: "no.such.action", chord: "Control+P" },
+        { action: ACTIONS.railToggle, chord: "Control+W" }, // reserved on this platform
+        { action: ACTIONS.composerFocus, chord: "Control+M" },
+      ]),
+    );
+    await wireClient(client, true);
+
+    const state = keybindingsStore.getState();
+    expect(state.warnings.map((w) => w.reason)).toEqual(["unknown-action", "reserved-chord"]);
+    expect(state.overrides).toEqual([{ action: ACTIONS.composerFocus, chord: "Control+M" }]);
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+    expect(bindingsFor(ACTIONS.railToggle)).toHaveLength(2);
+  });
+});
+
+describe("keybindings store: changed reconciliation", () => {
+  test("a changed notification rebinds the delta and leaves other bindings untouched (same object identity)", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    const untouched = bindingsFor(ACTIONS.railToggle);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, [{ action: ACTIONS.paletteOpen, chord: "Control+U" }]),
+    });
+
+    const bindings = bindingsFor(ACTIONS.paletteOpen);
+    expect(bindings).toHaveLength(1);
+    expect(serializeChord(bindings[0]?.chord ?? [])).toBe("Control+U");
+    // The delta discipline: rail.toggle's binding objects were never torn down.
+    expect(bindingsFor(ACTIONS.railToggle)).toEqual(untouched);
+    expect(bindingsFor(ACTIONS.railToggle)[0]).toBe(untouched[0]);
+    expect(keybindingsStore.getState().revision).toBe(4);
+  });
+
+  test("a changed notification that drops an override restores the action's defaults", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(3, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(1);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(4, []),
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    expect(keybindingsStore.getState().overrides).toEqual([]);
+    expect(keybindingsStore.getState().revision).toBe(4);
+  });
+
+  test("a changed notification can unbind an action (chord null)", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
+    await wireClient(client, true);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: null }]),
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen)).toHaveLength(0);
+    expect(keybindingsStore.getState().overrides).toEqual([{ action: ACTIONS.paletteOpen, chord: null }]);
+  });
+
+  test("a stale changed notification (older revision) is ignored", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(5, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, []),
+    });
+
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(keybindingsStore.getState().revision).toBe(5);
+  });
+});
+
+describe("keybindings store: patch", () => {
+  test("sends expectedRevision and applies the canonical response", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    const requested: KeybindingsRule[] = [{ action: ACTIONS.composerFocus, chord: "Control+M" }];
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, requested));
+    await wireClient(client, true);
+
+    const result = await keybindingsStore.getState().patchOverrides(requested);
+
+    expect(result.revision).toBe(4);
+    const patchCalls = client.calls.filter((c) => c.method === "evener/settings/keybindings/patch");
+    expect(patchCalls).toHaveLength(1);
+    expect(patchCalls[0]?.params).toEqual({
+      expectedRevision: 3,
+      config: { version: 1, rules: requested },
+    });
+    expect(bindingsFor(ACTIONS.composerFocus).map((b) => b.id)).toEqual([`${ACTIONS.composerFocus}#override`]);
+    expect(keybindingsStore.getState().revision).toBe(4);
+    expect(keybindingsStore.getState().conflict).toBeNull();
+  });
+
+  test("a revision conflict refreshes to the server's current state and surfaces the conflict", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => {
+      throw new WireError("revision conflict", -32013, {
+        evenerErrorInfo: "conflict",
+        current: overridesPayload(6, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+      });
+    });
+    await wireClient(client, true);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow("revision conflict");
+
+    const state = keybindingsStore.getState();
+    expect(state.revision).toBe(6);
+    expect(state.conflict).toBe("revision conflict");
+    expect(state.hubError).toBe("revision conflict");
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+  });
+
+  test("a non-conflict patch failure surfaces hubError and changes nothing", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => {
+      throw new WireError("state unavailable", -32014);
+    });
+    await wireClient(client, true);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow("state unavailable");
+
+    expect(keybindingsStore.getState().hubError).toBe("state unavailable");
+    expect(keybindingsStore.getState().conflict).toBeNull();
+    expect(bindingsFor(ACTIONS.composerFocus)).toHaveLength(2);
+  });
+
+  test("a post-rename durable failure applies the carried canonical state instead of surfacing hubError", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => {
+      throw new WireError("sync keybindings state directory: boom", -32603, {
+        evenerErrorInfo: "keybindingsPostRename",
+        applied: overridesPayload(4, [{ action: ACTIONS.railToggle, chord: "Control+R" }]),
+      });
+    });
+    await wireClient(client, true);
+
+    // The hub's rename already published the patch; only a follow-up durable
+    // step failed. The error carries the applied canonical state, so the
+    // write resolves as APPLIED - a blocking hubError here would disable
+    // editing over bindings that are already live (roborev PR #884 round 2).
+    const result = await keybindingsStore
+      .getState()
+      .patchOverrides([{ action: ACTIONS.railToggle, chord: "Control+R" }]);
+
+    expect(result.revision).toBe(4);
+    expect(keybindingsStore.getState().hubError).toBeNull();
+    expect(keybindingsStore.getState().revision).toBe(4);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+  });
+
+  test("patch against an unsupported server throws without a request", async () => {
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () => overridesPayload(3, []));
+    client.on("evener/settings/keybindings/patch", () => overridesPayload(4, []));
+    await wireClient(client, false);
+
+    await expect(
+      keybindingsStore.getState().patchOverrides([{ action: ACTIONS.composerFocus, chord: "Control+M" }]),
+    ).rejects.toThrow(/unavailable/);
+    expect(client.calls.filter((c) => c.method === "evener/settings/keybindings/patch")).toHaveLength(0);
+  });
+});
+
+describe("keybindings store: reconcile resilience", () => {
+  test("dropping an override whose default chord was reclaimed degrades to a warning and restores every action", async () => {
+    // The reviewer's reproduction. Payload 1 is legal via freed-chord
+    // reclaim: palette.open moves away, rail.toggle claims its default chord.
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [
+        { action: ACTIONS.paletteOpen, chord: "Control+Y" },
+        { action: ACTIONS.railToggle, chord: paletteDefault },
+      ]),
+    );
+    await wireClient(client, true);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([`${ACTIONS.railToggle}#override`]);
+
+    // Payload 2 drops palette.open's override: restoring its default needs
+    // the chord rail.toggle is holding. The reconcile must not throw.
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, [{ action: ACTIONS.railToggle, chord: paletteDefault }]),
+    });
+
+    const state = keybindingsStore.getState();
+    expect(state.hubError).toBeNull();
+    expect(state.revision).toBe(2);
+    // The restore wins: the rule claiming the restored default's chord is
+    // skipped with a conflict warning, so BOTH actions fall back to their
+    // defaults and every action stays bound.
+    expect(state.warnings).toHaveLength(1);
+    expect(state.warnings[0]?.reason).toBe("conflict");
+    expect(state.warnings[0]?.rule).toEqual({ action: ACTIONS.railToggle, chord: paletteDefault });
+    expect(state.warnings[0]?.conflictWith).toBe(ACTIONS.paletteOpen);
+    expect(state.overrides).toEqual([]);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+    expect(bindingsFor(ACTIONS.railToggle).map((b) => b.id)).toEqual([
+      ACTIONS.railToggle,
+      `${ACTIONS.railToggle}#mod-twin`,
+    ]);
+  });
+
+  test("a reconcile failure on the changed path sets hubError, keeps the revision retryable, and rolls back", async () => {
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    expect(keybindingsStore.getState().revision).toBe(1);
+
+    // Out-of-band wedge: a foreign binding squats palette.open's default
+    // chord, so restoring it (when the override is dropped) conflicts with a
+    // binding no rule can be reassigned to.
+    keybindingsRegistry
+      .getState()
+      .registerBinding({ id: "foreign", actionId: "foreign.action", chord: paletteDefault });
+
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, []),
+    });
+
+    const failed = keybindingsStore.getState();
+    // Nothing escaped the notification dispatch; the failure is surfaced.
+    expect(failed.hubError).not.toBeNull();
+    // The revision did NOT advance past a failed apply...
+    expect(failed.revision).toBe(1);
+    // ...and the registry rolled back to its last good state.
+    const paletteBindings = bindingsFor(ACTIONS.paletteOpen);
+    expect(paletteBindings.map((b) => b.id)).toEqual([`${ACTIONS.paletteOpen}#override`]);
+    expect(serializeChord(paletteBindings[0]?.chord ?? [])).toBe("Control+P");
+
+    // Removing the wedge makes the SAME revision retryable (the stale guard
+    // did not eat it).
+    keybindingsRegistry.getState().unregisterBinding("foreign");
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, []),
+    });
+    const retried = keybindingsStore.getState();
+    expect(retried.hubError).toBeNull();
+    expect(retried.revision).toBe(2);
+    expect(bindingsFor(ACTIONS.paletteOpen).map((b) => b.id)).toEqual([
+      ACTIONS.paletteOpen,
+      `${ACTIONS.paletteOpen}#mod-twin`,
+    ]);
+  });
+
+  test("resetKeybindingsStoreForTests is safe after a wedging attempt", async () => {
+    const paletteDefault = defaultChordOf(ACTIONS.paletteOpen);
+    const client = new FakeClient("ready");
+    client.on("evener/settings/keybindings/get", () =>
+      overridesPayload(1, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    );
+    await wireClient(client, true);
+    keybindingsRegistry
+      .getState()
+      .registerBinding({ id: "foreign", actionId: "foreign.action", chord: paletteDefault });
+
+    expect(() => resetKeybindingsStoreForTests()).not.toThrow();
+    expect(keybindingsStore.getState().revision).toBe(0);
+    expect(keybindingsStore.getState().overrides).toEqual([]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -167,14 +167,18 @@ function applyHubOverrides(payload: KeybindingsOverrides): void {
   const state = keybindingsStore.getState();
   if (payload.revision < state.revision) return;
   applyOverrideRules(payload.rules);
-  // A successful apply also supersedes any earlier apply failure's hubError.
+  // A successful apply supersedes any earlier apply failure's hubError AND
+  // any earlier patch's revision-race conflict - the store is now confirmed
+  // at this payload either way. Clearing one without the other was the
+  // parked 2b asymmetry: a stale conflict notice outlived the state it
+  // described (only a successful PATCH cleared it).
   // A GET payload carrying loadError (the hub's persisted state failed to
   // load; the fallback defaults are in effect and PATCH rejects) maps onto
   // hubError so the editing gate stays CLOSED with the diagnostic showing,
   // instead of flapping writable-then-failing on every save (roborev PR
   // #884 round 6). Broadcasts and patch responses never carry it, so an
   // ordinary apply clears hubError exactly as before.
-  keybindingsStore.setState({ revision: payload.revision, hubError: payload.loadError ?? null });
+  keybindingsStore.setState({ revision: payload.revision, hubError: payload.loadError ?? null, conflict: null });
 }
 
 function currentSupport(): "unknown" | "supported" | "unsupported" {
@@ -225,8 +229,11 @@ function setSupportFromConnection(): void {
     if (state.hubSupport !== support) keybindingsStore.setState({ hubSupport: support });
     return;
   }
-  if (state.hubSupport !== support || state.hubLoading || state.hubError !== null)
-    keybindingsStore.setState({ hubSupport: support, hubLoading: false, hubError: null });
+  // The conflict notice clears with hubError here too (the 2b clear
+  // asymmetry): a support drop disconnects the store from the hub state the
+  // conflict described, so keeping it would be as stale as keeping hubError.
+  if (state.hubSupport !== support || state.hubLoading || state.hubError !== null || state.conflict !== null)
+    keybindingsStore.setState({ hubSupport: support, hubLoading: false, hubError: null, conflict: null });
 }
 
 function onNotification(notification: AnyNotification): void {
@@ -355,6 +362,21 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
       keybindingsStore.setState({ hubError: error });
       throw new Error(error);
     }
+    // Pre-flight semantic validation (the parked 2b minor the settings
+    // editor makes live): the SAME simulation the reconcile path runs on a
+    // confirmed payload, run BEFORE the hub write. A rule the reconcile
+    // would skip - unknown action, unparseable or platform-reserved chord,
+    // or a conflict on the simulated final map - would otherwise be accepted
+    // by the hub (the server validates structure only) and then silently not
+    // apply. Reject instead, with the validation layer's own message, and
+    // leave hubError/conflict untouched: nothing hub-sourced happened. The
+    // currently-applied set re-validates clean (it did at apply time and the
+    // reserved lists are platform-static), so a warning always names a rule
+    // this call introduced.
+    const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, new Set(appliedOverrides.keys()));
+    if (preflight.warnings.length > 0) {
+      throw new Error(preflight.warnings.map((warning) => warning.message).join("\n"));
+    }
     const token = ++patchSerial;
     try {
       const result = await client.request("evener/settings/keybindings/patch", {
@@ -368,7 +390,6 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
       const payload = fromWireOverrides(result);
       if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");
       applyHubOverrides(payload);
-      keybindingsStore.setState({ hubError: null, conflict: null });
       return payload;
     } catch (error) {
       if (token === patchSerial && isCurrentReady(client, generation)) {

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -16,6 +16,7 @@
 import { useStore } from "zustand";
 import { createStore, type StoreApi } from "zustand/vanilla";
 import { serializeChord } from "../keybindings/chord";
+import { CHARACTER_KEY_TRIGGER_BINDING_ID } from "../keybindings/defaults";
 import { rebindAction, removeActionBindings, restoreDefaultBinding } from "../keybindings/overrides";
 import { type Binding, keybindingsRegistry } from "../keybindings/registry";
 import { type OverrideRule, type ValidationWarning, validateOverrideRules } from "../keybindings/validation";
@@ -23,6 +24,7 @@ import { WireError } from "../protocol/errors";
 import type { AppwireClientLike } from "../protocol/testing/fakeClient";
 import type { AnyNotification, KeybindingsOverrides } from "../protocol/types.gen";
 import { connectionStore } from "./connection";
+import { prefsStore } from "./prefs";
 
 export interface KeybindingsStoreState {
   hubSupport: "unknown" | "supported" | "unsupported";
@@ -30,15 +32,40 @@ export interface KeybindingsStoreState {
   hubError: string | null;
   /** Revision of the last confirmed hub payload (0 = shipped defaults). */
   revision: number;
+  /** Bumps on every successful applyHubOverrides - a confirmed payload for
+   * the current generation. Row-level error clearing keys on this (finding
+   * 33): preflight and generation-fence rejections deliberately never set
+   * hubError, so the hubError transition alone cannot clear their errors. */
+  appliedSerial: number;
   /** The validated rules currently applied to the registry. */
   overrides: readonly OverrideRule[];
+  /** The hub payload's rules VERBATIM, before validation filtering. The
+   * editor composes whole-payload PATCHes from THIS set, not from
+   * `overrides`: a rule validation skips (an unknown action from a newer
+   * client, an unparseable chord) is still the hub's state, and a PATCH
+   * composed from the validated set would silently delete it. */
+  rawOverrides: readonly OverrideRule[];
   /** Semantic-validation warnings from the last applied payload. */
   warnings: readonly ValidationWarning[];
+  /** True only while the applied state (revision/overrides/rawOverrides and
+   * the registry's effective bindings) was confirmed by the hub for the
+   * CURRENT ready generation. Set on every successful payload apply; cleared
+   * when the ready generation ends (disconnect, client replacement, test
+   * reset). Editing and patchOverrides both gate on it: a PATCH composed
+   * from the previous hub's raw set with the previous hub's revision would
+   * overwrite the new hub's config on a revision collision. */
+  loaded: boolean;
   /** Set when a patch lost the revision race; the store has already refreshed
    * to the server's current state when this is non-null. */
   conflict: string | null;
   refreshOverrides(): Promise<void>;
-  patchOverrides(rules: readonly OverrideRule[]): Promise<KeybindingsOverrides>;
+  /** Writes SERIALIZE at the store: at most one PATCH is in flight, and each
+   * write runs only after the previous one has fully landed. Pass a THUNK
+   * to compose the whole-payload rule set at execution time (against the
+   * then-current rawOverrides) - a rules array composed at call time would
+   * race the in-flight write it queues behind: same expectedRevision, and a
+   * payload missing the first edit's confirmed change. */
+  patchOverrides(rules: readonly OverrideRule[] | (() => readonly OverrideRule[])): Promise<KeybindingsOverrides>;
 }
 
 function initialState(): Omit<KeybindingsStoreState, "refreshOverrides" | "patchOverrides"> {
@@ -47,8 +74,11 @@ function initialState(): Omit<KeybindingsStoreState, "refreshOverrides" | "patch
     hubLoading: false,
     hubError: null,
     revision: 0,
+    appliedSerial: 0,
     overrides: [],
+    rawOverrides: [],
     warnings: [],
+    loaded: false,
     conflict: null,
   };
 }
@@ -61,11 +91,85 @@ let activeReadyClient: AppwireClientLike | null = null;
 let activeReadyEpoch = -1;
 let refreshSerial = 0;
 let patchSerial = 0;
+/** Set when an un-apply rolled back against a wedged registry (findings 31
+ * and 32): the overrides are STILL firing, so the rollback hubError is not
+ * stale and refreshFor's entry clear must not wipe it. Cleared by the next
+ * successful apply (which reconciles the registry past the wedge) and by
+ * resetKeybindingsStoreForTests. */
+let unapplyRolledBack = false;
+/** Set when a changed-notification is dropped because the current
+ * generation has no confirmed state yet (finding 25): the refresh that
+ * lands the state may carry a response PREDATING the dropped change, so a
+ * successful refresh with the flag set fires ONE follow-up fetch. Per
+ * generation: beginReadyGeneration starts every generation clean. */
+let missedChangeNotification = false;
+/** The write-serialization chain: every patchOverrides queues behind the
+ * previous write's full settlement (success OR failure). Reset with the
+ * rest of the store's wiring state in resetKeybindingsStoreForTests so a
+ * never-resolving write cannot leak into the next test. */
+let writeQueue: Promise<void> = Promise.resolve();
 
 /** The action -> effective override (serialized chord, or null for an unbind)
  * currently applied to the registry. Module-level like the template's wiring
  * state: it describes the registry singleton, not store state. */
 const appliedOverrides = new Map<string, string | null>();
+
+/** Restores defaults for every applied override and clears the applied map:
+ * the registry must stop presenting a hub's overrides the moment that hub's
+ * state stops being current (client replacement, test reset) - that
+ * staleness one layer down is the same defect as a stale store payload.
+ * Atomic, mirroring applyOverrideRules: two-phase (strip every applied
+ * action's bindings first, THEN restore each default) so a chord that moved
+ * between two overridden actions never trips a transient conflict mid-unwind,
+ * and any throw rolls the registry back to its pre-unwind snapshot. On
+ * rollback the applied map stays INTACT - clearing it while the registry
+ * still holds overrides would detach the unwind bookkeeping from the
+ * registry, and the next reconcile's delta math would misread the wedged
+ * bindings. The reset itself never propagates (a wedged registry - a foreign
+ * binding squatting a default chord - must not make reset throw); the next
+ * reconcile or the next test's registry rebuild retries from the intact map.
+ *
+ * ORDERING (the cheatsheetController contract): this mutates the registry
+ * ONLY. Callers must fire any store setState - which is what the
+ * character-key reconcile subscribes to - AFTER this returns, so the
+ * reconcile sees the final shape (restore re-registers the conditional "?"
+ * entry with no knowledge of the pref; the reconcile then removes it if the
+ * pref is off).
+ *
+ * Returns false when the restore rolled back (the registry still holds the
+ * overrides and the applied map is intact), true otherwise - callers that
+ * discard the hub payload state after un-applying must NOT do so on false:
+ * the retained payload is the only thing that can re-drive reconciliation
+ * once the wedge clears (finding 31). */
+function unapplyAllOverrides(): boolean {
+  if (appliedOverrides.size === 0) return true;
+  const snapshot = keybindingsRegistry.getState().bindings;
+  try {
+    for (const action of appliedOverrides.keys()) removeActionBindings(keybindingsRegistry, action);
+    // Pref-aware like the reconcile's restore: while the character-key
+    // pref is off the conditional "?" entry is not re-registered (the
+    // cheatsheetController owns it), so the restore cannot collide with a
+    // user rule holding exactly [Shift]+? (finding 27).
+    for (const action of appliedOverrides.keys())
+      restoreDefaultBinding(keybindingsRegistry, action, {
+        characterKeyTriggers: prefsStore.getState().characterKeyTriggers,
+      });
+  } catch {
+    // See the doc comment: roll back, keep the applied map, never propagate.
+    rollbackBindings(snapshot);
+    return false;
+  }
+  appliedOverrides.clear();
+  return true;
+}
+
+/** Surfaced when support loss or a client rewire could not un-apply the
+ * overrides (the restore rolled back against a wedged registry): the
+ * overrides are still in effect and the hub payload state is RETAINED, so
+ * the next refresh or connection change - which re-runs the un-apply or
+ * reconciles from the intact applied map - gets a fresh attempt. */
+const UNAPPLY_ROLLED_BACK_MESSAGE =
+  "Could not restore the built-in default shortcuts: a conflicting binding is holding a default chord. This hub's keybinding overrides are still in effect; restoring retries on the next refresh or connection change.";
 
 /** Structural check for a wire payload (get result, changed params, patch
  * response, conflict `current`). The server's own validation already ran; this
@@ -119,7 +223,19 @@ function rollbackBindings(snapshot: readonly Binding[]): void {
  * state before propagating, so callers surface the failure with the last
  * good bindings intact. */
 function applyOverrideRules(rules: readonly OverrideRule[]): void {
-  const validated = validateOverrideRules(rules, keybindingsRegistry, undefined, new Set(appliedOverrides.keys()));
+  // The pref gates BOTH the restore simulation and the actual restore
+  // below (finding 27): with character-key triggers off the live registry
+  // has no "?" cheatsheet binding, so neither a simulated nor a real
+  // restore may claim one - a real restore registering it would collide
+  // with a user rule holding exactly [Shift]+? and throw mid-reconcile.
+  const characterKeyTriggers = prefsStore.getState().characterKeyTriggers;
+  const validated = validateOverrideRules(
+    rules,
+    keybindingsRegistry,
+    undefined,
+    new Set(appliedOverrides.keys()),
+    characterKeyTriggers,
+  );
   const next = new Map<string, string | null>();
   for (const rule of validated.rules) {
     next.set(rule.action, rule.chord === null ? null : serializeChord(rule.chord));
@@ -139,7 +255,7 @@ function applyOverrideRules(rules: readonly OverrideRule[]): void {
         if (next.has(action)) {
           rebindAction(keybindingsRegistry, action, next.get(action) ?? null);
         } else {
-          restoreDefaultBinding(keybindingsRegistry, action);
+          restoreDefaultBinding(keybindingsRegistry, action, { characterKeyTriggers });
         }
       }
     } catch (error) {
@@ -167,18 +283,39 @@ function applyHubOverrides(payload: KeybindingsOverrides): void {
   const state = keybindingsStore.getState();
   if (payload.revision < state.revision) return;
   applyOverrideRules(payload.rules);
+  // The reconcile succeeded, so any rolled-back un-apply's wedge is cleared
+  // with it: the rollback hubError is now stale and may clear normally.
+  unapplyRolledBack = false;
   // A successful apply supersedes any earlier apply failure's hubError AND
   // any earlier patch's revision-race conflict - the store is now confirmed
   // at this payload either way. Clearing one without the other was the
   // parked 2b asymmetry: a stale conflict notice outlived the state it
   // described (only a successful PATCH cleared it).
-  // A GET payload carrying loadError (the hub's persisted state failed to
-  // load; the fallback defaults are in effect and PATCH rejects) maps onto
-  // hubError so the editing gate stays CLOSED with the diagnostic showing,
-  // instead of flapping writable-then-failing on every save (roborev PR
-  // #884 round 6). Broadcasts and patch responses never carry it, so an
-  // ordinary apply clears hubError exactly as before.
-  keybindingsStore.setState({ revision: payload.revision, hubError: payload.loadError ?? null, conflict: null });
+  // rawOverrides is retained VERBATIM (validation filtering already happened
+  // inside applyOverrideRules): an edit's whole-payload PATCH is composed
+  // from this set so a rule validation skips survives an unrelated edit.
+  // Only a successful reconcile advances it - a failed apply leaves the last
+  // good raw set beside the last good revision.
+  keybindingsStore.setState({
+    rawOverrides: payload.rules.map((rule) => ({ action: rule.action, chord: rule.chord })),
+    revision: payload.revision,
+    // Row-level error clearing keys on this bump (finding 33): preflight and
+    // generation-fence rejections deliberately never set hubError, so the
+    // hubError transition alone cannot clear a row error they left behind.
+    appliedSerial: state.appliedSerial + 1,
+    // Every call site is generation-guarded (refreshFor, the notification
+    // wrapper, patchOverrides), so a successful apply confirms the state for
+    // the CURRENT ready generation - editing and patching gate on this.
+    loaded: true,
+    // A GET payload carrying loadError (the hub's persisted state failed to
+    // load; the fallback defaults are in effect and PATCH rejects) maps onto
+    // hubError so the editing gate stays CLOSED with the diagnostic showing,
+    // instead of flapping writable-then-failing on every save (roborev PR
+    // #884 round 6). Broadcasts and patch responses never carry it, so an
+    // ordinary apply clears hubError exactly as before.
+    hubError: payload.loadError ?? null,
+    conflict: null,
+  });
 }
 
 function currentSupport(): "unknown" | "supported" | "unsupported" {
@@ -208,11 +345,22 @@ function invalidateReadyGeneration(): void {
   clientEpoch += 1;
   unwireNotification?.();
   unwireNotification = null;
+  // The ready generation that confirmed the loaded state just ended; nothing
+  // hub-sourced is current until the next generation's refresh lands. Reset
+  // the revision baseline WITH it: revision numbering is hub-scoped (finding
+  // 34 makes the same reset on the support-loss and rewire paths), and an
+  // automatic reconnect can be a hub RESTART serving a legitimately LOWER
+  // revision - applyHubOverrides' stale guard would otherwise reject that
+  // authoritative payload on every refresh, leaving the old hub's shortcuts
+  // live and editing silently disabled (roborev PR #884 round 11).
+  const state = keybindingsStore.getState();
+  if (state.loaded || state.revision !== 0) keybindingsStore.setState({ loaded: false, revision: 0 });
 }
 
 function beginReadyGeneration(client: AppwireClientLike): number {
   activeReadyClient = client;
   activeReadyEpoch = ++clientEpoch;
+  missedChangeNotification = false;
   const epoch = activeReadyEpoch;
   unwireNotification?.();
   unwireNotification = client.onNotification((notification) => {
@@ -226,18 +374,113 @@ function setSupportFromConnection(): void {
   const support = currentSupport();
   const state = keybindingsStore.getState();
   if (support === "supported") {
+    // A flap BACK from unsupported (finding 24): the pre-flap generation's
+    // in-flight work must not survive into the refreshed state - a patch
+    // response composed against the pre-flap revision, a queued write
+    // fenced at call time under the pre-flap generation, a notification
+    // dispatched before the transition. Begin a NEW ready generation on
+    // the transition (the clientEpoch bump fences all three paths; the
+    // notification rewire drops the old wrapper): isCurrentReady fails for
+    // every token captured pre-flap. The flap-back refresh trigger in
+    // onConnectionChange runs AFTER this and fires under the NEW epoch, so
+    // the new generation's own refresh is not fenced out by its own bump.
+    // Only the TRANSITION bumps: a same-value re-notification (hubSupport
+    // already "supported") and the unknown window (a transient disconnect
+    // keeps its state and its in-flight work) leave the generation intact.
+    // The DOWNWARD flap needs no bump: currentSupport() gates every path
+    // for the unsupported window itself, and refreshFor's entry guard
+    // refuses to run while unsupported.
+    if (state.hubSupport === "unsupported" && wiredClient !== null && activeReadyClient === wiredClient) {
+      beginReadyGeneration(wiredClient);
+    }
     if (state.hubSupport !== support) keybindingsStore.setState({ hubSupport: support });
     return;
   }
+  let unrestored = false;
+  if (support === "unsupported") {
+    // Support resolving to UNSUPPORTED is not the transient-disconnect case
+    // (a supported hub that is temporarily unreachable keeps its overrides
+    // firing - the ruled behavior): the feature set is KNOWN and does not
+    // advertise keybindings, so the settings section claims "the built-in
+    // defaults are in effect". The registry must match that claim. Un-apply
+    // BEFORE the setState - the character-key reconcile subscribes to the
+    // store and must see the final registry shape (see unapplyAllOverrides).
+    unrestored = !unapplyAllOverrides();
+    unapplyRolledBack = unrestored;
+  }
+  // The unsupported drop also discards the hub PAYLOAD state: retaining
+  // loaded/revision/rawOverrides across a flap would let a later supported
+  // reconnect's refresh be eaten by the stale guard (the retained revision
+  // can be HIGHER than the returning hub's - a restored backup, a reset
+  // state file) and would leave edits composing from the old hub's raw set
+  // with the old expectedRevision. EXCEPT when the un-apply rolled back:
+  // the registry still fires the overrides, so forgetting the payload would
+  // strand the section claiming "defaults in effect" against live user
+  // behavior with no way to re-drive reconciliation - retain the hub state
+  // and surface a retryable hubError instead (finding 31). The setState
+  // stays AFTER the registry mutation, per the reconcile ordering contract.
+  // Even on the rollback the REVISION resets (finding 34, aligned with the
+  // rewire path's finding 32): revision numbering is hub-scoped, so a
+  // retained old revision would let applyHubOverrides' stale guard silently
+  // discard a flap-back refresh carrying a LOWER revision (a restored
+  // backup, a reset state file), stranding the rollback state indefinitely.
+  // The raw set stays retained either way - it is what re-drives the retry.
+  // loaded drops too (finding 36, now fully aligned with the rewire path):
+  // the retained payload is retained-but-UNCONFIRMED - that is exactly what
+  // loaded means. Keeping it true would let a changed-notification landing
+  // between the flap-back and its refresh pass onNotification's loaded gate
+  // and apply against the pre-flap state, after which the authoritative
+  // refresh (revision possibly lower, or equal-but-different) is discarded
+  // by the stale guard - the notification's version stays unverified. With
+  // loaded false the notification takes the finding-25 dirty-flag path and
+  // the flap-back refresh is the confirmation point that flips loaded back.
+  const dropHubState =
+    support === "unsupported" &&
+    !unrestored &&
+    (state.loaded || state.revision !== 0 || state.overrides.length > 0 || state.rawOverrides.length > 0);
   // The conflict notice clears with hubError here too (the 2b clear
   // asymmetry): a support drop disconnects the store from the hub state the
   // conflict described, so keeping it would be as stale as keeping hubError.
-  if (state.hubSupport !== support || state.hubLoading || state.hubError !== null || state.conflict !== null)
-    keybindingsStore.setState({ hubSupport: support, hubLoading: false, hubError: null, conflict: null });
+  if (
+    state.hubSupport !== support ||
+    state.hubLoading ||
+    state.hubError !== null ||
+    state.conflict !== null ||
+    dropHubState
+  )
+    keybindingsStore.setState({
+      hubSupport: support,
+      hubLoading: false,
+      // A rolled-back un-apply's message survives the unknown window too
+      // (finding 32: a client swap re-runs this with support "unknown"
+      // before the new hub's features resolve, and the wedge it describes
+      // is still live in the registry).
+      hubError: unrestored || unapplyRolledBack ? UNAPPLY_ROLLED_BACK_MESSAGE : null,
+      conflict: null,
+      ...(dropHubState ? { loaded: false, revision: 0, overrides: [], rawOverrides: [], warnings: [] } : {}),
+      ...(unrestored ? { loaded: false, revision: 0 } : {}),
+    });
 }
 
 function onNotification(notification: AnyNotification): void {
   if (notification.method !== "evener/settings/keybindings/changed") return;
+  // A late notification landing during an unsupported window must not
+  // re-install overrides into a registry the support drop just un-applied.
+  if (currentSupport() !== "supported") return;
+  // A notification arriving before the CURRENT generation's refresh has
+  // confirmed state carries pre-refresh - potentially pre-flap - cargo
+  // (finding 24): its revision predates the flap, and applying it over the
+  // reset state would let the stale guard eat the in-flight refresh's
+  // older-but-current payload. Drop it; the refresh fetches the truth.
+  // Not lost, though (finding 25): mark the generation dirty so the
+  // refresh that confirms its state fires ONE follow-up fetch - the
+  // in-flight get's response may PREDATE the dropped change, and without
+  // the follow-up the store would settle on the older snapshot until the
+  // next unrelated refresh.
+  if (!keybindingsStore.getState().loaded) {
+    missedChangeNotification = true;
+    return;
+  }
   const payload = fromWireOverrides(notification.params);
   if (payload === undefined) return;
   try {
@@ -253,19 +496,34 @@ function onNotification(notification: AnyNotification): void {
 async function refreshFor(client: AppwireClientLike, epoch: number): Promise<void> {
   if (!isCurrentReady(client, epoch) || currentSupport() !== "supported") return;
   const serial = ++refreshSerial;
-  keybindingsStore.setState({ hubLoading: true, hubError: null });
+  keybindingsStore.setState({ hubLoading: true, ...(unapplyRolledBack ? {} : { hubError: null }) });
   try {
     const result = await client.request("evener/settings/keybindings/get", {});
     if (!isCurrentReady(client, epoch) || serial !== refreshSerial || currentSupport() !== "supported") return;
     const payload = fromWireOverrides(result);
     if (payload === undefined) throw new Error("Hub returned malformed keybindings overrides");
     applyHubOverrides(payload);
+    if (missedChangeNotification) {
+      // A changed-notification was dropped while this generation had no
+      // confirmed state (finding 25) and THIS get's response may predate
+      // it. One follow-up fetch converges: the serial guard makes any
+      // older in-flight refresh lose, and the flag is cleared FIRST so it
+      // cannot loop - a notification arriving after this load applies
+      // directly (loaded is now true) instead of re-arming the flag.
+      missedChangeNotification = false;
+      void refreshFor(client, epoch);
+    }
   } catch (error) {
-    if (isCurrentReady(client, epoch) && serial === refreshSerial) {
+    // currentSupport() is rechecked here as on the success path: a refresh
+    // rejecting after support was lost would otherwise overwrite the
+    // support-drop cleanup with a stale "could not load" hubError while the
+    // section claims the built-in defaults are in effect (finding 23).
+    if (isCurrentReady(client, epoch) && serial === refreshSerial && currentSupport() === "supported") {
       keybindingsStore.setState({ hubError: error instanceof Error ? error.message : String(error) });
     }
   } finally {
-    if (isCurrentReady(client, epoch) && serial === refreshSerial) keybindingsStore.setState({ hubLoading: false });
+    if (isCurrentReady(client, epoch) && serial === refreshSerial && currentSupport() === "supported")
+      keybindingsStore.setState({ hubLoading: false });
   }
 }
 
@@ -275,6 +533,28 @@ function rewireClient(client: AppwireClientLike): void {
   unwireReady?.();
   unwireReady = null;
   wiredClient = client;
+  // The loaded state belongs to the PREVIOUS hub. Until this client's
+  // refresh lands it must not present as current: a patch composed from the
+  // old raw set with the old expectedRevision can overwrite the new hub's
+  // config on a revision collision, and the registry firing the old hub's
+  // overrides is the same staleness one layer down. Un-apply first, THEN
+  // setState - the character-key reconcile subscribes to the store and must
+  // see the final registry shape (see unapplyAllOverrides). hubSupport is
+  // connection-sourced, not hub state, so it is left to
+  // setSupportFromConnection.
+  const unrestored = !unapplyAllOverrides();
+  unapplyRolledBack = unrestored;
+  if (!unrestored) {
+    keybindingsStore.setState({
+      revision: 0,
+      overrides: [],
+      rawOverrides: [],
+      warnings: [],
+      hubLoading: false,
+      hubError: null,
+      conflict: null,
+    });
+  }
   unwireReady = client.onReady(() => {
     const epoch = beginReadyGeneration(client);
     void refreshFor(client, epoch);
@@ -282,6 +562,25 @@ function rewireClient(client: AppwireClientLike): void {
   if (client.state === "ready") {
     const epoch = beginReadyGeneration(client);
     void refreshFor(client, epoch);
+  }
+  if (unrestored) {
+    // Finding 32 (mirror of finding 31's support-loss rollback): the restore
+    // rolled back against a wedged registry, so the OLD hub's overrides are
+    // still firing. Retain its confirmed payload (rawOverrides/overrides/
+    // warnings) so the display stays truthful and the new hub's incoming
+    // applies can reconcile from the intact applied map - but reset revision
+    // to 0: revision sequences are per-hub, and carrying the old hub's
+    // revision would eat the new hub's lower revisions via applyHubOverrides'
+    // stale guard. This setState comes AFTER the refresh kick above because
+    // refreshFor's entry clears hubError; when the refresh lands it either
+    // confirms (applyHubOverrides clears hubError) or re-fails the reconcile
+    // against the same wedge and surfaces its own hubError. hubLoading is
+    // left to the in-flight refresh.
+    keybindingsStore.setState({
+      revision: 0,
+      hubError: UNAPPLY_ROLLED_BACK_MESSAGE,
+      conflict: null,
+    });
   }
 }
 
@@ -311,6 +610,9 @@ function onConnectionChange(
     previous.features?.keybindingsSettings !== true &&
     state.client?.state === "ready"
   ) {
+    // setSupportFromConnection runs FIRST: on a flap-back it has already
+    // begun the new ready generation (finding 24), so this refresh belongs
+    // to the NEW epoch and is not fenced out by the transition bump.
     if (activeReadyClient === state.client) void refreshFor(state.client, activeReadyEpoch);
   }
 }
@@ -346,79 +648,181 @@ export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<Key
     if (client === null || client !== wiredClient || activeReadyClient !== client) return;
     await refreshFor(client, activeReadyEpoch);
   },
-  patchOverrides: async (rules): Promise<KeybindingsOverrides> => {
-    const state = keybindingsStore.getState();
-    const client = currentClient();
-    const generation = client === activeReadyClient ? activeReadyEpoch : -1;
-    if (
-      state.hubSupport !== "supported" ||
-      currentSupport() !== "supported" ||
-      client === null ||
-      client !== wiredClient ||
-      generation < 0 ||
-      client.state !== "ready"
-    ) {
-      const error = "Hub keybindings settings are unavailable.";
-      keybindingsStore.setState({ hubError: error });
-      throw new Error(error);
-    }
-    // Pre-flight semantic validation (the parked 2b minor the settings
-    // editor makes live): the SAME simulation the reconcile path runs on a
-    // confirmed payload, run BEFORE the hub write. A rule the reconcile
-    // would skip - unknown action, unparseable or platform-reserved chord,
-    // or a conflict on the simulated final map - would otherwise be accepted
-    // by the hub (the server validates structure only) and then silently not
-    // apply. Reject instead, with the validation layer's own message, and
-    // leave hubError/conflict untouched: nothing hub-sourced happened. The
-    // currently-applied set re-validates clean (it did at apply time and the
-    // reserved lists are platform-static), so a warning always names a rule
-    // this call introduced.
-    const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, new Set(appliedOverrides.keys()));
-    if (preflight.warnings.length > 0) {
-      throw new Error(preflight.warnings.map((warning) => warning.message).join("\n"));
-    }
-    const token = ++patchSerial;
-    try {
-      const result = await client.request("evener/settings/keybindings/patch", {
-        expectedRevision: state.revision,
-        config: { version: 1, rules: rules.map((rule) => ({ action: rule.action, chord: rule.chord })) },
-      });
-      if (token !== patchSerial || !isCurrentReady(client, generation)) {
-        const current = keybindingsStore.getState();
-        return { version: 1, revision: current.revision, rules: [...current.overrides] };
+  patchOverrides: (rulesOrCompose): Promise<KeybindingsOverrides> => {
+    // Fence the write to the ready generation it was CREATED under. A queued
+    // write executes only after the previous write settles, which can be
+    // after a rewire to a NEW hub: the thunk's compose-at-execution is right
+    // WITHIN one generation (finding 16), but a write whose generation has
+    // ended carries edit intent made against the hub whose state the user
+    // was looking at - landing it on the new hub's config is the wrong
+    // default even though the payload would compose cleanly there. It
+    // rejects with the same unavailable-class error instead, before any
+    // wire request.
+    const callClient = currentClient();
+    const callGeneration = callClient !== null && callClient === activeReadyClient ? activeReadyEpoch : -1;
+    const run = async (): Promise<KeybindingsOverrides> => {
+      // Compose at EXECUTION time: a thunk reads the raw set as the
+      // previous write left it, folding its confirmed payload into this
+      // write's rules instead of racing it.
+      const rules = typeof rulesOrCompose === "function" ? rulesOrCompose() : rulesOrCompose;
+      const state = keybindingsStore.getState();
+      const client = currentClient();
+      const generation = client === activeReadyClient ? activeReadyEpoch : -1;
+      // The call-time fence is checked SEPARATELY from the current-state
+      // guard below (finding 22): this write was created under a ready
+      // generation that has since ended, so the rejection belongs to a DEAD
+      // generation. Setting hubError here would land on the LIVING hub's
+      // freshly-loaded clean state - "Hub keybindings settings are
+      // unavailable" plus the round-3 editing gate would read the new hub
+      // read-only until something cleared it. Throw only.
+      if (callClient === null || callGeneration < 0 || !isCurrentReady(callClient, callGeneration)) {
+        throw new Error("Hub keybindings settings are unavailable.");
       }
-      const payload = fromWireOverrides(result);
-      if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");
-      applyHubOverrides(payload);
-      return payload;
-    } catch (error) {
-      if (token === patchSerial && isCurrentReady(client, generation)) {
-        // Post-rename durable failure: the patch APPLIED on the hub (the
-        // error carries the canonical applied state, and the broadcast
-        // reconciles every client). Apply locally and report success -
-        // surfacing hubError here would disable editing over bindings that
-        // are already live.
-        const applied = postRenameApplied(error);
-        if (applied !== undefined) {
-          applyHubOverrides(applied);
-          return applied;
-        }
-        const current = conflictCurrent(error);
-        if (current !== undefined) applyHubOverrides(current);
-        const message = error instanceof Error ? error.message : String(error);
-        keybindingsStore.setState({
-          hubError: message,
-          ...(current === undefined ? {} : { conflict: message }),
+      // Support resolved to UNSUPPORTED is the same hygiene class as the
+      // fence (finding 26): the unsupported state is deliberately clean -
+      // the section says the built-in defaults are in effect - and the
+      // write no longer owns it. A plain unsupported transition does not
+      // bump the generation (finding 24: currentSupport() gates the
+      // window), so a write QUEUED while supported can reach this point,
+      // as can one composed while unsupported. Both throw without hubError.
+      if (currentSupport() === "unsupported") {
+        throw new Error("Hub keybindings settings are unavailable.");
+      }
+      if (
+        state.hubSupport !== "supported" ||
+        state.loaded !== true ||
+        state.hubLoading ||
+        currentSupport() !== "supported" ||
+        client === null ||
+        client !== wiredClient ||
+        generation < 0 ||
+        client.state !== "ready"
+      ) {
+        // `loaded` is the defense-in-depth half of the editor's gate: the UI
+        // is not the store's contract, and a patch composed from a STALE
+        // generation's raw set (client replaced, refresh not yet landed) would
+        // send the old hub's expectedRevision and rules to the new hub.
+        // `hubLoading` is the same race WITHIN one generation: an in-flight
+        // refresh is about to land a payload whose revision may differ from
+        // the one a concurrent PATCH would send as expectedRevision.
+        const error = "Hub keybindings settings are unavailable.";
+        keybindingsStore.setState({ hubError: error });
+        throw new Error(error);
+      }
+      // Pre-flight semantic validation (the parked 2b minor the settings
+      // editor makes live): the SAME simulation the reconcile path runs on a
+      // confirmed payload, run BEFORE the hub write. A rule the reconcile
+      // would skip - unknown action, unparseable or platform-reserved chord,
+      // or a conflict on the simulated final map - would otherwise be accepted
+      // by the hub (the server validates structure only) and then silently not
+      // apply. Reject instead, with the validation layer's own message, and
+      // leave hubError/conflict untouched: nothing hub-sourced happened. The
+      // payload is composed from the hub's RAW rules (rawOverrides), so it can
+      // carry a PRESERVED rule validation skips - an unknown action from a
+      // newer client, say. That is a pre-existing condition, not a defect this
+      // call introduced: reject only on warnings the CURRENT raw set does not
+      // already produce, keyed by action+message (the baseline simulation runs
+      // against the same live registry and applied set, so a preserved rule
+      // reproduces its apply-time warning verbatim).
+      const applied = new Set(appliedOverrides.keys());
+      const pref = prefsStore.getState().characterKeyTriggers;
+      const baseline = validateOverrideRules(state.rawOverrides, keybindingsRegistry, undefined, applied, pref);
+      const baselineKeys = new Set(baseline.warnings.map((warning) => `${warning.rule.action} ${warning.message}`));
+      const preflight = validateOverrideRules(rules, keybindingsRegistry, undefined, applied, pref);
+      const introduced = preflight.warnings.filter(
+        (warning) => !baselineKeys.has(`${warning.rule.action} ${warning.message}`),
+      );
+      if (introduced.length > 0) {
+        throw new Error(introduced.map((warning) => warning.message).join("\n"));
+      }
+      const token = ++patchSerial;
+      try {
+        const result = await client.request("evener/settings/keybindings/patch", {
+          expectedRevision: state.revision,
+          config: { version: 1, rules: rules.map((rule) => ({ action: rule.action, chord: rule.chord })) },
         });
+        if (token !== patchSerial || !isCurrentReady(client, generation) || currentSupport() !== "supported") {
+          // A response landing after support loss must not re-apply: the
+          // unsupported branch already un-applied and reset the hub state.
+          const current = keybindingsStore.getState();
+          return { version: 1, revision: current.revision, rules: [...current.rawOverrides] };
+        }
+        const payload = fromWireOverrides(result);
+        if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");
+        applyHubOverrides(payload);
+        return payload;
+      } catch (error) {
+        if (token === patchSerial && isCurrentReady(client, generation) && currentSupport() === "supported") {
+          // Post-rename durable failure: the patch APPLIED on the hub (the
+          // error carries the canonical applied state, and the broadcast
+          // reconciles every client). Apply locally and report success -
+          // surfacing hubError here would disable editing over bindings that
+          // are already live.
+          const applied = postRenameApplied(error);
+          if (applied !== undefined) {
+            applyHubOverrides(applied);
+            return applied;
+          }
+          const current = conflictCurrent(error);
+          if (current !== undefined) applyHubOverrides(current);
+          const message = error instanceof Error ? error.message : String(error);
+          keybindingsStore.setState({
+            hubError: message,
+            ...(current === undefined ? {} : { conflict: message }),
+          });
+        }
+        throw error;
       }
-      throw error;
-    }
+    };
+    // Chain behind the previous write's SETTLEMENT: a failed write must not
+    // block the queue, and the next write composes against whatever state
+    // the failure left (the conflict path already refreshed it).
+    const result = writeQueue.then(run, run);
+    writeQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   },
 }));
 
 connectionStore.subscribe(onConnectionChange);
 const initialClient = connectionStore.getState().client;
 if (initialClient !== null) rewireClient(initialClient);
+
+// A characterKeyTriggers flip changes what the persisted rules MEAN: a rule
+// skipped while the pref was on (a Shift+? claim conflicting with the
+// built-in "?" trigger) validates clean once the pref is off, and an applied
+// rule that overlaps "?" stops validating when the pref flips back on.
+// Re-apply the hub's raw set through the same pref-aware simulation so the
+// effective map and the warnings list always reflect the CURRENT pref -
+// without the flip the skip (and its warning) would go stale in both
+// directions. Idempotent like every apply: an unchanged effective map
+// mutates nothing. The setState re-fires this store's subscribers - the
+// cheatsheetController's reconcile among them - which is total and
+// idempotent, so the two compose in either subscription order.
+prefsStore.subscribe((state, previous) => {
+  if (state.characterKeyTriggers === previous.characterKeyTriggers) return;
+  // The registry must mirror the pref BEFORE the re-apply mutates: tinykeys
+  // canonicalizes the shifted character, so the conditional entry and a
+  // Shift+? claim serialize identically - a pref-off re-apply registering
+  // that claim while the entry is still live would hit registerBinding's
+  // exact-match conflict and roll back. Unregistering is idempotent and
+  // mirrors what the cheatsheetController's reconcile is about to do (it
+  // re-derives the same end state and no-ops). The pref-ON direction needs
+  // no mirror: the re-apply's pref-authoritative simulation un-applies a
+  // conflicting claim first, and the reconcile - fired by the setState
+  // below - registers "?" against the clean map.
+  if (!state.characterKeyTriggers) keybindingsRegistry.getState().unregisterBinding(CHARACTER_KEY_TRIGGER_BINDING_ID);
+  try {
+    applyOverrideRules(keybindingsStore.getState().rawOverrides);
+  } catch (error) {
+    // Same posture as the changed-notification path: a reconcile failure
+    // surfaces as hubError (the registry has already rolled back to its last
+    // good state), never as an exception escaping the prefs dispatch.
+    keybindingsStore.setState({ hubError: error instanceof Error ? error.message : String(error) });
+  }
+});
 
 export function resetKeybindingsStoreForTests(): void {
   invalidateReadyGeneration();
@@ -427,18 +831,13 @@ export function resetKeybindingsStoreForTests(): void {
   wiredClient = null;
   refreshSerial += 1;
   patchSerial += 1;
+  missedChangeNotification = false;
+  unapplyRolledBack = false;
+  writeQueue = Promise.resolve();
   // Restore defaults for every applied override so the registry singleton
-  // cannot leak overrides into the next test. A wedged registry (a foreign
-  // binding squatting a default chord) must not make reset itself throw.
-  for (const action of appliedOverrides.keys()) {
-    try {
-      restoreDefaultBinding(keybindingsRegistry, action);
-    } catch {
-      // The next test rebuilds the registry from scratch; a failed restore
-      // here leaves the override binding in place, which that rebuild removes.
-    }
-  }
-  appliedOverrides.clear();
+  // cannot leak overrides into the next test (the next test rebuilds the
+  // registry from scratch, which removes any binding a wedged restore left).
+  unapplyAllOverrides();
   keybindingsStore.setState({ ...initialState() });
   setSupportFromConnection();
 }

--- a/cmd/evener-hub/frontend/src/stores/keybindings.ts
+++ b/cmd/evener-hub/frontend/src/stores/keybindings.ts
@@ -1,0 +1,432 @@
+// The keybindings overrides store: mirrors stores/transcriptDisplay.ts's hub
+// posture (feature gating, hubSupport, ready-generation wiring, conflict
+// refresh) for user keybinding overrides. The hub layer is the ONLY layer -
+// unlike transcript display there is no localStorage layer: an unsupported
+// or unreachable hub means defaults only, never a local fallback copy.
+//
+// Applied overrides live in the keybindings registry (src/keybindings/), not
+// in this store's state: startup `get` and every `changed` notification are
+// validated semantically (keybindings/validation.ts) and reconciled into the
+// registry as a DELTA - only actions whose effective chord changed are
+// rebound, and actions whose overrides vanished get their defaults restored -
+// so in-flight dispatcher state for untouched actions is never torn down.
+// Validation failures degrade to warnings + skipped rules; nothing here can
+// crash startup on malformed persisted data.
+
+import { useStore } from "zustand";
+import { createStore, type StoreApi } from "zustand/vanilla";
+import { serializeChord } from "../keybindings/chord";
+import { rebindAction, removeActionBindings, restoreDefaultBinding } from "../keybindings/overrides";
+import { type Binding, keybindingsRegistry } from "../keybindings/registry";
+import { type OverrideRule, type ValidationWarning, validateOverrideRules } from "../keybindings/validation";
+import { WireError } from "../protocol/errors";
+import type { AppwireClientLike } from "../protocol/testing/fakeClient";
+import type { AnyNotification, KeybindingsOverrides } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+
+export interface KeybindingsStoreState {
+  hubSupport: "unknown" | "supported" | "unsupported";
+  hubLoading: boolean;
+  hubError: string | null;
+  /** Revision of the last confirmed hub payload (0 = shipped defaults). */
+  revision: number;
+  /** The validated rules currently applied to the registry. */
+  overrides: readonly OverrideRule[];
+  /** Semantic-validation warnings from the last applied payload. */
+  warnings: readonly ValidationWarning[];
+  /** Set when a patch lost the revision race; the store has already refreshed
+   * to the server's current state when this is non-null. */
+  conflict: string | null;
+  refreshOverrides(): Promise<void>;
+  patchOverrides(rules: readonly OverrideRule[]): Promise<KeybindingsOverrides>;
+}
+
+function initialState(): Omit<KeybindingsStoreState, "refreshOverrides" | "patchOverrides"> {
+  return {
+    hubSupport: "unknown",
+    hubLoading: false,
+    hubError: null,
+    revision: 0,
+    overrides: [],
+    warnings: [],
+    conflict: null,
+  };
+}
+
+let wiredClient: AppwireClientLike | null = null;
+let unwireNotification: (() => void) | null = null;
+let unwireReady: (() => void) | null = null;
+let clientEpoch = 0;
+let activeReadyClient: AppwireClientLike | null = null;
+let activeReadyEpoch = -1;
+let refreshSerial = 0;
+let patchSerial = 0;
+
+/** The action -> effective override (serialized chord, or null for an unbind)
+ * currently applied to the registry. Module-level like the template's wiring
+ * state: it describes the registry singleton, not store state. */
+const appliedOverrides = new Map<string, string | null>();
+
+/** Structural check for a wire payload (get result, changed params, patch
+ * response, conflict `current`). The server's own validation already ran; this
+ * is the trust-boundary re-check so a malformed payload degrades to an error
+ * state instead of a crash. */
+function fromWireOverrides(value: unknown): KeybindingsOverrides | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.version !== 1) return undefined;
+  if (typeof candidate.revision !== "number" || !Number.isSafeInteger(candidate.revision) || candidate.revision < 0)
+    return undefined;
+  if (!Array.isArray(candidate.rules)) return undefined;
+  // loadError rides GET only: the hub's persisted state failed to load and
+  // rules carries the shipped-default fallback. String-or-absent.
+  if (candidate.loadError !== undefined && typeof candidate.loadError !== "string") return undefined;
+  for (const rule of candidate.rules) {
+    if (typeof rule !== "object" || rule === null || Array.isArray(rule)) return undefined;
+    const entry = rule as Record<string, unknown>;
+    if (typeof entry.action !== "string" || !(entry.chord === null || typeof entry.chord === "string"))
+      return undefined;
+  }
+  return value as KeybindingsOverrides;
+}
+
+/** Restores a bindings snapshot taken before a failed reconcile: unwinds
+ * every current binding and re-registers the snapshot in order, returning
+ * the registry to its last good state. Re-registering a previously-valid
+ * set cannot conflict. */
+function rollbackBindings(snapshot: readonly Binding[]): void {
+  const state = keybindingsRegistry.getState();
+  for (const binding of state.bindings) state.unregisterBinding(binding.id);
+  for (const binding of snapshot) {
+    state.registerBinding({
+      id: binding.id,
+      actionId: binding.actionId,
+      chord: binding.chord,
+      scope: binding.scope,
+      ...(binding.when === undefined ? {} : { when: binding.when }),
+      allowInEditable: binding.allowInEditable,
+      allowInModal: binding.allowInModal,
+      ignoreIfDefaultPrevented: binding.ignoreIfDefaultPrevented,
+    });
+  }
+}
+
+/** Reconciles the registry to the payload's effective overrides: validates,
+ * strips the bindings of every action whose effective chord changed, then
+ * re-establishes each (override or restored default). Two-phase so a payload
+ * that moves a chord between actions never trips a transient conflict. The
+ * mutation is atomic: a throw rolls the registry back to its pre-reconcile
+ * state before propagating, so callers surface the failure with the last
+ * good bindings intact. */
+function applyOverrideRules(rules: readonly OverrideRule[]): void {
+  const validated = validateOverrideRules(rules, keybindingsRegistry, undefined, new Set(appliedOverrides.keys()));
+  const next = new Map<string, string | null>();
+  for (const rule of validated.rules) {
+    next.set(rule.action, rule.chord === null ? null : serializeChord(rule.chord));
+  }
+  const changedActions = new Set<string>();
+  for (const [action, chord] of next) {
+    if (!appliedOverrides.has(action) || appliedOverrides.get(action) !== chord) changedActions.add(action);
+  }
+  for (const action of appliedOverrides.keys()) {
+    if (!next.has(action)) changedActions.add(action);
+  }
+  if (changedActions.size > 0) {
+    const snapshot = keybindingsRegistry.getState().bindings;
+    try {
+      for (const action of changedActions) removeActionBindings(keybindingsRegistry, action);
+      for (const action of changedActions) {
+        if (next.has(action)) {
+          rebindAction(keybindingsRegistry, action, next.get(action) ?? null);
+        } else {
+          restoreDefaultBinding(keybindingsRegistry, action);
+        }
+      }
+    } catch (error) {
+      rollbackBindings(snapshot);
+      throw error;
+    }
+  }
+  appliedOverrides.clear();
+  for (const [action, chord] of next) appliedOverrides.set(action, chord);
+  keybindingsStore.setState({
+    overrides: validated.rules.map((rule) => ({
+      action: rule.action,
+      chord: rule.chord === null ? null : serializeChord(rule.chord),
+    })),
+    warnings: validated.warnings,
+  });
+}
+
+/** Applies a confirmed hub payload (get result, changed params, patch
+ * response): stale revisions are ignored, the rest reconcile the registry.
+ * The revision advances ONLY after a successful reconcile: a failed apply
+ * leaves the previous revision in place so the payload stays retryable and
+ * a later `changed` with the same revision is not eaten by the stale guard. */
+function applyHubOverrides(payload: KeybindingsOverrides): void {
+  const state = keybindingsStore.getState();
+  if (payload.revision < state.revision) return;
+  applyOverrideRules(payload.rules);
+  // A successful apply also supersedes any earlier apply failure's hubError.
+  // A GET payload carrying loadError (the hub's persisted state failed to
+  // load; the fallback defaults are in effect and PATCH rejects) maps onto
+  // hubError so the editing gate stays CLOSED with the diagnostic showing,
+  // instead of flapping writable-then-failing on every save (roborev PR
+  // #884 round 6). Broadcasts and patch responses never carry it, so an
+  // ordinary apply clears hubError exactly as before.
+  keybindingsStore.setState({ revision: payload.revision, hubError: payload.loadError ?? null });
+}
+
+function currentSupport(): "unknown" | "supported" | "unsupported" {
+  const features = connectionStore.getState().features;
+  if (features === undefined) return "unknown";
+  return features.keybindingsSettings === true ? "supported" : "unsupported";
+}
+
+function currentClient(): AppwireClientLike | null {
+  return connectionStore.getState().client;
+}
+
+function isCurrentReady(client: AppwireClientLike, epoch: number): boolean {
+  return (
+    wiredClient === client &&
+    activeReadyClient === client &&
+    activeReadyEpoch === epoch &&
+    clientEpoch === epoch &&
+    connectionStore.getState().client === client &&
+    client.state === "ready"
+  );
+}
+
+function invalidateReadyGeneration(): void {
+  activeReadyClient = null;
+  activeReadyEpoch = -1;
+  clientEpoch += 1;
+  unwireNotification?.();
+  unwireNotification = null;
+}
+
+function beginReadyGeneration(client: AppwireClientLike): number {
+  activeReadyClient = client;
+  activeReadyEpoch = ++clientEpoch;
+  const epoch = activeReadyEpoch;
+  unwireNotification?.();
+  unwireNotification = client.onNotification((notification) => {
+    if (!isCurrentReady(client, epoch)) return;
+    onNotification(notification);
+  });
+  return epoch;
+}
+
+function setSupportFromConnection(): void {
+  const support = currentSupport();
+  const state = keybindingsStore.getState();
+  if (support === "supported") {
+    if (state.hubSupport !== support) keybindingsStore.setState({ hubSupport: support });
+    return;
+  }
+  if (state.hubSupport !== support || state.hubLoading || state.hubError !== null)
+    keybindingsStore.setState({ hubSupport: support, hubLoading: false, hubError: null });
+}
+
+function onNotification(notification: AnyNotification): void {
+  if (notification.method !== "evener/settings/keybindings/changed") return;
+  const payload = fromWireOverrides(notification.params);
+  if (payload === undefined) return;
+  try {
+    applyHubOverrides(payload);
+  } catch (error) {
+    // Same posture as refreshFor: a reconcile failure surfaces as hubError
+    // (the registry has already rolled back to its last good state), never
+    // as an exception escaping the client's notification dispatch.
+    keybindingsStore.setState({ hubError: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+async function refreshFor(client: AppwireClientLike, epoch: number): Promise<void> {
+  if (!isCurrentReady(client, epoch) || currentSupport() !== "supported") return;
+  const serial = ++refreshSerial;
+  keybindingsStore.setState({ hubLoading: true, hubError: null });
+  try {
+    const result = await client.request("evener/settings/keybindings/get", {});
+    if (!isCurrentReady(client, epoch) || serial !== refreshSerial || currentSupport() !== "supported") return;
+    const payload = fromWireOverrides(result);
+    if (payload === undefined) throw new Error("Hub returned malformed keybindings overrides");
+    applyHubOverrides(payload);
+  } catch (error) {
+    if (isCurrentReady(client, epoch) && serial === refreshSerial) {
+      keybindingsStore.setState({ hubError: error instanceof Error ? error.message : String(error) });
+    }
+  } finally {
+    if (isCurrentReady(client, epoch) && serial === refreshSerial) keybindingsStore.setState({ hubLoading: false });
+  }
+}
+
+function rewireClient(client: AppwireClientLike): void {
+  if (client === wiredClient) return;
+  invalidateReadyGeneration();
+  unwireReady?.();
+  unwireReady = null;
+  wiredClient = client;
+  unwireReady = client.onReady(() => {
+    const epoch = beginReadyGeneration(client);
+    void refreshFor(client, epoch);
+  });
+  if (client.state === "ready") {
+    const epoch = beginReadyGeneration(client);
+    void refreshFor(client, epoch);
+  }
+}
+
+function onConnectionChange(
+  state: ReturnType<typeof connectionStore.getState>,
+  previous: ReturnType<typeof connectionStore.getState>,
+): void {
+  if (state.client !== wiredClient && state.client !== null) rewireClient(state.client);
+  if (
+    state.client === wiredClient &&
+    previous.client === state.client &&
+    previous.state === "ready" &&
+    state.state !== "ready"
+  ) {
+    invalidateReadyGeneration();
+  }
+  if (state.client === null && wiredClient !== null) {
+    invalidateReadyGeneration();
+    unwireReady?.();
+    unwireReady = null;
+    wiredClient = null;
+  }
+  setSupportFromConnection();
+  if (
+    state.client === wiredClient &&
+    state.features?.keybindingsSettings === true &&
+    previous.features?.keybindingsSettings !== true &&
+    state.client?.state === "ready"
+  ) {
+    if (activeReadyClient === state.client) void refreshFor(state.client, activeReadyEpoch);
+  }
+}
+
+/** Extracts the server's current payload from a revision-conflict rejection
+ * (appwire CodeConflict -32013 with data.evenerErrorInfo "conflict"). */
+function conflictCurrent(error: unknown): KeybindingsOverrides | undefined {
+  if (!(error instanceof WireError) || error.code !== -32013 || typeof error.data !== "object" || error.data === null)
+    return undefined;
+  const data = error.data as Record<string, unknown>;
+  if (data.evenerErrorInfo !== "conflict") return undefined;
+  return fromWireOverrides(data.current);
+}
+
+/** Extracts the APPLIED canonical payload from a post-rename durable-failure
+ * rejection (appwire CodeInternalError -32603 with data.evenerErrorInfo
+ * "keybindingsPostRename"): the hub's rename already published the patch and
+ * only a follow-up sync failed, so the write must be treated as applied -
+ * not as a hubError that leaves editing disabled over live new bindings
+ * (roborev PR #884 round 2). */
+function postRenameApplied(error: unknown): KeybindingsOverrides | undefined {
+  if (!(error instanceof WireError) || error.code !== -32603 || typeof error.data !== "object" || error.data === null)
+    return undefined;
+  const data = error.data as Record<string, unknown>;
+  if (data.evenerErrorInfo !== "keybindingsPostRename") return undefined;
+  return fromWireOverrides(data.applied);
+}
+
+export const keybindingsStore: StoreApi<KeybindingsStoreState> = createStore<KeybindingsStoreState>(() => ({
+  ...initialState(),
+  refreshOverrides: async () => {
+    const client = currentClient();
+    if (client === null || client !== wiredClient || activeReadyClient !== client) return;
+    await refreshFor(client, activeReadyEpoch);
+  },
+  patchOverrides: async (rules): Promise<KeybindingsOverrides> => {
+    const state = keybindingsStore.getState();
+    const client = currentClient();
+    const generation = client === activeReadyClient ? activeReadyEpoch : -1;
+    if (
+      state.hubSupport !== "supported" ||
+      currentSupport() !== "supported" ||
+      client === null ||
+      client !== wiredClient ||
+      generation < 0 ||
+      client.state !== "ready"
+    ) {
+      const error = "Hub keybindings settings are unavailable.";
+      keybindingsStore.setState({ hubError: error });
+      throw new Error(error);
+    }
+    const token = ++patchSerial;
+    try {
+      const result = await client.request("evener/settings/keybindings/patch", {
+        expectedRevision: state.revision,
+        config: { version: 1, rules: rules.map((rule) => ({ action: rule.action, chord: rule.chord })) },
+      });
+      if (token !== patchSerial || !isCurrentReady(client, generation)) {
+        const current = keybindingsStore.getState();
+        return { version: 1, revision: current.revision, rules: [...current.overrides] };
+      }
+      const payload = fromWireOverrides(result);
+      if (payload === undefined) throw new Error("Hub returned malformed keybindings PATCH response");
+      applyHubOverrides(payload);
+      keybindingsStore.setState({ hubError: null, conflict: null });
+      return payload;
+    } catch (error) {
+      if (token === patchSerial && isCurrentReady(client, generation)) {
+        // Post-rename durable failure: the patch APPLIED on the hub (the
+        // error carries the canonical applied state, and the broadcast
+        // reconciles every client). Apply locally and report success -
+        // surfacing hubError here would disable editing over bindings that
+        // are already live.
+        const applied = postRenameApplied(error);
+        if (applied !== undefined) {
+          applyHubOverrides(applied);
+          return applied;
+        }
+        const current = conflictCurrent(error);
+        if (current !== undefined) applyHubOverrides(current);
+        const message = error instanceof Error ? error.message : String(error);
+        keybindingsStore.setState({
+          hubError: message,
+          ...(current === undefined ? {} : { conflict: message }),
+        });
+      }
+      throw error;
+    }
+  },
+}));
+
+connectionStore.subscribe(onConnectionChange);
+const initialClient = connectionStore.getState().client;
+if (initialClient !== null) rewireClient(initialClient);
+
+export function resetKeybindingsStoreForTests(): void {
+  invalidateReadyGeneration();
+  unwireReady?.();
+  unwireReady = null;
+  wiredClient = null;
+  refreshSerial += 1;
+  patchSerial += 1;
+  // Restore defaults for every applied override so the registry singleton
+  // cannot leak overrides into the next test. A wedged registry (a foreign
+  // binding squatting a default chord) must not make reset itself throw.
+  for (const action of appliedOverrides.keys()) {
+    try {
+      restoreDefaultBinding(keybindingsRegistry, action);
+    } catch {
+      // The next test rebuilds the registry from scratch; a failed restore
+      // here leaves the override binding in place, which that rebuild removes.
+    }
+  }
+  appliedOverrides.clear();
+  keybindingsStore.setState({ ...initialState() });
+  setSupportFromConnection();
+}
+
+export function useKeybindingsStore(): KeybindingsStoreState;
+export function useKeybindingsStore<T>(selector: (state: KeybindingsStoreState) => T): T;
+export function useKeybindingsStore<T>(selector?: (state: KeybindingsStoreState) => T): T | KeybindingsStoreState {
+  // Same Zustand hook in both arms; the overload only avoids exposing an
+  // optional selector to useStore's stricter TypeScript signature.
+  // biome-ignore lint/correctness/useHookAtTopLevel: both arms call the same hook
+  return selector ? useStore(keybindingsStore, selector) : useStore(keybindingsStore);
+}

--- a/cmd/evener-hub/frontend/src/stores/prefs.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.test.ts
@@ -118,6 +118,11 @@ describe("defaults (empty localStorage)", () => {
   test("notificationsLoudScope defaults to asks", () => {
     expect(prefsStore.getState().notificationsLoudScope).toBe("asks");
   });
+  // The WCAG 2.1.4 character-key turn-off (the p4 plan's Design decision 3):
+  // the turn-off exists, and the default is ON.
+  test("characterKeyTriggers defaults to true", () => {
+    expect(prefsStore.getState().characterKeyTriggers).toBe(true);
+  });
 });
 
 describe("hydration from existing localStorage", () => {
@@ -513,6 +518,19 @@ describe("setNotificationsLoudScope", () => {
     prefsStore.getState().setNotificationsLoudScope("all");
     expect(localStorage.getItem(KEY("notificationsLoudScope"))).toBe("all");
     expect(prefsStore.getState().notificationsLoudScope).toBe("all");
+  });
+});
+
+describe("setCharacterKeyTriggers", () => {
+  test("persists under its own evener.prefs.characterKeyTriggers key and updates state", () => {
+    prefsStore.getState().setCharacterKeyTriggers(false);
+    expect(localStorage.getItem(KEY("characterKeyTriggers"))).toBe("0");
+    expect(prefsStore.getState().characterKeyTriggers).toBe(false);
+    // A fresh hydration (what the next page load does) reads it back.
+    resetPrefsStoreForTests();
+    expect(prefsStore.getState().characterKeyTriggers).toBe(false);
+    prefsStore.getState().setCharacterKeyTriggers(true);
+    expect(localStorage.getItem(KEY("characterKeyTriggers"))).toBe("1");
   });
 });
 

--- a/cmd/evener-hub/frontend/src/stores/prefs.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.test.ts
@@ -534,6 +534,22 @@ describe("setCharacterKeyTriggers", () => {
   });
 });
 
+describe("setLastSettingsSection", () => {
+  test("persists under its own evener.prefs.lastSettingsSection key and updates state", () => {
+    expect(prefsStore.getState().lastSettingsSection).toBeNull();
+    prefsStore.getState().setLastSettingsSection("keybindings");
+    expect(localStorage.getItem(KEY("lastSettingsSection"))).toBe("keybindings");
+    expect(prefsStore.getState().lastSettingsSection).toBe("keybindings");
+    // A fresh hydration (what the next page load does) reads it back.
+    resetPrefsStoreForTests();
+    expect(prefsStore.getState().lastSettingsSection).toBe("keybindings");
+    // null is absence: the key is removed, never a literal "null" string.
+    prefsStore.getState().setLastSettingsSection(null);
+    expect(localStorage.getItem(KEY("lastSettingsSection"))).toBeNull();
+    expect(prefsStore.getState().lastSettingsSection).toBeNull();
+  });
+});
+
 describe("localStorage unavailable (e.g. Safari private mode)", () => {
   test("reading falls back to defaults rather than throwing", () => {
     vi.spyOn(MemoryStorage.prototype, "getItem").mockImplementation(() => {

--- a/cmd/evener-hub/frontend/src/stores/prefs.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.ts
@@ -107,6 +107,14 @@ export interface PrefsStoreState {
   // turn-off exists, per the p4 plan's Design decision 3). Browser-local by
   // controller ruling: NOT a hub settings key.
   characterKeyTriggers: boolean;
+  // The settings section the user last visited (a sections.ts id), so
+  // reopening Settings returns there instead of always landing on General.
+  // null = never visited (or cleared). Persisted as the RAW section-id
+  // string with no validation here - this store must not import the
+  // settings section inventory (layering), so an unrecognized stored value
+  // round-trips and the CONSUMER (Settings.tsx) falls back to the default
+  // section via isKnownSettingsSection.
+  lastSettingsSection: string | null;
   notifications: Record<NotificationKey, boolean>;
   notificationsLoudScope: NotificationsLoudScopePref;
 
@@ -119,6 +127,7 @@ export interface PrefsStoreState {
   setEnterToSend(value: boolean): void;
   setShowCost(value: boolean): void;
   setCharacterKeyTriggers(value: boolean): void;
+  setLastSettingsSection(value: string | null): void;
   setNotification(key: NotificationKey, value: boolean): void;
   setNotificationsLoudScope(value: NotificationsLoudScopePref): void;
 }
@@ -461,6 +470,7 @@ function loadInitialState(): Omit<
   | "setEnterToSend"
   | "setShowCost"
   | "setCharacterKeyTriggers"
+  | "setLastSettingsSection"
   | "setNotification"
   | "setNotificationsLoudScope"
 > {
@@ -480,6 +490,7 @@ function loadInitialState(): Omit<
     enterToSend: readBool("enterToSend", false),
     showCost: readBool("showCost", false),
     characterKeyTriggers: readBool("characterKeyTriggers", true),
+    lastSettingsSection: readRaw("lastSettingsSection"),
     notifications: loadNotifications(),
     notificationsLoudScope: readEnum("notificationsLoudScope", LOUD_SCOPE_VALUES, "asks"),
   };
@@ -543,6 +554,17 @@ export const prefsStore = createStore<PrefsStoreState>((set) => ({
   setCharacterKeyTriggers(value) {
     writeBool("characterKeyTriggers", value);
     set({ characterKeyTriggers: value });
+  },
+
+  setLastSettingsSection(value) {
+    // null is absence (never written as a literal), same contract as
+    // theme's "system".
+    if (value === null) {
+      removeRaw("lastSettingsSection");
+    } else {
+      writeRaw("lastSettingsSection", value);
+    }
+    set({ lastSettingsSection: value });
   },
 
   setNotification(key, value) {

--- a/cmd/evener-hub/frontend/src/stores/prefs.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.ts
@@ -101,6 +101,12 @@ export interface PrefsStoreState {
   // match the PINNED evener.prefs.enterToSend / evener.prefs.showCost keys.
   enterToSend: boolean;
   showCost: boolean;
+  // Keybindings (Settings -> Keybindings): whether character-key triggers -
+  // today exactly the "?" cheatsheet-overlay trigger - are live. WCAG 2.1.4
+  // requires a way to turn single-character shortcuts off; default ON (the
+  // turn-off exists, per the p4 plan's Design decision 3). Browser-local by
+  // controller ruling: NOT a hub settings key.
+  characterKeyTriggers: boolean;
   notifications: Record<NotificationKey, boolean>;
   notificationsLoudScope: NotificationsLoudScopePref;
 
@@ -112,6 +118,7 @@ export interface PrefsStoreState {
   setTranscriptStatus(key: TranscriptStatusKey, value: boolean): void;
   setEnterToSend(value: boolean): void;
   setShowCost(value: boolean): void;
+  setCharacterKeyTriggers(value: boolean): void;
   setNotification(key: NotificationKey, value: boolean): void;
   setNotificationsLoudScope(value: NotificationsLoudScopePref): void;
 }
@@ -453,6 +460,7 @@ function loadInitialState(): Omit<
   | "setTranscriptStatus"
   | "setEnterToSend"
   | "setShowCost"
+  | "setCharacterKeyTriggers"
   | "setNotification"
   | "setNotificationsLoudScope"
 > {
@@ -471,6 +479,7 @@ function loadInitialState(): Omit<
     transcript: loadTranscript(),
     enterToSend: readBool("enterToSend", false),
     showCost: readBool("showCost", false),
+    characterKeyTriggers: readBool("characterKeyTriggers", true),
     notifications: loadNotifications(),
     notificationsLoudScope: readEnum("notificationsLoudScope", LOUD_SCOPE_VALUES, "asks"),
   };
@@ -529,6 +538,11 @@ export const prefsStore = createStore<PrefsStoreState>((set) => ({
   setShowCost(value) {
     writeBool("showCost", value);
     set({ showCost: value });
+  },
+
+  setCharacterKeyTriggers(value) {
+    writeBool("characterKeyTriggers", value);
+    set({ characterKeyTriggers: value });
   },
 
   setNotification(key, value) {

--- a/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
@@ -520,6 +520,15 @@ const WIDGET_STYLESHEET_RE = /^widgets\/([a-z0-9-]+)\/\1\.module\.css$/;
 // .dangerText — failure text for a delegate's not-resumable reason and last
 // failed outcome reason. Error text is the danger hue's canonical, ungateable
 // job, the same as railDialog.module.css's .pickerError above.
+//
+// webui-keybindings-p4 task 6: panes/settings/sections/keybindings.module.css
+// earns the same exception for the same structural reason - it lives under
+// panes/settings/sections/, not widgets/<name>/, so it can never match
+// WIDGET_STYLESHEET_RE either. Its one semantic reach is --danger-ink on
+// .rowError and .captureError, the keybindings editor's inline validation and
+// hub-error text. Error text is the danger hue's canonical, ungateable job,
+// the same as railDialog.module.css's .pickerError and
+// delegateStatus.module.css's .dangerText above.
 const SEMANTIC_PATH_EXCEPTIONS = new Set([
   "shell/rail/RailRow.module.css",
   "shell/rail/railDialog.module.css",
@@ -531,6 +540,7 @@ const SEMANTIC_PATH_EXCEPTIONS = new Set([
   "panes/session/chrome/taskspanel.module.css",
   "panes/session/transcript/tools/sandboxescalation.module.css",
   "panes/session/transcript/tools/delegateStatus.module.css",
+  "panes/settings/sections/keybindings.module.css",
 ]);
 
 for (const [path, text] of OTHER_STYLESHEETS) {

--- a/cmd/evener-hub/internal/hubcore/config.go
+++ b/cmd/evener-hub/internal/hubcore/config.go
@@ -41,6 +41,8 @@ type WebConfig struct {
 	LaunchConfigRoot          string                  // root of the layered launch config (launch.toml, projects/<id>/{launch.toml,meta.toml}); user-editable, so distinct from HubStateRoot — defaults to cmdutil.DefaultConfigRoot() when empty
 	TranscriptDisplayStore    *TranscriptDisplayStore // hub-authoritative Desktop/Mobile transcript-display defaults; nil → load from HubStateRoot
 	TranscriptDisplayStoreErr error                   // diagnostic returned while loading the injected store; retained for startup diagnostics
+	KeybindingsStore          *KeybindingsStore       // hub-authoritative user keybinding overrides; nil → load from HubStateRoot
+	KeybindingsStoreErr       error                   // diagnostic returned while loading the injected store; retained for startup diagnostics
 	RunDir                    string                  // run directory where rendezvous files live
 	PastIndexPath             string                  // path to the SQLite past-index DB, for display in settings
 	Roster                    *Roster

--- a/cmd/evener-hub/internal/hubcore/keybindings_store.go
+++ b/cmd/evener-hub/internal/hubcore/keybindings_store.go
@@ -1,0 +1,382 @@
+package hubcore
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/evener/appwire"
+)
+
+const (
+	keybindingsSnapshotVersion uint64 = 1
+	keybindingsStateSubdir            = "keybindings"
+	keybindingsStateFilename          = "state.json"
+)
+
+type keybindingsSnapshot struct {
+	Version  uint64                    `json:"version"`
+	Revision uint64                    `json:"revision"`
+	Config   appwire.KeybindingsConfig `json:"config"`
+}
+
+type keybindingsStoreFaults struct {
+	BeforeRename func() error
+	AfterRename  func() error
+}
+
+// KeybindingsPostRenameError wraps a durable failure that happened AFTER the
+// rename published the new snapshot: the stored overrides advanced to the new
+// revision, but a follow-up directory sync or hook failed. Callers must treat
+// the patch as APPLIED - in particular the RPC layer must still broadcast the
+// new canonical state, or every other client stays on the pre-patch revision.
+type KeybindingsPostRenameError struct{ Err error }
+
+func (e *KeybindingsPostRenameError) Error() string { return e.Err.Error() }
+func (e *KeybindingsPostRenameError) Unwrap() error { return e.Err }
+
+// KeybindingsStore is the hub-authoritative store for user keybinding
+// overrides. One mutex serializes each durable update.
+type KeybindingsStore struct {
+	mu      sync.Mutex
+	fs      afero.Fs
+	root    string
+	state   keybindingsSnapshot
+	loadErr error
+	faults  keybindingsStoreFaults
+}
+
+// NewKeybindingsStore opens the keybindings state below stateRoot. A malformed
+// snapshot returns a usable shipped-default fallback together with the load
+// diagnostic; callers must retain both values and report the error.
+func NewKeybindingsStore(stateRoot string) (*KeybindingsStore, error) {
+	return newKeybindingsStoreFS(afero.NewOsFs(), stateRoot, keybindingsStoreFaults{})
+}
+
+// NewKeybindingsStoreForTest is NewKeybindingsStore plus a fault hook fired
+// after each rename publishes a patch, so tests outside this package can
+// exercise post-rename failure handling (KeybindingsPostRenameError).
+func NewKeybindingsStoreForTest(stateRoot string, afterRenameFault func() error) (*KeybindingsStore, error) {
+	return newKeybindingsStoreFS(afero.NewOsFs(), stateRoot, keybindingsStoreFaults{AfterRename: afterRenameFault})
+}
+
+func newKeybindingsStoreFS(fs afero.Fs, stateRoot string, faults keybindingsStoreFaults) (*KeybindingsStore, error) {
+	state, err := loadKeybindingsSnapshotFS(fs, stateRoot)
+	if err != nil {
+		state = keybindingsShippedSnapshot()
+	}
+	return &KeybindingsStore{
+		fs:      fs,
+		root:    stateRoot,
+		state:   state,
+		loadErr: err,
+		faults:  faults,
+	}, err
+}
+
+// Snapshot returns a deep value copy of the canonical overrides. The returned
+// rules slice is never shared with the store.
+func (s *KeybindingsStore) Snapshot() appwire.KeybindingsOverrides {
+	if s == nil {
+		return appwire.KeybindingsShippedDefaults()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return keybindingsSnapshotOverrides(s.state)
+}
+
+// LoadErr reports the diagnostic captured when the persisted state failed to
+// load at construction (Snapshot serves the shipped-default fallback in that
+// case, and Patch rejects). Nil when the state loaded cleanly.
+func (s *KeybindingsStore) LoadErr() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.loadErr
+}
+
+// Patch validates and durably replaces the overrides using optimistic
+// revision checking. A durable error before rename leaves the old state
+// published; an error after rename publishes the new canonical state in
+// memory and is returned wrapped in *KeybindingsPostRenameError so callers
+// can tell the applied-but-unfinished case apart from a rejected patch.
+func (s *KeybindingsStore) Patch(params appwire.KeybindingsPatchParams) (appwire.KeybindingsOverrides, error) {
+	if s == nil {
+		return appwire.KeybindingsOverrides{}, errors.New("keybindings store is not configured")
+	}
+	if err := appwire.ValidateKeybindingsConfig(params.Config); err != nil {
+		return appwire.KeybindingsOverrides{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.loadErr != nil {
+		return appwire.KeybindingsOverrides{}, fmt.Errorf("keybindings state is unavailable: %w", s.loadErr)
+	}
+
+	if s.state.Revision != params.ExpectedRevision {
+		return appwire.KeybindingsOverrides{}, keybindingsConflict(s.state, params.ExpectedRevision)
+	}
+	if reflect.DeepEqual(s.state.Config, params.Config) {
+		return keybindingsSnapshotOverrides(s.state), nil
+	}
+	if s.state.Revision == math.MaxUint64 {
+		return appwire.KeybindingsOverrides{}, errors.New("keybindings revision overflow")
+	}
+
+	next := keybindingsSnapshot{
+		Version:  s.state.Version,
+		Revision: s.state.Revision + 1,
+		Config:   cloneKeybindingsConfig(params.Config),
+	}
+	// A nil Rules slice marshals as "rules":null, which the loader's shape
+	// check rejects on restart (it would silently fall back to defaults) -
+	// normalize to the empty slice the shipped defaults use so a direct Go
+	// caller's nil round-trips.
+	if next.Config.Rules == nil {
+		next.Config.Rules = []appwire.KeybindingsRule{}
+	}
+	renamed, err := saveKeybindingsSnapshotFS(s.fs, s.root, next, s.faults)
+	if renamed {
+		s.state = next
+	}
+	if err != nil {
+		if renamed {
+			return appwire.KeybindingsOverrides{}, &KeybindingsPostRenameError{Err: err}
+		}
+		return appwire.KeybindingsOverrides{}, err
+	}
+	return keybindingsSnapshotOverrides(s.state), nil
+}
+
+func keybindingsConflict(state keybindingsSnapshot, expected uint64) appwire.WireError {
+	return appwire.WireError{
+		Code:    appwire.CodeConflict,
+		Message: fmt.Sprintf("keybindings revision conflict: expected %d, current %d", expected, state.Revision),
+		Data: appwire.KeybindingsConflictData{
+			EvenerErrorInfo: appwire.ErrorConflict,
+			Current:         keybindingsSnapshotOverrides(state),
+		},
+	}
+}
+
+func keybindingsStatePath(stateRoot string) string {
+	return filepath.Join(stateRoot, keybindingsStateSubdir, keybindingsStateFilename)
+}
+
+func loadKeybindingsSnapshotFS(fs afero.Fs, stateRoot string) (keybindingsSnapshot, error) {
+	empty := keybindingsShippedSnapshot()
+	if stateRoot == "" {
+		return empty, nil
+	}
+	data, err := afero.ReadFile(fs, keybindingsStatePath(stateRoot))
+	if os.IsNotExist(err) {
+		return empty, nil
+	}
+	if err != nil {
+		return empty, fmt.Errorf("read keybindings state: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return empty, nil
+	}
+
+	var state keybindingsSnapshot
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&state); err != nil {
+		return empty, fmt.Errorf("decode keybindings state: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return empty, errors.New("decode keybindings state: trailing JSON value")
+		}
+		return empty, fmt.Errorf("decode keybindings state trailing data: %w", err)
+	}
+	if err := validateKeybindingsSnapshotShape(data); err != nil {
+		return empty, fmt.Errorf("validate keybindings state shape: %w", err)
+	}
+	if err := validateKeybindingsSnapshot(state); err != nil {
+		return empty, fmt.Errorf("validate keybindings state: %w", err)
+	}
+	return state, nil
+}
+
+func saveKeybindingsSnapshotFS(fs afero.Fs, stateRoot string, state keybindingsSnapshot, faults keybindingsStoreFaults) (renamed bool, err error) {
+	if err := validateKeybindingsSnapshot(state); err != nil {
+		return false, err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return false, fmt.Errorf("marshal keybindings state: %w", err)
+	}
+	if stateRoot == "" {
+		return true, nil
+	}
+
+	path := keybindingsStatePath(stateRoot)
+	dir := filepath.Dir(path)
+	if err := fs.MkdirAll(dir, 0o700); err != nil {
+		return false, fmt.Errorf("create keybindings state directory: %w", err)
+	}
+	temp, err := afero.TempFile(fs, dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return false, fmt.Errorf("create temp keybindings state: %w", err)
+	}
+	tempPath := temp.Name()
+	defer func() {
+		if temp != nil {
+			_ = temp.Close()
+		}
+		if !renamed {
+			_ = fs.Remove(tempPath)
+		}
+	}()
+	if _, err := temp.Write(data); err != nil {
+		return false, fmt.Errorf("write temp keybindings state: %w", err)
+	}
+	if err := temp.Sync(); err != nil && !deletionSyncUnsupported(err) {
+		return false, fmt.Errorf("sync temp keybindings state: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return false, fmt.Errorf("close temp keybindings state: %w", err)
+	}
+	temp = nil
+	if faults.BeforeRename != nil {
+		if err := faults.BeforeRename(); err != nil {
+			return false, err
+		}
+	}
+	if err := fs.Rename(tempPath, path); err != nil {
+		return false, fmt.Errorf("rename keybindings state: %w", err)
+	}
+	renamed = true
+	directory, err := fs.Open(dir)
+	if err != nil {
+		return true, fmt.Errorf("open keybindings state directory: %w", err)
+	}
+	if err := directory.Sync(); err != nil && !deletionSyncUnsupported(err) {
+		_ = directory.Close()
+		return true, fmt.Errorf("sync keybindings state directory: %w", err)
+	}
+	if err := directory.Close(); err != nil {
+		return true, fmt.Errorf("close keybindings state directory: %w", err)
+	}
+	if faults.AfterRename != nil {
+		if err := faults.AfterRename(); err != nil {
+			return true, err
+		}
+	}
+	return true, nil
+}
+
+func validateKeybindingsSnapshot(state keybindingsSnapshot) error {
+	if state.Version != keybindingsSnapshotVersion {
+		return fmt.Errorf("unsupported keybindings state version %d", state.Version)
+	}
+	return appwire.ValidateKeybindingsConfig(state.Config)
+}
+
+func validateKeybindingsSnapshotShape(raw []byte) error {
+	top, err := keybindingsSnapshotObjectFields(raw)
+	if err != nil {
+		return err
+	}
+	if err := requireKeybindingsSnapshotFields(top, "version", "revision", "config"); err != nil {
+		return err
+	}
+	if bytes.Equal(bytes.TrimSpace(top["revision"]), []byte("null")) {
+		return errors.New("revision must be an unsigned integer")
+	}
+	configFields, err := keybindingsSnapshotObjectFields(top["config"])
+	if err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	if err := requireKeybindingsSnapshotFields(configFields, "version", "rules"); err != nil {
+		return fmt.Errorf("config: %w", err)
+	}
+	if bytes.Equal(bytes.TrimSpace(configFields["rules"]), []byte("null")) {
+		return errors.New("config: rules must be an array")
+	}
+	var rules []json.RawMessage
+	if err := json.Unmarshal(configFields["rules"], &rules); err != nil {
+		return fmt.Errorf("config: rules: %w", err)
+	}
+	for i, rawRule := range rules {
+		ruleFields, err := keybindingsSnapshotObjectFields(rawRule)
+		if err != nil {
+			return fmt.Errorf("rule %d: %w", i, err)
+		}
+		if err := requireKeybindingsSnapshotFields(ruleFields, "action", "chord"); err != nil {
+			return fmt.Errorf("rule %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func keybindingsSnapshotObjectFields(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	if fields == nil {
+		return nil, errors.New("expected JSON object")
+	}
+	return fields, nil
+}
+
+func requireKeybindingsSnapshotFields(fields map[string]json.RawMessage, names ...string) error {
+	for _, name := range names {
+		if _, ok := fields[name]; !ok {
+			return fmt.Errorf("missing required field %q", name)
+		}
+	}
+	return nil
+}
+
+func keybindingsShippedSnapshot() keybindingsSnapshot {
+	defaults := appwire.KeybindingsShippedDefaults()
+	return keybindingsSnapshot{
+		Version:  keybindingsSnapshotVersion,
+		Revision: defaults.Revision,
+		Config:   appwire.KeybindingsConfig{Version: defaults.Version, Rules: cloneKeybindingsRules(defaults.Rules)},
+	}
+}
+
+func keybindingsSnapshotOverrides(state keybindingsSnapshot) appwire.KeybindingsOverrides {
+	return appwire.KeybindingsOverrides{
+		Version:  state.Config.Version,
+		Revision: state.Revision,
+		Rules:    cloneKeybindingsRules(state.Config.Rules),
+	}
+}
+
+func cloneKeybindingsConfig(config appwire.KeybindingsConfig) appwire.KeybindingsConfig {
+	return appwire.KeybindingsConfig{Version: config.Version, Rules: cloneKeybindingsRules(config.Rules)}
+}
+
+func cloneKeybindingsRules(rules []appwire.KeybindingsRule) []appwire.KeybindingsRule {
+	if rules == nil {
+		return nil
+	}
+	cloned := make([]appwire.KeybindingsRule, len(rules))
+	for i, rule := range rules {
+		cloned[i] = rule
+		if rule.Chord != nil {
+			chord := *rule.Chord
+			cloned[i].Chord = &chord
+		}
+	}
+	return cloned
+}

--- a/cmd/evener-hub/internal/hubcore/keybindings_store_test.go
+++ b/cmd/evener-hub/internal/hubcore/keybindings_store_test.go
@@ -1,0 +1,341 @@
+package hubcore
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"math"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/evener/appwire"
+)
+
+func TestKeybindingsStoreMissingRootUsesShippedDefaults(t *testing.T) {
+	store, err := NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store == nil {
+		t.Fatal("NewKeybindingsStore returned nil store")
+	}
+	if got, want := store.Snapshot(), appwire.KeybindingsShippedDefaults(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Snapshot = %#v, want %#v", got, want)
+	}
+}
+
+func TestKeybindingsStorePatchIncrementsRevision(t *testing.T) {
+	store, err := NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+		{Action: "thread.close", Chord: nil},
+	}}
+	got, err := store.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: 0, Config: config})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Revision != 1 || !reflect.DeepEqual(got.Rules, config.Rules) || got.Version != 1 {
+		t.Fatalf("patch result=%#v", got)
+	}
+	if snapshot := store.Snapshot(); !reflect.DeepEqual(snapshot, got) {
+		t.Fatalf("snapshot=%#v, want patch result %#v", snapshot, got)
+	}
+}
+
+func TestKeybindingsStorePersistsAndReloads(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+shift+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := reloaded.Snapshot()
+	if got.Revision != 1 || !reflect.DeepEqual(got.Rules, config.Rules) {
+		t.Fatalf("reloaded snapshot=%#v, want revision 1/rules %#v", got, config.Rules)
+	}
+}
+
+func TestKeybindingsStoreNoOpDoesNotIncrementRevision(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := afero.ReadFile(afero.NewOsFs(), keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: 1, Config: config})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Revision != 1 || !reflect.DeepEqual(got.Rules, config.Rules) {
+		t.Fatalf("no-op result=%#v", got)
+	}
+	after, err := afero.ReadFile(afero.NewOsFs(), keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("no-op rewrote durable state: before=%q after=%q", before, after)
+	}
+}
+
+func TestKeybindingsStoreStaleRevisionReturnsCanonicalConflict(t *testing.T) {
+	store, err := NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: first}); err != nil {
+		t.Fatal(err)
+	}
+	stale := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+alt+n")},
+	}}
+	_, err = store.Patch(appwire.KeybindingsPatchParams{Config: stale})
+	if err == nil {
+		t.Fatal("stale patch unexpectedly succeeded")
+	}
+	var wireErr appwire.WireError
+	if !errors.As(err, &wireErr) {
+		t.Fatalf("stale error=%T %v, want appwire.WireError", err, err)
+	}
+	if wireErr.Code != appwire.CodeConflict {
+		t.Fatalf("stale code=%d, want %d", wireErr.Code, appwire.CodeConflict)
+	}
+	data, ok := wireErr.Data.(appwire.KeybindingsConflictData)
+	if !ok {
+		t.Fatalf("stale data=%T, want appwire.KeybindingsConflictData", wireErr.Data)
+	}
+	if data.EvenerErrorInfo != appwire.ErrorConflict || data.Current.Revision != 1 || !reflect.DeepEqual(data.Current.Rules, first.Rules) {
+		t.Fatalf("conflict data=%#v", data)
+	}
+}
+
+func TestKeybindingsStoreConcurrentPatchesSerialize(t *testing.T) {
+	store, err := NewKeybindingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			_, err := store.Patch(appwire.KeybindingsPatchParams{Config: config})
+			results <- err
+		})
+	}
+	wg.Wait()
+	close(results)
+	var success, conflicts int
+	for err := range results {
+		if err == nil {
+			success++
+			continue
+		}
+		var wireErr appwire.WireError
+		if errors.As(err, &wireErr) && wireErr.Code == appwire.CodeConflict {
+			conflicts++
+			continue
+		}
+		t.Fatalf("concurrent patch error=%T %v", err, err)
+	}
+	if success != 1 || conflicts != 1 || store.Snapshot().Revision != 1 {
+		t.Fatalf("success=%d conflicts=%d snapshot=%#v", success, conflicts, store.Snapshot())
+	}
+}
+
+func TestKeybindingsStoreMalformedSnapshotFallsBackAndBlocksPatches(t *testing.T) {
+	root := t.TempDir()
+	path := keybindingsStatePath(root)
+	if err := writeKeybindingsStateFile(afero.NewOsFs(), root, []byte(`{"version":1,"revision":0,"config":{}} trailing`)); err != nil {
+		t.Fatal(err)
+	}
+	before, err := afero.ReadFile(afero.NewOsFs(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, loadErr := NewKeybindingsStore(root)
+	if store == nil || loadErr == nil {
+		t.Fatalf("store=%#v loadErr=%v, want usable fallback and diagnostic", store, loadErr)
+	}
+	if got, want := store.Snapshot(), appwire.KeybindingsShippedDefaults(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback snapshot=%#v, want %#v", got, want)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); err == nil {
+		t.Fatal("patch against malformed snapshot unexpectedly succeeded")
+	}
+	after, err := afero.ReadFile(afero.NewOsFs(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("malformed evidence changed: before=%q after=%q", before, after)
+	}
+}
+
+func TestKeybindingsStoreEmptySnapshotUsesShippedDefaults(t *testing.T) {
+	root := t.TempDir()
+	if err := writeKeybindingsStateFile(afero.NewOsFs(), root, nil); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := store.Snapshot(), appwire.KeybindingsShippedDefaults(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("empty snapshot=%#v, want %#v", got, want)
+	}
+}
+
+func TestKeybindingsStoreRevisionOverflowIsRejected(t *testing.T) {
+	root := t.TempDir()
+	state := keybindingsSnapshot{
+		Version:  keybindingsSnapshotVersion,
+		Revision: math.MaxUint64,
+		Config:   appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{}},
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeKeybindingsStateFile(afero.NewOsFs(), root, data); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewKeybindingsStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: math.MaxUint64, Config: config}); err == nil || !strings.Contains(err.Error(), "overflow") {
+		t.Fatalf("overflow patch error=%v", err)
+	}
+	if got := store.Snapshot().Revision; got != math.MaxUint64 {
+		t.Fatalf("overflow changed revision=%d", got)
+	}
+}
+
+func TestKeybindingsStoreStrictSnapshotDecoding(t *testing.T) {
+	valid := keybindingsSnapshot{
+		Version: keybindingsSnapshotVersion,
+		Config:  appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{}},
+	}
+	encoded, err := json.Marshal(valid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name string
+		data string
+	}{
+		{name: "unknown field", data: strings.TrimSuffix(string(encoded), "}") + `,"unknown":true}`},
+		{name: "trailing value", data: string(encoded) + ` {}`},
+		{name: "invalid config", data: `{"version":1,"revision":0,"config":{"version":99,"rules":[]}}`},
+		{name: "empty rule action", data: `{"version":1,"revision":0,"config":{"version":1,"rules":[{"action":"","chord":"ctrl+n"}]}}`},
+		{name: "empty rule chord", data: `{"version":1,"revision":0,"config":{"version":1,"rules":[{"action":"thread.new","chord":""}]}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := writeKeybindingsStateFile(afero.NewOsFs(), root, []byte(tc.data)); err != nil {
+				t.Fatal(err)
+			}
+			store, loadErr := NewKeybindingsStore(root)
+			if store == nil || loadErr == nil {
+				t.Fatalf("store=%#v loadErr=%v, want fallback and diagnostic", store, loadErr)
+			}
+			if got := store.Snapshot(); !reflect.DeepEqual(got, appwire.KeybindingsShippedDefaults()) {
+				t.Fatalf("fallback=%#v", got)
+			}
+		})
+	}
+}
+
+func TestKeybindingsStoreStrictSnapshotRequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+	}{
+		{name: "missing revision", data: `{"version":1,"config":{"version":1,"rules":[]}}`},
+		{name: "missing config", data: `{"version":1,"revision":0}`},
+		{name: "missing config version", data: `{"version":1,"revision":0,"config":{"rules":[]}}`},
+		{name: "missing rules", data: `{"version":1,"revision":0,"config":{"version":1}}`},
+		{name: "null rules", data: `{"version":1,"revision":0,"config":{"version":1,"rules":null}}`},
+		{name: "missing rule action", data: `{"version":1,"revision":0,"config":{"version":1,"rules":[{"chord":"ctrl+n"}]}}`},
+		{name: "missing rule chord", data: `{"version":1,"revision":0,"config":{"version":1,"rules":[{"action":"thread.new"}]}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := writeKeybindingsStateFile(afero.NewOsFs(), root, []byte(tc.data)); err != nil {
+				t.Fatal(err)
+			}
+			before, err := afero.ReadFile(afero.NewOsFs(), keybindingsStatePath(root))
+			if err != nil {
+				t.Fatal(err)
+			}
+			store, loadErr := NewKeybindingsStore(root)
+			if store == nil || loadErr == nil {
+				t.Fatalf("store=%#v loadErr=%v, want fallback and diagnostic", store, loadErr)
+			}
+			if got := store.Snapshot(); !reflect.DeepEqual(got, appwire.KeybindingsShippedDefaults()) {
+				t.Fatalf("fallback=%#v", got)
+			}
+			config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+				{Action: "thread.new", Chord: new("ctrl+n")},
+			}}
+			if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); err == nil {
+				t.Fatal("patch against malformed snapshot unexpectedly succeeded")
+			}
+			after, err := afero.ReadFile(afero.NewOsFs(), keybindingsStatePath(root))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("malformed evidence changed: before=%q after=%q", before, after)
+			}
+		})
+	}
+}
+
+func writeKeybindingsStateFile(fs afero.Fs, root string, data []byte) error {
+	path := keybindingsStatePath(root)
+	if err := fs.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return afero.WriteFile(fs, path, data, 0o600)
+}

--- a/cmd/evener-hub/internal/hubcore/keybindings_store_write_test.go
+++ b/cmd/evener-hub/internal/hubcore/keybindings_store_write_test.go
@@ -1,0 +1,210 @@
+package hubcore
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/afero"
+
+	"primeradiant.com/evener/appwire"
+)
+
+type keybindingsReadFaultFs struct {
+	afero.Fs
+	path string
+	err  error
+}
+
+func (f *keybindingsReadFaultFs) Open(name string) (afero.File, error) {
+	if filepath.Clean(name) == filepath.Clean(f.path) {
+		return nil, f.err
+	}
+	return f.Fs.Open(name)
+}
+
+func TestKeybindingsStorePatchNormalizesNilRules(t *testing.T) {
+	// A direct Go caller can pass Rules:nil; persisted verbatim that is
+	// "rules":null, which the loader's shape check rejects on restart - the
+	// store normalizes to the empty slice instead (roborev PR #884 round 2).
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	store, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: appwire.KeybindingsConfig{Version: 1}}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := afero.ReadFile(fs, keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(data, []byte(`"rules":null`)) {
+		t.Fatalf("persisted state contains rules:null: %s", data)
+	}
+	reloaded, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{})
+	if err != nil {
+		t.Fatalf("reload after nil-rules patch: %v", err)
+	}
+	if got := reloaded.Snapshot(); got.Revision != 1 || got.Rules == nil || len(got.Rules) != 0 {
+		t.Fatalf("reloaded snapshot = %#v, want revision 1 with empty non-nil rules", got)
+	}
+}
+
+func TestKeybindingsStorePreRenameFailurePreservesOldState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	store, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: oldConfig}); err != nil {
+		t.Fatal(err)
+	}
+	before, err := afero.ReadFile(fs, keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantFailure := errors.New("before rename failed")
+	failing, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{
+		BeforeRename: func() error { return wantFailure },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+alt+n")},
+	}}
+	if _, err := failing.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: 1, Config: newConfig}); !errors.Is(err, wantFailure) {
+		t.Fatalf("pre-rename error=%v, want %v", err, wantFailure)
+	}
+	if got := failing.Snapshot(); got.Revision != 1 || !reflect.DeepEqual(got.Rules, oldConfig.Rules) {
+		t.Fatalf("pre-rename memory=%#v, want revision 1/rules %#v", got, oldConfig.Rules)
+	}
+	after, err := afero.ReadFile(fs, keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatalf("pre-rename disk changed: before=%q after=%q", before, after)
+	}
+}
+
+func TestKeybindingsStorePostRenameFailurePublishesNewState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	store, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: oldConfig}); err != nil {
+		t.Fatal(err)
+	}
+
+	wantFailure := errors.New("after rename failed")
+	failing, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{
+		AfterRename: func() error { return wantFailure },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newConfig := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+alt+n")},
+	}}
+	_, patchErr := failing.Patch(appwire.KeybindingsPatchParams{ExpectedRevision: 1, Config: newConfig})
+	if !errors.Is(patchErr, wantFailure) {
+		t.Fatalf("post-rename error=%v, want %v", patchErr, wantFailure)
+	}
+	// The applied-but-unfinished case must be distinguishable from a rejected
+	// patch: the RPC layer broadcasts on exactly this type.
+	if _, postRename := errors.AsType[*KeybindingsPostRenameError](patchErr); !postRename {
+		t.Fatalf("post-rename error type=%T, want *KeybindingsPostRenameError", patchErr)
+	}
+	if got := failing.Snapshot(); got.Revision != 2 || !reflect.DeepEqual(got.Rules, newConfig.Rules) {
+		t.Fatalf("post-rename memory=%#v, want revision 2/rules %#v", got, newConfig.Rules)
+	}
+	reloaded, err := newKeybindingsStoreFS(fs, root, keybindingsStoreFaults{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reloaded.Snapshot(); got.Revision != 2 || !reflect.DeepEqual(got.Rules, newConfig.Rules) {
+		t.Fatalf("post-rename reload=%#v, want revision 2/rules %#v", got, newConfig.Rules)
+	}
+}
+
+func TestKeybindingsStoreWriteValidatesBeforeCreatingState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	invalid := keybindingsSnapshot{Version: keybindingsSnapshotVersion}
+	if renamed, err := saveKeybindingsSnapshotFS(fs, root, invalid, keybindingsStoreFaults{}); renamed || err == nil {
+		t.Fatalf("invalid save renamed=%v err=%v, want no publication and error", renamed, err)
+	}
+	if _, err := fs.Stat(filepath.Join(root, keybindingsStateSubdir)); !errors.Is(err, afero.ErrFileNotFound) {
+		t.Fatalf("invalid save state directory error=%v, want absent", err)
+	}
+}
+
+func TestKeybindingsStoreWriteCleansTempAfterPreRenameFailure(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	state := keybindingsSnapshot{
+		Version: keybindingsSnapshotVersion,
+		Config:  appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{}},
+	}
+	wantFailure := errors.New("before rename failed")
+	if renamed, err := saveKeybindingsSnapshotFS(fs, root, state, keybindingsStoreFaults{BeforeRename: func() error { return wantFailure }}); renamed || !errors.Is(err, wantFailure) {
+		t.Fatalf("pre-rename save renamed=%v err=%v", renamed, err)
+	}
+	entries, err := afero.ReadDir(fs, filepath.Join(root, keybindingsStateSubdir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("pre-rename temp residue=%v", entries)
+	}
+}
+
+func TestKeybindingsStoreReadFailureFallsBackAndBlocksPatches(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	root := "/hub-state"
+	evidence := []byte("durable evidence that must not be overwritten")
+	if err := writeKeybindingsStateFile(fs, root, evidence); err != nil {
+		t.Fatal(err)
+	}
+	wantFailure := errors.New("state read failed")
+	faultFS := &keybindingsReadFaultFs{
+		Fs:   fs,
+		path: keybindingsStatePath(root),
+		err:  wantFailure,
+	}
+	store, loadErr := newKeybindingsStoreFS(faultFS, root, keybindingsStoreFaults{})
+	if store == nil || !errors.Is(loadErr, wantFailure) {
+		t.Fatalf("store=%#v loadErr=%v, want fallback and %v", store, loadErr, wantFailure)
+	}
+	if got := store.Snapshot(); !reflect.DeepEqual(got, appwire.KeybindingsShippedDefaults()) {
+		t.Fatalf("read-fault fallback=%#v", got)
+	}
+	config := appwire.KeybindingsConfig{Version: 1, Rules: []appwire.KeybindingsRule{
+		{Action: "thread.new", Chord: new("ctrl+n")},
+	}}
+	if _, err := store.Patch(appwire.KeybindingsPatchParams{Config: config}); !errors.Is(err, wantFailure) {
+		t.Fatalf("read-fault patch error=%v, want %v", err, wantFailure)
+	}
+	after, err := afero.ReadFile(fs, keybindingsStatePath(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, evidence) {
+		t.Fatalf("read-fault evidence changed: before=%q after=%q", evidence, after)
+	}
+}

--- a/cmd/evener-hub/main.go
+++ b/cmd/evener-hub/main.go
@@ -359,6 +359,10 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 	if transcriptDisplayStoreErr != nil {
 		_, _ = fmt.Fprintf(stderr, "[hub] transcript display state: %v\n", transcriptDisplayStoreErr)
 	}
+	keybindingsStore, keybindingsStoreErr := hubcore.NewKeybindingsStore(hubStateRoot)
+	if keybindingsStoreErr != nil {
+		_, _ = fmt.Fprintf(stderr, "[hub] keybindings state: %v\n", keybindingsStoreErr)
+	}
 
 	// Resolve the registry root once for this hub process. Launch configuration
 	// may override XDG_CONFIG_HOME for a child, so the child must receive this
@@ -375,6 +379,8 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 		PluginRoot:                pluginRoot,
 		TranscriptDisplayStore:    transcriptDisplayStore,
 		TranscriptDisplayStoreErr: transcriptDisplayStoreErr,
+		KeybindingsStore:          keybindingsStore,
+		KeybindingsStoreErr:       keybindingsStoreErr,
 		RunDir:                    runDir,
 		PastIndexPath:             pastIndexDB,
 		Roster:                    roster,

--- a/cmd/evener-hub/web.go
+++ b/cmd/evener-hub/web.go
@@ -49,6 +49,7 @@ type WebServer struct {
 	frontendHash              string
 	deletionStoreErr          error
 	transcriptDisplayStoreErr error
+	keybindingsStoreErr       error
 }
 
 var manifestMarshal = json.Marshal
@@ -66,6 +67,10 @@ func newWebServer(cfg hubcore.WebConfig, appwireTrace *appserver.WebSocketTrace)
 	transcriptDisplayStoreErr := cfg.TranscriptDisplayStoreErr
 	if cfg.TranscriptDisplayStore == nil {
 		cfg.TranscriptDisplayStore, transcriptDisplayStoreErr = hubcore.NewTranscriptDisplayStore(cfg.HubStateRoot)
+	}
+	keybindingsStoreErr := cfg.KeybindingsStoreErr
+	if cfg.KeybindingsStore == nil {
+		cfg.KeybindingsStore, keybindingsStoreErr = hubcore.NewKeybindingsStore(cfg.HubStateRoot)
 	}
 	sources := newHubSourceRegistry(cfg)
 	if cfg.CodexLauncher == nil && len(cfg.CodexLaunches) > 0 {
@@ -89,6 +94,7 @@ func newWebServer(cfg hubcore.WebConfig, appwireTrace *appserver.WebSocketTrace)
 		frontendHash:              fHash,
 		deletionStoreErr:          deletionStoreErr,
 		transcriptDisplayStoreErr: transcriptDisplayStoreErr,
+		keybindingsStoreErr:       keybindingsStoreErr,
 	}
 	if web.cfg.LiveModels == nil {
 		web.cfg.LiveModels = web.fetchLiveModels

--- a/cmd/evener-tui/hub_notification_coverage_test.go
+++ b/cmd/evener-tui/hub_notification_coverage_test.go
@@ -33,6 +33,9 @@ var notifyMethodsDeliberatelyIgnored = []string{
 	// Transcript display defaults configure the Web UI's projector. The TUI has
 	// its own transcript renderer and no matching live/default settings surface.
 	appwire.NotifyEvenerSettingsTranscriptDisplayChanged,
+	// Keybinding overrides configure the Web UI's dispatcher. The TUI has its
+	// own input handling and no remappable-binding surface.
+	appwire.NotifyEvenerSettingsKeybindingsChanged,
 }
 
 // kata e79v: evener/thread/modelRetry was added to the catalog and the TUI ignored

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -172,6 +172,8 @@ no router (reserved).
 | `evener/settings/overview` | hub | `EmptyParams` | `SettingsOverviewResponse` | Returns the settings overview field bag: hub/runtime, storage, agent roster, codex launch configs, and probed MCP servers — the six template-only settings sections' data. |
 | `evener/settings/transcriptDisplay/get` | hub | `EmptyParams` | `TranscriptDisplayDefaults` | Reads the canonical Desktop and Mobile transcript-display defaults. |
 | `evener/settings/transcriptDisplay/patch` | hub | `TranscriptDisplayDefaultsPatchParams` | `TranscriptDisplayPatchResponse` | Updates one transcript-display default using an expected revision and returns the canonical value. |
+| `evener/settings/keybindings/get` | hub | `EmptyParams` | `KeybindingsOverrides` | Reads the canonical user keybinding overrides (version, revision, rules). |
+| `evener/settings/keybindings/patch` | hub | `KeybindingsPatchParams` | `KeybindingsOverrides` | Replaces the user keybinding overrides using an expected revision and returns the canonical value. |
 | `evener/sandbox/escalation/resolve` | both | `SandboxEscalationResolveParams` | `EmptyResponse` | Delivers a human's approve/deny decision for a pending sandbox-exemption escalation (M7); the daemon unblocks the waiting tool-exec goroutine, the hub relays. |
 
 ## Notifications (server → client)
@@ -216,6 +218,7 @@ Pushed to subscribed connections; no `id`. The web client maps these in
 | `evener/sandbox/escalation/requested` | `SandboxEscalationRequested` | A harness-raised, human-gated sandbox-exemption approval card (M7); the tool-exec goroutine blocks until answered via evener/sandbox/escalation/resolve. |
 | `evener/sandbox/escalation/resolved` | `SandboxEscalationResolved` | A previously-raised sandbox escalation left the pending set — resolved, turn-interrupted, or cleared by session close (M7); every OTHER subscribed client clears its now-stale copy of the card. |
 | `evener/settings/transcriptDisplay/changed` | `TranscriptDisplayChangedParams` | Broadcast after a transcript-display default changes; carries the layout, revision, and canonical configuration. |
+| `evener/settings/keybindings/changed` | `KeybindingsOverrides` | Broadcast after the user keybinding overrides change; carries the revision and canonical rules. |
 
 ## Type reference
 
@@ -927,6 +930,24 @@ _(no fields)_
 | `threadId` | `string` |  |  |
 | `ref` | `string` |  |  |
 | `revision` | `uint64` |  |  |
+
+
+### `KeybindingsOverrides`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `version` | `int` |  |  |
+| `revision` | `uint64` |  |  |
+| `rules` | `[]appwire.KeybindingsRule` |  |  |
+| `loadError` | `string` | yes |  |
+
+
+### `KeybindingsPatchParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `expectedRevision` | `uint64` |  |  |
+| `config` | `appwire.KeybindingsConfig` |  |  |
 
 
 ### `LaunchConfigGetLayerParams`

--- a/docs/web-ui/README.md
+++ b/docs/web-ui/README.md
@@ -16,8 +16,10 @@ Design documentation for the web hub (`cmd/evener-hub`). Started 2026-06-16.
   it. Cited from live source comments.
 - **[keybindings.md](keybindings.md)** — the keybindings dispatcher: registry,
   scope stack, precedence layers, per-binding policy flags, and how to
-  register an action or a chord, plus the hub-persisted override sync
-  (payload contract, validation split, failure posture).
+  register an action or a chord, the shipped default binding map (including
+  the Phase 3 navigation chords and the AskDock keyboard contract), plus the
+  hub-persisted override sync (payload contract, validation split, failure
+  posture).
 - **[parity/](parity/)** — the behaviour-parity checklists the React rewrite was
   graded against, mined from the legacy hub before it was deleted. The code they
   cite is gone, so their `path:line` citations no longer resolve; they survive

--- a/docs/web-ui/README.md
+++ b/docs/web-ui/README.md
@@ -16,7 +16,8 @@ Design documentation for the web hub (`cmd/evener-hub`). Started 2026-06-16.
   it. Cited from live source comments.
 - **[keybindings.md](keybindings.md)** — the keybindings dispatcher: registry,
   scope stack, precedence layers, per-binding policy flags, and how to
-  register an action or a chord.
+  register an action or a chord, plus the hub-persisted override sync
+  (payload contract, validation split, failure posture).
 - **[parity/](parity/)** — the behaviour-parity checklists the React rewrite was
   graded against, mined from the legacy hub before it was deleted. The code they
   cite is gone, so their `path:line` citations no longer resolve; they survive

--- a/docs/web-ui/README.md
+++ b/docs/web-ui/README.md
@@ -14,6 +14,9 @@ Design documentation for the web hub (`cmd/evener-hub`). Started 2026-06-16.
 - **[ux-plan-2026-07.md](ux-plan-2026-07.md)** — the five-participant study of
   the SPA against the old server-rendered build, and the plan that came out of
   it. Cited from live source comments.
+- **[keybindings.md](keybindings.md)** — the keybindings dispatcher: registry,
+  scope stack, precedence layers, per-binding policy flags, and how to
+  register an action or a chord.
 - **[parity/](parity/)** — the behaviour-parity checklists the React rewrite was
   graded against, mined from the legacy hub before it was deleted. The code they
   cite is gone, so their `path:line` citations no longer resolve; they survive

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,10 +1,12 @@
 # Web UI keybindings
 
-Status: **current** (Phase 2b). The web hub's global keyboard chords are
+Status: **current** (Phase 3). The web hub's global keyboard chords are
 owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
 window-level dispatcher, instead of each component installing its own
 `keydown` listener. User overrides persist on the hub and sync to every
-paired browser.
+paired browser. Phase 3 added the first navigation bindings (session-pane
+cycling, transcript scroll) on that infrastructure, plus full keyboard
+operation of the AskDock ask-user surface.
 
 ## Architecture
 
@@ -24,7 +26,8 @@ Four pieces, all in `src/keybindings/` and all React-free:
 - **dispatcher.ts** — the single window-level `keydown` listener. On every
   registry change it rebuilds a tinykeys `createKeybindingsHandler` over the
   active scope set: the scope stack top-down, then the `global` scope.
-- **defaults.ts** — the built-in binding map (the six shell chords) and
+- **defaults.ts** — the built-in binding map (the six legacy shell chords
+  plus the six Phase 3 navigation chords) and
   `registerDefaultBindings`, which also registers each `$mod` chord's
   cross-platform Meta/Control twin (the pre-dispatcher listeners accepted
   `metaKey || ctrlKey` on every platform, so both work everywhere).
@@ -48,9 +51,10 @@ The one wiring point that touches React and the app's stores is
 `src/shell/installKeybindings.ts`: an idempotent per-window installer that
 registers the default bindings and attaches the dispatcher with the real
 predicates injected. AppShell calls it at mount; every component that
-registers a chord action (RailHost, Settings, SelectionQuote) calls it too,
-so those components' chords also work when they are mounted without the
-shell — their unit tests render them standalone.
+registers a chord action (RailHost, Settings, SelectionQuote, and every
+Session pane via its transcript-scroll hook) calls it too, so those
+components' chords also work when they are mounted without the shell —
+their unit tests render them standalone.
 
 ## Precedence
 
@@ -91,6 +95,168 @@ preventDefault'd. Multi-instance components rely on this: one SelectionQuote
 mounts per session pane, each registering `selection.quote`, and only the
 instance holding a captured selection accepts — the multi-instance
 equivalent of the per-component listeners the dispatcher replaced.
+Phase 3's transcript scroll uses the same contract, keyed on the focused
+pane instead of a captured selection (see below).
+
+## Default binding map (as shipped after Phase 3)
+
+Every entry of `DEFAULT_BINDINGS` (`src/keybindings/defaults.ts`), in map
+order. Chords are rendered the way `KeyHint`/`formatChord` render them:
+`$mod` reads as ⌘ on Apple platforms and Ctrl elsewhere, every other key
+name is verbatim. "Policy" lists only the flags that differ from the
+defaults (`allowInEditable: false`, `allowInModal: false`,
+`ignoreIfDefaultPrevented: true`).
+
+| Chord | Action | Scope | Non-default policy | What it does |
+|---|---|---|---|---|
+| ⌘K / Ctrl+K | `palette.open` | global | `allowInEditable`, `allowInModal` | Open the command palette |
+| ⌘B / Ctrl+B | `rail.toggle` | global | `allowInModal`, `ignoreIfDefaultPrevented: false` | Toggle the sidebar |
+| ⌘I / Ctrl+I | `composer.focus` | global | `allowInEditable` | Focus the composer |
+| ⌘J / Ctrl+J | `next-needs-you` | global | `allowInEditable` | Go to the next session needing you |
+| ⌘' / Ctrl+' | `selection.quote` | global | `allowInEditable`, `allowInModal` | Quote the selection into the composer |
+| Alt+ArrowRight | `session.next` | global | — | Focus the next session pane |
+| Alt+ArrowLeft | `session.previous` | global | — | Focus the previous session pane |
+| Alt+ArrowUp | `transcript.lineUp` | global | — | Scroll the focused pane's transcript up one line |
+| Alt+ArrowDown | `transcript.lineDown` | global | — | Scroll the focused pane's transcript down one line |
+| Alt+Shift+ArrowUp | `transcript.pageUp` | global | — | Scroll the focused pane's transcript up one page |
+| Alt+Shift+ArrowDown | `transcript.pageDown` | global | — | Scroll the focused pane's transcript down one page |
+| Escape | `settings.close` | settings | `allowInEditable` | Close settings |
+
+Match permissiveness, per chord (all of it exact preservation of the
+pre-dispatcher listeners — Phase 2a's ruling was no behavior change):
+
+- Every `$mod` chord also registers its cross-platform Meta/Control twin,
+  so e.g. Ctrl+K fires on macOS exactly like ⌘K. On top of that, the five
+  legacy `$mod` chords carry `legacyEitherMod`: the other of Meta/Ctrl is
+  an *optional* modifier on both the entry and its twin, so Meta+Ctrl+K
+  fires too.
+- ⌘K / ⌘I / ⌘J list `[Shift]+[Alt]` as optional modifiers (the legacy
+  AppShell listener had no shift/alt guard), so ⌘⇧K, ⌘⌥I, Ctrl+Shift+J
+  etc. all fire. This means `composer.focus` and `next-needs-you` keep
+  hijacking the browser's DevTools chords (⌘⌥I, Ctrl+Shift+J) exactly as
+  the legacy listeners did — see the provisional-status note below.
+- ⌘' allows an extra Shift but never Alt (the legacy `!event.altKey`
+  AltGr guard); ⌘B is strict — no extra modifiers at all.
+- `settings.close`'s Escape lists every modifier optional (the legacy
+  listener checked only `event.key === "Escape"`).
+- The six Phase 3 Alt chords are strict single-family chords with no
+  optional modifiers — Alt+ArrowUp and Alt+Shift+ArrowUp must stay
+  distinct bindings (line vs page scroll), which forbids a `[Shift]` on
+  the plain chord — and no `$mod` twin. All keep the default
+  `allowInEditable: false`, so plain Alt+Arrow keeps its native
+  word-move/selection meaning inside inputs and the composer.
+
+Two registered actions have **no default chord**: `transcript.scrollTop`
+and `transcript.scrollBottom`. Their handlers exist (each Session pane
+registers them), but the Phase 4 keymap decides whether they get a chord
+at all. Because `DEFAULT_BINDINGS` is the Settings section's row source
+and the override validator's action universe, chord-less actions appear in
+neither — an override payload naming one is skipped with an unknown-action
+warning.
+
+### Provisional status
+
+The six Phase 3 chords are provisional: Phase 4 owns the comprehensive
+keymap and may re-cut any of them (they are registry defaults, remappable
+via the Phase 2b overrides store from day one). The ledger records two
+known Phase 4 candidates:
+
+1. **Removing the legacy DevTools-chord hijack permissiveness.** ⌘⌥I and
+   Ctrl+Shift+J fire `composer.focus` and `next-needs-you` today because
+   Phase 2a preserved the legacy listeners' missing shift/alt guards
+   exactly. Revisiting that was deferred policy then and is still open.
+2. **Deciding chords for `transcript.scrollTop`/`scrollBottom`** — and, if
+   they stay chord-less, giving the validator/Settings story for actions
+   that exist outside `DEFAULT_BINDINGS`.
+
+## Phase 3: session-pane cycling
+
+`session.next` / `session.previous` (Alt+ArrowRight / Alt+ArrowLeft) cycle
+focus through the workspace's **session** panes — panes of
+`type === "session"` only; transcript/doc/tasks panels are not cycling
+targets. The semantics live in `src/shell/sessionCycle.ts`
+(`cycleSessionPane`), against the store; AppShell's handlers are one line
+each:
+
+- Order is `workspaceStore.panes` order, wrapping at both ends.
+- Fewer than two session panes open is a no-op (cycling one pane onto
+  itself would be motion without movement).
+- When the focused pane is not a session (settings, a doc, nothing
+  focused), `next` lands on the FIRST session pane and `previous` on the
+  LAST — the `nextNeedsYouRef` precedent for "current not in the list".
+- The handlers always **claim** the chord (they never decline), even when
+  cycling no-ops: Alt+ArrowLeft is the browser's Back shortcut, and
+  declining it would navigate the SPA's history underneath a user with a
+  single session open.
+- Desktop only: AppShell registers nothing on mobile (RailHost's
+  `rail.toggle` no-registration pattern), so the bindings are inert there.
+
+## Phase 3: transcript scroll
+
+`transcript.lineUp/lineDown` (Alt+ArrowUp/Down) and
+`transcript.pageUp/pageDown` (Alt+Shift+ArrowUp/Down) scroll the focused
+session pane's transcript; `transcript.scrollTop`/`scrollBottom` jump to
+the ends (chord-less for now). The seam is
+`src/panes/session/transcript/flow/useTranscriptScrollKeys.ts`, mounted
+once per Session pane:
+
+- **Per-pane multi-instance registration.** Every mounted Session pane
+  registers its own handlers for all six `transcript.*` actions on the
+  shared registry. Arbitration is the registry's multi-instance contract:
+  a handler returns `false` (declines) unless
+  `workspaceStore.focusedPaneId` is its own pane, so only the focused
+  pane's transcript scrolls. Unmount disposes only that pane's handlers.
+- **No new scroll math** — the mechanisms are the transcript flow stack's
+  own. Line steps write the virtualizer scroll element's `scrollTop`
+  directly by `TRANSCRIPT_LINE_SCROLL_PX` (40px), the same adjustment
+  `useTranscriptScroll`'s anchor-restore paths use; page steps use
+  `± 0.9 * clientHeight` (`TRANSCRIPT_PAGE_SCROLL_RATIO`). `scrollTop` is
+  the virtualizer's `scrollToIndex(0, { align: "start" })`; `scrollBottom`
+  is the hook's own `jumpToBottom` (error-anchor aware, pill clearing) —
+  the exact action the NewContentPill click target runs.
+- A pane whose VirtualList hasn't mounted (a dormant session renders
+  EmptyTranscript — no scroll element) declines, so such a keydown is not
+  preventDefault'd.
+- Mobile registers nothing; with no handler the bindings are inert there.
+
+## Phase 3: AskDock keyboard contract
+
+The AskDock ask-user answering surface
+(`src/panes/session/composer/askDock/AskDock.tsx`) is fully
+keyboard-operable. Its keys are **component-internal** `keydown` handlers,
+not registry bindings, so they are not remappable via the Phase 2b
+overrides store:
+
+- Every rendered control is a native element: radios (single-option
+  questions, arrows move+select inside the group), checkboxes
+  (multi-option), the free-text and note inputs, and the footer's primary
+  `<button>`. A multi-question batch's tab strip is ARIA tabs with a
+  roving tabindex and automatic activation (Arrow keys move and select;
+  Home/End jump the ends).
+- **Mod+Enter anywhere in a batch** invokes the footer primary action
+  (Send, or advance in the question walk). Bare Enter does the same only
+  from the free-text answer input. Both are IME-guarded
+  (`isComposing`).
+- **Alt+PageDown / Alt+PageUp** jump focus between batches directly,
+  wrapping at both ends, landing on the target batch's selected tab when
+  it has a tab strip, else its first answer control. The chord is strict
+  Alt-only (an extra modifier or an IME composition lets the key keep its
+  other meaning); with fewer than two batches the event is left alone, not
+  claimed. Alt+Arrow* was rejected for this because the transcript-scroll
+  bindings own it, and bare PageUp/PageDown keep their native meaning (the
+  dock is its own `overflow-y: auto` scroller).
+- **Escape is a deliberate no-op** — the component installs no Escape
+  handler at all. `docs/web-ui/parity/parity-m5-composer.md:120` documents
+  the legacy behavior: the dock is the one canonical response surface and
+  there is no alternate "collapse" state to escape to. AskDock.test.tsx
+  pins the no-op.
+- **Focus return after send**: when a send empties the dock, focus returns
+  to the composer through `composerFocus.ts`'s `requestComposerFocus` seam
+  (the request survives until the composer input row's hidden/inert lifts,
+  which this send just caused). When batches remain, the composer input
+  row is still hidden/inert, so focus moves to the first remaining batch's
+  entry control instead. A failed send keeps focus in the intact dock; a
+  stale outcome is a no-op.
 
 ## Registering an action and a binding
 
@@ -253,7 +419,9 @@ leaves room for:
 
 - **A keybinding editor** (Phase 4) — the store's `patchOverrides` is the
   write path it will use; the Settings section stays read-only until then.
-- **A shortcuts overlay / cheatsheet UI** (Phase 3).
+- **A shortcuts overlay / cheatsheet UI** — planned for Phase 3, not landed;
+  Phase 3 as executed shipped the navigation bindings, the AskDock keyboard
+  contract, and this map instead.
 - **Hold-modifier chord hints** (Phase 4) — `formatChord`/`formatSequence`
   exist for exactly this consumer.
 - `Binding.when` is still stored verbatim and never evaluated; scope-stack

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,16 +1,22 @@
 # Web UI keybindings
 
-Status: **current** (Phase 3). The web hub's global keyboard chords are
+Status: **current** (Phase 4b). The web hub's global keyboard chords are
 owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
 window-level dispatcher, instead of each component installing its own
 `keydown` listener. User overrides persist on the hub and sync to every
-paired browser. Phase 3 added the first navigation bindings (session-pane
+paired browser. Phase 3 added the navigation bindings (session-pane
 cycling, transcript scroll) on that infrastructure, plus full keyboard
-operation of the AskDock ask-user surface.
+operation of the AskDock ask-user surface. Phase 4a finalized the default
+map (strict Mod chords for ⌘K/⌘I/⌘J, new `settings` and transcript
+end-jump bindings) and shipped the two discoverability surfaces: the
+cheatsheet overlay (⌘/ or `?`) and hold-modifier hint chips.
+Phase 4b turned Settings → Keybindings into a capture-based editor over
+the synced overrides: pre-flight conflict validation, per-action
+unbind/reset (the Settings section below).
 
 ## Architecture
 
-Four pieces, all in `src/keybindings/` and all React-free:
+Seven pieces, all in `src/keybindings/` and all React-free:
 
 - **chord.ts** — the chord AST (`Chord` = required modifiers + optional
   modifiers + key; `KeySequence` = a list of presses). `parseChord` wraps
@@ -26,16 +32,21 @@ Four pieces, all in `src/keybindings/` and all React-free:
 - **dispatcher.ts** — the single window-level `keydown` listener. On every
   registry change it rebuilds a tinykeys `createKeybindingsHandler` over the
   active scope set: the scope stack top-down, then the `global` scope.
-- **defaults.ts** — the built-in binding map (the six legacy shell chords
-  plus the six Phase 3 navigation chords) and
-  `registerDefaultBindings`, which also registers each `$mod` chord's
-  cross-platform Meta/Control twin (the pre-dispatcher listeners accepted
-  `metaKey || ctrlKey` on every platform, so both work everywhere).
-  `DEFAULT_BINDINGS` is also the canonical action universe: each entry
-  carries the action's user-facing `title`, and the Settings keybindings
-  section enumerates it live. `registerDefaultBindingsForAction` and
-  `defaultBindingChordsForAction` are the per-action variants the overrides
-  layer uses to restore and to simulate restorations.
+- **defaults.ts** — the built-in binding map (the six legacy shell chords,
+  the six Phase 3 navigation chords, and the Phase 4a additions:
+  `settings`, `transcript.scrollTop`/`scrollBottom`, and the cheatsheet
+  triggers) and `registerDefaultBindings`, which also registers each
+  `$mod` chord's cross-platform Meta/Control twin (the pre-dispatcher
+  listeners accepted `metaKey || ctrlKey` on every platform, so both work
+  everywhere). `DEFAULT_BINDINGS` is also the canonical action universe:
+  each entry carries the action's user-facing `title`, and both the
+  Settings keybindings section and the cheatsheet overlay enumerate it
+  live. One entry is CONDITIONAL: the `?` cheatsheet trigger
+  (`CHARACTER_KEY_TRIGGER_BINDING_ID`), registered only while the
+  character-key-triggers pref is on (see the cheatsheet section below).
+  `registerDefaultBindingsForAction` and `defaultBindingChordsForAction`
+  are the per-action variants the overrides layer uses to restore and to
+  simulate restorations.
 - **overrides.ts** — `rebindAction(registry, actionId, chord | null)`
   replaces an action's current bindings (default + `#mod-twin` + any earlier
   `#override`) with a single `#override` binding that keeps the default's
@@ -46,15 +57,23 @@ Four pieces, all in `src/keybindings/` and all React-free:
   never throws: unknown actions, unparseable chords, reserved
   (browser/OS-claimed) chords, and conflicts each become a typed
   `ValidationWarning` and the rule is skipped.
+- **display.ts** — the shared read model for the two binding-list UIs
+  (Settings → Keybindings and the cheatsheet overlay):
+  `ACTION_DISPLAY_ROWS` (one row per action, in default-map order) and
+  `displayBindingsFor`, which picks an action's effective display bindings
+  from the live registry (the override alone when one is applied, else
+  every non-twin default entry). Both UIs read this module so no
+  hand-maintained copy can go stale.
 
 The one wiring point that touches React and the app's stores is
 `src/shell/installKeybindings.ts`: an idempotent per-window installer that
-registers the default bindings and attaches the dispatcher with the real
+registers the default bindings, installs the character-key-trigger
+reconcile (the `?` pref gating), and attaches the dispatcher with the real
 predicates injected. AppShell calls it at mount; every component that
-registers a chord action (RailHost, Settings, SelectionQuote, and every
-Session pane via its transcript-scroll hook) calls it too, so those
-components' chords also work when they are mounted without the shell —
-their unit tests render them standalone.
+registers a chord action (RailHost, Settings, SelectionQuote,
+CheatsheetOverlay, and every Session pane via its transcript-scroll hook)
+calls it too, so those components' chords also work when they are mounted
+without the shell — their unit tests render them standalone.
 
 ## Precedence
 
@@ -98,14 +117,16 @@ equivalent of the per-component listeners the dispatcher replaced.
 Phase 3's transcript scroll uses the same contract, keyed on the focused
 pane instead of a captured selection (see below).
 
-## Default binding map (as shipped after Phase 3)
+## Default binding map (final since Phase 4a)
 
 Every entry of `DEFAULT_BINDINGS` (`src/keybindings/defaults.ts`), in map
 order. Chords are rendered the way `KeyHint`/`formatChord` render them:
 `$mod` reads as ⌘ on Apple platforms and Ctrl elsewhere, every other key
 name is verbatim. "Policy" lists only the flags that differ from the
 defaults (`allowInEditable: false`, `allowInModal: false`,
-`ignoreIfDefaultPrevented: true`).
+`ignoreIfDefaultPrevented: true`). The `?` row is the map's one
+conditional entry: it is live only while the character-key-triggers pref
+is on (see the cheatsheet section below).
 
 | Chord | Action | Scope | Non-default policy | What it does |
 |---|---|---|---|---|
@@ -114,60 +135,64 @@ defaults (`allowInEditable: false`, `allowInModal: false`,
 | ⌘I / Ctrl+I | `composer.focus` | global | `allowInEditable` | Focus the composer |
 | ⌘J / Ctrl+J | `next-needs-you` | global | `allowInEditable` | Go to the next session needing you |
 | ⌘' / Ctrl+' | `selection.quote` | global | `allowInEditable`, `allowInModal` | Quote the selection into the composer |
+| ⌘, / Ctrl+, | `settings` | global | `allowInEditable` | Open settings (the action id IS the palette's `settings` command id) |
 | Alt+ArrowRight | `session.next` | global | — | Focus the next session pane |
 | Alt+ArrowLeft | `session.previous` | global | — | Focus the previous session pane |
 | Alt+ArrowUp | `transcript.lineUp` | global | — | Scroll the focused pane's transcript up one line |
 | Alt+ArrowDown | `transcript.lineDown` | global | — | Scroll the focused pane's transcript down one line |
 | Alt+Shift+ArrowUp | `transcript.pageUp` | global | — | Scroll the focused pane's transcript up one page |
 | Alt+Shift+ArrowDown | `transcript.pageDown` | global | — | Scroll the focused pane's transcript down one page |
+| Alt+Home | `transcript.scrollTop` | global | — | Jump the focused pane's transcript to the top |
+| Alt+End | `transcript.scrollBottom` | global | — | Jump the focused pane's transcript to the bottom |
 | Escape | `settings.close` | settings | `allowInEditable` | Close settings |
+| ⌘/ / Ctrl+/ | `cheatsheet.toggle` | global | `allowInEditable`, `allowInModal` | Open/close the keyboard shortcuts overlay |
+| ? | `cheatsheet.toggle` | global | conditional on the character-key-triggers pref | Open/close the keyboard shortcuts overlay |
+| Escape | `cheatsheet.close` | cheatsheet | `allowInEditable` | Close the keyboard shortcuts overlay |
 
-Match permissiveness, per chord (all of it exact preservation of the
-pre-dispatcher listeners — Phase 2a's ruling was no behavior change):
+Match permissiveness, per chord. The legacy chords preserve the
+pre-dispatcher listeners exactly except where Phase 4a deliberately
+tightened them — called out first:
 
+- **Phase 4a behavior change: ⌘K / ⌘I / ⌘J are now STRICT.** The 2a map
+  had carried the legacy AppShell listener's missing shift/alt guard as
+  `[Shift]+[Alt]` optionality, so ⌘⌥I fired `composer.focus` and
+  Ctrl+Shift+J fired `next-needs-you` — hijacking the browser's DevTools
+  chords. Phase 4a dropped that optionality
+  (`docs/superpowers/plans/2026-09-04-webui-keybindings-p4-plan.md`,
+  Design decision 1): ⌘⌥I, Ctrl+Shift+J, and ⌘⇧J now revert to the
+  browser. The `legacyEitherMod` either/both-Meta-Ctrl permissiveness
+  stays.
 - Every `$mod` chord also registers its cross-platform Meta/Control twin,
   so e.g. Ctrl+K fires on macOS exactly like ⌘K. On top of that, the five
   legacy `$mod` chords carry `legacyEitherMod`: the other of Meta/Ctrl is
   an *optional* modifier on both the entry and its twin, so Meta+Ctrl+K
   fires too.
-- ⌘K / ⌘I / ⌘J list `[Shift]+[Alt]` as optional modifiers (the legacy
-  AppShell listener had no shift/alt guard), so ⌘⇧K, ⌘⌥I, Ctrl+Shift+J
-  etc. all fire. This means `composer.focus` and `next-needs-you` keep
-  hijacking the browser's DevTools chords (⌘⌥I, Ctrl+Shift+J) exactly as
-  the legacy listeners did — see the provisional-status note below.
 - ⌘' allows an extra Shift but never Alt (the legacy `!event.altKey`
   AltGr guard); ⌘B is strict — no extra modifiers at all.
+- ⌘, (`settings`) and ⌘/ (`cheatsheet.toggle`) are new chords with no
+  legacy listener to match: strict `$mod` with the cross-platform twin
+  only, no `legacyEitherMod`.
+- `?` lists Shift as optional because tinykeys rejects an event carrying
+  any modifier the binding does not name, and every common layout types
+  `?` WITH Shift held — a bare `?` binding would never fire. Display
+  drops optional modifiers, so the row still reads `?`.
 - `settings.close`'s Escape lists every modifier optional (the legacy
-  listener checked only `event.key === "Escape"`).
-- The six Phase 3 Alt chords are strict single-family chords with no
+  listener checked only `event.key === "Escape"`); `cheatsheet.close`'s
+  Escape is the same.
+- The eight Alt chords are strict single-family chords with no
   optional modifiers — Alt+ArrowUp and Alt+Shift+ArrowUp must stay
   distinct bindings (line vs page scroll), which forbids a `[Shift]` on
   the plain chord — and no `$mod` twin. All keep the default
-  `allowInEditable: false`, so plain Alt+Arrow keeps its native
-  word-move/selection meaning inside inputs and the composer.
+  `allowInEditable: false`, so plain Alt+Arrow and Alt+Home/End keep
+  their native word-move/selection/caret meaning inside inputs and the
+  composer.
 
-Two registered actions have **no default chord**: `transcript.scrollTop`
-and `transcript.scrollBottom`. Their handlers exist (each Session pane
-registers them), but the Phase 4 keymap decides whether they get a chord
-at all. Because `DEFAULT_BINDINGS` is the Settings section's row source
-and the override validator's action universe, chord-less actions appear in
-neither — an override payload naming one is skipped with an unknown-action
-warning.
-
-### Provisional status
-
-The six Phase 3 chords are provisional: Phase 4 owns the comprehensive
-keymap and may re-cut any of them (they are registry defaults, remappable
-via the Phase 2b overrides store from day one). The ledger records two
-known Phase 4 candidates:
-
-1. **Removing the legacy DevTools-chord hijack permissiveness.** ⌘⌥I and
-   Ctrl+Shift+J fire `composer.focus` and `next-needs-you` today because
-   Phase 2a preserved the legacy listeners' missing shift/alt guards
-   exactly. Revisiting that was deferred policy then and is still open.
-2. **Deciding chords for `transcript.scrollTop`/`scrollBottom`** — and, if
-   they stay chord-less, giving the validator/Settings story for actions
-   that exist outside `DEFAULT_BINDINGS`.
+The map is final as of Phase 4a: the provisional ledger Phase 3 carried
+is closed — the DevTools-chord hijack permissiveness is gone (above) and
+`transcript.scrollTop`/`scrollBottom` have their chords. Every binding
+stays remappable through the hub-synced overrides store (Persistence
+below); Settings → Keybindings edits them directly (the Settings section
+at the end of this document).
 
 ## Phase 3: session-pane cycling
 
@@ -195,8 +220,8 @@ each:
 
 `transcript.lineUp/lineDown` (Alt+ArrowUp/Down) and
 `transcript.pageUp/pageDown` (Alt+Shift+ArrowUp/Down) scroll the focused
-session pane's transcript; `transcript.scrollTop`/`scrollBottom` jump to
-the ends (chord-less for now). The seam is
+session pane's transcript; `transcript.scrollTop`/`scrollBottom` (Alt+Home
+/ Alt+End since Phase 4a) jump to the ends. The seam is
 `src/panes/session/transcript/flow/useTranscriptScrollKeys.ts`, mounted
 once per Session pane:
 
@@ -257,6 +282,70 @@ overrides store:
   row is still hidden/inert, so focus moves to the first remaining batch's
   entry control instead. A failed send keeps focus in the intact dock; a
   stale outcome is a no-op.
+
+## Phase 4a: cheatsheet overlay
+
+`cheatsheet.toggle` opens a modal "Keyboard shortcuts" overlay
+(`src/shell/cheatsheet/CheatsheetOverlay.tsx`) listing every action with
+its EFFECTIVE chord, grouped Sessions / Transcript / Composer / General
+(anything the grouping doesn't name — including a future action — lands
+in General, so a new action can never silently vanish). Both the row list
+and the chords are live reads (`keybindings/display.ts` over the
+registry), so hub-synced overrides and unbound actions render truthfully
+— an action with no effective binding shows "Unbound".
+
+Triggers:
+
+- **⌘/ (Ctrl+/ elsewhere)** — the primary trigger, an ordinary default-map
+  binding for `cheatsheet.toggle`. `allowInEditable` (not a printable
+  character) and `allowInModal`, so the same chord also toggles the
+  overlay CLOSED while it is open.
+- **?** — the secondary trigger, and the default map's one CONDITIONAL
+  entry (`CHARACTER_KEY_TRIGGER_BINDING_ID`). It is registered exactly
+  while the **Character-key shortcuts** pref
+  (`prefsStore.characterKeyTriggers`, browser-local localStorage, default
+  ON) is on — the WCAG 2.1.4 turn-off for single-character shortcuts. The
+  pref surfaces as a Switch row at the top of Settings → Keybindings;
+  turning it off leaves every shortcut on a modifier chord. Because `?` is
+  a printable character it never fires from an editable target or over a
+  modal. The reconcile (`cheatsheetController.ts`) subscribes to both the
+  prefs store and the overrides store: an applied override (or unbind)
+  owns the action's whole chord set, so `?` never reappears on an
+  overridden `cheatsheet.toggle` — the override is the user's own
+  replacement for both triggers.
+- **Close**: Escape (the OverlayPanel's own handler claims it first
+  whenever focus is inside the dialog; the scope-gated `cheatsheet.close`
+  binding is the window-level backstop) or ⌘/ again.
+
+Desktop-only: AppShell mounts the overlay only off mobile, so no action
+is registered on a touch viewport and the trigger chords stay inert there
+(RailHost's `rail.toggle` no-registration pattern). The `?` reconcile
+installs with the dispatcher, not the overlay, so the pref invariant — and
+the Settings section's customized-marker comparison — holds on mobile too.
+
+## Phase 4a: hold-modifier hints
+
+Holding the primary modifier ALONE — ⌘ on Apple platforms, Ctrl elsewhere
+— for ~400ms fades hint chips in over the bound affordances
+(`src/shell/holdhints/`): the palette trigger, the rail toggle, the
+session tabs (one chip carrying both cycling chords), and the composer.
+Each chip shows the action's effective chord from the live registry (the
+same `display.ts` read the overlay and Settings make), so overrides show
+truthfully and an unbound action renders no chip. Chips anchor to the real
+elements at show time via their data attributes — never
+absolutely-positioned guesses — so an affordance that is not mounted (the
+rail's toggle exists in exactly one of its two states) renders no chip.
+
+Release hides the chips, and so does every other cleanup path: window
+blur, `visibilitychange`, any keydown that is not the tracked modifier (on
+macOS a chord's keyup may never arrive, so the keydown itself is the
+hide), and a 10s hard-timeout backstop. A stuck visible state must be
+impossible. The listeners are observers only — they never preventDefault
+or stopPropagation, so the dispatcher and every other keydown consumer see
+exactly the events they would see without this module. Under
+`prefers-reduced-motion` the chips appear instantly (no fade).
+Desktop-only by AppShell's mount gate: a touch viewport installs no
+listeners and renders no chips.
 
 ## Registering an action and a binding
 
@@ -389,7 +478,7 @@ not the store; the store carries `hubSupport`, `revision`, the validated
   advances only after a successful apply, so a failed payload stays
   retryable (a later `changed` with the same revision is not eaten by the
   stale guard).
-- **Patch** (used by the future editor): sends `expectedRevision` +
+- **Patch** (the editor's write path): sends `expectedRevision` +
   `{version: 1, rules}`; on success the canonical response is applied; on a
   conflict rejection the store refreshes to `data.current`, sets `conflict`
   and `hubError`, and rethrows.
@@ -402,27 +491,63 @@ warnings or a surfaced `hubError` with the last good (or default) bindings
 in place; the `changed`-notification path catches so a reconcile failure
 never escapes the client's notification dispatch.
 
-### Settings section
+### Settings section (Phase 4b editor)
 
-Settings → Keybindings is a **read-only** listing of the effective
-bindings: one row per action from `DEFAULT_BINDINGS` (never a
+Settings → Keybindings edits the synced overrides, not just lists them.
+Whenever the hub advertises `features.keybindingsSettings`
+(`hubSupport === "supported"`) every row is editable; an `unknown` or
+`unsupported` hub keeps the read-only listing and its status text — the
+overrides layer is hub-only by design, so there is nothing to edit
+against. The rows themselves are unchanged from Phase 4a: one per action
+from `DEFAULT_BINDINGS` via `keybindings/display.ts` (never a
 hand-maintained copy), the chord rendered with the `KeyHint` widget from
-the live registry, and a "Customized" marker on actions whose effective
-bindings differ from the default map (including unbound actions). The
-store's `hubSupport`/`hubError`/validation warnings surface as quiet status
-or alert text. Editing arrives with the Phase 4 editor.
+the live registry, a "Customized" marker on actions whose effective
+bindings differ from the default map (including unbound actions; the `?`
+entry's pref-conditional registration is not itself a customization), and
+the **Character-key shortcuts** Switch row at the top owning the WCAG
+2.1.4 pref.
+
+- **Capture.** Clicking a row's chord ("Change the shortcut for {title}",
+  or "Set a shortcut" when unbound) swaps the row's controls for a focused
+  capture box showing "Press new shortcut…". Held modifiers echo live as
+  `KeyHint` chips; the first non-modifier press records the chord. Plain
+  Enter saves, plain Escape cancels, Enter/Escape WITH a modifier record
+  as chords (Escape itself stays bindable). Clicking away cancels. The
+  capture box preventDefaults and stopPropagations every keydown, so the
+  dispatcher and `settings.close`'s own Escape stay inert while capturing.
+- **Single-press only.** Capture records one press — no multi-press
+  sequences — matching the all-single-press default map (multi-press
+  conflict checking is deliberately coarser). Bare-character chords (a
+  plain "A") CAN be authored; the character-key pref governs only the
+  built-in `?` trigger, not user-authored character chords, so bind bare
+  characters only if you know you mean it.
+- **Conflict semantics.** Every save is pre-flight validated in the store
+  — the same `validateOverrideRules` simulation over the final effective
+  map the reconcile path uses — BEFORE any hub request. A chord already
+  held by another binding in the same scope is rejected inline with a
+  message naming the chord, the scope, and the action holding it; the
+  capture box stays open so another chord can be tried, and nothing
+  reaches the hub. Reserved (browser/OS-claimed) and unparseable chords
+  reject the same way. A passing save sends the FULL replacement rule set
+  with `expectedRevision` optimistic concurrency (the apply flow above); a
+  revision conflict refreshes to the server's current payload.
+- **Unbind / Reset.** "Unbind" (bound actions) writes a `chord: null`
+  rule; "Reset" (actions carrying an override) drops the action from the
+  payload, restoring its defaults through the reconcile's
+  `restoreDefaultBinding`. Failures surface inline under the row.
+- **cheatsheet.toggle.** The ⌘/ base chord edits like any other. The `?`
+  character-key entry renders read-only with a note while it is
+  registered: it follows the character-key pref and the
+  cheatsheetController reconcile, not this editor — and because an
+  override owns the action's whole chord set, rebinding or unbinding the
+  base chord replaces `?` too.
+
+The store's `hubSupport`/`hubError`/validation warnings surface as the
+same quiet status or alert text as before.
 
 ## Deliberately not here yet
 
-Later phases of the webui-keybindings plan add, and this module already
-leaves room for:
-
-- **A keybinding editor** (Phase 4) — the store's `patchOverrides` is the
-  write path it will use; the Settings section stays read-only until then.
-- **A shortcuts overlay / cheatsheet UI** — planned for Phase 3, not landed;
-  Phase 3 as executed shipped the navigation bindings, the AskDock keyboard
-  contract, and this map instead.
-- **Hold-modifier chord hints** (Phase 4) — `formatChord`/`formatSequence`
-  exist for exactly this consumer.
 - `Binding.when` is still stored verbatim and never evaluated; scope-stack
   membership is the only gating the dispatcher applies.
+- Multi-press (sequence) chords — the default map is single-press
+  throughout and the editor's capture records one press, by design.

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -312,7 +312,20 @@ Triggers:
   prefs store and the overrides store: an applied override (or unbind)
   owns the action's whole chord set, so `?` never reappears on an
   overridden `cheatsheet.toggle` — the override is the user's own
-  replacement for both triggers.
+  replacement for both triggers. A pref flip also RE-VALIDATES the
+  persisted rules (the overrides store's prefs subscription re-applies
+  the raw set): the simulation treats `?` as pref-authoritative — the
+  re-apply runs in the flip instant, before the reconcile has
+  unregistered/re-registered the entry, and must simulate the map the
+  reconcile is about to establish — so a chord claimed while the pref
+  was off (say `composer.focus` on Shift+?) is un-applied by the
+  restore-wins rule with a conflict warning when the pref flips back
+  on, and a rule skipped while the pref was on applies when it flips
+  off. The reconcile's register path is separately overlap-checked as
+  the guard for overlaps validation does not manage (a foreign binding
+  squatting the chord): it skips the registration and surfaces a
+  `character-key-conflict` warning naming the holder in the Settings
+  section's warnings list until the overlap clears.
 - **Close**: Escape (the OverlayPanel's own handler claims it first
   whenever focus is inside the dialog; the scope-gated `cheatsheet.close`
   binding is the window-level backstop) or ⌘/ again.
@@ -403,7 +416,19 @@ it pushes `SETTINGS_SCOPE` and registers `settings.close` in one effect.
 
 Overrides are stored **on the hub**, not in the browser. There is no
 localStorage layer: an unsupported or unreachable hub means built-in
-defaults only, never a local fallback copy.
+defaults only, never a local fallback copy. Live-registry posture follows
+the same claim: when support resolves to **unsupported** (the feature set
+is known and does not advertise keybindings) any applied overrides are
+un-applied through the same atomic unwind the reconcile uses, because the
+settings section tells the user the built-in defaults are in effect — and
+the hub payload state (`loaded`/`revision`/`overrides`/`rawOverrides`) is
+discarded with them, so a supported reconnect accepts the returning hub's
+revision whatever it is (a restored backup can be LOWER than the old hub's)
+and edits compose from the new payload. Late `changed` notifications and
+in-flight PATCH responses landing during an unsupported window are dropped,
+not applied. A supported hub that is merely **unreachable** (transient
+disconnect) keeps its overrides firing — the rows show them read-only
+until the hub returns.
 
 ### Server side
 
@@ -454,7 +479,10 @@ default.
   wins** — the rule is skipped with a `conflict` warning and its action
   falls back to its own defaults, so every action stays bound. A chord freed
   earlier in the same payload (rebind-away or unbind) can be claimed by a
-  later rule.
+  later rule. The restored set mirrors the character-key pref: while the
+  pref is off the live registry has no `?` binding, so the simulated restore
+  does not claim one either — resetting `cheatsheet.toggle` cannot
+  phantom-conflict with a user chord that overlaps `?`.
 
 ### Apply flow
 
@@ -481,7 +509,24 @@ not the store; the store carries `hubSupport`, `revision`, the validated
 - **Patch** (the editor's write path): sends `expectedRevision` +
   `{version: 1, rules}`; on success the canonical response is applied; on a
   conflict rejection the store refreshes to `data.current`, sets `conflict`
-  and `hubError`, and rethrows.
+  and `hubError`, and rethrows. The store rejects a patch while any refresh
+  is in flight (`hubLoading`): the in-flight payload can land at any
+  revision, and a concurrent PATCH's `expectedRevision` would race it.
+  Writes also **serialize at the store**: `patchOverrides` calls chain onto
+  a pending-write queue, so at most one PATCH is in flight and each write
+  runs only after the previous one settles. Callers pass a composition
+  THUNK (`() => replacementRules(...)`) so the whole-payload rule set is
+  composed at execution time against the raw set the previous write left
+  behind — composing at call time would race the queued-ahead write with a
+  stale `expectedRevision` and a payload missing its confirmed change (a
+  self-inflicted conflict). A failed write settles the queue entry without
+  blocking the next one. Each write is also fenced to the ready generation
+  it was CREATED under: the client and epoch are captured at call time, and
+  a queued write whose generation ended while it waited (client replaced,
+  generation bumped) rejects with the same unavailable-class error before
+  any wire request — compose-at-execution is right within one generation,
+  but an edit made against one hub's displayed state must not land on the
+  next hub's config.
 
 ### Failure posture
 
@@ -511,10 +556,26 @@ the **Character-key shortcuts** Switch row at the top owning the WCAG
   or "Set a shortcut" when unbound) swaps the row's controls for a focused
   capture box showing "Press new shortcut…". Held modifiers echo live as
   `KeyHint` chips; the first non-modifier press records the chord. Plain
-  Enter saves, plain Escape cancels, Enter/Escape WITH a modifier record
-  as chords (Escape itself stays bindable). Clicking away cancels. The
+  Enter saves. Plain Escape ALWAYS cancels the capture — bare Escape
+  cannot be assigned through the editor (Escape-as-cancel is the
+  keybinding-editor convention), so the two built-in Escape bindings
+  (Close settings, Close the keyboard shortcuts overlay) are restored via
+  **Reset to default** rather than re-captured. Enter/Escape WITH a
+  modifier still record as chords (Shift+Escape is bindable). Clicking
+  away cancels, whether or not the click target can take focus. The
   capture box preventDefaults and stopPropagations every keydown, so the
   dispatcher and `settings.close`'s own Escape stay inert while capturing.
+  IME composition keydowns are ignored with the dispatcher's own guard
+  (`isComposing` / `keyCode === 229` / `Process` / `Unidentified`), so a
+  composition or its commit Enter can never record or save. A save is a
+  hub round trip that can outlive the box: a click-away cancel mid-save
+  bumps a per-capture generation token, and the stale save's resolution
+  applies only while its generation is current — it cannot close or
+  repaint a capture the user reopened before it landed. Editability loss
+  (a disconnect, support loss, hub replacement, or a hub error making the
+  section read-only) cancels an open capture the same way — generation
+  bumped, no focus return — so an interactive box never strands in the
+  read-only listing.
 - **Single-press only.** Capture records one press — no multi-press
   sequences — matching the all-single-press default map (multi-press
   conflict checking is deliberately coarser). Bare-character chords (a
@@ -532,9 +593,11 @@ the **Character-key shortcuts** Switch row at the top owning the WCAG
   with `expectedRevision` optimistic concurrency (the apply flow above); a
   revision conflict refreshes to the server's current payload.
 - **Unbind / Reset.** "Unbind" (bound actions) writes a `chord: null`
-  rule; "Reset" (actions carrying an override) drops the action from the
-  payload, restoring its defaults through the reconcile's
-  `restoreDefaultBinding`. Failures surface inline under the row.
+  rule; "Reset" (actions carrying a RAW override rule — including a
+  persisted rule validation skips, where dropping it is exactly the
+  meaningful action) drops the action from the payload, restoring its
+  defaults through the reconcile's `restoreDefaultBinding`. Failures
+  surface inline under the row.
 - **cheatsheet.toggle.** The ⌘/ base chord edits like any other. The `?`
   character-key entry renders read-only with a note while it is
   registered: it follows the character-key pref and the

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,0 +1,141 @@
+# Web UI keybindings
+
+Status: **current** (Phase 2a). The web hub's global keyboard chords are
+owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
+window-level dispatcher, instead of each component installing its own
+`keydown` listener.
+
+## Architecture
+
+Four pieces, all in `src/keybindings/` and all React-free:
+
+- **chord.ts** — the chord AST (`Chord` = required modifiers + optional
+  modifiers + key; `KeySequence` = a list of presses). `parseChord` wraps
+  tinykeys' `parseKeybinding`, so `$mod` resolves to `Meta` on Apple
+  platforms and `Control` elsewhere at parse time. `serializeChord`
+  round-trips an AST to a tinykeys string; `formatChord`/`formatSequence`
+  render one for humans.
+- **registry.ts** — a vanilla zustand store holding three things: the
+  **action registry** (action id → its handlers, in registration order), the
+  **bindings** (chord → action id, plus scope and policy flags), and the
+  **scope stack**. The app-wide singleton is `keybindingsRegistry`; tests
+  build their own with `createKeybindingsRegistry()`.
+- **dispatcher.ts** — the single window-level `keydown` listener. On every
+  registry change it rebuilds a tinykeys `createKeybindingsHandler` over the
+  active scope set: the scope stack top-down, then the `global` scope.
+- **defaults.ts** — the built-in binding map (the six shell chords) and
+  `registerDefaultBindings`, which also registers each `$mod` chord's
+  cross-platform Meta/Control twin (the pre-dispatcher listeners accepted
+  `metaKey || ctrlKey` on every platform, so both work everywhere).
+
+The one wiring point that touches React and the app's stores is
+`src/shell/installKeybindings.ts`: an idempotent per-window installer that
+registers the default bindings and attaches the dispatcher with the real
+predicates injected. AppShell calls it at mount; every component that
+registers a chord action (RailHost, Settings, SelectionQuote) calls it too,
+so those components' chords also work when they are mounted without the
+shell — their unit tests render them standalone.
+
+## Precedence
+
+When a `keydown` arrives, in order:
+
+1. **IME composition** (`event.isComposing` / `keyCode === 229`) is ignored,
+   blanket.
+2. **Scope resolution**: the scope stack, top-down, then `global`. The first
+   (highest-precedence) binding for the chord claims it outright — a
+   shadowed or policy-blocked binding never falls through to a
+   lower-precedence twin, and a codeless synthetic event is matched against
+   a code-synthesized view (`fireEvent`-style events carry no `code`, and
+   tinykeys' `isKeyboardEvent` gate would otherwise drop them).
+3. **Per-binding policy** on the matched binding, in this order:
+   - `ignoreIfDefaultPrevented` (default **true**): a keydown another
+     handler already claimed is ignored. This is how Settings' Escape
+     coexists with a Dialog's own Escape-to-close (OverlayPanel
+     preventDefaults; the binding then skips).
+   - `allowInModal` (default **false**): an open modal suppresses the
+     binding. The injected predicate is
+     `paletteStore.getState().open || target.closest('[aria-modal="true"]')`
+     — the palette is not an `[aria-modal]` element, so the store half is
+     required. `palette.open`, `rail.toggle` and `selection.quote` are
+     exempt (`allowInModal: true`) because their pre-dispatcher listeners
+     had no modal guard.
+   - `allowInEditable` (default **false**): an editable event target
+     (`input`/`textarea`/`select`/contenteditable) suppresses the binding.
+     `rail.toggle` keeps this suppression so Ctrl+B keeps its emacs
+     "cursor back" meaning in native text fields; the other Mod chords
+     fire from editable targets, as they always have.
+
+A binding whose action is not (yet) registered does not fire and does not
+preventDefault. When an action has handlers, they run in registration order
+until one accepts the event: a handler returns `false` to decline (the next
+handler is tried) and `true`/`undefined` to accept (iteration stops and the
+binding preventDefaults). An event every handler declines is not
+preventDefault'd. Multi-instance components rely on this: one SelectionQuote
+mounts per session pane, each registering `selection.quote`, and only the
+instance holding a captured selection accepts — the multi-instance
+equivalent of the per-component listeners the dispatcher replaced.
+
+## Registering an action and a binding
+
+```ts
+import { ACTIONS } from "../keybindings/actions";
+import { keybindingsRegistry } from "../keybindings/registry";
+import { installKeybindings } from "./installKeybindings";
+
+// In a component effect; the disposer runs on unmount.
+useEffect(() => {
+  installKeybindings();
+  return keybindingsRegistry.getState().registerAction(ACTIONS.myAction, (event) => {
+    // ...
+  });
+}, []);
+```
+
+A new chord is a `registerBinding` call (or, for a built-in, a new entry in
+`DEFAULT_BINDINGS`):
+
+```ts
+keybindingsRegistry.getState().registerBinding({
+  id: "my-feature.my-chord",      // unique; duplicates throw
+  actionId: ACTIONS.myAction,
+  chord: "$mod+Shift+P",          // tinykeys syntax; [Alt] = optional modifier
+  scope: "my-pane",               // optional; defaults to "global"
+});
+```
+
+Registering the same chord twice in the SAME scope throws; the same chord in
+a DIFFERENT scope is allowed and shadowed deterministically by scope-stack
+order. A pane that owns a scope pushes it while open and pops it on unmount
+(`pushScope` returns an idempotent disposer) — Settings.tsx is the template:
+it pushes `SETTINGS_SCOPE` and registers `settings.close` in one effect.
+
+## Testing conventions
+
+- Module tests (`src/keybindings/*.test.ts`) use a private
+  `createKeybindingsRegistry()` and attach a dispatcher to `window`
+  directly. jsdom resolves `$mod` to `Control` on every host, so module
+  tests press Mod chords with `ctrlKey`.
+- App-level tests press chords the way the existing suites do
+  (`user.keyboard("{Meta>}k{/Meta}")`, `fireEvent.keyDown(...)`) — the
+  Meta/Control twin registration makes those exercise the same path
+  production does. Include `code` or don't; both match.
+- Migration/behavior tests for the shell chords live in
+  `src/shell/keybindingsMigration.test.tsx`. Assert observable effects (the
+  palette opened, `requestComposerFocus` was called, the pane closed), not
+  dispatcher internals.
+- Determinism: no timers, no network, no localStorage in the module itself.
+  A component's action registration/scope push must be undone by its effect
+  cleanup so the next test in the file starts clean.
+
+## Deliberately not here yet
+
+Phase 2a is a behavior-preserving migration only. Later phases of the
+webui-keybindings plan add, and this module already leaves room for:
+
+- **Server persistence / user remapping** (Phase 2b) — `Binding.when` is
+  stored verbatim and never evaluated yet; bindings are the compiled-in
+  defaults only.
+- **A shortcuts overlay / cheatsheet UI** (Phase 3).
+- **Hold-modifier chord hints** (Phase 4) — `formatChord`/`formatSequence`
+  exist for exactly this consumer.

--- a/docs/web-ui/keybindings.md
+++ b/docs/web-ui/keybindings.md
@@ -1,9 +1,10 @@
 # Web UI keybindings
 
-Status: **current** (Phase 2a). The web hub's global keyboard chords are
+Status: **current** (Phase 2b). The web hub's global keyboard chords are
 owned by one module, `cmd/evener-hub/frontend/src/keybindings/`, and one
 window-level dispatcher, instead of each component installing its own
-`keydown` listener.
+`keydown` listener. User overrides persist on the hub and sync to every
+paired browser.
 
 ## Architecture
 
@@ -27,6 +28,21 @@ Four pieces, all in `src/keybindings/` and all React-free:
   `registerDefaultBindings`, which also registers each `$mod` chord's
   cross-platform Meta/Control twin (the pre-dispatcher listeners accepted
   `metaKey || ctrlKey` on every platform, so both work everywhere).
+  `DEFAULT_BINDINGS` is also the canonical action universe: each entry
+  carries the action's user-facing `title`, and the Settings keybindings
+  section enumerates it live. `registerDefaultBindingsForAction` and
+  `defaultBindingChordsForAction` are the per-action variants the overrides
+  layer uses to restore and to simulate restorations.
+- **overrides.ts** — `rebindAction(registry, actionId, chord | null)`
+  replaces an action's current bindings (default + `#mod-twin` + any earlier
+  `#override`) with a single `#override` binding that keeps the default's
+  scope and policy flags, or unbinds it on `null`. No twin expansion for user
+  chords. Every throwing path throws before mutating.
+  `restoreDefaultBinding` re-registers the action's defaults.
+- **validation.ts** — `validateOverrideRules(rules, registry, platform?)`
+  never throws: unknown actions, unparseable chords, reserved
+  (browser/OS-claimed) chords, and conflicts each become a typed
+  `ValidationWarning` and the rule is skipped.
 
 The one wiring point that touches React and the app's stores is
 `src/shell/installKeybindings.ts`: an idempotent per-window installer that
@@ -128,14 +144,117 @@ it pushes `SETTINGS_SCOPE` and registers `settings.close` in one effect.
   A component's action registration/scope push must be undone by its effect
   cleanup so the next test in the file starts clean.
 
+## Persistence (Phase 2b)
+
+Overrides are stored **on the hub**, not in the browser. There is no
+localStorage layer: an unsupported or unreachable hub means built-in
+defaults only, never a local fallback copy.
+
+### Server side
+
+`cmd/evener-hub/internal/hubcore/keybindings_store.go` keeps one snapshot
+`{version, revision, config}` at `<HubStateRoot>/keybindings/state.json`,
+written temp-file + rename + fsync. Three appwire methods
+(`appwire/keybindings.go`, handlers in `cmd/evener-hub/app_rpc_keybindings.go`):
+
+- `evener/settings/keybindings/get` → the canonical payload.
+- `evener/settings/keybindings/patch` — optimistic concurrency: params are
+  `{expectedRevision, config}`; a stale `expectedRevision` is rejected with
+  appwire `CodeConflict` (-32013) whose `data` carries
+  `evenerErrorInfo: "conflict"` and `current`, the server's present payload.
+  A no-op patch returns current without touching disk.
+- `evener/settings/keybindings/changed` — broadcast to all clients, only
+  when the revision actually changed.
+
+The feature is advertised as `features.keybindingsSettings`; an older hub
+simply omits it.
+
+### Payload contract
+
+```json
+{ "version": 1, "revision": 3, "rules": [ { "action": "palette.open", "chord": "Control+P" } ] }
+```
+
+`rules` is the whole override set, not a delta: `chord` (a tinykeys string)
+rebinds the action, `chord: null` unbinds it, and an action absent from
+`rules` is on its defaults. Revision 0 with empty rules is the shipped
+default.
+
+### Validation split
+
+- **Server — structure only.** It does not know the frontend action
+  registry, so it enforces the shape: strict decode (unknown fields and
+  trailing JSON rejected), `version == 1`, required per-rule `action`/`chord`
+  keys, non-empty/non-whitespace action and chord strings, revision
+  optimism. A state file that fails the raw-shape re-check on load falls
+  back to shipped defaults and the store goes read-only (patches are
+  rejected) until the file is fixed.
+- **Frontend — semantics** (`src/keybindings/validation.ts`): action ids
+  against the default map, chord parseability, the survey's platform-split
+  never-use list (chords the browser will never deliver to the page), and
+  conflicts against a simulation of the FINAL effective map the payload
+  would produce. The simulation includes the implied default-restoration of
+  every currently-overridden action the payload drops, iterated to a
+  fixpoint; when a rule's chord collides with a restoration, **the restore
+  wins** — the rule is skipped with a `conflict` warning and its action
+  falls back to its own defaults, so every action stays bound. A chord freed
+  earlier in the same payload (rebind-away or unbind) can be claimed by a
+  later rule.
+
+### Apply flow
+
+`src/stores/keybindings.ts` owns sync. Applied state lives in the registry,
+not the store; the store carries `hubSupport`, `revision`, the validated
+`overrides`, `warnings`, `hubError`, and `conflict`.
+
+- **Startup**: once the connection is ready and the feature is advertised,
+  `get` → structural re-check of the wire payload (`fromWireOverrides`:
+  version 1, safe-integer revision ≥ 0, well-formed rules) → semantic
+  validation → reconcile.
+- **Changed**: the same payload path; revisions older than the store's are
+  ignored.
+- **Reconcile** is a delta: only actions whose effective chord changed are
+  rebound, two-phase (strip every changed action's bindings, then
+  re-establish each via `rebindAction` or `restoreDefaultBinding`) so a
+  payload moving a chord between actions never trips a transient conflict.
+  Untouched actions keep their exact binding objects — in-flight dispatcher
+  state is never torn down. The mutation is atomic: a throw rolls the
+  registry back to a pre-reconcile snapshot, and the store's `revision`
+  advances only after a successful apply, so a failed payload stays
+  retryable (a later `changed` with the same revision is not eaten by the
+  stale guard).
+- **Patch** (used by the future editor): sends `expectedRevision` +
+  `{version: 1, rules}`; on success the canonical response is applied; on a
+  conflict rejection the store refreshes to `data.current`, sets `conflict`
+  and `hubError`, and rethrows.
+
+### Failure posture
+
+Nothing here can crash startup on persisted data. Malformed payloads,
+validation failures, unreachable hubs, and reconcile throws all degrade to
+warnings or a surfaced `hubError` with the last good (or default) bindings
+in place; the `changed`-notification path catches so a reconcile failure
+never escapes the client's notification dispatch.
+
+### Settings section
+
+Settings → Keybindings is a **read-only** listing of the effective
+bindings: one row per action from `DEFAULT_BINDINGS` (never a
+hand-maintained copy), the chord rendered with the `KeyHint` widget from
+the live registry, and a "Customized" marker on actions whose effective
+bindings differ from the default map (including unbound actions). The
+store's `hubSupport`/`hubError`/validation warnings surface as quiet status
+or alert text. Editing arrives with the Phase 4 editor.
+
 ## Deliberately not here yet
 
-Phase 2a is a behavior-preserving migration only. Later phases of the
-webui-keybindings plan add, and this module already leaves room for:
+Later phases of the webui-keybindings plan add, and this module already
+leaves room for:
 
-- **Server persistence / user remapping** (Phase 2b) — `Binding.when` is
-  stored verbatim and never evaluated yet; bindings are the compiled-in
-  defaults only.
+- **A keybinding editor** (Phase 4) — the store's `patchOverrides` is the
+  write path it will use; the Settings section stays read-only until then.
 - **A shortcuts overlay / cheatsheet UI** (Phase 3).
 - **Hold-modifier chord hints** (Phase 4) — `formatChord`/`formatSequence`
   exist for exactly this consumer.
+- `Binding.when` is still stored verbatim and never evaluated; scope-stack
+  membership is the only gating the dispatcher applies.


### PR DESCRIPTION
# Consolidated keybindings stack

One PR for the whole keybindings system, rebased onto current `main` with the history cleaned up: the 49 commits across the six stacked PRs are folded into 5 readable feature commits, with all 19 roborev rounds and the two post-review fixes squashed into the commits they belong to.

This PR supersedes #860, #861, #863, #871, and #874 (closed with pointers). #853 (the survey) already merged.

## The five commits

1. **`feat(web): keybinding dispatcher built on tinykeys`** — the `src/keybindings` module (chord parsing/formatting, action registry, default binding map, dispatcher) and the shell-chord migration. Per-binding `defaultPrevented` opt-out, `allowInModal`, Meta/Control twins, multi-instance registration, strict twins, `contenteditable=false` islands.
2. **`feat(hub,web): persistent keybinding overrides`** — the appwire wire contract, the hub-side overrides store and settings RPC handlers, and the frontend override machinery: rebind primitive with semantic validation, an overrides store with hub sync and atomic/retryable/restore-aware reconcile, a read-only settings section, and optional-modifier overlap detection.
3. **`feat(web): navigation keybindings and ask-dock keyboard operation`** — session-pane cycling, transcript scroll chords, Alt+PageDown/Alt+PageUp batch jump and focus return in the ask dock.
4. **`feat(web): final binding map, cheatsheet overlay, hold-modifier hints`** — the finalized default map (strict mod chords, ⌘, for settings, transcript jumps), the registry-sourced cheatsheet overlay on ⌘/ with a pref-gated `?` trigger, and hold-modifier hint chips.
5. **`feat(web): capture-based keybindings editor in settings`** — chord capture with canonical Space naming and IME guards, pre-flight conflict rejection with display-title holder names, unbind/reset, unsupported-hub fallback, last-visited settings section persistence, plus the 19 hardening rounds (stale-hub fencing, atomic un-apply, serialized writes, support-flap convergence, hub-error retry).

## Merge-conflict resolution notes (vs the stacked tips)

Main moved under the stack in two places; resolutions here:

- **AskDock.tsx / AskDock.test.tsx** — main's #854 (dock as a scrollable transcript row: `IntersectionObserver` focus greeting, `pendingGreeted` edge in the store, `AskDockAnnouncements` as the single live region) is combined with the Phase 3 keyboard contract (`FIRST_CONTROL_SELECTOR`, Alt+Page batch jump, focus return, `onKeyDown` on the dock div). Both test suites are spliced in whole.
- **TUI notification coverage** — `evener/settings/keybindings/changed` is added to `notifyMethodsDeliberatelyIgnored` (the TUI has no remappable-binding surface).
- **Lint modernization** — the 2b Go test helpers (`keybindingsChordPtr`/`keybindingsChord`) replaced with Go 1.26 `new(expr)` to satisfy main's current `modernize` lint.

Tree-equivalence to a true `main`+stack merge was verified with `git merge-tree`: only the two AskDock files conflicted there, and they are exactly the files resolved by hand here.

## Verification

- `make lint`, `make vet`, `make test` (all 8 modules incl. the frontend gate): PASS on the final head.
- Frontend: 2443 tests green; Biome clean.
- Real-Chrome interactive verification of the shipped chords (CDP-driven): clean; report at `interactive-test-report.md` in the p4 worktree (not committed). Alt+arrow session-cycling chords were covered by the Phase 3 automated suites rather than the headless run.
- The earlier stacked PRs carry the full roborev trail (19 rounds on #874, all fixed and verified; the one repeat finding — `+`-key capture — is a documented false positive with a pinning test at `keybindings.test.tsx`).

## Docs

`docs/web-ui/keybindings.md` covers the dispatcher architecture, the persistence contract, the final binding map, the cheatsheet overlay, hold hints, and the editor.
