### PR TITLE
Improve session-start directory selection on desktop and mobile

### DIFF
--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -12,7 +12,7 @@ import { applyViewport, clearViewportOverride, connectPage, createStartupDeadlin
 import { describeBrowserStartupFailure, startBrowserGuard } from "../browserGuardProcess.mjs";
 
 const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
-const WIDTHS = [390, 899, 900];
+const WIDTHS = [320, 390, 899, 900, 1440];
 // The staging cap (attachments/limits.ts MAX_ATTACHMENTS), so the row is
 // measured at the widest the product allows it to get.
 const STAGED_ATTACHMENTS = 8;
@@ -42,6 +42,10 @@ async function measureAt(cdpEndpoint, vitePort, width) {
   const { send } = page;
   try {
     await applyViewport(send, { width, height: 900 });
+    await navigateTo(page, `http://127.0.0.1:${vitePort}/spawnguard.html`);
+    await evaluate(send, "window.settledSpawn");
+    const directoryFailures = await evaluate(send, "window.exerciseDirectoryPicker()");
+    if (directoryFailures.length) throw new Error(`Directory picker at ${width}px: ${directoryFailures.join("; ")}`);
     await navigateTo(page, `http://127.0.0.1:${vitePort}/spawnguard.html`);
     await evaluate(send, "window.settledSpawn");
     // Stage before measuring, at every width: the page is navigated fresh per
@@ -330,7 +334,7 @@ async function main() {
       const failures = assertResult(result, width);
       if (failures.length === 0) {
         console.log(
-          `${width}px ... PASS - Spawn breakpoint, in-card control row, rows, accessibility, ${STAGED_ATTACHMENTS} staged attachment tiles, and overflow`,
+          `${width}px ... PASS - Spawn directory picker, breakpoint, in-card control row, rows, accessibility, ${STAGED_ATTACHMENTS} staged attachment tiles, and overflow`,
         );
       } else {
         failed++;

--- a/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
@@ -25,9 +25,26 @@ fake.on("model/list", () => ({
     { provider: "openai", model: "gpt-5" },
   ],
 }));
-fake.on("evener/projects/recent", () => ({ data: [] }));
-fake.on("evener/paths/complete", () => ({ data: [] }));
-fake.on("evener/path/validate", () => ({ path: "", valid: true }));
+const directoryRoot = "/home/test/projects/team/experiments/session-start-interface";
+const directoryTree = new Map<string, string[]>([
+  ["/home/test", [directoryRoot]],
+  [directoryRoot, Array.from({ length: 35 }, (_, i) => `${directoryRoot}/folder-${i}`)],
+]);
+for (const child of directoryTree.get(directoryRoot) ?? []) directoryTree.set(child, []);
+fake.on("evener/projects/recent", () => ({ data: [directoryRoot] }));
+fake.on("evener/paths/complete", ({ prefix }) => ({ data: directoryTree.get(prefix.replace(/\/+$/, "")) ?? [] }));
+fake.on("evener/path/validate", ({ path }) => {
+  const resolved = path === "~" ? "/home/test" : path;
+  return {
+    path: resolved,
+    valid: directoryTree.has(resolved),
+    error: directoryTree.has(resolved) ? undefined : "Directory not found",
+  };
+});
+fake.on("evener/dirs/create", ({ path }) => {
+  directoryTree.set(path, []);
+  return { path, created: true };
+});
 fake.on("evener/plugin/preview", () => ({
   plugins: [
     {
@@ -345,6 +362,91 @@ function openSpawnPlugins(): void {
   summary.click();
 }
 
+async function directoryElement<T extends HTMLElement>(selector: string): Promise<T> {
+  const deadline = performance.now() + 10_000;
+  for (;;) {
+    const element = document.querySelector<T>(selector);
+    if (element && isElementVisible(element) && !(element instanceof HTMLButtonElement && element.disabled))
+      return element;
+    if (performance.now() > deadline) throw new Error(`Directory picker did not expose ${selector}`);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  }
+}
+
+// Exercise the production picker with a long path and enough children to
+// scroll. Geometry must keep the confirmation visible even with a keyboard.
+async function exerciseDirectoryPicker() {
+  const mobile = window.innerWidth <= 899;
+  const trigger = await directoryElement<HTMLButtonElement>(
+    mobile ? '[data-label="Working directory"] button' : "#spawn-cwd",
+  );
+  trigger.focus();
+  trigger.click();
+  const recent = await directoryElement<HTMLButtonElement>(`button[aria-label="Open recent ${directoryRoot}"]`);
+  recent.click();
+  await directoryElement<HTMLButtonElement>(`button[aria-label="Open ${directoryRoot}/folder-34"]`);
+  const dialog = await directoryElement<HTMLElement>('[role="dialog"]');
+  const confirm = Array.from(dialog.querySelectorAll<HTMLButtonElement>("button")).find(
+    (button) => button.textContent === "Use this folder",
+  );
+  if (!confirm) throw new Error("Directory picker has no confirmation");
+  const failures: string[] = [];
+  function measure(label: string) {
+    const panel = dialog.getBoundingClientRect();
+    const action = confirm?.getBoundingClientRect();
+    const visibleBottom =
+      window.innerHeight -
+      (mobile ? Number.parseFloat(document.documentElement.style.getPropertyValue("--keyboard-inset")) || 0 : 0);
+    if (
+      !confirm ||
+      !isElementVisible(confirm) ||
+      !action ||
+      action.width <= 0 ||
+      action.height <= 0 ||
+      action.top < 0 ||
+      action.bottom > visibleBottom + 1
+    )
+      failures.push(`${label}: confirmation outside visible viewport`);
+    if (panel.left < -1 || panel.right > window.innerWidth + 1) failures.push(`${label}: dialog overflows viewport`);
+    for (const button of dialog.querySelectorAll("button")) {
+      const box = button.getBoundingClientRect();
+      if (box.width > 0 && (box.left < panel.left - 1 || box.right > panel.right + 1))
+        failures.push(`${label}: control overflows dialog`);
+    }
+  }
+  measure("browse");
+  if (mobile) {
+    document.documentElement.style.setProperty("--keyboard-inset", "300px");
+    measure("keyboard");
+  }
+  const newFolder = Array.from(dialog.querySelectorAll<HTMLButtonElement>("button")).find(
+    (button) => button.textContent === "New folder",
+  );
+  if (!newFolder) throw new Error("Directory picker has no creation action");
+  newFolder.click();
+  const nameInput = await directoryElement<HTMLInputElement>('input[autocomplete="off"]:not([aria-label="Path"])');
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+  if (!setter) throw new Error("Input value setter missing");
+  setter.call(nameInput, "a-new-directory-with-a-long-readable-name");
+  nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  nameInput.form?.requestSubmit();
+  const created = `${directoryRoot}/a-new-directory-with-a-long-readable-name`;
+  const deadline = performance.now() + 10_000;
+  while (document.querySelector<HTMLInputElement>('input[aria-label="Path"]')?.value !== created || confirm.disabled) {
+    if (performance.now() > deadline) throw new Error("Directory creation did not settle");
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  }
+  measure("created");
+  if (!dialog.contains(document.activeElement)) failures.push("Creation lost dialog focus");
+  confirm.click();
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  if (!trigger.textContent?.includes(created)) failures.push("Confirmed path was not stored on the launch form");
+  if (document.activeElement !== trigger) failures.push("Confirmation did not restore trigger focus");
+  document.documentElement.style.removeProperty("--keyboard-inset");
+  return failures;
+}
+
 const settled = settleSpawn();
 
 declare global {
@@ -353,6 +455,7 @@ declare global {
     settledSpawn: Promise<true>;
     stageSpawnAttachments: typeof stageSpawnAttachments;
     openSpawnPlugins: typeof openSpawnPlugins;
+    exerciseDirectoryPicker: typeof exerciseDirectoryPicker;
   }
 }
 
@@ -360,3 +463,5 @@ window.measureSpawn = measureSpawn;
 window.settledSpawn = settled;
 window.stageSpawnAttachments = stageSpawnAttachments;
 window.openSpawnPlugins = openSpawnPlugins;
+
+window.exerciseDirectoryPicker = exerciseDirectoryPicker;

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.module.css
@@ -111,3 +111,20 @@
     width: 100%;
   }
 }
+
+/* Directory identity gets its own line so the final path component remains
+ * readable even when its parents are long. */
+.row[data-label="Working directory"] .rowButton {
+  flex-wrap: wrap;
+}
+.row[data-label="Working directory"] .rowValue {
+  order: 3;
+  flex-basis: 100%;
+  margin-left: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+.row[data-label="Working directory"] .caret {
+  margin-left: auto;
+}

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.test.tsx
@@ -23,6 +23,8 @@ function props(overrides: Partial<MobileSettingRowsProps> = {}): MobileSettingRo
     complete: vi.fn(async () => []),
     listRecents: vi.fn(async () => []),
     fallbackDir: "/tmp",
+    validatePath: async (path) => ({ valid: true, path }),
+    createDirectory: async () => {},
     onCwdPanelClose: vi.fn(),
     branch: "main",
     reasoningEffort: "",
@@ -100,16 +102,17 @@ test("option sheets commit a selection and return focus to the row", async () =>
   expect(document.activeElement).toBe(within(row).getByRole("button"));
 });
 
-test("the working-directory sheet uses the existing path panel and closes with Escape", async () => {
+test("browsing a directory and cancelling preserves the session directory", async () => {
   const user = userEvent.setup();
   const onCwdChange = vi.fn();
-  renderRows({ onCwdChange });
+  renderRows({ onCwdChange, complete: async () => ["/tmp/project/child"] });
 
   const rowButton = screen.getByRole("button", { name: "Working directory: /tmp/project" });
   const row = rowButton.parentElement!;
   await user.click(rowButton);
   const dialog = await screen.findByRole("dialog", { name: "Choose working directory" });
-  expect(within(dialog).getByRole("combobox", { name: "Path" })).toBeTruthy();
+  await user.click(await within(dialog).findByText("child"));
+  expect(onCwdChange).not.toHaveBeenCalled();
   await user.keyboard("{Escape}");
 
   expect(screen.queryByRole("dialog", { name: "Choose working directory" })).toBeNull();
@@ -129,14 +132,16 @@ test("selecting a recent working directory stamps the committed value, not the p
 
   await user.click(screen.getByRole("button", { name: "Working directory: /old/project" }));
   const dialog = await screen.findByRole("dialog", { name: "Choose working directory" });
-  await user.click(await within(dialog).findByRole("option", { name: /new\/project/ }));
+  await user.click(await within(dialog).findByRole("button", { name: "Open recent /new/project" }));
 
+  expect(onCwdChange).not.toHaveBeenCalled();
+  await user.click(within(dialog).getByRole("button", { name: "Use this folder" }));
   expect(onCwdChange).toHaveBeenLastCalledWith("/new/project");
   expect(localStorage.getItem(GLOBAL_LAST_WORKING_DIR_KEY)).toBe("/new/project");
   expect(localStorage.getItem(GLOBAL_LAST_WORKING_DIR_KEY)).not.toBe("/old/project");
 });
 
-test("pressing Enter on a typed working directory stamps the committed value, not the previous cwd", async () => {
+test("confirming a typed working directory stamps the committed value, not the previous cwd", async () => {
   const user = userEvent.setup();
   localStorage.setItem(GLOBAL_LAST_WORKING_DIR_KEY, "/old/project");
   const onCwdChange = vi.fn();
@@ -148,8 +153,10 @@ test("pressing Enter on a typed working directory stamps the committed value, no
 
   await user.click(screen.getByRole("button", { name: "Working directory: /old/project" }));
   const dialog = await screen.findByRole("dialog", { name: "Choose working directory" });
-  expect(within(dialog).getByRole("combobox", { name: "Path" })).toBeTruthy();
-  await user.keyboard("/new/typed/project{Enter}");
+  const pathInput = within(dialog).getByRole("textbox", { name: "Path" });
+  await user.clear(pathInput);
+  await user.type(pathInput, "/new/typed/project{Enter}");
+  await user.click(within(dialog).getByRole("button", { name: "Use this folder" }));
 
   expect(onCwdChange).toHaveBeenLastCalledWith("/new/typed/project");
   expect(localStorage.getItem(GLOBAL_LAST_WORKING_DIR_KEY)).toBe("/new/typed/project");

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.tsx
@@ -8,12 +8,13 @@
 // picker on every other.
 import { useEffect, useRef, useState } from "react";
 import type { PathFieldPanelProps } from "../../widgets";
-import { Button, PathFieldPanel, Sheet } from "../../widgets";
+import { Button, Sheet } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
 import styles from "./MobileSettingRows.module.css";
 import { PluginSelectionPanel } from "./PluginSelectionPanel";
 import { type PluginSelectionState, selectedPluginNames } from "./pluginSelectionState";
 import type { PluginPreviewLoadState } from "./usePluginPreview";
+import { WorkingDirectoryPicker, type WorkingDirectoryPickerProps } from "./WorkingDirectoryPicker";
 
 export interface MobilePickerOption {
   value: string;
@@ -29,6 +30,8 @@ export interface MobileSettingRowsProps {
   complete: PathFieldPanelProps["complete"];
   listRecents: NonNullable<PathFieldPanelProps["listRecents"]>;
   fallbackDir: string;
+  validatePath: WorkingDirectoryPickerProps["validatePath"];
+  createDirectory: WorkingDirectoryPickerProps["createDirectory"];
   onCwdPanelClose: (value: string) => void;
   branch: string;
   reasoningEffort: string;
@@ -162,6 +165,8 @@ export function MobileSettingRows({
   complete,
   listRecents,
   fallbackDir,
+  validatePath,
+  createDirectory,
   onCwdPanelClose,
   branch,
   reasoningEffort,
@@ -186,8 +191,7 @@ export function MobileSettingRows({
     lastTriggerRef.current.focus();
   }, [openPicker]);
 
-  function closePicker(committedCwd = cwd): void {
-    if (openPicker === "Working directory") onCwdPanelClose(committedCwd);
+  function closePicker(): void {
     if (openPicker === "Plugins") setPluginDraft(pluginSelection);
     setOpenPicker(null);
   }
@@ -294,27 +298,22 @@ export function MobileSettingRows({
         onChange={onAccessChange}
       />
 
-      <Sheet
-        open={openPicker === "Working directory"}
-        side="bottom"
-        onClose={closePicker}
-        title="Choose working directory"
-      >
-        <div className={CLASS.sheetBody}>
-          <PathFieldPanel
-            kind="dir"
-            value={cwd}
-            onChange={onCwdChange}
-            onCommit={(value) => {
-              onCwdChange(value);
-              closePicker(value);
-            }}
-            complete={complete}
-            listRecents={listRecents}
-            fallbackDir={fallbackDir}
-          />
-        </div>
-      </Sheet>
+      {openPicker === "Working directory" && (
+        <WorkingDirectoryPicker
+          value={cwd}
+          fallbackDir={fallbackDir}
+          complete={complete}
+          listRecents={listRecents}
+          validatePath={validatePath}
+          createDirectory={createDirectory}
+          onClose={closePicker}
+          onPick={(path) => {
+            onCwdChange(path);
+            onCwdPanelClose(path);
+            closePicker();
+          }}
+        />
+      )}
 
       <Sheet
         open={pluginsSupported && openPicker === "Plugins" && pluginResponse !== undefined}

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.tsx
@@ -300,6 +300,7 @@ export function MobileSettingRows({
 
       {openPicker === "Working directory" && (
         <WorkingDirectoryPicker
+          key={cwd}
           value={cwd}
           fallbackDir={fallbackDir}
           complete={complete}

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2304,3 +2304,29 @@ test("typing a working directory reloads the model catalog only after confirmati
   );
   expect(fake.calls.filter((call) => call.method === "model/list")).toHaveLength(baseline + 1);
 });
+
+test.each(["desktop", "mobile"])("%s directory picker follows route directory changes while open", async (surface) => {
+  const user = userEvent.setup();
+  window.history.pushState({}, "", "/new?dir=%2Fhome%2Fme%2Fapp");
+  renderSpawn(readyClient());
+  await waitFor(() => expectWorkingDir("/home/me/app"));
+  await user.click(
+    surface === "desktop"
+      ? workingDir()
+      : screen.getByLabelText(/^Working directory:/, { selector: "button:not(#spawn-cwd)" }),
+  );
+  const input = await screen.findByRole("textbox", { name: "Path" });
+  await user.clear(input);
+  await user.type(input, "/uncommitted");
+  act(() => {
+    window.history.pushState({}, "", "/new?dir=%2Fhome%2Fother");
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+  await waitFor(() =>
+    expect((screen.getByRole("textbox", { name: "Path" }) as HTMLInputElement).value).toBe("/home/other"),
+  );
+  const confirm = screen.getByRole("button", { name: "Use this folder" });
+  await waitFor(() => expect((confirm as HTMLButtonElement).disabled).toBe(false));
+  await user.click(confirm);
+  expectWorkingDir("/home/other");
+});

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2279,21 +2279,28 @@ test("an effort the fallback ladder cannot name is still offered, not silently s
   expect(started?.reasoningEffort ?? "").toBe(displayed);
 });
 
-// The Effort ladder needs the scoped model catalog. The loader is keyed by
-// harness+cwd, but its request is debounced so every character typed into the
-// working-directory path does not issue a separate model/list RPC.
-test("typing a working directory does not reload the model catalog per keystroke", async () => {
+// The model catalog follows the committed directory, not the picker's draft.
+test("typing a working directory reloads the model catalog only after confirmation", async () => {
   const user = userEvent.setup();
   const fake = readyClient();
   renderSpawn(fake);
   await settled();
+  await waitFor(() => expect(fake.calls.some((call) => call.method === "model/list")).toBe(true));
 
   const baseline = fake.calls.filter((call) => call.method === "model/list").length;
-  await user.type(screen.getByLabelText(/^Working directory:/, { selector: "#spawn-cwd" }), "/tmp/some/project");
-  await settled();
+  await user.click(workingDir());
+  const input = await screen.findByRole("textbox", { name: "Path" });
+  await user.clear(input);
+  await user.type(input, "/tmp/some/project{Enter}");
+  const confirm = screen.getByRole("button", { name: "Use this folder" });
+  await waitFor(() => expect((confirm as HTMLButtonElement).disabled).toBe(false));
+  expect(fake.calls.filter((call) => call.method === "model/list")).toHaveLength(baseline);
+  await user.click(confirm);
 
-  // 17 characters typed. One reload for the settled path is the contract; a
-  // reload per character is the defect.
-  const perKeystroke = fake.calls.filter((call) => call.method === "model/list").length - baseline;
-  expect(perKeystroke).toBeLessThanOrEqual(1);
+  await waitFor(() =>
+    expect(fake.calls.filter((call) => call.method === "model/list").at(-1)?.params).toMatchObject({
+      cwd: "/tmp/some/project",
+    }),
+  );
+  expect(fake.calls.filter((call) => call.method === "model/list")).toHaveLength(baseline + 1);
 });

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -127,7 +127,7 @@ function renderSpawn(client: FakeClient) {
 const LAST_WORKING_DIR_KEY = "evener-hub.spawn-defaults.global.last-working-dir";
 
 function workingDir(): HTMLElement {
-  return screen.getByLabelText("Working directory");
+  return screen.getByLabelText(/^Working directory:/, { selector: "#spawn-cwd" });
 }
 
 // The DESKTOP Model field's closed trigger (ModelField -> ModelCatalog): a
@@ -198,15 +198,23 @@ test("the directory is established before composing the prompt", async () => {
   await settled();
 
   const card = screen.getByTestId("spawn-prompt-card");
-  const dir = screen.getByLabelText("Working directory");
+  const dir = screen.getByLabelText(/^Working directory:/, { selector: "#spawn-cwd" });
   expect(dir.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+});
+
+test("the desktop directory trigger announces the confirmed path", async () => {
+  const user = userEvent.setup();
+  renderSpawn(readyClient());
+  await settled();
+  await setWorkingDir(user, "/tmp/project");
+  expect(screen.getByLabelText("Working directory: /tmp/project", { selector: "#spawn-cwd" })).toBe(workingDir());
 });
 
 test("the configuration row is working directory, model and effort - and nothing else", async () => {
   renderSpawn(readyClient());
   await settled();
 
-  expect(screen.getByLabelText("Working directory")).toBeTruthy();
+  expect(screen.getByLabelText(/^Working directory:/, { selector: "#spawn-cwd" })).toBeTruthy();
   expect(screen.getAllByText("Model").length).toBeGreaterThan(0);
   expect(screen.getByLabelText("Effort")).toBeTruthy();
 });
@@ -2281,7 +2289,7 @@ test("typing a working directory does not reload the model catalog per keystroke
   await settled();
 
   const baseline = fake.calls.filter((call) => call.method === "model/list").length;
-  await user.type(screen.getByLabelText("Working directory"), "/tmp/some/project");
+  await user.type(screen.getByLabelText(/^Working directory:/, { selector: "#spawn-cwd" }), "/tmp/some/project");
   await settled();
 
   // 17 characters typed. One reload for the settled path is the contract; a

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -123,9 +123,7 @@ function renderSpawn(client: FakeClient) {
   );
 }
 
-// The working directory is a PathField: the closed field is a trigger holding
-// the path as text, and the value is entered inside its browse panel (which is
-// portaled to document.body, so it is queried from `screen`, not the form).
+// The working directory is changed through an explicit-confirmation picker.
 const LAST_WORKING_DIR_KEY = "evener-hub.spawn-defaults.global.last-working-dir";
 
 function workingDir(): HTMLElement {
@@ -156,10 +154,12 @@ function expectWorkingDir(path: string): void {
 
 async function setWorkingDir(user: ReturnType<typeof userEvent.setup>, path: string): Promise<void> {
   await user.click(workingDir());
-  // The panel opens pre-filled and fully selected, so typing replaces whatever
-  // was there; Enter with no row highlighted commits the typed literal.
-  await screen.findByRole("combobox", { name: "Path" });
-  await user.keyboard(`${path}{Enter}`);
+  const input = await screen.findByRole("textbox", { name: "Path" });
+  await user.clear(input);
+  await user.type(input, `${path}{Enter}`);
+  const confirm = screen.getByRole("button", { name: "Use this folder" });
+  await waitFor(() => expect((confirm as HTMLButtonElement).disabled).toBe(false));
+  await user.click(confirm);
 }
 
 /** Waits for the mount-time catalogs to land. The Advanced-options toggle is
@@ -193,15 +193,13 @@ afterEach(() => {
 // Prompt card first, taking the page's slack; ONE configuration row beneath it
 // (working directory, model, effort); harness in Advanced options.
 
-test("the prompt card leads the page, ahead of every configuration field", async () => {
+test("the directory is established before composing the prompt", async () => {
   renderSpawn(readyClient());
   await settled();
 
   const card = screen.getByTestId("spawn-prompt-card");
   const dir = screen.getByLabelText("Working directory");
-  // DOCUMENT_POSITION_FOLLOWING (4): the directory field comes AFTER the card in
-  // document order - see MDN's Node.compareDocumentPosition bitmask.
-  expect(card.compareDocumentPosition(dir) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(dir.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 });
 
 test("the configuration row is working directory, model and effort - and nothing else", async () => {
@@ -617,10 +615,10 @@ test("a missing working directory still exposes plugin selection before Create &
       error: "stat /tmp/new: no such file or directory",
     }));
   });
+  window.history.pushState({}, "", "/new?dir=/tmp/new");
   renderSpawn(fake);
   await settled();
 
-  await setWorkingDir(user, "/tmp/new");
   await openDesktopPluginSelection(user);
   await user.click(screen.getByRole("switch", { name: "beta" }));
   await waitFor(() =>
@@ -923,9 +921,9 @@ test("clearing an invalid selection after preview failure reaches Create & start
     }));
   });
   connectionStore.getState().connect(fake);
+  window.history.pushState({}, "", "/new?dir=/tmp/new");
   renderSpawn(fake);
   await settled();
-  await setWorkingDir(user, "/tmp/new");
   await openDesktopPluginSelection(user);
   await user.click(screen.getByRole("switch", { name: "beta" }));
   await waitFor(() =>
@@ -1078,59 +1076,35 @@ test("kata 11ee: a navigation with no ?dir=/?prompt= at all leaves already-typed
   expect((screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement).value).toBe("typed by hand");
 });
 
-// Spec 3.7: browsing writes the working-directory field continuously, so the
-// last-used-directory global is stamped once when the panel closes rather than
-// on every browse step.
-test("stamps the last-working-directory global when the browse panel closes", async () => {
+test("only confirming a directory updates the launch defaults", async () => {
   const user = userEvent.setup();
   renderSpawn(readyClient((f) => f.on("evener/paths/complete", () => ({ data: ["/tmp/project/src"] }))));
   await settled();
-
   await user.click(workingDir());
-  await screen.findByRole("combobox", { name: "Path" });
-  // Browsing alone must not stamp - only the close does.
-  await user.click(await screen.findByText("src"));
+  await user.click(await screen.findByRole("button", { name: "Open /tmp/project/src" }));
   expect(localStorage.getItem(LAST_WORKING_DIR_KEY)).toBeNull();
-
-  await user.keyboard("{Escape}");
-  await waitFor(() => expect(localStorage.getItem(LAST_WORKING_DIR_KEY)).toBe("/tmp/project/src"));
+  await user.click(screen.getByRole("button", { name: "Use this folder" }));
+  expect(localStorage.getItem(LAST_WORKING_DIR_KEY)).toBe("/tmp/project/src");
 });
 
-// kata cp3m: Escape closes the working-directory browse popover only - the
-// popover's own Escape handler (widgets/popover) both preventDefault()s and
-// stopPropagation()s (verified live: a document/window-level listener never
-// even sees the keydown), so it must never reach a form-level or route-level
-// handler and discard the draft or navigate the pane away. Live reproduction
-// against a real build (headless AND headed Chrome, mouse-click and
-// keyboard-commit directory selection, with and without a model chosen
-// first) did not reproduce the kata's reported discard; this regression test
-// locks the correct behavior in place either way - prompt, model, and
-// working directory all survive Escape, and no navigation occurs.
-test("kata cp3m: Escape after selecting a working directory closes only the popover - the draft survives", async () => {
+test("Escape discards directory browsing while preserving the prompt and launch directory", async () => {
   const user = userEvent.setup();
+  window.history.pushState({}, "", "/new?dir=%2Ftmp%2Fproject");
   const fake = readyClient((f) => f.on("evener/paths/complete", () => ({ data: ["/tmp/project/src"] })));
   renderSpawn(fake);
   await settled();
-
   await user.type(screen.getByRole("textbox", { name: "Prompt" }), "my important draft text");
   await user.click(workingDir());
-  await screen.findByRole("combobox", { name: "Path" });
-  await user.click(await screen.findByText("src"));
-  expectWorkingDir("/tmp/project/src");
-
-  const pathnameBeforeEscape = window.location.pathname;
+  await user.click(await screen.findByRole("button", { name: "Open /tmp/project/src" }));
+  const pathname = window.location.pathname;
   await user.keyboard("{Escape}");
-
-  // The popover is gone...
-  await waitFor(() => expect(screen.queryByRole("combobox", { name: "Path" })).toBeNull());
-  // ...but nothing else moved: no submit was attempted, no navigation
-  // happened, and every field the user had already filled in is untouched.
+  expect(screen.queryByRole("dialog", { name: "Choose working directory" })).toBeNull();
   expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
-  expect(window.location.pathname).toBe(pathnameBeforeEscape);
+  expect(window.location.pathname).toBe(pathname);
   expect((screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement).value).toBe(
     "my important draft text",
   );
-  expectWorkingDir("/tmp/project/src");
+  expectWorkingDir("/tmp/project");
 });
 
 // The read side of that same global (spec 3.4): with no ?dir= prefill and no
@@ -1147,7 +1121,7 @@ test("the browse panel opens on the stamped last-working-directory global", asyn
   expectWorkingDir("Working directory");
 
   await user.click(workingDir());
-  await screen.findByRole("combobox", { name: "Path" });
+  await screen.findByRole("textbox", { name: "Path" });
 
   await waitFor(() => expect(complete.mock.calls.map(([params]) => params.prefix)).toContain("/home/me/lastone/"));
 });
@@ -1170,8 +1144,8 @@ test("survives a null data payload from either list RPC", async () => {
   await user.click(workingDir());
 
   // The panel is up, listing nothing, rather than having thrown its tree away.
-  expect(await screen.findByRole("combobox", { name: "Path" })).toBeTruthy();
-  expect(await screen.findByText("Nothing here.")).toBeTruthy();
+  expect(await screen.findByRole("textbox", { name: "Path" })).toBeTruthy();
+  expect(await screen.findByText("No subfolders to display.")).toBeTruthy();
 });
 
 test("offers to create a missing directory, then creates it and spawns", async () => {
@@ -1184,11 +1158,11 @@ test("offers to create a missing directory, then creates it and spawns", async (
     }));
     f.on("evener/dirs/create", () => ({ path: "/tmp/new", created: true }));
   });
+  window.history.pushState({}, "", "/new?dir=/tmp/new");
   renderSpawn(fake);
   await settled();
 
   await user.type(screen.getByRole("textbox", { name: "Prompt" }), "go");
-  await setWorkingDir(user, "/tmp/new");
   await user.click(screen.getByTestId("spawn-submit"));
 
   await user.click(await screen.findByRole("button", { name: "Create & start" }));
@@ -1212,11 +1186,11 @@ test("aborts with the validator message for a non-fixable working dir, then a co
         : { path: "/etc/hosts", valid: false, error: "path is not a directory" },
     );
   });
+  window.history.pushState({}, "", "/new?dir=/etc/hosts");
   renderSpawn(fake);
   await settled();
 
   await user.type(screen.getByRole("textbox", { name: "Prompt" }), "go");
-  await setWorkingDir(user, "/etc/hosts");
   await user.click(screen.getByTestId("spawn-submit"));
 
   expect(await screen.findByText("path is not a directory")).toBeTruthy();

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -1,20 +1,6 @@
-// The spawn pane: starts a new agent.
-//
-// This page IS the composer, not a form that happens to contain one - it renders
-// the same widgets/promptcard the session composer does, with its own primary
-// verb ("Start") in the card's corner. The prompt leads and takes the page's
-// vertical slack; beneath it sits ONE compact configuration row (working
-// directory widest, since it is the only field that changes often, then model
-// and effort), with the branch riding the directory row as a read-only HEAD
-// readout rather than a peer field. Harness lives in Advanced options: most
-// installs have exactly one, and a field whose answer is always "evener" should
-// not lead the page.
-//
-// Behind that: sticky-default layering + stale-model cleanup, the schema-driven
-// advanced options (which also host the access-mode field, 9ct0 §3.3), image
-// attachments, working-dir preflight, and ?dir=/?prompt= URL prefill (floor §1,
-// parity-m6-surfaces.md). The recent-prompts row is a decided parity drop
-// (Jesse 2026-07-22).
+// Session creation keeps the project directory above the prompt and the
+// less frequently changed launch settings below it. The directory picker
+// commits once, so browsing does not churn directory-dependent configuration.
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { friendlyLaunchErrorMessage } from "../../protocol/errors";
 import type {
@@ -38,7 +24,6 @@ import {
   IconButton,
   Loader,
   PaneScaffold,
-  PathField,
   PromptCard,
   Select,
   SendIcon,
@@ -52,6 +37,7 @@ import { requireClass } from "../../widgets/internal/requireClass";
 import type { ModelCatalog, ModelCatalogEntry } from "../../widgets/modelCatalog";
 import { modelListToCatalog } from "../../widgets/modelCatalog/catalogClient";
 import { mergeCatalogEntry, mergeCatalogSnapshot } from "../../widgets/modelCatalog/scopedCatalog";
+import { basename } from "../../widgets/pathfield/pathRows";
 import { ModelSwitchTrigger } from "../session/chrome/ModelSwitchTrigger";
 import { AttachmentTile } from "../session/composer/AttachmentTile";
 import { AttachIcon } from "../session/composer/attachments/AttachIcon";
@@ -85,6 +71,7 @@ import {
 import { startThread } from "./startThread";
 import { readUrlPrefill } from "./urlPrefill";
 import { usePluginPreview } from "./usePluginPreview";
+import { DirectoryIcon, WorkingDirectoryPicker } from "./WorkingDirectoryPicker";
 
 // No route params: /new resolves to spawn with an empty param object; the
 // ?dir=/?prompt= prefill is read from window.location.search, not params.
@@ -128,7 +115,9 @@ const CLASS = {
   cfgDir: requireClass(styles.cfgDir, "spawn.module.css", "cfgDir"),
   cfgModel: requireClass(styles.cfgModel, "spawn.module.css", "cfgModel"),
   branch: requireClass(styles.branch, "spawn.module.css", "branch"),
-  branchSeparator: requireClass(styles.branchSeparator, "spawn.module.css", "branchSeparator"),
+  directoryButton: requireClass(styles.directoryButton, "spawn.module.css", "directoryButton"),
+  directoryText: requireClass(styles.directoryText, "spawn.module.css", "directoryText"),
+  directoryPath: requireClass(styles.directoryPath, "spawn.module.css", "directoryPath"),
   notice: requireClass(styles.notice, "spawn.module.css", "notice"),
   attachments: requireClass(styles.attachments, "spawn.module.css", "attachments"),
   leading: requireClass(styles.leading, "spawn.module.css", "leading"),
@@ -159,6 +148,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   const [model, setModel] = useState(""); // qualified "provider/model", or "" for the harness default
   const [reasoningEffort, setReasoningEffort] = useState("");
   const [cwd, setCwd] = useState("");
+  const [directoryOpen, setDirectoryOpen] = useState(false);
   const [branch, setBranch] = useState(""); // display-only (floor §1.7)
   const [accessMode, setAccessMode] = useState("");
   const [harnesses, setHarnesses] = useState<HarnessDescriptor[]>([]);
@@ -313,6 +303,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
         .then((r) => ({ valid: r.valid, error: r.error, path: r.path })),
     [client],
   );
+  const createDirectory = useCallback((path: string) => createDir(client, path), [client]);
   const resolveConfig = useCallback(
     (overrides: LaunchConfigLayer) =>
       client.request("evener/launch/resolve", {
@@ -831,15 +822,52 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
           </div>
         )}
 
+        <div className={CLASS.cfgDir}>
+          <button
+            type="button"
+            id="spawn-cwd"
+            className={CLASS.directoryButton}
+            aria-label="Working directory"
+            aria-haspopup="dialog"
+            aria-expanded={directoryOpen}
+            onClick={() => setDirectoryOpen(true)}
+          >
+            <DirectoryIcon />
+            <span className={CLASS.directoryText}>
+              <strong>{cwd ? basename(cwd) || "/" : "Working directory"}</strong>
+              <span className={CLASS.directoryPath}>{cwd || "Choose a folder"}</span>
+            </span>
+            <span>Change…</span>
+          </button>
+          {branch !== "" && (
+            <span className={CLASS.branch} data-testid="spawn-branch">
+              {branch}
+            </span>
+          )}
+        </div>
+        {directoryOpen && (
+          <WorkingDirectoryPicker
+            value={cwd}
+            fallbackDir={getGlobalLastWorkingDir()}
+            complete={complete}
+            listRecents={listRecents}
+            validatePath={validatePath}
+            createDirectory={createDirectory}
+            onClose={() => setDirectoryOpen(false)}
+            onPick={(path) => {
+              setCwd(path);
+              setGlobalLastWorkingDir(path);
+              setDirectoryOpen(false);
+            }}
+          />
+        )}
+
         <div className={CLASS.mobilePromptIntro} data-testid="spawn-mobile-prompt-intro">
           <h3 className={CLASS.mobilePromptHeading}>What should the agent do?</h3>
           <p className={CLASS.mobilePromptSubtitle}>Leave blank to start a dormant session.</p>
         </div>
 
-        {/* The prompt comes FIRST and takes the page's slack: writing the
-            prompt is what starting an agent IS, and everything below it is
-            configuration that mostly stays where it was last left. The card is
-            the same widgets/promptcard the session composer renders. */}
+        {/* The prompt shares its card and attachment controls with the session composer. */}
         <Dropzone onFiles={(files) => attachments.ingestFiles(files, (message) => toasts.push("error", message))}>
           <PromptCard
             data-testid="spawn-prompt-card"
@@ -949,45 +977,8 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
           </div>
         )}
 
-        {/* ONE compact row of configuration beneath the card, widest field
-            first: the working directory is the only one that changes often.
-            Harness moved into Advanced options - most installs have exactly one,
-            and a field whose answer is always "evener" should not lead the page. */}
+        {/* Model and effort share the secondary settings row. */}
         <div className={CLASS.cfg}>
-          <div className={CLASS.cfgDir}>
-            <FormRow label="Working directory" htmlFor="spawn-cwd">
-              <PathField
-                id="spawn-cwd"
-                value={cwd}
-                onChange={setCwd}
-                kind="dir"
-                listRecents={listRecents}
-                complete={complete}
-                // With no ?dir= prefill and no per-project blob the field starts
-                // empty; the panel then opens on the last directory a session was
-                // launched in rather than on $HOME (spec 3.4). Read here rather
-                // than captured at mount so it reflects the latest stamp.
-                fallbackDir={getGlobalLastWorkingDir()}
-                placeholder="Working directory"
-                // Browsing writes the field on every step, so the last-used
-                // directory is recorded once the panel closes rather than
-                // continuously (spec 3.7).
-                onPanelClose={setGlobalLastWorkingDir}
-              />
-            </FormRow>
-            {/* Branch is a read-only HEAD readout, not a peer field: it rides
-                the directory row as a mono suffix ("~/code/evener · main") because
-                it is a property of that directory. */}
-            {branch !== "" && (
-              <span className={CLASS.branch} data-testid="spawn-branch" title={`HEAD ${branch}`}>
-                <span className={CLASS.branchSeparator} aria-hidden="true">
-                  ·
-                </span>
-                {branch}
-              </span>
-            )}
-          </div>
-
           {/* data-testid on the wrapper, not the trigger: the trigger is
               ModelCatalog's own button and has no hook to give, and the pane
               now renders a SECOND "— change model" button (the card's
@@ -1081,6 +1072,8 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             cwd={cwd}
             onCwdChange={setCwd}
             complete={complete}
+            validatePath={validatePath}
+            createDirectory={createDirectory}
             listRecents={listRecents}
             fallbackDir={getGlobalLastWorkingDir()}
             onCwdPanelClose={setGlobalLastWorkingDir}

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -847,6 +847,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
         </div>
         {directoryOpen && (
           <WorkingDirectoryPicker
+            key={cwd}
             value={cwd}
             fallbackDir={getGlobalLastWorkingDir()}
             complete={complete}

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -827,7 +827,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             type="button"
             id="spawn-cwd"
             className={CLASS.directoryButton}
-            aria-label="Working directory"
+            aria-label={`Working directory: ${cwd || "Choose a folder"}`}
             aria-haspopup="dialog"
             aria-expanded={directoryOpen}
             onClick={() => setDirectoryOpen(true)}

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.test.tsx
@@ -126,3 +126,14 @@ test("root and empty folders remain selectable", async () => {
   await user.click(screen.getByRole("button", { name: "Use this folder" }));
   expect(onPick).toHaveBeenCalledWith("/");
 });
+
+test.each(["pending", "failed"])("a validated directory remains selectable when listing is %s", async (listing) => {
+  const { user, onPick } = setup({
+    complete: () => (listing === "failed" ? Promise.reject(new Error("listing unavailable")) : new Promise(() => {})),
+  });
+  if (listing === "failed") await screen.findByRole("alert");
+  const confirm = screen.getByRole("button", { name: "Use this folder" });
+  await waitFor(() => expect((confirm as HTMLButtonElement).disabled).toBe(false));
+  await user.click(confirm);
+  expect(onPick).toHaveBeenCalledWith("/work");
+});

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.test.tsx
@@ -43,14 +43,15 @@ test("typed paths are validated and canonicalized before selection", async () =>
 });
 
 test("an invalid typed path cannot accidentally select the previously browsed folder", async () => {
+  const validationDetail = "fixture-path-validation-detail";
   const { user, onPick } = setup({
-    validatePath: async (path) => ({ valid: path !== "/missing", path, error: "not found" }),
+    validatePath: async (path) => ({ valid: path !== "/missing", path, error: validationDetail }),
   });
   await screen.findByRole("button", { name: "Open /work/app" });
   const input = screen.getByRole("textbox", { name: "Path" });
   await user.clear(input);
   await user.type(input, "/missing{Enter}");
-  await screen.findByRole("alert");
+  expect((await screen.findByRole("alert")).textContent).toBe(validationDetail);
   expect((screen.getByRole("button", { name: "Use this folder" }) as HTMLButtonElement).disabled).toBe(true);
   expect(onPick).not.toHaveBeenCalled();
 });

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.test.tsx
@@ -1,0 +1,127 @@
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test, vi } from "vitest";
+import { WorkingDirectoryPicker, type WorkingDirectoryPickerProps } from "./WorkingDirectoryPicker";
+
+afterEach(cleanup);
+
+function setup(overrides: Partial<WorkingDirectoryPickerProps> = {}) {
+  const props: WorkingDirectoryPickerProps = {
+    value: "/work",
+    onClose: vi.fn(),
+    onPick: vi.fn(),
+    complete: async (prefix) => (prefix === "/work/" ? ["/work/app", "/work/other"] : []),
+    listRecents: async () => ["/recent/app"],
+    validatePath: async (path) => ({ valid: true, path: path === "~" ? "/home/test" : path }),
+    createDirectory: async () => {},
+    ...overrides,
+  };
+  render(<WorkingDirectoryPicker {...props} />);
+  return { ...props, user: userEvent.setup() };
+}
+
+test("navigation and recent folders stay draft until explicitly selected", async () => {
+  const { user, onPick } = setup();
+  await user.click(await screen.findByRole("button", { name: "Open /work/app" }));
+  expect(onPick).not.toHaveBeenCalled();
+  await user.click(screen.getByRole("button", { name: "Parent directory" }));
+  await screen.findByRole("button", { name: "Open /work/other" });
+  await user.click(screen.getByRole("button", { name: "Open recent /recent/app" }));
+  await user.click(screen.getByRole("button", { name: "Use this folder" }));
+  expect(onPick).toHaveBeenCalledWith("/recent/app");
+});
+
+test("typed paths are validated and canonicalized before selection", async () => {
+  const { user, onPick } = setup();
+  const input = screen.getByRole("textbox", { name: "Path" });
+  await user.clear(input);
+  await user.type(input, "~{Enter}");
+  await waitFor(() => expect((input as HTMLInputElement).value).toBe("/home/test"));
+  expect(onPick).not.toHaveBeenCalled();
+  await user.click(screen.getByRole("button", { name: "Use this folder" }));
+  expect(onPick).toHaveBeenCalledWith("/home/test");
+});
+
+test("an invalid typed path cannot accidentally select the previously browsed folder", async () => {
+  const { user, onPick } = setup({
+    validatePath: async (path) => ({ valid: path !== "/missing", path, error: "not found" }),
+  });
+  await screen.findByRole("button", { name: "Open /work/app" });
+  const input = screen.getByRole("textbox", { name: "Path" });
+  await user.clear(input);
+  await user.type(input, "/missing{Enter}");
+  await screen.findByRole("alert");
+  expect((screen.getByRole("button", { name: "Use this folder" }) as HTMLButtonElement).disabled).toBe(true);
+  expect(onPick).not.toHaveBeenCalled();
+});
+
+test("creating a folder navigates into it without starting or selecting a session", async () => {
+  const createDirectory = vi.fn(async () => {});
+  const { user, onPick } = setup({ createDirectory });
+  await screen.findByRole("button", { name: "Open /work/app" });
+  await user.click(screen.getByRole("button", { name: "New folder" }));
+  await user.type(screen.getByRole("textbox", { name: "Folder name" }), "new project{Enter}");
+  await waitFor(() =>
+    expect((screen.getByRole("textbox", { name: "Path" }) as HTMLInputElement).value).toBe("/work/new project"),
+  );
+  expect(createDirectory).toHaveBeenCalledExactlyOnceWith("/work/new project");
+  expect(onPick).not.toHaveBeenCalled();
+  await user.click(screen.getByRole("button", { name: "Use this folder" }));
+  expect(onPick).toHaveBeenCalledWith("/work/new project");
+});
+
+test("creation failures preserve the folder name and allow retry", async () => {
+  const createDirectory = vi.fn().mockRejectedValueOnce(new Error("permission denied")).mockResolvedValue(undefined);
+  const { user } = setup({ createDirectory });
+  await screen.findByRole("button", { name: "Open /work/app" });
+  await user.click(screen.getByRole("button", { name: "New folder" }));
+  await user.type(screen.getByRole("textbox", { name: "Folder name" }), "draft{Enter}");
+  await screen.findByRole("alert");
+  expect((screen.getByRole("textbox", { name: "Folder name" }) as HTMLInputElement).value).toBe("draft");
+  await user.click(screen.getByRole("button", { name: "Create folder" }));
+  await waitFor(() =>
+    expect((screen.getByRole("textbox", { name: "Path" }) as HTMLInputElement).value).toBe("/work/draft"),
+  );
+});
+
+test.each(["create", "cancel"])("%s new folder keeps focus inside the dialog for Escape", async (action) => {
+  const { user, onClose } = setup();
+  await screen.findByRole("button", { name: "Open /work/app" });
+  await user.click(screen.getByRole("button", { name: "New folder" }));
+  if (action === "create") {
+    await user.type(screen.getByRole("textbox", { name: "Folder name" }), "new{Enter}");
+    await waitFor(() =>
+      expect((screen.getByRole("textbox", { name: "Path" }) as HTMLInputElement).value).toBe("/work/new"),
+    );
+  } else {
+    await user.click(screen.getByRole("button", { name: "Cancel new folder" }));
+  }
+  expect(screen.getByRole("dialog").contains(document.activeElement)).toBe(true);
+  await user.keyboard("{Escape}");
+  expect(onClose).toHaveBeenCalledOnce();
+});
+
+test("a late directory listing cannot replace a newer navigation", async () => {
+  let resolveListing: (paths: string[]) => void = () => {};
+  const oldListing = new Promise<string[]>((resolve) => {
+    resolveListing = resolve;
+  });
+  const { user } = setup({
+    complete: (prefix) => (prefix === "/work/" ? oldListing : Promise.resolve(["/recent/app/src"])),
+  });
+  await user.click(await screen.findByRole("button", { name: "Open recent /recent/app" }));
+  const folders = screen.getByRole("region", { name: "Folders" });
+  await within(folders).findByRole("button", { name: "Open /recent/app/src" });
+  await act(async () => resolveListing(["/work/stale"]));
+  expect(within(folders).queryByRole("button", { name: "Open /work/stale" })).toBeNull();
+});
+
+test("root and empty folders remain selectable", async () => {
+  const { user, onPick } = setup({ value: "/", complete: async () => [] });
+  await waitFor(() =>
+    expect((screen.getByRole("button", { name: "Use this folder" }) as HTMLButtonElement).disabled).toBe(false),
+  );
+  expect((screen.getByRole("button", { name: "Parent directory" }) as HTMLButtonElement).disabled).toBe(true);
+  await user.click(screen.getByRole("button", { name: "Use this folder" }));
+  expect(onPick).toHaveBeenCalledWith("/");
+});

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.test.tsx
@@ -137,3 +137,29 @@ test.each(["pending", "failed"])("a validated directory remains selectable when 
   await user.click(confirm);
   expect(onPick).toHaveBeenCalledWith("/work");
 });
+
+test("a created directory can be selected while its listing is pending", async () => {
+  const { user, onPick } = setup({
+    complete: (prefix) => (prefix === "/work/" ? Promise.resolve([]) : new Promise(() => {})),
+  });
+  const newFolder = screen.getByRole("button", { name: "New folder" });
+  await waitFor(() => expect((newFolder as HTMLButtonElement).disabled).toBe(false));
+  await user.click(newFolder);
+  await user.type(screen.getByRole("textbox", { name: "Folder name" }), "new project{Enter}");
+  await waitFor(() =>
+    expect((screen.getByRole("textbox", { name: "Path" }) as HTMLInputElement).value).toBe("/work/new project"),
+  );
+  const confirm = screen.getByRole("button", { name: "Use this folder" });
+  await waitFor(() => expect((confirm as HTMLButtonElement).disabled).toBe(false));
+  await user.click(confirm);
+  expect(onPick).toHaveBeenCalledWith("/work/new project");
+});
+
+test("first path focus lets typing replace the initial directory", async () => {
+  const { user } = setup();
+  await screen.findByRole("button", { name: "Open /work/app" });
+  const input = screen.getByRole("textbox", { name: "Path" });
+  await user.click(input);
+  await user.keyboard("/replacement");
+  expect((input as HTMLInputElement).value).toBe("/replacement");
+});

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
@@ -88,7 +88,10 @@ export function WorkingDirectoryPicker({
     try {
       const result = await validatePath(path.trim(), "dir");
       if (!mounted.current || request.current !== id) return;
-      if (!result.valid) throw new Error(result.error || "This path is not a directory.");
+      if (!result.valid) {
+        setError(result.error || "This path is not a directory.");
+        return;
+      }
       const canonical = result.path || path.trim();
       setCurrent(canonical);
       setTyped(canonical);

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
@@ -1,0 +1,351 @@
+import { type FormEvent, useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { friendlyErrorMessage } from "../../protocol/errors";
+import { Button, type PathFieldPanelProps } from "../../widgets";
+import { OverlayPanel } from "../../widgets/dialog/OverlayPanel";
+import { requireClass } from "../../widgets/internal/requireClass";
+import { basename, childrenPrefix, parentOf } from "../../widgets/pathfield/pathRows";
+import styles from "./workingDirectoryPicker.module.css";
+
+export interface WorkingDirectoryPickerProps {
+  value: string;
+  fallbackDir?: string;
+  complete: PathFieldPanelProps["complete"];
+  listRecents: () => Promise<string[]>;
+  validatePath: (path: string, kind: string) => Promise<{ valid: boolean; path?: string; error?: string }>;
+  createDirectory: (path: string) => Promise<void>;
+  onPick: (path: string) => void;
+  onClose: () => void;
+}
+
+const CLASS = {
+  panel: requireClass(styles.panel, "workingDirectoryPicker.module.css", "panel"),
+  body: requireClass(styles.body, "workingDirectoryPicker.module.css", "body"),
+  browser: requireClass(styles.browser, "workingDirectoryPicker.module.css", "browser"),
+  recents: requireClass(styles.recents, "workingDirectoryPicker.module.css", "recents"),
+  browse: requireClass(styles.browse, "workingDirectoryPicker.module.css", "browse"),
+  navigation: requireClass(styles.navigation, "workingDirectoryPicker.module.css", "navigation"),
+  crumbs: requireClass(styles.crumbs, "workingDirectoryPicker.module.css", "crumbs"),
+  pathForm: requireClass(styles.pathForm, "workingDirectoryPicker.module.css", "pathForm"),
+  input: requireClass(styles.input, "workingDirectoryPicker.module.css", "input"),
+  listHeading: requireClass(styles.listHeading, "workingDirectoryPicker.module.css", "listHeading"),
+  folders: requireClass(styles.folders, "workingDirectoryPicker.module.css", "folders"),
+  row: requireClass(styles.row, "workingDirectoryPicker.module.css", "row"),
+  path: requireClass(styles.path, "workingDirectoryPicker.module.css", "path"),
+  footer: requireClass(styles.footer, "workingDirectoryPicker.module.css", "footer"),
+  destination: requireClass(styles.destination, "workingDirectoryPicker.module.css", "destination"),
+  actions: requireClass(styles.actions, "workingDirectoryPicker.module.css", "actions"),
+  create: requireClass(styles.create, "workingDirectoryPicker.module.css", "create"),
+  status: requireClass(styles.status, "workingDirectoryPicker.module.css", "status"),
+};
+
+export function DirectoryIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M2 3h4l2 2h6v8H2V3Z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+/** The launch directory is committed once. Navigation, typing and creation
+ * stay local so cancelled browsing cannot reload the session's configuration. */
+export function WorkingDirectoryPicker({
+  value,
+  fallbackDir,
+  complete,
+  listRecents,
+  validatePath,
+  createDirectory,
+  onPick,
+  onClose,
+}: WorkingDirectoryPickerProps) {
+  const initialPath = value || fallbackDir || "~";
+  const [current, setCurrent] = useState(initialPath);
+  const [typed, setTyped] = useState(initialPath);
+  const [entries, setEntries] = useState<string[] | null>(null);
+  const [recents, setRecents] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [folderName, setFolderName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const request = useRef(0);
+  const mounted = useRef(true);
+  const pathInput = useRef<HTMLInputElement>(null);
+  const goButton = useRef<HTMLButtonElement>(null);
+  const nameInput = useRef<HTMLInputElement>(null);
+  const wasCreating = useRef(false);
+  const pathId = useId();
+  const nameId = useId();
+
+  async function browse(path: string) {
+    // Rows disappear during navigation. Keep focus on a persistent control
+    // without opening the phone keyboard when browsing by touch.
+    if (document.activeElement !== pathInput.current) goButton.current?.focus();
+    const id = ++request.current;
+    setEntries(null);
+    setError(null);
+    setCreating(false);
+    try {
+      const result = await validatePath(path.trim(), "dir");
+      if (!mounted.current || request.current !== id) return;
+      if (!result.valid) throw new Error(result.error || "This path is not a directory.");
+      const canonical = result.path || path.trim();
+      setCurrent(canonical);
+      setTyped(canonical);
+      const children = await complete(childrenPrefix(canonical), false);
+      if (mounted.current && request.current === id) setEntries(children);
+    } catch (err) {
+      if (mounted.current && request.current === id) setError(friendlyErrorMessage(err));
+    }
+  }
+
+  // Each opening mounts a fresh draft. Late responses cannot revive a closed
+  // picker or replace a directory selected by a newer navigation.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: opening snapshot; callbacks belong to this picker lifetime
+  useEffect(() => {
+    mounted.current = true;
+    void browse(initialPath);
+    listRecents().then(
+      (paths) => {
+        if (mounted.current) setRecents([...new Set(paths)]);
+      },
+      () => {},
+    );
+    return () => {
+      mounted.current = false;
+      request.current++;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (creating) {
+      wasCreating.current = true;
+      nameInput.current?.focus();
+    } else if (!busy && wasCreating.current) {
+      // Creation removes the focused form while Go is disabled. Restore only
+      // after that persistent control has become enabled in the rendered DOM.
+      wasCreating.current = false;
+      goButton.current?.focus();
+    }
+  }, [creating, busy]);
+
+  const ready = entries !== null && typed === current && !busy;
+  const segments = current.split("/").filter(Boolean);
+  const crumbs = segments.map((label, index) => ({
+    label,
+    path: `${current.startsWith("/") ? "/" : ""}${segments.slice(0, index + 1).join("/")}`,
+  }));
+
+  async function create(event: FormEvent) {
+    event.preventDefault();
+    if (!ready) return;
+    const name = folderName.trim();
+    if (!name || name === "." || name === ".." || name.includes("/") || name.includes("\0")) {
+      setError("Enter a folder name without slashes.");
+      return;
+    }
+    const path = `${childrenPrefix(current)}${name}`;
+    if (entries?.includes(path)) {
+      setError("A folder with this name already exists.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await createDirectory(path);
+      if (!mounted.current) return;
+      await browse(path);
+    } catch (err) {
+      if (mounted.current) setError(friendlyErrorMessage(err));
+    } finally {
+      if (mounted.current) setBusy(false);
+    }
+  }
+
+  return createPortal(
+    <OverlayPanel
+      open
+      onClose={onClose}
+      title="Choose working directory"
+      panelClassName={CLASS.panel}
+      bodyClassName={CLASS.body}
+      footer={
+        <div className={CLASS.footer}>
+          <div className={CLASS.destination}>
+            <span>Use this directory</span>
+            <strong>{basename(current) || "/"}</strong>
+            <span className={CLASS.path}>{current}</span>
+          </div>
+          <div className={CLASS.actions}>
+            <Button variant="quiet" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button disabled={!ready || creating} onClick={() => onPick(current)}>
+              Use this folder
+            </Button>
+          </div>
+        </div>
+      }
+    >
+      <div className={CLASS.browser}>
+        <aside className={CLASS.recents} aria-label="Recent directories">
+          <h3>Recent</h3>
+          {recents.map((path) => (
+            <button
+              className={CLASS.row}
+              type="button"
+              key={path}
+              disabled={busy}
+              aria-label={`Open recent ${path}`}
+              onClick={() => void browse(path)}
+            >
+              <strong>{basename(path) || "/"}</strong>
+              <span className={CLASS.path}>{parentOf(path)}</span>
+            </button>
+          ))}
+          {recents.length === 0 && <p className={CLASS.status}>No recent directories.</p>}
+          <h3>Locations</h3>
+          <Button variant="quiet" disabled={busy} onClick={() => void browse("~")}>
+            Home
+          </Button>
+        </aside>
+        <div className={CLASS.browse}>
+          <div className={CLASS.navigation}>
+            <Button
+              variant="secondary"
+              aria-label="Parent directory"
+              disabled={busy || current === "/"}
+              onClick={() => void browse(parentOf(current))}
+            >
+              ↑
+            </Button>
+            <nav className={CLASS.crumbs} aria-label="Directory breadcrumbs">
+              <Button variant="quiet" disabled={busy} onClick={() => void browse("/")}>
+                /
+              </Button>
+              {crumbs.length > 3 && (
+                <details>
+                  <summary aria-label="Earlier directories">…</summary>
+                  {crumbs.slice(0, -3).map((crumb) => (
+                    <Button key={crumb.path} variant="quiet" disabled={busy} onClick={() => void browse(crumb.path)}>
+                      {crumb.label}
+                    </Button>
+                  ))}
+                </details>
+              )}
+              {crumbs.slice(-3).map((crumb) => (
+                <Button variant="quiet" key={crumb.path} disabled={busy} onClick={() => void browse(crumb.path)}>
+                  {crumb.label}
+                </Button>
+              ))}
+            </nav>
+          </div>
+          <form
+            className={CLASS.pathForm}
+            onSubmit={(event) => {
+              event.preventDefault();
+              if (!busy) void browse(typed);
+            }}
+          >
+            <input
+              id={pathId}
+              ref={pathInput}
+              className={CLASS.input}
+              aria-label="Path"
+              value={typed}
+              spellCheck={false}
+              autoComplete="off"
+              disabled={busy}
+              onChange={(event) => {
+                request.current++;
+                setTyped(event.target.value);
+                setError(null);
+              }}
+            />
+            <Button ref={goButton} variant="secondary" type="submit" disabled={busy || !typed.trim()}>
+              Go
+            </Button>
+          </form>
+          <div className={CLASS.listHeading}>
+            <span>Folders</span>
+            <Button
+              variant="quiet"
+              size="sm"
+              disabled={!ready}
+              onClick={() => {
+                setCreating(true);
+                setFolderName("");
+                setError(null);
+              }}
+            >
+              New folder
+            </Button>
+          </div>
+          {creating && (
+            <form className={CLASS.create} onSubmit={(event) => void create(event)}>
+              <label htmlFor={nameId}>Folder name</label>
+              <input
+                id={nameId}
+                ref={nameInput}
+                className={CLASS.input}
+                value={folderName}
+                disabled={busy}
+                onChange={(event) => setFolderName(event.target.value)}
+                autoComplete="off"
+              />
+              <div className={CLASS.actions}>
+                <Button
+                  variant="quiet"
+                  disabled={busy}
+                  onClick={() => {
+                    setCreating(false);
+                    setError(null);
+                  }}
+                >
+                  Cancel new folder
+                </Button>
+                <Button type="submit" disabled={busy}>
+                  {busy ? "Creating…" : "Create folder"}
+                </Button>
+              </div>
+            </form>
+          )}
+          {error && (
+            <p className={CLASS.status} role="alert">
+              {error}
+            </p>
+          )}
+          <section className={CLASS.folders} aria-label="Folders" aria-busy={entries === null && error === null}>
+            {entries === null ? (
+              !error && (
+                <p className={CLASS.status} role="status">
+                  Loading directories…
+                </p>
+              )
+            ) : entries.length === 0 ? (
+              <p className={CLASS.status} role="status">
+                No subfolders to display.
+              </p>
+            ) : (
+              entries.map((path) => (
+                <button
+                  type="button"
+                  className={CLASS.row}
+                  disabled={busy}
+                  aria-label={`Open ${path}`}
+                  key={path}
+                  onClick={() => void browse(path)}
+                >
+                  <DirectoryIcon />
+                  <span>{basename(path)}</span>
+                  <span aria-hidden="true">›</span>
+                </button>
+              ))
+            )}
+          </section>
+        </div>
+      </div>
+    </OverlayPanel>,
+    document.body,
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
@@ -63,6 +63,7 @@ export function WorkingDirectoryPicker({
   const [current, setCurrent] = useState(initialPath);
   const [typed, setTyped] = useState(initialPath);
   const [entries, setEntries] = useState<string[] | null>(null);
+  const [validated, setValidated] = useState(false);
   const [recents, setRecents] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -82,6 +83,7 @@ export function WorkingDirectoryPicker({
     // without opening the phone keyboard when browsing by touch.
     if (document.activeElement !== pathInput.current) goButton.current?.focus();
     const id = ++request.current;
+    setValidated(false);
     setEntries(null);
     setError(null);
     setCreating(false);
@@ -95,6 +97,7 @@ export function WorkingDirectoryPicker({
       const canonical = result.path || path.trim();
       setCurrent(canonical);
       setTyped(canonical);
+      setValidated(true);
       const children = await complete(childrenPrefix(canonical), false);
       if (mounted.current && request.current === id) setEntries(children);
     } catch (err) {
@@ -132,7 +135,7 @@ export function WorkingDirectoryPicker({
     }
   }, [creating, busy]);
 
-  const ready = entries !== null && typed === current && !busy;
+  const ready = validated && typed === current && !busy;
   const segments = current.split("/").filter(Boolean);
   const crumbs = segments.map((label, index) => ({
     label,

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
@@ -72,6 +72,7 @@ export function WorkingDirectoryPicker({
   const request = useRef(0);
   const mounted = useRef(true);
   const pathInput = useRef<HTMLInputElement>(null);
+  const pathFocused = useRef(false);
   const goButton = useRef<HTMLButtonElement>(null);
   const nameInput = useRef<HTMLInputElement>(null);
   const wasCreating = useRef(false);
@@ -139,6 +140,8 @@ export function WorkingDirectoryPicker({
   }, [creating, busy]);
 
   const ready = validated && typed === current && !busy;
+  // Paths belong to the Linux/macOS hub, regardless of the browser OS.
+  // Match the shared path helpers and supported hub builds in .goreleaser.yml.
   const segments = current.split("/").filter(Boolean);
   const crumbs = segments.map((label, index) => ({
     label,
@@ -163,7 +166,8 @@ export function WorkingDirectoryPicker({
     try {
       await createDirectory(path);
       if (!mounted.current) return;
-      await browse(path);
+      // Creation is complete; browsing owns validation and listing independently.
+      void browse(path);
     } catch (err) {
       if (mounted.current) setError(friendlyErrorMessage(err));
     } finally {
@@ -265,6 +269,12 @@ export function WorkingDirectoryPicker({
               spellCheck={false}
               autoComplete="off"
               disabled={busy}
+              onFocus={(event) => {
+                if (!pathFocused.current) {
+                  pathFocused.current = true;
+                  event.currentTarget.select();
+                }
+              }}
               onChange={(event) => {
                 request.current++;
                 setTyped(event.target.value);

--- a/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/WorkingDirectoryPicker.tsx
@@ -90,6 +90,8 @@ export function WorkingDirectoryPicker({
     try {
       const result = await validatePath(path.trim(), "dir");
       if (!mounted.current || request.current !== id) return;
+      // Selection requires an existing directory; New folder explicitly creates
+      // a child before it becomes a selectable destination.
       if (!result.valid) {
         setError(result.error || "This path is not a directory.");
         return;
@@ -105,7 +107,8 @@ export function WorkingDirectoryPicker({
     }
   }
 
-  // Each opening mounts a fresh draft. Late responses cannot revive a closed
+  // Callers key this draft by the committed directory so external route changes
+  // discard stale browsing. Late responses cannot revive a closed
   // picker or replace a directory selected by a newer navigation.
   // biome-ignore lint/correctness/useExhaustiveDependencies: opening snapshot; callbacks belong to this picker lifetime
   useEffect(() => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
@@ -1,10 +1,4 @@
-/* The spawn form layout. Tokens only; neutral surfaces that never use color for
- * attention.
- *
- * Prompt card first, then ONE configuration row beneath it: writing the prompt
- * is what starting an agent IS, and the config is settings that mostly stay
- * where they were last left. The card's own min-height (Textarea's minLines)
- * takes the page's vertical slack, so there is no dead gap under the actions. */
+/* Session creation: project directory, prompt, then secondary settings. */
 .form {
   display: flex;
   flex-direction: column;
@@ -74,9 +68,7 @@
   font-size: var(--font-size-body);
 }
 
-/* One compact row of configuration, wrapping to stacked rows on a narrow
- * viewport. The working directory is the only field that changes often, so it
- * takes the row's free width and the other two size to their content. */
+/* Secondary launch settings wrap with the available pane width. */
 .cfg {
   display: flex;
   flex-wrap: wrap;
@@ -84,16 +76,54 @@
   gap: var(--space-3);
 }
 
-/* The directory field plus its branch suffix. `flex: 1 1 240px` with
- * `min-width: 0` gives it the row's slack while still letting it shrink below
- * its content on a phone (a PathField trigger holds a full path, so its natural
- * width is large enough to push the row wide without this). */
 .cfgDir {
   display: flex;
-  flex: 1 1 240px;
+  flex-direction: column;
   min-width: 0;
-  align-items: baseline;
-  gap: var(--space-1);
+  gap: var(--space-2);
+}
+.directoryButton {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--surface-2);
+  color: var(--ink-hi);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.directoryButton:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+.directoryButton:hover {
+  background: var(--hover-1);
+}
+.directoryButton > svg {
+  flex: none;
+}
+.directoryButton > span:last-child {
+  flex: none;
+  color: var(--ink-mid);
+}
+.directoryText {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.directoryText strong {
+  font-weight: var(--font-weight-medium);
+  overflow-wrap: anywhere;
+}
+.directoryPath {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  overflow-wrap: anywhere;
 }
 
 /* The model picker is a composite widget, so it gets a label span + widget
@@ -112,26 +142,12 @@
   border-left: 2px solid transparent;
 }
 
-/* The branch is a read-only HEAD readout riding the directory row, not a peer
- * field: mono because it is an identifier, --ink-low because it is the row's
- * least actionable fact, and flex:none so a long branch name never steals the
- * directory field's width. */
 .branch {
-  flex: none;
-  display: inline-flex;
-  align-items: baseline;
-  gap: var(--space-1);
-  max-width: 40%;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  color: var(--ink-low);
+  padding-left: var(--space-3);
+  color: var(--ink-mid);
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
-}
-
-.branchSeparator {
-  color: var(--ink-low);
+  overflow-wrap: anywhere;
 }
 
 /* Matches widgets/formrow's .label exactly: the Model field renders its label
@@ -192,7 +208,8 @@
     min-height: 96px;
   }
 
-  .cfg {
+  .cfg,
+  .cfgDir {
     display: none;
   }
 

--- a/cmd/evener-hub/frontend/src/panes/spawn/workingDirectoryPicker.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/workingDirectoryPicker.module.css
@@ -1,0 +1,223 @@
+.panel {
+  composes: panel from "../../widgets/dialog/dialog.module.css";
+  width: min(760px, calc(100vw - var(--space-8)));
+  max-height: calc(100dvh - var(--space-8));
+  border-radius: var(--radius-pane);
+  overflow: hidden;
+}
+
+.body {
+  padding: 0;
+  min-height: 0;
+}
+
+.browser {
+  display: flex;
+  min-height: 340px;
+}
+.recents {
+  width: 180px;
+  flex: none;
+  padding: var(--space-3);
+  background: var(--surface-inset);
+  border-right: 1px solid var(--edge);
+}
+.recents h3 {
+  margin: var(--space-3) 0 var(--space-2);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-medium);
+}
+
+.browse {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-4);
+}
+.navigation {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+.crumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
+.crumbs button {
+  min-width: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+.crumbs details {
+  position: relative;
+}
+.crumbs summary {
+  cursor: pointer;
+  padding: var(--space-2);
+}
+.crumbs details[open] {
+  background: var(--surface-2);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+}
+.pathForm {
+  display: flex;
+  gap: var(--space-2);
+}
+.input {
+  composes: input from "../../widgets/input/input.module.css";
+  min-width: 0;
+  flex: 1;
+  font-family: var(--font-mono);
+}
+.listHeading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: var(--space-3) 0 var(--space-1);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+.folders {
+  min-width: 0;
+}
+.row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 40px;
+  padding: var(--space-2);
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--ink-hi);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.row:hover {
+  background: var(--hover-1);
+}
+.row:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}
+.row:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.row svg {
+  flex: none;
+  color: var(--ink-mid);
+}
+.folders .row span:first-of-type {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+:where(.recents) .row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+}
+.path {
+  font-size: var(--font-size-caption);
+  color: var(--ink-mid);
+  overflow-wrap: anywhere;
+}
+.footer {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  gap: var(--space-4);
+  min-width: 0;
+}
+.destination {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow-wrap: anywhere;
+}
+.destination > span:first-child {
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+.destination strong {
+  font-weight: var(--font-weight-medium);
+}
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+.create {
+  padding: var(--space-3);
+  border-radius: var(--radius-control);
+  background: var(--surface-inset);
+}
+.create label {
+  display: block;
+  margin-bottom: var(--space-1);
+}
+.create .actions {
+  margin-top: var(--space-3);
+}
+.status {
+  color: var(--ink-mid);
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 899px) {
+  .panel {
+    position: fixed;
+    inset: 0 0 var(--keyboard-inset, 0px);
+    width: 100%;
+    max-height: none;
+    border-radius: 0;
+  }
+  .body {
+    flex: 1;
+  }
+  .browser {
+    flex-direction: column-reverse;
+    min-height: 0;
+  }
+  .recents {
+    width: auto;
+    border-right: 0;
+    border-top: 1px solid var(--edge);
+  }
+  .browse {
+    padding: var(--space-3);
+  }
+  .input {
+    font-size: 16px;
+  }
+  .row {
+    min-height: var(--tap-min);
+  }
+  .footer {
+    flex-direction: column;
+    align-items: stretch;
+    padding-bottom: env(safe-area-inset-bottom);
+    gap: var(--space-2);
+  }
+  .footer .actions {
+    flex-wrap: nowrap;
+  }
+  .footer .actions > button {
+    flex: 1;
+  }
+}
+
+.create .input {
+  width: 100%;
+}

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -1999,7 +1999,11 @@ test("kata 11ee: navigating to /new?dir= a second time, with the spawn pane alre
   // The working directory is a PathField: its closed trigger holds the path as
   // text (plus a chevron and a screen-reader hint), so the value is matched
   // inside that text rather than read off an input's .value.
-  await waitFor(() => expect(screen.getByLabelText("Working directory").textContent).toContain("/home/me/app"));
+  await waitFor(() =>
+    expect(screen.getByLabelText(/^Working directory:/, { selector: "#spawn-cwd" }).textContent).toContain(
+      "/home/me/app",
+    ),
+  );
 
   // A second /new?dir= navigation (e.g. RailRow's own spawnInProject, for a
   // DIFFERENT project) while the spawn pane is already open and focused -
@@ -2015,7 +2019,11 @@ test("kata 11ee: navigating to /new?dir= a second time, with the spawn pane alre
   // shows the SECOND navigation's dir, not the first one silently retained.
   const tabs = document.querySelectorAll(".dv-tab");
   expect(Array.from(tabs).map((t) => t.textContent)).toEqual(["New session"]);
-  await waitFor(() => expect(screen.getByLabelText("Working directory").textContent).toContain("/home/other"));
+  await waitFor(() =>
+    expect(screen.getByLabelText(/^Working directory:/, { selector: "#spawn-cwd" }).textContent).toContain(
+      "/home/other",
+    ),
+  );
 });
 
 // --- mobile full-bleed shell (2026-07-30-mobile-session-layout-design.md, decision 1) ---


### PR DESCRIPTION
The session-start directory chooser previously changed the launch directory while browsing, squeezed long paths into a small popover, and only offered directory creation when starting a session. This gives desktop and mobile an explicit directory selection flow with breadcrumbs, an editable path, recent directories, and inline folder creation.

Browsing and creation stay local until **Use this folder** confirms the selection; Cancel and Escape preserve the original launch directory. Desktop gives the directory its own row above the prompt. Mobile uses a full-height picker with confirmation above the keyboard, and long paths wrap instead of losing their final component.

Uses the existing directory APIs and shared modal focus scope. General file/path fields retain their existing behavior.

Validation:
- `make test-web` passed (unit tests, typecheck, and lint).
- `make test-web-browser` passed all five browser guards.
- Expanded spawnguard passed at 320, 390, 899, 900, and 1440 pixels, covering navigation, creation, confirmation visibility, and focus restoration.
- Picker tests cover draft selection, canonical paths, invalid paths, creation/retry, stalled or failed listings, stale responses, root selection, and focus after creation/cancellation. Spawn integration tests cover route changes while desktop and mobile pickers are open and catalog refresh only after confirmation.

Keyboard positioning uses a simulated CSS inset; physical mobile keyboard behavior was not tested.

