### PR TITLE
Move sidebar identity and settings to top row

### DIFF
--- a/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
@@ -49,6 +49,48 @@ async function measureOnPage(cdpEndpoint, vitePort, viewport, expression) {
     await navigateTo(page, `http://127.0.0.1:${vitePort}/shellguard.html`);
     await evaluate(send, "window.settledShell");
     await waitForFonts(send);
+    await evaluate(
+      send,
+      "Promise.all(document.getAnimations().filter(a => a.effect.getTiming().iterations !== Infinity).map(a => a.finished))",
+    );
+    const header = JSON.parse(
+      await evaluate(
+        send,
+        `JSON.stringify((() => {
+      const brand = document.querySelector('[data-testid="rail-brand"]');
+      const settings = document.querySelector('[data-testid="rail-settings"]');
+      const search = document.querySelector('[data-testid="rail-search"]');
+      const hide = brand?.querySelector('[aria-label="Hide sidebar"]');
+      const identity = [...(brand?.querySelectorAll('span') ?? [])].find(el => el.textContent === 'fake-evener-hub');
+      return [identity, settings, search, ...(window.innerWidth > 899 ? [hide] : [])].map(el => {
+        if (!el || !brand?.contains(el)) return null;
+        const r = el.getBoundingClientRect();
+        return { left: r.left, right: r.right, top: r.top, bottom: r.bottom, width: r.width, height: r.height };
+      });
+    })())`,
+      ),
+    );
+    for (let i = 0; i < header.length; i++) {
+      const box = header[i];
+      if (!box || box.width <= 0 || box.height <= 0) {
+        throw new Error(
+          `rail header at ${viewport.width}px: missing visible ${["identity", "Settings", "Search", "Hide sidebar"][i]}`,
+        );
+      }
+      if (box.left < 0 || box.right > viewport.width)
+        throw new Error(`rail header escapes ${viewport.width}px viewport`);
+      if (i > 0) {
+        const previous = header[i - 1];
+        if (
+          previous.right > box.left ||
+          Math.abs((previous.top + previous.bottom) / 2 - (box.top + box.bottom) / 2) > 1
+        ) {
+          throw new Error(
+            `rail header at ${viewport.width}px: identity, Settings, Search, Hide sidebar must align on one row in order`,
+          );
+        }
+      }
+    }
     return JSON.parse(await evaluate(send, expression));
   } finally {
     await clearViewportOverride(send);
@@ -179,9 +221,7 @@ async function main() {
     try {
       await waitForHttp(`http://127.0.0.1:${vitePort}/shellguard.html`, "vite dev server", guard.getViteLaunchError);
     } catch (error) {
-      throw new Error(
-        describeBrowserStartupFailure({ error, subsystem: "vite", viteStderr: guard.getViteError() }),
-      );
+      throw new Error(describeBrowserStartupFailure({ error, subsystem: "vite", viteStderr: guard.getViteError() }));
     }
     const startupDeadline = createStartupDeadline();
     try {

--- a/cmd/evener-hub/frontend/src/dev/shellguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/shellguard-entry.tsx
@@ -16,6 +16,7 @@
 import { createRoot } from "react-dom/client";
 import { FakeClient } from "../protocol/testing/fakeClient";
 import type { NavigationReadParams, NavigationReadResponse } from "../protocol/types.gen";
+import railStyles from "../shell/rail/Rail.module.css";
 import "../styles/tokens.css";
 import "../styles/global.css";
 
@@ -241,11 +242,8 @@ function leakingElements(viewportBottom: number): { selector: string; top: numbe
 function measureShell() {
   const de = document.documentElement;
   const shell = root.firstElementChild;
-  // The rail's scroll container: the footer owns data-testid="rail-settings";
-  // its parent is the rail root, and the rail's .body is the one child whose
-  // overflow-y is not visible.
-  const settings = document.querySelector("[data-testid='rail-settings']");
-  const rail = settings?.parentElement?.parentElement ?? null;
+  // Select the rail directly, independently of header control placement.
+  const rail = document.querySelector(`.${railStyles.rail}`);
   const railBody =
     rail === null ? null : ([...rail.children].find((el) => getComputedStyle(el).overflowY !== "visible") ?? null);
   // The rail's full ancestor chain up to <body>, with the computed properties
@@ -355,22 +353,17 @@ function scrollMetrics(el: Element | null) {
   };
 }
 
-// The mobile Sheet panel hosting the rail, located from the rail's one
-// stable anchor (the settings button's testid). Shared by both mobile
+// The mobile Sheet panel hosting the rail. Shared by both mobile
 // measurements so the ancestor walk lives in exactly one place.
 function mobileRailPanel(): Element | null {
-  const settings = document.querySelector("[data-testid='rail-settings']");
-  const footer = settings?.parentElement ?? null;
-  const rail = footer?.parentElement ?? null;
+  const rail = document.querySelector(`.${railStyles.rail}`);
   const panelBody = rail?.parentElement ?? null;
   return panelBody?.parentElement ?? null;
 }
 
 function measureMobileSidebar() {
-  const settings = document.querySelector("[data-testid='rail-settings']");
-  const footer = settings?.parentElement ?? null;
-  const rail = footer?.parentElement ?? null;
-  const railBody = footer?.previousElementSibling ?? null;
+  const rail = document.querySelector(`.${railStyles.rail}`);
+  const railBody = rail?.querySelector(`.${railStyles.body}`) ?? null;
   const panelBody = rail?.parentElement ?? null;
   const panel = mobileRailPanel();
   const panelText = panel?.textContent ?? "";

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.module.css
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.module.css
@@ -47,10 +47,8 @@
   }
 }
 
-/* The sidebar owns its own chrome (c8gt): a header zone stacking the status/
- * actions row (needs-you Badge leading, search and hide icon buttons
- * trailing - no wordmark, the footer's daemon identity is the rail's only
- * branding) and the primary "+ New session" button - a column so none of it
+/* The sidebar owns its own chrome: a header zone stacking the identity/
+ * status/actions row and the primary "+ New session" button - a column so none of it
  * steals a full-width top bar's worth of the workspace's vertical space. */
 .header {
   flex: none;
@@ -67,22 +65,13 @@
   gap: var(--space-2);
 }
 
-/* The header/footer icon buttons' GLYPHS: they're text glyphs (⌕ ☰ ⚙), so
+/* The header icon buttons' GLYPHS: they're text glyphs (⌕ ☰ ⚙), so
  * they size to the button's font-size - the IconButton's icon span is 1em x
  * 1em of it - never to the box. md made the boxes 32px but left the glyphs
  * at --font-size-ui (13px); --font-size-pane-title (16px) reads at the md
  * box's scale. */
-.brand button,
-.footer button {
+.brand button {
   font-size: var(--font-size-pane-title);
-}
-
-/* Grows to fill the row's spare width, pushing the search/hide icon buttons
- * to the trailing edge while the needs-you Badge (when present) stays
- * leading - the role the retired "evener" wordmark's own flex: 1 1 auto
- * played before the wordmark was removed. */
-.brandSpacer {
-  flex: 1 1 auto;
 }
 
 /* Stretches the primary Button to the rail's full width without touching the
@@ -91,18 +80,7 @@
   display: grid;
 }
 
-/* Pinned footer: identity + settings gear. The scrolling .body (flex:1 1 auto)
- * pushes it to the bottom, so it never eats space from the tree. */
-.footer {
-  flex: none;
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-4);
-  border-top: 1px solid var(--edge);
-}
-
-.footerIdentity {
+.brandIdentity {
   flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
@@ -140,6 +140,37 @@ afterEach(() => {
 });
 
 describe("resource-backed Rail", () => {
+  test("places identity and Settings before Search in the top row and preserves navigation", () => {
+    installState();
+    connectionStore.setState({ serverInfo: { name: "evener-hub", version: "0.0.0" } });
+    const onHide = vi.fn();
+    render(<Rail onHide={onHide} />);
+    const brand = within(screen.getByTestId("rail-brand"));
+    const identity = brand.getByText("evener-hub");
+    const settings = brand.getByRole("button", { name: "Settings" });
+    const search = brand.getByRole("button", { name: "Search" });
+    const hide = brand.getByRole("button", { name: "Hide sidebar" });
+    for (const [left, right] of [
+      [identity, settings],
+      [settings, search],
+      [search, hide],
+    ] as const) {
+      expect(left.compareDocumentPosition(right) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+    expect(screen.getAllByText("evener-hub")).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: "Settings" })).toHaveLength(1);
+    const previousPath = window.location.pathname;
+    try {
+      window.history.replaceState({}, "", "/new");
+      fireEvent.click(settings);
+      expect(window.location.pathname).toBe("/settings");
+      fireEvent.click(hide);
+      expect(onHide).toHaveBeenCalledOnce();
+    } finally {
+      window.history.replaceState({}, "", previousPath);
+    }
+  });
+
   test("renders loaded global and project resources without a transport read", () => {
     installState([
       sectionResource("live", [summary({ title: "Live resource" })]),

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -78,10 +78,8 @@ const CLASS = {
   rail: requireClass(styles.rail, "Rail.module.css", "rail"),
   header: requireClass(styles.header, "Rail.module.css", "header"),
   brand: requireClass(styles.brand, "Rail.module.css", "brand"),
-  brandSpacer: requireClass(styles.brandSpacer, "Rail.module.css", "brandSpacer"),
+  brandIdentity: requireClass(styles.brandIdentity, "Rail.module.css", "brandIdentity"),
   newSession: requireClass(styles.newSession, "Rail.module.css", "newSession"),
-  footer: requireClass(styles.footer, "Rail.module.css", "footer"),
-  footerIdentity: requireClass(styles.footerIdentity, "Rail.module.css", "footerIdentity"),
   body: requireClass(styles.body, "Rail.module.css", "body"),
   parentScrollRail: requireClass(styles.parentScrollRail, "Rail.module.css", "parentScrollRail"),
   parentScrollBody: requireClass(styles.parentScrollBody, "Rail.module.css", "parentScrollBody"),
@@ -1077,8 +1075,16 @@ function NavigationRail({
       )}
       <div className={CLASS.header}>
         <div data-testid="rail-brand" className={CLASS.brand}>
+          <span className={CLASS.brandIdentity}>{serverInfo?.name ?? "evener"}</span>
           {needsYou > 0 && <Badge count={needsYou} tone="attention" />}
-          <span className={CLASS.brandSpacer} />
+          <IconButton
+            data-testid="rail-settings"
+            label="Settings"
+            icon={<span aria-hidden="true">⚙</span>}
+            variant="quiet"
+            size="md"
+            onClick={() => navigate("/settings")}
+          />
           <Tooltip label="Search sessions and commands">
             <IconButton
               data-testid="rail-search"
@@ -1183,17 +1189,6 @@ function NavigationRail({
             )}
           </>
         )}
-      </div>
-      <div className={CLASS.footer}>
-        <span className={CLASS.footerIdentity}>{serverInfo?.name ?? "evener"}</span>
-        <IconButton
-          data-testid="rail-settings"
-          label="Settings"
-          icon={<span aria-hidden="true">⚙</span>}
-          variant="quiet"
-          size="md"
-          onClick={() => navigate("/settings")}
-        />
       </div>
       {sectionRenameTarget && (
         <Dialog


### PR DESCRIPTION
## Summary
- Move the hub identity and Settings gear left of Search in the sidebar header on desktop and mobile.
- Remove the footer and preserve Settings navigation.
- Add unit and browser layout regression coverage.

## Verification
- `make test-web` passed
- `make test-web-browser` passed
- `git diff --check` passed