### PR TITLE
Show timestamps on every conversation message

### DIFF
--- a/appwire/types.go
+++ b/appwire/types.go
@@ -2258,6 +2258,8 @@ type WarningParams struct {
 // "user" for human-sent steering (rendered as a user message) and omitted
 // entirely for daemon-originated steering (issue #24).
 type EvenerSteeringInjectedParams struct {
+	// StartedAt is the server event timestamp in epoch milliseconds.
+	StartedAt        *int64      `json:"startedAt,omitempty"`
 	ThreadID         string      `json:"threadId"`
 	Ref              string      `json:"ref"`
 	Text             string      `json:"text,omitempty"`

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
@@ -2,18 +2,22 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanup, render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, expect, test } from "vitest";
 import type { ItemModel, TurnModel } from "../../../../protocol/model";
+import { SessionNowContext } from "../../liveness";
 import { ignoringTurn, itemRendererFor } from "../types";
 import { AgentMessageItem } from "./AgentMessageItem";
-import { formatClockTime } from "./format";
 
 afterEach(cleanup);
 
 const turn: TurnModel = { id: "turn_1", status: "inProgress", items: [] };
 
 const STARTED_AT = "2026-07-29T12:41:00Z";
-const TIME = formatClockTime(STARTED_AT)!;
+const TIME = "5m ago";
+const NOW = Date.parse("2026-07-29T12:46:00Z");
+const renderMessage = (ui: ReactNode) =>
+  render(ui, { wrapper: ({ children }) => <SessionNowContext value={NOW}>{children}</SessionNowContext> });
 
 function item(overrides: Partial<ItemModel> = {}): ItemModel {
   return { id: "item_1", turnId: "turn_1", type: "agentMessage", text: "", ...overrides };
@@ -31,13 +35,13 @@ test("is memoized ignoring turn identity - a fresh turn object on every streamin
 // --- settled: Markdown ------------------------------------------------------
 
 test("settled renders through Markdown - a markdown token actually gets parsed, not shown as literal source", () => {
-  render(<AgentMessageItem item={item({ text: "**bold text**" })} turn={turn} live={false} />);
+  renderMessage(<AgentMessageItem item={item({ text: "**bold text**" })} turn={turn} live={false} />);
   const strong = screen.getByText("bold text");
   expect(strong.tagName).toBe("STRONG");
 });
 
 test("settled with blank text and no pendingText renders nothing at all", () => {
-  const { container } = render(<AgentMessageItem item={item({ text: "" })} turn={turn} live={false} />);
+  const { container } = renderMessage(<AgentMessageItem item={item({ text: "" })} turn={turn} live={false} />);
   expect(container.firstChild).toBeNull();
 });
 
@@ -48,7 +52,7 @@ test("settled with blank text and no pendingText renders nothing at all", () => 
 // preview (widgets/markdown/streaming.ts).
 
 test("live parses markdown WHILE streaming - emphasis renders as emphasis, not literal source", () => {
-  const { container } = render(
+  const { container } = renderMessage(
     <AgentMessageItem item={item({ pendingText: ["**bold", " text**"] })} turn={turn} live={true} />,
   );
   expect(container.querySelector("strong")?.textContent).toBe("bold text");
@@ -56,7 +60,7 @@ test("live parses markdown WHILE streaming - emphasis renders as emphasis, not l
 });
 
 test("live auto-closes a marker truncated at the stream tail - bold renders before its closer arrives", () => {
-  const { container } = render(
+  const { container } = renderMessage(
     <AgentMessageItem item={item({ pendingText: ["the answer is **bo"] })} turn={turn} live={true} />,
   );
   expect(container.querySelector("strong")?.textContent).toBe("bo");
@@ -64,7 +68,7 @@ test("live auto-closes a marker truncated at the stream tail - bold renders befo
 });
 
 test("auto-close is preview-only: a genuinely unterminated SETTLED source stays literal", () => {
-  const { container } = render(
+  const { container } = renderMessage(
     <AgentMessageItem item={item({ text: "the answer is **bo" })} turn={turn} live={false} />,
   );
   expect(container.querySelector("strong")).toBeNull();
@@ -72,17 +76,21 @@ test("auto-close is preview-only: a genuinely unterminated SETTLED source stays 
 });
 
 test("live with no pendingText yet (item just started, zero deltas so far) renders nothing rather than an empty shell", () => {
-  const { container } = render(<AgentMessageItem item={item({ pendingText: undefined })} turn={turn} live={true} />);
+  const { container } = renderMessage(
+    <AgentMessageItem item={item({ pendingText: undefined })} turn={turn} live={true} />,
+  );
   expect(container.firstChild).toBeNull();
 });
 
 test("live with an empty pendingText array is treated the same as no pendingText", () => {
-  const { container } = render(<AgentMessageItem item={item({ pendingText: [] })} turn={turn} live={true} />);
+  const { container } = renderMessage(<AgentMessageItem item={item({ pendingText: [] })} turn={turn} live={true} />);
   expect(container.firstChild).toBeNull();
 });
 
 test("incremental growth: re-rendering with more pendingText chunks grows the streamed content without duplication", () => {
-  const { rerender } = render(<AgentMessageItem item={item({ pendingText: ["Hel"] })} turn={turn} live={true} />);
+  const { rerender } = renderMessage(
+    <AgentMessageItem item={item({ pendingText: ["Hel"] })} turn={turn} live={true} />,
+  );
   expect(screen.getByTestId("agent-message-stream").textContent?.trim()).toBe("Hel");
   rerender(<AgentMessageItem item={item({ pendingText: ["Hel", "lo"] })} turn={turn} live={true} />);
   expect(screen.getByTestId("agent-message-stream").textContent?.trim()).toBe("Hello");
@@ -95,7 +103,7 @@ test("incremental growth: re-rendering with more pendingText chunks grows the st
 
 test("live streaming settles cleanly: the stream wrapper unmounts, settled Markdown takes over, no duplicated content", () => {
   const liveItem = item({ pendingText: ["Hel", "lo"] });
-  const { rerender } = render(<AgentMessageItem item={liveItem} turn={turn} live={true} />);
+  const { rerender } = renderMessage(<AgentMessageItem item={liveItem} turn={turn} live={true} />);
   expect(screen.getByTestId("agent-message-stream").textContent?.trim()).toBe("Hello");
 
   const settledItem = { ...liveItem, text: "Hello", pendingText: undefined };
@@ -113,7 +121,7 @@ test("live streaming settles cleanly: the stream wrapper unmounts, settled Markd
 
 test("rapid-settle: a single-chunk live frame immediately followed by settlement still lands correctly", () => {
   const liveItem = item({ pendingText: ["Done."] });
-  const { rerender } = render(<AgentMessageItem item={liveItem} turn={turn} live={true} />);
+  const { rerender } = renderMessage(<AgentMessageItem item={liveItem} turn={turn} live={true} />);
   expect(screen.getByTestId("agent-message-stream").textContent?.trim()).toBe("Done.");
 
   const settledItem = { ...liveItem, text: "Done.", pendingText: undefined };
@@ -127,13 +135,13 @@ test("rapid-settle: settling WITHOUT ever having rendered live (turn/completed a
   // idempotent-finalize) - the item can go from not-yet-rendered straight
   // to settled with full text, no live frame ever observed by this
   // component instance.
-  render(<AgentMessageItem item={item({ text: "straight to settled" })} turn={turn} live={false} />);
+  renderMessage(<AgentMessageItem item={item({ text: "straight to settled" })} turn={turn} live={false} />);
   expect(screen.queryByTestId("agent-message-stream")).toBeNull();
   expect(screen.getByText("straight to settled")).toBeTruthy();
 });
 
 test("both live and settled render inside the same stable wrapper testid", () => {
-  const { container, rerender } = render(
+  const { container, rerender } = renderMessage(
     <AgentMessageItem item={item({ pendingText: ["x"] })} turn={turn} live={true} />,
   );
   expect(container.querySelector('[data-testid="agent-message-item"]')).toBeTruthy();
@@ -146,7 +154,7 @@ test("both live and settled render inside the same stable wrapper testid", () =>
 // boundaries only (opensExchange), in BOTH the live and settled branches.
 
 test("exchange-opening agent message shows the speaker header: name, meta, and a decorative avatar", () => {
-  render(
+  renderMessage(
     <AgentMessageItem
       item={item({ text: "the reply", startedAt: STARTED_AT })}
       turn={turn}
@@ -167,7 +175,7 @@ test("exchange-opening agent message shows the speaker header: name, meta, and a
 });
 
 test("the speaker header renders in the LIVE branch too - the eyebrow appeared in both, and the header keeps that parity", () => {
-  render(
+  renderMessage(
     <AgentMessageItem
       item={item({ pendingText: ["streaming"], startedAt: STARTED_AT })}
       turn={turn}
@@ -183,7 +191,7 @@ test("the speaker header renders in the LIVE branch too - the eyebrow appeared i
 
 test("the speaker header survives the live-to-settled transition on the same instance", () => {
   const liveItem = item({ pendingText: ["Hi"], startedAt: STARTED_AT });
-  const { rerender } = render(
+  const { rerender } = renderMessage(
     <AgentMessageItem item={liveItem} turn={turn} live={true} opensExchange agentLabel="k3" />,
   );
   expect(screen.getByTestId("agent-speaker-header")).toBeTruthy();
@@ -204,21 +212,23 @@ test("the speaker header survives the live-to-settled transition on the same ins
 // a dangling separator, and no meta element at all when both are absent.
 
 test("meta with label only (no startedAt): just the label, no dangling separator", () => {
-  render(<AgentMessageItem item={item({ text: "r" })} turn={turn} live={false} opensExchange agentLabel="k3" />);
+  renderMessage(<AgentMessageItem item={item({ text: "r" })} turn={turn} live={false} opensExchange agentLabel="k3" />);
   const header = screen.getByTestId("agent-speaker-header");
   expect(header.textContent).toBe("Agentk3");
   expect(header.textContent).not.toContain("·");
 });
 
 test("meta with time only (no agentLabel): just the time, no dangling separator", () => {
-  render(<AgentMessageItem item={item({ text: "r", startedAt: STARTED_AT })} turn={turn} live={false} opensExchange />);
+  renderMessage(
+    <AgentMessageItem item={item({ text: "r", startedAt: STARTED_AT })} turn={turn} live={false} opensExchange />,
+  );
   const header = screen.getByTestId("agent-speaker-header");
   expect(header.textContent).toBe(`Agent${TIME}`);
   expect(header.textContent).not.toContain("·");
 });
 
 test("meta with neither label nor time: no meta element at all, just the name", () => {
-  render(<AgentMessageItem item={item({ text: "r" })} turn={turn} live={false} opensExchange />);
+  renderMessage(<AgentMessageItem item={item({ text: "r" })} turn={turn} live={false} opensExchange />);
   const header = screen.getByTestId("agent-speaker-header");
   expect(header.textContent).toBe("Agent");
   // One child: the name span only - an empty meta span would still carry
@@ -227,7 +237,7 @@ test("meta with neither label nor time: no meta element at all, just the name", 
 });
 
 test("meta with an unparseable startedAt drops the time rather than guessing", () => {
-  render(
+  renderMessage(
     <AgentMessageItem
       item={item({ text: "r", startedAt: "not a timestamp" })}
       turn={turn}
@@ -240,7 +250,7 @@ test("meta with an unparseable startedAt drops the time rather than guessing", (
 });
 
 test("continuation fragments render no header, no avatar, no opens-exchange marker", () => {
-  render(
+  renderMessage(
     <AgentMessageItem
       item={item({ text: "more work", startedAt: STARTED_AT })}
       turn={turn}
@@ -256,7 +266,7 @@ test("continuation fragments render no header, no avatar, no opens-exchange mark
 });
 
 test("mid-exchange LIVE fragments render no header either - the trigger is opensExchange, not liveness", () => {
-  render(<AgentMessageItem item={item({ pendingText: ["work"] })} turn={turn} live={true} agentLabel="k3" />);
+  renderMessage(<AgentMessageItem item={item({ pendingText: ["work"] })} turn={turn} live={true} agentLabel="k3" />);
   expect(screen.queryByTestId("agent-speaker-header")).toBeNull();
   expect(screen.queryByTestId("speaker-avatar")).toBeNull();
 });
@@ -309,7 +319,7 @@ test("the opener's gap resolves the tokens.css --speaker-gap", () => {
 // fully rounded, the SAME wrapper live and settled.
 
 test("every fragment renders its prose inside the bubble wrapper, live and settled", () => {
-  const { rerender } = render(<AgentMessageItem item={item({ pendingText: ["x"] })} turn={turn} live={true} />);
+  const { rerender } = renderMessage(<AgentMessageItem item={item({ pendingText: ["x"] })} turn={turn} live={true} />);
   const liveBubble = screen.getByTestId("agent-bubble");
   expect(liveBubble.contains(screen.getByTestId("agent-message-stream"))).toBe(true);
   rerender(<AgentMessageItem item={item({ text: "x", pendingText: undefined })} turn={turn} live={false} />);
@@ -318,7 +328,7 @@ test("every fragment renders its prose inside the bubble wrapper, live and settl
 });
 
 test("an opener bubble sits in the column under the speaker header; a continuation bubbles with no header and no avatar", () => {
-  render(
+  renderMessage(
     <AgentMessageItem item={item({ text: "the reply" })} turn={turn} live={false} opensExchange agentLabel="k3" />,
   );
   const root = screen.getByTestId("agent-message-item");
@@ -329,7 +339,7 @@ test("an opener bubble sits in the column under the speaker header; a continuati
 });
 
 test("a continuation fragment's bubble carries the uniform-radius continuation class", () => {
-  render(<AgentMessageItem item={item({ text: "more work" })} turn={turn} live={false} agentLabel="k3" />);
+  renderMessage(<AgentMessageItem item={item({ text: "more work" })} turn={turn} live={false} agentLabel="k3" />);
   const bubble = screen.getByTestId("agent-bubble");
   expect(bubble.className).toContain("continuation");
   expect(screen.queryByTestId("agent-speaker-header")).toBeNull();
@@ -371,3 +381,19 @@ test("the stream caret's blink sits behind the reduced-motion gate, keeping the 
   expect(gate).not.toBeNull();
   expect(gate![1]).toMatch(/\.stream\s*>\s*div\s*>\s*:last-child::after\s*\{[^}]*animation:\s*none/);
 });
+
+for (const live of [false, true]) {
+  test(`continuation message exposes its timestamp while live=${live}`, () => {
+    const { container } = renderMessage(
+      <AgentMessageItem
+        item={item({ text: "reply", pendingText: ["reply"], startedAt: STARTED_AT })}
+        turn={turn}
+        live={live}
+      />,
+    );
+    const time = container.querySelector("time");
+    expect(time?.dateTime).toBe("2026-07-29T12:41:00.000Z");
+    expect(time?.textContent).toBe("5m ago");
+    expect(time?.title).toBeTruthy();
+  });
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.tsx
@@ -18,9 +18,10 @@
 // messages.md, decisions 1-2): at exchange boundaries ONLY (opensExchange -
 // the same trigger the old caption eyebrow fired on, never mid-exchange) the
 // message takes the speaker header - avatar tile + "Agent" + meta (model
-// label and clock time, each only when defined). The opener is a flex row
-// [avatar][column(header, prose)]; mid-exchange fragments render bare (no
-// avatar, no header) and align under the run via TurnBlock's content-column
+// label and relative time, each only when defined). The opener is a flex
+// row [avatar][column(header, prose)]; mid-exchange fragments show their
+// timestamp without a speaker avatar or header and align under the run via
+// TurnBlock's content-column
 // indent, so no indent is added here. The header renders in BOTH the live
 // and settled branches, exactly where the eyebrow appeared, so a stream
 // that starts and settles within a frame keeps the same DOM shape.
@@ -34,7 +35,7 @@ import { requireClass } from "../../../../widgets/internal/requireClass";
 import { SpeakerAvatar } from "../../../../widgets/speakeravatar";
 import { type ItemRenderProps, ignoringTurn, registerItemRenderer } from "../types";
 import styles from "./agentmessageitem.module.css";
-import { formatClockTime } from "./format";
+import { MessageTimestamp } from "./MessageTimestamp";
 
 const CLASS = {
   message: requireClass(styles.message, "agentmessageitem.module.css", "message"),
@@ -48,15 +49,6 @@ const CLASS = {
   stream: requireClass(styles.stream, "agentmessageitem.module.css", "stream"),
 };
 
-// The header meta is "{model label} · {clock time}", each part only when
-// defined: a missing label or an absent/unparseable startedAt drops just
-// that part, never leaving a dangling "·", and with neither defined there
-// is no meta element at all.
-function metaText(agentLabel: string | undefined, startedAt: string | undefined): string | undefined {
-  const parts = [agentLabel, formatClockTime(startedAt)].filter((p): p is string => p !== undefined && p !== "");
-  return parts.length > 0 ? parts.join(" · ") : undefined;
-}
-
 // Memoized ignoring `turn` identity (types.ts's ignoringTurn): this
 // component never reads `turn` at all (only `item`/`live`, destructured
 // below), so a fresh turn object on every streaming delta targeting a
@@ -67,11 +59,21 @@ export const AgentMessageItem = memo(function AgentMessageItem({
   opensExchange,
   agentLabel,
 }: ItemRenderProps) {
-  const meta = opensExchange ? metaText(agentLabel, item.startedAt) : undefined;
+  const time = Date.parse(item.startedAt ?? "");
+  const hasTime = Number.isFinite(time);
+  const timestamp = hasTime ? <MessageTimestamp value={time} /> : null;
+  const meta =
+    agentLabel || hasTime ? (
+      <span className={CLASS.meta}>
+        {agentLabel}
+        {agentLabel && hasTime ? " · " : null}
+        {timestamp}
+      </span>
+    ) : null;
   const speaker = opensExchange ? (
     <div className={CLASS.header} data-testid="agent-speaker-header">
       <span className={CLASS.name}>Agent</span>
-      {meta !== undefined && <span className={CLASS.meta}>{meta}</span>}
+      {meta}
     </div>
   ) : null;
 
@@ -103,7 +105,14 @@ export const AgentMessageItem = memo(function AgentMessageItem({
         {children}
       </div>
     );
-    if (!opensExchange) return root(bubble, CLASS.message);
+    if (!opensExchange)
+      return root(
+        <>
+          {timestamp}
+          {bubble}
+        </>,
+        CLASS.message,
+      );
     return root(
       <>
         <SpeakerAvatar speaker="agent" />

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/MessageTimestamp.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/MessageTimestamp.tsx
@@ -1,0 +1,8 @@
+import { Timestamp } from "../../../../widgets/timestamp";
+import { useSessionNow } from "../../liveness";
+
+// Only this leaf consumes clock ticks, keeping message prose out of timer renders.
+export function MessageTimestamp({ value }: { value: number }) {
+  const now = useSessionNow();
+  return <Timestamp value={value} now={now} />;
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/UserMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/UserMessageItem.test.tsx
@@ -14,8 +14,8 @@ import { connectionStore } from "../../../../stores/connection";
 import { resetThreadsStoreForTests } from "../../../../stores/threads";
 import { Toast } from "../../../../widgets";
 import { readDraft } from "../../composer/draft";
+import { SessionNowContext } from "../../liveness";
 import { ignoringTurn, itemRendererFor } from "../types";
-import { formatClockTime } from "./format";
 import { UserMessageItem, UserMessageView } from "./UserMessageItem";
 import styles from "./usermessageitem.module.css";
 
@@ -84,17 +84,16 @@ test("the avatar tile is decorative (aria-hidden) - the header already names the
   expect(avatar.getAttribute("aria-hidden")).toBe("true");
 });
 
-test("the clock time renders in the header when startedAt is present", () => {
-  const startedAt = "2026-07-29T14:05:00.000Z";
-  render(<UserMessageView item={item({ text: "hello", startedAt })} />);
-  // Local HH:MM projection of the instant, matching formatClockTime.
-  const d = new Date(startedAt);
-  const expected = `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
-  const root = screen.getByTestId("user-message-item");
-  const header = root.querySelector(`.${styles.header}`) as HTMLElement;
-  const time = header.querySelector(`.${styles.time}`);
-  expect(time).not.toBeNull();
-  expect(time!.textContent).toBe(expected);
+test("message timestamp advances with the shared clock and preserves the exact instant", () => {
+  const message = <UserMessageView item={item({ text: "hello", startedAt: "2026-07-29T14:05:00.000Z" })} />;
+  const { container, rerender } = render(
+    <SessionNowContext value={Date.parse("2026-07-29T14:10:00Z")}>{message}</SessionNowContext>,
+  );
+  expect(container.querySelector("time")?.textContent).toBe("5m ago");
+  expect(container.querySelector("time")?.dateTime).toBe("2026-07-29T14:05:00.000Z");
+  expect(container.querySelector("time")?.title).toBeTruthy();
+  rerender(<SessionNowContext value={Date.parse("2026-07-29T14:11:00Z")}>{message}</SessionNowContext>);
+  expect(container.querySelector("time")?.textContent).toBe("6m ago");
 });
 
 test("no time node at all (no placeholder) when startedAt is absent", () => {
@@ -468,7 +467,7 @@ test("a user-sourced steer reuses the same view WITHOUT the exchange marker", ()
 test("UserMessageView accepts speaker/name/timeIso overrides for non-user speakers (delegate_send bubbles)", () => {
   render(
     <UserMessageView
-      item={item({ text: "status?", startedAt: "2026-08-06T10:05:00Z" })}
+      item={item({ text: "status?", startedAt: "2026-08-06T10:00:00Z" })}
       speaker="agent"
       name="Agent → dlg_abc123"
       timeIso="2026-08-06T10:05:00Z"
@@ -476,11 +475,7 @@ test("UserMessageView accepts speaker/name/timeIso overrides for non-user speake
   );
   expect(screen.getByText("Agent → dlg_abc123")).toBeTruthy();
   expect(screen.getByTestId("user-bubble").textContent).toBe("status?");
-  // The header time comes from timeIso, formatted by the same formatClockTime
-  // the default path uses - compute the expectation rather than hardcoding a
-  // timezone-dependent literal.
-  const expected = formatClockTime("2026-08-06T10:05:00Z");
-  if (expected !== undefined) expect(screen.getByText(expected)).toBeTruthy();
+  expect(screen.getByTestId("user-message-item").querySelector("time")?.dateTime).toBe("2026-08-06T10:05:00.000Z");
 });
 
 test("UserMessageView defaults are unchanged: user speaker, 'You' name, item.startedAt time", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/UserMessageItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/UserMessageItem.tsx
@@ -1,7 +1,7 @@
 // The userMessage item renderer: the slack-lean speaker treatment
 // (docs/web-ui/specs/2026-07-29-transcript-slack-lean-messages.md, decisions
 // 1, 2, 5). Speaker identity is a one-line header - avatar tile, then "You"
-// at body size, then the message's clock time at caption - replacing the old
+// at body size, then the message's relative time at caption - replacing the old
 // stacked caption eyebrow, which was too faint to scan exchange boundaries
 // by. The whole message is one flex row (avatar + content column), so the
 // header and the text share the column the TurnBlock gutter aligns
@@ -25,7 +25,7 @@ import { SpeakerAvatar, type SpeakerAvatarSpeaker } from "../../../../widgets/sp
 import { writeDraft } from "../../composer/draft";
 import { ImageGallery } from "../flow/ImageGallery";
 import { type ItemRenderProps, ignoringTurn, registerItemRenderer } from "../types";
-import { formatClockTime } from "./format";
+import { MessageTimestamp } from "./MessageTimestamp";
 import styles from "./usermessageitem.module.css";
 
 const CLASS = {
@@ -115,10 +115,8 @@ export function UserMessageView({
   name?: string;
   timeIso?: string;
 }) {
-  // No placeholder when the wire carries no startedAt: a header with no time
-  // shows no time rather than a guess (formatClockTime returns undefined for
-  // a missing or unparseable timestamp).
-  const time = formatClockTime(timeIso ?? item.startedAt);
+  // Missing or invalid server timestamps stay absent rather than showing a guess.
+  const time = Date.parse(timeIso ?? item.startedAt ?? "");
   return (
     <div
       className={CLASS.message}
@@ -131,7 +129,11 @@ export function UserMessageView({
       <div className={CLASS.content}>
         <div className={CLASS.header}>
           <span className={CLASS.name}>{name}</span>
-          {time !== undefined && <span className={CLASS.time}>{time}</span>}
+          {Number.isFinite(time) && (
+            <span className={CLASS.time}>
+              <MessageTimestamp value={time} />
+            </span>
+          )}
           {actions !== undefined && <div className={CLASS.actions}>{actions}</div>}
         </div>
         <div className={CLASS.body} data-testid="user-bubble">

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -1500,7 +1500,7 @@ test('evener/steering/injected with source "user" appends a steering item to the
     model,
     {
       method: "evener/steering/injected",
-      params: { threadId: "thr_t", ref: "ref_t", text: "please also check X", source: "user" },
+      params: { threadId: "thr_t", ref: "ref_t", text: "please also check X", source: "user", startedAt: 1000 },
     },
     1002,
   );
@@ -1512,6 +1512,7 @@ test('evener/steering/injected with source "user" appends a steering item to the
     turnId: "turn_1",
     type: "steering",
     text: "please also check X",
+    startedAt: "1970-01-01T00:00:01.000Z",
     status: "completed",
     source: "user",
   });

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -1274,6 +1274,7 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
             id: `item_steering_live_${activeTurnId}_${steeringCount}`,
             turnId: activeTurnId,
             type: "steering",
+            ...(params.startedAt !== undefined ? { startedAt: epochMsToISO(params.startedAt) } : {}),
             text: params.text ?? "",
             images: imagesToItemImages(params.images),
             status: "completed",

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -332,6 +332,7 @@ export interface EvenerSkillInfo {
 }
 
 export interface EvenerSteeringInjectedParams {
+  startedAt?: number;
   threadId: string;
   ref: string;
   text?: string;

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -543,6 +543,7 @@ _(no fields)_
 
 | Field | Go type | Omitempty | Embedded |
 |-------|---------|-----------|----------|
+| `startedAt` | `*int64` | yes |  |
 | `threadId` | `string` |  |  |
 | `ref` | `string` |  |  |
 | `text` | `string` | yes |  |

--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -78,6 +78,7 @@ type AppEventProjector struct {
 	midSessionAnnouncementTurnID string
 	assistantItem                string
 	assistantText                string
+	messageStartByID             map[string]time.Time
 	provisionalCommunicateItems  map[string]string
 	communicateCommittedCalls    map[string]struct{}
 	communicatePhases            map[string]communicatePhase
@@ -215,7 +216,38 @@ func (p *AppEventProjector) clearSkillCandidate() {
 	p.skillCandidate = skillActivationCandidate{}
 }
 
-func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification {
+func (p *AppEventProjector) Project(event events.SessionEvent) (out []AppNotification) {
+	// Message lifecycles share one timing rule: keep the first visible event's
+	// timestamp through completion. One-shot messages use their own event time.
+	defer func() {
+		for i := range out {
+			if reset, ok := out[i].Params.(appwire.AgentMessageResetParams); ok {
+				delete(p.messageStartByID, reset.ItemID)
+			}
+			params, ok := out[i].Params.(appwire.ItemLifecycleParams)
+			if !ok || (params.Item.Type != "userMessage" && params.Item.Type != "agentMessage") {
+				continue
+			}
+			startedAt, exists := p.messageStartByID[params.Item.ID]
+			if !exists {
+				startedAt = event.Timestamp
+			}
+			if !startedAt.IsZero() {
+				ms := startedAt.UnixMilli()
+				params.Item.StartedAt = &ms
+			}
+			if out[i].Method == appwire.NotifyItemStarted {
+				if p.messageStartByID == nil {
+					p.messageStartByID = map[string]time.Time{}
+				}
+				p.messageStartByID[params.Item.ID] = startedAt
+			} else {
+				delete(p.messageStartByID, params.Item.ID)
+			}
+			out[i].Params = params
+		}
+	}()
+
 	if p.threadID == "" {
 		p.threadID = event.SessionID
 	}
@@ -929,6 +961,9 @@ func (p *AppEventProjector) Project(event events.SessionEvent) []AppNotification
 		}
 		if data.ClientMutationID != "" {
 			params["clientMutationId"] = data.ClientMutationID
+		}
+		if !event.Timestamp.IsZero() {
+			params["startedAt"] = event.Timestamp.UnixMilli()
 		}
 		return []AppNotification{p.notification(appwire.NotifyEvenerSteeringInjected, params)}
 	case events.EventCompactionTurn:
@@ -1953,6 +1988,7 @@ func (p *AppEventProjector) openTurn(stableID string, at time.Time) (string, []A
 func (p *AppEventProjector) resetTurnScopedState() {
 	p.assistantItem = ""
 	p.assistantText = ""
+	p.messageStartByID = nil
 	p.reasoningItem = ""
 	p.toolItemsByKey = map[string]string{}
 	p.toolArgsByKey = map[string]string{}

--- a/internal/appprojector/message_timestamps_test.go
+++ b/internal/appprojector/message_timestamps_test.go
@@ -1,0 +1,62 @@
+package appprojector
+
+import (
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/appwire"
+)
+
+func TestMessageTimestamps(t *testing.T) {
+	at := time.Unix(1700000000, 0).UTC()
+	for _, event := range []events.SessionEvent{
+		{Kind: events.EventUserInput, Data: events.UserInputData{Text: "hello"}},
+		{Kind: events.EventAssistantTextEnd, Data: events.AssistantTextEndData{Text: "reply"}},
+		{Kind: events.EventCommunicate, Data: events.CommunicateData{Message: "reply"}},
+		{Kind: events.EventCommunicate, Data: events.CommunicateData{CallID: "call", Message: "reply"}},
+	} {
+		t.Run(string(event.Kind), func(t *testing.T) {
+			for _, stamp := range []time.Time{at, {}} {
+				p := NewAppEventProjector("thread", "ref")
+				event.Timestamp = stamp
+				item := notificationThreadItem(t, p.Project(event), appwire.NotifyItemCompleted)
+				if stamp.IsZero() {
+					if item.StartedAt != nil {
+						t.Fatalf("missing timestamp became %v", *item.StartedAt)
+					}
+				} else if item.StartedAt == nil || *item.StartedAt != at.UnixMilli() {
+					t.Fatalf("message timestamp = %v, want %d", item.StartedAt, at.UnixMilli())
+				}
+			}
+		})
+	}
+}
+
+func TestStreamingMessageKeepsTimestampOnCompletion(t *testing.T) {
+	at := time.Unix(1700000000, 0).UTC()
+	for _, pair := range [][2]events.SessionEvent{
+		{{Kind: events.EventAssistantTextDelta, Data: events.AssistantTextDeltaData{Delta: "reply"}}, {Kind: events.EventAssistantTextEnd, Data: events.AssistantTextEndData{Text: "reply"}}},
+		{{Kind: events.EventCommunicatePreviewStart, Data: events.CommunicatePreviewStartData{CallID: "call"}}, {Kind: events.EventCommunicate, Data: events.CommunicateData{CallID: "call", Message: "reply"}}},
+	} {
+		t.Run(string(pair[0].Kind), func(t *testing.T) {
+			p := NewAppEventProjector("thread", "ref")
+			pair[0].Timestamp = at
+			pair[1].Timestamp = at.Add(time.Minute)
+			started := notificationThreadItem(t, p.Project(pair[0]), appwire.NotifyItemStarted)
+			completed := notificationThreadItem(t, p.Project(pair[1]), appwire.NotifyItemCompleted)
+			if started.StartedAt == nil || completed.StartedAt == nil || *started.StartedAt != at.UnixMilli() || *completed.StartedAt != at.UnixMilli() {
+				t.Fatalf("stream timestamp changed: start=%v complete=%v", started.StartedAt, completed.StartedAt)
+			}
+		})
+	}
+}
+
+func TestUserSteeringTimestamp(t *testing.T) {
+	p := NewAppEventProjector("thread", "ref")
+	out := p.Project(events.SessionEvent{Kind: events.EventSteeringInjected, Timestamp: time.Unix(1700000000, 0), Data: events.SteeringInjectedData{Text: "adjust", Source: "user"}})
+	params := out[0].Params.(map[string]any)
+	if params["startedAt"] != int64(1700000000000) {
+		t.Fatalf("steering timestamp = %v", params["startedAt"])
+	}
+}

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -285,6 +285,19 @@ func DefaultImageProjector(image llm.ImageData) appwire.InputItem {
 
 // ProjectTurn maps a typed transcript turn into AppWire transcript items.
 func ProjectTurn(turnID string, turnIndex int, turn schema.Turn, toolNames map[string]string, imageProjector ImageProjector, outputImageProjector OutputImageProjector) (out []appwire.ThreadItem) {
+	// A persisted message has the entry's recorded instant, not a duration.
+	defer func() {
+		if turn.Timestamp.IsZero() {
+			return
+		}
+		for i := range out {
+			if out[i].Type == "userMessage" || out[i].Type == "agentMessage" || (out[i].Type == "steering" && out[i].Source == "user") {
+				ms := turn.Timestamp.UnixMilli()
+				out[i].StartedAt = &ms
+			}
+		}
+	}()
+
 	if imageProjector == nil {
 		imageProjector = DefaultImageProjector
 	}

--- a/internal/apptranscript/message_timestamps_test.go
+++ b/internal/apptranscript/message_timestamps_test.go
@@ -1,0 +1,38 @@
+package apptranscript
+
+import (
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/llm"
+)
+
+func TestMessageTimestampsFromTranscript(t *testing.T) {
+	at := time.Unix(1700000000, 0).UTC()
+	for _, turn := range []schema.Turn{
+		{Kind: schema.TurnUserInput, Message: llm.User("hello")},
+		{Kind: schema.TurnSteering, SteeringSource: "user", Message: llm.User("adjust")},
+		{Kind: schema.TurnAssistant, Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{
+			{Kind: llm.ContentText, Text: "reply"},
+			{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: "call", Name: "communicate", Arguments: []byte(`{"message":"another reply"}`)}},
+		}}},
+	} {
+		for _, stamp := range []time.Time{at, {}} {
+			turn.Timestamp = stamp
+			items := ProjectTurn("turn", 1, turn, nil, nil, nil)
+			if len(items) == 0 {
+				t.Fatal("no messages projected")
+			}
+			for _, item := range items {
+				if stamp.IsZero() {
+					if item.StartedAt != nil {
+						t.Fatalf("missing timestamp became %v", *item.StartedAt)
+					}
+				} else if item.StartedAt == nil || *item.StartedAt != at.UnixMilli() {
+					t.Fatalf("%s timestamp = %v, want %d", item.Type, item.StartedAt, at.UnixMilli())
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
User messages and agent replies now show relative timestamps with the exact time on hover, including agent continuation messages and human steering. The timestamp uses the existing shared widget and session clock, with clock updates isolated from message prose.

The live and replay projectors previously omitted message timestamps. Live messages now keep their first visible event time through completion; replay uses the recorded transcript entry time. Historical entries without a timestamp remain unstamped. A live timestamp can therefore differ after reload because transcripts do not persist first-token timing.

Validation:
- Projector, transcript, AppWire, and hub Go suites passed.
- `make lint`, `make vet`, and the full `make test-web` gate passed (typecheck, frontend tests, and Biome).
- The 193 focused message/reducer tests also passed.
- All five `make test-web-browser` guards passed.
- Real Chrome desktop and 375px previews confirmed timestamps on user, agent opener, and agent continuation messages with no mobile overflow.
- Independent code review found no actionable issues.

GitHub CI is running against the PR head.
