### PR TITLE
Persist structured model switch identities in transcripts

### DIFF
--- a/agent/doctor/sessions.go
+++ b/agent/doctor/sessions.go
@@ -177,10 +177,8 @@ func sessionRow(b bucket, paths Paths, meta schema.SessionMeta, delegates delega
 
 // sessionModels reports the model(s) a session used: the model recorded at
 // creation (the transcript header, immutable) plus the session's current
-// model from meta. A header/meta mismatch is the durable trace of a
-// mid-session model switch — the switch marker text itself
-// (schema.TurnModelSwitch) is presentational prose, not a structured field, so
-// this compares the two canonical structured sources instead of parsing it.
+// model from meta. This summary compares the two endpoint identities; it does
+// not enumerate intermediate transitions from MODEL_SWITCH records.
 func sessionModels(headerModel, metaModel string) []string {
 	switch {
 	case headerModel == "" && metaModel == "":

--- a/agent/schema/turn.go
+++ b/agent/schema/turn.go
@@ -147,6 +147,16 @@ type TurnFailureCause struct {
 	Status   int    `json:"status,omitempty"`
 }
 
+// ModelSwitchInfo records the resolved provider instances and model IDs on
+// either side of a successful model switch. These are configuration identities,
+// not model aliases reported by a provider response.
+type ModelSwitchInfo struct {
+	OldProvider string `json:"old_provider"`
+	OldModel    string `json:"old_model"`
+	NewProvider string `json:"new_provider"`
+	NewModel    string `json:"new_model"`
+}
+
 // Turn is the Session's typed history item. Steering turns are kept distinct for observability,
 // but are converted to user-role messages when building the LLM request.
 type Turn struct {
@@ -182,6 +192,8 @@ type Turn struct {
 	// Hook carries the detail of one completed plugin hook. Set only on
 	// TurnHookCompleted turns; nil everywhere else.
 	Hook *HookInfo `json:"hook,omitempty"`
+	// ModelSwitch carries resolved identities on TurnModelSwitch turns.
+	ModelSwitch *ModelSwitchInfo `json:"model_switch,omitempty"`
 	// ResponseID is the provider's response identifier (from llm.Response.ID),
 	// recorded on assistant turns and surfaced in ATIF trajectory export.
 	ResponseID                      string `json:"response_id,omitempty"`

--- a/agent/session.go
+++ b/agent/session.go
@@ -1287,7 +1287,12 @@ func (s *Session) SetModel(model string) error {
 	// systemMessage by both projection paths and excluded from
 	// expandHistory. Must be appended (and thus visible to a replaying
 	// client) before the live-only EventModelChanged notification below.
-	s.appendTurn(schema.TurnModelSwitch, llm.System(markerText))
+	marker := schema.NewTurn(schema.TurnModelSwitch, llm.System(markerText))
+	marker.ModelSwitch = &schema.ModelSwitchInfo{
+		OldProvider: oldProfile.ID(), OldModel: oldProfile.Model(),
+		NewProvider: nextProfile.ID(), NewModel: nextProfile.Model(),
+	}
+	s.recordTurn(marker, marker)
 	s.emit(events.EventModelChanged, events.ModelChangedData{
 		OldProvider:           oldProfile.ID(),
 		OldModel:              oldProfile.Model(),

--- a/agent/session_model_switch_marker_test.go
+++ b/agent/session_model_switch_marker_test.go
@@ -87,6 +87,48 @@ func TestSetModel_AppendsMarkerTurnOnSuccess(t *testing.T) {
 	}
 }
 
+// TestSetModel_PersistsModelSwitchIdentity exercises the durable semantic record,
+// including two transitions whose intermediate model is absent from meta.json.
+func TestSetModel_PersistsModelSwitchIdentity(t *testing.T) {
+	t.Parallel()
+	sess := newSession(t,
+		withProfile(NewOpenAIProfile("gpt-5.4")),
+		withAdapter(&fakeAdapter{name: "openai"}),
+		withAdapter(&fakeAdapter{name: "anthropic"}),
+		withConfig(SessionConfig{StateDir: t.TempDir(), NoProjectPrompts: true,
+			ResolveProfile: testResolver, testOnly: testConfig{skipGitSnapshot: true}}),
+	)
+	for _, model := range []string{"openai/gpt-5.2", "anthropic/claude-opus-4-6"} {
+		if err := sess.SetModel(model); err != nil {
+			t.Fatal(err)
+		}
+	}
+	data, err := readTranscriptFull(sess.TranscriptPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []schema.ModelSwitchInfo
+	for _, entry := range data.Entries {
+		if entry.Turn.Kind != schema.TurnModelSwitch {
+			continue
+		}
+		if entry.Turn.ModelSwitch == nil {
+			t.Fatal("persisted model switch has no structured identity")
+		}
+		got = append(got, *entry.Turn.ModelSwitch)
+	}
+	want := []schema.ModelSwitchInfo{
+		{OldProvider: "openai", OldModel: "gpt-5.4", NewProvider: "openai", NewModel: "gpt-5.2"},
+		{OldProvider: "openai", OldModel: "gpt-5.2", NewProvider: "anthropic", NewModel: "claude-opus-4-6"},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("persisted transitions = %+v, want %+v", got, want)
+	}
+	if marker := lastMarkerTurn(t, sess); marker.ModelSwitch == nil || *marker.ModelSwitch != want[1] {
+		t.Fatalf("live history transition = %+v, want %+v", marker.ModelSwitch, want[1])
+	}
+}
+
 // TestSetModel_FailedSwitchAppendsNoMarker verifies a rejected switch never
 // appends a marker turn.
 func TestSetModel_FailedSwitchAppendsNoMarker(t *testing.T) {

--- a/docs/tools/transcripts.md
+++ b/docs/tools/transcripts.md
@@ -37,6 +37,26 @@ mutated.
 then one semantic *entry* per turn. Provider requests and responses are never transcript
 records. Immutable once written.
 
+**Model switches.** A successful explicit model switch appends a `MODEL_SWITCH`
+turn. Its `message` is display text; `turn.model_switch` carries the resolved
+configuration identities for readers that need model history:
+
+```json
+{"old_provider":"openai","old_model":"gpt-5.4","new_provider":"anthropic","new_model":"claude-opus-4-6"}
+```
+
+Provider fields identify configured provider instances, and model fields identify
+selected model IDs. These describe the configured transition, not a provider's
+response-reported model or automatic per-request fallback. The turn timestamp is
+when the switch marker was recorded. Rejected switches do not append a marker.
+
+Earlier v2 switch markers have no `model_switch` object; their structured
+transition is unknown, and readers must not recover it by parsing display prose.
+Evener's strict decoder rejects fields its build does not know, so an older
+binary cannot read a transcript containing this field. Upgrade transcript
+readers together with writers; this addition does not change format version 2
+or introduce a migration or permissive decoder.
+
 **Turn number.** The addressing unit across both tools. A 0-based index over *entry*
 lines (the header does not advance it). It is what every tool emits
 and accepts — outline lines, markdown headings, `range`, `expand_turn` — so they compose


### PR DESCRIPTION
Model-switch transcript markers currently contain only display prose, so offline readers cannot recover intermediate model selections reliably. Persist the resolved old/new provider-instance and model IDs in `turn.model_switch` on the existing `MODEL_SWITCH` turn. Keep its display message and recording path unchanged.

The object describes an explicit configuration transition, not response-reported models or automatic request fallbacks. Older v2 markers have no structured identity. Evener's existing strict decoder means older binaries cannot read transcripts containing this new field; readers must be upgraded with writers. No format migration or decoder relaxation is added.

Validation:
- A real Session.SetModel test switches within a provider and across providers, then reads the on-disk transcript and checks both transitions and live history.
- Existing rejected-switch and model-history exclusion tests remain in place.
- Passed `go test ./agent/... ./internal/apptranscript/... ./internal/appprojector/... -short -count=1`.
- Passed `make generate` (no generated diff), `make lint`, and `make vet`.
