### PR TITLE
Limit golangci-lint concurrency to two CPUs

### DIFF
--- a/.golangci-appwire.yml
+++ b/.golangci-appwire.yml
@@ -1,5 +1,8 @@
 version: "2"
 
+run:
+  concurrency: 2
+
 # server/appwire_*.go carries the codex/appwire wire protocol, which forces
 # camelCase JSON tags, inside package `server`, which is snake_case everywhere
 # else (server.go alone holds 119 snake tags). evener-namingcheck expressed that

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 
 run:
+  concurrency: 2
   timeout: 5m
   tests: true
 


### PR DESCRIPTION
Parallel module and worktree lint runs each default to the machine's full CPU count, creating CPU contention during local development. Set `run.concurrency: 2` in both `.golangci.yml` and `.golangci-appwire.yml` to bound each linter process in local and CI runs.

All linter rules, test analysis, module scheduling, and cache isolation remain unchanged. This is a per-process limit; concurrent processes can still exceed two CPUs in aggregate, and individual runs may take longer.

Validation: both configurations pass `golangci-lint config verify` with pinned version 2.13.1, and `git diff --check` passes. Full lint and performance benchmarks were not run.
