### PR TITLE
fix(agent): stop labeling routine context-budget clamps as errors

### DIFF
--- a/.golangci-appwire.yml
+++ b/.golangci-appwire.yml
@@ -1,5 +1,8 @@
 version: "2"
 
+run:
+  concurrency: 2
+
 # server/appwire_*.go carries the codex/appwire wire protocol, which forces
 # camelCase JSON tags, inside package `server`, which is snake_case everywhere
 # else (server.go alone holds 119 snake tags). evener-namingcheck expressed that

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 
 run:
+  concurrency: 2
   timeout: 5m
   tests: true
 

--- a/agent/cov_s2_modelcall_test.go
+++ b/agent/cov_s2_modelcall_test.go
@@ -64,4 +64,16 @@ func TestS2Cov_MaybeWarnContextUsage(t *testing.T) {
 	if !col.contains("Context usage at") {
 		t.Fatalf("no context-usage warning emitted; got %v", col.messages())
 	}
+	// The informational notice must not carry the diagnostic classifier's
+	// generic error title/hint (final_fix_warning_test.go's output-reduction
+	// test covers the same contract for the clamp warning): the Web UI renders
+	// the title on the warning chip, and "Evener error" there reads as a
+	// failure for what is routine context accounting.
+	for _, w := range col.warnings() {
+		if strings.Contains(w.Message, "Context usage at") {
+			if w.Title == "Evener error" || strings.Contains(strings.ToLower(w.Hint), "session log") {
+				t.Fatalf("context-usage warning classified as an error: title=%q hint=%q", w.Title, w.Hint)
+			}
+		}
+	}
 }

--- a/agent/cov_s2_selfcompact_test.go
+++ b/agent/cov_s2_selfcompact_test.go
@@ -111,9 +111,10 @@ func TestS2Cov_MaybeNudgeSelfCompact_NudgesOnceThenLatches(t *testing.T) {
 // channel closes on Close), so a test can wait for all warnings to be recorded
 // before asserting rather than racing the drain goroutine.
 type chanCollector struct {
-	mu   sync.Mutex
-	msgs []string
-	done chan struct{}
+	mu       sync.Mutex
+	msgs     []string
+	warnData []events.WarningData
+	done     chan struct{}
 }
 
 // newChanCollector returns a collector whose done channel is ready, so a test
@@ -129,6 +130,7 @@ func (c *chanCollector) drain(sess *Session) {
 			if w, ok := ev.Data.(events.WarningData); ok {
 				c.mu.Lock()
 				c.msgs = append(c.msgs, w.Message)
+				c.warnData = append(c.warnData, w)
 				c.mu.Unlock()
 			}
 		}
@@ -151,4 +153,12 @@ func (c *chanCollector) messages() []string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]string(nil), c.msgs...)
+}
+
+// warnings returns the full WarningData payloads seen so far, for assertions
+// that need a warning's title or hint rather than its message text.
+func (c *chanCollector) warnings() []events.WarningData {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]events.WarningData(nil), c.warnData...)
 }

--- a/agent/final_fix_warning_test.go
+++ b/agent/final_fix_warning_test.go
@@ -92,6 +92,13 @@ func TestSessionTokenBudgetOutputReductionEmitsOneWarning(t *testing.T) {
 			t.Fatalf("warning message %q missing %q", message, want)
 		}
 	}
+	// A routine output clamp is budget arithmetic, not a failure: the title and
+	// hint must not classify it as an error the way an unexpected failure would
+	// (diagnostic.FromError's evenerFailure), or the Web UI renders it as an
+	// "Evener error" chip telling the reader to check the session log.
+	if warnings[0].Title == "Evener error" || strings.Contains(strings.ToLower(warnings[0].Hint), "session log") {
+		t.Fatalf("output-reduction warning classified as an error: title=%q hint=%q", warnings[0].Title, warnings[0].Hint)
+	}
 }
 
 func TestSessionContinuationOutputReductionsEmitOneFinalWarning(t *testing.T) {

--- a/agent/session_model_call.go
+++ b/agent/session_model_call.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"primeradiant.com/evener/agent/diagnostic"
 	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/sandbox"
@@ -96,7 +97,14 @@ func (s *Session) maybeWarnContextUsage(profile *provider.Profile, req llm.Reque
 
 	msg := fmt.Sprintf("Context usage at ~%d%% of context window", pct)
 	s.emit(events.EventWarning, events.WarningData{
-		Message:           msg,
+		Message: msg,
+		// Same reasoning as warnOutputReduction: an informational context
+		// notice, with an explicit neutral title so the classifier's keyword
+		// fallback cannot stamp its generic "Evener error" title and
+		// session-log hint onto it.
+		Source:            string(diagnostic.SourceEvener),
+		Title:             "Context budget",
+		Hint:              "The conversation is nearing the model's context window; compaction will manage it. No action needed.",
 		ApproxTokens:      approxTokens,
 		ContextWindowSize: cw,
 		Percent:           pct,
@@ -1277,10 +1285,22 @@ func (s *Session) warnOutputReduction(profile *provider.Profile, budget llm.Toke
 	if s == nil || profile == nil || !budget.LimitedOutput {
 		return
 	}
-	s.emit(events.EventWarning, warningDataFromError(fmt.Sprintf(
-		"Output allocation reduced for %s/%s: requested=%d admitted=%d",
-		profile.ID(), profile.Model(), budget.RequestedOutput, budget.AdmittedOutput,
-	), nil))
+	// An explicit neutral title and hint, both because this is budget
+	// arithmetic succeeding (not a failure) and because leaving them blank
+	// lets the diagnostic classifier's keyword fallback stamp its generic
+	// "Evener error" title and session-log hint onto the warning — which the
+	// Web UI renders as an error chip for a routine clamp. FromFields
+	// preserves a supplied title/hint verbatim, so this survives every
+	// re-derivation downstream (sendEvent enrichment, projector projection).
+	s.emit(events.EventWarning, events.WarningData{
+		Message: fmt.Sprintf(
+			"Output allocation reduced for %s/%s: requested=%d admitted=%d",
+			profile.ID(), profile.Model(), budget.RequestedOutput, budget.AdmittedOutput,
+		),
+		Source: string(diagnostic.SourceEvener),
+		Title:  "Context budget",
+		Hint:   "The model's output allocation was reduced to fit its context window. No action needed.",
+	})
 }
 
 func isLocalContextBudgetError(err error) bool {

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -2,6 +2,7 @@ package appprojector
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -44,6 +45,36 @@ func TestAppEventProjectorCarriesUserInputTranscriptEntryIndex(t *testing.T) {
 	item := notificationThreadItem(t, out, appwire.NotifyItemCompleted)
 	if item.TranscriptEntryIndex != 3 {
 		t.Fatalf("transcript entry index=%d, want 3", item.TranscriptEntryIndex)
+	}
+}
+
+func TestProject_InformationalWarningKeepsNeutralTitle(t *testing.T) {
+	p := NewAppEventProjector("th_1", "local:th_1")
+	// The agent's informational context-budget warnings (an output clamp, a
+	// context-usage notice) carry an explicit neutral title and hint so the
+	// classifier's keyword fallback cannot stamp its generic "Evener error"
+	// title and session-log hint onto them — the Web UI renders the title on
+	// the warning chip, and that title read as a failure for routine budget
+	// arithmetic. This is the wire-side half of that contract: whatever title
+	// the emitter supplied must survive projection verbatim.
+	out := p.Project(events.SessionEvent{Kind: events.EventWarning, SessionID: "th_1", Data: events.WarningData{
+		Message: "Output allocation reduced for inst/model: requested=100 admitted=50",
+		Source:  "evener",
+		Title:   "Context budget",
+		Hint:    "The model's output allocation was reduced to fit its context window. No action needed.",
+	}})
+	if len(out) != 1 || out[0].Method != appwire.NotifyWarning {
+		t.Fatalf("notifications=%+v", out)
+	}
+	params, ok := out[0].Params.(map[string]any)
+	if !ok {
+		t.Fatalf("params=%T", out[0].Params)
+	}
+	if params["title"] != "Context budget" {
+		t.Fatalf("title=%v, want the emitter-supplied neutral title", params["title"])
+	}
+	if strings.Contains(fmt.Sprint(params["hint"]), "session log") {
+		t.Fatalf("hint=%v, want the emitter-supplied hint, not the generic session-log guidance", params["hint"])
 	}
 }
 


### PR DESCRIPTION
## Problem

When a model's output allocation plus its total possible input exceeds the provider's context window, the Web UI showed an **error** — but this is not an error. Admission correctly clamps the output to fit (budget arithmetic succeeding), and the request proceeds normally.

## Root cause

`warnOutputReduction` emitted its informational "Output allocation reduced …" message through `warningDataFromError(msg, nil)`. With no recognizable error and no keywords in the message, the diagnostic classifier's keyword fallback (`diagnostic.FromError` / `FromFields`) stamped its generic **"Evener error"** title and "Check the Evener session log and daemon state." hint onto the warning. The Web UI's `WarningItem` renders that title on the warning chip, so a routine clamp displayed as an error chip instructing the reader to check the session log.

The same mislabeling applied to the 80% context-usage notice (`maybeWarnContextUsage`).

## Fix

Both informational context notices now carry an explicit neutral title and hint on their `WarningData`:

- Title: **"Context budget"**
- Hint: "The model's output allocation was reduced to fit its context window. No action needed." (clamp) / "The conversation is nearing the model's context window; compaction will manage it. No action needed." (usage)

`diagnostic.FromFields` preserves a supplied title/hint verbatim, so the neutral labeling survives every re-derivation downstream (sendEvent enrichment, projector projection onto the wire). Genuine failures — turn errors, provider errors, unrecoverable admission failures — keep their existing error classification and display.

## Tests

- `agent/final_fix_warning_test.go` — the output-reduction warning's title/hint must not be the error classification (failed before the fix, passes after).
- `agent/cov_s2_modelcall_test.go` — the same contract for the context-usage warning (adds a `warnings()` accessor to the test collector).
- `internal/appprojector/appwire_projection_test.go` — the wire notification carries the emitter-supplied neutral title verbatim.

## Verification

- `make lint` — PASS
- `make build` — PASS (incl. frontend production build)
- `ROOT_FULL=1 make test` — PASS (all modules + web suite)
- End-to-end repro: caps with input + output > window now emit `title="Context budget"`, no `EventError`.
