### PR TITLE
Reclaim retained session scratch at process start

### DIFF
--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -585,11 +585,21 @@ func (e *LocalExecutionEnvironment) unsandboxedScratchDir() string {
 // first .git entry — so the probe returned "" there anyway and the anchor fell
 // back to RootDir, exactly as it does now.
 func (e *LocalExecutionEnvironment) newSessionScratch() (*sandbox.SessionScratch, error) {
-	workspaceRoot := e.RootDir
-	if root, ok := structuralWorktreeRoot(e.RootDir); ok {
-		workspaceRoot = root
+	return sandbox.NewSessionScratch(e.sandboxTmpBase, SessionScratchWorkspaceRoot(e.RootDir))
+}
+
+// SessionScratchWorkspaceRoot reports the workspace a session started in dir
+// anchors its scratch to: the structural worktree root when dir sits in one, and
+// dir itself when it does not. Everything that decides whether a scratch base
+// lies inside the workspace has to ask this one function — the allocator above
+// and the startup reclaim in cmd/evener both do — or the two disagree about
+// which tree a directory belongs to and the reclaim sweeps a base allocation
+// refuses to use.
+func SessionScratchWorkspaceRoot(dir string) string {
+	if root, ok := structuralWorktreeRoot(dir); ok {
+		return root
 	}
-	return sandbox.NewSessionScratch(e.sandboxTmpBase, workspaceRoot)
+	return dir
 }
 
 // retainUnsandboxedScratch releases this env's unsandboxed per-session

--- a/agent/sandbox/session_scratch.go
+++ b/agent/sandbox/session_scratch.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 )
@@ -96,6 +97,20 @@ func canonicalScratchRoot(root string) (string, error) {
 }
 
 func sessionScratchBase(requested, workspaceRoot string) (string, error) {
+	bases := sessionScratchBases(requested, workspaceRoot)
+	if len(bases) == 0 {
+		return "", noSessionScratchBaseError(workspaceRoot)
+	}
+	return bases[0], nil
+}
+
+// sessionScratchBases lists, in allocation-preference order, every base a
+// session on this workspace may end up in: the requested base (or the temp dir)
+// and the user cache dir, each canonical, keeping only the ones that exist as a
+// directory outside the workspace. Allocation takes the first; a reclaim has to
+// visit them all, because a workspace that contains the temp dir sends its
+// sessions to the cache dir instead.
+func sessionScratchBases(requested, workspaceRoot string) []string {
 	first := requested
 	if strings.TrimSpace(first) == "" {
 		first = sessionScratchTempDir()
@@ -104,6 +119,7 @@ func sessionScratchBase(requested, workspaceRoot string) (string, error) {
 	if cache, err := sessionScratchUserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
 		candidates = append(candidates, cache)
 	}
+	var bases []string
 	for _, candidate := range candidates {
 		absolute, err := filepath.Abs(candidate)
 		if err != nil || pathWithin(absolute, workspaceRoot) {
@@ -117,9 +133,15 @@ func sessionScratchBase(requested, workspaceRoot string) (string, error) {
 		if err != nil || pathWithin(canonical, workspaceRoot) {
 			continue
 		}
-		return canonical, nil
+		if !slices.Contains(bases, canonical) {
+			bases = append(bases, canonical)
+		}
 	}
-	return "", fmt.Errorf("sandbox: no session scratch base outside workspace %q", workspaceRoot)
+	return bases
+}
+
+func noSessionScratchBaseError(workspaceRoot string) error {
+	return fmt.Errorf("sandbox: no session scratch base outside workspace %q", workspaceRoot)
 }
 
 func pathWithin(path, root string) bool {
@@ -152,18 +174,32 @@ func (s *SessionScratch) Cleanup() error {
 }
 
 // SweepCrashedSessionScratch reclaims the session scratch directories left in
-// the base a new session would allocate from. A session releases its lease and
-// keeps its directory at close and on handoff, so nothing else ever removes
-// those: this is what makes retention safe rather than a permanent leak. It
+// every base a session on workspaceRoot may allocate from. A session releases
+// its lease and keeps its directory at close and on handoff, so nothing else
+// ever removes those: this is what makes retention safe rather than a permanent
+// leak. It sweeps all the allocation bases rather than the one this workspace
+// would pick, because a workspace containing the temp dir allocates from the
+// cache dir instead, and it skips a base inside workspaceRoot for the same
+// reason allocation refuses one: nothing Evener owns is ever written there. It
 // reports only the failures an operator can act on — an unreadable base, a
 // directory it owned but could not remove — so it is best called once at
 // process start, off the startup path.
-func SweepCrashedSessionScratch() error {
-	base, err := sessionScratchBase("", "")
+func SweepCrashedSessionScratch(workspaceRoot string) error {
+	canonicalWorkspace, err := canonicalScratchRoot(workspaceRoot)
 	if err != nil {
 		return err
 	}
-	return sweepCrashedSessionScratch(base)
+	bases := sessionScratchBases("", canonicalWorkspace)
+	if len(bases) == 0 {
+		return noSessionScratchBaseError(workspaceRoot)
+	}
+	var failures []error
+	for _, base := range bases {
+		if err := sweepCrashedSessionScratch(base); err != nil {
+			failures = append(failures, err)
+		}
+	}
+	return errors.Join(failures...)
 }
 
 // sweepCrashedSessionScratch removes old Evener-owned children only when their

--- a/agent/sandbox/session_scratch.go
+++ b/agent/sandbox/session_scratch.go
@@ -96,48 +96,70 @@ func canonicalScratchRoot(root string) (string, error) {
 	return canonical, nil
 }
 
+// sessionScratchBase returns the base a new session allocates in, and stops at
+// the first one that serves: a session start must not wait on the cache
+// filesystem, which may be slow or unavailable, once the temp dir has answered.
 func sessionScratchBase(requested, workspaceRoot string) (string, error) {
-	bases := sessionScratchBases(requested, workspaceRoot)
-	if len(bases) == 0 {
-		return "", noSessionScratchBaseError(workspaceRoot)
+	if base, ok := validSessionScratchBase(preferredSessionScratchCandidate(requested), workspaceRoot); ok {
+		return base, nil
 	}
-	return bases[0], nil
+	if cache, err := sessionScratchUserCacheDir(); err == nil {
+		if base, ok := validSessionScratchBase(cache, workspaceRoot); ok {
+			return base, nil
+		}
+	}
+	return "", noSessionScratchBaseError(workspaceRoot)
 }
 
 // sessionScratchBases lists, in allocation-preference order, every base a
 // session on this workspace may end up in: the requested base (or the temp dir)
-// and the user cache dir, each canonical, keeping only the ones that exist as a
-// directory outside the workspace. Allocation takes the first; a reclaim has to
-// visit them all, because a workspace that contains the temp dir sends its
-// sessions to the cache dir instead.
+// and the user cache dir, each canonical and listed once. Allocation stops at
+// the first; a reclaim has to visit them all, because a workspace that contains
+// the temp dir sends its own sessions to the cache dir instead.
 func sessionScratchBases(requested, workspaceRoot string) []string {
-	first := requested
-	if strings.TrimSpace(first) == "" {
-		first = sessionScratchTempDir()
-	}
-	candidates := []string{first}
-	if cache, err := sessionScratchUserCacheDir(); err == nil && strings.TrimSpace(cache) != "" {
+	candidates := []string{preferredSessionScratchCandidate(requested)}
+	if cache, err := sessionScratchUserCacheDir(); err == nil {
 		candidates = append(candidates, cache)
 	}
 	var bases []string
 	for _, candidate := range candidates {
-		absolute, err := filepath.Abs(candidate)
-		if err != nil || pathWithin(absolute, workspaceRoot) {
-			continue
-		}
-		info, err := os.Stat(absolute)
-		if err != nil || !info.IsDir() {
-			continue
-		}
-		canonical, err := filepath.EvalSymlinks(absolute)
-		if err != nil || pathWithin(canonical, workspaceRoot) {
-			continue
-		}
-		if !slices.Contains(bases, canonical) {
-			bases = append(bases, canonical)
+		base, ok := validSessionScratchBase(candidate, workspaceRoot)
+		if ok && !slices.Contains(bases, base) {
+			bases = append(bases, base)
 		}
 	}
 	return bases
+}
+
+// preferredSessionScratchCandidate is the base a caller asked for, or the temp
+// dir when it asked for none.
+func preferredSessionScratchCandidate(requested string) string {
+	if strings.TrimSpace(requested) == "" {
+		return sessionScratchTempDir()
+	}
+	return requested
+}
+
+// validSessionScratchBase reports the canonical form of candidate when Evener
+// may keep session scratch there: an existing directory, outside the workspace
+// both as named and as resolved.
+func validSessionScratchBase(candidate, workspaceRoot string) (string, bool) {
+	if strings.TrimSpace(candidate) == "" {
+		return "", false
+	}
+	absolute, err := filepath.Abs(candidate)
+	if err != nil || pathWithin(absolute, workspaceRoot) {
+		return "", false
+	}
+	info, err := os.Stat(absolute)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	canonical, err := filepath.EvalSymlinks(absolute)
+	if err != nil || pathWithin(canonical, workspaceRoot) {
+		return "", false
+	}
+	return canonical, true
 }
 
 func noSessionScratchBaseError(workspaceRoot string) error {

--- a/agent/sandbox/session_scratch.go
+++ b/agent/sandbox/session_scratch.go
@@ -151,14 +151,31 @@ func (s *SessionScratch) Cleanup() error {
 	return errors.Join(releaseErr, os.RemoveAll(dir))
 }
 
+// SweepCrashedSessionScratch reclaims the session scratch directories left in
+// the base a new session would allocate from. A session releases its lease and
+// keeps its directory at close and on handoff, so nothing else ever removes
+// those: this is what makes retention safe rather than a permanent leak. It
+// reports only the failures an operator can act on — an unreadable base, a
+// directory it owned but could not remove — so it is best called once at
+// process start, off the startup path.
+func SweepCrashedSessionScratch() error {
+	base, err := sessionScratchBase("", "")
+	if err != nil {
+		return err
+	}
+	return sweepCrashedSessionScratch(base)
+}
+
 // sweepCrashedSessionScratch removes old Evener-owned children only when their
-// lease is currently acquirable. Errors leave the candidate untouched.
-func sweepCrashedSessionScratch(base string) {
+// lease is currently acquirable. A candidate whose lease is held, or whose age
+// cannot be read, is left untouched and is not an error: it is someone else's.
+func sweepCrashedSessionScratch(base string) error {
 	entries, err := sessionScratchReadDir(base)
 	if err != nil {
-		return
+		return fmt.Errorf("sandbox: read session scratch base %q: %w", base, err)
 	}
 	cutoff := time.Now().Add(-crashedSessionScratchMaxAge)
+	var failures []error
 	for _, entry := range entries {
 		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), sessionScratchPrefix) {
 			continue
@@ -175,6 +192,9 @@ func sweepCrashedSessionScratch(base string) {
 		if err := lease.Release(); err != nil {
 			continue
 		}
-		_ = os.RemoveAll(dir)
+		if err := os.RemoveAll(dir); err != nil {
+			failures = append(failures, fmt.Errorf("sandbox: remove crashed session scratch %q: %w", dir, err))
+		}
 	}
+	return errors.Join(failures...)
 }

--- a/agent/sandbox/session_scratch_test.go
+++ b/agent/sandbox/session_scratch_test.go
@@ -1,6 +1,7 @@
 package sandbox
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -249,4 +250,22 @@ func fileMode(t *testing.T, path string) os.FileMode {
 		t.Fatal(err)
 	}
 	return info.Mode().Perm()
+}
+
+func TestSweepCrashedSessionScratchReportsUnusableBase(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing-base")
+	if err := sweepCrashedSessionScratch(missing); err == nil {
+		t.Error("sweep of an unreadable base reported success")
+	}
+
+	oldTemp, oldCache := sessionScratchTempDir, sessionScratchUserCacheDir
+	sessionScratchTempDir = func() string { return missing }
+	sessionScratchUserCacheDir = func() (string, error) { return "", errors.New("no cache dir") }
+	t.Cleanup(func() {
+		sessionScratchTempDir = oldTemp
+		sessionScratchUserCacheDir = oldCache
+	})
+	if err := SweepCrashedSessionScratch(); err == nil {
+		t.Error("sweep with no usable scratch base reported success")
+	}
 }

--- a/agent/sandbox/session_scratch_test.go
+++ b/agent/sandbox/session_scratch_test.go
@@ -269,3 +269,22 @@ func TestSweepCrashedSessionScratchReportsUnusableBase(t *testing.T) {
 		t.Error("sweep with no usable scratch base reported success")
 	}
 }
+
+func TestSessionScratchAllocationLeavesCacheBaseAloneWhenTempBaseWorks(t *testing.T) {
+	consulted := false
+	oldCache := sessionScratchUserCacheDir
+	sessionScratchUserCacheDir = func() (string, error) {
+		consulted = true
+		return "", errors.New("cache base is unavailable")
+	}
+	t.Cleanup(func() { sessionScratchUserCacheDir = oldCache })
+
+	scratch, err := NewSessionScratch(t.TempDir(), t.TempDir())
+	if err != nil {
+		t.Fatalf("NewSessionScratch: %v", err)
+	}
+	t.Cleanup(func() { _ = scratch.Cleanup() })
+	if consulted {
+		t.Error("allocation reached for the user cache base while the temp base was usable")
+	}
+}

--- a/agent/sandbox/session_scratch_test.go
+++ b/agent/sandbox/session_scratch_test.go
@@ -265,7 +265,7 @@ func TestSweepCrashedSessionScratchReportsUnusableBase(t *testing.T) {
 		sessionScratchTempDir = oldTemp
 		sessionScratchUserCacheDir = oldCache
 	})
-	if err := SweepCrashedSessionScratch(); err == nil {
+	if err := SweepCrashedSessionScratch(t.TempDir()); err == nil {
 		t.Error("sweep with no usable scratch base reported success")
 	}
 }

--- a/cmd/evener/main.go
+++ b/cmd/evener/main.go
@@ -380,19 +380,19 @@ func (c subcommandExitError) Error() string { return fmt.Sprintf("exit code %d",
 // runWithScratchReclaim and runServeWithScratchReclaim are the production entry
 // points to `evener` and `evener serve`. Reclaiming the session scratch that
 // sessions retained and never came back for belongs to a real process start, so
-// it hangs off the entry points rather than run and runServe themselves, where a
-// test driving either would sweep the developer's own scratch bases. serve
-// parses its --work-dir inside runServe, so its reclaim reads the process
-// working directory; that root only decides whether a scratch base inside the
-// workspace is off limits.
+// it hangs off these adapters rather than run and runServe themselves, where a
+// test driving either would sweep the developer's own scratch bases. serve takes
+// it as a dependency rather than up front because the workspace to leave alone
+// is the one serve resolves from its own --dir.
 func runWithScratchReclaim(ctx context.Context, cfg runConfig) error {
 	startScratchReclaim(cfg.workDir)
 	return run(ctx, cfg)
 }
 
 func runServeWithScratchReclaim(args []string) error {
-	startScratchReclaim("")
-	return runServe(args)
+	deps := defaultServeDeps()
+	deps.reclaimScratch = startScratchReclaim
+	return runServeWithDeps(args, deps)
 }
 
 func dispatchCLICommand(args []string, stdin io.Reader, stdout, stderr io.Writer) (bool, string, error) {

--- a/cmd/evener/main.go
+++ b/cmd/evener/main.go
@@ -101,7 +101,7 @@ func defaultMainDepsWithStdin(stdin *os.File) mainDeps {
 		},
 		exit: os.Exit, dispatch: dispatchCLICommand,
 		startCPU: cmdutil.StartCPUProfile, startTrace: cmdutil.StartTrace,
-		notify: signal.NotifyContext, run: run,
+		notify: signal.NotifyContext, run: runWithScratchReclaim,
 	}
 }
 
@@ -377,9 +377,27 @@ type subcommandExitError int
 
 func (c subcommandExitError) Error() string { return fmt.Sprintf("exit code %d", int(c)) }
 
+// runWithScratchReclaim and runServeWithScratchReclaim are the production entry
+// points to `evener` and `evener serve`. Reclaiming the session scratch that
+// sessions retained and never came back for belongs to a real process start, so
+// it hangs off the entry points rather than run and runServe themselves, where a
+// test driving either would sweep the developer's own scratch bases. serve
+// parses its --work-dir inside runServe, so its reclaim reads the process
+// working directory; that root only decides whether a scratch base inside the
+// workspace is off limits.
+func runWithScratchReclaim(ctx context.Context, cfg runConfig) error {
+	startScratchReclaim(cfg.workDir)
+	return run(ctx, cfg)
+}
+
+func runServeWithScratchReclaim(args []string) error {
+	startScratchReclaim("")
+	return runServe(args)
+}
+
 func dispatchCLICommand(args []string, stdin io.Reader, stdout, stderr io.Writer) (bool, string, error) {
 	return dispatchCLICommandWith(args, stdin, stdout, stderr, cliCommandRunners{
-		serve: runServe,
+		serve: runServeWithScratchReclaim,
 		launchCheck: func(args []string, _ io.Reader, stdout, stderr io.Writer) error {
 			return launchcheck.RunLaunchCheck(args, stdout, stderr)
 		},

--- a/cmd/evener/main_test.go
+++ b/cmd/evener/main_test.go
@@ -796,9 +796,10 @@ func TestMakeRedirectURLReader_EmptyLine(t *testing.T) {
 
 func TestDispatchCLICommand_ServeError(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	// runServe rather than the production runServeWithScratchReclaim: reclaiming
-	// scratch belongs to a real start, and a test that dispatches serve must not
-	// sweep the developer's own scratch bases.
+	// runServe rather than the production runServeWithScratchReclaim, which is
+	// the same path plus the scratch reclaim: reclaiming belongs to a real daemon
+	// start, and a test that dispatches serve must not sweep the developer's own
+	// scratch bases.
 	handled, label, err := dispatchCLICommandWith([]string{"serve"}, strings.NewReader(""), &stdout, &stderr,
 		cliCommandRunners{serve: runServe})
 	if err == nil {

--- a/cmd/evener/main_test.go
+++ b/cmd/evener/main_test.go
@@ -796,7 +796,11 @@ func TestMakeRedirectURLReader_EmptyLine(t *testing.T) {
 
 func TestDispatchCLICommand_ServeError(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	handled, label, err := dispatchCLICommand([]string{"serve"}, strings.NewReader(""), &stdout, &stderr)
+	// runServe rather than the production runServeWithScratchReclaim: reclaiming
+	// scratch belongs to a real start, and a test that dispatches serve must not
+	// sweep the developer's own scratch bases.
+	handled, label, err := dispatchCLICommandWith([]string{"serve"}, strings.NewReader(""), &stdout, &stderr,
+		cliCommandRunners{serve: runServe})
 	if err == nil {
 		t.Fatal("dispatchCLICommand(serve) error = nil, want error")
 	}

--- a/cmd/evener/run.go
+++ b/cmd/evener/run.go
@@ -127,7 +127,6 @@ func run(ctx context.Context, cfg runConfig) error {
 	if err := runEnsureUserConfigDirs(); err != nil {
 		return err
 	}
-	go reclaimCrashedSessionScratch(os.Stderr)
 	resolvedPlugins, err := runResolvePlugins(ctx, cfg.pluginDirs, cfg.enabledPlugins)
 	if fatal := fatalLaunchPluginError(err, cfg.enabledPlugins); fatal != nil {
 		return fatal

--- a/cmd/evener/run.go
+++ b/cmd/evener/run.go
@@ -127,6 +127,7 @@ func run(ctx context.Context, cfg runConfig) error {
 	if err := runEnsureUserConfigDirs(); err != nil {
 		return err
 	}
+	go reclaimCrashedSessionScratch(os.Stderr)
 	resolvedPlugins, err := runResolvePlugins(ctx, cfg.pluginDirs, cfg.enabledPlugins)
 	if fatal := fatalLaunchPluginError(err, cfg.enabledPlugins); fatal != nil {
 		return fatal

--- a/cmd/evener/sandbox.go
+++ b/cmd/evener/sandbox.go
@@ -15,34 +15,36 @@ var probeSandboxHost = func() sandbox.HostFacts {
 	return sandbox.RealProber{}.Probe()
 }
 
-// startScratchReclaim runs the reclaim for workspaceRoot on its own goroutine,
-// falling back to the process working directory when the command did not name
-// one. A working directory that cannot be read skips the reclaim rather than
-// sweeping with no workspace to exclude: the command is about to fail on the
-// same lookup.
-func startScratchReclaim(workspaceRoot string) {
-	if strings.TrimSpace(workspaceRoot) == "" {
+// startScratchReclaim runs the reclaim for a command working in workingDir on
+// its own goroutine, falling back to the process working directory when the
+// command did not name one. A working directory that cannot be read skips the
+// reclaim rather than sweeping with no workspace to exclude: the command is
+// about to fail on the same lookup.
+func startScratchReclaim(workingDir string) {
+	if strings.TrimSpace(workingDir) == "" {
 		wd, err := os.Getwd()
 		if err != nil {
 			return
 		}
-		workspaceRoot = wd
+		workingDir = wd
 	}
-	go reclaimCrashedSessionScratch(workspaceRoot, os.Stderr)
+	go reclaimCrashedSessionScratch(workingDir, os.Stderr)
 }
 
 // reclaimCrashedSessionScratch removes the session scratch directories that
 // sessions retained (lease released, directory kept) and never came back for.
-// workspaceRoot is this process's working directory, which decides the same
-// thing it decides for allocation: a scratch base inside it is not Evener's.
-// The reclaim reads every scratch base and probes a lease per candidate, so
-// startup runs it on its own goroutine and never waits on it; that outliving
-// goroutine is why the callers hand it os.Stderr rather than a writer the
-// caller owns. What it could not remove it names and leaves for the next start:
-// two processes starting together can race on one directory, and the loser's
-// failure is reclaimed the next time either of them starts.
-func reclaimCrashedSessionScratch(workspaceRoot string, warnings io.Writer) {
-	if err := sandbox.SweepCrashedSessionScratch(workspaceRoot); err != nil {
+// workingDir is the directory the command runs in, which the reclaim anchors to
+// the same workspace root a session would (execenv.SessionScratchWorkspaceRoot),
+// so a scratch base inside the workspace is off limits to the reclaim for
+// exactly the reason it is off limits to allocation: nothing Evener owns is ever
+// written there. The reclaim reads every scratch base and probes a lease per
+// candidate, so startup runs it on its own goroutine and never waits on it; that
+// outliving goroutine is why the callers hand it os.Stderr rather than a writer
+// the caller owns. What it could not remove it names and leaves for the next
+// start: two processes starting together can race on one directory, and the
+// loser's failure is reclaimed the next time either of them starts.
+func reclaimCrashedSessionScratch(workingDir string, warnings io.Writer) {
+	if err := sandbox.SweepCrashedSessionScratch(execenv.SessionScratchWorkspaceRoot(workingDir)); err != nil {
 		fmt.Fprintf(warnings, "warning: reclaiming crashed session scratch: %v; retrying at the next start\n", err) //nolint:errcheck
 	}
 }

--- a/cmd/evener/sandbox.go
+++ b/cmd/evener/sandbox.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"primeradiant.com/evener/agent"
@@ -14,14 +15,35 @@ var probeSandboxHost = func() sandbox.HostFacts {
 	return sandbox.RealProber{}.Probe()
 }
 
+// startScratchReclaim runs the reclaim for workspaceRoot on its own goroutine,
+// falling back to the process working directory when the command did not name
+// one. A working directory that cannot be read skips the reclaim rather than
+// sweeping with no workspace to exclude: the command is about to fail on the
+// same lookup.
+func startScratchReclaim(workspaceRoot string) {
+	if strings.TrimSpace(workspaceRoot) == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return
+		}
+		workspaceRoot = wd
+	}
+	go reclaimCrashedSessionScratch(workspaceRoot, os.Stderr)
+}
+
 // reclaimCrashedSessionScratch removes the session scratch directories that
 // sessions retained (lease released, directory kept) and never came back for.
-// It reads the whole scratch base and probes a lease per candidate, so startup
-// runs it on its own goroutine and never waits on it; that outliving goroutine
-// is why the callers hand it os.Stderr rather than a writer the caller owns.
-func reclaimCrashedSessionScratch(warnings io.Writer) {
-	if err := sandbox.SweepCrashedSessionScratch(); err != nil {
-		fmt.Fprintf(warnings, "warning: reclaiming crashed session scratch: %v\n", err) //nolint:errcheck
+// workspaceRoot is this process's working directory, which decides the same
+// thing it decides for allocation: a scratch base inside it is not Evener's.
+// The reclaim reads every scratch base and probes a lease per candidate, so
+// startup runs it on its own goroutine and never waits on it; that outliving
+// goroutine is why the callers hand it os.Stderr rather than a writer the
+// caller owns. What it could not remove it names and leaves for the next start:
+// two processes starting together can race on one directory, and the loser's
+// failure is reclaimed the next time either of them starts.
+func reclaimCrashedSessionScratch(workspaceRoot string, warnings io.Writer) {
+	if err := sandbox.SweepCrashedSessionScratch(workspaceRoot); err != nil {
+		fmt.Fprintf(warnings, "warning: reclaiming crashed session scratch: %v; retrying at the next start\n", err) //nolint:errcheck
 	}
 }
 

--- a/cmd/evener/sandbox.go
+++ b/cmd/evener/sandbox.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"primeradiant.com/evener/agent"
@@ -11,6 +12,17 @@ import (
 
 var probeSandboxHost = func() sandbox.HostFacts {
 	return sandbox.RealProber{}.Probe()
+}
+
+// reclaimCrashedSessionScratch removes the session scratch directories that
+// sessions retained (lease released, directory kept) and never came back for.
+// It reads the whole scratch base and probes a lease per candidate, so startup
+// runs it on its own goroutine and never waits on it; that outliving goroutine
+// is why the callers hand it os.Stderr rather than a writer the caller owns.
+func reclaimCrashedSessionScratch(warnings io.Writer) {
+	if err := sandbox.SweepCrashedSessionScratch(); err != nil {
+		fmt.Fprintf(warnings, "warning: reclaiming crashed session scratch: %v\n", err) //nolint:errcheck
+	}
 }
 
 // configureSandbox parses the --sandbox / --sandbox-net flag values into the

--- a/cmd/evener/scratch_reclaim_unix_test.go
+++ b/cmd/evener/scratch_reclaim_unix_test.go
@@ -88,7 +88,8 @@ func TestReclaimCrashedSessionScratchSkipsWorkspaceContainedTempBase(t *testing.
 // TestReclaimCrashedSessionScratchSweepsEveryAllocationBase covers the scratch
 // this host allocated for OTHER workspaces: a workspace containing the temp dir
 // allocates from the user cache dir, so a startup whose own temp dir is usable
-// still has to reclaim there.
+// still has to reclaim there — and a live owner in that base keeps its scratch
+// just as it does in the temp base.
 func TestReclaimCrashedSessionScratchSweepsEveryAllocationBase(t *testing.T) {
 	workspace := t.TempDir()
 	temp := t.TempDir()
@@ -97,7 +98,12 @@ func TestReclaimCrashedSessionScratchSweepsEveryAllocationBase(t *testing.T) {
 
 	fromTemp := newRetainedSessionScratch(t, temp, workspace)
 	fromCache := newRetainedSessionScratch(t, cache, workspace)
-	age(t, fromTemp, fromCache)
+	liveInCache, err := sandbox.NewSessionScratch(cache, workspace)
+	if err != nil {
+		t.Fatalf("NewSessionScratch: %v", err)
+	}
+	t.Cleanup(func() { _ = liveInCache.Cleanup() })
+	age(t, fromTemp, fromCache, liveInCache.Dir)
 
 	var warnings bytes.Buffer
 	reclaimCrashedSessionScratch(workspace, &warnings)
@@ -106,6 +112,9 @@ func TestReclaimCrashedSessionScratchSweepsEveryAllocationBase(t *testing.T) {
 		if _, err := os.Stat(dir); !os.IsNotExist(err) {
 			t.Errorf("abandoned scratch %q survived startup reclaim: %v", dir, err)
 		}
+	}
+	if _, err := os.Stat(liveInCache.Dir); err != nil {
+		t.Errorf("startup reclaim removed the leased scratch %q from the cache base: %v", liveInCache.Dir, err)
 	}
 	if warnings.Len() != 0 {
 		t.Errorf("startup reclaim reported a failure: %s", warnings.String())

--- a/cmd/evener/scratch_reclaim_unix_test.go
+++ b/cmd/evener/scratch_reclaim_unix_test.go
@@ -4,6 +4,9 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +14,7 @@ import (
 	"time"
 
 	"primeradiant.com/evener/agent/sandbox"
+	"primeradiant.com/evener/llm"
 )
 
 // TestReclaimCrashedSessionScratchRemovesOnlyAbandonedScratch drives the startup
@@ -168,4 +172,91 @@ func newRetainedSessionScratch(t *testing.T, base, workspace string) string {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(scratch.Dir) })
 	return scratch.Dir
+}
+
+// TestReclaimCrashedSessionScratchAnchorsAtTheWorktreeRoot pins the reclaim to
+// the workspace allocation anchors to. A command run from a subdirectory of a
+// git worktree allocates against the worktree root, so a scratch base anywhere
+// under that root — not merely under the directory the command started in — is
+// one Evener never allocates into.
+func TestReclaimCrashedSessionScratchAnchorsAtTheWorktreeRoot(t *testing.T) {
+	workspace := newGitWorkspace(t)
+	workspaceTemp := filepath.Join(workspace, "tmp")
+	sub := filepath.Join(workspace, "sub")
+	for _, dir := range []string{workspaceTemp, sub} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("create %q: %v", dir, err)
+		}
+	}
+	cache := redirectUserCacheDir(t)
+	t.Setenv("TMPDIR", workspaceTemp)
+
+	insideWorkspace := newRetainedSessionScratch(t, workspaceTemp, "")
+	abandoned := newRetainedSessionScratch(t, cache, workspace)
+	age(t, insideWorkspace, abandoned)
+
+	var warnings bytes.Buffer
+	reclaimCrashedSessionScratch(sub, &warnings)
+
+	if _, err := os.Stat(insideWorkspace); err != nil {
+		t.Errorf("reclaim from %q removed %q, a base inside the worktree: %v", sub, insideWorkspace, err)
+	}
+	if _, err := os.Stat(abandoned); !os.IsNotExist(err) {
+		t.Errorf("abandoned scratch %q in the cache base survived the reclaim: %v", abandoned, err)
+	}
+	if warnings.Len() != 0 {
+		t.Errorf("startup reclaim reported a failure: %s", warnings.String())
+	}
+}
+
+// newGitWorkspace returns a throwaway directory that reads as a git worktree
+// root, which is what a session anchors its scratch to.
+func newGitWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatalf("create .git: %v", err)
+	}
+	return root
+}
+
+// TestServeReclaimsScratchAnchoredAtItsDirFlag drives serve's own flag parsing
+// from an unrelated working directory: the daemon allocates its scratch against
+// --dir, so the reclaim it starts has to read that same workspace and leave a
+// scratch base inside it alone.
+func TestServeReclaimsScratchAnchoredAtItsDirFlag(t *testing.T) {
+	stateDir := t.TempDir()
+	workspace := newGitWorkspace(t)
+	workspaceTemp := filepath.Join(workspace, "tmp")
+	if err := os.MkdirAll(workspaceTemp, 0o700); err != nil {
+		t.Fatalf("create workspace temp dir: %v", err)
+	}
+	cache := redirectUserCacheDir(t)
+	t.Setenv("TMPDIR", workspaceTemp)
+
+	insideWorkspace := newRetainedSessionScratch(t, workspaceTemp, "")
+	abandoned := newRetainedSessionScratch(t, cache, workspace)
+	age(t, insideWorkspace, abandoned)
+
+	var warnings bytes.Buffer
+	stop := errors.New("stop after startup")
+	deps := defaultServeDeps()
+	deps.ensureConfigDirs = func() error { return nil }
+	deps.seedMarketplaces = func(context.Context) error { return nil }
+	deps.reclaimScratch = func(workingDir string) { reclaimCrashedSessionScratch(workingDir, &warnings) }
+	deps.newClient = func(string, io.Writer) (*llm.Client, func() error, error) { return nil, nil, stop }
+
+	args := []string{"--dir", workspace, "--state-dir", stateDir, "--model", "openai/gpt-test"}
+	if err := runServeWithDeps(args, deps); !errors.Is(err, stop) {
+		t.Fatalf("serve error = %v, want %v", err, stop)
+	}
+	if _, err := os.Stat(insideWorkspace); err != nil {
+		t.Errorf("serve's reclaim removed %q, a base inside its --dir workspace: %v", insideWorkspace, err)
+	}
+	if _, err := os.Stat(abandoned); !os.IsNotExist(err) {
+		t.Errorf("abandoned scratch %q in the cache base survived serve's reclaim: %v", abandoned, err)
+	}
+	if warnings.Len() != 0 {
+		t.Errorf("serve's reclaim reported a failure: %s", warnings.String())
+	}
 }

--- a/cmd/evener/scratch_reclaim_unix_test.go
+++ b/cmd/evener/scratch_reclaim_unix_test.go
@@ -1,0 +1,69 @@
+//go:build unix
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/sandbox"
+)
+
+// TestReclaimCrashedSessionScratchRemovesOnlyAbandonedScratch drives the startup
+// reclaim over the base a real session allocates from (os.TempDir, TMPDIR here)
+// with three real scratch directories: one retained past the reclaim window with
+// no owner left, one whose owner still holds its lease, and one retained just
+// now. Only the first belongs to nobody.
+func TestReclaimCrashedSessionScratchRemovesOnlyAbandonedScratch(t *testing.T) {
+	base := t.TempDir()
+	workspace := t.TempDir()
+	t.Setenv("TMPDIR", base)
+
+	abandoned := newRetainedSessionScratch(t, base, workspace)
+	fresh := newRetainedSessionScratch(t, base, workspace)
+	live, err := sandbox.NewSessionScratch(base, workspace)
+	if err != nil {
+		t.Fatalf("NewSessionScratch: %v", err)
+	}
+	t.Cleanup(func() { _ = live.Cleanup() })
+
+	stale := time.Now().Add(-48 * time.Hour)
+	for _, dir := range []string{abandoned, live.Dir} {
+		if err := os.Chtimes(dir, stale, stale); err != nil {
+			t.Fatalf("age %q: %v", dir, err)
+		}
+	}
+
+	var warnings bytes.Buffer
+	reclaimCrashedSessionScratch(&warnings)
+
+	if _, err := os.Stat(abandoned); !os.IsNotExist(err) {
+		t.Errorf("abandoned session scratch %q survived startup reclaim: %v", abandoned, err)
+	}
+	for _, dir := range []string{live.Dir, fresh} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("startup reclaim removed %q: %v", dir, err)
+		}
+	}
+	if warnings.Len() != 0 {
+		t.Errorf("startup reclaim reported a failure: %s", warnings.String())
+	}
+}
+
+// newRetainedSessionScratch allocates a session scratch directory and retains it
+// exactly as session teardown does: the lease is released and the directory is
+// left on disk for the reclaim to find.
+func newRetainedSessionScratch(t *testing.T, base, workspace string) string {
+	t.Helper()
+	scratch, err := sandbox.NewSessionScratch(base, workspace)
+	if err != nil {
+		t.Fatalf("NewSessionScratch: %v", err)
+	}
+	if err := scratch.Retain(); err != nil {
+		t.Fatalf("Retain: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(scratch.Dir) })
+	return scratch.Dir
+}

--- a/cmd/evener/scratch_reclaim_unix_test.go
+++ b/cmd/evener/scratch_reclaim_unix_test.go
@@ -5,6 +5,8 @@ package main
 import (
 	"bytes"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,15 +31,10 @@ func TestReclaimCrashedSessionScratchRemovesOnlyAbandonedScratch(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = live.Cleanup() })
 
-	stale := time.Now().Add(-48 * time.Hour)
-	for _, dir := range []string{abandoned, live.Dir} {
-		if err := os.Chtimes(dir, stale, stale); err != nil {
-			t.Fatalf("age %q: %v", dir, err)
-		}
-	}
+	age(t, abandoned, live.Dir)
 
 	var warnings bytes.Buffer
-	reclaimCrashedSessionScratch(&warnings)
+	reclaimCrashedSessionScratch(workspace, &warnings)
 
 	if _, err := os.Stat(abandoned); !os.IsNotExist(err) {
 		t.Errorf("abandoned session scratch %q survived startup reclaim: %v", abandoned, err)
@@ -49,6 +46,102 @@ func TestReclaimCrashedSessionScratchRemovesOnlyAbandonedScratch(t *testing.T) {
 	}
 	if warnings.Len() != 0 {
 		t.Errorf("startup reclaim reported a failure: %s", warnings.String())
+	}
+}
+
+// TestReclaimCrashedSessionScratchSkipsWorkspaceContainedTempBase pins the
+// reclaim to the bases allocation actually used. A workspace that contains the
+// temp dir pushes allocation onto the user cache dir, so the abandoned scratch
+// to reclaim is there — and the prefixed directory sitting in the workspace's
+// own temp dir was never Evener's to remove.
+func TestReclaimCrashedSessionScratchSkipsWorkspaceContainedTempBase(t *testing.T) {
+	workspace := t.TempDir()
+	workspaceTemp := filepath.Join(workspace, "tmp")
+	if err := os.MkdirAll(workspaceTemp, 0o700); err != nil {
+		t.Fatalf("create workspace temp dir: %v", err)
+	}
+	cache := redirectUserCacheDir(t)
+	t.Setenv("TMPDIR", workspaceTemp)
+
+	abandoned := newRetainedSessionScratch(t, "", workspace)
+	if !strings.HasPrefix(abandoned, cache+string(filepath.Separator)) {
+		t.Fatalf("allocation for workspace %q chose %q, want a child of the cache base %q", workspace, abandoned, cache)
+	}
+	insideWorkspace := newRetainedSessionScratch(t, workspaceTemp, "")
+
+	age(t, abandoned, insideWorkspace)
+
+	var warnings bytes.Buffer
+	reclaimCrashedSessionScratch(workspace, &warnings)
+
+	if _, err := os.Stat(abandoned); !os.IsNotExist(err) {
+		t.Errorf("abandoned scratch %q in the cache base survived startup reclaim: %v", abandoned, err)
+	}
+	if _, err := os.Stat(insideWorkspace); err != nil {
+		t.Errorf("startup reclaim removed %q from a base inside the workspace: %v", insideWorkspace, err)
+	}
+	if warnings.Len() != 0 {
+		t.Errorf("startup reclaim reported a failure: %s", warnings.String())
+	}
+}
+
+// TestReclaimCrashedSessionScratchSweepsEveryAllocationBase covers the scratch
+// this host allocated for OTHER workspaces: a workspace containing the temp dir
+// allocates from the user cache dir, so a startup whose own temp dir is usable
+// still has to reclaim there.
+func TestReclaimCrashedSessionScratchSweepsEveryAllocationBase(t *testing.T) {
+	workspace := t.TempDir()
+	temp := t.TempDir()
+	cache := redirectUserCacheDir(t)
+	t.Setenv("TMPDIR", temp)
+
+	fromTemp := newRetainedSessionScratch(t, temp, workspace)
+	fromCache := newRetainedSessionScratch(t, cache, workspace)
+	age(t, fromTemp, fromCache)
+
+	var warnings bytes.Buffer
+	reclaimCrashedSessionScratch(workspace, &warnings)
+
+	for _, dir := range []string{fromTemp, fromCache} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("abandoned scratch %q survived startup reclaim: %v", dir, err)
+		}
+	}
+	if warnings.Len() != 0 {
+		t.Errorf("startup reclaim reported a failure: %s", warnings.String())
+	}
+}
+
+// redirectUserCacheDir points os.UserCacheDir at a throwaway directory and
+// returns its canonical path, so a test drives the real cache-base selection
+// without touching the developer's cache.
+func redirectUserCacheDir(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, "cache"))
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("UserCacheDir: %v", err)
+	}
+	if err := os.MkdirAll(cache, 0o700); err != nil {
+		t.Fatalf("create cache base: %v", err)
+	}
+	canonical, err := filepath.EvalSymlinks(cache)
+	if err != nil {
+		t.Fatalf("resolve cache base: %v", err)
+	}
+	return canonical
+}
+
+// age moves directories past the reclaim window.
+func age(t *testing.T, dirs ...string) {
+	t.Helper()
+	stale := time.Now().Add(-48 * time.Hour)
+	for _, dir := range dirs {
+		if err := os.Chtimes(dir, stale, stale); err != nil {
+			t.Fatalf("age %q: %v", dir, err)
+		}
 	}
 }
 

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -347,7 +347,6 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	if err := deps.ensureConfigDirs(); err != nil {
 		return err
 	}
-	go reclaimCrashedSessionScratch(os.Stderr)
 	resolvePlugins := deps.resolvePlugins
 	if resolvePlugins == nil {
 		resolvePlugins = func(ctx context.Context, explicit []string, enabled *[]string) (plugins.LaunchPluginResolution, error) {

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -347,6 +347,7 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	if err := deps.ensureConfigDirs(); err != nil {
 		return err
 	}
+	go reclaimCrashedSessionScratch(os.Stderr)
 	resolvePlugins := deps.resolvePlugins
 	if resolvePlugins == nil {
 		resolvePlugins = func(ctx context.Context, explicit []string, enabled *[]string) (plugins.LaunchPluginResolution, error) {

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -161,6 +161,14 @@ type serveDeps struct {
 	prepareAppIdentityFromEntries func(sourceID, threadID, ref string, header transcript.Header, entries []transcript.Entry) (server.PreparedAppIdentity, error)
 	updateSessionID               func(*rvreg.Registration, string) error
 	observeCallbacks              func(serveCallbackObserver)
+	// reclaimScratch removes the session scratch that daemons now gone
+	// retained, for a serve working in the directory it is handed — the one
+	// resolved from --dir, so the reclaim reads the workspace the daemon
+	// allocates against. Only the production entry point sets it, because
+	// reclaiming belongs to a real daemon start: tests drive runServe and
+	// runServeWithDeps, and the nil they leave here is what keeps a test run
+	// off the developer's own scratch bases.
+	reclaimScratch func(workingDir string)
 }
 
 type serveCallbackObserver struct {
@@ -389,6 +397,9 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 		if err != nil {
 			return fmt.Errorf("cannot determine working directory: %w", err)
 		}
+	}
+	if deps.reclaimScratch != nil {
+		deps.reclaimScratch(wd)
 	}
 	seedMarketplaces := deps.seedMarketplaces
 	if seedMarketplaces == nil {


### PR DESCRIPTION
## What was wrong

`sweepCrashedSessionScratch` had no production caller — only tests invoked it. The whole scratch handoff convention rests on it: a session that closes or hands its scratch off *retains* it (lease released, directory kept), on the premise that a sweeper later reclaims the directories whose owner is gone. Nothing ran that sweep, so every parked-worktree retention, every losing side of an `AdoptSessionScratch`, and every crashed session's scratch was permanent on disk.

## What changed

- `sandbox.SweepCrashedSessionScratch(workspaceRoot)` (new, exported) sweeps every base a session may allocate from — the temp dir and the user cache dir, canonical and deduplicated, each skipped when it lies inside the workspace, exactly as allocation skips it. Allocation takes the first of those bases; the reclaim visits them all, because a workspace containing the temp dir sends its own sessions to the cache dir instead. The removal gate is unchanged: Evener prefix, older than the 24h window, **and** the lease acquirable. A lease still held means a live owner, and that directory is never touched.
- `sweepCrashedSessionScratch` now returns what it could not reclaim (unreadable base; a directory it owned but `RemoveAll` failed on) instead of discarding it. Contended leases and unreadable ages stay silent skips — they are not failures.
- `evener` and `evener serve` start one reclaim each on its own goroutine. `run` anchors it at `cfg.workDir` from the dispatch entry (`runWithScratchReclaim` in main.go); `serve` anchors it at its resolved `--dir` from inside `runServeWithDeps`, through a `serveDeps.reclaimScratch` hook that only the dispatch entry (`runServeWithScratchReclaim`) sets, so every test that calls `runServe` or `runServeWithDeps` leaves it nil and never sweeps a developer's real bases.
- Failures print as a `warning:` line on os.Stderr naming the directory and saying it will retry at the next start. Two processes starting together can race on one directory (one unlinks the lease file, the other recreates it, the first's rmdir fails); the loser reports and the next start reclaims it.
- No ticker. The sweep's contract does not ask for one, and one call per process start reclaims the same directories.
- Inherent to the retention design, not new here: a directory whose lease was released while a live process still writes to it (the losing side of an adopt, or a parked environment retained at close) becomes removable once it is older than the window — but only to a *second* evener process starting, since a process sweeps before it mints anything.

## How it is tested

`cmd/evener/scratch_reclaim_unix_test.go` drives `reclaimCrashedSessionScratch` over real bases (TMPDIR and a redirected `os.UserCacheDir`) holding real `sandbox.NewSessionScratch` directories:

- `...RemovesOnlyAbandonedScratch`: one retained past the window with no owner, one whose owner still holds its lease, one retained just now. Only the abandoned one may disappear, and the reclaim must report nothing.
- `...SkipsWorkspaceContainedTempBase`: TMPDIR inside the workspace pushes allocation onto the cache dir; the abandoned scratch there is reclaimed and the prefixed directory in the workspace's own temp dir is left alone.
- `...SweepsEveryAllocationBase`: abandoned scratch in *both* bases is reclaimed even though allocation for this workspace would only ever pick the temp dir, while a live lease in the cache base keeps its directory. Dropping the lease gate fails that case with `startup reclaim removed the leased scratch ".../Library/Caches/evener-sandbox-3256226104" from the cache base`.

Failures watched first: the initial wiring failed with `undefined: reclaimCrashedSessionScratch` — production had no entry point at all — and, with the wiring present but the sweep call neutered, `abandoned session scratch ".../evener-sandbox-974319947" survived startup reclaim: <nil>`. The multi-base test failed against the single-base version with `abandoned scratch ".../Library/Caches/evener-sandbox-1946824502" survived startup reclaim: <nil>`.

`TestSweepCrashedSessionScratchReportsUnusableBase` covers the new error return for an unreadable base and for a host with no usable scratch base.

## Round four (roborev on f2f5ebd)

- **Reclaim and allocation anchor the workspace the same way.** `execenv.SessionScratchWorkspaceRoot(dir)` (the structural git worktree root when there is one, else `dir`; it never forks git) is now the one function both `newSessionScratch` and the reclaim call, and both then canonicalise through the same Abs plus EvalSymlinks path. Before, `serve` reclaimed from the process cwd and ignored `--dir`, and a bare `run` passed a raw subdirectory while allocation anchored at the worktree root, so the workspace exclusion could pass the wrong tree and the sweep could remove stale `evener-sandbox-*` directories under a workspace-contained TMPDIR that allocation never uses.
- **Allocation short-circuits again.** `sessionScratchBase` takes the first valid candidate and touches nothing past it, so a slow or unavailable user cache directory cannot delay session start when the temp base serves; only `sessionScratchBases`, used by the reclaim, enumerates. Both share `validSessionScratchBase`. An empty candidate is now rejected rather than resolving to the cwd.
- Tests, each watched failing first: `TestReclaimCrashedSessionScratchAnchorsAtTheWorktreeRoot` (reclaim started from a subdirectory removed a base inside the worktree), `TestServeReclaimsScratchAnchoredAtItsDirFlag` (serve's reclaim removed a base inside its `--dir` workspace when anchored at the cwd), and `TestSessionScratchAllocationLeavesCacheBaseAloneWhenTempBaseWorks` (allocation reached for the user cache base while the temp base was usable; it pins the short-circuit by asserting the cache-dir lookup is never called).

## Gates

- `gofmt -l` on the changed files: clean
- `make vet`, `go vet -tags evenerfuzz ./...` (root + agent): clean
- `make lint-golangci`: PASS
- `go test -race ./agent/sandbox/... -count=1`: ok, 0 FAIL
- `go test -race ./cmd/evener/... -count=1`: ok, 0 FAIL
- `go test -tags evenerfuzz -run Fuzz ./agent/sandbox/ -count=1`: ok, 0 FAIL
- `go test ./agent/ -count=1 -timeout 40m` (`GOMAXPROCS=4`): ok, 0 FAIL
- `go test -race ./agent/execenv/... -count=1`: ok, 0 FAIL

Closes #893

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT

