### PR TITLE
Fence the delegate isolation lane create on close

### DIFF
--- a/agent/delegate_isolation_close_test.go
+++ b/agent/delegate_isolation_close_test.go
@@ -1,0 +1,151 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/worktree"
+	"primeradiant.com/evener/identifier"
+)
+
+// reserveWorktreeIsolatedDelegate takes a create reservation for a delegate
+// spawned with isolation:"worktree", which is what prepareIsolation needs
+// before it can cut the lane.
+func reserveWorktreeIsolatedDelegate(t *testing.T, root *Session, task string) (delegateRuntime, *delegateStartReservation, identifier.Project) {
+	t.Helper()
+	runtime := delegateRuntime{owner: root}
+	ctx := context.Background()
+	args := delegateArgs{Task: task, Isolation: "worktree", DelegationAllowance: new(0)}
+	selection, err := root.selectSubagentModel(ctx, args.Model, args.AgentType)
+	if err != nil {
+		t.Fatalf("selectSubagentModel: %v", err)
+	}
+	toolNameCeiling := root.stableDelegateEffectiveToolNameCeiling(selection, args, args.Isolation)
+	descriptor, project, err := runtime.describe(ctx, args, args.Task, args.Isolation, nil, selection, toolNameCeiling)
+	if err != nil {
+		t.Fatalf("describe delegate: %v", err)
+	}
+	reservation, err := root.delegateController.ReserveCreate(rootDelegateActor(root.ID()), descriptor)
+	if err != nil {
+		t.Fatalf("ReserveCreate: %v", err)
+	}
+	return runtime, reservation, project
+}
+
+// assertNoDelegateLane checks that nothing of an isolation lane for delegateID
+// remains: no worktree, no branch, no sidecar.
+func assertNoDelegateLane(t *testing.T, r *wtRepo, delegateID, lanePath string) {
+	t.Helper()
+	if laneWorktreePresent(lanePath) {
+		t.Errorf("the isolation lane %s was left behind", lanePath)
+	}
+	if r.branchExists(t, delegateID) {
+		t.Errorf("the branch %q cut for the isolation lane was left behind", delegateID)
+	}
+	sidecar := filepath.Join(metaDirForLane(lanePath), worktree.EncodeSidecarName(delegateID)+".json")
+	if _, err := os.Stat(sidecar); err == nil {
+		t.Errorf("the sidecar %s was left behind", sidecar)
+	}
+}
+
+// Cutting a delegate's isolation lane forks git on the PARENT's environment,
+// the one Close reaps the process table of. It is not a manage_worktree
+// operation, so the dispatch's close fence never sees it: without an admission
+// of its own, a close that begins while the lane's git is in flight walks
+// straight past it and cleans the environment underneath, leaving a
+// half-created lane nobody owns.
+func TestDelegateIsolation_CloseWaitsForTheLaneCreateItRaces(t *testing.T) {
+	r := newWorktreeRepo(t)
+	root := r.s
+	runtime, reservation, project := reserveWorktreeIsolatedDelegate(t, root, "close under the lane create")
+	lanePath := reservation.worktreePath
+
+	closeBegun := make(chan struct{})
+	closeDone := make(chan struct{})
+	envCleaned := make(chan struct{})
+	var cleanedOnce sync.Once
+	var held, cleanupDuringCreate atomic.Bool
+
+	root.cfg.testOnly.closeAfterDisposeSweepJoin = func() { close(closeBegun) }
+	root.cfg.testOnly.envCleanupObserved = func(execenv.ExecutionEnvironment) {
+		cleanedOnce.Do(func() { close(envCleaned) })
+	}
+	root.cfg.testOnly.worktreeGitRunner = func(ctx context.Context, env execenv.ExecutionEnvironment) worktree.GitRunner {
+		inner := gitRunner(ctx, env)
+		return func(args ...string) (string, error) {
+			if len(args) >= 2 && args[0] == "worktree" && args[1] == "add" && held.CompareAndSwap(false, true) {
+				go func() {
+					defer close(closeDone)
+					root.Close()
+				}()
+				<-closeBegun
+				select {
+				case <-envCleaned:
+					cleanupDuringCreate.Store(true)
+				case <-time.After(closeFenceProbe):
+				}
+			}
+			return inner(args...)
+		}
+	}
+
+	isolation, err := runtime.prepareIsolation(context.Background(), reservation, project, nil)
+	if !held.Load() {
+		t.Fatal("the create never reached git worktree add; the test observed nothing")
+	}
+	<-closeDone
+
+	if cleanupDuringCreate.Load() {
+		t.Error("the close cleaned the environment while the delegate lane's create still held its git")
+	}
+	if err != nil {
+		assertNoDelegateLane(t, r, reservation.delegateID, lanePath)
+		return
+	}
+	t.Cleanup(func() { isolation.cleanup(root, reservation.delegateID) })
+	if !laneWorktreePresent(isolation.worktreePath) {
+		t.Errorf("the create reported success but left no lane at %s", isolation.worktreePath)
+	}
+}
+
+// A spawn that reaches the isolation step once the close has begun cannot be
+// fenced — the close may already be past its join — so cutting the lane would
+// add a locked worktree, a branch and a sidecar against an environment being
+// reaped and stores being closed. The refusal has to reach the caller with no
+// git run at all.
+func TestDelegateIsolation_LaneCreateAfterCloseBeganIsRefused(t *testing.T) {
+	r := newWorktreeRepo(t)
+	root := r.s
+	runtime, reservation, project := reserveWorktreeIsolatedDelegate(t, root, "spawn after close began")
+	lanePath := reservation.worktreePath
+
+	root.Close()
+
+	var calls atomic.Int64
+	root.cfg.testOnly.worktreeGitRunner = func(ctx context.Context, env execenv.ExecutionEnvironment) worktree.GitRunner {
+		inner := gitRunner(ctx, env)
+		return func(args ...string) (string, error) {
+			calls.Add(1)
+			return inner(args...)
+		}
+	}
+
+	isolation, err := runtime.prepareIsolation(context.Background(), reservation, project, nil)
+	if !errors.Is(err, errWorktreeOpWhileClosing) {
+		t.Fatalf("isolation prepared while closing = %v, want the closing refusal", err)
+	}
+	if isolation.worktreePath != "" || isolation.env != nil {
+		t.Errorf("refused isolation = %+v, want nothing built", isolation)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Errorf("the refused create ran %d git commands, want none", got)
+	}
+	assertNoDelegateLane(t, r, reservation.delegateID, lanePath)
+}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1450,7 +1450,39 @@ func (runtime delegateRuntime) prepareIsolation(ctx context.Context, reservation
 	s := runtime.owner
 	isolation := delegateIsolation{worktreeProject: project}
 	workingDir := reservation.worktreePath
+	var (
+		laneAdmission envWorkID
+		laneFenced    bool
+	)
+	// The lane's admission is named for the create until an undo actually
+	// starts: a create still in flight must not read as a rollback in a fence
+	// warning (worktreeCreate renames its own for the same reason).
+	rollback := func() {
+		if laneFenced {
+			s.relabelEnvWork(laneAdmission, "delegate lane rollback for "+workingDir)
+		}
+		isolation.cleanup(s, reservation.delegateID)
+	}
 	if workingDir != "" {
+		// Cutting the lane forks git on the PARENT's environment, whose process
+		// table a close reaps, and so does the rollback every failure below owes
+		// it. Neither is a manage_worktree operation, so the dispatch's close
+		// fence never sees them; admit them here as ONE span, for the reason
+		// worktreeCreate's create/rollback admission is one span — an admission
+		// asked for where the rollback starts would be refused by the very close
+		// that made the rollback necessary, and an unfenced rollback races the
+		// environment cleanup it exists to keep residue out of.
+		//
+		// A refused admission refuses the spawn, which is the dispatch's answer
+		// for the dispatch's reason: no lane has been cut yet, and cutting one
+		// against an environment being reaped and stores being closed leaves
+		// exactly the locked worktree, branch and sidecar this admission is here
+		// to prevent.
+		laneAdmission, laneFenced = s.beginEnvWork("create delegate lane " + workingDir)
+		if !laneFenced {
+			return isolation, fmt.Errorf(`delegate isolation:"worktree": %w`, errWorktreeOpWhileClosing)
+		}
+		defer s.endEnvWork(laneAdmission)
 		path, _, _, _, createdProject, err := s.createDelegateWorktree(ctx, reservation.delegateID)
 		if err != nil {
 			return isolation, err
@@ -1458,13 +1490,13 @@ func (runtime delegateRuntime) prepareIsolation(ctx context.Context, reservation
 		isolation.worktreePath = path
 		isolation.worktreeProject = createdProject
 		if filepath.Clean(path) != filepath.Clean(workingDir) {
-			isolation.cleanup(s, reservation.delegateID)
+			rollback()
 			return delegateIsolation{}, fmt.Errorf("delegate isolation path %q does not match reserved path %q", path, workingDir)
 		}
 	}
 	env, ownsFresh, err := s.prepareSubagentEnvironment(workingDir, requestedSandbox)
 	if err != nil {
-		isolation.cleanup(s, reservation.delegateID)
+		rollback()
 		return delegateIsolation{}, err
 	}
 	isolation.env = env

--- a/agent/delegate_stop_won_isolation_test.go
+++ b/agent/delegate_stop_won_isolation_test.go
@@ -19,22 +19,8 @@ import (
 func TestDelegateResourceCreate_StopWinningConstructFailureCleansIsolation(t *testing.T) {
 	r := newWorktreeRepo(t)
 	root := r.s
-	runtime := delegateRuntime{owner: root}
 	ctx := context.Background()
-	args := delegateArgs{Task: "stop mid-construct", Isolation: "worktree", DelegationAllowance: new(0)}
-	selection, err := root.selectSubagentModel(ctx, args.Model, args.AgentType)
-	if err != nil {
-		t.Fatalf("selectSubagentModel: %v", err)
-	}
-	toolNameCeiling := root.stableDelegateEffectiveToolNameCeiling(selection, args, args.Isolation)
-	descriptor, project, err := runtime.describe(ctx, args, args.Task, args.Isolation, nil, selection, toolNameCeiling)
-	if err != nil {
-		t.Fatalf("describe delegate: %v", err)
-	}
-	reservation, err := root.delegateController.ReserveCreate(rootDelegateActor(root.ID()), descriptor)
-	if err != nil {
-		t.Fatalf("ReserveCreate: %v", err)
-	}
+	runtime, reservation, project := reserveWorktreeIsolatedDelegate(t, root, "stop mid-construct")
 	isolation, err := runtime.prepareIsolation(ctx, reservation, project, nil)
 	if err != nil {
 		t.Fatalf("prepareIsolation: %v", err)

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -161,8 +161,9 @@ func (s *Session) registerEnvWorkLocked(label string) envWorkID {
 
 // beginEnvWork admits work that runs commands on the session's execution
 // environment and must therefore finish before Close reaps that environment's
-// process table: a whole manage_worktree call at its dispatch, and the rollback
-// a refused or failed operation owes after its swap has already released the
+// process table: a whole manage_worktree call at its dispatch, the cut of a
+// delegate's isolation lane and the rollback that undoes it, and the rollback a
+// refused or failed operation owes after its swap has already released the
 // swap's own admission. It is the beginDispose idiom again — the closing check
 // AND the envWorkWG Add happen under one s.mu hold, so a successful Add
 // happens-before Close()'s join. A true return MUST be paired with a (deferred)
@@ -181,10 +182,11 @@ func (s *Session) registerEnvWorkLocked(label string) envWorkID {
 // is already being torn down, and the close may already be past its join — and
 // the two kinds of caller answer that differently, on purpose:
 //
-//   - The manage_worktree DISPATCH refuses the call (errWorktreeOpWhileClosing).
-//     The operation has not started, and running it unfenced would lock lanes
-//     and write sidecars against an environment being reaped and stores being
-//     closed. A closing session was never going to complete it anyway.
+//   - The manage_worktree DISPATCH refuses the call, and a delegate's
+//     isolation step refuses the spawn (errWorktreeOpWhileClosing). The work
+//     has not started, and running it unfenced would lock lanes and write
+//     sidecars against an environment being reaped and stores being closed. A
+//     closing session was never going to complete it anyway.
 //   - A ROLLBACK proceeds best-effort, exactly as it did before the fence
 //     existed. Its admission failing is the expected case — the close is what
 //     made the rollback necessary — and it is an undo the session already owes,

--- a/agent/session_tools_worktree.go
+++ b/agent/session_tools_worktree.go
@@ -321,11 +321,12 @@ func (s *Session) serveDisposeOnlyWorktreeTool() {
 	_ = s.reg.Register(t)
 }
 
-// errWorktreeOpWhileClosing is what the manage_worktree dispatch returns when
-// the session began closing before the call could be admitted on the close
-// fence. It is the operation-level sibling of errSwapWhileClosing: an
-// unadmitted operation cannot be waited for, and the close may already be past
-// its join, so the only safe answer is to run nothing at all.
+// errWorktreeOpWhileClosing is what the manage_worktree dispatch, and the
+// isolation step of a delegate spawned with isolation:"worktree", return when
+// the session began closing before the work could be admitted on the close
+// fence. It is the operation-level sibling of errSwapWhileClosing: unadmitted
+// work cannot be waited for, and the close may already be past its join, so the
+// only safe answer is to run nothing at all.
 var errWorktreeOpWhileClosing = errors.New("the session is closing; operation refused")
 
 // worktreeOpLabel names a manage_worktree call for a close-fence warning: the


### PR DESCRIPTION
## What was wrong

Cutting a delegate's isolation lane (`createDelegateWorktree`, reached from `prepareIsolation` when a delegate is spawned with `isolation:"worktree"`) forks git on the **parent** session's execution environment — the one `Close` reaps the process table of. It is not a `manage_worktree` operation, so the dispatch admission PR #878 added never sees it, and `prepareIsolation` took no admission of its own.

So a close beginning while the lane's git was in flight walked straight past it: it joined `envWorkWG` (empty), disposed lanes, closed stores and cleaned the environment underneath a running `git worktree add`. The residue is a locked worktree, a branch and a sidecar nobody owns; and the rollback the close itself caused ran against an environment already torn down.

## What changed

`prepareIsolation` takes one `beginEnvWork` admission spanning the lane create **and** every rollback the isolation step owes it (path mismatch, `prepareSubagentEnvironment` failure), labelled `create delegate lane <path>` and renamed when an undo actually starts. It is one span for the same reason `worktreeCreate`'s create/rollback admission is one span: an admission asked for where the rollback starts would be refused by the very close that made the rollback necessary.

A refused admission refuses the spawn with `errWorktreeOpWhileClosing` — the dispatch's answer for the dispatch's reason: no lane has been cut yet, and cutting one against an environment being reaped and stores being closed leaves exactly the residue the admission exists to prevent.

Doc comments on `beginEnvWork` and `errWorktreeOpWhileClosing`, which enumerate what the fence admits and who refuses, now name this caller. No change to the fence itself.

## How it is tested

`agent/delegate_isolation_close_test.go`, both watched failing first against the unfixed code:

- `TestDelegateIsolation_CloseWaitsForTheLaneCreateItRaces` holds the create at `git worktree add` through the session's git-runner seam, starts a `Close()` there, and watches `envCleanupObserved`. Failed with `the close cleaned the environment while the delegate lane's create still held its git`. Now the create completes first, and the create-refused arm asserts no lane, branch or sidecar is left.
- `TestDelegateIsolation_LaneCreateAfterCloseBeganIsRefused` reserves the delegate, closes the session, then prepares isolation. Failed with `isolation prepared while closing = <nil>, want the closing refusal`. Now it refuses, runs zero git commands, and leaves nothing on disk.

The reservation setup the new tests needed already existed inline in `delegate_stop_won_isolation_test.go`; it is extracted to `reserveWorktreeIsolatedDelegate` and shared rather than copied.

## Gates

- `gofmt -l` on every changed `.go`: clean.
- `go vet ./...` and `go vet -tags evenerfuzz ./...`: clean.
- `make lint-golangci`, `make lint-evenerfuzz lint-eval lint-gofmt` (CI's own invocations): PASS.
- `go test -race ./agent/... -count=1`: exit 0, 0 FAIL (plus a focused race re-run of the two tests touched after that build: 0 FAIL).
- `go test -tags evenerfuzz -run Fuzz ./agent/ -count=1`: exit 0, 0 FAIL.
- `go test ./agent/ -count=1 -timeout 30m`: exit 0, 0 FAIL.

Closes #901

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT