### PR TITLE
Retain an untracked delegate runtime's scratch at root close

### DIFF
--- a/agent/delegate_resource_create_test.go
+++ b/agent/delegate_resource_create_test.go
@@ -1024,7 +1024,7 @@ func TestDelegateResourceCreate_MissingRestoreInputsCloseResumabilityBeforeClean
 	// This boundary models process loss, not a graceful shutdown. A graceful
 	// Close now durably stops committed generations and therefore waits for the
 	// construction owner that a crash fixture intentionally does not retain.
-	root.discardRestoredCandidate(true)
+	root.discardRestoredCandidate()
 
 	restored, err := restoreDelegateResourceBootstrapSession(client, profile, workspace, meta, stateDir)
 	if err != nil {

--- a/agent/delegate_resource_runtime_test.go
+++ b/agent/delegate_resource_runtime_test.go
@@ -109,7 +109,7 @@ func TestRestoredDelegatePostStartPopulationEmitsTaskCorrection(t *testing.T) {
 		t.Fatal("restoreIdle unexpectedly reused a resident child")
 	}
 	defer func() {
-		sub.sess.discardRestoredCandidate(sub.ownsEnv)
+		sub.sess.discardRestoredCandidate()
 		_, _ = root.delegateController.FailCommittedRestart(started.lease, delegatePermanentStartFailure(context.Canceled, "test_cleanup"))
 	}()
 
@@ -2250,7 +2250,7 @@ func TestDelegateResourceRuntime_ColdIdleUsesCommittedConfigTemplatesAndToolCeil
 	if !restored {
 		t.Fatal("cold idle delegate was reported retained")
 	}
-	defer sub.sess.discardRestoredCandidate(sub.ownsEnv)
+	defer sub.sess.discardRestoredCandidate()
 	if sub.sess.cfg.MaxToolRoundsPerInput != 17 || sub.sess.cfg.ReasoningEffort != "high" {
 		t.Fatalf("restored config = rounds:%d effort:%q", sub.sess.cfg.MaxToolRoundsPerInput, sub.sess.cfg.ReasoningEffort)
 	}
@@ -2293,7 +2293,7 @@ func TestDelegateResourceRuntime_ColdIdleInheritsLiveLifetimeContext(t *testing.
 	if !restored {
 		t.Fatal("cold idle delegate was reported retained")
 	}
-	defer sub.sess.discardRestoredCandidate(sub.ownsEnv)
+	defer sub.sess.discardRestoredCandidate()
 
 	cancelOwner()
 	select {
@@ -2326,7 +2326,7 @@ func TestDelegateResourceRuntime_ColdIdleReusesExactSharedRootTaskStore(t *testi
 	if err != nil {
 		t.Fatalf("restoreIdle: %v", err)
 	}
-	defer sub.sess.discardRestoredCandidate(sub.ownsEnv)
+	defer sub.sess.discardRestoredCandidate()
 	if got := sub.sess.getOrCreateTaskStore(); got != want {
 		t.Fatalf("shared TaskStore pointer = %p, want exact root pointer %p", got, want)
 	}

--- a/agent/delegate_resource_worktree_test.go
+++ b/agent/delegate_resource_worktree_test.go
@@ -416,7 +416,7 @@ func TestStableDelegateWorktree_SandboxRestoreUsesDescriptorNotLegacyJob(t *test
 		t.Fatal("stable descriptor restore unexpectedly reused a resident child")
 	}
 	defer func() {
-		sub.sess.discardRestoredCandidate(sub.ownsEnv)
+		sub.sess.discardRestoredCandidate()
 		_, _ = root.delegateController.FailCommittedRestart(started.lease, delegatePermanentStartFailure(context.Canceled, "test_cleanup"))
 	}()
 	if got := sub.sess.currentEnv().WorkingDirectory(); got != descriptorDir {

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -498,12 +498,12 @@ func (s *Session) reconstructDelegateAttentionRuntime(owner *Session, started de
 		candidate := sub
 		tracked, inserted, trackErr := owner.subagents.admitReconstructed(candidate, attach)
 		if trackErr != nil {
-			candidate.sess.discardRestoredCandidate(candidate.ownsEnv)
+			candidate.sess.discardRestoredCandidate()
 			finishRestore(nil, trackErr)
 			return nil, trackErr
 		}
 		if !inserted {
-			candidate.sess.discardRestoredCandidate(candidate.ownsEnv)
+			candidate.sess.discardRestoredCandidate()
 			sub = tracked
 			restored = false
 		}
@@ -669,7 +669,7 @@ func (s *Session) prepareDeferredOwedStart(start deferredOwedDelegateAttentionSt
 		return false, errors.New("owed candidate conflicts with controller runtime state")
 	}
 	start.owner.subagents.removeSession(start.sub.id, start.sub.sess)
-	start.sub.sess.discardRestoredCandidate(start.sub.ownsEnv)
+	start.sub.sess.discardRestoredCandidate()
 	return false, persistErr
 }
 
@@ -847,13 +847,13 @@ func (runtime delegateRuntime) send(ctx context.Context, delegateID, message str
 			return s.delegateController.AttachRuntime(started.lease, selected.sess)
 		})
 		if trackErr != nil {
-			candidate.sess.discardRestoredCandidate(candidate.ownsEnv)
+			candidate.sess.discardRestoredCandidate()
 			return runtime.failStableSendStartAfterDispatch(ctx, started, delegateID, waiter, maxWaitMS, trackErr, func() {
 				finishRestore(nil, trackErr)
 			})
 		}
 		if !inserted {
-			candidate.sess.discardRestoredCandidate(candidate.ownsEnv)
+			candidate.sess.discardRestoredCandidate()
 			sub = tracked
 			restored = false
 		}
@@ -1676,14 +1676,15 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 	if err != nil {
 		return nil, false, err
 	}
+	child.ownsEnv = ownsFresh
 	discardEnv = false
 	if child.delegateController != s.delegateController || child.owningDelegateID != started.lease.delegateID {
-		child.discardRestoredCandidate(ownsFresh)
+		child.discardRestoredCandidate()
 		return nil, false, errors.New("restored delegate did not inherit the exact controller binding")
 	}
 	for name := range child.reg.RegisteredNames() {
 		if !hasString(descriptor.ToolNameCeiling, name) {
-			child.discardRestoredCandidate(ownsFresh)
+			child.discardRestoredCandidate()
 			return nil, false, fmt.Errorf("restored delegate tool %q exceeds the committed ceiling", name)
 		}
 	}
@@ -1700,7 +1701,7 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 			child.emit(events.EventTaskUpdated, taskUpdatedData(summary, child.taskStoreOwnerSessionID(), epoch, revision))
 			return nil
 		}); err != nil {
-			child.discardRestoredCandidate(ownsFresh)
+			child.discardRestoredCandidate()
 			return nil, false, fmt.Errorf("restore committed delegate tasks: %w", err)
 		}
 	}
@@ -1717,7 +1718,6 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 		startedAt:        now,
 		endedAt:          &now,
 		stableDescriptor: &stableDescriptor,
-		ownsEnv:          ownsFresh,
 	}
 	child.SetNotifyFunc(func() { s.driveChildIfNotStopGated(sub) })
 	return sub, true, nil
@@ -2272,7 +2272,5 @@ func (s *Session) closeOwnedDelegateRuntimeTree(ctx context.Context) error {
 	if s == nil || !s.ownsDelegateController || s.delegateController == nil {
 		return nil
 	}
-	return s.delegateController.closeRuntimeTree(ctx, func(child *Session, _ bool) {
-		child.close(ctx, false)
-	})
+	return s.delegateController.closeRuntimeTree(ctx)
 }

--- a/agent/delegate_tree_reclaim.go
+++ b/agent/delegate_tree_reclaim.go
@@ -376,14 +376,13 @@ func (s *Session) reclaimDelegateRuntimeCapacity(required int) (err error) {
 		if entry.runtime == nil {
 			continue
 		}
-		ownsEnv := entry.ownerRuntime.ownsChildEnvironment(entry.runtime)
 		if entry.ownerRuntime != nil && entry.ownerRuntime.subagents != nil {
 			entry.ownerRuntime.subagents.removeSession(entry.childSessionID, entry.runtime)
 		}
 		if closeRuntime := s.cfg.testOnly.delegateRuntimeReclaimClose; closeRuntime != nil {
 			closeRuntime(entry.runtime)
 		} else {
-			teardownChildSession(context.Background(), entry.runtime, ownsEnv, retainChildScratch)
+			teardownChildSession(context.Background(), entry.runtime, retainChildScratch)
 		}
 		closed[entry.delegateID] = entry.runtime
 	}

--- a/agent/delegate_tree_stop.go
+++ b/agent/delegate_tree_stop.go
@@ -508,7 +508,7 @@ func (c *delegateTreeController) CloseResumability(actor delegateActor, delegate
 // never creates a second stop: each root subtree is drained through the same
 // durable stop operation, in stable order, before the next one can begin.
 func (c *delegateTreeController) Close(ctx context.Context) error {
-	if err := c.closeRuntimeTree(ctx, nil); err != nil {
+	if err := c.closeRuntimeTree(ctx); err != nil {
 		return err
 	}
 	return c.store.Close()
@@ -517,20 +517,14 @@ func (c *delegateTreeController) Close(ctx context.Context) error {
 // closeRuntimeTree fences admission, durably stops every stable root, joins the
 // exact stop reconciliation, and tears resident sessions down leaf-first. Every
 // resident runtime is a child session — on its owner's environment or on a
-// clone sharing the owner's process table — so the default policy is the child
-// teardown (teardownChildSession, scratch retained), never Session.Close. The
-// caller may supply its own policy; root Session shutdown does, so it keeps its
-// shared environment alive until its own final cleanup. ownsEnv is the owner's
-// record of whether the child's environment was built for it. The delegate
-// store remains open for subsequent worktree disposal evidence.
-func (c *delegateTreeController) closeRuntimeTree(ctx context.Context, closeChild func(child *Session, ownsEnv bool)) error {
+// clone sharing the owner's process table — so each takes the child teardown
+// (teardownChildSession, scratch retained), never Session.Close: a shared
+// environment stays alive for the owner's own final cleanup, and a clone's
+// scratch is released here whether or not any owner's subagent map named it.
+// The delegate store remains open for subsequent worktree disposal evidence.
+func (c *delegateTreeController) closeRuntimeTree(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
-	}
-	if closeChild == nil {
-		closeChild = func(child *Session, ownsEnv bool) {
-			teardownChildSession(ctx, child, ownsEnv, retainChildScratch)
-		}
 	}
 	c.mu.Lock()
 	if !c.closing {
@@ -545,25 +539,12 @@ func (c *delegateTreeController) closeRuntimeTree(ctx context.Context, closeChil
 		allMembers[id] = struct{}{}
 	}
 	children := make([]*Session, 0, len(allMembers))
-	// Each resident runtime's owner, read now while the tree is intact: the
-	// close policy asks the owner whether the child's environment is its own.
-	owners := make(map[*Session]*Session, len(allMembers))
 	for _, id := range c.memberIDsLeafFirstLocked(allMembers) {
 		live := c.live[id]
-		if live == nil {
+		if live == nil || live.runtime == nil {
 			continue
 		}
-		if aggregate := c.durable[id]; aggregate != nil {
-			if live.runtime != nil {
-				owners[live.runtime] = c.ownerRuntimeLocked(aggregate)
-			}
-			if live.binding != nil && live.binding.runtime != nil {
-				owners[live.binding.runtime] = c.ownerRuntimeLocked(aggregate)
-			}
-		}
-		if live.runtime != nil {
-			children = append(children, live.runtime)
-		}
+		children = append(children, live.runtime)
 	}
 	if pending != nil {
 		pendingCancelPlan = c.cancelPlanForStopLocked(pending)
@@ -625,7 +606,7 @@ func (c *delegateTreeController) closeRuntimeTree(ctx context.Context, closeChil
 			continue
 		}
 		closed[child] = struct{}{}
-		closeChild(child, owners[child].ownsChildEnvironment(child))
+		teardownChildSession(ctx, child, retainChildScratch)
 	}
 	if _, err := c.joinStopReconcileDriver(ctx); err != nil {
 		return err

--- a/agent/sandbox_delegate_role_floor_test.go
+++ b/agent/sandbox_delegate_role_floor_test.go
@@ -337,7 +337,7 @@ func TestRestoreDelegate_ReadOnlyRoleSandboxFloor(t *testing.T) {
 			if sub == nil || !restored {
 				t.Fatalf("compatible restored role policy = sub:%v restored:%t", sub, restored)
 			}
-			defer sub.sess.discardRestoredCandidate(sub.ownsEnv)
+			defer sub.sess.discardRestoredCandidate()
 			assertReadOnlyDelegateBackend(t, sub.sess, tc.wantMode, tc.wantWriteBlocked)
 		})
 	}

--- a/agent/sandbox_delegate_test.go
+++ b/agent/sandbox_delegate_test.go
@@ -132,7 +132,8 @@ func TestDiscardRestoredCandidateDisposesSandboxScratch(t *testing.T) {
 		t.Fatalf("EnableSandbox: %v", err)
 	}
 	tmp := local.Wrapper.SessionTmp()
-	child.discardRestoredCandidate(true)
+	child.ownsEnv = true
+	child.discardRestoredCandidate()
 	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
 		t.Errorf("discarded restore candidate retained sandbox scratch: %v", err)
 	}
@@ -161,7 +162,8 @@ func TestDiscardRestoredCandidateDisposesUnsandboxedScratch(t *testing.T) {
 		t.Fatal("an unsandboxed env minted no session scratch, so there is nothing to dispose")
 	}
 
-	candidate.discardRestoredCandidate(true)
+	candidate.ownsEnv = true
+	candidate.discardRestoredCandidate()
 
 	// The lease file lives inside the scratch dir, so the directory's removal is
 	// the lease's removal too.
@@ -173,7 +175,7 @@ func TestDiscardRestoredCandidateDisposesUnsandboxedScratch(t *testing.T) {
 // A candidate does not always OWN what it holds: prepareSubagentEnvironment
 // hands back the parent's environment untouched when the delegate needs neither
 // a working-dir re-root nor a box of its own. close() already guards its scratch
-// handoff on the subagent's ownsEnv for exactly that reason, and the discard path
+// handoff on the child's ownsEnv for exactly that reason, and the discard path
 // has to make the same distinction — otherwise aborting one candidate deletes the
 // scratch dir out from under the live parent still working in it.
 func TestDiscardRestoredCandidateLeavesASharedEnvironmentAlone(t *testing.T) {
@@ -202,7 +204,7 @@ func TestDiscardRestoredCandidateLeavesASharedEnvironmentAlone(t *testing.T) {
 		t.Fatalf("NewSession on the parent's environment: %v", err)
 	}
 
-	candidate.discardRestoredCandidate(false)
+	candidate.discardRestoredCandidate()
 
 	if _, err := os.Stat(sharedScratch); err != nil {
 		t.Errorf("discarding a candidate on the parent's shared environment removed its scratch %s: %v", sharedScratch, err)
@@ -409,7 +411,8 @@ func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T)
 		t.Fatal("the child env minted no session scratch, so there is nothing to dispose")
 	}
 
-	disposeUnadoptedSubagentSession(owned, true)
+	owned.ownsEnv = true
+	disposeUnadoptedSubagentSession(owned)
 
 	if got := owned.State(); got != SessionClosed {
 		t.Errorf("unadopted child state = %q, want %q", got, SessionClosed)
@@ -439,7 +442,7 @@ func TestDisposeUnadoptedSubagentSessionDisposesEveryScratchItOwns(t *testing.T)
 		t.Fatalf("NewSession on the parent's environment: %v", err)
 	}
 
-	disposeUnadoptedSubagentSession(sharing, false)
+	disposeUnadoptedSubagentSession(sharing)
 
 	if got := sharing.State(); got != SessionClosed {
 		t.Errorf("child sharing the parent's environment was left %q, want %q", got, SessionClosed)
@@ -550,7 +553,8 @@ func TestDisposeUnadoptedSubagentSessionLeavesTheParentsProcessesAlone(t *testin
 		t.Fatalf("NewSession on a fresh clone: %v", err)
 	}
 
-	disposeUnadoptedSubagentSession(child, true)
+	child.ownsEnv = true
+	disposeUnadoptedSubagentSession(child)
 
 	// No bound needed: a Cleanup that reached this process would have signalled
 	// it, waited out the termination grace and killed it, all before the dispose

--- a/agent/session.go
+++ b/agent/session.go
@@ -91,9 +91,17 @@ type Session struct {
 	// response through an injected transport without touching the network.
 	httpClient httpDoer
 	env        execenv.ExecutionEnvironment
-	clock      clock.Clock
-	stateDir   string
-	installID  string
+	// ownsEnv is true when this session is a child whose execution environment was
+	// built FOR it (a working-dir re-root and/or a per-delegate sandbox) rather
+	// than shared with its parent. Such an environment owns scratch dirs and
+	// file-tool fds no parent cleanup reaches, so the child's teardown settles
+	// them; a shared one belongs to the live parent and is left alone. The child
+	// records it because a teardown can reach a child no parent bookkeeping names
+	// — a runtime the stable controller holds for its own close.
+	ownsEnv   bool
+	clock     clock.Clock
+	stateDir  string
+	installID string
 	// origin marks how the session was launched: "test" for agentic-testing
 	// runs (set from EVENER_SESSION_ORIGIN on fresh create), empty for normal
 	// sessions. Preserved across resume from the persisted SessionMeta.Origin.

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -461,7 +461,7 @@ func (s *Session) close(ctx context.Context, cleanupEnv bool) {
 		// parent owns cleanup of that env (step 4), so a child's teardown never
 		// runs it; what a child owns is its scratch, retained for the handoff.
 		for _, sub := range subs {
-			teardownChildSession(budgetCtx, sub.sess, sub.ownsEnv, retainChildScratch)
+			teardownChildSession(budgetCtx, sub.sess, retainChildScratch)
 		}
 		if s.ownsArtifactStore && s.artifactStore != nil {
 			if err := s.artifactStore.Close(); err != nil {
@@ -631,14 +631,14 @@ func (s *Session) retainParkedWorktreeEnvironmentScratch() {
 }
 
 // discardRestoredCandidate tears down a restore candidate nothing ever adopted.
-// ownsEnv says whether the candidate's execution environment is one built FOR it
-// (a working-dir re-root and/or a per-delegate box) rather than the parent's own:
-// prepareSubagentEnvironment returns the parent's environment untouched when the
-// delegate needs neither, and a shared environment belongs to the live parent
-// still working in it. It is the same distinction close() makes before retaining
-// a child's scratch (subagent.ownsEnv), read here so an aborted candidate never
-// deletes a scratch dir out from under its parent.
-func (s *Session) discardRestoredCandidate(ownsEnv bool) {
+// The candidate's own ownsEnv says whether its execution environment is one
+// built FOR it (a working-dir re-root and/or a per-delegate box) rather than
+// the parent's own: prepareSubagentEnvironment returns the parent's environment
+// untouched when the delegate needs neither, and a shared environment belongs
+// to the live parent still working in it. It is the same distinction close()
+// makes before retaining a child's scratch, read here so an aborted candidate
+// never deletes a scratch dir out from under its parent.
+func (s *Session) discardRestoredCandidate() {
 	s.closeOnce.Do(func() {
 		s.responseSideEffectsMu.Lock()
 		s.mu.Lock()
@@ -659,7 +659,7 @@ func (s *Session) discardRestoredCandidate(ownsEnv bool) {
 			_ = s.jobManager.store.Close()
 		}
 		for _, sub := range subs {
-			sub.sess.discardRestoredCandidate(sub.ownsEnv)
+			sub.sess.discardRestoredCandidate()
 		}
 		if s.ownsArtifactStore && s.artifactStore != nil {
 			_ = s.artifactStore.Close()
@@ -669,7 +669,7 @@ func (s *Session) discardRestoredCandidate(ownsEnv bool) {
 		// teardown (which RETAINS both scratch dirs for the human handoff), there
 		// is no one left to retain them for: both go, the same decision the
 		// create-path twin of this abort (disposeUnadoptedSubagentSession) makes.
-		releaseOwnedChildEnvironment(s.currentEnv(), ownsEnv, disposeChildScratch)
+		releaseOwnedChildEnvironment(s.currentEnv(), s.ownsEnv, disposeChildScratch)
 		if s.mcpMgr != nil {
 			s.mcpMgr.Close()
 		}

--- a/agent/session_lifecycle_slots_fuzz_test.go
+++ b/agent/session_lifecycle_slots_fuzz_test.go
@@ -316,9 +316,10 @@ func FuzzLcyc_DiscardRestoredCandidate(f *testing.F) {
 			}
 		}
 
+		parent.ownsEnv = true
 		for _, code := range teardown {
 			if code == 0 {
-				parent.discardRestoredCandidate(true)
+				parent.discardRestoredCandidate()
 			} else {
 				parent.Close()
 			}
@@ -327,7 +328,7 @@ func FuzzLcyc_DiscardRestoredCandidate(f *testing.F) {
 			}
 		}
 		// Idempotence: a final round of both must remain a no-op.
-		parent.discardRestoredCandidate(true)
+		parent.discardRestoredCandidate()
 		parent.Close()
 		if st := parent.State(); st != SessionClosed {
 			t.Fatalf("post-idempotence state %q, want %q", st, SessionClosed)

--- a/agent/session_lifecycle_tail_coverage_fuzz_test.go
+++ b/agent/session_lifecycle_tail_coverage_fuzz_test.go
@@ -202,7 +202,8 @@ func FuzzSessionLifecycleTeardownCoverage(f *testing.F) {
 
 		discard := sltcNewSession(t, false, false)
 		discard.mcpMgr = &mcp.Manager{}
-		discard.discardRestoredCandidate(true)
+		discard.ownsEnv = true
+		discard.discardRestoredCandidate()
 
 		parent := sltcNewSession(t, false, false)
 		parent.mcpMgr = &mcp.Manager{}
@@ -211,7 +212,8 @@ func FuzzSessionLifecycleTeardownCoverage(f *testing.F) {
 		child.mu.Lock()
 		child.env = execenv.NewLocalExecutionEnvironment(t.TempDir())
 		child.mu.Unlock()
-		parent.subagents.track(&subagent{id: "owned", sess: child, ownsEnv: true, done: make(chan struct{})})
+		child.ownsEnv = true
+		parent.subagents.track(&subagent{id: "owned", sess: child, done: make(chan struct{})})
 		parent.Close()
 	})
 }

--- a/agent/session_tool_artifacts_test.go
+++ b/agent/session_tool_artifacts_test.go
@@ -459,7 +459,8 @@ func TestSessionArtifactStoreDiscardOwnedRestoredCandidateClosesStore(t *testing
 	if err != nil {
 		t.Fatalf("restore candidate: %v", err)
 	}
-	candidate.discardRestoredCandidate(true)
+	candidate.ownsEnv = true
+	candidate.discardRestoredCandidate()
 	if got := store.closeCount.Load(); got != 1 {
 		t.Fatalf("discard owned candidate close count = %d, want 1", got)
 	}

--- a/agent/session_tools_worktree_dispose.go
+++ b/agent/session_tools_worktree_dispose.go
@@ -204,7 +204,7 @@ func (s *Session) disposeStableDelegateLane(ctx context.Context, id string, forc
 func (s *Session) disposeStableExecute(ctx context.Context, run worktree.GitRunner, state stableDelegateWorktreeSnapshot, lanePath, metaDir string, sub *subagent, lanePresent bool, st worktree.LockState, forceDirty, alreadyClosed bool) (WorktreeDisposeResult, error) {
 	id := state.delegateID
 	if sub != nil && sub.sess != nil {
-		teardownChildSession(ctx, sub.sess, sub.ownsEnv, retainChildScratch)
+		teardownChildSession(ctx, sub.sess, retainChildScratch)
 		s.subagents.removeSession(state.descriptor.ChildSessionID, sub.sess)
 	}
 	lane := isolationLane{delegateID: id, path: lanePath}

--- a/agent/subagent_teardown_unix_test.go
+++ b/agent/subagent_teardown_unix_test.go
@@ -145,7 +145,8 @@ func TestParentCloseReleasesAnOwnedUnsandboxedChildScratchLease(t *testing.T) {
 	if !scratchLeaseHeld(t, scratch) {
 		t.Fatal("the child's scratch lease is not held before the parent closes")
 	}
-	parent.subagents.track(&subagent{id: child.id, sess: child, ownsEnv: true, done: make(chan struct{})})
+	child.ownsEnv = true
+	parent.subagents.track(&subagent{id: child.id, sess: child, done: make(chan struct{})})
 
 	parent.Close()
 
@@ -285,7 +286,8 @@ func TestDisposedLaneChildLeavesTheRootEnvironmentAlone(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(childScratch) })
 	ended := time.Now()
-	root.subagents.track(&subagent{id: "child-" + id, sess: child, ownsEnv: true, status: SubagentFailed, endedAt: &ended, done: make(chan struct{})})
+	child.ownsEnv = true
+	root.subagents.track(&subagent{id: "child-" + id, sess: child, status: SubagentFailed, endedAt: &ended, done: make(chan struct{})})
 	pid, done, release := startInFlightProcess(t, rootLocal)
 	rootScratch := heldParentScratch(t, rootLocal)
 
@@ -340,7 +342,7 @@ func TestControllerCloseRuntimeTreeLeavesTheRootEnvironmentAlone(t *testing.T) {
 	}
 	seedDelegateReclaimRuntimeSession(t, c, "dlg_resident", "", time.Unix(5, 0).UTC(), false, false, resident)
 
-	if err := c.closeRuntimeTree(context.Background(), nil); err != nil {
+	if err := c.closeRuntimeTree(context.Background()); err != nil {
 		t.Fatalf("closeRuntimeTree: %v", err)
 	}
 
@@ -349,6 +351,70 @@ func TestControllerCloseRuntimeTreeLeavesTheRootEnvironmentAlone(t *testing.T) {
 	}
 	assertInFlightProcessSurvived(t, "the controller close", pid, done)
 	assertParentScratchUntouched(t, "the controller close", sharedScratch)
+
+	release()
+	if err := <-done; err != nil {
+		t.Fatalf("the root's process after release: %v", err)
+	}
+}
+
+// A stable delegate's runtime can be resident in the controller's tree while
+// the owner's subagent map never tracked it: the create path attaches the
+// runtime to the controller before the owner adopts the child, so a start that
+// loses to a concurrent stop leaves the controller holding a runtime no map
+// entry names. Such a runtime still owns its clone's scratch, and the root's
+// close of the runtime tree is the only teardown it ever gets: it has to
+// release the lease and keep the directory, like every other child teardown.
+func TestRootCloseReleasesAnUntrackedResidentRuntimeScratchLease(t *testing.T) {
+	c, _ := newDelegateControllerTestHarness(t, 8, 4)
+	shared := execenv.NewLocalExecutionEnvironment(t.TempDir())
+	t.Cleanup(shared.Cleanup)
+	root := &Session{delegateController: c, ownsDelegateController: true, env: shared}
+	c.rootRuntime = root
+	pid, done, release := startInFlightProcess(t, shared)
+	sharedScratch := heldParentScratch(t, shared)
+
+	// The shape prepareSubagentEnvironment builds for a working_dir delegate.
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	childEnv := shared.WithWorkingDirectory(t.TempDir())
+	resident, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), childEnv, SessionConfig{
+		MaxSubagentDepth: 1,
+		testOnly:         testConfig{skipGitSnapshot: true},
+	})
+	if err != nil {
+		t.Fatalf("NewSession on the delegate's clone: %v", err)
+	}
+	resident.ownsEnv = true
+	if _, err := childEnv.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand on the delegate's clone: %v", err)
+	}
+	scratch := childEnv.SessionScratchDir()
+	if scratch == "" {
+		t.Fatal("the resident runtime minted no session scratch, so there is nothing to release")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(scratch) })
+	if !scratchLeaseHeld(t, scratch) {
+		t.Fatal("the resident runtime's scratch lease is not held before the root closes")
+	}
+	// Resident in the tree, and named by no entry in the root's subagent map.
+	seedDelegateReclaimRuntimeSession(t, c, "dlg_untracked", "", time.Unix(5, 0).UTC(), false, false, resident)
+
+	if err := root.closeOwnedDelegateRuntimeTree(context.Background()); err != nil {
+		t.Fatalf("closeOwnedDelegateRuntimeTree: %v", err)
+	}
+
+	if got := resident.State(); got != SessionClosed {
+		t.Errorf("untracked resident runtime state after the root close = %q, want %q", got, SessionClosed)
+	}
+	if _, err := os.Stat(scratch); err != nil {
+		t.Errorf("the root close removed the runtime's scratch %s, want it retained for the handoff: %v", scratch, err)
+	}
+	if scratchLeaseHeld(t, scratch) {
+		t.Errorf("the untracked runtime's scratch %s lease is still held after the root closed", scratch)
+	}
+	assertInFlightProcessSurvived(t, "the root's delegate tree close", pid, done)
+	assertParentScratchUntouched(t, "the root's delegate tree close", sharedScratch)
 
 	release()
 	if err := <-done; err != nil {

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -119,12 +119,6 @@ type subagent struct {
 	// or resume that raced ahead wins and the gate is refused. Reversed on every
 	// pre-eviction dispose refusal/failure exit.
 	disposeGated bool
-	// ownsEnv is true when prepareSubagentRun built the child a FRESH execution env
-	// (a working-dir re-root and/or a per-delegate sandbox) rather than sharing the
-	// parent's. Such an env may own a sandbox scratch dir + file-tool fds that the
-	// parent's env cleanup does not reach. Unadopted setup failures dispose it;
-	// normal teardown retains its scratch until the explicit disposal operation.
-	ownsEnv bool
 }
 
 type preparedSubagentRun struct {
@@ -209,13 +203,15 @@ const (
 // the one an unsandboxed clone minted on its first command — and that is
 // released here, both kinds together, per scratch: retained on a handoff,
 // disposed when the child is dropped. A shared environment is left untouched
-// in every respect: the parent is still working in it.
-func teardownChildSession(ctx context.Context, sess *Session, ownsEnv bool, scratch childScratchDisposition) {
+// in every respect: the parent is still working in it. Which of the two the
+// child runs on is the child's own record (Session.ownsEnv), so a teardown
+// reaching a child no parent bookkeeping names still settles it correctly.
+func teardownChildSession(ctx context.Context, sess *Session, scratch childScratchDisposition) {
 	if sess == nil {
 		return
 	}
 	sess.close(ctx, false)
-	releaseOwnedChildEnvironment(sess.currentEnv(), ownsEnv, scratch)
+	releaseOwnedChildEnvironment(sess.currentEnv(), sess.ownsEnv, scratch)
 }
 
 // releaseOwnedChildEnvironment is teardownChildSession's environment step on
@@ -235,31 +231,18 @@ func releaseOwnedChildEnvironment(env execenv.ExecutionEnvironment, ownsEnv bool
 	}
 }
 
-// ownsChildEnvironment reports whether child, a session this one tracks, runs
-// on an environment built for it (subagent.ownsEnv) rather than on this
-// session's own. A child this session does not track answers false: the safe
-// answer, since a teardown then touches nothing beyond the child's own
-// resources.
-func (s *Session) ownsChildEnvironment(child *Session) bool {
-	if s == nil || s.subagents == nil || child == nil {
-		return false
-	}
-	sub := s.subagents.get(child.id)
-	return sub != nil && sub.sess == child && sub.ownsEnv
-}
-
 // disposeUnadoptedSubagentSession tears down a child that never became a
 // tracked/adopted delegate: the create-path twin of discardRestoredCandidate.
 // No owner is left to hand anything to, so its owned scratch goes with it.
-func disposeUnadoptedSubagentSession(sess *Session, ownsEnv bool) {
-	teardownChildSession(context.Background(), sess, ownsEnv, disposeChildScratch)
+func disposeUnadoptedSubagentSession(sess *Session) {
+	teardownChildSession(context.Background(), sess, disposeChildScratch)
 }
 
 func (p *preparedSubagentRun) disposeUnadopted() {
 	if p == nil || p.sub == nil {
 		return
 	}
-	disposeUnadoptedSubagentSession(p.sub.sess, p.sub.ownsEnv)
+	disposeUnadoptedSubagentSession(p.sub.sess)
 }
 
 func hasString(items []string, want string) bool {
@@ -1023,8 +1006,11 @@ func (s *Session) prepareSubagentRunFromSelection(
 		}
 		return nil, err
 	}
+	// The child owns a fresh env iff we re-rooted to a lane and/or enforced a
+	// per-delegate sandbox; otherwise subEnv is the shared parent env.
+	subSess.ownsEnv = ownsFreshEnv
 	disposeUnadopted := func() {
-		disposeUnadoptedSubagentSession(subSess, ownsFreshEnv)
+		disposeUnadoptedSubagentSession(subSess)
 	}
 	if len(canonicalGrantTools) > 0 {
 		var missing []string
@@ -1087,7 +1073,7 @@ func (s *Session) prepareSubagentRunFromSelection(
 			return nil, err
 		}
 		for _, ev := range evicted {
-			teardownChildSession(context.Background(), ev.sess, ev.ownsEnv, retainChildScratch)
+			teardownChildSession(context.Background(), ev.sess, retainChildScratch)
 		}
 	}
 
@@ -1127,9 +1113,6 @@ func (s *Session) prepareSubagentRunFromSelection(
 		agentType:    agentType,
 		createdAt:    now,
 		startedAt:    now,
-		// The child owns a fresh env iff we re-rooted to a lane and/or enforced a
-		// per-delegate sandbox; otherwise subEnv is the shared parent env.
-		ownsEnv: ownsFreshEnv,
 	}
 	if frozen != nil {
 		descriptor := cloneDelegateStartDescriptor(*frozen)

--- a/agent/subagents_branches_test.go
+++ b/agent/subagents_branches_test.go
@@ -547,7 +547,7 @@ func TestPreparedSubagentRunDisposeUnadoptedNilSub(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestDisposeUnadoptedSubagentSessionNil(t *testing.T) {
-	disposeUnadoptedSubagentSession(nil, false) // should be a no-op
+	disposeUnadoptedSubagentSession(nil) // should be a no-op
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What was wrong

`closeOwnedDelegateRuntimeTree` overrode the stable controller's runtime-tree teardown with `child.close(ctx, false)` and no scratch step. A resident delegate runtime therefore kept its clone's scratch lease — a held flock plus a directory the crashed-scratch sweeper can never reclaim — for the rest of the process's life.

Restoring the controller's own teardown at that call site is not enough. The `ownsEnv` flag `closeRuntimeTree` fed the policy came from the owner's subagent map (`ownsChildEnvironment`), and that map by construction has no entry for the runtime that leaks: the create path calls `AttachRuntime` before `adopt`, so a start that loses to a concurrent stop (`failCommittedStart`, stop-won, not claimed for close) leaves the controller holding a runtime no map entry names. The map-derived answer for such a runtime is `false`, so the child teardown skips the scratch step exactly where it is needed. Verified: swapping the override for the default policy leaves the new test failing on the same message.

The same gap exists in runtime reclamation, which asks `entry.ownerRuntime` — nil whenever the parent delegate is not resident.

## What changed

The fact that decides the scratch step belongs to the child: its execution environment was either built for it (a working-dir re-root and/or a per-delegate box) or shared with its parent. `prepareSubagentRunFromSelection` and the committed-delegate restore now record it on the child `Session` (`Session.ownsEnv`) instead of only on the parent's `subagent` entry, and every teardown reads it from the child — parent close, terminal eviction, reclamation, lane disposal, unadopted disposal, and the controller's runtime-tree close.

That makes three things redundant, so they go: `teardownChildSession`'s `ownsEnv` parameter, `closeRuntimeTree`'s owner-lookup map and its `closeChild` policy parameter, and the root-close override itself. `discardRestoredCandidate` loses its parameter for the same reason. The shared-environment protection is unchanged: a child on its parent's own environment records `ownsEnv` false and its teardown still touches nothing beyond its own resources.

## How it is tested

`TestRootCloseReleasesAnUntrackedResidentRuntimeScratchLease` (`agent/subagent_teardown_unix_test.go`): a stable delegate whose runtime is resident in the tree, on a `WithWorkingDirectory` clone it owns, and named by no entry in the root's subagent map; the root closes its delegate runtime tree; the clone's scratch directory must survive with its lease released, while the root's own in-flight process and scratch lease are untouched.

It failed first on `the untracked runtime's scratch /private/var/.../evener-sandbox-2628359841 lease is still held after the root closed`, both against `main` and against the issue's literal fix shape.

## Gates

- `gofmt -l` on the changed Go files: clean
- `go vet ./...` and `go vet -tags evenerfuzz ./...`: clean
- `make lint-golangci`, `make lint-evenerfuzz lint-eval`: PASS
- `go test -tags evenerfuzz -run Fuzz ./agent/ -count=1`: exit 0, `grep -c FAIL` = 0
- `go test -race ./agent/... -count=1`: exit 0, `grep -c FAIL` = 0 (`agent` 1153s)
- `go test ./agent/ -count=1 -timeout 30m`: exit 0, `grep -c FAIL` = 0

Closes #902

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT