### PR TITLE
fix(plugins): walk doctor's orphan cache under the store lock

### DIFF
--- a/internal/plugins/coverage_atomic_git_fuzz_unix_test.go
+++ b/internal/plugins/coverage_atomic_git_fuzz_unix_test.go
@@ -198,6 +198,19 @@ func coverageLocks(t *testing.T) {
 	if _, err := acquireLock(context.Background(), "x/lock", 0); err == nil {
 		t.Fatal("want open error")
 	}
+	// acquireExistingLock differs only in its open: a lock file that is not
+	// there is not an error, it is a store no writer has ever locked.
+	lockOpenFile = func(string, int, os.FileMode) (lockFile, error) { return nil, os.ErrNotExist }
+	missingRelease, mErr := acquireExistingLock(context.Background(), "x/lock", 0)
+	if mErr != nil {
+		t.Fatalf("absent lock file: %v", mErr)
+	}
+	missingRelease()
+	lockOpenFile = func(string, int, os.FileMode) (lockFile, error) { return nil, boom }
+	if _, err := acquireExistingLock(context.Background(), "x/lock", 0); err == nil {
+		t.Fatal("want existing-lock open error")
+	}
+
 	lockOpenFile = func(string, int, os.FileMode) (lockFile, error) { return &coverageLockFile{}, nil }
 	lockFlock = func(int, int) error { return boom }
 	if _, err := acquireLock(context.Background(), "x/lock", 0); err == nil {

--- a/internal/plugins/coverage_doctor_gc_fuzz_test.go
+++ b/internal/plugins/coverage_doctor_gc_fuzz_test.go
@@ -41,11 +41,11 @@ func FuzzDoctorGCCoverage(f *testing.F) {
 func coverageDoctor(t *testing.T) {
 	origReadDir, origStat := doctorReadDir, doctorStat
 	origCreateTemp, origRemove := doctorCreateTemp, doctorRemove
-	origGitAvailable := doctorGitAvailable
+	origGitAvailable, origAcquireLock := doctorGitAvailable, doctorAcquireLock
 	t.Cleanup(func() {
 		doctorReadDir, doctorStat = origReadDir, origStat
 		doctorCreateTemp, doctorRemove = origCreateTemp, origRemove
-		doctorGitAvailable = origGitAvailable
+		doctorGitAvailable, doctorAcquireLock = origGitAvailable, origAcquireLock
 	})
 
 	root := t.TempDir()
@@ -59,6 +59,26 @@ func coverageDoctor(t *testing.T) {
 	}
 
 	boom := errors.New("boom")
+	// The walk reaches the store lock only once there is a cache directory to
+	// walk, and everything past the lock is stubbed from here on.
+	if err := os.MkdirAll(m.cacheDir(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	doctorAcquireLock = func(context.Context, string, time.Duration) (func(), error) { return nil, boom }
+	if got := m.doctorOrphanCacheDirs(); len(got) != 1 || got[0].Level != LevelWarn {
+		t.Fatalf("held lock findings = %#v", got)
+	}
+	doctorAcquireLock = func(context.Context, string, time.Duration) (func(), error) { return func() {}, nil }
+	if err := os.WriteFile(m.registryPath(), []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.doctorOrphanCacheDirs(); len(got) != 1 || got[0].Level != LevelFail {
+		t.Fatalf("corrupt registry findings = %#v", got)
+	}
+	if err := SaveRegistry(m.registryPath(), reg); err != nil {
+		t.Fatal(err)
+	}
+
 	doctorReadDir = func(path string) ([]os.DirEntry, error) {
 		switch filepath.Base(path) {
 		case "cache":
@@ -69,7 +89,7 @@ func coverageDoctor(t *testing.T) {
 			return nil, boom
 		}
 	}
-	if got := m.doctorOrphanCacheDirs(nil); len(got) != 0 {
+	if got := m.doctorOrphanCacheDirs(); len(got) != 0 {
 		t.Fatalf("market read error findings = %#v", got)
 	}
 
@@ -85,7 +105,7 @@ func coverageDoctor(t *testing.T) {
 			return nil, boom
 		}
 	}
-	if got := m.doctorOrphanCacheDirs(nil); len(got) != 0 {
+	if got := m.doctorOrphanCacheDirs(); len(got) != 0 {
 		t.Fatalf("plugin read error findings = %#v", got)
 	}
 
@@ -101,9 +121,13 @@ func coverageDoctor(t *testing.T) {
 			return nil, boom
 		}
 	}
-	known := map[string]bool{filepath.Join(root, "cache", "market", "plugin", "sha"): true}
-	if got := m.doctorOrphanCacheDirs(known); len(got) != 0 {
-		t.Fatalf("known findings = %#v", got)
+	if err := SaveRegistry(m.registryPath(), Registry{Plugins: map[string][]InstallEntry{
+		"plugin@market": {{InstallPath: filepath.Join(root, "cache", "market", "plugin", "sha"), Source: Source{Kind: SourceGitHub, Repo: "acme/plugin"}}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := m.doctorOrphanCacheDirs(); len(got) != 0 {
+		t.Fatalf("referenced findings = %#v", got)
 	}
 
 	doctorGitAvailable = func() bool { return false }

--- a/internal/plugins/coverage_misc_fuzz_test.go
+++ b/internal/plugins/coverage_misc_fuzz_test.go
@@ -241,7 +241,7 @@ func fuzzGCDoctorEdges(t *testing.T) {
 	if _, err := m.Gc(context.Background()); err == nil {
 		t.Fatal("gc cache file succeeded")
 	}
-	findings := m.doctorOrphanCacheDirs(nil)
+	findings := m.doctorOrphanCacheDirs()
 	if len(findings) != 1 || findings[0].Level != LevelFail {
 		t.Fatalf("orphan findings = %#v", findings)
 	}

--- a/internal/plugins/doctor.go
+++ b/internal/plugins/doctor.go
@@ -23,6 +23,7 @@ var (
 	doctorCreateTemp   = func(dir, pattern string) (doctorTempFile, error) { return os.CreateTemp(dir, pattern) }
 	doctorRemove       = os.Remove
 	doctorGitAvailable = gitAvailable
+	doctorAcquireLock  = acquireLock
 )
 
 // Doctor finding levels.
@@ -45,6 +46,13 @@ const (
 // fetch/pull before doctor flags it as stale. Directory sources have no
 // "pull" and are never flagged for staleness.
 const marketplaceStaleAfter = 30 * 24 * time.Hour
+
+// doctorOrphanLockWait is how long the orphaned-cache-directory walk waits for
+// the store lock. Doctor is a report somebody is sitting in front of, so it
+// does not queue behind the git fetches install, upgrade and marketplace
+// refresh hold that lock across; a lock still busy after this becomes a
+// finding of its own.
+const doctorOrphanLockWait = time.Second
 
 // DoctorFinding is one read-only plugin-store health check result. Level is
 // one of LevelOK, LevelWarn, LevelFail.
@@ -95,7 +103,6 @@ func (m *Manager) Doctor() ([]DoctorFinding, error) {
 	}
 
 	var findings []DoctorFinding
-	knownPaths := map[string]bool{}
 
 	keys := make([]string, 0, len(reg.Plugins))
 	for key := range reg.Plugins {
@@ -107,12 +114,10 @@ func (m *Manager) Doctor() ([]DoctorFinding, error) {
 		if len(entries) == 0 {
 			continue
 		}
-		e := entries[0]
-		knownPaths[filepath.Clean(e.InstallPath)] = true
-		findings = append(findings, m.doctorEntry(key, e)...)
+		findings = append(findings, m.doctorEntry(key, entries[0])...)
 	}
 
-	findings = append(findings, m.doctorOrphanCacheDirs(knownPaths)...)
+	findings = append(findings, m.doctorOrphanCacheDirs()...)
 
 	names := make([]string, 0, len(mk))
 	for name := range mk {
@@ -203,7 +208,43 @@ func sourceCannotUpgrade(src Source) bool {
 // doctorOrphanCacheDirs walks cache/<marketplace>/<plugin>/<sha> and flags any
 // sha-dir that no registry entry's InstallPath points at — left behind by a
 // crash mid-install/upgrade, or a superseded dir awaiting the gc sweep (§12).
-func (m *Manager) doctorOrphanCacheDirs(knownPaths map[string]bool) []DoctorFinding {
+//
+// Alone among Doctor's checks this one draws its conclusion from two pieces of
+// store state, so a writer caught between them invents it: a materialize
+// creates the sha-dir before it records the entry, and gc drops the entry
+// before it removes the dir, and either window makes a live plugin look
+// orphaned. Reading the registry and the cache under the store lock — the lock
+// both of those writers hold — is what makes "has no registry entry" true
+// rather than merely momentary. The registry Doctor's other checks read is the
+// one from before the lock, so this reads its own.
+func (m *Manager) doctorOrphanCacheDirs() []DoctorFinding {
+	// A store with no cache directory has no orphans and no writer to wait
+	// for, and it is asked before the lock because taking the lock creates the
+	// lock file: on a store that does not exist yet, Doctor would be creating
+	// the very thing it is only reporting on.
+	if _, err := doctorStat(m.cacheDir()); errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+
+	release, err := m.acquireStoreLock(context.Background(), doctorAcquireLock, m.lockPath(), doctorOrphanLockWait)
+	if err != nil {
+		return []DoctorFinding{{
+			Level: LevelWarn, Category: catRegistry,
+			Message:     fmt.Sprintf("skipped the check for unreferenced cache directories: %v", err),
+			Remediation: "re-run the check once the plugin operation holding the store lock has finished",
+		}}
+	}
+	defer release()
+
+	reg, err := m.loadRegistry()
+	if err != nil {
+		return []DoctorFinding{{
+			Level: LevelFail, Category: catRegistry,
+			Message: fmt.Sprintf("reading the registry for the unreferenced cache directory check: %v", err),
+		}}
+	}
+	referenced := referencedInstallPaths(reg)
+
 	marketplaceEnts, err := doctorReadDir(m.cacheDir())
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -239,7 +280,7 @@ func (m *Manager) doctorOrphanCacheDirs(knownPaths map[string]bool) []DoctorFind
 					continue
 				}
 				shaPath := filepath.Join(plugPath, shaEnt.Name())
-				if knownPaths[filepath.Clean(shaPath)] {
+				if referenced[filepath.Clean(shaPath)] {
 					continue
 				}
 				findings = append(findings, DoctorFinding{

--- a/internal/plugins/doctor.go
+++ b/internal/plugins/doctor.go
@@ -23,7 +23,7 @@ var (
 	doctorCreateTemp   = func(dir, pattern string) (doctorTempFile, error) { return os.CreateTemp(dir, pattern) }
 	doctorRemove       = os.Remove
 	doctorGitAvailable = gitAvailable
-	doctorAcquireLock  = acquireLock
+	doctorAcquireLock  = acquireExistingLock
 )
 
 // Doctor finding levels.
@@ -218,10 +218,8 @@ func sourceCannotUpgrade(src Source) bool {
 // rather than merely momentary. The registry Doctor's other checks read is the
 // one from before the lock, so this reads its own.
 func (m *Manager) doctorOrphanCacheDirs() []DoctorFinding {
-	// A store with no cache directory has no orphans and no writer to wait
-	// for, and it is asked before the lock because taking the lock creates the
-	// lock file: on a store that does not exist yet, Doctor would be creating
-	// the very thing it is only reporting on.
+	// A store with no cache directory has no orphans to report and no writer
+	// to wait for, so it is answered without going near the lock at all.
 	if _, err := doctorStat(m.cacheDir()); errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}

--- a/internal/plugins/doctor_test.go
+++ b/internal/plugins/doctor_test.go
@@ -124,6 +124,91 @@ func TestDoctor_OrphanCacheDir_NoneWhenReferenced(t *testing.T) {
 	}
 }
 
+// A materialize creates its sha directory before it records the registry
+// entry, and gc drops the entry before it removes the directory, so a walk
+// that runs between either pair calls a live install an orphan. Waiting for
+// the writer is only half of it: the registry the walk compares the cache
+// against has to be the one the writer left, not the one Doctor read on its
+// way in.
+func TestDoctor_OrphanCacheDir_ReadsTheRegistryAMaterializeLeftBehind(t *testing.T) {
+	m := NewManager(t.TempDir())
+	dir := m.pluginCacheDir("acme", "widget", "deadbeef")
+	if err := SaveRegistry(m.registryPath(), Registry{Plugins: map[string][]InstallEntry{}}); err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
+	if err != nil {
+		t.Fatalf("materialize acquire: %v", err)
+	}
+	// The window a materialize leaves open: the directory is on disk and the
+	// registry does not name it yet.
+	writePlugin(t, dir, "widget", nil)
+
+	type report struct {
+		findings []DoctorFinding
+		err      error
+	}
+	reports := make(chan report, 1)
+	go func() {
+		findings, doctorErr := m.Doctor()
+		reports <- report{findings, doctorErr}
+	}()
+
+	// Long enough that a walk which does not wait for the lock has already
+	// made its (wrong) report by the time the entry lands.
+	time.Sleep(200 * time.Millisecond)
+	saveErr := SaveRegistry(m.registryPath(), Registry{Plugins: map[string][]InstallEntry{
+		"widget@acme": {{InstallPath: dir, Version: "1.0.0", Enabled: true, Source: Source{Kind: SourceGitHub, Repo: "acme/widget"}}},
+	}})
+	release()
+	if saveErr != nil {
+		t.Fatal(saveErr)
+	}
+
+	got := <-reports
+	if got.err != nil {
+		t.Fatalf("Doctor: %v", got.err)
+	}
+	if hasFinding(got.findings, "orphaned cache directory") {
+		t.Errorf("a materialize in flight was reported as an orphan: %+v", got.findings)
+	}
+}
+
+// A writer that holds the store lock for longer than the walk is willing to
+// wait is exactly the writer whose half-finished work the walk would
+// misreport, so the report says the check was skipped rather than guessing at
+// it.
+func TestDoctor_OrphanCacheDir_ReportsAHeldStoreLockInsteadOfGuessing(t *testing.T) {
+	m := NewManager(t.TempDir())
+	dir := m.pluginCacheDir("acme", "widget", "deadbeef")
+	writePlugin(t, dir, "widget", nil)
+	if err := SaveRegistry(m.registryPath(), Registry{Plugins: map[string][]InstallEntry{}}); err != nil {
+		t.Fatal(err)
+	}
+
+	release, err := acquireLock(context.Background(), m.lockPath(), time.Second)
+	if err != nil {
+		t.Fatalf("writer acquire: %v", err)
+	}
+	defer release()
+
+	findings, err := m.Doctor()
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if hasFinding(findings, "orphaned cache directory") {
+		t.Errorf("orphan claimed while a writer holds the store lock: %+v", findings)
+	}
+	f := findFinding(t, findings, "unreferenced cache directories")
+	if f.Level != LevelWarn {
+		t.Errorf("skipped check level = %s, want %s", f.Level, LevelWarn)
+	}
+	if f.Remediation == "" {
+		t.Error("skipped check has no remediation")
+	}
+}
+
 func TestDoctor_VersionMismatchWarns(t *testing.T) {
 	m := NewManager(t.TempDir())
 	dir := filepath.Join(t.TempDir(), "widget")

--- a/internal/plugins/doctor_test.go
+++ b/internal/plugins/doctor_test.go
@@ -209,6 +209,57 @@ func TestDoctor_OrphanCacheDir_ReportsAHeldStoreLockInsteadOfGuessing(t *testing
 	}
 }
 
+// storeTree is every path under root, relative and sorted: what a read-only
+// verb has to hand back untouched.
+func storeTree(t *testing.T, root string) []string {
+	t.Helper()
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, _ fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		paths = append(paths, rel)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	slices.Sort(paths)
+	return paths
+}
+
+// The store lock is a file the writers create, so waiting on it the way they
+// take it would leave one behind in a store that has never had a writer —
+// a mutation from the one verb that promises to make none. Such a store also
+// has nobody to wait for, so the walk still answers.
+func TestDoctor_OrphanCacheDir_LeavesAStoreWithNoLockFileAlone(t *testing.T) {
+	m := NewManager(t.TempDir())
+	orphan := m.pluginCacheDir("acme", "widget", "deadbeef")
+	writePlugin(t, orphan, "widget", nil)
+	if err := SaveRegistry(m.registryPath(), Registry{Plugins: map[string][]InstallEntry{}}); err != nil {
+		t.Fatal(err)
+	}
+	before := storeTree(t, m.Root)
+
+	findings, err := m.Doctor()
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if f := findFinding(t, findings, orphan); f.Level != LevelWarn {
+		t.Errorf("orphan cache dir level = %s, want %s", f.Level, LevelWarn)
+	}
+	if _, statErr := os.Stat(m.lockPath()); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("Doctor created the store lock %s (stat err = %v)", m.lockPath(), statErr)
+	}
+	if after := storeTree(t, m.Root); !slices.Equal(before, after) {
+		t.Errorf("Doctor changed the store\nbefore = %v\nafter  = %v", before, after)
+	}
+}
+
 func TestDoctor_VersionMismatchWarns(t *testing.T) {
 	m := NewManager(t.TempDir())
 	dir := filepath.Join(t.TempDir(), "widget")

--- a/internal/plugins/doctor_unix_test.go
+++ b/internal/plugins/doctor_unix_test.go
@@ -1,0 +1,44 @@
+//go:build unix
+
+package plugins
+
+import (
+	"os"
+	"testing"
+)
+
+// A store the running user may read but not write — root-owned, or on a
+// read-only mount — still has an answer to give: the walk waits on the lock
+// file, it never writes to it. Opening the lock for writing turned such a
+// store's orphan report into a lock complaint whose remediation would never
+// come true, where an unlocked walk reported the orphans fine.
+func TestDoctor_OrphanCacheDir_WalksAStoreWithAReadOnlyLockFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a mode that denies write still opens for writing")
+	}
+	m := NewManager(t.TempDir())
+	orphan := m.pluginCacheDir("acme", "widget", "deadbeef")
+	writePlugin(t, orphan, "widget", nil)
+	if err := SaveRegistry(m.registryPath(), Registry{Plugins: map[string][]InstallEntry{}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(m.lockPath(), nil, 0o444); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chmod(m.lockPath(), 0o644); err != nil {
+			t.Error(err)
+		}
+	})
+
+	findings, err := m.Doctor()
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if f := findFinding(t, findings, orphan); f.Level != LevelWarn {
+		t.Errorf("orphan cache dir level = %s, want %s", f.Level, LevelWarn)
+	}
+	if hasFinding(findings, "unreferenced cache directories") {
+		t.Errorf("a lock file that denies writes was reported as contention: %+v", findings)
+	}
+}

--- a/internal/plugins/gc.go
+++ b/internal/plugins/gc.go
@@ -17,6 +17,21 @@ var (
 	gcRemoveAll   = os.RemoveAll
 )
 
+// referencedInstallPaths is the set of materialized directories the registry
+// names — the ones that are live rather than orphaned. Gc removes what is not
+// in it and Doctor reports what is not in it, and the two have to agree: a
+// directory Doctor calls orphaned that Gc would keep sends the user to a
+// command that does nothing.
+func referencedInstallPaths(reg Registry) map[string]bool {
+	referenced := make(map[string]bool, len(reg.Plugins))
+	for _, entries := range reg.Plugins {
+		for _, e := range entries {
+			referenced[filepath.Clean(e.InstallPath)] = true
+		}
+	}
+	return referenced
+}
+
 // Gc sweeps cacheDir() (cache/<marketplace>/<plugin>/<sha>/) for materialized
 // plugin dirs that no registry entry's InstallPath references, and removes
 // them. It returns the removed paths.
@@ -41,12 +56,7 @@ func (m *Manager) Gc(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	referenced := make(map[string]bool, len(reg.Plugins))
-	for _, entries := range reg.Plugins {
-		for _, e := range entries {
-			referenced[filepath.Clean(e.InstallPath)] = true
-		}
-	}
+	referenced := referencedInstallPaths(reg)
 
 	marketplaceEntries, err := gcReadDir(m.cacheDir())
 	if err != nil {

--- a/internal/plugins/locks.go
+++ b/internal/plugins/locks.go
@@ -80,20 +80,29 @@ func acquireLock(ctx context.Context, lockPath string, timeout time.Duration) (f
 	return flockUntil(ctx, f, lockPath, timeout)
 }
 
-// acquireExistingLock is acquireLock without the O_CREATE: it waits on a lock
-// file that is already there and, when there is none, hands back a release
-// that does nothing.
+// acquireExistingLock waits on a lock file that is already there, opening it
+// read-only, and hands back a release that does nothing when there is none.
+// Both differences from acquireLock make the same point: waiting on a lock is
+// not a write.
 //
-// Doctor's orphaned-cache walk reads under the lock rather than writing, and
-// creating the lock file is a write — the one mutation a read-only verb would
-// leave behind in a store that already exists. It can walk unlocked when there
-// is no lock file, because the writers create theirs before they touch
-// anything else: no lock file means no writer has ever locked this store, so
-// nothing can be materializing or collecting under the walk. (In a real store
-// the case cannot arise at all: the cache directory the walk is there to read
-// was created by a writer, which created the lock file first.)
+// Doctor's orphaned-cache walk reads under the lock, so acquireLock's O_CREATE
+// would leave a lock file behind in a store that has none — the one mutation a
+// read-only verb would make in a store that already exists. The read-only open
+// is the other half: flock is granted on a descriptor opened either way, so
+// asking for write access only turned a store the caller may read but not
+// write (root-owned, or a read-only mount) into a lock complaint where an
+// unlocked walk had reported its orphans fine.
+//
+// Walking unlocked when there is no lock file is safe because the writers
+// create theirs before they touch anything else: no lock file means no writer
+// has ever locked this store. In a real store the case cannot arise at all —
+// the cache directory the walk is there to read was made by a writer, which
+// created the lock file first. The window that is left needs the lock file
+// deleted out of band and a writer recreating it in the moment after this open
+// failed, which leaves the walk exactly where every walk was before it took a
+// lock at all.
 func acquireExistingLock(ctx context.Context, lockPath string, timeout time.Duration) (func(), error) {
-	f, err := lockOpenFile(lockPath, os.O_RDWR, 0)
+	f, err := lockOpenFile(lockPath, os.O_RDONLY, 0)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return func() {}, nil

--- a/internal/plugins/locks.go
+++ b/internal/plugins/locks.go
@@ -2,7 +2,9 @@ package plugins
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"time"
@@ -75,6 +77,36 @@ func acquireLock(ctx context.Context, lockPath string, timeout time.Duration) (f
 	if err != nil {
 		return nil, fmt.Errorf("opening lock %s: %w", lockPath, err)
 	}
+	return flockUntil(ctx, f, lockPath, timeout)
+}
+
+// acquireExistingLock is acquireLock without the O_CREATE: it waits on a lock
+// file that is already there and, when there is none, hands back a release
+// that does nothing.
+//
+// Doctor's orphaned-cache walk reads under the lock rather than writing, and
+// creating the lock file is a write — the one mutation a read-only verb would
+// leave behind in a store that already exists. It can walk unlocked when there
+// is no lock file, because the writers create theirs before they touch
+// anything else: no lock file means no writer has ever locked this store, so
+// nothing can be materializing or collecting under the walk. (In a real store
+// the case cannot arise at all: the cache directory the walk is there to read
+// was created by a writer, which created the lock file first.)
+func acquireExistingLock(ctx context.Context, lockPath string, timeout time.Duration) (func(), error) {
+	f, err := lockOpenFile(lockPath, os.O_RDWR, 0)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return func() {}, nil
+		}
+		return nil, fmt.Errorf("opening lock %s: %w", lockPath, err)
+	}
+	return flockUntil(ctx, f, lockPath, timeout)
+}
+
+// flockUntil is the wait both acquires share: retry the exclusive flock on an
+// already-open lock file until it is granted, ctx is canceled, or timeout
+// elapses.
+func flockUntil(ctx context.Context, f lockFile, lockPath string, timeout time.Duration) (func(), error) {
 	deadline := lockNow().Add(timeout)
 	backoff := 10 * time.Millisecond
 	for {

--- a/internal/plugins/paths.go
+++ b/internal/plugins/paths.go
@@ -63,8 +63,8 @@ const (
 // cache, marketplace and plugin directories in install, gc and the marketplace
 // verbs); past Doctor's own refusal (the cache directory and the lock file the
 // orphaned-cache walk names on its way to that lock); or in a test naming a
-// path to plant a file at. A new caller
-// that fits none of those derives here instead.
+// path to plant a file at. A new caller that fits none of those derives here
+// instead.
 func (m *Manager) storePath(parts ...string) (string, error) {
 	if err := m.storeRootError(); err != nil {
 		return "", err

--- a/internal/plugins/paths.go
+++ b/internal/plugins/paths.go
@@ -61,8 +61,9 @@ const (
 // is that each is only reached once the root is known to be usable: under the
 // store lock, which acquireStoreLock would not have granted otherwise (the
 // cache, marketplace and plugin directories in install, gc and the marketplace
-// verbs); past Doctor's own refusal (doctorOrphanCacheDirs walks cacheDir with
-// no lock at all); or in a test naming a path to plant a file at. A new caller
+// verbs); past Doctor's own refusal (the cache directory and the lock file the
+// orphaned-cache walk names on its way to that lock); or in a test naming a
+// path to plant a file at. A new caller
 // that fits none of those derives here instead.
 func (m *Manager) storePath(parts ...string) (string, error) {
 	if err := m.storeRootError(); err != nil {


### PR DESCRIPTION
## What was wrong

`Manager.Doctor`'s orphaned-cache-directory check is the only finding it draws from two pieces of store state at once: the install paths `installed_plugins.json` names, and the directories under `cache/<marketplace>/<plugin>/<sha>`. Every writer that changes either one holds the store lock; the walk held nothing (`paths.go` said so out loud). A materialize creates its sha directory before it records the entry, and `Gc` drops the entry before it removes the directory, so a walk that lands in either window reports a live plugin as an orphan and sends the user to a `gc` that will not touch it.

## The choice, and why

**Take the lock**, not "mark the finding best-effort". Doctor had no locked checks at all, so there was no existing bounded wait to copy; the wait is a new judgement call. Two things decided it:

- Hedging the prose does not make the report right, and a hedge is not testable as behaviour — it is a string. Locking makes "has no registry entry" true rather than merely momentary.
- Locking alone would not have fixed it either. The walk has to re-read the registry *under* the lock: the snapshot Doctor's other checks share is from before the wait, so a materialize that finishes while the walk waits would still be missing from it. That is why `doctorOrphanCacheDirs` loads the registry itself instead of taking a `knownPaths` map from `Doctor`.

The wait is one second, not the thirty seconds every mutation takes. Doctor is a report somebody is sitting in front of, and install/upgrade/marketplace-refresh hold that lock across git fetches; queuing behind one is worse than saying so. A lock still held after a second becomes a `WARN` finding naming the contention, in the same `registry` category, with a remediation.

## Waiting on a lock is not a write

Doctor is documented read-only, so it takes the lock through `acquireExistingLock` rather than the writers' `acquireLock`. Two differences, one point:

- **No `O_CREATE`.** `acquireLock` creates the lock file it waits on, which would leave a `.lock` behind in a store that has none — a mutation of an existing store from the one verb that promises to make none.
- **`O_RDONLY`.** `flock` is granted on a descriptor opened either way, and a read-only holder still excludes a read-write one. Asking for write access only broke stores the caller may read and not write (root-owned, or a read-only mount), turning their orphan report into a lock complaint whose remediation would never come true.

When the lock file does not exist the walk runs unlocked with a no-op release: writers create their lock file before they touch anything else, so no lock file means no writer has ever locked this store. In a real store the case cannot arise at all, since the cache directory the walk reads was made by a writer that created the lock file first. The window that remains needs the lock file deleted out of band and a writer recreating it in the moment after the failed open, which leaves the walk exactly where every walk was before it took a lock at all.

The lock is only reached once the cache directory exists — a store with no cache has no orphans and nobody to wait for, so it is answered without going near the lock.

## What changed

- `internal/plugins/doctor.go` — `doctorOrphanCacheDirs` takes the store lock for `doctorOrphanLockWait` (1s) through `acquireStoreLock`, loads the registry under it, and reports a lock it cannot get as a `WARN` finding instead of walking anyway.
- `internal/plugins/locks.go` — `acquireExistingLock` (no `O_CREATE`, `O_RDONLY`, no-op release when the file is absent). The two acquires now share the retry loop as `flockUntil`; the writers' acquire is otherwise untouched.
- `internal/plugins/gc.go` — `referencedInstallPaths` extracted from `Gc` and shared with the walk. `Gc` removes what is not in that set and Doctor reports what is not in it; they have to agree, or the finding's remediation is a no-op. Note that the shared set counts every entry under a registry key, matching `Gc`, where Doctor's own per-plugin loop looks at `entries[0]`; writers only ever store one entry per key, so nothing diverges today.
- `internal/plugins/paths.go` — the note that the walk runs "with no lock at all" is no longer true.
- The `evenerfuzz` coverage harnesses follow the signature, stub `doctorAcquireLock` for the contention and registry-read branches, and cover `acquireExistingLock`'s two open outcomes.

## How it is tested

Four tests, each watched failing first:

- `TestDoctor_OrphanCacheDir_ReadsTheRegistryAMaterializeLeftBehind` — a real `flock` holder stands in for a materialize: the sha directory is on disk, the registry does not name it, and the entry lands just before the lock is released. Failed with `a materialize in flight was reported as an orphan: [{Level:WARN ... orphaned cache directory .../cache/acme/widget/deadbeef has no registry entry ...}]`.
- `TestDoctor_OrphanCacheDir_ReportsAHeldStoreLockInsteadOfGuessing` — the holder keeps the lock past the wait. Failed on `orphan claimed while a writer holds the store lock`, then `no finding contains "unreferenced cache directories"`.
- `TestDoctor_OrphanCacheDir_LeavesAStoreWithNoLockFileAlone` — snapshots the store's whole file list around the call. Failed on `Doctor created the store lock .../001/.lock (stat err = <nil>)` and on the tree diff showing the added `.lock`.
- `TestDoctor_OrphanCacheDir_WalksAStoreWithAReadOnlyLockFile` (unix, skipped as root) — a `0444` lock file. Failed on `no finding contains ".../cache/acme/widget/deadbeef"`, the report carrying `skipped the check for unreferenced cache directories: ... permission denied` instead.

All four use the real lock, not a stub. The existing `TestDoctor_OrphanCacheDir` and `TestDoctor_OrphanCacheDir_NoneWhenReferenced` still pass on a quiet store.

## Gates

- `gofmt -l` on the changed files: clean.
- `go vet ./...` and `go vet -tags evenerfuzz ./...`: clean.
- `make lint-golangci`: PASS. `make lint-evenerfuzz`: PASS.
- `go test -race ./internal/plugins/... -count=1`: ok, 0 FAIL.
- `go test -tags evenerfuzz -run Fuzz ./internal/plugins/ -count=1` (seed replay): ok, 0 FAIL.
- `go test ./cmd/evener-doctor/ -count=1` and the plugin CLI tests in `./cmd/evener/`: ok, 0 FAIL. `agent/` untouched.

Closes #899

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT