### PR TITLE
test(execenv): await the signalled child instead of racing the grace

### DIFF
--- a/agent/execenv/sandbox_lifecycle_test.go
+++ b/agent/execenv/sandbox_lifecycle_test.go
@@ -9,11 +9,18 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"primeradiant.com/evener/agent/sandbox"
 )
+
+// TRIPWIRE: every real process this file spawns does milliseconds of work — a
+// shell writing one file, or a signalled child running a trap that stats one
+// directory. A ceiling this generous fires only when a process wedges, never
+// because the runner is loaded.
+const processTripwire = 30 * time.Second
 
 // TestEnableSandboxProvisionsSeatbeltBackend: EnableSandbox provisions the kernel
 // wrapper for whichever backend resolved — bubblewrap on Linux, sandbox-exec
@@ -236,6 +243,12 @@ func TestCleanupRetainsOwnedTmpAfterChildGrace(t *testing.T) {
 	}
 	env := NewLocalExecutionEnvironment(dir)
 	env.ownedSessionTmp = tmp
+	// Cleanup escalates to SIGKILL a fixed grace after the SIGTERM, so a child
+	// the host has not scheduled by then dies before its trap can record what it
+	// saw. Awaiting the exit inside Terminate holds the escalation behind the
+	// child's own shutdown, leaving the ordering in Cleanup as the only thing the
+	// sentinel below can be reporting on.
+	env.commandFactory = awaitedTerminationFactory{}
 	sentinel := filepath.Join(dir, "tmp-was-present")
 	ready := filepath.Join(dir, "trap-installed")
 
@@ -252,19 +265,37 @@ sleep 300 & wait`
 		t.Fatalf("StreamCommand: %v", err)
 	}
 
-	deadline := time.Now().Add(5 * time.Second)
+	// The awaited Terminate blocks Cleanup until the child exits, and the child is
+	// reaped only here, so the reaper has to be running before Cleanup is called.
+	exited := make(chan int, 1)
+	go func() {
+		code, _ := h.Wait()
+		exited <- code
+	}()
+
+	readyBy := time.Now().Add(processTripwire)
 	for {
 		if _, err := os.Stat(ready); err == nil {
 			break
 		}
-		if time.Now().After(deadline) {
+		if time.Now().After(readyBy) {
 			t.Fatal("child never signaled trap readiness")
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
 
 	env.Cleanup()
-	_, _ = h.Wait()
+
+	select {
+	case code := <-exited:
+		// The trap ends in `exit 0`; anything else means the child died on a signal
+		// with its handler unfinished, which says nothing about the tmp's lifetime.
+		if code != 0 {
+			t.Fatalf("child exited %d instead of completing its TERM trap, so its observation of the owned tmp never happened", code)
+		}
+	case <-time.After(processTripwire):
+		t.Fatal("child never exited after Cleanup's SIGTERM/grace/SIGKILL sequence")
+	}
 
 	if _, err := os.Stat(sentinel); err != nil {
 		t.Fatalf("Cleanup disposed the owned tmp before signaling the child (TMPDIR pulled out from under graceful shutdown): sentinel missing, stat err = %v", err)
@@ -277,6 +308,48 @@ sleep 300 & wait`
 	}
 	if _, err := os.Stat(tmp.Dir); !os.IsNotExist(err) {
 		t.Errorf("manual scratch cleanup must remove the owned tmp, stat err = %v", err)
+	}
+}
+
+// awaitedTerminationFactory hands out real shell runtimes whose Terminate
+// returns only once the signalled child has exited. A test that needs to see
+// what a child did while it was shutting down installs it so Cleanup's SIGKILL
+// escalation cannot land mid-shutdown on a loaded host.
+type awaitedTerminationFactory struct{}
+
+func (awaitedTerminationFactory) Shell(command string) commandRuntime {
+	return &awaitedTerminationRuntime{
+		commandRuntime: systemCommandRuntimeFactory{}.Shell(command),
+		exited:         make(chan struct{}),
+	}
+}
+
+func (awaitedTerminationFactory) Argv(name string, args ...string) commandRuntime {
+	return systemCommandRuntimeFactory{}.Argv(name, args...)
+}
+
+type awaitedTerminationRuntime struct {
+	commandRuntime
+	exited chan struct{}
+	once   sync.Once
+}
+
+func (r *awaitedTerminationRuntime) Wait() error {
+	err := r.commandRuntime.Wait()
+	r.once.Do(func() { close(r.exited) })
+	return err
+}
+
+// Terminate signals as the system runtime does, then waits out the child's
+// shutdown. The reaper (StreamHandle.Wait) has to be running on another
+// goroutine for the exit to be observed here.
+func (r *awaitedTerminationRuntime) Terminate() {
+	r.commandRuntime.Terminate()
+	timer := time.NewTimer(processTripwire)
+	defer timer.Stop()
+	select {
+	case <-r.exited:
+	case <-timer.C:
 	}
 }
 
@@ -602,7 +675,7 @@ func wrapperConfinedEnvAt(t *testing.T, worktree string) *LocalExecutionEnvironm
 // write beside it: the two must name the same directory.
 func assertFileToolsShareTheShellScratch(t *testing.T, env *LocalExecutionEnvironment) {
 	t.Helper()
-	if _, err := env.ExecCommand(context.Background(), `printf shell > "$EVENER_SCRATCH_DIR/probe"`, 5000, "", nil); err != nil {
+	if _, err := env.ExecCommand(context.Background(), `printf shell > "$EVENER_SCRATCH_DIR/probe"`, int(processTripwire.Milliseconds()), "", nil); err != nil {
 		t.Fatalf("shell write into the scratch: %v", err)
 	}
 	scratch := env.SessionScratchDir()
@@ -789,7 +862,7 @@ func TestAdoptSessionScratchRetiresTheSourcesFileToolLayers(t *testing.T) {
 		"unsandboxed": func(t *testing.T, worktree string) *LocalExecutionEnvironment {
 			env := NewLocalExecutionEnvironment(worktree)
 			t.Cleanup(func() { env.Cleanup(); env.DisposeUnadoptedScratch() })
-			if _, err := env.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+			if _, err := env.ExecCommand(context.Background(), "true", int(processTripwire.Milliseconds()), "", nil); err != nil {
 				t.Fatalf("ExecCommand: %v", err)
 			}
 			return env
@@ -841,7 +914,7 @@ func TestScratchSandboxForDoesNotInstallALayerForARootMovedAway(t *testing.T) {
 	}
 	owner := NewLocalExecutionEnvironment(t.TempDir())
 	t.Cleanup(func() { owner.Cleanup(); owner.DisposeUnadoptedScratch() })
-	if _, err := owner.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+	if _, err := owner.ExecCommand(context.Background(), "true", int(processTripwire.Milliseconds()), "", nil); err != nil {
 		t.Fatalf("ExecCommand: %v", err)
 	}
 	scratch := owner.SessionScratchDir()


### PR DESCRIPTION
## What was wrong

**The grace race.** `TestCleanupRetainsOwnedTmpAfterChildGrace` has a real bash child record, in its SIGTERM trap, whether the owned session tmp still exists, and then reads the sentinel back. `Cleanup` escalates to SIGKILL a fixed grace after the signal — 200ms for the whole test binary, since `grace_test.go` shrinks `terminateGrace` package-wide. A runner that leaves the child unscheduled for that long kills it mid-trap, so the sentinel never lands and the test reports `Cleanup disposed the owned tmp before signaling the child` for a disposal that never happened. That is the message both CI failures carried. Nothing in the test awaited the child; it raced a production timer against the host scheduler.

**The spawn caps.** The readiness poll and three real command spawns in the same file were bounded at 5s of wall clock. A spawn that is merely slow under load then fails a test whose code is correct.

## What changed (test-only)

- `env.commandFactory` gets `awaitedTerminationFactory`: real shell runtimes whose `Terminate` signals as the system runtime does and then returns only once the child has exited. Cleanup's SIGKILL escalation now sits behind the child's own shutdown, so the sentinel reports on the ordering inside `Cleanup` and nothing else. This is the awaited completion the testing doctrine asks for (process exit), not a widened deadline.
- The test asserts the child's exit code before reading the sentinel, so a child that dies on a signal with its handler unfinished is reported as that instead of as a disposal.
- One named `processTripwire` (30s) replaces the readiness deadline and the three `5000`ms `ExecCommand` caps. `ExecCommand` already awaits the process result; the parameter is a ceiling, so it is now a tripwire that fires when a spawn wedges rather than a budget a loaded host can blow.

No production code changed.

## How it is tested

Forced interleavings, both directions:

| forcing | old | new |
| --- | --- | --- |
| `sleep 0.5` ahead of the trap body (child slower than the grace) | FAIL 3/3, `sentinel missing, stat err = ... no such file or directory` | PASS 5/5 |
| `sleep 6` ahead of each probe spawn | FAIL, all five affected tests, `shell write into the scratch: context deadline exceeded` / `ExecCommand: context deadline exceeded` | PASS |
| `WATCH` pointed at a directory that does not exist (the real regression) | n/a | FAIL on the disposal message — the assertion keeps its teeth |

## Gates

- `gofmt -l` on the changed file: clean.
- `go vet ./...` and `go vet -tags evenerfuzz ./...`: clean.
- `make lint-golangci`: PASS (107s).
- `go test -race ./agent/execenv/... -count=1`: ok, 0 FAIL (`/tmp/896-race-execenv.log`).
- `go test -tags evenerfuzz -run Fuzz ./agent/execenv/ -count=1`: ok, 0 FAIL.
- `go test ./agent/ -count=1 -timeout 30m`: `ok primeradiant.com/evener/agent 703.754s`, 0 FAIL (`/tmp/896-full.log`).
- Stability under real load: the four affected tests `-count=20` while the host sat at load average 136 (concurrent full-suite runs from other worktrees) — 20/20 pass.

Closes #896

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
