### PR TITLE
Pin the scratch move's mid-flight interval

### DIFF
--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -189,6 +189,25 @@ type LocalExecutionEnvironment struct {
 	// (AdoptSessionScratch).
 	unsandboxedScratch       *sandbox.SessionScratch
 	unsandboxedScratchFailed bool
+
+	// scratchMovedOut, when non-nil, runs on the SOURCE of a scratch move
+	// (AdoptSessionScratch) at the point its two fields have been taken and the
+	// target has not yet installed them — the interval in which a command
+	// spawned on this env finds it owning nothing and mints a fresh scratch. It
+	// is an instance-local test seam, set through
+	// ObserveScratchMoveWindowForTesting, so a test can drive that interleaving
+	// deterministically instead of racing for it; nil in production, and not
+	// copied by either clone path.
+	scratchMovedOut func()
+}
+
+// ObserveScratchMoveWindowForTesting installs fn as this environment's
+// scratch-move window observer (scratchMovedOut). It is exported because what
+// the window costs is settled by a SESSION's close, which lives in another
+// package and cannot reach the field. Install it before the move it observes;
+// changing it while one is in flight is not safe.
+func (e *LocalExecutionEnvironment) ObserveScratchMoveWindowForTesting(fn func()) {
+	e.scratchMovedOut = fn
 }
 
 // sandbox returns the environment's fd-anchored enforcement layer, or nil when
@@ -801,10 +820,25 @@ func (e *LocalExecutionEnvironment) AdoptSessionScratch(from *LocalExecutionEnvi
 	// The two envs' locks are never held together, so swaps in opposite
 	// directions cannot deadlock; whatever this env keeps is retained after
 	// both are released.
+	//
+	// Between the two, `from` owns nothing, and a command a child sharing it
+	// spawns there mints a scratch this move never sees. That interval needs no
+	// bookkeeping of its own: its outcome is the one a spawn landing just AFTER
+	// the move produces, which is how an emptied source already behaves, and
+	// what accounts for the scratch is the ENVIRONMENT, not the move. A session
+	// keeps every environment it swapped away from within its close's reach
+	// (worktreeRestoreEnv or abandonedEnvs, both recorded under the install's
+	// own lock hold and fenced against close), and that is what releases the
+	// lease. A "moving" flag making the mint wait would change no outcome, and
+	// it would put a blocking wait in commandEnvironment's overlay, which every
+	// spawn on every environment goes through.
 	from.scratchMu.Lock()
 	owned, unsandboxed := from.ownedSessionTmp, from.unsandboxedScratch
 	from.ownedSessionTmp, from.unsandboxedScratch = nil, nil
 	from.scratchMu.Unlock()
+	if window := from.scratchMovedOut; window != nil {
+		window()
+	}
 	e.scratchMu.Lock()
 	if e.ownedSessionTmp == nil {
 		e.ownedSessionTmp, owned = owned, nil

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -196,18 +196,25 @@ type LocalExecutionEnvironment struct {
 	// spawned on this env finds it owning nothing and mints a fresh scratch. It
 	// is an instance-local test seam, set through
 	// ObserveScratchMoveWindowForTesting, so a test can drive that interleaving
-	// deterministically instead of racing for it; nil in production, and not
-	// copied by either clone path.
+	// deterministically instead of racing for it. Guarded by scratchMu like the
+	// two fields above; nil in production, and not copied by either clone path.
 	scratchMovedOut func()
 }
 
 // ObserveScratchMoveWindowForTesting installs fn as this environment's
-// scratch-move window observer (scratchMovedOut). It is exported because what
-// the window costs is settled by a SESSION's close, which lives in another
-// package and cannot reach the field. Install it before the move it observes;
-// changing it while one is in flight is not safe.
-func (e *LocalExecutionEnvironment) ObserveScratchMoveWindowForTesting(fn func()) {
+// scratch-move window observer (scratchMovedOut), returning a restore func. It
+// is exported because what the window costs is settled by a SESSION's close,
+// which lives in another package and cannot reach the field.
+func (e *LocalExecutionEnvironment) ObserveScratchMoveWindowForTesting(fn func()) (restore func()) {
+	e.scratchMu.Lock()
+	defer e.scratchMu.Unlock()
+	orig := e.scratchMovedOut
 	e.scratchMovedOut = fn
+	return func() {
+		e.scratchMu.Lock()
+		defer e.scratchMu.Unlock()
+		e.scratchMovedOut = orig
+	}
 }
 
 // sandbox returns the environment's fd-anchored enforcement layer, or nil when
@@ -824,19 +831,27 @@ func (e *LocalExecutionEnvironment) AdoptSessionScratch(from *LocalExecutionEnvi
 	// Between the two, `from` owns nothing, and a command a child sharing it
 	// spawns there mints a scratch this move never sees. That interval needs no
 	// bookkeeping of its own: its outcome is the one a spawn landing just AFTER
-	// the move produces, which is how an emptied source already behaves, and
-	// what accounts for the scratch is the ENVIRONMENT, not the move. A session
-	// keeps every environment it swapped away from within its close's reach
-	// (worktreeRestoreEnv or abandonedEnvs, both recorded under the install's
-	// own lock hold and fenced against close), and that is what releases the
-	// lease. A "moving" flag making the mint wait would change no outcome, and
-	// it would put a blocking wait in commandEnvironment's overlay, which every
-	// spawn on every environment goes through.
+	// the move produces, which is how an emptied source already behaves. The
+	// one thing it does not reproduce is timing, not outcome — the source's
+	// invalidateSandboxFS below runs after the interval, so a layer the mint
+	// had just built is retired where the later ordering would have kept it,
+	// costing one lazy rebuild and nothing else.
+	//
+	// What accounts for the scratch is the ENVIRONMENT, not the move. A session
+	// keeps every environment it swapped away from within its close's reach:
+	// worktreeRestoreEnv or abandonedEnvs, and swapEnvAndRefresh writes the
+	// install and BOTH records under one s.mu hold, which close reads under the
+	// same lock — so a close can never observe an installed target without the
+	// source recorded. That record is what releases the lease. A "moving" flag
+	// making the mint wait would change no outcome, and it would put a blocking
+	// wait in commandEnvironment's overlay, which every spawn on every
+	// environment goes through.
 	from.scratchMu.Lock()
 	owned, unsandboxed := from.ownedSessionTmp, from.unsandboxedScratch
 	from.ownedSessionTmp, from.unsandboxedScratch = nil, nil
+	window := from.scratchMovedOut
 	from.scratchMu.Unlock()
-	if window := from.scratchMovedOut; window != nil {
+	if window != nil {
 		window()
 	}
 	e.scratchMu.Lock()

--- a/agent/session_worktree_swap_scratch_unix_test.go
+++ b/agent/session_worktree_swap_scratch_unix_test.go
@@ -449,6 +449,127 @@ func TestWorktreeSwap_CloseAfterTheEnterRetainsTheParkedEnvironmentScratch(t *te
 	}
 }
 
+// armMidMoveMint has env run one command inside the interval of the next
+// scratch move that empties it — what a child sharing the object does when it
+// finds no scratch there — and returns where to read the scratch that command
+// minted. Empty after the move means the interval was never entered.
+func armMidMoveMint(t *testing.T, env *execenv.LocalExecutionEnvironment) *string {
+	t.Helper()
+	minted := new(string)
+	env.ObserveScratchMoveWindowForTesting(func() {
+		if *minted != "" {
+			return
+		}
+		if _, err := env.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+			t.Errorf("child command on the source environment mid-move: %v", err)
+		}
+		*minted = env.SessionScratchDir()
+	})
+	t.Cleanup(func() { env.ObserveScratchMoveWindowForTesting(nil) })
+	return minted
+}
+
+// assertMidMoveOutcome checks the three things that have to hold once a child
+// sharing the source object minted a scratch inside a move's interval: the
+// environment the session landed on carries the session's own scratch across
+// (the move took it before any mint could reach it), the source keeps exactly
+// what the interval minted, and the session's close releases both leases while
+// keeping both directories for the handoff.
+func assertMidMoveOutcome(t *testing.T, s *Session, source *execenv.LocalExecutionEnvironment, carried, midMove string) {
+	t.Helper()
+	if midMove == "" {
+		t.Fatal("the enter moved no scratch off the source environment, so no interval was observed")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(midMove) })
+	if midMove == carried {
+		t.Fatalf("the mid-move command got the session's own scratch %q, so the source had not been emptied yet", carried)
+	}
+	if got := currentLocalEnv(t, s).SessionScratchDir(); got != carried {
+		t.Errorf("entered environment scratch = %q, want the %q the session carried across", got, carried)
+	}
+	if got := source.SessionScratchDir(); got != midMove {
+		t.Errorf("source environment scratch = %q, want the %q minted mid-move", got, midMove)
+	}
+
+	s.Close()
+
+	for name, dir := range map[string]string{"session": carried, "mid-move": midMove} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Errorf("close removed the %s scratch %s, want it retained for the handoff: %v", name, dir, err)
+		}
+		if scratchLeaseHeld(t, dir) {
+			t.Errorf("the %s scratch %s lease is still held after the close", name, dir)
+		}
+	}
+}
+
+// The scratch move is two locked steps — take the source's fields, then
+// install them on the target — and the two locks are never held together, so
+// swaps in opposite directions cannot deadlock. That leaves an interval in
+// which the source owns nothing, and a child sharing the source object can
+// spawn there: its command finds no scratch and mints one the move never sees.
+//
+// The session accounts for that scratch anyway, because it accounts for the
+// ENVIRONMENT: whichever of the two records the swap makes for the source — the
+// enter's park or the abandoned set a later enter adds it to — is made under
+// the install's own lock hold, and close is fenced against the swap that makes
+// it (envWorkWG), so a close can never observe an installed target without the
+// source recorded. Both records are exercised here; both end in a released
+// lease and a kept directory.
+func TestWorktreeSwap_ScratchMintedOnTheSourceMidMoveStaysAccountedFor(t *testing.T) {
+	t.Run("source the enter parks", func(t *testing.T) {
+		sr := newScriptedLaneRepo(t)
+		r := sr.wt()
+		launch := currentLocalEnv(t, r.s)
+		if _, err := launch.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+			t.Fatalf("root command on the launch environment: %v", err)
+		}
+		carried := launch.SessionScratchDir()
+		if carried == "" {
+			t.Fatal("the root's command minted no session scratch")
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(carried) })
+		midMove := armMidMoveMint(t, launch)
+
+		if _, err := r.create(t, map[string]any{"name": "lane"}); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+
+		assertMidMoveOutcome(t, r.s, launch, carried, *midMove)
+	})
+
+	// A second enter parks nothing — worktreeRestoreEnv already holds the launch
+	// environment — so the lane the session came from is reachable from nothing
+	// it holds, and only the abandoned set keeps it within the close's reach.
+	t.Run("source a second enter abandons", func(t *testing.T) {
+		sr := newScriptedLaneRepo(t)
+		r := sr.wt()
+		launch := currentLocalEnv(t, r.s)
+		if _, err := launch.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+			t.Fatalf("root command on the launch environment: %v", err)
+		}
+		carried := launch.SessionScratchDir()
+		if carried == "" {
+			t.Fatal("the root's command minted no session scratch")
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(carried) })
+		if _, err := r.create(t, map[string]any{"name": "a"}); err != nil {
+			t.Fatalf("create a: %v", err)
+		}
+		laneA := currentLocalEnv(t, r.s)
+		if laneA == launch {
+			t.Fatal("the first enter did not swap the session onto a lane clone")
+		}
+		midMove := armMidMoveMint(t, laneA)
+
+		if _, err := r.create(t, map[string]any{"name": "b"}); err != nil {
+			t.Fatalf("create b: %v", err)
+		}
+
+		assertMidMoveOutcome(t, r.s, laneA, carried, *midMove)
+	})
+}
+
 // heldScratchDirsIn lists the session scratch dirs under base whose lease is
 // still held by a live owner.
 func heldScratchDirsIn(t *testing.T, base string) []string {

--- a/agent/session_worktree_swap_scratch_unix_test.go
+++ b/agent/session_worktree_swap_scratch_unix_test.go
@@ -456,7 +456,7 @@ func TestWorktreeSwap_CloseAfterTheEnterRetainsTheParkedEnvironmentScratch(t *te
 func armMidMoveMint(t *testing.T, env *execenv.LocalExecutionEnvironment) *string {
 	t.Helper()
 	minted := new(string)
-	env.ObserveScratchMoveWindowForTesting(func() {
+	t.Cleanup(env.ObserveScratchMoveWindowForTesting(func() {
 		if *minted != "" {
 			return
 		}
@@ -464,8 +464,7 @@ func armMidMoveMint(t *testing.T, env *execenv.LocalExecutionEnvironment) *strin
 			t.Errorf("child command on the source environment mid-move: %v", err)
 		}
 		*minted = env.SessionScratchDir()
-	})
-	t.Cleanup(func() { env.ObserveScratchMoveWindowForTesting(nil) })
+	}))
 	return minted
 }
 


### PR DESCRIPTION
## What was wrong

`AdoptSessionScratch` (`agent/execenv/local.go`) moves both per-session scratch kinds in two locked steps — take the source's fields under its `scratchMu`, release, install under the target's — and never holds both locks, so swaps in opposite directions cannot deadlock. Between the two the source owns nothing, and a command a child sharing that environment object spawns there mints a fresh scratch the move never sees.

## What I found, and the choice

**The leak half is already closed, and the remaining half is not worth code.** I did not add a moving flag or reorder the abandoned-set record.

The issue's second fix shape asks whether recording the source before clearing its fields would retain a mid-interval mint. Recording already happens *after* the adopt (step 2 of `swapEnvAndRefresh`), and that is fine: the install (`s.env = next`), `record()`, and `recordAbandonedEnvironmentLocked` all happen under one `s.mu` hold, and close reads both records under the same lock — so a close can never observe an installed target without the source recorded. (Not `envWorkWG`: that fence is bounded by the close budget and can be walked past, so it is not what makes this airtight.) Either record covers it — `worktreeRestoreEnv` for the environment an enter parks, `abandonedEnvs` for the one a later enter drops (PR #878) — and close retains each: lease released, directory kept for the handoff. A swap refused at step 2 leaves the source installed, so close's own `Cleanup` reaches it. `resumeWorktreeReentry`'s adopt runs before anything can observe the session, so its window is unreachable.

That leaves the wasted-scratch half, and it is not waste. The interval's end state is the one a spawn landing just *after* the move produces — the source is emptied either way, and its next command mints — which is already the designed behaviour (`TestFileToolLayerFollowsTheScratchAcrossAdoption`, "the env that was left mints a fresh scratch for its next command"). The interleaving is linearizable; it reaches no state a legal serial ordering does not. What it does not reproduce is timing: the source's `invalidateSandboxFS` runs after the interval, so a file-tool layer the mint had just built is retired where the later ordering would have kept it — one lazy rebuild, not a different outcome. The mint is a real spawn with a real `$TMPDIR` need, not a directory nobody asked for.

A "moving" flag would change no outcome and would put a blocking wait in `commandEnvironment`'s overlay, on the path of every spawn on every environment. So the interval gets pinned by a test instead of closed by a mechanism, and `AdoptSessionScratch` gains a comment recording why, so the next reader does not re-derive it.

## What changed

- `agent/execenv/local.go`: one instance-local test seam, `scratchMovedOut`, run on the source between the two steps, installed via `ObserveScratchMoveWindowForTesting` (returns a restore func, and it and the move's read both go through `scratchMu` like the sibling scratch fields). Instance-local rather than package-level so parallel tests cannot trip each other's; exported because what the interval costs is settled by a *session's* close, which lives in `package agent`. Plus the comment on `AdoptSessionScratch` explaining the interval.
- `agent/session_worktree_swap_scratch_unix_test.go`: `TestWorktreeSwap_ScratchMintedOnTheSourceMidMoveStaysAccountedFor`, two subtests for the two shapes of source (the enter's parked environment, and the lane a second enter abandons). Each runs a real command through the interval and asserts the target carries the session's own scratch across, the source keeps exactly what the interval minted, and the close leaves both directories present with no held lease.

## How it is tested

The test passes as written — which is the finding, so I falsified it three ways instead of watching it fail once. Each mutation was applied, run, and reverted; each went red on exactly the assertion it targets:

| Mutation | Failure |
|---|---|
| drop `retainParkedWorktreeEnvironmentScratch()` from close | `source the enter parks`: "the mid-move scratch … lease is still held after the close" |
| drop `retainAbandonedEnvironmentScratch()` from close | `source a second enter abandons`: same, on the abandoned lane |
| clear the source's fields again after the move (a naive moving-flag "fix") | "source environment scratch = \"\", want the … minted mid-move", plus the held lease |
| move the seam before `from.scratchMu.Lock()` (outside the interval) | "the mid-move command got the session's own scratch …, so the source had not been emptied yet" |

The last one is the liveness check: it proves the seam sits inside the interval and not beside it.

## Gates

All foreground, all clean, full logs kept.

- `gofmt -l` on the changed files: no output
- `go vet ./...` and `go vet -tags evenerfuzz ./...`: exit 0
- `make lint-golangci` (the invocation CI runs): PASS (245s)
- `go test -race ./agent/execenv/... -count=1`: ok, `grep -c FAIL` = 0 (`/tmp/898-execenv-race.log`)
- `go test -race ./agent/ -count=1`: ok 1589s, `grep -c FAIL` = 0 (`/tmp/898-agent-race.log`)
- `go test -tags evenerfuzz -run Fuzz ./agent/execenv/ -count=1`: ok, 0 FAIL; same for `./agent/`: ok 206s, 0 FAIL
- `go test ./agent/ -count=1 -timeout 30m`: ok 561s, `grep -c FAIL` = 0 (`/tmp/898-full.log`)

Closes #898

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
