### PR TITLE
Reuse waitForCondition for the shell receipt wait

### DIFF
--- a/agent/job_shell_test.go
+++ b/agent/job_shell_test.go
@@ -80,13 +80,9 @@ func waitForShellReceiptResolved(t *testing.T, jm *jobManager, jobID string) {
 	t.Helper()
 	// TRIPWIRE: the receipt is dropped a few store appends past the removal, so
 	// this only bounds a genuine finalization hang.
-	deadline := time.Now().Add(30 * time.Second)
-	for shellReceiptHeld(jm, jobID) {
-		if time.Now().After(deadline) {
-			t.Fatalf("job %s still holds its delegate shell receipt", jobID)
-		}
-		time.Sleep(2 * time.Millisecond)
-	}
+	waitForCondition(t, 30*time.Second, "job "+jobID+" to release its delegate shell receipt", func() bool {
+		return !shellReceiptHeld(jm, jobID)
+	})
 }
 
 // shellReceiptPollHook observes a receipt wait's look at a job, so a test can
@@ -111,8 +107,10 @@ func setShellReceiptPollHook(t *testing.T, fire func(jobID string)) {
 }
 
 // shellReceiptHeld reports whether the stable-delegate controller still holds a
-// committed process receipt for jobID. Root-owned shells never take one, so it
-// is always false for a job manager with no controller.
+// committed process receipt for jobID. Only a job manager bound to a stable
+// delegate parent has a lease, and beginStableDelegateShellReceipt takes a
+// receipt only for a non-empty lease, so root-owned shells never hold one and
+// this is always false for them.
 func shellReceiptHeld(jm *jobManager, jobID string) bool {
 	shellReceiptPollHook.mu.Lock()
 	fire := shellReceiptPollHook.fire


### PR DESCRIPTION
Completes the review of #911.

## What changed

Test-only, two points from that review:

1. `waitForShellReceiptResolved` duplicated `waitForCondition` (`agent/poll_test.go`) line for line — same deadline, same 2ms poll, same fatal on expiry. It now calls that helper, keeping the TRIPWIRE comment that explains why 30s sits far above the expected receipt drop.
2. The comment on `shellReceiptHeld` claimed root-owned shells take the unchanged path because their job manager has no delegate controller. That is wrong: a root session's job manager does carry one (`agent/session_init.go:351` copies `s.delegateController`, set at `agent/delegate_runtime.go:2054`). Root shells are receipt-free because only `bindStableDelegateParent` (`agent/jobs.go:248`) sets a delegate lease, and `beginStableDelegateShellReceipt` (`agent/job_shell.go:557`) takes a receipt only for a non-empty lease. The comment now states that mechanism.

No behaviour change: the wait still settles the instant the receipt is released.

## Gates

- `gofmt -l` on the changed file: clean
- `GOMAXPROCS=4 go test -race ./agent/ -run 'ForegroundShellTimeoutReportsCommittedShellOnce|FinishedShellWaitOutlivesRunningMapRemoval|TestNoBareWallClockDeadlineInAgentTests' -count=3`: exit 0, 0 FAIL (the deadline audit lists `waitForCondition` as deadline-establishing, and still passes on the tripwire comment)
- `go vet ./...` and `go vet -tags evenerfuzz ./...` in `agent/`: clean
- `golangci-lint` via `dev module-lint` for the agent module: PASS

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT