### PR TITLE
test(web): wait on transcript readiness, not on where the mount landed

### DIFF
--- a/cmd/evener-hub/frontend/scripts/transcriptscrollguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/transcriptscrollguard/run.mjs
@@ -109,9 +109,10 @@ async function main() {
       if (initial.errors.length > 0) failures.push(`page errors: ${initial.errors.join("; ")}`);
       if (initial.clientHeight <= 0) {
         failures.push(`scroll container has no height (clientHeight ${initial.clientHeight}) - the harness did not render`);
-      } else if (initial.scrollHeight <= initial.clientHeight * 4) {
+      } else if (initial.scrollHeight <= initial.overflowRequired) {
         failures.push(
-          `transcript did not overflow several times over (scrollHeight ${initial.scrollHeight}, clientHeight ${initial.clientHeight})`,
+          `transcript did not overflow several times over (scrollHeight ${initial.scrollHeight}, ` +
+            `clientHeight ${initial.clientHeight}, needs more than ${initial.overflowRequired})`,
         );
       }
       if (initial.turns !== 42) failures.push(`expected 42 scripted turns in the model, found ${initial.turns}`);

--- a/cmd/evener-hub/frontend/src/dev/transcriptSettle.test.ts
+++ b/cmd/evener-hub/frontend/src/dev/transcriptSettle.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+
+import { expect, test } from "vitest";
+import {
+  createTranscriptSettleTracker,
+  SETTLE_OVERFLOW_FACTOR,
+  SETTLE_QUIESCENT_FRAMES,
+  type TranscriptGeometry,
+  type TranscriptSettleBlocker,
+  type TranscriptSettleSample,
+  type TranscriptSettleTracker,
+} from "./transcriptSettle";
+
+const TURNS = 42;
+const PORT = 725;
+
+/** A rendered, overflowing transcript sitting `bottomGap` px above the true bottom. */
+function rendered(bottomGap = 0): TranscriptGeometry {
+  const scrollHeight = 11_487;
+  return { scrollHeight, clientHeight: PORT, scrollTop: scrollHeight - PORT - bottomGap };
+}
+
+function sample(geometry: TranscriptGeometry | null, turns = TURNS): TranscriptSettleSample {
+  return { turns, geometry };
+}
+
+/** Feeds one sample repeatedly, returning the last verdict. */
+function hold(tracker: TranscriptSettleTracker, one: TranscriptSettleSample, frames: number) {
+  let blocker: TranscriptSettleBlocker | null = { kind: "unmounted" };
+  for (let i = 0; i < frames; i++) blocker = tracker.observe(one);
+  return blocker;
+}
+
+// The first frame has nothing to compare against, so a run of
+// SETTLE_QUIESCENT_FRAMES unchanged frames needs one frame more than that.
+const FRAMES_TO_READY = SETTLE_QUIESCENT_FRAMES + 1;
+
+// --- ready ------------------------------------------------------------------
+
+test("a rendered transcript that holds still becomes ready to drive", () => {
+  const tracker = createTranscriptSettleTracker(TURNS);
+  expect(hold(tracker, sample(rendered()), FRAMES_TO_READY)).toBeNull();
+});
+
+test("a transcript parked a few pixels above the true bottom is still ready to drive", () => {
+  // A webfont that swaps in after the mount's scroll-to-end grows the content
+  // below the fold with no scroll event and no item-count change, so nothing
+  // re-anchors the landing. Where the mount landed is the runner's assertion to
+  // make; withholding readiness for it strands the guard on a condition that
+  // will never come true.
+  const tracker = createTranscriptSettleTracker(TURNS);
+  expect(hold(tracker, sample(rendered(21)), FRAMES_TO_READY)).toBeNull();
+});
+
+test("readiness needs the stillness run to be consecutive, not merely accumulated", () => {
+  const tracker = createTranscriptSettleTracker(TURNS);
+  hold(tracker, sample(rendered()), SETTLE_QUIESCENT_FRAMES);
+  // One frame of movement resets the run, so the next frame cannot complete it.
+  tracker.observe(sample({ ...rendered(), scrollHeight: 11_500, scrollTop: 11_500 - PORT }));
+  expect(tracker.observe(sample(rendered()))).not.toBeNull();
+  expect(hold(tracker, sample(rendered()), SETTLE_QUIESCENT_FRAMES)).toBeNull();
+});
+
+// --- withheld, and for the right reason -------------------------------------
+
+test("an unmounted scroll element is named as such, not as a geometry failure", () => {
+  const tracker = createTranscriptSettleTracker(TURNS);
+  expect(hold(tracker, sample(null), FRAMES_TO_READY)).toEqual({ kind: "unmounted" });
+});
+
+test("a half-loaded thread names the turns it is missing", () => {
+  const tracker = createTranscriptSettleTracker(TURNS);
+  expect(hold(tracker, sample(rendered(), 17), FRAMES_TO_READY)).toEqual({ kind: "turns", turns: 17, expected: TURNS });
+});
+
+test("a transcript that never overflows never becomes ready, and the overflow is what is named", () => {
+  const tracker = createTranscriptSettleTracker(TURNS);
+  const short: TranscriptGeometry = { scrollHeight: PORT + 40, clientHeight: PORT, scrollTop: 40 };
+  expect(hold(tracker, sample(short), 500)).toEqual({
+    kind: "overflow",
+    scrollHeight: PORT + 40,
+    clientHeight: PORT,
+    required: PORT * SETTLE_OVERFLOW_FACTOR,
+  });
+});
+
+test("geometry that keeps moving names the movement, not the overflow it already has", () => {
+  const tracker = createTranscriptSettleTracker(TURNS);
+  let blocker: TranscriptSettleBlocker | null = null;
+  for (let i = 0; i < 500; i++) {
+    const grown = 11_487 + i;
+    blocker = tracker.observe(sample({ scrollHeight: grown, clientHeight: PORT, scrollTop: grown - PORT }));
+  }
+  expect(blocker?.kind).toBe("moving");
+});
+
+test("a stillness run still short of the requirement names how far it got", () => {
+  const tracker = createTranscriptSettleTracker(TURNS);
+  expect(hold(tracker, sample(rendered()), SETTLE_QUIESCENT_FRAMES)).toEqual({
+    kind: "quiescing",
+    frames: SETTLE_QUIESCENT_FRAMES - 1,
+    required: SETTLE_QUIESCENT_FRAMES,
+  });
+});

--- a/cmd/evener-hub/frontend/src/dev/transcriptSettle.test.ts
+++ b/cmd/evener-hub/frontend/src/dev/transcriptSettle.test.ts
@@ -3,6 +3,7 @@
 import { expect, test } from "vitest";
 import {
   createTranscriptSettleTracker,
+  describeTranscriptSettleBlocker,
   SETTLE_OVERFLOW_FACTOR,
   SETTLE_QUIESCENT_FRAMES,
   type TranscriptGeometry,
@@ -101,4 +102,24 @@ test("a stillness run still short of the requirement names how far it got", () =
     frames: SETTLE_QUIESCENT_FRAMES - 1,
     required: SETTLE_QUIESCENT_FRAMES,
   });
+});
+
+// --- the blocker's own account of itself -----------------------------------
+
+test("every blocker carries the numbers that decided it into its description", () => {
+  // The wording is free to change; what a reader has to be able to recover from
+  // a tripwire message is the geometry that withheld readiness, since that is
+  // the whole reason this reports a blocker instead of a ceiling.
+  const evidence: [TranscriptSettleBlocker, string[]][] = [
+    [{ kind: "unmounted" }, []],
+    [{ kind: "turns", turns: 17, expected: 42 }, ["17", "42"]],
+    [{ kind: "overflow", scrollHeight: 765, clientHeight: 725, required: 2900 }, ["765", "725", "2900"]],
+    [{ kind: "moving", scrollHeight: 11487, scrollTop: 10741 }, ["11487", "10741"]],
+    [{ kind: "quiescing", frames: 3, required: 20 }, ["3", "20"]],
+  ];
+  for (const [blocker, numbers] of evidence) {
+    const described = describeTranscriptSettleBlocker(blocker);
+    expect(described.length).toBeGreaterThan(0);
+    for (const number of numbers) expect(described).toContain(number);
+  }
 });

--- a/cmd/evener-hub/frontend/src/dev/transcriptSettle.ts
+++ b/cmd/evener-hub/frontend/src/dev/transcriptSettle.ts
@@ -1,0 +1,144 @@
+// When is the transcriptscrollguard harness ready to be DRIVEN? This is the
+// readiness decision transcriptscrollguard-entry.tsx spins on before its first
+// probe, kept here as a pure frame-by-frame tracker so both the ready verdict
+// and the reason it is being withheld can be tested without a browser.
+//
+// Readiness is exactly two things:
+//
+//   the fixture rendered   - the scripted turns are all in the model and the
+//     scroll container overflows its port several times over. A harness that
+//     rendered nothing then fails HERE, naming the harness, instead of as a
+//     geometry mystery in a downstream pill assertion
+//     (docs/developing-evener/testing.md's unfalsifiable-fixture trap).
+//
+//   the mount stopped moving it - scrollHeight AND scrollTop unchanged for
+//     SETTLE_QUIESCENT_FRAMES consecutive frames. This half is load-bearing:
+//     the mount's own scrollToIndex(count-1, {align:"end"}) reconcile loop
+//     stays active while post-mount measurement corrections keep moving its
+//     target, and while it is active it claims ANY scroll-offset change
+//     (including the guard's scroll-away) as part of its programmatic scroll
+//     and yanks back - a spurious failure the runner cannot tell from a
+//     product regression.
+//
+// DELIBERATELY NOT a readiness condition: where the mount landed. Opening a
+// session scrolls to the end from the virtualizer's estimates and measures
+// once (useTranscriptScroll's mount effect); nothing re-anchors that landing
+// afterwards unless a scroll event or an item-count mutation arrives. A
+// webfont that swaps in AFTER that landing grows the content below the fold
+// without either, so the transcript sits a few pixels short of the true
+// bottom with no pill - measured at 21px on a cold profile, scrollHeight
+// 11466 -> 11487 at document.fonts.ready with scrollTop pinned at 10741. That
+// is a real product property worth asserting, but asserting it HERE, inside a
+// wait, turns it into a timeout that reports whichever condition was true all
+// along. The runner asserts the mount's own visible contract (no pill at
+// mount) on the sample this tracker returns; where the jump lands is what
+// clickPillAndSettle measures, to 1px, which is the property this guard exists
+// for.
+
+/** The transcript scroll container's live geometry. */
+export interface TranscriptGeometry {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+/** One frame's observation of the mounting transcript. */
+export interface TranscriptSettleSample {
+  /** Turns currently in the thread model. */
+  turns: number;
+  /** The scroll container's geometry, or null while VirtualList is unmounted. */
+  geometry: TranscriptGeometry | null;
+}
+
+/** Why readiness is still being withheld, carrying the numbers that decided it. */
+export type TranscriptSettleBlocker =
+  | { kind: "unmounted" }
+  | { kind: "turns"; turns: number; expected: number }
+  | { kind: "overflow"; scrollHeight: number; clientHeight: number; required: number }
+  | { kind: "moving"; scrollHeight: number; scrollTop: number }
+  | { kind: "quiescing"; frames: number; required: number };
+
+/**
+ * Consecutive frames of unchanged geometry that mean the mount's reconcile
+ * loop has stopped. Twenty at a 60Hz vsync is a third of a second of stillness;
+ * the loop's own corrections land within a handful of frames of each other, so
+ * a run this long cannot span two of them.
+ */
+export const SETTLE_QUIESCENT_FRAMES = 20;
+
+/**
+ * How far the transcript must overflow its port to count as rendered. The
+ * scripted thread overflows ~16x (measured 11487px of content in a 725px
+ * port), so this is a floor no healthy fixture approaches, not a threshold.
+ */
+export const SETTLE_OVERFLOW_FACTOR = 4;
+
+export interface TranscriptSettleTracker {
+  /** Records one frame. Returns null once the transcript is ready to drive. */
+  observe(sample: TranscriptSettleSample): TranscriptSettleBlocker | null;
+}
+
+/** Human-readable form of a blocker, for the harness's tripwire message. */
+export function describeTranscriptSettleBlocker(blocker: TranscriptSettleBlocker): string {
+  switch (blocker.kind) {
+    case "unmounted":
+      return "the transcript VirtualList scroll element never mounted";
+    case "turns":
+      return `only ${blocker.turns} of ${blocker.expected} scripted turns reached the model`;
+    case "overflow":
+      return (
+        `the transcript never overflowed its scroll port (scrollHeight ${blocker.scrollHeight}, ` +
+        `clientHeight ${blocker.clientHeight}, needs more than ${blocker.required})`
+      );
+    case "moving":
+      return (
+        `the transcript's geometry never stopped moving (last scrollHeight ${blocker.scrollHeight}, ` +
+        `scrollTop ${blocker.scrollTop})`
+      );
+    case "quiescing":
+      return `the transcript held still for only ${blocker.frames} of ${blocker.required} consecutive frames`;
+  }
+}
+
+/**
+ * Tracks readiness across frames. `expectedTurns` is the scripted thread's turn
+ * count: the fixture is not rendered until every one of them is in the model.
+ */
+export function createTranscriptSettleTracker(expectedTurns: number): TranscriptSettleTracker {
+  let quiescentFrames = 0;
+  // No frame has been seen yet, so the first one can never read as "unchanged".
+  let lastScrollHeight = Number.NaN;
+  let lastScrollTop = Number.NaN;
+
+  return {
+    observe({ turns, geometry }) {
+      if (geometry === null) {
+        quiescentFrames = 0;
+        return { kind: "unmounted" };
+      }
+      if (turns !== expectedTurns) {
+        quiescentFrames = 0;
+        return { kind: "turns", turns, expected: expectedTurns };
+      }
+
+      const { scrollHeight, clientHeight, scrollTop } = geometry;
+      const stillStanding = scrollHeight === lastScrollHeight && scrollTop === lastScrollTop;
+      lastScrollHeight = scrollHeight;
+      lastScrollTop = scrollTop;
+
+      const required = clientHeight * SETTLE_OVERFLOW_FACTOR;
+      if (scrollHeight <= required) {
+        quiescentFrames = 0;
+        return { kind: "overflow", scrollHeight, clientHeight, required };
+      }
+      if (!stillStanding) {
+        quiescentFrames = 0;
+        return { kind: "moving", scrollHeight, scrollTop };
+      }
+
+      quiescentFrames++;
+      if (quiescentFrames >= SETTLE_QUIESCENT_FRAMES) return null;
+      return { kind: "quiescing", frames: quiescentFrames, required: SETTLE_QUIESCENT_FRAMES };
+    },
+  };
+}

--- a/cmd/evener-hub/frontend/src/dev/transcriptSettle.ts
+++ b/cmd/evener-hub/frontend/src/dev/transcriptSettle.ts
@@ -70,6 +70,10 @@ export const SETTLE_QUIESCENT_FRAMES = 20;
  * How far the transcript must overflow its port to count as rendered. The
  * scripted thread overflows ~16x (measured 11487px of content in a 725px
  * port), so this is a floor no healthy fixture approaches, not a threshold.
+ *
+ * scripts/transcriptscrollguard/run.mjs re-asserts the same overflow on the
+ * measurement it is handed, and reads the floor from that measurement's
+ * `overflowRequired` rather than keeping a second copy of this factor.
  */
 export const SETTLE_OVERFLOW_FACTOR = 4;
 

--- a/cmd/evener-hub/frontend/src/dev/transcriptscrollguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/transcriptscrollguard-entry.tsx
@@ -34,6 +34,7 @@ import { Toast } from "../widgets";
 import {
   createTranscriptSettleTracker,
   describeTranscriptSettleBlocker,
+  SETTLE_OVERFLOW_FACTOR,
   type TranscriptGeometry,
 } from "./transcriptSettle";
 import "../styles/tokens.css";
@@ -237,6 +238,12 @@ function pillElement(): HTMLElement | null {
 interface TranscriptScrollMetrics extends TranscriptGeometry {
   /** Bottom gap: scrollHeight - clientHeight - scrollTop. 0 at the true bottom. */
   bottomGap: number;
+  /**
+   * The scrollHeight this transcript has to beat to count as rendered. Carried
+   * on the measurement so the runner can re-assert the overflow on what it was
+   * handed without keeping its own copy of SETTLE_OVERFLOW_FACTOR.
+   */
+  overflowRequired: number;
   pill: boolean;
   pillText: string | null;
   turns: number;
@@ -250,6 +257,7 @@ function metrics(): TranscriptScrollMetrics {
   return {
     ...geometry,
     bottomGap: geometry.scrollHeight - geometry.clientHeight - geometry.scrollTop,
+    overflowRequired: geometry.clientHeight * SETTLE_OVERFLOW_FACTOR,
     pill: pill !== null,
     pillText: pill?.textContent ?? null,
     turns: modelTurnCount,
@@ -262,11 +270,20 @@ function nextFrame(): Promise<void> {
   return new Promise((resolve) => requestAnimationFrame(() => resolve()));
 }
 
-// SETTLE_TRIPWIRE_MS bounds the readiness spin below. TRIPWIRE: it is a hang
-// guard, never the synchronisation mechanism - transcriptSettle.ts's own
-// conditions are, and the blocker they report is what the message names. It
-// sits far above the work it covers, which is SETTLE_QUIESCENT_FRAMES + 1
-// animation frames and nothing else: measured on one host at 350ms
+// SETTLE_TRIPWIRE_MS bounds the readiness spin below. TRIPWIRE: it is never
+// the synchronisation mechanism - transcriptSettle.ts's conditions are, and
+// the blocker they report is what the message names. What it bounds is a
+// settle that keeps PRODUCING frames and never becomes ready. A frame loop
+// that stalls is not covered here at all: the deadline is only re-read after
+// `await nextFrame()`, so if requestAnimationFrame stops firing this spin
+// never reaches the check, the enclosing CDP call times out first, and the
+// blocker is lost with it (issue #919).
+//
+// It sits far above the work it covers, which is whatever of the mount, the
+// INITIAL_TURN_COUNT-turn hydration and the virtualizer's reconcile loop is
+// still outstanding when the spin starts, plus the quiescence run itself.
+// Measured on one host: the mount reached stable end-anchored geometry within
+// ~1.1s of navigation, and the quiescence run then cost 21 frames - 350ms
 // unthrottled, 432ms under 10x and 730ms under 20x Chrome CPU throttling.
 //
 // It is also bounded ABOVE, by the runner's own Runtime.evaluate ceiling

--- a/cmd/evener-hub/frontend/src/dev/transcriptscrollguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/transcriptscrollguard-entry.tsx
@@ -31,6 +31,11 @@ import { ClientProvider } from "../shell/clientContext";
 import { connectionStore } from "../stores/connection";
 import { threadsStore } from "../stores/threads";
 import { Toast } from "../widgets";
+import {
+  createTranscriptSettleTracker,
+  describeTranscriptSettleBlocker,
+  type TranscriptGeometry,
+} from "./transcriptSettle";
 import "../styles/tokens.css";
 import "../styles/global.css";
 
@@ -207,21 +212,29 @@ createRoot(rootEl).render(
 // The transcript's scroll container: TranscriptBody's
 // [data-testid="transcript-virtual-list"] section directly wraps the
 // VirtualList root (the one overflow-y:auto node the whole flow hangs off).
-function scrollElement(): HTMLElement {
+// Null before it mounts, which the settle tracker reads as a state to keep
+// waiting through rather than an error.
+function findScrollElement(): HTMLElement | null {
   const section = document.querySelector('[data-testid="transcript-virtual-list"]');
   const el = section?.querySelector(":scope > div");
-  if (!(el instanceof HTMLElement)) throw new Error("transcript VirtualList scroll element is not mounted");
+  return el instanceof HTMLElement ? el : null;
+}
+
+function scrollElement(): HTMLElement {
+  const el = findScrollElement();
+  if (el === null) throw new Error("transcript VirtualList scroll element is not mounted");
   return el;
+}
+
+function geometryOf(el: HTMLElement): TranscriptGeometry {
+  return { scrollTop: el.scrollTop, scrollHeight: el.scrollHeight, clientHeight: el.clientHeight };
 }
 
 function pillElement(): HTMLElement | null {
   return document.querySelector<HTMLElement>('[data-testid="new-content-pill"]');
 }
 
-interface TranscriptScrollMetrics {
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
+interface TranscriptScrollMetrics extends TranscriptGeometry {
   /** Bottom gap: scrollHeight - clientHeight - scrollTop. 0 at the true bottom. */
   bottomGap: number;
   pill: boolean;
@@ -232,13 +245,11 @@ interface TranscriptScrollMetrics {
 }
 
 function metrics(): TranscriptScrollMetrics {
-  const el = scrollElement();
+  const geometry = geometryOf(scrollElement());
   const pill = pillElement();
   return {
-    scrollTop: el.scrollTop,
-    scrollHeight: el.scrollHeight,
-    clientHeight: el.clientHeight,
-    bottomGap: el.scrollHeight - el.clientHeight - el.scrollTop,
+    ...geometry,
+    bottomGap: geometry.scrollHeight - geometry.clientHeight - geometry.scrollTop,
     pill: pill !== null,
     pillText: pill?.textContent ?? null,
     turns: modelTurnCount,
@@ -251,54 +262,42 @@ function nextFrame(): Promise<void> {
   return new Promise((resolve) => requestAnimationFrame(() => resolve()));
 }
 
-// Settle condition for the initial mount: the full scripted thread is in the
-// model, the scroll element exists, the transcript overflows the viewport by
-// a wide margin, AND the mount has gone QUIESCENT - geometry unchanged for
-// SETTLE_QUIESCENT_FRAMES consecutive frames with the reader at the bottom
-// and the pill hidden. The quiescence half is load-bearing: the mount's own
-// scrollToIndex(...) reconcile loop stays active while post-mount
-// measurement corrections keep moving its target, and while it is active it
-// claims ANY scroll-offset change (including the guard's scroll-away) as
-// part of its programmatic scroll and yanks back - a spurious failure the
-// runner cannot tell from a product regression. Waiting it out here makes
-// the phases downstream deterministic. The runner asserts the overflow
-// margin itself; here it is only the readiness signal, so a harness that
-// rendered nothing fails HERE (naming the harness) instead of as a geometry
-// mystery downstream (docs/developing-evener/testing.md's
-// unfalsifiable-fixture trap).
-const SETTLE_QUIESCENT_FRAMES = 20;
+// SETTLE_TRIPWIRE_MS bounds the readiness spin below. TRIPWIRE: it is a hang
+// guard, never the synchronisation mechanism - transcriptSettle.ts's own
+// conditions are, and the blocker they report is what the message names. It
+// sits far above the work it covers, which is SETTLE_QUIESCENT_FRAMES + 1
+// animation frames and nothing else: measured on one host at 350ms
+// unthrottled, 432ms under 10x and 730ms under 20x Chrome CPU throttling.
+//
+// It is also bounded ABOVE, by the runner's own Runtime.evaluate ceiling
+// (browserGuardCdp.mjs, 30s): this whole spin runs inside one such call, so a
+// tripwire past that ceiling never fires - the transport times out first and
+// the guard reports `timeout calling Runtime.evaluate after 30000ms` with the
+// blocker lost. Verified by running the non-overflowing fixture against a 90s
+// value. Raising this without raising that ceiling trades a named condition
+// for a transport error.
+const SETTLE_TRIPWIRE_MS = 25_000;
+
 // Callable, not a module-load one-shot: the runner awaits webfonts FIRST
 // (waitForFonts over CDP) and only then calls this, because a late-arriving
 // font changes row geometry after load - settling must measure the
-// post-font geometry, or a font-driven shift could surface the pill before
-// the scroll-away phase and make the runner's pill assertions pass for the
-// wrong reason.
+// post-font geometry, or a font-driven shift could move the pill under the
+// scroll-away phase and make the runner's pill assertions pass for the wrong
+// reason.
 async function waitForTranscriptSettled(): Promise<TranscriptScrollMetrics> {
-  const deadline = performance.now() + 15_000;
-  let quiescentFrames = 0;
-  let lastScrollHeight = -1;
-  let lastScrollTop = -1;
+  const tracker = createTranscriptSettleTracker(INITIAL_TURN_COUNT);
+  const deadline = performance.now() + SETTLE_TRIPWIRE_MS;
   for (;;) {
     await nextFrame();
     throwOnPageErrors("initial render");
-    const section = document.querySelector('[data-testid="transcript-virtual-list"]');
-    const el = section?.querySelector(":scope > div");
-    if (el instanceof HTMLElement && modelTurnCount === INITIAL_TURN_COUNT) {
-      const overflowed = el.scrollHeight > el.clientHeight * 4;
-      const atBottom = el.scrollHeight - el.clientHeight - el.scrollTop <= 1;
-      const still = el.scrollHeight === lastScrollHeight && el.scrollTop === lastScrollTop;
-      if (overflowed && atBottom && still && pillElement() === null) quiescentFrames++;
-      else quiescentFrames = 0;
-      if (quiescentFrames >= SETTLE_QUIESCENT_FRAMES) return metrics();
-      lastScrollHeight = el.scrollHeight;
-      lastScrollTop = el.scrollTop;
-    }
+    const el = findScrollElement();
+    const blocker = tracker.observe({ turns: modelTurnCount, geometry: el === null ? null : geometryOf(el) });
+    if (blocker === null) return metrics();
     if (performance.now() > deadline) {
       throw new Error(
-        `transcript harness: transcript never settled into an overflow within 15s ` +
-          `(turns=${modelTurnCount}/${INITIAL_TURN_COUNT}, section=${section !== null}, ` +
-          `quiescentFrames=${quiescentFrames}, ` +
-          `body children: ${[...document.body.children].map((el) => el.tagName).join(",")})`,
+        `transcript harness: the transcript never became ready to drive within ${SETTLE_TRIPWIRE_MS}ms - ` +
+          `${describeTranscriptSettleBlocker(blocker)} ` +
+          `(body children: ${[...document.body.children].map((child) => child.tagName).join(",")})`,
       );
     }
   }

--- a/cmd/evener-hub/frontend/src/dev/transcriptscrollguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/transcriptscrollguard-entry.tsx
@@ -279,21 +279,24 @@ function nextFrame(): Promise<void> {
 // never reaches the check, the enclosing CDP call times out first, and the
 // blocker is lost with it (issue #919).
 //
-// It sits far above the work it covers, which is whatever of the mount, the
-// INITIAL_TURN_COUNT-turn hydration and the virtualizer's reconcile loop is
-// still outstanding when the spin starts, plus the quiescence run itself.
+// The value is derived, not picked. What it covers is whatever of the mount,
+// the INITIAL_TURN_COUNT-turn hydration and the virtualizer's reconcile loop
+// is still outstanding when the spin starts, plus the quiescence run itself.
 // Measured on one host: the mount reached stable end-anchored geometry within
 // ~1.1s of navigation, and the quiescence run then cost 21 frames - 350ms
-// unthrottled, 432ms under 10x and 730ms under 20x Chrome CPU throttling.
+// unthrottled, 432ms under 10x and 730ms under 20x Chrome CPU throttling. So
+// the worst measured readiness run is ~2s, and this is a wide multiple of it.
 //
-// It is also bounded ABOVE, by the runner's own Runtime.evaluate ceiling
+// It is bounded ABOVE as well, by the runner's own Runtime.evaluate ceiling
 // (browserGuardCdp.mjs, 30s): this whole spin runs inside one such call, so a
 // tripwire past that ceiling never fires - the transport times out first and
 // the guard reports `timeout calling Runtime.evaluate after 30000ms` with the
-// blocker lost. Verified by running the non-overflowing fixture against a 90s
-// value. Raising this without raising that ceiling trades a named condition
-// for a transport error.
-const SETTLE_TRIPWIRE_MS = 25_000;
+// blocker lost (verified against a 90s value). At 15s the spin reports its
+// own blocker with that ceiling still 15s away. Every second added here buys
+// a broken fixture another second of silence and spends margin against the
+// stall this cannot see (issue #919), so widening it needs a measurement that
+// says the run got slower, not a hunch that it might.
+const SETTLE_TRIPWIRE_MS = 15_000;
 
 // Callable, not a module-load one-shot: the runner awaits webfonts FIRST
 // (waitForFonts over CDP) and only then calls this, because a late-arriving


### PR DESCRIPTION
## What was wrong

`transcriptscrollguard`'s mount settle spun until four things held together: the transcript overflowed, its geometry held still, no pill was showing, **and** it sat within 1px of the true bottom. That last clause is a product property the mount does not guarantee, so the spin could wait for something that was never going to arrive — and when the 15s ceiling fired it blamed the one condition that had been true the entire time.

Opening a session scrolls to the end from the virtualizer's estimates and measures once (`useTranscriptScroll`'s mount effect). Nothing re-anchors that landing without a scroll event or an item-count change. **A webfont that swaps in AFTER the landing supplies neither**: content grows below the fold, `scrollTop` stays put, and the reader is left a few pixels short with no pill.

Instrumented on a failing run:

| t (ms) | scrollHeight | scrollTop | gap | `document.fonts` |
|---|---|---|---|---|
| 1073 | 11466 | 10741 | 0 | loading |
| 1165 | 11487 | 10741 | **21** | loaded |

The 21px gap then held for all 901 remaining frames — 60fps the whole way, `overflow` true on every one of them — and the guard reported `transcript never settled into an overflow within 15s`.

## What changed

Readiness is now the real condition and nothing else: the scripted turns are in the model, the scroll container is mounted and overflows its port, and its geometry holds still for `SETTLE_QUIESCENT_FRAMES`. That decision moves into `src/dev/transcriptSettle.ts` as a pure frame-by-frame tracker returning either "ready" or a structured blocker, so both the verdict and the reason it is withheld are testable without a browser, and the tripwire message names the blocker instead of the ceiling.

Two knock-on effects worth calling out:

- The runner's `pill is visible at mount` assertion was **unreachable** under the old spin (readiness could only return with the pill hidden). It is live again.
- The 15s ceiling becomes a named `SETTLE_TRIPWIRE_MS`, bounded *above* by `browserGuardCdp`'s 30s `Runtime.evaluate` ceiling that the whole spin runs inside. A 90s value was tried and never fired: the transport timed out first and the blocker was lost (`timeout calling Runtime.evaluate after 30000ms`). The comment records that so the next person does not "generously" raise it back into silence.

Harness-only; no production frontend change.

## How it is tested

`src/dev/transcriptSettle.test.ts` (8 cases). The one that failed first is `a transcript parked a few pixels above the true bottom is still ready to drive`, red on `expected { kind: 'atBottom', bottomGap: 21 } to be null`. The negative case has a permanent home there too: `a transcript that never overflows never becomes ready, and the overflow is what is named`.

**Forced interleaving.** Holding the woff2 responses over CDP (`Fetch.enable` on `*.woff2`, released after 800ms) so the swap lands after the mount's scroll-to-end reproduced the CI failure verbatim, 3/3:

```
transcript harness: transcript never settled into an overflow within 15s
(turns=42/42, section=true, quiescentFrames=0, body children: DIV,SCRIPT)
```

With the new tracker the same delay passed 5/5, the jump still landing at `bottomGap 0`. Unthrottled, HEAD failed 4 of 10 runs on this host; the fix passed 10 of 10. The interception lever was removed before committing.

**Negative case re-verified end to end**, by temporarily shrinking the fixture to a single short turn:

```
transcript harness: the transcript never became ready to drive within 15000ms -
the transcript never overflowed its scroll port (scrollHeight 725, clientHeight 725,
needs more than 2900)
```

Settle cost measured for the tripwire's doc comment: 21 frames, 350ms unthrottled, 432ms under 10x and 730ms under 20x Chrome CPU throttling.

## Gates

The `web` job's exact commands, foreground, full logs kept: `make test-web` (PASS web-typecheck / web-test / web-lint, 0 FAIL), `make build-web` (exit 0), `make test-web-browser` (PASS on all five guards — layoutguard, overflowguard, shellguard, spawnguard, transcriptscrollguard — 0 FAIL).

Closes #900

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
