### PR TITLE
fix(hub,registry): credential JSON onboarding, template-only add-form inputs, row-level vars_env resolution

### DIFF
--- a/appwire/types.go
+++ b/appwire/types.go
@@ -2662,10 +2662,12 @@ type InstanceEntry struct {
 
 // ProviderDescriptor is a registry provider the add form can build on: its
 // id and display name, the protocol and auth scheme it defaults to, and the
-// variables its transport and credential read. Vars maps a template
-// placeholder name to the environment variable name it is fed by (the same
-// shape as registry.Transport.VarsEnv), so a typed override can be sent
-// keyed by the name the registry actually substitutes. VarsEnv is the same
+// variables its URL templates read. Vars maps a template placeholder name
+// to the environment variable name it is fed by, so a typed override can be
+// sent keyed by the name the registry actually substitutes. It is
+// registry.Transport.VarsEnv restricted to the placeholders some URL
+// template reads (Registry.TemplateVarsEnv): a vars_env entry nothing
+// substitutes, such as a credential's own variable, gets no input. VarsEnv is the same
 // environment-variable names alone, sorted. It stays a list because v3
 // peers — a TUI built before Vars existed — decode it as one, and
 // ProtocolVersion is compared exactly, so a wire shape cannot change under

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -2666,9 +2666,10 @@ type InstanceEntry struct {
 // to the environment variable name it is fed by, so a typed override can be
 // sent keyed by the name the registry actually substitutes. It is
 // registry.Transport.VarsEnv restricted to the placeholders some URL
-// template reads (Registry.TemplateVarsEnv): a vars_env entry nothing
-// substitutes, such as a credential's own variable, gets no input. VarsEnv is the same
-// environment-variable names alone, sorted. It stays a list because v3
+// template reads or a host rule consumes (Registry.TemplateVarsEnv): a
+// vars_env entry nothing substitutes, such as a credential's own variable,
+// gets no input. VarsEnv is the same environment-variable names alone,
+// sorted. It stays a list because v3
 // peers — a TUI built before Vars existed — decode it as one, and
 // ProtocolVersion is compared exactly, so a wire shape cannot change under
 // v3; new readers use Vars.

--- a/cmd/evener-hub/app_instances.go
+++ b/cmd/evener-hub/app_instances.go
@@ -54,13 +54,17 @@ func (c *hubInstancesController) List() appwire.InstanceListResponse {
 			if !ok {
 				continue
 			}
+			// Only the variables a URL template reads become inputs; the
+			// rest of vars_env (a credential's own variable) has no
+			// instance-level meaning the add form could give it.
+			vars := r.TemplateVarsEnv(id)
 			providers = append(providers, appwire.ProviderDescriptor{
 				ID:        id,
 				Name:      p.Name,
 				Protocol:  p.Protocol,
 				Auth:      p.Transport.Auth,
-				VarsEnv:   slices.Sorted(maps.Values(p.Transport.VarsEnv)),
-				Vars:      maps.Clone(p.Transport.VarsEnv),
+				VarsEnv:   slices.Sorted(maps.Values(vars)),
+				Vars:      vars,
 				APIKeyEnv: append([]string(nil), p.APIKeyEnv...),
 				Implicit:  registry.BoolValue(p.Implicit),
 			})

--- a/cmd/evener-hub/app_instances_test.go
+++ b/cmd/evener-hub/app_instances_test.go
@@ -8,6 +8,7 @@ package hub
 
 import (
 	"errors"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -216,6 +217,32 @@ func TestInstances_ListReportsAvailableProvidersAndUserLayer(t *testing.T) {
 	}
 	if resp.Instances == nil || resp.AvailableProviders == nil {
 		t.Fatal("both lists are always arrays on the wire, never null")
+	}
+}
+
+// TestInstances_ListOffersOnlyTemplateVars pins that a descriptor's variable
+// inputs are the ones the registry substitutes: google-vertex's snapshot env
+// list also names GOOGLE_APPLICATION_CREDENTIALS, which instance vars never
+// feed (the credential is read from the environment or the store), so an
+// input for it would persist a value nothing reads (roborev round 19).
+func TestInstances_ListOffersOnlyTemplateVars(t *testing.T) {
+	f := newInstancesFixture(t, nil)
+	resp := f.ctl.List()
+	var vertex *appwire.ProviderDescriptor
+	for i := range resp.AvailableProviders {
+		if resp.AvailableProviders[i].ID == "google-vertex" {
+			vertex = &resp.AvailableProviders[i]
+		}
+	}
+	if vertex == nil {
+		t.Fatalf("AvailableProviders has no google-vertex: %+v", resp.AvailableProviders)
+	}
+	wantVars := map[string]string{"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION", "GOOGLE_VERTEX_PROJECT": "GOOGLE_VERTEX_PROJECT"}
+	if !maps.Equal(vertex.Vars, wantVars) {
+		t.Fatalf("google-vertex descriptor Vars = %v, want only the URL template's variables %v", vertex.Vars, wantVars)
+	}
+	if want := []string{"GOOGLE_VERTEX_LOCATION", "GOOGLE_VERTEX_PROJECT"}; !slices.Equal(vertex.VarsEnv, want) {
+		t.Fatalf("google-vertex descriptor VarsEnv = %v, want %v", vertex.VarsEnv, want)
 	}
 }
 

--- a/cmd/evener-hub/app_instances_test.go
+++ b/cmd/evener-hub/app_instances_test.go
@@ -237,11 +237,17 @@ func TestInstances_ListOffersOnlyTemplateVars(t *testing.T) {
 	if vertex == nil {
 		t.Fatalf("AvailableProviders has no google-vertex: %+v", resp.AvailableProviders)
 	}
-	wantVars := map[string]string{"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION", "GOOGLE_VERTEX_PROJECT": "GOOGLE_VERTEX_PROJECT"}
-	if !maps.Equal(vertex.Vars, wantVars) {
-		t.Fatalf("google-vertex descriptor Vars = %v, want only the URL template's variables %v", vertex.Vars, wantVars)
+	// GOOGLE_VERTEX_ENDPOINT is read only by the OpenAI-compatible rows' own
+	// base URL, which is also the only place models.dev maps it.
+	wantVars := map[string]string{
+		"GOOGLE_VERTEX_ENDPOINT": "GOOGLE_VERTEX_ENDPOINT",
+		"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION",
+		"GOOGLE_VERTEX_PROJECT":  "GOOGLE_VERTEX_PROJECT",
 	}
-	if want := []string{"GOOGLE_VERTEX_LOCATION", "GOOGLE_VERTEX_PROJECT"}; !slices.Equal(vertex.VarsEnv, want) {
+	if !maps.Equal(vertex.Vars, wantVars) {
+		t.Fatalf("google-vertex descriptor Vars = %v, want only the URL templates' variables %v", vertex.Vars, wantVars)
+	}
+	if want := []string{"GOOGLE_VERTEX_ENDPOINT", "GOOGLE_VERTEX_LOCATION", "GOOGLE_VERTEX_PROJECT"}; !slices.Equal(vertex.VarsEnv, want) {
 		t.Fatalf("google-vertex descriptor VarsEnv = %v, want %v", vertex.VarsEnv, want)
 	}
 }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/ConnectProviderDialog.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/ConnectProviderDialog.test.tsx
@@ -647,4 +647,85 @@ describe("ConnectProviderDialog", () => {
     expect(screen.queryByRole("dialog", { name: "Set API key for work" })).toBeNull();
     expect(screen.getByRole("dialog", { name: "Connect provider" })).toBeTruthy();
   });
+
+  test("saving a credential JSON still requires an explicit successful credential test", async () => {
+    const vertex = instance({
+      name: "vertex",
+      providerId: "google-vertex",
+      auth: "gcp-adc",
+      authModes: ["adc", "credentialJson"],
+    });
+    const json = '{"type":"authorized_user","client_id":"a","client_secret":"b","refresh_token":"c"}';
+    let saved = false;
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/list", () => ({
+      instances: [saved ? { ...vertex, activeSource: "store", hasStoredFile: true } : vertex],
+      availableProviders: [],
+    }));
+    connectionStore.getState().connect(fake);
+    fake.on("evener/auth/credentialJson/set", (params) => {
+      expect(params).toEqual({ provider: "vertex", value: json });
+      saved = true;
+      return {
+        provider: "vertex",
+        supported: true,
+        signedIn: true,
+        activeSource: "store",
+        authModes: ["adc", "credentialJson"],
+        hasStoredOAuth: false,
+        hasStoredFile: true,
+      };
+    });
+    fake.on("evener/auth/test", (params) => {
+      expect(params).toEqual({ provider: "vertex" });
+      return { provider: "vertex", status: "success", message: "untrusted provider message" };
+    });
+    const onConnected = vi.fn();
+    render(<ConnectProviderDialog onClose={() => {}} onConnected={onConnected} />);
+    const chooser = await screen.findByRole("dialog", { name: "Connect provider" });
+    const user = userEvent.setup();
+
+    expect(within(chooser).queryByRole("button", { name: "Set API key" })).toBeNull();
+    await user.click(within(chooser).getByRole("button", { name: "Set credential JSON" }));
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    expect(screen.getByRole("dialog", { name: "Set Google credential JSON for vertex" })).toBeTruthy();
+
+    await user.click(screen.getByLabelText("Credential JSON for vertex"));
+    await user.paste(json);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    const returnedChooser = await screen.findByRole("dialog", { name: "Connect provider" });
+    expect(within(returnedChooser).getByText("Configured via stored credential JSON")).toBeTruthy();
+    expect(within(returnedChooser).getByRole("button", { name: "Replace credential JSON" })).toBeTruthy();
+    expect(onConnected).not.toHaveBeenCalled();
+
+    await user.click(within(returnedChooser).getByRole("button", { name: "Test connection" }));
+    await vi.waitFor(() => expect(onConnected).toHaveBeenCalledTimes(1));
+  });
+
+  test("a credential-JSON editor closes if its instance stops offering the mode", async () => {
+    const vertex = instance({
+      name: "vertex",
+      providerId: "google-vertex",
+      auth: "gcp-adc",
+      authModes: ["adc", "credentialJson"],
+    });
+    let listCalls = 0;
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/list", () => {
+      listCalls += 1;
+      return { instances: [listCalls === 1 ? vertex : { ...vertex, authModes: ["adc"] }], availableProviders: [] };
+    });
+    connectionStore.getState().connect(fake);
+    render(<ConnectProviderDialog onClose={() => {}} onConnected={() => {}} />);
+    await userEvent.setup().click(await screen.findByRole("button", { name: "Set credential JSON" }));
+    expect(screen.getByRole("dialog", { name: "Set Google credential JSON for vertex" })).toBeTruthy();
+
+    await act(async () => {
+      await credentialsStore.getState().fetch();
+    });
+
+    expect(screen.queryByRole("dialog", { name: "Set Google credential JSON for vertex" })).toBeNull();
+    expect(screen.getByRole("dialog", { name: "Connect provider" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Set credential JSON" })).toBeNull();
+  });
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/ConnectProviderDialog.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/ConnectProviderDialog.test.tsx
@@ -728,4 +728,22 @@ describe("ConnectProviderDialog", () => {
     expect(screen.getByRole("dialog", { name: "Connect provider" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Set credential JSON" })).toBeNull();
   });
+
+  test("a removed credential-JSON instance does not reopen its editor when restored", async () => {
+    const vertex = instance({
+      name: "vertex",
+      providerId: "google-vertex",
+      auth: "gcp-adc",
+      authModes: ["adc", "credentialJson"],
+    });
+    connectFakeClient({ instances: [vertex], availableProviders: [] });
+    render(<ConnectProviderDialog onClose={() => {}} onConnected={() => {}} />);
+    await userEvent.setup().click(await screen.findByRole("button", { name: "Set credential JSON" }));
+    expect(screen.getByRole("dialog", { name: "Set Google credential JSON for vertex" })).toBeTruthy();
+    await act(async () => credentialsStore.setState({ instances: [] }));
+    expect(screen.getByRole("dialog", { name: "Connect provider" })).toBeTruthy();
+    await act(async () => credentialsStore.setState({ instances: [vertex] }));
+    expect(screen.getByRole("dialog", { name: "Connect provider" })).toBeTruthy();
+    expect(screen.queryByRole("dialog", { name: "Set Google credential JSON for vertex" })).toBeNull();
+  });
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/ConnectProviderDialog.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/ConnectProviderDialog.tsx
@@ -8,7 +8,7 @@ import { requireClass } from "../../../../widgets/internal/requireClass";
 import { useConnectedEffect } from "../useConnectedEffect";
 import styles from "./ConnectProviderDialog.module.css";
 import { activeSourceLabel, safeCredentialTestResult } from "./credentialLabels";
-import { AddInstanceDialog, ApiKeyDialog } from "./instanceDialogs";
+import { AddInstanceDialog, ApiKeyDialog, CredentialJsonDialog } from "./instanceDialogs";
 import { DeviceCodeDialog, OAuthRedirectDialog } from "./oauthDialogs";
 import { type OAuthEditor, startOAuthFlow } from "./oauthFlow";
 
@@ -27,7 +27,11 @@ const CLASS = {
   diagnostics: requireClass(styles.diagnostics, "ConnectProviderDialog.module.css", "diagnostics"),
 };
 
-type OpenEditor = { kind: "add" } | { kind: "apiKey"; name: string } | OAuthEditor | null;
+// A stored-value editor's kind doubles as the auth mode that offers it, so
+// the same lookup finds the instance a "Set API key" or "Set credential
+// JSON" editor is open for and closes the editor once that mode is gone.
+type StoredValueEditor = { kind: "apiKey" | "credentialJson"; name: string };
+type OpenEditor = { kind: "add" } | StoredValueEditor | OAuthEditor | null;
 
 const TEST_INTERRUPTED_MESSAGE = "Provider configuration refreshed while testing. Test the connection again.";
 
@@ -106,14 +110,21 @@ export function ConnectProviderDialog({ onClose, onConnected }: ConnectProviderD
     );
   }, [instances]);
 
+  const storedValueEditorInstance = useCallback(
+    (editor: StoredValueEditor) =>
+      instances.find(
+        (candidate) => candidate.name === editor.name && (candidate.authModes ?? []).includes(editor.kind),
+      ),
+    [instances],
+  );
+
   useEffect(() => {
     setOpenEditor((editor) =>
-      editor?.kind === "apiKey" &&
-      !instances.some((instance) => instance.name === editor.name && (instance.authModes ?? []).includes("apiKey"))
+      (editor?.kind === "apiKey" || editor?.kind === "credentialJson") && !storedValueEditorInstance(editor)
         ? null
         : editor,
     );
-  }, [instances]);
+  }, [storedValueEditorInstance]);
 
   const closeEditor = useCallback(() => {
     operationVersion.current += 1;
@@ -173,11 +184,12 @@ export function ConnectProviderDialog({ onClose, onConnected }: ConnectProviderD
     }
   }
 
-  if (openEditor?.kind === "apiKey") {
-    const instance = instances.find(
-      (candidate) => candidate.name === openEditor.name && (candidate.authModes ?? []).includes("apiKey"),
-    );
-    if (instance) return <ApiKeyDialog instance={instance} onCancel={closeEditor} onSuccess={closeEditor} />;
+  if (openEditor?.kind === "apiKey" || openEditor?.kind === "credentialJson") {
+    const instance = storedValueEditorInstance(openEditor);
+    if (instance) {
+      const Editor = openEditor.kind === "apiKey" ? ApiKeyDialog : CredentialJsonDialog;
+      return <Editor instance={instance} onCancel={closeEditor} onSuccess={closeEditor} />;
+    }
   }
   if (openEditor?.kind === "add") {
     return <AddInstanceDialog availableProviders={availableProviders} onCancel={closeEditor} onSuccess={closeEditor} />;
@@ -244,6 +256,7 @@ export function ConnectProviderDialog({ onClose, onConnected }: ConnectProviderD
               const providerName =
                 availableProviders.find((provider) => provider.id === instance.providerId)?.name ?? instance.providerId;
               const supportsApiKey = (instance.authModes ?? []).includes("apiKey");
+              const supportsCredentialJson = (instance.authModes ?? []).includes("credentialJson");
               const supportsOAuth = (instance.authModes ?? []).includes("oauth");
               const pending =
                 testState?.name === instance.name && testState.version === instanceVersion.current && testState.pending;
@@ -271,6 +284,14 @@ export function ConnectProviderDialog({ onClose, onConnected }: ConnectProviderD
                     {supportsApiKey && (
                       <Button variant="secondary" onClick={() => chooseEditor({ kind: "apiKey", name: instance.name })}>
                         {instance.hasStoredFile ? "Replace API key" : "Set API key"}
+                      </Button>
+                    )}
+                    {supportsCredentialJson && (
+                      <Button
+                        variant="secondary"
+                        onClick={() => chooseEditor({ kind: "credentialJson", name: instance.name })}
+                      >
+                        {instance.hasStoredFile ? "Replace credential JSON" : "Set credential JSON"}
                       </Button>
                     )}
                     {supportsOAuth && (

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -1440,10 +1440,12 @@ templates that may contain `{model}` and `{VAR}`; empty means the protocol
 default (§6.1), `-` means unsupported. Variables resolve in this order: the
 user layer's `Vars` (instance config), then the environment through
 `VarsEnv` (a user-layer `vars_env` merges key-wise like `vars`; the
-provider's mapping is consulted first, then the resolved row's own — a
-models.dev per-model `api` template maps its placeholders on the row alone,
-which is where `google-vertex`'s OpenAI-compatible rows carry
-`GOOGLE_VERTEX_ENDPOINT`), then `Vars`
+provider's mapping is consulted, or the resolved row's own when the
+provider has none for the name — a models.dev per-model `api` template maps
+its placeholders on the row alone, which is where `google-vertex`'s
+OpenAI-compatible rows carry `GOOGLE_VERTEX_ENDPOINT`; a provider mapping
+whose variable is unset does not fall back to the row's, since the user
+redirected that name on purpose), then `Vars`
 from the curated and upstream layers (defaults), then the variable is left
 unresolved with a warning and the error naming the variable and the
 instance fires at the first request (§4.2). That order is what makes

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -1439,7 +1439,11 @@ them needs request signing or non-SSE framing.
 templates that may contain `{model}` and `{VAR}`; empty means the protocol
 default (§6.1), `-` means unsupported. Variables resolve in this order: the
 user layer's `Vars` (instance config), then the environment through
-`VarsEnv` (a user-layer `vars_env` merges key-wise like `vars`), then `Vars`
+`VarsEnv` (a user-layer `vars_env` merges key-wise like `vars`; the
+provider's mapping is consulted first, then the resolved row's own — a
+models.dev per-model `api` template maps its placeholders on the row alone,
+which is where `google-vertex`'s OpenAI-compatible rows carry
+`GOOGLE_VERTEX_ENDPOINT`), then `Vars`
 from the curated and upstream layers (defaults), then the variable is left
 unresolved with a warning and the error naming the variable and the
 instance fires at the first request (§4.2). That order is what makes

--- a/docs/superpowers/specs/2026-08-28-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-08-28-provider-registry-design.md
@@ -1868,7 +1868,9 @@ change shape (`appwire/types.go:2488-2523`): `InstanceEntry` drops `Type` and
 `APIKeyEnv` entry. `InstanceCreateParams` and `InstanceEditParams` follow;
 `InstanceListResponse.AvailableTypes` becomes `AvailableProviders` (registry
 ids with display names and `VarsEnv`, so the add form can render the right
-variable inputs). The credentials pane lists every curated implicit
+variable inputs — only the `VarsEnv` entries a URL template reads,
+`Registry.TemplateVarsEnv`, since a models.dev `env` list also names a
+credential's own variable that instance `vars` never feed). The credentials pane lists every curated implicit
 provider whether or not it currently has a credential (§5.2 resolves them
 regardless), which is where a fresh install signs in to `openai-codex` or
 enters its first key. That pane is fed by the `evener/auth/*` RPCs, which

--- a/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
+++ b/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
@@ -165,10 +165,7 @@ Also in this section:
 
 **Hub behaviour, no code change:** the add dialog lists the provider (with
 a `GOOGLE_VERTEX_EXPRESS_BASE_URL` input it renders for every `vars_env`
-name a URL template reads (`Registry.TemplateVarsEnv`, added 2026-09-06 so
-`google-vertex` no longer offers a `GOOGLE_APPLICATION_CREDENTIALS` input
-that instance vars never feed, roborev round 19) — optional; the dialog
-submits it under the template key `BASE_URL`,
+name — optional; the dialog submits it under the template key `BASE_URL`,
 so a typed value takes effect (fixed 2026-09-05, roborev round 1)); after
 creation the instance's `authModes` is `["apiKey"]`, so the sheet offers
 **Set API key**, which stores the key in `credentials.toml` under the
@@ -442,5 +439,12 @@ recorded per `docs/developing-evener/agentic-testing.md`.
   the sorted env-var-name list because the TUI decodes
   `evener/instance/list` through the shared types and `ProtocolVersion` is
   compared exactly, so no v3 wire shape may change.
+- **Resolved 2026-09-06, roborev round 19 (follow-up PR):** the add form
+  rendered a `GOOGLE_APPLICATION_CREDENTIALS` input for `google-vertex`
+  because models.dev's `env` list names it beside the project and location
+  and every entry became a `VarsEnv` input; instance `vars` only feed
+  template placeholders, so the value was persisted and ignored. The hub now
+  builds the descriptor from `Registry.TemplateVarsEnv`, the `vars_env`
+  entries a URL template reads or a host rule consumes.
 - User OAuth ("Sign in with Google") is the natural next spec if per-user
   credentials or remote hubs without pasteable JSON become a requirement.

--- a/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
+++ b/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
@@ -165,7 +165,10 @@ Also in this section:
 
 **Hub behaviour, no code change:** the add dialog lists the provider (with
 a `GOOGLE_VERTEX_EXPRESS_BASE_URL` input it renders for every `vars_env`
-name — optional; the dialog submits it under the template key `BASE_URL`,
+name a URL template reads (`Registry.TemplateVarsEnv`, added 2026-09-06 so
+`google-vertex` no longer offers a `GOOGLE_APPLICATION_CREDENTIALS` input
+that instance vars never feed, roborev round 19) — optional; the dialog
+submits it under the template key `BASE_URL`,
 so a typed value takes effect (fixed 2026-09-05, roborev round 1)); after
 creation the instance's `authModes` is `["apiKey"]`, so the sheet offers
 **Set API key**, which stores the key in `credentials.toml` under the

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -233,7 +233,7 @@ func (r *Registry) canonicalVarLookup(rec, base *record, shape Transport) func(s
 	for _, name := range hostRuleAuthorityVars(shape.HostRule) {
 		authority[name] = true
 	}
-	actual := r.varLookup(rec)
+	actual := r.varLookup(rec, shape)
 	defaults := r.defaultVarLookup(base)
 	return func(name string) (string, bool) {
 		if authority[name] {

--- a/llm/registry/instances.go
+++ b/llm/registry/instances.go
@@ -95,7 +95,7 @@ func (r *Registry) effectiveAPIKeyEnv(rec *record) []string {
 	base := r.curated[rec.providerID]
 	own, _, _ := r.resolveBaseURL(rec, rec.head.Transport)
 	live, _, _ := r.resolveBaseURL(base, base.head.Transport)
-	defaults, _, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base))
+	defaults, _, _ := r.resolveBaseURLWith(base, base.head.Transport, r.defaultVarLookup(base, base.head.Transport))
 	if own == live || own == defaults {
 		return rec.head.APIKeyEnv
 	}
@@ -234,7 +234,7 @@ func (r *Registry) canonicalVarLookup(rec, base *record, shape Transport) func(s
 		authority[name] = true
 	}
 	actual := r.varLookup(rec, shape)
-	defaults := r.defaultVarLookup(base)
+	defaults := r.defaultVarLookup(base, shape)
 	return func(name string) (string, bool) {
 		if authority[name] {
 			if v, ok := actual(name); ok && hostRuleInputAdmissible(shape.HostRule, name, v) {

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -1024,9 +1024,15 @@ func (r *Registry) resolveBaseURL(rec *record, t Transport) (string, []string, [
 
 // defaultVarLookup consults only the curated and upstream defaults — no user
 // vars, no environment (spec §10's "after substituting the curated defaults").
-func (r *Registry) defaultVarLookup(rec *record) func(string) (string, bool) {
+func (r *Registry) defaultVarLookup(rec *record, t Transport) func(string) (string, bool) {
 	return func(name string) (string, bool) {
+		// The provider's own default, or, for a name it does not set, the
+		// default of t, the transport shape being resolved — a row's own
+		// curated `vars` merged in by transportShape — mirroring varLookupWith.
 		v, ok := rec.head.Transport.Vars[name]
+		if !ok {
+			v, ok = t.Vars[name]
+		}
 		return v, ok && v != ""
 	}
 }

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -906,11 +906,16 @@ func expandTemplate(tpl string, lookup func(string) (string, bool)) (string, []s
 
 // varLookupWith is the spec §9.1 variable order with a warnings sink: the
 // user layer's vars, then the environment through vars_env, then the curated
-// and upstream defaults. A user `vars` entry whose $ENV reference is unset
-// warns and resolves to nothing instead of falling through to vars_env or
-// the curated default, so the URL never silently uses the value the user
-// meant to replace (spec §10).
-func (r *Registry) varLookupWith(rec *record, warn func(string)) func(string) (string, bool) {
+// and upstream defaults. The vars_env mappings and the defaults are the
+// provider's own first and then those of t, the transport being resolved:
+// a row's own mapping, merged in by transportShape, is where models.dev
+// keeps a per-model api template's placeholders (GOOGLE_VERTEX_ENDPOINT on
+// google-vertex's OpenAI-compatible rows), and a caller resolving the
+// provider's own transport passes it as t, which adds nothing. A user
+// `vars` entry whose $ENV reference is unset warns and resolves to nothing
+// instead of falling through to vars_env or the curated default, so the URL
+// never silently uses the value the user meant to replace (spec §10).
+func (r *Registry) varLookupWith(rec *record, t Transport, warn func(string)) func(string) (string, bool) {
 	return func(name string) (string, bool) {
 		if v, ok := rec.userVars[name]; ok {
 			expanded, missing := expandEnv(v, r.env)
@@ -924,13 +929,17 @@ func (r *Registry) varLookupWith(rec *record, warn func(string)) func(string) (s
 				return expanded, true
 			}
 		}
-		if envName, ok := rec.head.Transport.VarsEnv[name]; ok {
-			if v, ok := r.env(envName); ok && v != "" {
-				return v, true
+		for _, varsEnv := range []map[string]string{rec.head.Transport.VarsEnv, t.VarsEnv} {
+			if envName, ok := varsEnv[name]; ok {
+				if v, ok := r.env(envName); ok && v != "" {
+					return v, true
+				}
 			}
 		}
-		if v, ok := rec.head.Transport.Vars[name]; ok && v != "" {
-			return v, true
+		for _, vars := range []map[string]string{rec.head.Transport.Vars, t.Vars} {
+			if v, ok := vars[name]; ok && v != "" {
+				return v, true
+			}
 		}
 		return "", false
 	}
@@ -938,8 +947,8 @@ func (r *Registry) varLookupWith(rec *record, warn func(string)) func(string) (s
 
 // varLookup is varLookupWith for the callers that have no warnings channel
 // (the hidden computation and the endpoint stop).
-func (r *Registry) varLookup(rec *record) func(string) (string, bool) {
-	return r.varLookupWith(rec, func(string) {})
+func (r *Registry) varLookup(rec *record, t Transport) func(string) (string, bool) {
+	return r.varLookupWith(rec, t, func(string) {})
 }
 
 // resolveBaseURLWith substitutes t.BaseURL for rec using lookup, applying
@@ -1001,7 +1010,7 @@ func (r *Registry) resolveBaseURLVia(t Transport, lookup, env func(string) (stri
 // host-rule failures and the unresolved $ENV references of user `vars`.
 func (r *Registry) resolveBaseURL(rec *record, t Transport) (string, []string, []string) {
 	var varWarnings []string
-	url, missing, warnings := r.resolveBaseURLWith(rec, t, r.varLookupWith(rec, func(w string) { varWarnings = append(varWarnings, w) }))
+	url, missing, warnings := r.resolveBaseURLWith(rec, t, r.varLookupWith(rec, t, func(w string) { varWarnings = append(varWarnings, w) }))
 	return url, missing, append(warnings, varWarnings...)
 }
 
@@ -1064,27 +1073,26 @@ func (r *Registry) UnresolvedBaseURL(id string) (unset, problems []string) {
 
 // TemplateVarsEnv lists the variables a curated provider's URL templates
 // read, as a vars_env map restricted to them: a placeholder in the base URL
-// or an endpoint template (the provider's own transport or one of its rows';
-// top-level glob rows carry capabilities, not transports) or an input of the
-// host rule. The mappings come from the provider's vars_env and from its
-// rows' — a models.dev per-model api template maps its placeholders on the
-// row alone (convertModel), which is where google-vertex's OpenAI-compatible
-// rows keep GOOGLE_VERTEX_ENDPOINT — with the provider's own entry winning a
-// name both carry. A vars_env entry no template reads is left out —
+// or an endpoint template — the provider's own transport, one of its rows',
+// or a top-level glob row's when the glob matches one of its rows
+// (applyGlobs merges that transport into the row before substitution) — or
+// an input of the host rule. The mappings come from the same transports,
+// with the provider's own entry winning a name both carry: a models.dev
+// per-model api template maps its placeholders on the row alone
+// (convertModel), which is where google-vertex's OpenAI-compatible rows keep
+// GOOGLE_VERTEX_ENDPOINT. A vars_env entry no template reads is left out —
 // models.dev lists GOOGLE_APPLICATION_CREDENTIALS beside the Vertex project
 // and location, but the credential is read from the environment or the
 // store, never substituted — so a form built on the result offers no input
 // the registry would ignore. A provider with no curated base URL at all
 // (cloudflare-ai-gateway, watsonx: models.dev publishes no api for them)
-// keeps its whole map: the user supplies the URL, and a placeholder they
-// type still resolves from instance vars. Nil for an unknown id.
+// keeps every provider-level mapping: the user supplies the URL, and a
+// placeholder they type still resolves from instance vars. Nil for an
+// unknown id.
 func (r *Registry) TemplateVarsEnv(id string) map[string]string {
 	rec, ok := r.curated[id]
 	if !ok {
 		return nil
-	}
-	if rec.head.Transport.BaseURL == "" {
-		return mergeStringMap(nil, rec.head.Transport.VarsEnv)
 	}
 	referenced := map[string]bool{}
 	var mapped map[string]string
@@ -1096,6 +1104,21 @@ func (r *Registry) TemplateVarsEnv(id string) map[string]string {
 		}
 		mapped = mergeStringMap(mapped, t.VarsEnv)
 	}
+	matchesRow := func(glob string) bool {
+		for rowID := range rec.head.Models {
+			if matchGlob(glob, rowID) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, rows := range r.topGlobs {
+		for glob, row := range rows {
+			if row.Transport != nil && matchesRow(glob) {
+				note(*row.Transport)
+			}
+		}
+	}
 	for _, row := range rec.head.Models {
 		if row.Transport != nil {
 			note(*row.Transport)
@@ -1104,6 +1127,11 @@ func (r *Registry) TemplateVarsEnv(id string) map[string]string {
 	note(rec.head.Transport)
 	for _, name := range hostRuleAuthorityVars(rec.head.Transport.HostRule) {
 		referenced[name] = true
+	}
+	if rec.head.Transport.BaseURL == "" {
+		for name := range rec.head.Transport.VarsEnv {
+			referenced[name] = true
+		}
 	}
 	out := map[string]string{}
 	for name, env := range mapped {

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -906,15 +906,19 @@ func expandTemplate(tpl string, lookup func(string) (string, bool)) (string, []s
 
 // varLookupWith is the spec §9.1 variable order with a warnings sink: the
 // user layer's vars, then the environment through vars_env, then the curated
-// and upstream defaults. The vars_env mappings and the defaults are the
-// provider's own first and then those of t, the transport being resolved:
-// a row's own mapping, merged in by transportShape, is where models.dev
-// keeps a per-model api template's placeholders (GOOGLE_VERTEX_ENDPOINT on
-// google-vertex's OpenAI-compatible rows), and a caller resolving the
-// provider's own transport passes it as t, which adds nothing. A user
-// `vars` entry whose $ENV reference is unset warns and resolves to nothing
-// instead of falling through to vars_env or the curated default, so the URL
-// never silently uses the value the user meant to replace (spec §10).
+// and upstream defaults. A vars_env mapping or a default is the provider's
+// own, or, for a name the provider does not map at all, that of t, the
+// transport shape being resolved: a row's own mapping, merged in by
+// transportShape, is where models.dev keeps a per-model api template's
+// placeholders (GOOGLE_VERTEX_ENDPOINT on google-vertex's OpenAI-compatible
+// rows), and a caller resolving the provider's own transport passes it as t,
+// which adds nothing. A provider mapping whose variable is unset does not
+// fall back to the row's: a user who redirected the name (a user-layer
+// vars_env merges into the provider's) meant to replace that value, so the
+// URL stays unresolved and warned rather than silently reading the stock
+// variable — the same rule spec §10 states for a user `vars` entry whose
+// $ENV reference is unset, which warns and resolves to nothing instead of
+// falling through to vars_env or the curated default.
 func (r *Registry) varLookupWith(rec *record, t Transport, warn func(string)) func(string) (string, bool) {
 	return func(name string) (string, bool) {
 		if v, ok := rec.userVars[name]; ok {
@@ -929,17 +933,21 @@ func (r *Registry) varLookupWith(rec *record, t Transport, warn func(string)) fu
 				return expanded, true
 			}
 		}
-		for _, varsEnv := range []map[string]string{rec.head.Transport.VarsEnv, t.VarsEnv} {
-			if envName, ok := varsEnv[name]; ok {
-				if v, ok := r.env(envName); ok && v != "" {
-					return v, true
-				}
-			}
+		envName, mapped := rec.head.Transport.VarsEnv[name]
+		if !mapped {
+			envName, mapped = t.VarsEnv[name]
 		}
-		for _, vars := range []map[string]string{rec.head.Transport.Vars, t.Vars} {
-			if v, ok := vars[name]; ok && v != "" {
+		if mapped {
+			if v, ok := r.env(envName); ok && v != "" {
 				return v, true
 			}
+		}
+		def, has := rec.head.Transport.Vars[name]
+		if !has {
+			def, has = t.Vars[name]
+		}
+		if has && def != "" {
+			return def, true
 		}
 		return "", false
 	}

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -1084,7 +1084,8 @@ func (r *Registry) UnresolvedBaseURL(id string) (unset, problems []string) {
 // or an endpoint template — the provider's own transport, one of its rows',
 // or a top-level glob row's when the glob matches one of its rows
 // (applyGlobs merges that transport into the row before substitution) — or
-// an input of the host rule. The mappings come from the same transports,
+// an input of any of those transports' host rules. The mappings come from
+// the same transports,
 // with the provider's own entry winning a name both carry: a models.dev
 // per-model api template maps its placeholders on the row alone
 // (convertModel), which is where google-vertex's OpenAI-compatible rows keep
@@ -1110,6 +1111,9 @@ func (r *Registry) TemplateVarsEnv(id string) map[string]string {
 				referenced[m[1]] = true
 			}
 		}
+		for _, name := range hostRuleAuthorityVars(t.HostRule) {
+			referenced[name] = true
+		}
 		mapped = mergeStringMap(mapped, t.VarsEnv)
 	}
 	matchesRow := func(glob string) bool {
@@ -1133,9 +1137,6 @@ func (r *Registry) TemplateVarsEnv(id string) map[string]string {
 		}
 	}
 	note(rec.head.Transport)
-	for _, name := range hostRuleAuthorityVars(rec.head.Transport.HostRule) {
-		referenced[name] = true
-	}
 	if rec.head.Transport.BaseURL == "" {
 		for name := range rec.head.Transport.VarsEnv {
 			referenced[name] = true

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -1064,16 +1064,23 @@ func (r *Registry) UnresolvedBaseURL(id string) (unset, problems []string) {
 
 // TemplateVarsEnv lists the variables a curated provider's URL templates
 // read, as the vars_env map restricted to them: a placeholder in the base
-// URL or an endpoint template (the provider's own or a row's) or an input of
-// the host rule. A vars_env entry no template reads is left out — models.dev
-// lists GOOGLE_APPLICATION_CREDENTIALS beside the Vertex project and
-// location, but the credential is read from the environment or the store,
-// never substituted — so a form built on the result offers no input the
-// registry would ignore. Nil for an unknown id.
+// URL or an endpoint template (the provider's own transport or one of its
+// rows'; top-level glob rows carry capabilities, not transports) or an input
+// of the host rule. A vars_env entry no template reads is left out —
+// models.dev lists GOOGLE_APPLICATION_CREDENTIALS beside the Vertex project
+// and location, but the credential is read from the environment or the
+// store, never substituted — so a form built on the result offers no input
+// the registry would ignore. A provider with no curated base URL at all
+// (cloudflare-ai-gateway, watsonx: models.dev publishes no api for them)
+// keeps its whole map: the user supplies the URL, and a placeholder they
+// type still resolves from instance vars. Nil for an unknown id.
 func (r *Registry) TemplateVarsEnv(id string) map[string]string {
 	rec, ok := r.curated[id]
 	if !ok {
 		return nil
+	}
+	if rec.head.Transport.BaseURL == "" {
+		return mergeStringMap(nil, rec.head.Transport.VarsEnv)
 	}
 	referenced := map[string]bool{}
 	note := func(t Transport) {

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -1063,10 +1063,14 @@ func (r *Registry) UnresolvedBaseURL(id string) (unset, problems []string) {
 }
 
 // TemplateVarsEnv lists the variables a curated provider's URL templates
-// read, as the vars_env map restricted to them: a placeholder in the base
-// URL or an endpoint template (the provider's own transport or one of its
-// rows'; top-level glob rows carry capabilities, not transports) or an input
-// of the host rule. A vars_env entry no template reads is left out —
+// read, as a vars_env map restricted to them: a placeholder in the base URL
+// or an endpoint template (the provider's own transport or one of its rows';
+// top-level glob rows carry capabilities, not transports) or an input of the
+// host rule. The mappings come from the provider's vars_env and from its
+// rows' — a models.dev per-model api template maps its placeholders on the
+// row alone (convertModel), which is where google-vertex's OpenAI-compatible
+// rows keep GOOGLE_VERTEX_ENDPOINT — with the provider's own entry winning a
+// name both carry. A vars_env entry no template reads is left out —
 // models.dev lists GOOGLE_APPLICATION_CREDENTIALS beside the Vertex project
 // and location, but the credential is read from the environment or the
 // store, never substituted — so a form built on the result offers no input
@@ -1083,24 +1087,26 @@ func (r *Registry) TemplateVarsEnv(id string) map[string]string {
 		return mergeStringMap(nil, rec.head.Transport.VarsEnv)
 	}
 	referenced := map[string]bool{}
+	var mapped map[string]string
 	note := func(t Transport) {
 		for _, tpl := range []string{t.BaseURL, t.Endpoint, t.StreamEndpoint, t.ModelsEndpoint, t.CountTokensEndpoint} {
 			for _, m := range placeholderRe.FindAllStringSubmatch(tpl, -1) {
 				referenced[m[1]] = true
 			}
 		}
+		mapped = mergeStringMap(mapped, t.VarsEnv)
 	}
-	note(rec.head.Transport)
 	for _, row := range rec.head.Models {
 		if row.Transport != nil {
 			note(*row.Transport)
 		}
 	}
+	note(rec.head.Transport)
 	for _, name := range hostRuleAuthorityVars(rec.head.Transport.HostRule) {
 		referenced[name] = true
 	}
 	out := map[string]string{}
-	for name, env := range rec.head.Transport.VarsEnv {
+	for name, env := range mapped {
 		if referenced[name] {
 			out[name] = env
 		}

--- a/llm/registry/load.go
+++ b/llm/registry/load.go
@@ -1062,6 +1062,45 @@ func (r *Registry) UnresolvedBaseURL(id string) (unset, problems []string) {
 	return slices.Compact(unset), slices.Compact(warnings)
 }
 
+// TemplateVarsEnv lists the variables a curated provider's URL templates
+// read, as the vars_env map restricted to them: a placeholder in the base
+// URL or an endpoint template (the provider's own or a row's) or an input of
+// the host rule. A vars_env entry no template reads is left out — models.dev
+// lists GOOGLE_APPLICATION_CREDENTIALS beside the Vertex project and
+// location, but the credential is read from the environment or the store,
+// never substituted — so a form built on the result offers no input the
+// registry would ignore. Nil for an unknown id.
+func (r *Registry) TemplateVarsEnv(id string) map[string]string {
+	rec, ok := r.curated[id]
+	if !ok {
+		return nil
+	}
+	referenced := map[string]bool{}
+	note := func(t Transport) {
+		for _, tpl := range []string{t.BaseURL, t.Endpoint, t.StreamEndpoint, t.ModelsEndpoint, t.CountTokensEndpoint} {
+			for _, m := range placeholderRe.FindAllStringSubmatch(tpl, -1) {
+				referenced[m[1]] = true
+			}
+		}
+	}
+	note(rec.head.Transport)
+	for _, row := range rec.head.Models {
+		if row.Transport != nil {
+			note(*row.Transport)
+		}
+	}
+	for _, name := range hostRuleAuthorityVars(rec.head.Transport.HostRule) {
+		referenced[name] = true
+	}
+	out := map[string]string{}
+	for name, env := range rec.head.Transport.VarsEnv {
+		if referenced[name] {
+			out[name] = env
+		}
+	}
+	return out
+}
+
 // ProviderIDs lists the curated registry ids, sorted.
 func (r *Registry) ProviderIDs() []string { return sortedKeys(r.curated) }
 

--- a/llm/registry/load_test.go
+++ b/llm/registry/load_test.go
@@ -794,6 +794,16 @@ func TestTemplateVarsEnv(t *testing.T) {
 			"GOOGLE_APPLICATION_CREDENTIALS": "GOOGLE_APPLICATION_CREDENTIALS",
 		},
 	}}}
+	// No curated base URL, but a row with its own template: the provider's
+	// whole map stays offered (the user types the URL) and the row's mapping
+	// is offered too.
+	r.curated["typed-url"] = &record{head: Provider{
+		Transport: Transport{VarsEnv: map[string]string{"ACCOUNT": "EXAMPLE_ACCOUNT"}},
+		Models: map[string]Model{"m": {Transport: &Transport{
+			BaseURL: "https://{REGION}.example.test/v1",
+			VarsEnv: map[string]string{"REGION": "EXAMPLE_REGION"},
+		}}},
+	}}
 	for _, tt := range []struct {
 		id   string
 		want map[string]string
@@ -807,6 +817,7 @@ func TestTemplateVarsEnv(t *testing.T) {
 		// No curated base URL (models.dev publishes no api): the user types
 		// the URL, so every vars_env entry stays offered.
 		{id: "watsonx", want: map[string]string{"WATSONX_AI_PROJECT_ID": "WATSONX_AI_PROJECT_ID"}},
+		{id: "typed-url", want: map[string]string{"ACCOUNT": "EXAMPLE_ACCOUNT", "REGION": "EXAMPLE_REGION"}},
 		{id: "no-such-provider"},
 	} {
 		t.Run(tt.id, func(t *testing.T) {
@@ -814,6 +825,21 @@ func TestTemplateVarsEnv(t *testing.T) {
 				t.Fatalf("TemplateVarsEnv(%q) = %v, want %v", tt.id, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestTemplateVarsEnvTopLevelGlob: a top-level glob row may carry a transport
+// (applyGlobs merges it into every matching row before substitution), so its
+// placeholders and mappings are offered to the providers that have a matching
+// row and to no other.
+func TestTemplateVarsEnvTopLevelGlob(t *testing.T) {
+	glob := "[models.\"*llama-3.3-70b*\"]\nbase_url = \"https://{GLOB_REGION}.example.test/v1\"\nvars_env = { \"GLOB_REGION\" = \"EXAMPLE_GLOB_REGION\" }\n"
+	r := fixtureLoad(t, nil, "", WithOverlay(overlayWith(glob)))
+	if got := r.TemplateVarsEnv("google-vertex")["GLOB_REGION"]; got != "EXAMPLE_GLOB_REGION" {
+		t.Fatalf("google-vertex (has llama-3.3-70b rows) TemplateVarsEnv = %v, want GLOB_REGION mapped", r.TemplateVarsEnv("google-vertex"))
+	}
+	if got := r.TemplateVarsEnv("openai"); got["GLOB_REGION"] != "" {
+		t.Fatalf("openai (no matching row) TemplateVarsEnv = %v, want no GLOB_REGION", got)
 	}
 }
 

--- a/llm/registry/load_test.go
+++ b/llm/registry/load_test.go
@@ -773,12 +773,18 @@ func TestUnresolvedBaseURL(t *testing.T) {
 // no template reads and the registry never substitutes (roborev round 19).
 func TestTemplateVarsEnv(t *testing.T) {
 	r := fixtureLoad(t, nil, "")
+	// A row's own base URL carries its own vars_env mapping (models.dev's
+	// per-model api templates, convertModel): the row is the only place
+	// REGION is read or mapped, and the provider's UNREAD is read nowhere.
 	r.curated["row-only"] = &record{head: Provider{
 		Transport: Transport{
 			BaseURL: "https://example.test/v1",
-			VarsEnv: map[string]string{"REGION": "EXAMPLE_REGION", "UNREAD": "EXAMPLE_UNREAD"},
+			VarsEnv: map[string]string{"UNREAD": "EXAMPLE_UNREAD"},
 		},
-		Models: map[string]Model{"m": {Transport: &Transport{BaseURL: "https://{REGION}.example.test/v1"}}},
+		Models: map[string]Model{"m": {Transport: &Transport{
+			BaseURL: "https://{REGION}.example.test/v1",
+			VarsEnv: map[string]string{"REGION": "EXAMPLE_REGION"},
+		}}},
 	}}
 	r.curated["rule-only"] = &record{head: Provider{Transport: Transport{
 		BaseURL:  "{GOOGLE_VERTEX_HOST}/v1",
@@ -792,7 +798,9 @@ func TestTemplateVarsEnv(t *testing.T) {
 		id   string
 		want map[string]string
 	}{
-		{id: "google-vertex", want: map[string]string{"GOOGLE_VERTEX_PROJECT": "GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION"}},
+		// GOOGLE_VERTEX_ENDPOINT is read and mapped only by the OpenAI-compatible
+		// rows' own base URL; GOOGLE_APPLICATION_CREDENTIALS by nothing.
+		{id: "google-vertex", want: map[string]string{"GOOGLE_VERTEX_PROJECT": "GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION", "GOOGLE_VERTEX_ENDPOINT": "GOOGLE_VERTEX_ENDPOINT"}},
 		{id: "openai", want: map[string]string{"BASE_URL": "OPENAI_BASE_URL"}},
 		{id: "row-only", want: map[string]string{"REGION": "EXAMPLE_REGION"}},
 		{id: "rule-only", want: map[string]string{"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION"}},

--- a/llm/registry/load_test.go
+++ b/llm/registry/load_test.go
@@ -794,6 +794,16 @@ func TestTemplateVarsEnv(t *testing.T) {
 			"GOOGLE_APPLICATION_CREDENTIALS": "GOOGLE_APPLICATION_CREDENTIALS",
 		},
 	}}}
+	// The host rule and its input mapping live on a row's own transport
+	// (the schema allows a row host_rule; transportShape merges it).
+	r.curated["row-rule-only"] = &record{head: Provider{
+		Transport: Transport{BaseURL: "https://example.test/v1", VarsEnv: map[string]string{"UNREAD": "EXAMPLE_UNREAD"}},
+		Models: map[string]Model{"m": {Transport: &Transport{
+			BaseURL:  "{GOOGLE_VERTEX_HOST}/v1",
+			HostRule: HostRuleVertexLocation,
+			VarsEnv:  map[string]string{"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION"},
+		}}},
+	}}
 	// No curated base URL, but a row with its own template: the provider's
 	// whole map stays offered (the user types the URL) and the row's mapping
 	// is offered too.
@@ -814,6 +824,7 @@ func TestTemplateVarsEnv(t *testing.T) {
 		{id: "openai", want: map[string]string{"BASE_URL": "OPENAI_BASE_URL"}},
 		{id: "row-only", want: map[string]string{"REGION": "EXAMPLE_REGION"}},
 		{id: "rule-only", want: map[string]string{"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION"}},
+		{id: "row-rule-only", want: map[string]string{"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION"}},
 		// No curated base URL (models.dev publishes no api): the user types
 		// the URL, so every vars_env entry stays offered.
 		{id: "watsonx", want: map[string]string{"WATSONX_AI_PROJECT_ID": "WATSONX_AI_PROJECT_ID"}},

--- a/llm/registry/load_test.go
+++ b/llm/registry/load_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -760,6 +761,46 @@ func TestUnresolvedBaseURL(t *testing.T) {
 			}
 			if len(problems) != 1 || !strings.Contains(problems[0], tt.wantProblem) {
 				t.Fatalf("UnresolvedBaseURL(%q) problems = %v, want one naming %s", tt.id, problems, tt.wantProblem)
+			}
+		})
+	}
+}
+
+// TestTemplateVarsEnv covers which vars_env entries an add form should offer:
+// the ones a URL template reads, wherever that template lives (a row's own
+// base URL counts), plus a host rule's inputs. The models.dev env list also
+// names the credential's own variable (GOOGLE_APPLICATION_CREDENTIALS), which
+// no template reads and the registry never substitutes (roborev round 19).
+func TestTemplateVarsEnv(t *testing.T) {
+	r := fixtureLoad(t, nil, "")
+	r.curated["row-only"] = &record{head: Provider{
+		Transport: Transport{
+			BaseURL: "https://example.test/v1",
+			VarsEnv: map[string]string{"REGION": "EXAMPLE_REGION", "UNREAD": "EXAMPLE_UNREAD"},
+		},
+		Models: map[string]Model{"m": {Transport: &Transport{BaseURL: "https://{REGION}.example.test/v1"}}},
+	}}
+	r.curated["rule-only"] = &record{head: Provider{Transport: Transport{
+		BaseURL:  "{GOOGLE_VERTEX_HOST}/v1",
+		HostRule: HostRuleVertexLocation,
+		VarsEnv: map[string]string{
+			"GOOGLE_VERTEX_LOCATION":         "GOOGLE_VERTEX_LOCATION",
+			"GOOGLE_APPLICATION_CREDENTIALS": "GOOGLE_APPLICATION_CREDENTIALS",
+		},
+	}}}
+	for _, tt := range []struct {
+		id   string
+		want map[string]string
+	}{
+		{id: "google-vertex", want: map[string]string{"GOOGLE_VERTEX_PROJECT": "GOOGLE_VERTEX_PROJECT", "GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION"}},
+		{id: "openai", want: map[string]string{"BASE_URL": "OPENAI_BASE_URL"}},
+		{id: "row-only", want: map[string]string{"REGION": "EXAMPLE_REGION"}},
+		{id: "rule-only", want: map[string]string{"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION"}},
+		{id: "no-such-provider"},
+	} {
+		t.Run(tt.id, func(t *testing.T) {
+			if got := r.TemplateVarsEnv(tt.id); !maps.Equal(got, tt.want) {
+				t.Fatalf("TemplateVarsEnv(%q) = %v, want %v", tt.id, got, tt.want)
 			}
 		})
 	}

--- a/llm/registry/load_test.go
+++ b/llm/registry/load_test.go
@@ -838,8 +838,8 @@ func TestTemplateVarsEnvTopLevelGlob(t *testing.T) {
 	if got := r.TemplateVarsEnv("google-vertex")["GLOB_REGION"]; got != "EXAMPLE_GLOB_REGION" {
 		t.Fatalf("google-vertex (has llama-3.3-70b rows) TemplateVarsEnv = %v, want GLOB_REGION mapped", r.TemplateVarsEnv("google-vertex"))
 	}
-	if got := r.TemplateVarsEnv("openai"); got["GLOB_REGION"] != "" {
-		t.Fatalf("openai (no matching row) TemplateVarsEnv = %v, want no GLOB_REGION", got)
+	if got, want := r.TemplateVarsEnv("openai"), map[string]string{"BASE_URL": "OPENAI_BASE_URL"}; !maps.Equal(got, want) {
+		t.Fatalf("openai (no matching row) TemplateVarsEnv = %v, want %v", got, want)
 	}
 }
 

--- a/llm/registry/load_test.go
+++ b/llm/registry/load_test.go
@@ -796,6 +796,9 @@ func TestTemplateVarsEnv(t *testing.T) {
 		{id: "openai", want: map[string]string{"BASE_URL": "OPENAI_BASE_URL"}},
 		{id: "row-only", want: map[string]string{"REGION": "EXAMPLE_REGION"}},
 		{id: "rule-only", want: map[string]string{"GOOGLE_VERTEX_LOCATION": "GOOGLE_VERTEX_LOCATION"}},
+		// No curated base URL (models.dev publishes no api): the user types
+		// the URL, so every vars_env entry stays offered.
+		{id: "watsonx", want: map[string]string{"WATSONX_AI_PROJECT_ID": "WATSONX_AI_PROJECT_ID"}},
 		{id: "no-such-provider"},
 	} {
 		t.Run(tt.id, func(t *testing.T) {

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -640,14 +640,13 @@ func (r *Registry) transportShape(rec *record, row Model, proto string) Transpor
 // protocol defaults, and variable substitution (spec §9.1).
 func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transport, []string) {
 	t := r.transportShape(rec, row, proto)
-	// The templates, captured before substitution, are the authoritative list
-	// of variables Resolved may expose (URL parts such as a region, resource,
-	// or project). Resolved is serialized by `evener models inspect`, so no
-	// vars_env value that a template does not reference is ever exposed.
-	templates := []string{rec.head.Transport.BaseURL, t.Endpoint, t.StreamEndpoint, t.ModelsEndpoint, t.CountTokensEndpoint}
-	if row.Transport != nil && row.Transport.BaseURL != "" {
-		templates = append(templates, row.Transport.BaseURL)
-	}
+	// The templates the URL is built from, captured before substitution, are
+	// the authoritative list of variables Resolved may expose (URL parts such
+	// as a region, resource, or project): the effective base URL template —
+	// the row's own when it has one, else the provider's — and the endpoint
+	// templates. Resolved is serialized by `evener models inspect`, so no
+	// vars_env value that the URL does not use is ever exposed.
+	templates := []string{t.BaseURL, t.Endpoint, t.StreamEndpoint, t.ModelsEndpoint, t.CountTokensEndpoint}
 
 	var warnings, varWarnings []string
 	// One lookup serves the base URL, the endpoint templates, and the Vars
@@ -669,10 +668,23 @@ func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transpo
 	slices.Sort(varWarnings)
 	warnings = append(warnings, slices.Compact(varWarnings)...)
 	resolved := map[string]string{}
+	referenced := map[string]bool{}
 	for _, tpl := range templates {
 		for _, m := range placeholderRe.FindAllStringSubmatch(tpl, -1) {
+			referenced[m[1]] = true
 			if v, ok := lookup(m[1]); ok {
 				resolved[m[1]] = v
+			}
+		}
+	}
+	// A host the vertex-location rule derived from the location used the
+	// location as surely as a path placeholder would have, so it is exposed
+	// too (and the regional warning reads it). A host supplied directly used
+	// no location.
+	if t.HostRule == HostRuleVertexLocation && referenced["GOOGLE_VERTEX_HOST"] {
+		if _, direct := lookup("GOOGLE_VERTEX_HOST"); !direct {
+			if loc, ok := lookup("GOOGLE_VERTEX_LOCATION"); ok {
+				resolved["GOOGLE_VERTEX_LOCATION"] = loc
 			}
 		}
 	}

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -457,7 +457,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	}
 	warnings = append(warnings, rec.notes...)
 	if transport.HostRule == HostRuleVertexLocation {
-		if loc, ok := r.varLookup(rec, transport)("GOOGLE_VERTEX_LOCATION"); ok && loc != "global" && loc != "us" && loc != "eu" {
+		if loc, ok := r.varLookup(rec, rec.head.Transport)("GOOGLE_VERTEX_LOCATION"); ok && loc != "global" && loc != "us" && loc != "eu" {
 			for _, p := range vertexGlobalOnly {
 				if strings.Contains(hit.wireID, p) {
 					warnings = append(warnings, fmt.Sprintf("regional Vertex location %q supports Claude Sonnet 4.6 and earlier; use global, us, or eu for %s", loc, hit.wireID))

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -457,7 +457,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	}
 	warnings = append(warnings, rec.notes...)
 	if transport.HostRule == HostRuleVertexLocation {
-		if loc, ok := r.varLookup(rec)("GOOGLE_VERTEX_LOCATION"); ok && loc != "global" && loc != "us" && loc != "eu" {
+		if loc, ok := r.varLookup(rec, transport)("GOOGLE_VERTEX_LOCATION"); ok && loc != "global" && loc != "us" && loc != "eu" {
 			for _, p := range vertexGlobalOnly {
 				if strings.Contains(hit.wireID, p) {
 					warnings = append(warnings, fmt.Sprintf("regional Vertex location %q supports Claude Sonnet 4.6 and earlier; use global, us, or eu for %s", loc, hit.wireID))
@@ -651,7 +651,7 @@ func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transpo
 	// One lookup serves the base URL, the endpoint templates, and the Vars
 	// scan, so a user `vars` entry with an unset $ENV reference is reported
 	// once however many templates read it (spec §10).
-	lookup := r.varLookupWith(rec, func(w string) { varWarnings = append(varWarnings, w) })
+	lookup := r.varLookupWith(rec, t, func(w string) { varWarnings = append(varWarnings, w) })
 	url, missing, hostWarnings := r.resolveBaseURLWith(rec, t, lookup)
 	t.BaseURL = url
 	warnings = append(warnings, hostWarnings...)

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -457,7 +457,9 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	}
 	warnings = append(warnings, rec.notes...)
 	if transport.HostRule == HostRuleVertexLocation {
-		if loc, ok := r.varLookup(rec, rec.head.Transport)("GOOGLE_VERTEX_LOCATION"); ok && loc != "global" && loc != "us" && loc != "eu" {
+		// The location the URL was actually built with (buildTransport's
+		// Vars), whichever mapping supplied it.
+		if loc, ok := transport.Vars["GOOGLE_VERTEX_LOCATION"]; ok && loc != "global" && loc != "us" && loc != "eu" {
 			for _, p := range vertexGlobalOnly {
 				if strings.Contains(hit.wireID, p) {
 					warnings = append(warnings, fmt.Sprintf("regional Vertex location %q supports Claude Sonnet 4.6 and earlier; use global, us, or eu for %s", loc, hit.wireID))

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -1117,3 +1117,21 @@ func TestResolve_RowMappedVarsEnvReadsTheEnvironment(t *testing.T) {
 		})
 	}
 }
+
+// TestResolve_WebSearchCanonicalGateRowDefault: a curated row's own `vars`
+// default is curated data like the provider's, so the canonical first-party
+// resolution reads it for an authority placeholder the row's base URL
+// names, exactly as the actual resolution does; the two sides agree and the
+// vendor's hosted tool survives (roborev PR #924 round 5).
+func TestResolve_WebSearchCanonicalGateRowDefault(t *testing.T) {
+	overlay := "[providers.rowdefault]\nimplicit = true\nprotocol = \"openai-chat\"\nbase_url = \"https://{HOST}/v1\"\nvars = { \"HOST\" = \"provider.example.test\" }\nweb_search = true\n" +
+		"[providers.rowdefault.models.\"m\"]\nbase_url = \"https://{ROW_HOST}/v1\"\nvars = { \"ROW_HOST\" = \"row.example.test\" }\n"
+	r := fixtureLoad(t, nil, "", WithOverlay(overlayWith(overlay)))
+	res := mustResolve(t, r, "rowdefault/m")
+	if res.Transport.BaseURL != "https://row.example.test/v1" {
+		t.Fatalf("row default must resolve the row's own base URL: %+v", res.Transport)
+	}
+	if bp(res.Caps.WebSearch) != "true" || hasWarning(res, "web_search disabled") {
+		t.Fatalf("a row resolved from its curated default is first-party: web_search = %s, warnings %v", bp(res.Caps.WebSearch), res.Warnings)
+	}
+}

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -1032,3 +1032,40 @@ func TestStripDatedSuffix(t *testing.T) {
 		}
 	}
 }
+
+// TestResolve_RowMappedVarsEnvReadsTheEnvironment: models.dev maps a
+// per-model api template's placeholders on the row alone (convertModel), so
+// google-vertex's OpenAI-compatible rows are the only place
+// GOOGLE_VERTEX_ENDPOINT is mapped. The lookup consults the row's mapping
+// after the provider's, so the environment variable resolves the row's URL
+// (roborev PR #924 round 2); a user instance's own vars_env still wins.
+func TestResolve_RowMappedVarsEnvReadsTheEnvironment(t *testing.T) {
+	env := map[string]string{
+		"GOOGLE_VERTEX_PROJECT":  "p",
+		"GOOGLE_VERTEX_LOCATION": "us-central1",
+		"GOOGLE_VERTEX_ENDPOINT": "us-central1-aiplatform.googleapis.com",
+		"MY_ENDPOINT":            "my-endpoint.example.test",
+	}
+	r := fixtureLoad(t, env, "[providers.mine]\nbase = \"google-vertex\"\nvars_env = { \"GOOGLE_VERTEX_ENDPOINT\" = \"MY_ENDPOINT\" }\n")
+	for _, tt := range []struct {
+		ref, host string
+	}{
+		{ref: "google-vertex/meta/llama-3.3-70b-instruct-maas", host: "us-central1-aiplatform.googleapis.com"},
+		{ref: "mine/meta/llama-3.3-70b-instruct-maas", host: "my-endpoint.example.test"},
+	} {
+		res, err := r.Resolve(tt.ref)
+		if err != nil {
+			t.Fatalf("Resolve(%q): %v", tt.ref, err)
+		}
+		want := "https://" + tt.host + "/v1/projects/p/locations/us-central1/endpoints/openapi"
+		if res.Transport.BaseURL != want {
+			t.Fatalf("Resolve(%q) BaseURL = %q, want %q (warnings %v)", tt.ref, res.Transport.BaseURL, want, res.Warnings)
+		}
+		if got := res.Transport.Vars["GOOGLE_VERTEX_ENDPOINT"]; got != tt.host {
+			t.Fatalf("Resolve(%q) Vars[GOOGLE_VERTEX_ENDPOINT] = %q, want %q", tt.ref, got, tt.host)
+		}
+		if hasWarning(res, "unresolved variable GOOGLE_VERTEX_ENDPOINT") {
+			t.Fatalf("Resolve(%q) warned about the row-mapped variable: %v", tt.ref, res.Warnings)
+		}
+	}
+}

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -261,6 +261,14 @@ func TestResolve_TransportAssembly(t *testing.T) {
 	if res := mustResolve(t, r, "google-vertex-anthropic/claude-sonnet-4-6"); hasWarning(res, "regional") {
 		t.Fatal("Sonnet 4.6 and earlier are fine on regional endpoints")
 	}
+	// The warning is about the location the URL was built with: an instance
+	// whose own base_url carries no location placeholder reaches no regional
+	// endpoint, whatever the environment says.
+	r = fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.gw]\nbase = \"google-vertex-anthropic\"\nbase_url = \"https://gw.example.test/v1\"\n")
+	if res := mustResolve(t, r, "gw/claude-opus-5"); hasWarning(res, "regional") || res.Transport.BaseURL != "https://gw.example.test/v1" {
+		t.Fatalf("literal base_url must not warn about a location it does not use: %+v", res)
+	}
 }
 
 func TestResolve_HeadersAndCredential(t *testing.T) {

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"maps"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1037,35 +1038,51 @@ func TestStripDatedSuffix(t *testing.T) {
 // per-model api template's placeholders on the row alone (convertModel), so
 // google-vertex's OpenAI-compatible rows are the only place
 // GOOGLE_VERTEX_ENDPOINT is mapped. The lookup consults the row's mapping
-// after the provider's, so the environment variable resolves the row's URL
-// (roborev PR #924 round 2); a user instance's own vars_env still wins.
+// when the provider has none, so the environment variable resolves the
+// row's URL (roborev PR #924 round 2). A user instance's own vars_env
+// remap wins, and when its variable is unset the URL stays unresolved with
+// a warning rather than silently reading the row's stock variable — the
+// user redirected that name on purpose.
 func TestResolve_RowMappedVarsEnvReadsTheEnvironment(t *testing.T) {
-	env := map[string]string{
+	const remap = "[providers.mine]\nbase = \"google-vertex\"\nvars_env = { \"GOOGLE_VERTEX_ENDPOINT\" = \"MY_ENDPOINT\" }\n"
+	stock := map[string]string{
 		"GOOGLE_VERTEX_PROJECT":  "p",
 		"GOOGLE_VERTEX_LOCATION": "us-central1",
 		"GOOGLE_VERTEX_ENDPOINT": "us-central1-aiplatform.googleapis.com",
-		"MY_ENDPOINT":            "my-endpoint.example.test",
 	}
-	r := fixtureLoad(t, env, "[providers.mine]\nbase = \"google-vertex\"\nvars_env = { \"GOOGLE_VERTEX_ENDPOINT\" = \"MY_ENDPOINT\" }\n")
+	withRemap := maps.Clone(stock)
+	withRemap["MY_ENDPOINT"] = "my-endpoint.example.test"
 	for _, tt := range []struct {
-		ref, host string
+		name, ref string
+		env       map[string]string
+		host      string // empty: the endpoint stays unresolved
 	}{
-		{ref: "google-vertex/meta/llama-3.3-70b-instruct-maas", host: "us-central1-aiplatform.googleapis.com"},
-		{ref: "mine/meta/llama-3.3-70b-instruct-maas", host: "my-endpoint.example.test"},
+		{name: "row mapping reads the environment", ref: "google-vertex/meta/llama-3.3-70b-instruct-maas", env: stock, host: "us-central1-aiplatform.googleapis.com"},
+		{name: "instance remap wins", ref: "mine/meta/llama-3.3-70b-instruct-maas", env: withRemap, host: "my-endpoint.example.test"},
+		{name: "unset instance remap stays unresolved", ref: "mine/meta/llama-3.3-70b-instruct-maas", env: stock},
 	} {
-		res, err := r.Resolve(tt.ref)
-		if err != nil {
-			t.Fatalf("Resolve(%q): %v", tt.ref, err)
-		}
-		want := "https://" + tt.host + "/v1/projects/p/locations/us-central1/endpoints/openapi"
-		if res.Transport.BaseURL != want {
-			t.Fatalf("Resolve(%q) BaseURL = %q, want %q (warnings %v)", tt.ref, res.Transport.BaseURL, want, res.Warnings)
-		}
-		if got := res.Transport.Vars["GOOGLE_VERTEX_ENDPOINT"]; got != tt.host {
-			t.Fatalf("Resolve(%q) Vars[GOOGLE_VERTEX_ENDPOINT] = %q, want %q", tt.ref, got, tt.host)
-		}
-		if hasWarning(res, "unresolved variable GOOGLE_VERTEX_ENDPOINT") {
-			t.Fatalf("Resolve(%q) warned about the row-mapped variable: %v", tt.ref, res.Warnings)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r := fixtureLoad(t, tt.env, remap)
+			res, err := r.Resolve(tt.ref)
+			if err != nil {
+				t.Fatalf("Resolve(%q): %v", tt.ref, err)
+			}
+			if tt.host == "" {
+				if !strings.Contains(res.Transport.BaseURL, "{GOOGLE_VERTEX_ENDPOINT}") || !hasWarning(res, "unresolved variable GOOGLE_VERTEX_ENDPOINT") {
+					t.Fatalf("Resolve(%q) BaseURL = %q warnings %v, want the endpoint unresolved and warned", tt.ref, res.Transport.BaseURL, res.Warnings)
+				}
+				return
+			}
+			want := "https://" + tt.host + "/v1/projects/p/locations/us-central1/endpoints/openapi"
+			if res.Transport.BaseURL != want {
+				t.Fatalf("Resolve(%q) BaseURL = %q, want %q (warnings %v)", tt.ref, res.Transport.BaseURL, want, res.Warnings)
+			}
+			if got := res.Transport.Vars["GOOGLE_VERTEX_ENDPOINT"]; got != tt.host {
+				t.Fatalf("Resolve(%q) Vars[GOOGLE_VERTEX_ENDPOINT] = %q, want %q", tt.ref, got, tt.host)
+			}
+			if hasWarning(res, "unresolved variable GOOGLE_VERTEX_ENDPOINT") {
+				t.Fatalf("Resolve(%q) warned about the row-mapped variable: %v", tt.ref, res.Warnings)
+			}
+		})
 	}
 }

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -269,6 +269,29 @@ func TestResolve_TransportAssembly(t *testing.T) {
 	if res := mustResolve(t, r, "gw/claude-opus-5"); hasWarning(res, "regional") || res.Transport.BaseURL != "https://gw.example.test/v1" {
 		t.Fatalf("literal base_url must not warn about a location it does not use: %+v", res)
 	}
+	// A template that names only the host still reaches the regional endpoint:
+	// the vertex-location rule derives the host from the location, so the
+	// location counts as used, is exposed, and is warned about.
+	r = fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.hostonly]\nbase = \"google-vertex-anthropic\"\nbase_url = \"{GOOGLE_VERTEX_HOST}/v1/custom\"\n")
+	if res := mustResolve(t, r, "hostonly/claude-opus-5"); !hasWarning(res, "regional") || res.Transport.BaseURL != "https://europe-west1-aiplatform.googleapis.com/v1/custom" || res.Transport.Vars["GOOGLE_VERTEX_LOCATION"] != "europe-west1" {
+		t.Fatalf("host derived from the location must warn and expose the location: %+v", res)
+	}
+	// A row's own literal base_url replaces the provider template, so the
+	// provider template's location is neither used nor exposed nor warned about.
+	r = fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.rowgw]\nbase = \"google-vertex-anthropic\"\n[providers.rowgw.models.\"claude-opus-5\"]\nbase_url = \"https://gw.example.test/v1\"\n")
+	if res := mustResolve(t, r, "rowgw/claude-opus-5"); hasWarning(res, "regional") || res.Transport.BaseURL != "https://gw.example.test/v1" || res.Transport.Vars["GOOGLE_VERTEX_LOCATION"] != "" {
+		t.Fatalf("row base_url must not use, expose, or warn about the provider template's location: %+v", res)
+	}
+	// A host supplied directly (an instance var) is used as-is: the rule
+	// derives nothing from the location, so the location is neither exposed
+	// nor warned about.
+	r = fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.directhost]\nbase = \"google-vertex-anthropic\"\nbase_url = \"{GOOGLE_VERTEX_HOST}/v1/custom\"\n[providers.directhost.vars]\nGOOGLE_VERTEX_HOST = \"https://gw.example.test\"\n")
+	if res := mustResolve(t, r, "directhost/claude-opus-5"); hasWarning(res, "regional") || res.Transport.BaseURL != "https://gw.example.test/v1/custom" || res.Transport.Vars["GOOGLE_VERTEX_LOCATION"] != "" {
+		t.Fatalf("a directly supplied host must not expose or warn about the location: %+v", res)
+	}
 }
 
 func TestResolve_HeadersAndCredential(t *testing.T) {


### PR DESCRIPTION
Follow-ups from the PR #879 review (roborev rounds 18 and 19), split out so that PR could land.

## Connect provider dialog offers the credential JSON editor

The onboarding dialog (`ConnectProviderDialog`) only knew the `apiKey` editor, so a gcp-adc instance there had "Test connection" and nothing else; pasting a service-account key or `application_default_credentials.json` was only reachable from Settings → Providers & credentials. The dialog now offers **Set credential JSON** / **Replace credential JSON** for an instance whose `authModes` include `credentialJson`, reusing `CredentialJsonDialog`. A stored-value editor's kind doubles as the auth mode that offers it, so one lookup renders the editor and closes it when the mode disappears. Saving returns to the chooser and still requires an explicit successful connection test, like the API-key path.

Tests: `ConnectProviderDialog.test.tsx` — save-then-test flow for a credential JSON (asserts the request shape, the "Configured via stored credential JSON" label, the Replace label, and that `onConnected` waits for the test), and the editor closing when the instance stops offering the mode.

## Add-form inputs only for variables a URL template reads

models.dev's env list for `google-vertex` names `GOOGLE_APPLICATION_CREDENTIALS` beside the project and location, and the registry folds every entry into `Transport.VarsEnv` keyed by itself. The hub built the add form's variable inputs from that whole map, so the form rendered a credential-file input whose value was persisted under `vars` and never read: instance vars only feed `{PLACEHOLDER}` substitution, and the credential is read from the environment or the store. Pre-existing on main (the same list fed `varsEnv` before `vars` existed).

New `Registry.TemplateVarsEnv(id)`: the `vars_env` mappings (the provider's and its rows', since models.dev maps a per-model `api` template's placeholders on the row alone) restricted to placeholders some URL template reads (the provider's base URL and endpoint templates, or a row's own) or a host rule consumes (`hostRuleAuthorityVars`). That also surfaces `GOOGLE_VERTEX_ENDPOINT`, which only `google-vertex`'s OpenAI-compatible rows read and which the form never offered before. A provider with no curated base URL at all (`cloudflare-ai-gateway`, `watsonx`) keeps its whole map, since the user types the URL and a placeholder they type still resolves from instance vars. The hub builds both `ProviderDescriptor.Vars` and `VarsEnv` from it; the wire shape is unchanged. Across the embedded catalog only `google-vertex`, `google-vertex-anthropic`, and `privatemode-ai` (literal localhost base URL) lose an input.

Tests: `TestTemplateVarsEnv` (fixture `google-vertex`, `openai`, `watsonx`; a synthetic provider whose only reference is a row template; one whose only reference is a host-rule input; unknown id) and `TestInstances_ListOffersOnlyTemplateVars` (verified red against the unfiltered code). Docs: `appwire/types.go` descriptor comment and the two spec passages that describe the add form's inputs.

## Row-level `vars_env` now resolves from the environment

Found by roborev while reviewing the above: the variable lookup only ever read the provider-level `vars_env`, so a mapping that lives on a row alone (models.dev maps a per-model `api` template's placeholders on the row, which is where `google-vertex`'s OpenAI-compatible rows carry `GOOGLE_VERTEX_ENDPOINT`) never read the environment, and those rows' URLs stayed unexpanded unless the value was typed as an instance var. `varLookupWith` now takes the transport shape being resolved and consults its `vars_env`/`vars` for a name the provider does not map at all; `buildTransport` passes the merged row transport, head-level callers pass the provider's transport (no change), and the canonical first-party lookup passes its curated shape so both sides of that gate read the same mappings. A provider or instance mapping whose variable is unset does not fall back to the row's stock mapping: the URL stays unresolved with the warning, as spec §10 already rules for an unset user `vars` reference. A catalog-wide differential shows the first-party gate only ever tightens under this change, and only on the eight Vertex MaaS rows that main was sending to a URL containing the literal placeholder.

Tests: `TestResolve_RowMappedVarsEnvReadsTheEnvironment` (stock environment resolves the MaaS row; an instance `vars_env` remap wins; the same remap unset stays unresolved and warned). Spec §9.1 sentence updated.

Two smaller refinements from the later review rounds: the add-form scan takes a host rule's inputs from every transport it visits (a row or glob may carry its own `host_rule`), and `Resolved.Transport.Vars` is now exactly the variables the effective URL was built with, the row's own base URL template when it has one, plus a location the vertex-location rule derived the host from. The regional Vertex warning reads that, so it fires for a host-only template on a regional location and stays quiet for a literal override that reaches no regional endpoint. No curated provider's `Vars` change.

## Verification

`make vet`, `make lint`, `make test`, `make test-web`, `make fuzz-gap-check` green; scoped review of the branch with one fix round (the credential-JSON close rule is now pinned by a "does not reopen when restored" test that fails when the effect is narrowed, and the no-base-URL case is pinned by the `watsonx` row).

https://claude.ai/code/session_01KqwE2HUhZDJvbqhmKPv5xz
