### PR TITLE
test(build): resolve the make fixture root through its symlinks

### DIFF
--- a/runtime_pair_build_test.go
+++ b/runtime_pair_build_test.go
@@ -685,22 +685,8 @@ func TestMakeTestWebBrowserFailureReplaysLogAndRetainsEvidence(t *testing.T) {
 
 func TestMakeTestWebRetainsFailedProcessStateWithinTMPDIR(t *testing.T) {
 	fixture := newBuildWebFixture(t)
-	frontendDir := filepath.Join(fixture.root, "cmd", "evener-hub", "frontend")
-	writeTestFile(t, filepath.Join(frontendDir, "package-lock.json"), []byte("{}\n"), 0o644)
-	writeTestFile(t, filepath.Join(frontendDir, "package.json"), []byte("{}\n"), 0o644)
+	retained := runFailedTestWeb(t, fixture)
 
-	command := exec.Command("make", "test-web")
-	command.Dir = fixture.root
-	command.Env = append(fixture.environment(""), "EVENER_TEST_NPM_FAIL_COMMAND=run test")
-	output, err := command.CombinedOutput()
-	if err == nil {
-		t.Fatalf("make test-web succeeded despite injected npm failure; output = %s", output)
-	}
-
-	retained := fullLogsPath(output)
-	if retained == "" {
-		t.Fatalf("make test-web did not name retained evidence; output = %s", output)
-	}
 	if !strings.HasPrefix(retained, fixture.root+string(os.PathSeparator)) {
 		t.Fatalf("retained web root = %q, want child of inherited TMPDIR %q", retained, fixture.root)
 	}
@@ -708,6 +694,42 @@ func TestMakeTestWebRetainsFailedProcessStateWithinTMPDIR(t *testing.T) {
 		if _, statErr := os.Stat(filepath.Join(retained, relative)); statErr != nil {
 			t.Errorf("retained web evidence %s: %v", relative, statErr)
 		}
+	}
+}
+
+func TestMakeTestWebRetainsFailedProcessStateUnderSymlinkedTMPDIR(t *testing.T) {
+	// t.TempDir caches its base directory on the first call for the
+	// remainder of the test, so TMPDIR has to name the symlink before the
+	// fixture makes its first t.TempDir call; t.TempDir itself can't be
+	// used to build that symlink.
+	tempRoot, err := os.MkdirTemp("", "evener-symlinked-tmpdir")
+	if err != nil {
+		t.Fatalf("make temp root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tempRoot) })
+	realTemp := filepath.Join(tempRoot, "real")
+	if err := os.Mkdir(realTemp, 0o755); err != nil {
+		t.Fatalf("mkdir real temp root: %v", err)
+	}
+	linked := filepath.Join(tempRoot, "link")
+	if err := os.Symlink(realTemp, linked); err != nil {
+		t.Fatalf("symlink temp root: %v", err)
+	}
+	t.Setenv("TMPDIR", linked)
+
+	fixture := newBuildWebFixture(t)
+
+	resolvedTemp, err := filepath.EvalSymlinks(realTemp)
+	if err != nil {
+		t.Fatalf("resolve temp root: %v", err)
+	}
+	if !strings.HasPrefix(fixture.root, resolvedTemp+string(os.PathSeparator)) {
+		t.Fatalf("fixture root = %q, want a path beneath the resolved temp root %q", fixture.root, resolvedTemp)
+	}
+
+	retained := runFailedTestWeb(t, fixture)
+	if !strings.HasPrefix(retained, fixture.root+string(os.PathSeparator)) {
+		t.Fatalf("retained web root = %q, want child of inherited TMPDIR %q", retained, fixture.root)
 	}
 }
 
@@ -860,6 +882,15 @@ func newRuntimeBuildFixture(t *testing.T) runtimeBuildFixture {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		t.Fatalf("mkdir fixture root: %v", err)
 	}
+	// The scripts under test resolve TMPDIR with `pwd -P`
+	// (scripts/lib/scratch-lib.sh) and report resolved paths back, so the
+	// fixture root has to be the resolved spelling for those paths to compare
+	// as children of it.
+	resolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatalf("resolve fixture root: %v", err)
+	}
+	root = resolved
 	fakeBin := filepath.Join(root, "fake-bin")
 	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
 		t.Fatalf("mkdir fake bin: %v", err)
@@ -1282,6 +1313,29 @@ func (fixture runtimeBuildFixture) environment(failPackage string) []string {
 		"EVENER_TEST_GO_LOG="+fixture.logPath,
 		"EVENER_TEST_GO_FAIL_PACKAGE="+failPackage,
 	)
+}
+
+// runFailedTestWeb runs `make test-web` in fixture with the frontend test step
+// failing, and returns the retained evidence root the run named.
+func runFailedTestWeb(t *testing.T, fixture runtimeBuildFixture) string {
+	t.Helper()
+	frontendDir := filepath.Join(fixture.root, "cmd", "evener-hub", "frontend")
+	writeTestFile(t, filepath.Join(frontendDir, "package-lock.json"), []byte("{}\n"), 0o644)
+	writeTestFile(t, filepath.Join(frontendDir, "package.json"), []byte("{}\n"), 0o644)
+
+	command := exec.Command("make", "test-web")
+	command.Dir = fixture.root
+	command.Env = append(fixture.environment(""), "EVENER_TEST_NPM_FAIL_COMMAND=run test")
+	output, err := command.CombinedOutput()
+	if err == nil {
+		t.Fatalf("make test-web succeeded despite injected npm failure; output = %s", output)
+	}
+
+	retained := fullLogsPath(output)
+	if retained == "" {
+		t.Fatalf("make test-web did not name retained evidence; output = %s", output)
+	}
+	return retained
 }
 
 func browserEvidenceRoot(t *testing.T, fixture runtimeBuildFixture, command string) string {


### PR DESCRIPTION
## What was wrong

`newRuntimeBuildFixture` (runtime_pair_build_test.go) built the fixture root as `filepath.Join(t.TempDir(), "fixture with spaces")` and handed that spelling to `make` as `TMPDIR`. The scripts under test do not keep it: `scratch_dir` (scripts/lib/scratch-lib.sh) resolves `TMPDIR` with `cd … && pwd -P`, mints its scratch under the resolved root, and reports resolved paths back — through `full logs: …` and through the npm/node process-state records.

So whenever the temp root is reached through a symlink, every path the scripts report is the resolved spelling while the fixture's own is the unresolved one, and the three containment checks fail:

- `TestMakeWebCommandsContainNodeProcessState`
- `TestMakeTestWebRetainsFailedProcessStateWithinTMPDIR`
- `TestMakeTestWebInterruptRetainsEvidenceAndReapsChecks`

macOS hits it on every run (`TMPDIR` lives behind `/var` -> `/private/var`); Linux CI never does, because its `/tmp` is a real directory. It was never macOS-specific — any symlinked temp root does it.

## What changed

One canonicalisation at the point the fixture root is derived: `filepath.EvalSymlinks` on the root right after it is created, before `fake-bin`, the process log, and `environment()`'s `TMPDIR`/`GOPATH`/`GOCACHE` derive from it. No darwin special case, no required `TMPDIR` setting for developers, no per-assertion patching.

## How it is tested

New `TestMakeTestWebRetainsFailedProcessStateUnderSymlinkedTMPDIR` proves it on any OS instead of waiting for a Mac. It mints its own temp root with `os.MkdirTemp` (`t.TempDir` caches its base on the first call, so `t.Setenv("TMPDIR", …)` after one is too late to redirect the fixture), symlinks it, points `TMPDIR` at the link, and asserts both that the fixture root lands beneath the *resolved* root and that the retained evidence root is a child of the fixture root. The `make test-web` failure run it shares with its neighbour moved into `runFailedTestWeb`.

It failed first on the unfixed fixture, on the link-versus-real distinction rather than anything macOS-shaped:

```
runtime_pair_build_test.go:727: fixture root = ".../evener-symlinked-tmpdir1201354263/link/TestMake…/001/fixture with spaces",
    want a path beneath the resolved temp root ".../evener-symlinked-tmpdir1201354263/real"
runtime_pair_build_test.go:732: retained web root = ".../evener-symlinked-tmpdir1201354263/real/TestMake…/001/fixture with spaces/evener-test-web.HBLA7C",
    want child of inherited TMPDIR ".../evener-symlinked-tmpdir1201354263/link/TestMake…/001/fixture with spaces"
```

(the second line was observed with the first assertion temporarily demoted to `t.Logf`, then restored).

## Gates

All foreground, all clean, on macOS:

- `gofmt -l runtime_pair_build_test.go`, `make lint-gofmt` — clean
- `go vet ./...` and `go vet -tags evenerfuzz ./...` — exit 0
- `make lint-golangci`, `make lint-evenerfuzz` — PASS
- `GOMAXPROCS=4 go test -race . -count=1` under the default (symlinked) `TMPDIR` — ok, 0 FAIL
- the same under a canonically resolved `TMPDIR` — ok, 0 FAIL
- `GOMAXPROCS=4 go test -tags evenerfuzz -run Fuzz . -count=1` — ok, 0 FAIL
- the three issue tests plus the new one, verbose, under both `TMPDIR` spellings — 4/4 PASS each

Closes #909

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT