### PR TITLE
fix(agent): settle the worktree clone a shared-env child enters

### DIFF
--- a/agent/cov_s5_subagents_helpers_test.go
+++ b/agent/cov_s5_subagents_helpers_test.go
@@ -115,3 +115,43 @@ func TestS5Cov_SubagentNeedsCommunicateNudge(t *testing.T) {
 		t.Error("a named agent should not need the nudge")
 	}
 }
+
+// uncomparableEnv is an execution environment Go cannot compare with `==`: a
+// struct VALUE carrying a map. Nothing calls its methods; the embedded
+// interface is there to satisfy the type.
+type uncomparableEnv struct {
+	execenv.ExecutionEnvironment
+	roots map[string]string
+}
+
+// Environment ownership is decided by identity — a child settles the
+// environment it holds unless that is the very object its live parent works in
+// — so the comparison has to answer for any environment a session can run on,
+// including a double whose dynamic type `==` refuses to compare.
+func TestS5Cov_SameEnvironment(t *testing.T) {
+	first := execenv.NewLocalExecutionEnvironment(t.TempDir())
+	second := execenv.NewLocalExecutionEnvironment(t.TempDir())
+	if !sameEnvironment(first, first) {
+		t.Error("an environment is not the same as itself")
+	}
+	if sameEnvironment(first, second) {
+		t.Error("two distinct environments compared equal")
+	}
+	if sameEnvironment(first, first.WithWorkingDirectory(t.TempDir())) {
+		t.Error("a clone compared equal to the environment it was built from")
+	}
+	if !sameEnvironment(nil, nil) {
+		t.Error("two absent environments are not the same")
+	}
+	if sameEnvironment(first, nil) || sameEnvironment(nil, first) {
+		t.Error("an environment compared equal to none at all")
+	}
+	// `==` would panic on this pair rather than answer.
+	one := uncomparableEnv{roots: map[string]string{"a": "b"}}
+	if sameEnvironment(one, one) {
+		t.Error("an environment nothing can alias compared equal")
+	}
+	if sameEnvironment(first, one) {
+		t.Error("environments of different types compared equal")
+	}
+}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1712,7 +1712,7 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 	if err != nil {
 		return nil, false, err
 	}
-	child.ownsEnv = ownsFresh
+	child.recordEnvironmentOwnership(childEnv, ownsFresh)
 	discardEnv = false
 	if child.delegateController != s.delegateController || child.owningDelegateID != started.lease.delegateID {
 		child.discardRestoredCandidate()

--- a/agent/session.go
+++ b/agent/session.go
@@ -98,10 +98,15 @@ type Session struct {
 	// them; a shared one belongs to the live parent and is left alone. The child
 	// records it because a teardown can reach a child no parent bookkeeping names
 	// — a runtime the stable controller holds for its own close.
-	ownsEnv   bool
-	clock     clock.Clock
-	stateDir  string
-	installID string
+	ownsEnv bool
+	// parentSharedEnv is the environment a child was handed when it is the live
+	// parent's own object (ownsEnv false) — the one environment this session must
+	// never settle and whose scratch it must never take. Nil on a root session and
+	// on a child whose environment was built for it.
+	parentSharedEnv execenv.ExecutionEnvironment
+	clock           clock.Clock
+	stateDir        string
+	installID       string
 	// origin marks how the session was launched: "test" for agentic-testing
 	// runs (set from EVENER_SESSION_ORIGIN on fresh create), empty for normal
 	// sessions. Preserved across resume from the persisted SessionMeta.Origin.

--- a/agent/session_env_swap.go
+++ b/agent/session_env_swap.go
@@ -65,9 +65,19 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 	// after them would find next already owning a fresh one, keep it, and retain
 	// the session's original — a silently changed $EVENER_SCRATCH_DIR and an
 	// extra retained directory per enter.
+	//
+	// A session running on its parent's own environment object (parentSharedEnv)
+	// is exempt from the move in both directions: it neither takes the scratch
+	// the parent is working in (current == shared, an enter) nor hands its own
+	// clone's scratch off to the parent (next == shared, an exit). The clone
+	// provisions its own scratch on its first command instead, and the child's
+	// own teardown is what settles it — moving it here would either steal the
+	// live parent's scratch out from under it or leave the parent holding a
+	// lease that belongs to a session already gone.
 	s.mu.Lock()
 	closing := s.closing
 	current, _ := s.env.(*execenv.LocalExecutionEnvironment)
+	shared := s.parentSharedEnv
 	var admission envWorkID
 	if !closing {
 		admission = s.registerEnvWorkLocked("environment swap to " + next.WorkingDirectory())
@@ -77,7 +87,7 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 		return errSwapWhileClosing
 	}
 	defer s.endEnvWork(admission)
-	if current != nil {
+	if current != nil && shared != current && shared != next {
 		next.AdoptSessionScratch(current)
 	}
 	// Step 0b — the context step 1's git runs under. Every command below forks

--- a/agent/session_env_swap.go
+++ b/agent/session_env_swap.go
@@ -40,8 +40,9 @@ var errSwapWhileClosing = errors.New("manage_worktree: the session is closing; e
 // what next adopted (lease released, directory kept, the handoff a close makes)
 // and returns errSwapWhileClosing for the op to surface. A swap exempt from the
 // move rolls back nothing: there is no adopted lease to release, and the
-// environment it would have released is the live parent's own. Both `closing` and the
-// install are written under s.mu, so one of the two always sees the other.
+// environment it would have released is the live parent's own. Both `closing`
+// and the install are written under s.mu, so one of the two always sees the
+// other.
 //
 // A swap that passes that first check is ADMITTED: it registers on envWorkWG
 // under the same s.mu hold that read `closing` (the beginDispose idiom), so the
@@ -77,12 +78,13 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 	// live parent's scratch out from under it or leave the parent holding a
 	// lease that belongs to a session already gone.
 	//
-	// Inside a kernel box the exemption costs the clone nothing: ReRoot carries
-	// the wrapper's session tmp onto the clone (sandbox.Wrapper.ReRoot), so the
-	// child goes on working in the box's tmp — the only directory that box
-	// grants — while the lease stays with the environment the live parent
-	// closes. Moving it would hand a lease on the parent's one writable
-	// directory to a session whose teardown then releases it under it.
+	// Inside a kernel box the exemption costs the clone nothing: the box's
+	// session tmp is the scratch the wrapper carries across a re-root
+	// (sandbox.Wrapper.ReRoot), so the clone reports and works in the same one
+	// with no move at all, and its lease belongs to the parent's environment —
+	// the one the live parent closes. Moving it would hand that lease to a
+	// session whose teardown then releases it under a parent still working in
+	// the directory.
 	s.mu.Lock()
 	closing := s.closing
 	current, _ := s.env.(*execenv.LocalExecutionEnvironment)
@@ -96,7 +98,7 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 		return errSwapWhileClosing
 	}
 	defer s.endEnvWork(admission)
-	moved := current != nil && shared != current && shared != next
+	moved := current != nil && !sameEnvironment(shared, current) && !sameEnvironment(shared, next)
 	if moved {
 		next.AdoptSessionScratch(current)
 	}
@@ -144,12 +146,24 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 	s.mu.Lock()
 	if s.closing {
 		s.mu.Unlock()
-		// Roll back exactly what step 0 moved. A swap that moved nothing has
-		// nothing to release, and next may be the live parent's own environment
-		// (the target of a shared child's exit), whose scratch the parent is
-		// still working in.
-		if moved {
+		// Roll back exactly what step 0 moved: the session's own scratch, whose
+		// directory is kept for the handoff its close would have made.
+		//
+		// A swap exempt from the move has no adopted lease to release, and what
+		// it must do instead depends on what next is. On a shared child's exit
+		// next is the live parent's own environment, whose scratch the parent is
+		// still working in: hands off entirely. On that child's enter next is a
+		// clone this session built and is now abandoning, and step 1's git
+		// snapshot mints a scratch on an environment that owns none — so the
+		// clone leaves with a directory and a lease nothing else will ever
+		// reference. It goes with the clone, the same decision every other
+		// discarded clone's takes (the re-entry probes, the worktree control
+		// env, a spawn that failed before adoption).
+		switch {
+		case moved:
 			next.RetainSessionScratch()
+		case shared != nil && !sameEnvironment(shared, next):
+			next.DisposeUnadoptedScratch()
 		}
 		return errSwapWhileClosing
 	}

--- a/agent/session_env_swap.go
+++ b/agent/session_env_swap.go
@@ -36,13 +36,14 @@ var errSwapWhileClosing = errors.New("manage_worktree: the session is closing; e
 // still holds the OLD environment, which owns nothing any more: a close in that
 // window would leave next's lease with no teardown owner. So the swap refuses
 // to start once the session is closing, and re-checks under s.mu before
-// installing; a close that began meanwhile rolls the move back by retaining
-// what next adopted (lease released, directory kept, the handoff a close makes)
-// and returns errSwapWhileClosing for the op to surface. A swap exempt from the
-// move rolls back nothing: there is no adopted lease to release, and the
-// environment it would have released is the live parent's own. Both `closing`
-// and the install are written under s.mu, so one of the two always sees the
-// other.
+// installing; a close that began meanwhile undoes step 0 and returns
+// errSwapWhileClosing for the op to surface. What the undo is follows what step
+// 0 did: a swap that moved the scratch retains it on next (lease released,
+// directory kept, the handoff a close makes); an exempt ENTER drops what the
+// refresh minted on next, a clone nothing will reach again; an exempt EXIT
+// leaves next alone, because next is the live parent's own environment. Both
+// `closing` and the install are written under s.mu, so one of the two always
+// sees the other.
 //
 // A swap that passes that first check is ADMITTED: it registers on envWorkWG
 // under the same s.mu hold that read `closing` (the beginDispose idiom), so the
@@ -156,9 +157,9 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 		// clone this session built and is now abandoning, and step 1's git
 		// snapshot mints a scratch on an environment that owns none — so the
 		// clone leaves with a directory and a lease nothing else will ever
-		// reference. It goes with the clone, the same decision every other
-		// discarded clone's takes (the re-entry probes, the worktree control
-		// env, a spawn that failed before adoption).
+		// reference. It goes with the clone, the decision every other discarded
+		// clone's scratch takes (the re-entry probes, the worktree control env,
+		// a spawn that failed before adoption).
 		switch {
 		case moved:
 			next.RetainSessionScratch()

--- a/agent/session_env_swap.go
+++ b/agent/session_env_swap.go
@@ -38,7 +38,9 @@ var errSwapWhileClosing = errors.New("manage_worktree: the session is closing; e
 // to start once the session is closing, and re-checks under s.mu before
 // installing; a close that began meanwhile rolls the move back by retaining
 // what next adopted (lease released, directory kept, the handoff a close makes)
-// and returns errSwapWhileClosing for the op to surface. Both `closing` and the
+// and returns errSwapWhileClosing for the op to surface. A swap exempt from the
+// move rolls back nothing: there is no adopted lease to release, and the
+// environment it would have released is the live parent's own. Both `closing` and the
 // install are written under s.mu, so one of the two always sees the other.
 //
 // A swap that passes that first check is ADMITTED: it registers on envWorkWG
@@ -74,6 +76,13 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 	// own teardown is what settles it — moving it here would either steal the
 	// live parent's scratch out from under it or leave the parent holding a
 	// lease that belongs to a session already gone.
+	//
+	// Inside a kernel box the exemption costs the clone nothing: ReRoot carries
+	// the wrapper's session tmp onto the clone (sandbox.Wrapper.ReRoot), so the
+	// child goes on working in the box's tmp — the only directory that box
+	// grants — while the lease stays with the environment the live parent
+	// closes. Moving it would hand a lease on the parent's one writable
+	// directory to a session whose teardown then releases it under it.
 	s.mu.Lock()
 	closing := s.closing
 	current, _ := s.env.(*execenv.LocalExecutionEnvironment)
@@ -87,7 +96,8 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 		return errSwapWhileClosing
 	}
 	defer s.endEnvWork(admission)
-	if current != nil && shared != current && shared != next {
+	moved := current != nil && shared != current && shared != next
+	if moved {
 		next.AdoptSessionScratch(current)
 	}
 	// Step 0b — the context step 1's git runs under. Every command below forks
@@ -134,7 +144,13 @@ func (s *Session) swapEnvAndRefresh(next *execenv.LocalExecutionEnvironment, rec
 	s.mu.Lock()
 	if s.closing {
 		s.mu.Unlock()
-		next.RetainSessionScratch()
+		// Roll back exactly what step 0 moved. A swap that moved nothing has
+		// nothing to release, and next may be the live parent's own environment
+		// (the target of a shared child's exit), whose scratch the parent is
+		// still working in.
+		if moved {
+			next.RetainSessionScratch()
+		}
 		return errSwapWhileClosing
 	}
 	ei.KnowledgeCutoff = s.envInfo.KnowledgeCutoff // profile-derived, not env-derived; swap must not clobber it

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1012,7 +1012,7 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	// nothing was re-rooted, that one is the caller's to dispose or to keep.
 	reenteredEnv := s.env
 	defer func() {
-		if restoreComplete || reenteredEnv == env {
+		if restoreComplete || sameEnvironment(reenteredEnv, env) {
 			return
 		}
 		disposeUnadoptedScratch(reenteredEnv)

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -581,11 +581,15 @@ func (s *Session) close(ctx context.Context, cleanupEnv bool) {
 
 // recordAbandonedEnvironmentLocked remembers an environment the swap has just
 // installed over, when the session can no longer reach it: not the environment
-// just installed, and not the one an enter parked (worktreeRestoreEnv, which
-// close retains separately). The clone between two enters is the case that
-// matters — a switch does not re-park, so the environment the session came from
-// is dropped from every session reference while a child spawned in it still
-// holds the object and can mint a scratch there afterwards.
+// just installed, not the one an enter parked (worktreeRestoreEnv, which close
+// retains separately), and not the live parent's own environment
+// (parentSharedEnv) — a session on its parent's own environment never records
+// it as one of its own abandoned clones, structurally rather than as a
+// consequence of enter always parking it first. The clone between two enters
+// is the case that matters otherwise — a switch does not re-park, so the
+// environment the session came from is dropped from every session reference
+// while a child spawned in it still holds the object and can mint a scratch
+// there afterwards.
 //
 // The caller holds s.mu and has already run the swap's record, so
 // worktreeRestoreEnv is the parked environment this swap decided on. An
@@ -593,7 +597,7 @@ func (s *Session) close(ctx context.Context, cleanupEnv bool) {
 // scan keeps that true by construction rather than by trust, so the slice is
 // bounded by the number of worktree switches a session actually made.
 func (s *Session) recordAbandonedEnvironmentLocked(prior, next *execenv.LocalExecutionEnvironment) {
-	if prior == nil || prior == next || prior == s.worktreeRestoreEnv {
+	if prior == nil || prior == next || prior == s.worktreeRestoreEnv || prior == s.parentSharedEnv {
 		return
 	}
 	if slices.Contains(s.abandonedEnvs, prior) {
@@ -607,12 +611,16 @@ func (s *Session) recordAbandonedEnvironmentLocked(prior, next *execenv.LocalExe
 // directories for the handoff, and retires their file-tool layers through the
 // drain — RetainSessionScratch does both.
 //
-// Only close calls it, after the current environment's Cleanup and for the same
-// reason the parked environment's retain runs there: an abandoned environment
-// shares the current clone's process table, so its processes are already reaped
-// and running Cleanup on it would reap that table a second time. What is left on
+// close calls it after the current environment's Cleanup, for the same reason
+// the parked environment's retain runs there: an abandoned environment shares
+// the current clone's process table, so its processes are already reaped and
+// running Cleanup on it would reap that table a second time. What is left on
 // it is what a shared child minted after the session moved on, which nothing
-// else will ever release.
+// else will ever release. teardownChildSession also calls it, unconditionally
+// and without a Cleanup of its own: a session whose environment is its live
+// parent's own never runs cleanupEnv at all, so this is the only place that
+// ever drains a worktree clone such a child built for itself and then swapped
+// away from.
 func (s *Session) retainAbandonedEnvironmentScratch() {
 	s.mu.Lock()
 	abandoned := s.abandonedEnvs
@@ -639,13 +647,13 @@ func (s *Session) retainParkedWorktreeEnvironmentScratch() {
 }
 
 // discardRestoredCandidate tears down a restore candidate nothing ever adopted.
-// The candidate's own ownsEnv says whether its execution environment is one
-// built FOR it (a working-dir re-root and/or a per-delegate box) rather than
-// the parent's own: prepareSubagentEnvironment returns the parent's environment
-// untouched when the delegate needs neither, and a shared environment belongs
-// to the live parent still working in it. It is the same distinction close()
-// makes before retaining a child's scratch, read here so an aborted candidate
-// never deletes a scratch dir out from under its parent.
+// The candidate's own environmentOwnedAtTeardown says whether its execution
+// environment is one built FOR it (a working-dir re-root and/or a per-delegate
+// box) rather than the parent's own: prepareSubagentEnvironment returns the
+// parent's environment untouched when the delegate needs neither, and a shared
+// environment belongs to the live parent still working in it. It is the same
+// distinction close() makes before retaining a child's scratch, read here so an
+// aborted candidate never deletes a scratch dir out from under its parent.
 func (s *Session) discardRestoredCandidate() {
 	s.closeOnce.Do(func() {
 		s.responseSideEffectsMu.Lock()
@@ -677,7 +685,7 @@ func (s *Session) discardRestoredCandidate() {
 		// teardown (which RETAINS both scratch dirs for the human handoff), there
 		// is no one left to retain them for: both go, the same decision the
 		// create-path twin of this abort (disposeUnadoptedSubagentSession) makes.
-		releaseOwnedChildEnvironment(s.currentEnv(), s.ownsEnv, disposeChildScratch)
+		releaseOwnedChildEnvironment(s.environmentOwnedAtTeardown(), disposeChildScratch)
 		if s.mcpMgr != nil {
 			s.mcpMgr.Close()
 		}

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -597,7 +597,7 @@ func (s *Session) close(ctx context.Context, cleanupEnv bool) {
 // scan keeps that true by construction rather than by trust, so the slice is
 // bounded by the number of worktree switches a session actually made.
 func (s *Session) recordAbandonedEnvironmentLocked(prior, next *execenv.LocalExecutionEnvironment) {
-	if prior == nil || prior == next || prior == s.worktreeRestoreEnv || prior == s.parentSharedEnv {
+	if prior == nil || prior == next || prior == s.worktreeRestoreEnv || sameEnvironment(prior, s.parentSharedEnv) {
 		return
 	}
 	if slices.Contains(s.abandonedEnvs, prior) {

--- a/agent/session_worktree_swap_scratch_unix_test.go
+++ b/agent/session_worktree_swap_scratch_unix_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -912,5 +913,99 @@ func TestWorktreeSwap_CloseDuringASharedChildExitKeepsTheParentScratchLease(t *t
 	assertParentScratchUntouched(t, "the exit refused under the child's close", parentScratch)
 	if _, err := os.Stat(cloneScratch); err != nil {
 		t.Errorf("the child's teardown removed its entered clone's scratch %s, want it retained for the handoff: %v", cloneScratch, err)
+	}
+	if scratchLeaseHeld(t, cloneScratch) {
+		t.Errorf("the entered clone's scratch %s lease is still held after the child's teardown", cloneScratch)
+	}
+}
+
+// A shared child (no working dir of its own) can enter a worktree it is
+// switching into while its own close races that very enter. moved is false on
+// such a child's enter — its current environment IS s.parentSharedEnv, so
+// step 0 has nothing to move — but step 1's git snapshot still runs real git
+// on next, the clone the enter built, and running a command is what mints
+// next its own scratch, with a lease, on an environment that owns none. If
+// the child's own close wins the race before step 2 installs next, the swap
+// refuses — but its rollback retains only what step 0 moved, and step 0
+// moved nothing here, so next's freshly minted scratch and lease are left
+// with no owner: nothing ever references next again.
+//
+// The hook releases as soon as the child's own close has BEGUN, never waiting
+// for it to return: the enter runs inside the manage_worktree dispatch, which
+// holds the close fence, so waiting would deadlock the two against each other
+// — the same deadlock TestWorktreeSwap_CloseDuringASharedChildExitKeepsTheParentScratchLease
+// avoids, there for a shared child's exit instead of its enter.
+func TestWorktreeSwap_CloseDuringASharedChildEnterDropsTheRefreshScratch(t *testing.T) {
+	// The shared base repo is built once per package run under the temp dir
+	// current at that moment; build it before this test redirects TMPDIR to a
+	// directory it will delete. (Same discipline as
+	// TestWorktreeSwap_SnapshotOnTheEnteredCloneUsesTheSessionScratch.)
+	worktreeBaseRepo(t)
+	isolated := t.TempDir()
+	t.Setenv("TMPDIR", isolated)
+	cfg := worktreeTestSessionConfig()
+	cfg.testOnly.skipGitSnapshot = false
+	r := newWorktreeRepoWithConfig(t, cfg)
+	parent := r.s
+	sibling := r.addSiblingWorktree(t, "child-lane", "child-branch")
+
+	ctx := context.WithValue(context.Background(), ctxDelegationAllowance, 2)
+	prepared, err := parent.prepareSubagentRun(ctx, "child task", "", "", 0, "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("prepareSubagentRun: %v", err)
+	}
+	t.Cleanup(func() { releasePreparedTreeSlot(prepared) })
+	child := prepared.sub.sess
+	if child.currentEnv() != parent.currentEnv() {
+		t.Fatal("the spawned child did not land on the parent's environment; this test would prove nothing")
+	}
+	if child.ownsEnv {
+		t.Fatal("the spawned child recorded that it owns the parent's environment; this test would prove nothing")
+	}
+	child.mu.Lock()
+	child.worktreeGitVersionOK = true
+	child.stateDir = r.stateDir
+	child.mu.Unlock()
+
+	before := scratchDirsIn(t, isolated)
+
+	closeBegun := make(chan struct{})
+	closeDone := make(chan struct{})
+	child.cfg.testOnly.closeAfterDisposeSweepJoin = func() { close(closeBegun) }
+	child.cfg.testOnly.swapEnvAfterAdopt = func(context.Context) {
+		go func() {
+			defer close(closeDone)
+			teardownChildSession(context.Background(), child, retainChildScratch)
+		}()
+		<-closeBegun
+	}
+
+	rt := child.reg.Get("manage_worktree")
+	if rt == nil {
+		t.Fatal("registry is missing manage_worktree")
+	}
+	_, enterErr := rt.Exec(t.Context(), child.currentEnv(), map[string]any{"operation": "switch", "path": sibling})
+	<-closeDone
+
+	if enterErr == nil {
+		t.Error("the enter succeeded while the child's own close began under it, want a refusal")
+	}
+	after := scratchDirsIn(t, isolated)
+	slices.Sort(before)
+	slices.Sort(after)
+	if !slices.Equal(before, after) {
+		t.Errorf("scratch dirs under %s changed from %v to %v; a refused enter must leave the scratch base exactly as it found it", isolated, before, after)
+	}
+	beforeSet := make(map[string]bool, len(before))
+	for _, dir := range before {
+		beforeSet[dir] = true
+	}
+	for _, dir := range after {
+		if beforeSet[dir] {
+			continue
+		}
+		if scratchLeaseHeld(t, dir) {
+			t.Errorf("the refused enter left %s behind with its lease still held", dir)
+		}
 	}
 }

--- a/agent/session_worktree_swap_scratch_unix_test.go
+++ b/agent/session_worktree_swap_scratch_unix_test.go
@@ -919,16 +919,16 @@ func TestWorktreeSwap_CloseDuringASharedChildExitKeepsTheParentScratchLease(t *t
 	}
 }
 
-// A shared child (no working dir of its own) can enter a worktree it is
-// switching into while its own close races that very enter. moved is false on
-// such a child's enter — its current environment IS s.parentSharedEnv, so
-// step 0 has nothing to move — but step 1's git snapshot still runs real git
-// on next, the clone the enter built, and running a command is what mints
-// next its own scratch, with a lease, on an environment that owns none. If
-// the child's own close wins the race before step 2 installs next, the swap
-// refuses — but its rollback retains only what step 0 moved, and step 0
-// moved nothing here, so next's freshly minted scratch and lease are left
-// with no owner: nothing ever references next again.
+// A shared child (no working dir of its own) can enter a worktree while its own
+// close races that very enter. Step 0 moves nothing on such a child's enter —
+// its current environment IS the parent's own object — but step 1's git
+// snapshot runs real git on next, the clone the enter built, and running a
+// command is what mints a scratch, with a lease, on an environment that owns
+// none. When the close wins before step 2 installs next, nothing will ever
+// reference that clone again, so the refused enter leaves the scratch base
+// exactly as it found it: the clone's directory goes with the clone, lease and
+// all. The control enter below is what makes that an assertion about disposal
+// rather than about a scratch no one minted.
 //
 // The hook releases as soon as the child's own close has BEGUN, never waiting
 // for it to return: the enter runs inside the manage_worktree dispatch, which
@@ -966,6 +966,35 @@ func TestWorktreeSwap_CloseDuringASharedChildEnterDropsTheRefreshScratch(t *test
 	child.worktreeGitVersionOK = true
 	child.stateDir = r.stateDir
 	child.mu.Unlock()
+
+	// The control: the same enter with no close under it. The refresh alone
+	// mints the entered clone's scratch — nothing runs a command on that clone
+	// — which is the directory the racing arm below has to dispose.
+	controlPrepared, err := parent.prepareSubagentRun(ctx, "control task", "", "", 0, "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("prepareSubagentRun for the control: %v", err)
+	}
+	control := controlPrepared.sub.sess
+	control.mu.Lock()
+	control.worktreeGitVersionOK = true
+	control.stateDir = r.stateDir
+	control.mu.Unlock()
+	controlTool := control.reg.Get("manage_worktree")
+	if controlTool == nil {
+		t.Fatal("registry is missing manage_worktree on the control child")
+	}
+	if _, err := controlTool.Exec(t.Context(), control.currentEnv(), map[string]any{"operation": "switch", "path": sibling}); err != nil {
+		t.Fatalf("control switch by path onto the sibling worktree: %v", err)
+	}
+	controlScratch := currentLocalEnv(t, control).SessionScratchDir()
+	if controlScratch == "" {
+		t.Fatal("the enter's refresh minted no scratch on the entered clone, so the racing arm below would prove nothing")
+	}
+	if !scratchLeaseHeld(t, controlScratch) {
+		t.Fatal("the scratch the enter's refresh minted holds no lease, so the racing arm below would prove nothing")
+	}
+	teardownChildSession(context.Background(), control, retainChildScratch)
+	releasePreparedTreeSlot(controlPrepared)
 
 	before := scratchDirsIn(t, isolated)
 

--- a/agent/session_worktree_swap_scratch_unix_test.go
+++ b/agent/session_worktree_swap_scratch_unix_test.go
@@ -829,3 +829,88 @@ func TestParentCloseAfterExitRetainsEachAbandonedEnvironmentAndNotTheLaunchOne(t
 		}
 	}
 }
+
+// A shared child (no working dir of its own) can exit a worktree it entered
+// while its own close races that very exit. The exit's swap runs on the
+// child's own environment, and its rollback installs nothing when the child
+// is closing — but next, the environment the exit is swapping BACK ONTO, is
+// the live parent's own object (shared == next: a shared child's exit is
+// exempt from the scratch move, see swapEnvAndRefresh's step 0). The
+// rollback's RetainSessionScratch must not run on that object: the parent is
+// still working in it, and retaining releases a lease nothing adopted.
+//
+// The hook releases as soon as the child's own close has BEGUN, never waiting
+// for it to return: the exit runs inside the manage_worktree dispatch, which
+// holds the close fence, so waiting would deadlock the two against each other
+// — the same deadlock TestWorktreeSwap_CloseDuringTheSwapLeavesNoOwnerlessLease
+// avoids, here between a child and its own close instead of a root and its own.
+func TestWorktreeSwap_CloseDuringASharedChildExitKeepsTheParentScratchLease(t *testing.T) {
+	r := newWorktreeRepo(t)
+	parent := r.s
+	shared := currentLocalEnv(t, parent)
+	if _, err := shared.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("root command on the parent's environment: %v", err)
+	}
+	parentScratch := heldParentScratch(t, shared)
+	sibling := r.addSiblingWorktree(t, "child-lane", "child-branch")
+
+	ctx := context.WithValue(context.Background(), ctxDelegationAllowance, 2)
+	prepared, err := parent.prepareSubagentRun(ctx, "child task", "", "", 0, "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("prepareSubagentRun: %v", err)
+	}
+	t.Cleanup(func() { releasePreparedTreeSlot(prepared) })
+	child := prepared.sub.sess
+	if child.currentEnv() != parent.currentEnv() {
+		t.Fatal("the spawned child did not land on the parent's environment; this test would prove nothing")
+	}
+	if child.ownsEnv {
+		t.Fatal("the spawned child recorded that it owns the parent's environment; this test would prove nothing")
+	}
+	child.mu.Lock()
+	child.worktreeGitVersionOK = true
+	child.stateDir = r.stateDir
+	child.mu.Unlock()
+
+	rt := child.reg.Get("manage_worktree")
+	if rt == nil {
+		t.Fatal("registry is missing manage_worktree")
+	}
+	if _, err := rt.Exec(t.Context(), child.currentEnv(), map[string]any{"operation": "switch", "path": sibling}); err != nil {
+		t.Fatalf("switch by path onto the sibling worktree: %v", err)
+	}
+	clone := currentLocalEnv(t, child)
+	if clone == shared {
+		t.Fatal("the switch left the child on the parent's environment; this test would prove nothing")
+	}
+	if _, err := clone.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand on the entered clone: %v", err)
+	}
+	cloneScratch := clone.SessionScratchDir()
+	if cloneScratch == "" {
+		t.Fatal("the entered clone minted no session scratch, so there is nothing to settle")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(cloneScratch) })
+
+	closeBegun := make(chan struct{})
+	closeDone := make(chan struct{})
+	child.cfg.testOnly.closeAfterDisposeSweepJoin = func() { close(closeBegun) }
+	child.cfg.testOnly.swapEnvAfterAdopt = func(context.Context) {
+		go func() {
+			defer close(closeDone)
+			teardownChildSession(context.Background(), child, retainChildScratch)
+		}()
+		<-closeBegun
+	}
+
+	_, exitErr := rt.Exec(t.Context(), child.currentEnv(), map[string]any{"operation": "exit"})
+	<-closeDone
+
+	if exitErr == nil {
+		t.Error("the exit succeeded while the child's own close began under it, want a refusal")
+	}
+	assertParentScratchUntouched(t, "the exit refused under the child's close", parentScratch)
+	if _, err := os.Stat(cloneScratch); err != nil {
+		t.Errorf("the child's teardown removed its entered clone's scratch %s, want it retained for the handoff: %v", cloneScratch, err)
+	}
+}

--- a/agent/subagent_teardown_unix_test.go
+++ b/agent/subagent_teardown_unix_test.go
@@ -600,3 +600,153 @@ func TestDiscardedRestoreCandidateDisposesItsCloneScratch(t *testing.T) {
 		t.Fatalf("the root's process after release: %v", err)
 	}
 }
+
+// A delegate spawned with neither a working dir nor a box of its own runs on
+// its parent's very environment object, and it keeps manage_worktree, so it can
+// enter a worktree from there. The environment it enters is a clone the child
+// built for itself, whatever it started on, and the scratch that clone
+// provisions is the child's own: its teardown is the only thing that will ever
+// reach that lease. It has to release it — while leaving the parent's own
+// environment alone, scratch and process table alike.
+func TestSharedEnvChildTeardownReleasesTheEnteredWorktreeScratch(t *testing.T) {
+	r := newWorktreeRepo(t)
+	parent := r.s
+	shared := currentLocalEnv(t, parent)
+	pid, done, release := startInFlightProcess(t, shared)
+	sharedScratch := heldParentScratch(t, shared)
+	sibling := r.addSiblingWorktree(t, "child-lane", "child-branch")
+
+	ctx := context.WithValue(context.Background(), ctxDelegationAllowance, 2)
+	prepared, err := parent.prepareSubagentRun(ctx, "child task", "", "", 0, "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("prepareSubagentRun: %v", err)
+	}
+	t.Cleanup(func() { releasePreparedTreeSlot(prepared) })
+	child := prepared.sub.sess
+	if child.currentEnv() != parent.currentEnv() {
+		t.Fatal("the spawned child did not land on the parent's environment; this test would prove nothing")
+	}
+	if child.ownsEnv {
+		t.Fatal("the spawned child recorded that it owns the parent's environment; this test would prove nothing")
+	}
+	child.mu.Lock()
+	child.worktreeGitVersionOK = true
+	child.stateDir = r.stateDir
+	child.mu.Unlock()
+
+	rt := child.reg.Get("manage_worktree")
+	if rt == nil {
+		t.Fatal("registry is missing manage_worktree")
+	}
+	if _, err := rt.Exec(t.Context(), child.currentEnv(), map[string]any{"operation": "switch", "path": sibling}); err != nil {
+		t.Fatalf("switch by path onto the sibling worktree: %v", err)
+	}
+	clone := currentLocalEnv(t, child)
+	if clone == shared {
+		t.Fatal("the switch left the child on the parent's environment; this test would prove nothing")
+	}
+	if _, err := clone.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand on the entered clone: %v", err)
+	}
+	scratch := clone.SessionScratchDir()
+	if scratch == "" {
+		t.Fatal("the entered clone minted no session scratch, so there is nothing to release")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(scratch) })
+	if !scratchLeaseHeld(t, scratch) {
+		t.Fatal("the entered clone's scratch lease is not held before the child's teardown")
+	}
+
+	teardownChildSession(context.Background(), child, retainChildScratch)
+
+	if _, err := os.Stat(scratch); err != nil {
+		t.Errorf("the child's teardown removed the entered clone's scratch %s, want it retained for the handoff: %v", scratch, err)
+	}
+	if scratchLeaseHeld(t, scratch) {
+		t.Errorf("the entered clone's scratch %s lease is still held after the shared child's teardown", scratch)
+	}
+	assertParentScratchUntouched(t, "the shared child's teardown", sharedScratch)
+	assertInFlightProcessSurvived(t, "the shared child's teardown", pid, done)
+
+	release()
+	if err := <-done; err != nil {
+		t.Fatalf("the parent's process after release: %v", err)
+	}
+}
+
+// The same shared-environment child must not take the scratch OFF the
+// environment it shares with its still-working parent: the parent is working in
+// that directory, and a child that carried it into a worktree would silently
+// change the parent's scratch and then release a lease the parent still needs.
+// The entered clone provisions one of its own, an exit hands it to nobody, and
+// the child's teardown settles the clone it left behind — the parent's scratch
+// is the parent's throughout.
+func TestSharedEnvChildKeepsItsWorktreeScratchAcrossExit(t *testing.T) {
+	r := newWorktreeRepo(t)
+	parent := r.s
+	shared := currentLocalEnv(t, parent)
+	if _, err := shared.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand to mint the parent's scratch: %v", err)
+	}
+	parentScratch := heldParentScratch(t, shared)
+	sibling := r.addSiblingWorktree(t, "child-lane", "child-branch")
+
+	ctx := context.WithValue(context.Background(), ctxDelegationAllowance, 2)
+	prepared, err := parent.prepareSubagentRun(ctx, "child task", "", "", 0, "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("prepareSubagentRun: %v", err)
+	}
+	t.Cleanup(func() { releasePreparedTreeSlot(prepared) })
+	child := prepared.sub.sess
+	if child.currentEnv() != parent.currentEnv() {
+		t.Fatal("the spawned child did not land on the parent's environment; this test would prove nothing")
+	}
+	if child.ownsEnv {
+		t.Fatal("the spawned child recorded that it owns the parent's environment; this test would prove nothing")
+	}
+	child.mu.Lock()
+	child.worktreeGitVersionOK = true
+	child.stateDir = r.stateDir
+	child.mu.Unlock()
+
+	rt := child.reg.Get("manage_worktree")
+	if rt == nil {
+		t.Fatal("registry is missing manage_worktree")
+	}
+	if _, err := rt.Exec(t.Context(), child.currentEnv(), map[string]any{"operation": "switch", "path": sibling}); err != nil {
+		t.Fatalf("switch by path onto the sibling worktree: %v", err)
+	}
+	clone := currentLocalEnv(t, child)
+	if clone == shared {
+		t.Fatal("the switch left the child on the parent's environment; this test would prove nothing")
+	}
+	if _, err := clone.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+		t.Fatalf("ExecCommand on the entered clone: %v", err)
+	}
+	cloneScratch := clone.SessionScratchDir()
+	if cloneScratch == "" {
+		t.Fatal("the entered clone minted no session scratch, so there is nothing to settle")
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(cloneScratch) })
+	if cloneScratch == parentScratch {
+		t.Errorf("the entered clone's scratch is the parent's own %s, want a scratch of its own", parentScratch)
+	}
+
+	if _, err := rt.Exec(t.Context(), child.currentEnv(), map[string]any{"operation": "exit"}); err != nil {
+		t.Fatalf("exit back to the parent's environment: %v", err)
+	}
+	if got := shared.SessionScratchDir(); got != parentScratch {
+		t.Errorf("the child's exit changed the parent's environment scratch to %q, want its own %q", got, parentScratch)
+	}
+	assertParentScratchUntouched(t, "the child's exit", parentScratch)
+
+	teardownChildSession(context.Background(), child, retainChildScratch)
+
+	if _, err := os.Stat(cloneScratch); err != nil {
+		t.Errorf("the child's teardown removed the entered clone's scratch %s, want it retained for the handoff: %v", cloneScratch, err)
+	}
+	if scratchLeaseHeld(t, cloneScratch) {
+		t.Errorf("the entered clone's scratch %s lease is still held after the child's teardown", cloneScratch)
+	}
+	assertParentScratchUntouched(t, "the shared child's teardown", parentScratch)
+}

--- a/agent/subagent_teardown_unix_test.go
+++ b/agent/subagent_teardown_unix_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/sandbox"
 	"primeradiant.com/evener/llm"
 )
 
@@ -749,4 +750,73 @@ func TestSharedEnvChildKeepsItsWorktreeScratchAcrossExit(t *testing.T) {
 		t.Errorf("the entered clone's scratch %s lease is still held after the child's teardown", cloneScratch)
 	}
 	assertParentScratchUntouched(t, "the shared child's teardown", parentScratch)
+}
+
+// A shared child spawned inside its parent's kernel box (a bwrap-backed
+// sandbox) enters a second worktree the same way any shared child does — no
+// working dir of its own, so it starts on its parent's very environment
+// object, and manage_worktree's own re-root swaps it onto a clone. The
+// parent's wrapper carries the box's session tmp, and WithWorkingDirectory
+// re-roots the wrapper while carrying that same tmp forward (see
+// agent/sandbox/reroot.go's Wrapper.ReRoot), so the entered clone works in the
+// box's tmp without any scratch move — and the LEASE stays the parent's the
+// whole time: the clone never records itself as owning it, so the child's
+// teardown settles nothing on the box.
+func TestSharedEnvChildInsideTheParentBoxKeepsTheParentScratchLease(t *testing.T) {
+	_, laneA, laneB, home := sbxMainAndLanes(t)
+	facts := sbxBwrapFacts(home)
+	parent := sbxWorktreeSession(t)
+	boxed := execenv.NewLocalExecutionEnvironment(laneA)
+	if err := boxed.EnableSandbox(sbxResolve(t, facts, laneA, sandbox.ModeWorkspaceWrite)); err != nil {
+		t.Fatalf("EnableSandbox: %v", err)
+	}
+	parent.mu.Lock()
+	parent.env = boxed
+	parent.mu.Unlock()
+	boxTmp := boxed.SessionScratchDir()
+	if boxTmp == "" {
+		t.Fatal("EnableSandbox minted no session scratch for the box")
+	}
+	if !scratchLeaseHeld(t, boxTmp) {
+		t.Fatal("the box's scratch lease is not held")
+	}
+
+	ctx := context.WithValue(context.Background(), ctxDelegationAllowance, 2)
+	prepared, err := parent.prepareSubagentRun(ctx, "child task", "", "", 0, "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("prepareSubagentRun: %v", err)
+	}
+	t.Cleanup(func() { releasePreparedTreeSlot(prepared) })
+	child := prepared.sub.sess
+	if child.currentEnv() != parent.currentEnv() {
+		t.Fatal("the spawned child did not land on the parent's boxed environment; this test would prove nothing")
+	}
+	if child.ownsEnv {
+		t.Fatal("the spawned child recorded that it owns the parent's boxed environment; this test would prove nothing")
+	}
+
+	// Enter with the env-swap primitive, not the manage_worktree tool: a
+	// wrappered env would try to spawn /usr/bin/bwrap for the tool's own git
+	// commands, and there is no real bwrap on this host. The tool surface for a
+	// shared child entering a worktree is covered by the unsandboxed tests
+	// above in this file.
+	if err := child.enterWorktree(laneB, true); err != nil {
+		t.Fatalf("enterWorktree: %v", err)
+	}
+	clone := currentLocalEnv(t, child)
+	if clone == boxed {
+		t.Fatal("the enter left the child on the parent's own environment object; this test would prove nothing")
+	}
+	if got := clone.SessionScratchDir(); got != boxTmp {
+		t.Errorf("entered clone scratch = %q, want the box's own %q carried by the re-rooted wrapper", got, boxTmp)
+	}
+
+	teardownChildSession(context.Background(), child, retainChildScratch)
+
+	if _, err := os.Stat(boxTmp); err != nil {
+		t.Errorf("the child's teardown removed the box's scratch %s, want it retained for the live parent: %v", boxTmp, err)
+	}
+	if !scratchLeaseHeld(t, boxTmp) {
+		t.Errorf("the child's teardown released the box's scratch %s lease while the parent is still working in it", boxTmp)
+	}
 }

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -225,6 +226,24 @@ func teardownChildSession(ctx context.Context, sess *Session, scratch childScrat
 	releaseOwnedChildEnvironment(sess.environmentOwnedAtTeardown(), scratch)
 }
 
+// sameEnvironment reports whether a and b are the same execution environment.
+// Identity is what every ownership decision here asks, and each environment a
+// session runs on is a pointer, so `==` answers it — with one trap: `==` on two
+// interfaces holding the same NON-comparable dynamic type panics at runtime
+// instead of answering, and an environment is an interface a struct value may
+// satisfy. A value nothing else can alias is not the same environment as
+// anything, which is the answer this returns where `==` would end the process.
+func sameEnvironment(a, b execenv.ExecutionEnvironment) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	ta := reflect.TypeOf(a)
+	if ta != reflect.TypeOf(b) || !ta.Comparable() {
+		return false
+	}
+	return a == b
+}
+
 // environmentOwnedAtTeardown returns the environment this session's own
 // teardown settles, or nil when the session is still holding the one its live
 // parent works in. Ownership is not frozen at spawn: a child handed its
@@ -237,7 +256,7 @@ func (s *Session) environmentOwnedAtTeardown() execenv.ExecutionEnvironment {
 	if s.ownsEnv {
 		return s.env
 	}
-	if s.parentSharedEnv == nil || s.env == s.parentSharedEnv {
+	if s.parentSharedEnv == nil || sameEnvironment(s.env, s.parentSharedEnv) {
 		return nil
 	}
 	return s.env

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -193,33 +193,64 @@ const (
 //
 // Invariant: a session runs Cleanup only on an environment whose process table
 // it constructed, at its own close, and never on a child's. A child's
-// environment is either the parent's own (a delegate with neither a working
-// dir nor a box of its own) or a WithWorkingDirectory clone built for it, and a
-// clone shares the parent's process table by pointer, so Cleanup on either one
-// signals the parent's in-flight tools. A child's own processes end without it:
-// its job manager stops its shells and cancellation ends its tool commands at
+// environment is the parent's own (a delegate with neither a working dir nor a
+// box of its own), a WithWorkingDirectory clone built for it at spawn, or — a
+// delegate on the parent's own environment can still build one mid-life by
+// entering a worktree — a clone the child built for itself later. Every clone
+// shares the process table it was cloned from by pointer, so Cleanup on one
+// signals that table's live owner. A child's own processes end without it: its
+// job manager stops its shells and cancellation ends its tool commands at
 // close, and whatever survives is reaped when the table's owner closes. What a
-// child owns outright is its clone's scratch — the sandbox-provisioned dir and
-// the one an unsandboxed clone minted on its first command — and that is
+// child owns outright is its clone's scratch — the sandbox-provisioned dir, the
+// one an unsandboxed clone minted on its first command, and the one a
+// shared-environment child minted after entering a worktree — and that is
 // released here, both kinds together, per scratch: retained on a handoff,
-// disposed when the child is dropped. A shared environment is left untouched
-// in every respect: the parent is still working in it. Which of the two the
-// child runs on is the child's own record (Session.ownsEnv), so a teardown
-// reaching a child no parent bookkeeping names still settles it correctly.
+// disposed when the child is dropped. The parent's own environment is left
+// untouched in every respect: the parent is still working in it. Which
+// environment (if any) a teardown settles is Session.environmentOwnedAtTeardown's
+// decision, so a teardown reaching a child no parent bookkeeping names still
+// settles it correctly.
 func teardownChildSession(ctx context.Context, sess *Session, scratch childScratchDisposition) {
 	if sess == nil {
 		return
 	}
 	sess.close(ctx, false)
-	releaseOwnedChildEnvironment(sess.currentEnv(), sess.ownsEnv, scratch)
+	// Every entry is a clone the child built for itself by entering or switching
+	// worktrees and then swapped away from: no child close runs the cleanupEnv
+	// block that drains sess.abandonedEnvs, so this is the only teardown that
+	// reaches them. Retaining releases their leases without touching any process
+	// table — the parent's own object can never be in this list
+	// (recordAbandonedEnvironmentLocked excludes it by construction).
+	sess.retainAbandonedEnvironmentScratch()
+	releaseOwnedChildEnvironment(sess.environmentOwnedAtTeardown(), scratch)
+}
+
+// environmentOwnedAtTeardown returns the environment this session's own
+// teardown settles, or nil when the session is still holding the one its live
+// parent works in. Ownership is not frozen at spawn: a child handed its
+// parent's own environment builds one of its own the moment it enters a
+// worktree, and that clone's scratch is the child's — nothing else will ever
+// reach it. The parent's object is the one thing this never names.
+func (s *Session) environmentOwnedAtTeardown() execenv.ExecutionEnvironment {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ownsEnv {
+		return s.env
+	}
+	if s.parentSharedEnv == nil || s.env == s.parentSharedEnv {
+		return nil
+	}
+	return s.env
 }
 
 // releaseOwnedChildEnvironment is teardownChildSession's environment step on
 // its own, for the one child close that is not a close(): a restore candidate
 // nothing adopted is discarded by discardRestoredCandidate, which settles the
 // candidate's own resources and then makes exactly this decision for its env.
-func releaseOwnedChildEnvironment(env execenv.ExecutionEnvironment, ownsEnv bool, scratch childScratchDisposition) {
-	if !ownsEnv {
+// env is nil when the child is still holding its parent's own environment —
+// there is nothing for this teardown to settle.
+func releaseOwnedChildEnvironment(env execenv.ExecutionEnvironment, scratch childScratchDisposition) {
+	if env == nil {
 		return
 	}
 	if scratch == disposeChildScratch {
@@ -228,6 +259,20 @@ func releaseOwnedChildEnvironment(env execenv.ExecutionEnvironment, ownsEnv bool
 	}
 	if local, ok := env.(*execenv.LocalExecutionEnvironment); ok {
 		local.RetainSessionScratch()
+	}
+}
+
+// recordEnvironmentOwnership records whether env was built FOR this child
+// (ownsFresh) or is the live parent's own object it was handed instead. A
+// child that does not own env keeps a reference to it in parentSharedEnv so a
+// later teardown — including one that finds env swapped for a clone the child
+// built for itself mid-life — knows which environment, if either, is its own
+// to settle. Both call sites write this before the session is published
+// anywhere else reachable, so no lock is needed.
+func (s *Session) recordEnvironmentOwnership(env execenv.ExecutionEnvironment, ownsFresh bool) {
+	s.ownsEnv = ownsFresh
+	if !ownsFresh {
+		s.parentSharedEnv = env
 	}
 }
 
@@ -1008,7 +1053,7 @@ func (s *Session) prepareSubagentRunFromSelection(
 	}
 	// The child owns a fresh env iff we re-rooted to a lane and/or enforced a
 	// per-delegate sandbox; otherwise subEnv is the shared parent env.
-	subSess.ownsEnv = ownsFreshEnv
+	subSess.recordEnvironmentOwnership(subEnv, ownsFreshEnv)
 	disposeUnadopted := func() {
 		disposeUnadoptedSubagentSession(subSess)
 	}


### PR DESCRIPTION
## What was wrong

A delegate spawned with neither a `working_dir` nor a box of its own runs on its parent's very environment object (`Session.ownsEnv` false, `prepareSubagentEnvironment` returns the parent's env untouched), and it keeps the full `manage_worktree` tool — only worktree isolation or a zero delegation allowance strips it. So such a child can `enter` a worktree, which runs `swapEnvAndRefresh` and installs a clone of its own.

Two things then went wrong, both verified against the real spawn and enter paths:

- **The enter took the parent's scratch.** Step 0's `next.AdoptSessionScratch(current)` ran unconditionally, moving the directory the live parent was working in onto the child's clone; the parent's environment was left owning none and minted a fresh one on its next command.
- **The teardown settled nothing.** `teardownChildSession` decided from `ownsEnv`, frozen at spawn and still false, so `releaseOwnedChildEnvironment` returned immediately; and the parked/abandoned retains added by #878 run only under `if cleanupEnv` in `Session.close`, which a child teardown never sets. The clone's scratch lease was held for the rest of the daemon's uptime.

## What changed

A child now records the environment its parent handed it (`Session.parentSharedEnv`, set beside `ownsEnv` at spawn and at delegate restore through `recordEnvironmentOwnership`).

- `swapEnvAndRefresh` skips the scratch move in both directions when that object is the source or the target: an enter leaves the parent's scratch where the parent is working and the clone provisions its own on its first command; an exit hands the clone's scratch to nobody.
- `environmentOwnedAtTeardown` replaces the raw `ownsEnv` read at both teardown call sites: ownership is no longer frozen at spawn, so the clone a child built for itself mid-life is settled, while the parent's own object never is.
- `teardownChildSession` also drains `abandonedEnvs` (the clones an enter-then-exit or a switch left behind), which only `close`'s `cleanupEnv` block reached before. `recordAbandonedEnvironmentLocked` now excludes `parentSharedEnv` structurally, so the parent's object can never enter that list.

No teardown path calls `Cleanup()`: leases are released and directories kept, so the invariant that a session reaps only a process table it constructed still holds. Root-session behaviour is unchanged (`parentSharedEnv` is nil there).

## How it is tested

Two new tests in `agent/subagent_teardown_unix_test.go`, both through the real spawn path (`prepareSubagentRun` with a delegation allowance) and the real enter path (the child's own `manage_worktree` `switch` by path onto a sibling worktree), asserting real lease files and directories:

- `TestSharedEnvChildTeardownReleasesTheEnteredWorktreeScratch` failed on main with `the entered clone's scratch /…/evener-sandbox-2445113863 lease is still held after the shared child's teardown`.
- `TestSharedEnvChildKeepsItsWorktreeScratchAcrossExit` failed on main with `the entered clone's scratch is the parent's own /…/evener-sandbox-1775178725, want a scratch of its own`, and on the same lease message.

Both also pin that the parent's scratch and its in-flight process are untouched.

## Gates

- `gofmt -l` on every changed file: clean.
- `go vet ./...` and `go vet -tags evenerfuzz ./...`: exit 0.
- `make lint-golangci`, `make lint-evenerfuzz lint-eval` (as CI runs them): PASS.
- `GOMAXPROCS=4 go test -race ./agent/ -count=1`: `ok … 1262.542s`, 0 FAIL.
- `GOMAXPROCS=4 go test -tags evenerfuzz -run Fuzz ./agent/ -count=1`: 0 FAIL.
- `GOMAXPROCS=4 go test ./agent/ -count=1 -timeout 40m`: `ok … 465.553s`, 0 FAIL.

Closes #913

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT