### PR TITLE
fix(execenv): bound the glob walk's listings, matches, and memory

### DIFF
--- a/agent/cov_s3_shelltools_test.go
+++ b/agent/cov_s3_shelltools_test.go
@@ -3,8 +3,10 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -189,5 +191,55 @@ func TestS3Cov_GlobTool_FullyExcludedResultExplainsRatherThanEmpties(t *testing.
 	}
 	if !strings.Contains(res.Output, "index.js") {
 		t.Fatalf("expected include_ignored=true to find the match, got: %q", res.Output)
+	}
+}
+
+// truncatingGlobEnv wraps an execenv.ExecutionEnvironment and implements
+// execenv.GlobExcluder with a fixed, pre-truncated result, so the tool
+// boundary below can be tested without building a tree large enough to
+// actually trip the real match cap.
+type truncatingGlobEnv struct {
+	execenv.ExecutionEnvironment
+	matches     []string
+	truncatedAt int
+}
+
+func (e *truncatingGlobEnv) GlobWithExclusions(ctx context.Context, pattern, basePath string, includeIgnored bool) ([]string, int, int, error) {
+	return e.matches, 0, e.truncatedAt, nil
+}
+
+// TestS3Cov_GlobTool_TruncationNoteNamesTheCapWithoutDroppingMatches proves
+// the glob tool boundary surfaces GlobExcluder's truncatedAt (#497): when a
+// glob call hits the match cap, the tool result must still contain every
+// match it collected *and* say the listing was capped, so a model cannot
+// mistake a partial result for the whole answer. A bare
+// strings.Join(matches, "\n") is indistinguishable from an uncapped result,
+// which is exactly the failure mode this guards against.
+func TestS3Cov_GlobTool_TruncationNoteNamesTheCapWithoutDroppingMatches(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	s := newSession(t, withDir(dir))
+
+	const capAt = 7
+	matches := make([]string, capAt)
+	for i := range matches {
+		matches[i] = fmt.Sprintf("/match/%02d.txt", i)
+	}
+	s.env = &truncatingGlobEnv{ExecutionEnvironment: s.env, matches: matches, truncatedAt: capAt}
+
+	res := s3cov_exec(t, s, "glob", `{"pattern":"**/*","path":"."}`)
+	if res.IsError {
+		t.Fatalf("glob error: %v", res.Output)
+	}
+	for _, m := range matches {
+		if !strings.Contains(res.Output, m) {
+			t.Fatalf("truncated glob result dropped match %q: %q", m, res.Output)
+		}
+	}
+	if !strings.Contains(res.Output, strconv.Itoa(capAt)) {
+		t.Fatalf("truncated glob result does not name the cap (%d): %q", capAt, res.Output)
+	}
+	if res.Output == strings.Join(matches, "\n") {
+		t.Fatal("truncated glob result is indistinguishable from the bare match list; a model can't tell truncation happened")
 	}
 }

--- a/agent/execenv/execenv.go
+++ b/agent/execenv/execenv.go
@@ -178,6 +178,7 @@ type ExecutionEnvironment interface {
 type GlobExcluder interface {
 	// GlobWithExclusions behaves like Glob but also returns the number of
 	// candidate matches dropped by the default dotfile/gitignore exclusion
-	// (always 0 when includeIgnored is true).
-	GlobWithExclusions(ctx context.Context, pattern, basePath string, includeIgnored bool) (matches []string, excluded int, err error)
+	// (always 0 when includeIgnored is true), and truncatedAt: the match cap
+	// that cut the listing short, or 0 when every match is reported.
+	GlobWithExclusions(ctx context.Context, pattern, basePath string, includeIgnored bool) (matches []string, excluded int, truncatedAt int, err error)
 }

--- a/agent/execenv/gitignore.go
+++ b/agent/execenv/gitignore.go
@@ -38,10 +38,13 @@ type ignoreDir struct {
 }
 
 // loadIgnoreSet walks fsys (rooted at the search base) collecting every
-// .gitignore file's rules. It is best-effort: unreadable files are skipped
-// rather than failing the search, and a base with no .gitignore files
-// anywhere (including one that is not inside a git repository at all) yields
-// an ignoreSet that matches nothing.
+// .gitignore file's rules. It is best-effort for I/O errors: unreadable files
+// are skipped rather than failing the search, and a base with no .gitignore
+// files anywhere (including one that is not inside a git repository at all)
+// yields an ignoreSet that matches nothing. The one error it does return is
+// budget refusing to let the walk keep going — that has to reach the caller,
+// since a partial ignoreSet built from a walk that gave up partway through
+// would silently under-exclude the rest of a huge tree.
 //
 // skip, when non-nil, is consulted for every path (relative to fsys' root,
 // slash-separated) before it is descended into or read; skip returning true
@@ -51,8 +54,14 @@ type ignoreDir struct {
 // this walk otherwise has no other way to honor, since fsys itself (a
 // symlink-refusing, root-confined secureDirFS) enforces confinement but not
 // masking. The off-path caller (no masking concept) passes a no-op skip.
-func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool) *ignoreSet {
+//
+// budget is the same one the caller's glob walk spends listings from, so
+// ignore discovery and pattern matching together are bounded as one call's
+// worth of work rather than each getting its own unbounded pass over the
+// tree.
+func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool, budget *globBudget) (*ignoreSet, error) {
 	set := &ignoreSet{}
+	var budgetErr error
 	_ = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return nil //nolint:nilerr // best-effort: skip unreadable entries
@@ -71,6 +80,16 @@ func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool) *ignoreSet {
 			if p != "." && strings.HasPrefix(d.Name(), ".") {
 				return fs.SkipDir
 			}
+			// cycleSafe is always true here: fs.WalkDir never follows a
+			// symlink into a directory, so this walk can never re-enter
+			// itself the way the pattern walk's /proc/<pid>/root case does.
+			// The flag only picks the refusal's wording, not whether the
+			// bound applies — an unbounded walk over a huge tree costs
+			// unbounded work whether or not it could have looped.
+			if err := budget.listing(true); err != nil {
+				budgetErr = err
+				return err
+			}
 			return nil
 		}
 		if d.Name() != ".gitignore" {
@@ -85,7 +104,7 @@ func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool) *ignoreSet {
 		set.dirs = append(set.dirs, ignoreDir{rel: dir, matcher: matcher})
 		return nil
 	})
-	return set
+	return set, budgetErr
 }
 
 // matches reports whether relPath (slash-separated, relative to the search

--- a/agent/execenv/gitignore.go
+++ b/agent/execenv/gitignore.go
@@ -2,6 +2,7 @@ package execenv
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"path"
 	"strings"
@@ -64,6 +65,15 @@ func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool, budget *globBudge
 	var budgetErr error
 	_ = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
+			// A budget refusal is not an unreadable entry: skipping it would
+			// let the directory that tripped the bound be read again by
+			// whatever walks next, and would leave this set reported as
+			// complete when it stopped partway, silently under-excluding the
+			// rest of the tree.
+			if _, refused := errors.AsType[*globBudgetError](err); refused {
+				budgetErr = err
+				return err
+			}
 			return nil //nolint:nilerr // best-effort: skip unreadable entries
 		}
 		if p != "." && skip != nil && skip(p) {

--- a/agent/execenv/gitignore_covtest_test.go
+++ b/agent/execenv/gitignore_covtest_test.go
@@ -40,7 +40,10 @@ func TestIgnoreSet_Matches_PathEqualsDir(t *testing.T) {
 		"sub":            {Mode: os.ModeDir | 0o755},
 		"sub/.gitignore": {Data: []byte(content)},
 	}
-	set := loadIgnoreSet(fsys, nil)
+	set, err := loadIgnoreSet(fsys, nil, &globBudget{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	// "sub" == id.rel, so rel becomes "." — "*.log" won't match "."
 	if set.matches("sub", false) {
 		t.Fatal("expected sub (file) NOT to be ignored")
@@ -112,9 +115,12 @@ func TestLoadIgnoreSet_SkipFile(t *testing.T) {
 		"skipme":          {Data: []byte("data\n")},
 		"skipme/file.txt": {Data: []byte("data\n")},
 	}
-	set := loadIgnoreSet(fsys, func(relPath string) bool {
+	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return relPath == "skipme"
-	})
+	}, &globBudget{})
+	if err != nil {
+		t.Fatal(err)
+	}
 	// The .gitignore at root should still be loaded.
 	if !set.matches("test.tmp", false) {
 		t.Fatal("expected test.tmp to be ignored by root .gitignore")
@@ -156,5 +162,9 @@ func loadIgnoreSetFromLines(t *testing.T, dir string, lines ...string) *ignoreSe
 	fsys := fstest.MapFS{
 		path: {Data: []byte(content)},
 	}
-	return loadIgnoreSet(fsys, nil)
+	set, err := loadIgnoreSet(fsys, nil, &globBudget{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return set
 }

--- a/agent/execenv/gitignore_covtest_test.go
+++ b/agent/execenv/gitignore_covtest_test.go
@@ -40,7 +40,7 @@ func TestIgnoreSet_Matches_PathEqualsDir(t *testing.T) {
 		"sub":            {Mode: os.ModeDir | 0o755},
 		"sub/.gitignore": {Data: []byte(content)},
 	}
-	set, err := loadIgnoreSet(fsys, nil, &globBudget{})
+	set, err := loadIgnoreSet(fsys, nil, newGlobBudget("glob"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestLoadIgnoreSet_SkipFile(t *testing.T) {
 	}
 	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return relPath == "skipme"
-	}, &globBudget{})
+	}, newGlobBudget("glob"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func loadIgnoreSetFromLines(t *testing.T, dir string, lines ...string) *ignoreSe
 	fsys := fstest.MapFS{
 		path: {Data: []byte(content)},
 	}
-	set, err := loadIgnoreSet(fsys, nil, &globBudget{})
+	set, err := loadIgnoreSet(fsys, nil, newGlobBudget("glob"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -1,0 +1,211 @@
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// stubMaxGlobDirListings lowers the directory-listing budget for a test and
+// restores it when the test ends, so a budget test can use a tree small
+// enough for t.TempDir() rather than one large enough to trip the real
+// (100,000) bound.
+func stubMaxGlobDirListings(t *testing.T, n int) {
+	t.Helper()
+	orig := maxGlobDirListings
+	maxGlobDirListings = n
+	t.Cleanup(func() { maxGlobDirListings = orig })
+}
+
+// stubMaxGlobMatches lowers the match-count budget for a test and restores it
+// when the test ends.
+func stubMaxGlobMatches(t *testing.T, n int) {
+	t.Helper()
+	orig := maxGlobMatches
+	maxGlobMatches = n
+	t.Cleanup(func() { maxGlobMatches = orig })
+}
+
+// globBudgetFixture builds a t.TempDir() tree of n sibling directories, each
+// holding one leaf.txt and one leaf.md, so tests can glob for one extension,
+// both extensions, or count total directories without rebuilding the tree.
+func globBudgetFixture(t *testing.T, n int) (root string) {
+	t.Helper()
+	root = t.TempDir()
+	for i := range n {
+		dir := filepath.Join(root, fmt.Sprintf("dir%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "leaf.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "leaf.md"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// TestGlobStopsAtTheDirectoryListingBudgetWithFileIdentity is the unit-scale
+// reproduction of #497: maxUnidentifiedGlobDirs only ever counted directories
+// whose FileInfo carries no file identity, but ext4/APFS/HFS+ give every
+// directory (dev, ino) identity, so the bound was unreachable on a real
+// filesystem. A `**` glob rooted at a huge real directory tree (like `/`) had
+// termination (the ancestor/SameFile cycle check) but no bound on the work or
+// memory it could spend getting there. This proves the bound now counts every
+// listing, not only identity-less ones — using a real os-backed tree so the
+// test cannot silently drift onto the identity-less arm the old bound covered.
+func TestGlobStopsAtTheDirectoryListingBudgetWithFileIdentity(t *testing.T) {
+	const dirCount = 40
+	root := globBudgetFixture(t, dirCount)
+
+	info, err := os.Stat(filepath.Join(root, "dir00"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasFileIdentity(info) {
+		t.Fatalf("a real directory must carry file identity, else this test exercises the wrong bound")
+	}
+
+	const budget = 8
+	stubMaxGlobDirListings(t, budget)
+
+	var counter *countingFS
+	stubGlobBaseFS(t, func(dir string) fs.FS {
+		counter = &countingFS{FS: os.DirFS(dir)}
+		return counter
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.txt", root, true)
+	if err == nil {
+		t.Fatalf("Glob over a %d-directory tree with a listing budget of %d returned no error and %d matches; the listing budget was not enforced", dirCount, budget, len(matches))
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the glob visibly instead", err)
+	}
+	if counter.calls > budget+1 {
+		t.Fatalf("walk made %d directory listings against a budget of %d, want at most %d", counter.calls, budget, budget+1)
+	}
+	if counter.calls >= dirCount+1 {
+		t.Fatalf("walk listed all %d directories instead of stopping early (%d listings made)", dirCount+1, counter.calls)
+	}
+}
+
+// TestGlobTruncatesAtTheMatchCap proves globMatches's other missing bound: the
+// GlobWalk callback appended every match to the result slice forever, so a
+// `**` pattern with millions of hits accumulated all of them in memory before
+// GlobWithExclusions ever got a chance to return. The cap must also stop the
+// walk itself once it trips, not merely truncate the slice after a full walk
+// completes — a truncate-after-the-fact fix would satisfy the match count but
+// still pay the full listing cost, which is the resource the bug actually
+// wastes. That is why this compares against an uncapped control run over the
+// identical tree rather than a hand-picked listing count.
+func TestGlobTruncatesAtTheMatchCap(t *testing.T) {
+	const fileCount = 24
+	root := globBudgetFixture(t, fileCount)
+
+	var full *countingFS
+	stubGlobBaseFS(t, func(dir string) fs.FS {
+		full = &countingFS{FS: os.DirFS(dir)}
+		return full
+	})
+	fullMatches, _, fullTruncatedAt, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.txt", root, true)
+	if err != nil {
+		t.Fatalf("uncapped control run: %v", err)
+	}
+	if len(fullMatches) != fileCount || fullTruncatedAt != 0 {
+		t.Fatalf("uncapped control run = (%d matches, truncatedAt=%d), want (%d, 0)", len(fullMatches), fullTruncatedAt, fileCount)
+	}
+
+	stubMaxGlobMatches(t, 5)
+
+	var capped *countingFS
+	stubGlobBaseFS(t, func(dir string) fs.FS {
+		capped = &countingFS{FS: os.DirFS(dir)}
+		return capped
+	})
+	matches, _, truncatedAt, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.txt", root, true)
+	if err != nil {
+		t.Fatalf("capped run: %v", err)
+	}
+	if len(matches) != 5 {
+		t.Fatalf("capped run returned %d matches, want exactly 5", len(matches))
+	}
+	if truncatedAt != 5 {
+		t.Fatalf("capped run reported truncatedAt=%d, want 5", truncatedAt)
+	}
+	if capped.calls >= full.calls {
+		t.Fatalf("capped run made %d directory listings, want fewer than the uncapped run's %d listings (the walk must stop once the match cap trips, not just truncate the result afterward)", capped.calls, full.calls)
+	}
+}
+
+// TestGlobBudgetIsSharedAcrossBraceExpandedPatterns proves the budget has to
+// live at the glob call, not at each expanded pattern:
+// globpattern.Expand can turn one brace pattern into up to
+// globpattern.MaxExpansions (256) separately-walked patterns, and globMatches
+// runs a fresh globWalkFS per pattern. A budget scoped to that walk would let
+// a 256-way brace expansion multiply the cap by 256 instead of bounding the
+// call it belongs to. Two extensions stand in for two expansions here.
+func TestGlobBudgetIsSharedAcrossBraceExpandedPatterns(t *testing.T) {
+	const fileCount = 24
+	root := globBudgetFixture(t, fileCount)
+
+	stubMaxGlobMatches(t, 5)
+
+	matches, _, truncatedAt, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.{txt,md}", root, true)
+	if err != nil {
+		t.Fatalf("GlobWithExclusions: %v", err)
+	}
+	if len(matches) > 5 {
+		t.Fatalf("brace-expanded glob (two patterns) returned %d matches, want at most 5 shared across the whole call, not 5 per expanded pattern", len(matches))
+	}
+	if truncatedAt != 5 {
+		t.Fatalf("brace-expanded glob reported truncatedAt=%d, want 5 (the call-wide cap)", truncatedAt)
+	}
+}
+
+// TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked covers the third
+// defect behind #497: w.listed is a map keyed by every directory the walk has
+// ever listed, and nothing ever removes an entry once admit adds it. The
+// ancestor cycle check in admit only ever consults ancestors of the directory
+// currently being admitted, so a wide, shallow tree (siblings, not nesting)
+// should cost the walk O(1) retained identities, not one per directory
+// visited. This builds a wide real tree, so hasFileIdentity is true throughout,
+// and pins the failure via retained() rather than via a memory measurement
+// that would be flaky to assert on directly.
+func TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked(t *testing.T) {
+	const siblingCount = 30
+	root := globBudgetFixture(t, siblingCount)
+
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: &globBudget{}}
+	if _, err := w.ReadDir("."); err != nil {
+		t.Fatalf("listing the root: %v", err)
+	}
+	for i := range siblingCount {
+		dir := fmt.Sprintf("dir%02d", i)
+		if _, err := w.ReadDir(dir); err != nil {
+			t.Fatalf("listing %s: %v", dir, err)
+		}
+	}
+
+	if retained := w.retained(); retained > 2 {
+		t.Fatalf("walk retained %d directory identities after listing %d sibling directories; retained count grew with the number of directories listed, not with the depth of the path being walked (want at most 2: the root plus the sibling being listed)", retained, siblingCount)
+	}
+
+	// The cycle check must still work after whatever pruning made the count
+	// above small — a fix that throws identity away entirely would pass the
+	// retention assertion but silently reopen #369 (the `**` / never
+	// terminating). A directory symlink back at the tree root must still be
+	// refused as a readdir on an already-listed ancestor.
+	if err := os.Symlink(root, filepath.Join(root, "loop")); err != nil {
+		t.Skipf("directory symlinks unavailable on this platform: %v", err)
+	}
+	_, err := w.ReadDir("loop")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("ReadDir(loop) through a symlink back at the tree root = %v, want an fs.ErrNotExist PathError (the walk refusing an already-listed ancestor)", err)
+	}
+}

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -251,13 +252,7 @@ func TestGlobBudgetIsSharedAcrossBraceExpandedPatterns(t *testing.T) {
 // former avoids.
 func TestGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 	const fileCount = 30
-	root := t.TempDir()
-	for i := range fileCount {
-		p := filepath.Join(root, fmt.Sprintf("leaf%03d.txt", i))
-		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
+	root := flatEntriesFixture(t, fileCount)
 
 	const budget = 10
 	stubMaxGlobDirEntries(t, budget)
@@ -317,6 +312,69 @@ func TestGrepWalkIsChargedToTheBudget(t *testing.T) {
 	}
 	if budgetErr.op != "grep" {
 		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}
+
+// TestGrepWalkDoesNotChargeSkippedDirectories proves grepNative's own walk
+// charges the listing budget only for directories it actually descends into.
+// The d.IsDir() block in grepNative's callback charges budget.listing(true)
+// before the dot-directory and gitignore filepath.SkipDir checks further down
+// the same callback run, so a directory the walk immediately skips still
+// costs budget. The tree here mixes both kinds of exclusion the callback
+// applies — dot-prefixed directories and directories a root .gitignore
+// matches — and its excluded directories alone outnumber the lowered listing
+// budget, while only a handful of directories are ever actually listed.
+// loadIgnoreSet runs first over the same tree on the same budget, and it
+// skips only the dot-prefixed directories, not the gitignored ones, so its
+// own pass already charges for every gitignored directory before grepNative's
+// walk begins; the budget below is sized comfortably above that cost alone,
+// so only the walk's redundant charge for the directories it was about to
+// skip anyway can push the call over it.
+func TestGrepWalkDoesNotChargeSkippedDirectories(t *testing.T) {
+	root := t.TempDir()
+
+	const realCount = 3
+	for i := range realCount {
+		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf("dir%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "dir00", "leaf.txt"), []byte("needle\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const dotCount = 20
+	for i := range dotCount {
+		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf(".excluded%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const gitignoredCount = 10
+	gitignoreLines := make([]string, 0, gitignoredCount)
+	for i := range gitignoredCount {
+		dir := fmt.Sprintf("ignored%02d", i)
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		gitignoreLines = append(gitignoreLines, dir+"/")
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(strings.Join(gitignoreLines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const budget = 25
+	stubMaxGlobDirListings(t, budget)
+
+	out, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	if budgetErr, refused := errors.AsType[*globBudgetError](err); refused {
+		t.Fatalf("grepNative over a tree with %d dot-excluded and %d gitignored directories against only %d listed directories, with a listing budget of %d well above ignore discovery's own cost, refused: %v; the walk is charging directories it is about to skip toward the budget instead of only the ones it actually descends into", dotCount, gitignoredCount, realCount, budget, budgetErr)
+	}
+	if err != nil {
+		t.Fatalf("grepNative: %v", err)
+	}
+	if !strings.Contains(out, "needle") {
+		t.Fatalf("grepNative(%q) = %q, want a match for the needle in dir00/leaf.txt", "needle", out)
 	}
 }
 
@@ -650,11 +708,17 @@ func TestGlobIgnoreDiscoveryStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 	}
 }
 
-// TestGrepWalkStopsOnADirectoryWithTooManyEntries is the same contract for
-// grep's two best-effort walks. Both loadIgnoreSet's callback and grepNative's
-// own walk callback skip past any error they are handed, so an oversized
-// directory would be read in full by each of them in turn and the call would
-// come back reporting no matches and no error at all.
+// TestGrepWalkStopsOnADirectoryWithTooManyEntries pins grep's ignore
+// discovery surfacing the entries refusal, not grepNative's own walk. root
+// itself is the one oversized directory here (30 files, no subdirectories),
+// and loadIgnoreSet's fs.WalkDir walk lists it before grepNative's own walk
+// ever starts, so the refusal always comes from ignore discovery's callback
+// swallowing-guard. It cannot also pin the equivalent guard in grepNative's
+// own walk callback: that guard only matters if a directory grows past the
+// entries bound between ignore discovery's pass and the walk's own, which a
+// deterministic test cannot construct — ignore discovery's skip set is
+// always a subset of the walk's, so ignore discovery always reaches (and
+// refuses) any oversized directory first.
 func TestGrepWalkStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 	const fileCount = 30
 	const budget = 10

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -45,6 +45,16 @@ func stubMaxGlobDirEntries(t *testing.T, n int) {
 	t.Cleanup(func() { maxGlobDirEntries = orig })
 }
 
+// stubMaxGlobLiveEntries lowers the call-wide live-entry budget for a test
+// and restores it when the test ends, so a budget test can use a tree small
+// enough for t.TempDir() rather than one large enough to trip the real bound.
+func stubMaxGlobLiveEntries(t *testing.T, n int) {
+	t.Helper()
+	orig := maxGlobLiveEntries
+	maxGlobLiveEntries = n
+	t.Cleanup(func() { maxGlobLiveEntries = orig })
+}
+
 // stubGlobDirChunk shrinks the per-syscall chunk size for a test and restores
 // it when the test ends, so a bounded listing has to make several chunk reads
 // over a fixture small enough for t.TempDir() instead of a directory too
@@ -301,19 +311,154 @@ func TestGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 	}
 }
 
+// TestGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree proves the
+// call-wide live-entry bound catches what maxGlobDirEntries cannot: a walk
+// holds every ancestor directory's listing alive while it descends into a
+// child, so a deep tree's peak live total is the per-directory entry count
+// times its depth, not any single listing's size. Every directory in the
+// chain here holds fewer entries than a lowered maxGlobDirEntries, so the
+// per-directory cap never trips on its own, but the sum the walk is holding
+// live grows with every level it descends and crosses a lowered
+// maxGlobLiveEntries partway down. peakLiveEntries has to be checked
+// directly, not just the refusal, because a fix that walked the whole tree
+// and only complained at the end would return the same error this test's
+// errors.As check accepts; comparing what was actually held live against the
+// tree's full entry count is what tells the two apart.
+func TestGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree(t *testing.T) {
+	root := t.TempDir()
+
+	const depth = 10    // d00..d09
+	const perLevel = 5  // every directory in the chain holds this many entries
+	const decoySize = 8 // files in a directory outside the chain
+	const perDirBudget = 20
+	const liveBudget = 30
+
+	cur := root
+	for i := range depth {
+		cur = filepath.Join(cur, fmt.Sprintf("d%02d", i))
+		if err := os.MkdirAll(cur, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Every non-leaf directory holds perLevel-1 padding files plus the
+		// subdirectory that continues the chain; the leaf holds perLevel
+		// padding files and no subdirectory, so every level's own listing is
+		// the same size.
+		padding := perLevel - 1
+		if i == depth-1 {
+			padding = perLevel
+		}
+		for p := range padding {
+			if err := os.WriteFile(filepath.Join(cur, fmt.Sprintf("pad%02d.txt", p)), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// zzz_decoy sorts after the whole d00..d09 chain, so the walk finishes
+	// descending and backing out of the chain before it ever lists this
+	// directory: it contributes to the tree's total entry count but is never
+	// one of the chain's ancestors, so it can never be live at the same time
+	// as the chain's peak.
+	decoy := filepath.Join(root, "zzz_decoy")
+	if err := os.MkdirAll(decoy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range decoySize {
+		if err := os.WriteFile(filepath.Join(decoy, fmt.Sprintf("leaf%02d.txt", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Total entries in the tree: root's own listing (d00 + zzz_decoy = 2),
+	// plus the chain (depth*perLevel), plus the decoy's own files.
+	totalEntries := 2 + depth*perLevel + decoySize
+
+	stubMaxGlobDirEntries(t, perDirBudget)
+	stubMaxGlobLiveEntries(t, liveBudget)
+
+	var seenBudget *globBudget
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *globBudget) fs.FS {
+		seenBudget = budget
+		return boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.txt", root, true)
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Glob over a %d-level tree (peak live so far: %d) with a live-entry budget of %d = (%d matches, %v), want a *globBudgetError; nothing bounds how many entries a walk may hold live across the listings it still has open", depth, seenBudget.peakLiveEntries, liveBudget, len(matches), err)
+	}
+	if budgetErr.kind != budgetLiveEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetLiveEntries", budgetErr.kind)
+	}
+	if seenBudget.peakLiveEntries < liveBudget {
+		t.Fatalf("globBudget.peakLiveEntries = %d, want at least the live-entry budget of %d", seenBudget.peakLiveEntries, liveBudget)
+	}
+	if seenBudget.peakLiveEntries >= totalEntries {
+		t.Fatalf("globBudget.peakLiveEntries = %d, want strictly less than the tree's %d total entries (a fix that walked the whole tree before complaining must not pass this)", seenBudget.peakLiveEntries, totalEntries)
+	}
+}
+
+// TestGlobSucceedsOnAWideShallowTreeUnderTheLiveEntryCeiling is the control
+// for TestGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree above: it
+// holds the same 60 total entries (10 sibling directories of 5 files each,
+// plus the root's own 10-entry listing), but spread across siblings instead
+// of nested, so the walk only ever holds the root's listing plus whichever
+// one sibling it is currently reading — one directory's worth plus the root —
+// no matter how many siblings it has already finished with. The live-entry
+// budget is lowered to the same value the nested test uses, and the call
+// still has to succeed and report every match: a naive cumulative counter
+// that summed every listing ever made instead of releasing the ones the walk
+// has left would grow with every sibling visited and refuse partway through
+// this tree instead, which would break every large flat repository.
+func TestGlobSucceedsOnAWideShallowTreeUnderTheLiveEntryCeiling(t *testing.T) {
+	root := t.TempDir()
+
+	const siblings = 10
+	const filesPerSibling = 5
+	const perDirBudget = 20
+	const liveBudget = 30
+
+	for i := range siblings {
+		dir := filepath.Join(root, fmt.Sprintf("sib%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for f := range filesPerSibling {
+			if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("leaf%02d.txt", f)), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	stubMaxGlobDirEntries(t, perDirBudget)
+	stubMaxGlobLiveEntries(t, liveBudget)
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.txt", root, true)
+	if err != nil {
+		t.Fatalf("Glob over a %d-directory wide tree (same %d total entries as the nested tree above) under a live-entry budget of %d = %v, want nil error; the bound must charge only what the walk is currently holding live, not a running total across the whole call", siblings, siblings*(filesPerSibling+1), liveBudget, err)
+	}
+	if want := siblings * filesPerSibling; len(matches) != want {
+		t.Fatalf("Glob over the wide tree returned %d matches, want %d", len(matches), want)
+	}
+}
+
 // TestGlobStopsReadingAChunkedListingOnCancellation proves the other half of
-// reading a directory in chunks: readDirChunked's loop never looks at ctx
-// between one chunk and the next, so a cancellation landing mid-listing is
-// not noticed until the whole directory has been pulled through — up to
-// maxGlobDirEntries/globDirChunk pointless chunks of work after the caller
-// asked to stop. cancelFS only checks ctx once, when a listing starts, and
+// reading a directory in chunks: readDirChunked's loop checks ctx between one
+// chunk and the next, so a cancellation landing mid-listing is noticed within
+// about one more chunk of work rather than after the whole directory has been
+// pulled through. cancelFS only checks ctx once, when a listing starts, and
 // the walk callback that finally sees ctx.Err() only runs after ReadDir
-// returns — so the call comes back reporting context.Canceled either way,
-// and a test that checked only that would pass today without pinning
-// anything. What has to be pinned is the chunk loop itself stopping
+// returns, so the call reports context.Canceled either way regardless of how
+// much of the directory the loop actually read — a test that checked only
+// the returned error would pass even if the loop read every remaining chunk
+// before giving up. What has to be pinned is the chunk loop itself stopping
 // promptly, which is why this also counts how many entries actually came out
 // of the directory file, the same way pacedDirEntriesFS's read counter does
-// for TestGlobStopsOnADirectoryWithTooManyEntries above.
+// for TestGlobStopsOnADirectoryWithTooManyEntries above. Losing the ctx check
+// between chunks would let the loop keep pulling chunks until the directory
+// is exhausted — up to maxGlobDirEntries/globDirChunk chunks of pointless
+// work after the caller asked to stop — while still reporting the same
+// context.Canceled this test's error check alone cannot tell apart from that.
 func TestGlobStopsReadingAChunkedListingOnCancellation(t *testing.T) {
 	const fileCount = 40
 	const chunkSize = 5
@@ -338,16 +483,19 @@ func TestGlobStopsReadingAChunkedListingOnCancellation(t *testing.T) {
 	}
 }
 
-// TestGrepWalkIsChargedToTheBudget proves grepNative's own directory walk has
-// no bound of its own, distinct from the ignore-discovery bound
-// TestGrepIgnoreDiscoveryIsChargedToTheBudget already covers: grepWalk is a
-// plain fs.WalkDir with nothing charging its listings to a budget, so a huge
-// tree grepNative walks after ignore discovery completes still costs
-// unbounded work. The tree here has no .gitignore and is small enough that
-// ignore discovery alone stays well under the lowered listing budget, so a
-// refusal can only be attributed to the walk grepNative runs over the tree it
-// is grepping, not to the ignore-discovery pass that already has its own
-// test above.
+// TestGrepWalkIsChargedToTheBudget proves grepNative's own directory walk
+// charges every directory it descends into to the same budget
+// TestGrepIgnoreDiscoveryIsChargedToTheBudget already covers for ignore
+// discovery: grepWalk's callback calls budget.listing(true) once per
+// directory, so a huge tree grepNative walks after ignore discovery completes
+// still costs bounded work rather than an unbounded second pass. The tree
+// here has no .gitignore and is small enough that ignore discovery alone
+// stays well under the lowered listing budget, so a refusal can only be
+// attributed to the walk grepNative runs over the tree it is grepping, not to
+// the ignore-discovery pass that already has its own test above. Removing the
+// budget.listing(true) call from grepWalk's callback would let this walk
+// relist the whole tree for free, and the refusal this test asserts would
+// never come.
 func TestGrepWalkIsChargedToTheBudget(t *testing.T) {
 	const dirCount = 30
 	const budget = 40
@@ -370,18 +518,25 @@ func TestGrepWalkIsChargedToTheBudget(t *testing.T) {
 // TestGrepWalkDoesNotChargeSkippedDirectories proves grepNative's own walk
 // charges the listing budget only for directories it actually descends into.
 // The d.IsDir() block in grepNative's callback charges budget.listing(true)
-// before the dot-directory and gitignore filepath.SkipDir checks further down
-// the same callback run, so a directory the walk immediately skips still
-// costs budget. The tree here mixes both kinds of exclusion the callback
-// applies — dot-prefixed directories and directories a root .gitignore
-// matches — and its excluded directories alone outnumber the lowered listing
-// budget, while only a handful of directories are ever actually listed.
-// loadIgnoreSet runs first over the same tree on the same budget, and it
-// skips only the dot-prefixed directories, not the gitignored ones, so its
-// own pass already charges for every gitignored directory before grepNative's
-// walk begins; the budget below is sized comfortably above that cost alone,
-// so only the walk's redundant charge for the directories it was about to
-// skip anyway can push the call over it.
+// only after the dot-directory and gitignore filepath.SkipDir checks earlier
+// in the same callback run, so a directory the walk immediately skips costs
+// nothing. The tree here mixes both kinds of exclusion the callback applies —
+// dot-prefixed directories and directories a root .gitignore matches — and
+// its excluded directories alone outnumber the lowered listing budget, while
+// only a handful of directories are ever actually listed. loadIgnoreSet runs
+// first over the same tree on the same budget, and it skips only the
+// dot-prefixed directories, not the gitignored ones, so its own pass already
+// charges the base plus every real and gitignored directory (1 + 3 + 10 = 14
+// listings) before grepNative's walk begins. grepWalk's own pass then adds 4
+// more — the base plus the 3 real directories it actually descends into —
+// for a total of 18, comfortably under the budget of 25 and comfortably
+// above ignore discovery's 14-listing cost alone, so headroom cannot hide a
+// regression here. Moving the charge above the skip checks would instead
+// start charging the 20 dot and 10 gitignored directories the walk was about
+// to skip anyway, which on their own are more than enough to cross the
+// budget of 25 partway through (the walk gives up as soon as the running
+// total does, well short of a legitimate 18): that is the only way this test
+// can fail.
 func TestGrepWalkDoesNotChargeSkippedDirectories(t *testing.T) {
 	root := t.TempDir()
 
@@ -645,13 +800,18 @@ func TestGlobBudgetErrorRecordsWhetherTheWalkCouldDetectCycles(t *testing.T) {
 // TestSandboxedGlobTruncatesToAStablePrefix proves the sandboxed walk's match
 // cap truncates to a deterministic prefix rather than to whichever entries
 // the filesystem's raw directory order happened to hand back first.
-// secureDirFS.ReadDir returns df.ReadDir(-1) unsorted, unlike os.DirFS (which
-// sorts), so which files survive a cap tripping mid-listing is otherwise the
-// filesystem's business, not the glob's. Every file is written in
-// reverse-lexical order and given an identical mtime, so neither creation
-// order nor modification time can accidentally line up with the alphabetical
-// order the fix is supposed to guarantee, and two back-to-back runs over the
-// unchanged tree must agree with each other and with that order.
+// secureDirFS.ReadDir lists through readDirChunked, which sorts the entries
+// lexically once the whole chunked read finishes, so which files survive a
+// cap tripping mid-listing is the glob's business, not an accident of the
+// fd-backed listing's own order (which has no ordering guarantee of its own
+// to begin with). Every file is written in reverse-lexical order and given an
+// identical mtime, so neither creation order nor modification time can
+// accidentally line up with the alphabetical order the sort guarantees, and
+// two back-to-back runs over the unchanged tree must agree with each other
+// and with that order. An unsorted ReadDir would let the raw fd order decide
+// which files survive truncation instead, breaking the fixture's guarantee
+// that both runs and the lexically-first "want" prefix agree with each
+// other: that is the only way this test can fail.
 func TestSandboxedGlobTruncatesToAStablePrefix(t *testing.T) {
 	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
 
@@ -790,5 +950,35 @@ func TestGrepWalkStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 	}
 	if budgetErr.op != "grep" {
 		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}
+
+// TestGlobBudgetErrorAdviceDependsOnTheOperationAndTheBound pins that advice
+// and entryAdvice each name the lever that can actually fix the refusal they
+// describe, not one that only sounds plausible. A model acts on this advice
+// directly: a grep's pattern is a regex applied to file contents after the
+// walk has already listed everything, so narrowing it cannot reduce how much
+// the walk lists, while a glob's pattern controls what gets listed in the
+// first place, and one oversized directory is a different lever again from a
+// whole call's listing count. Advice that names the wrong lever sends a model
+// off to change something that cannot help, so this asserts the three
+// distinctions structurally instead of embedding either method's wording:
+// collapsing any one of them to a single return value still passes every
+// other test in this package.
+func TestGlobBudgetErrorAdviceDependsOnTheOperationAndTheBound(t *testing.T) {
+	grepListings := &globBudgetError{op: "grep", kind: budgetListings}
+	globListings := &globBudgetError{op: "glob", kind: budgetListings}
+	if grepAdvice, globAdvice := grepListings.advice(), globListings.advice(); grepAdvice == globAdvice {
+		t.Fatalf("advice() collapsed the grep/glob distinction for a listings refusal: grep = %q, glob = %q; narrowing a grep's pattern cannot reduce how much it lists, so the two operations need different advice", grepAdvice, globAdvice)
+	}
+
+	grepEntries := &globBudgetError{op: "grep", kind: budgetEntries}
+	globEntries := &globBudgetError{op: "glob", kind: budgetEntries}
+	if grepEntryAdvice, globEntryAdvice := grepEntries.entryAdvice(), globEntries.entryAdvice(); grepEntryAdvice == globEntryAdvice {
+		t.Fatalf("entryAdvice() collapsed the grep/glob distinction for an entries refusal: grep = %q, glob = %q; a grep cannot spell a pattern that lists less of one directory, so the two operations need different advice", grepEntryAdvice, globEntryAdvice)
+	}
+
+	if entryAdvice, callAdvice := globEntries.entryAdvice(), globListings.advice(); entryAdvice == callAdvice {
+		t.Fatalf("entryAdvice() collapsed into advice() for the same operation: entryAdvice = %q, advice = %q; one oversized directory and a whole call's listing count are not the same lever, so they need different advice", entryAdvice, callAdvice)
 	}
 }

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -65,10 +65,18 @@ func stubGlobDirChunk(t *testing.T, n int) {
 // that asks for everything at once (n <= 0 — what an unbounded listing does)
 // still gets the whole directory back in a single call, which is what makes
 // this double also show that today's listing pulls everything at once.
+//
+// When cancel is set, a file also cancels on its cancelOn'th ReadDir(n) call —
+// the same shape countingFS uses for a whole directory listing, scoped down to
+// the chunk calls inside one — so a test can watch how much of a listing a
+// chunk loop keeps pulling after the context that should have stopped it is
+// cancelled.
 type pacedDirEntriesFS struct {
 	fs.FS
-	read *int
-	pace int
+	read     *int
+	pace     int
+	cancelOn int
+	cancel   context.CancelFunc
 }
 
 func (p pacedDirEntriesFS) Open(name string) (fs.File, error) {
@@ -80,13 +88,16 @@ func (p pacedDirEntriesFS) Open(name string) (fs.File, error) {
 	if !ok {
 		return f, nil
 	}
-	return &pacedDirEntriesFile{ReadDirFile: rdf, read: p.read, pace: p.pace}, nil
+	return &pacedDirEntriesFile{ReadDirFile: rdf, read: p.read, pace: p.pace, cancelOn: p.cancelOn, cancel: p.cancel}, nil
 }
 
 type pacedDirEntriesFile struct {
 	fs.ReadDirFile
-	read *int
-	pace int
+	read     *int
+	pace     int
+	cancelOn int
+	cancel   context.CancelFunc
+	calls    int
 }
 
 func (p *pacedDirEntriesFile) ReadDir(n int) ([]fs.DirEntry, error) {
@@ -95,6 +106,10 @@ func (p *pacedDirEntriesFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	}
 	entries, err := p.ReadDirFile.ReadDir(n)
 	*p.read += len(entries)
+	p.calls++
+	if p.cancel != nil && p.calls == p.cancelOn {
+		p.cancel()
+	}
 	return entries, err
 }
 
@@ -144,8 +159,8 @@ func TestGlobStopsAtTheDirectoryListingBudgetWithFileIdentity(t *testing.T) {
 	stubMaxGlobDirListings(t, budget)
 
 	var counter *countingFS
-	stubGlobBaseFS(t, func(dir string, budget *globBudget) fs.FS {
-		counter = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget}}
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *globBudget) fs.FS {
+		counter = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}}
 		return counter
 	})
 
@@ -178,8 +193,8 @@ func TestGlobTruncatesAtTheMatchCap(t *testing.T) {
 	root := globBudgetFixture(t, fileCount)
 
 	var full *countingFS
-	stubGlobBaseFS(t, func(dir string, budget *globBudget) fs.FS {
-		full = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget}}
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *globBudget) fs.FS {
+		full = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}}
 		return full
 	})
 	fullMatches, _, fullTruncatedAt, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.txt", root, true)
@@ -193,8 +208,8 @@ func TestGlobTruncatesAtTheMatchCap(t *testing.T) {
 	stubMaxGlobMatches(t, 5)
 
 	var capped *countingFS
-	stubGlobBaseFS(t, func(dir string, budget *globBudget) fs.FS {
-		capped = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget}}
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *globBudget) fs.FS {
+		capped = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}}
 		return capped
 	})
 	matches, _, truncatedAt, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.txt", root, true)
@@ -259,9 +274,9 @@ func TestGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 
 	var read int
 	var seenBudget *globBudget
-	stubGlobBaseFS(t, func(dir string, callBudget *globBudget) fs.FS {
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, callBudget *globBudget) fs.FS {
 		seenBudget = callBudget
-		return boundedDirFS{FS: pacedDirEntriesFS{FS: os.DirFS(dir), read: &read, pace: 5}, budget: callBudget}
+		return boundedDirFS{FS: pacedDirEntriesFS{FS: os.DirFS(dir), read: &read, pace: 5}, budget: callBudget, ctx: ctx}
 	})
 
 	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "*.txt", root, true)
@@ -283,6 +298,43 @@ func TestGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 	}
 	if seenBudget.peakDirEntries < budget || seenBudget.peakDirEntries >= fileCount {
 		t.Fatalf("globBudget.peakDirEntries = %d, want at least the entry budget of %d but strictly less than the directory's %d entries (a listing that materializes everything before refusing must not pass this)", seenBudget.peakDirEntries, budget, fileCount)
+	}
+}
+
+// TestGlobStopsReadingAChunkedListingOnCancellation proves the other half of
+// reading a directory in chunks: readDirChunked's loop never looks at ctx
+// between one chunk and the next, so a cancellation landing mid-listing is
+// not noticed until the whole directory has been pulled through — up to
+// maxGlobDirEntries/globDirChunk pointless chunks of work after the caller
+// asked to stop. cancelFS only checks ctx once, when a listing starts, and
+// the walk callback that finally sees ctx.Err() only runs after ReadDir
+// returns — so the call comes back reporting context.Canceled either way,
+// and a test that checked only that would pass today without pinning
+// anything. What has to be pinned is the chunk loop itself stopping
+// promptly, which is why this also counts how many entries actually came out
+// of the directory file, the same way pacedDirEntriesFS's read counter does
+// for TestGlobStopsOnADirectoryWithTooManyEntries above.
+func TestGlobStopsReadingAChunkedListingOnCancellation(t *testing.T) {
+	const fileCount = 40
+	const chunkSize = 5
+	root := flatEntriesFixture(t, fileCount)
+	stubGlobDirChunk(t, chunkSize)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var read int
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *globBudget) fs.FS {
+		fsys := pacedDirEntriesFS{FS: os.DirFS(dir), read: &read, pace: chunkSize, cancelOn: 2, cancel: cancel}
+		return boundedDirFS{FS: fsys, budget: budget, ctx: ctx}
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(ctx, "*.txt", root, true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Glob over a listing cancelled mid-chunk = (%v, %v), want context.Canceled", matches, err)
+	}
+	if want := chunkSize * 3; read > want {
+		t.Fatalf("listing kept reading after cancellation: read %d of %d entries in the directory, want at most %d (about one chunk past the one that observed the cancellation)", read, fileCount, want)
 	}
 }
 
@@ -449,8 +501,8 @@ func TestGlobIgnoreDiscoveryIsChargedToTheBudget(t *testing.T) {
 	stubMaxGlobDirListings(t, budget)
 
 	var counter *countingFS
-	stubGlobBaseFS(t, func(dir string, budget *globBudget) fs.FS {
-		counter = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget}}
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *globBudget) fs.FS {
+		counter = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}}
 		return counter
 	})
 
@@ -715,10 +767,12 @@ func TestGlobIgnoreDiscoveryStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 // ever starts, so the refusal always comes from ignore discovery's callback
 // swallowing-guard. It cannot also pin the equivalent guard in grepNative's
 // own walk callback: that guard only matters if a directory grows past the
-// entries bound between ignore discovery's pass and the walk's own, which a
-// deterministic test cannot construct — ignore discovery's skip set is
-// always a subset of the walk's, so ignore discovery always reaches (and
-// refuses) any oversized directory first.
+// entries bound between ignore discovery's pass and the walk's own, and no
+// static tree can produce that — ignore discovery's skip set is always a
+// subset of the walk's, so ignore discovery always reaches (and refuses) any
+// oversized directory first. Only concurrent growth reaches it, which
+// TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+// forces by growing the directory inside a stubbed walk.
 func TestGrepWalkStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 	const fileCount = 30
 	const budget = 10

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -1,12 +1,18 @@
 package execenv
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
+	"testing/fstest"
+	"time"
+
+	"primeradiant.com/evener/agent/sandbox"
 )
 
 // stubMaxGlobDirListings lowers the directory-listing budget for a test and
@@ -168,15 +174,21 @@ func TestGlobBudgetIsSharedAcrossBraceExpandedPatterns(t *testing.T) {
 	}
 }
 
-// TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked covers the third
-// defect behind #497: w.listed is a map keyed by every directory the walk has
-// ever listed, and nothing ever removes an entry once admit adds it. The
-// ancestor cycle check in admit only ever consults ancestors of the directory
-// currently being admitted, so a wide, shallow tree (siblings, not nesting)
-// should cost the walk O(1) retained identities, not one per directory
-// visited. This builds a wide real tree, so hasFileIdentity is true throughout,
-// and pins the failure via retained() rather than via a memory measurement
-// that would be flaky to assert on directly.
+// retained reports how many directory identities this walk is holding, which
+// is the walk's own memory cost: the cycle check consults only the ancestors
+// of the directory it is admitting, so this must track the depth of the path
+// being walked, not the number of directories the walk has ever listed.
+func (w *globWalkFS) retained() int { return len(w.chain) }
+
+// TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked pins the walk's own
+// memory cost, the third defect behind #497. The ancestor cycle check in
+// admit consults only the ancestors of the directory it is admitting, so what
+// the walk holds has to scale with the depth of the path it is on and not
+// with how many directories it has listed in total. A wide, shallow tree
+// (siblings, not nesting) separates the two: 30 siblings are 30 listings at
+// depth one. It builds a real tree so hasFileIdentity is true throughout, and
+// reads retained() rather than measuring memory, which would be flaky to
+// assert on directly.
 func TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked(t *testing.T) {
 	const siblingCount = 30
 	root := globBudgetFixture(t, siblingCount)
@@ -207,5 +219,180 @@ func TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked(t *testing.T) {
 	_, err := w.ReadDir("loop")
 	if !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("ReadDir(loop) through a symlink back at the tree root = %v, want an fs.ErrNotExist PathError (the walk refusing an already-listed ancestor)", err)
+	}
+}
+
+// TestGlobIgnoreDiscoveryIsChargedToTheBudget proves loadIgnoreSet's own
+// fs.WalkDir has no bound of its own: it runs to completion before the first
+// globMatches call even exists, so a glob whose pattern walk touches almost
+// nothing can still spend unbounded work collecting .gitignore rules across a
+// huge tree. The pattern here names a file that does not exist anywhere in
+// the tree and has no glob metacharacters, so doublestar's no-meta-character
+// fast path resolves it with a single Stat and never lists a directory — any
+// charge against the budget has to come from ignore discovery, not from the
+// pattern walk. include_ignored skips ignore discovery entirely, so the
+// identical call must not trip the same budget: that is the control that
+// proves the failure is ignore discovery's, not some other unbounded walk.
+func TestGlobIgnoreDiscoveryIsChargedToTheBudget(t *testing.T) {
+	const dirCount = 40
+	root := globBudgetFixture(t, dirCount)
+	stubMaxGlobDirListings(t, 8)
+
+	matches, _, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "does-not-exist.txt", root, false)
+	if err == nil {
+		t.Fatalf("GlobWithExclusions(include_ignored=false) over a %d-directory tree with a listing budget of 8 returned no error and %d matches; ignore discovery is not charged to the budget", dirCount, len(matches))
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the glob visibly instead", err)
+	}
+
+	if _, _, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "does-not-exist.txt", root, true); err != nil {
+		t.Fatalf("GlobWithExclusions(include_ignored=true) = %v, want nil (ignore discovery is skipped entirely, so it cannot trip the budget)", err)
+	}
+}
+
+// TestGlobWalkRefusesACycleThroughAnUnlistedAncestor pins the ancestor check
+// for the exact shape doublestar creates when a pattern's meta-free prefix
+// names a path directly: the very first listing the walk ever makes can be
+// several levels below the root, so neither the root (".") nor the path's own
+// parent has ever been pushed onto the chain. identity's fallback (a fresh
+// fs.Stat on a chain miss) has to find the cycle anyway, by walking up to an
+// ancestor it has never listed and stat'ing it fresh.
+//
+// This is a characterization pin, not a red test: it already passes on the
+// current tree. It would fail if identity's chain-miss fallback were replaced
+// by an always-false lookup, since then nothing would catch the cycle before
+// the walk ever lists "." or "a".
+func TestGlobWalkRefusesACycleThroughAnUnlistedAncestor(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, filepath.Join(root, "a", "loop")); err != nil {
+		t.Skipf("directory symlinks unavailable on this platform: %v", err)
+	}
+
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: &globBudget{}}
+	_, err := w.ReadDir("a/loop")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("ReadDir(a/loop) as the walk's first-ever listing = %v, want an fs.ErrNotExist PathError (the ancestor cycle back to root, caught via a fresh stat rather than the chain)", err)
+	}
+	if _, ok := errors.AsType[*fs.PathError](err); !ok {
+		t.Fatalf("ReadDir(a/loop) = %v (%T), want an *fs.PathError", err, err)
+	}
+}
+
+// TestGlobBudgetErrorRecordsWhetherTheWalkCouldDetectCycles asserts the
+// budget refusal structurally rather than by matching its prose: a caller
+// (or a test) has to be able to tell "this filesystem could never have
+// detected a symlink cycle" from "this really is an enormous tree" without
+// parsing a sentence. cycleSafe carries that distinction — false for an
+// identity-less fstest.MapFS, which can never rule out a cycle, true for an
+// os.DirFS tree, which can — and budget records the bound that was crossed.
+func TestGlobBudgetErrorRecordsWhetherTheWalkCouldDetectCycles(t *testing.T) {
+	stubMaxGlobDirListings(t, 1)
+
+	mapTree := fstest.MapFS{"dir00/leaf.txt": &fstest.MapFile{Data: []byte("x")}}
+	mw := &globWalkFS{FS: mapTree, ctx: t.Context(), budget: &globBudget{}}
+	if _, err := mw.ReadDir("."); err != nil {
+		t.Fatalf("listing the MapFS root: %v", err)
+	}
+	_, err := mw.ReadDir("dir00")
+	var mapErr *globBudgetError
+	if !errors.As(err, &mapErr) {
+		t.Fatalf("tripping the budget over an identity-less MapFS = %v (%T), want a *globBudgetError", err, err)
+	}
+	if mapErr.cycleSafe {
+		t.Fatalf("globBudgetError.cycleSafe = true for an identity-less filesystem that can never detect a cycle, want false")
+	}
+	if mapErr.budget != maxGlobDirListings {
+		t.Fatalf("globBudgetError.budget = %d, want %d (the active budget)", mapErr.budget, maxGlobDirListings)
+	}
+
+	root := globBudgetFixture(t, 1)
+	ow := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: &globBudget{}}
+	if _, err := ow.ReadDir("."); err != nil {
+		t.Fatalf("listing the os.DirFS root: %v", err)
+	}
+	_, err = ow.ReadDir("dir00")
+	var osErr *globBudgetError
+	if !errors.As(err, &osErr) {
+		t.Fatalf("tripping the budget over an os.DirFS tree = %v (%T), want a *globBudgetError", err, err)
+	}
+	if !osErr.cycleSafe {
+		t.Fatalf("globBudgetError.cycleSafe = false for an os-backed filesystem that can detect a cycle, want true")
+	}
+	if osErr.budget != maxGlobDirListings {
+		t.Fatalf("globBudgetError.budget = %d, want %d (the active budget)", osErr.budget, maxGlobDirListings)
+	}
+}
+
+// TestSandboxedGlobTruncatesToAStablePrefix proves the sandboxed walk's match
+// cap truncates to a deterministic prefix rather than to whichever entries
+// the filesystem's raw directory order happened to hand back first.
+// secureDirFS.ReadDir returns df.ReadDir(-1) unsorted, unlike os.DirFS (which
+// sorts), so which files survive a cap tripping mid-listing is otherwise the
+// filesystem's business, not the glob's. Every file is written in
+// reverse-lexical order and given an identical mtime, so neither creation
+// order nor modification time can accidentally line up with the alphabetical
+// order the fix is supposed to guarantee, and two back-to-back runs over the
+// unchanged tree must agree with each other and with that order.
+func TestSandboxedGlobTruncatesToAStablePrefix(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const fileCount = 12
+	fixedMod := time.Now()
+	for i := fileCount - 1; i >= 0; i-- {
+		p := filepath.Join(worktree, fmt.Sprintf("file%02d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(p, fixedMod, fixedMod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stubMaxGlobMatches(t, 4)
+
+	want := []string{
+		filepath.Join(worktree, "file00.txt"),
+		filepath.Join(worktree, "file01.txt"),
+		filepath.Join(worktree, "file02.txt"),
+		filepath.Join(worktree, "file03.txt"),
+	}
+
+	first, _, truncatedAt, err := env.GlobWithExclusions(t.Context(), "*.txt", worktree, true)
+	if err != nil {
+		t.Fatalf("first sandboxed glob: %v", err)
+	}
+	if truncatedAt != 4 {
+		t.Fatalf("first run truncatedAt = %d, want 4", truncatedAt)
+	}
+	second, _, _, err := env.GlobWithExclusions(t.Context(), "*.txt", worktree, true)
+	if err != nil {
+		t.Fatalf("second sandboxed glob: %v", err)
+	}
+
+	if !slices.Equal(first, second) {
+		t.Fatalf("two sandboxed globs over the same unchanged tree returned different truncated prefixes: %v vs %v", first, second)
+	}
+	if !slices.Equal(first, want) {
+		t.Fatalf("sandboxed glob truncated to %v, want the lexically first 4: %v", first, want)
+	}
+}
+
+// TestGlobMatchesReportsCancellationAfterTheCapTripped proves globMatches's
+// cap fast path does not shadow a cancellation that landed at the same
+// moment: budget.full() returning early must still check ctx first, or a
+// call cancelled right after the cap tripped comes back reporting truncated
+// success instead of the cancellation the caller actually asked for.
+func TestGlobMatchesReportsCancellationAfterTheCapTripped(t *testing.T) {
+	budget := &globBudget{truncated: true}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	matches, err := globMatches(ctx, fstest.MapFS{}, "*.txt", budget)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("globMatches with a tripped cap and a cancelled context = (%v, %v), want context.Canceled", matches, err)
 	}
 }

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -34,6 +34,69 @@ func stubMaxGlobMatches(t *testing.T, n int) {
 	t.Cleanup(func() { maxGlobMatches = orig })
 }
 
+// stubMaxGlobDirEntries lowers the per-directory entry budget for a test and
+// restores it when the test ends, so a budget test can use a directory small
+// enough for t.TempDir() rather than one large enough to trip the real bound.
+func stubMaxGlobDirEntries(t *testing.T, n int) {
+	t.Helper()
+	orig := maxGlobDirEntries
+	maxGlobDirEntries = n
+	t.Cleanup(func() { maxGlobDirEntries = orig })
+}
+
+// stubGlobDirChunk shrinks the per-syscall chunk size for a test and restores
+// it when the test ends, so a bounded listing has to make several chunk reads
+// over a fixture small enough for t.TempDir() instead of a directory too
+// large to build here.
+func stubGlobDirChunk(t *testing.T, n int) {
+	t.Helper()
+	orig := globDirChunk
+	globDirChunk = n
+	t.Cleanup(func() { globDirChunk = orig })
+}
+
+// pacedDirEntriesFS wraps a directory so a test can observe how many entries
+// a chunked reader actually pulls from it. Its files hand back at most pace
+// entries per ReadDir(n) call once the caller asks for more than that,
+// mirroring the short reads a real filesystem can hand a chunked reader, so a
+// small fixture can still force several round trips instead of resolving in
+// the one big read a directory too large to build here would need. A caller
+// that asks for everything at once (n <= 0 — what an unbounded listing does)
+// still gets the whole directory back in a single call, which is what makes
+// this double also show that today's listing pulls everything at once.
+type pacedDirEntriesFS struct {
+	fs.FS
+	read *int
+	pace int
+}
+
+func (p pacedDirEntriesFS) Open(name string) (fs.File, error) {
+	f, err := p.FS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	rdf, ok := f.(fs.ReadDirFile)
+	if !ok {
+		return f, nil
+	}
+	return &pacedDirEntriesFile{ReadDirFile: rdf, read: p.read, pace: p.pace}, nil
+}
+
+type pacedDirEntriesFile struct {
+	fs.ReadDirFile
+	read *int
+	pace int
+}
+
+func (p *pacedDirEntriesFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if n > 0 && n > p.pace {
+		n = p.pace
+	}
+	entries, err := p.ReadDirFile.ReadDir(n)
+	*p.read += len(entries)
+	return entries, err
+}
+
 // globBudgetFixture builds a t.TempDir() tree of n sibling directories, each
 // holding one leaf.txt and one leaf.md, so tests can glob for one extension,
 // both extensions, or count total directories without rebuilding the tree.
@@ -80,8 +143,8 @@ func TestGlobStopsAtTheDirectoryListingBudgetWithFileIdentity(t *testing.T) {
 	stubMaxGlobDirListings(t, budget)
 
 	var counter *countingFS
-	stubGlobBaseFS(t, func(dir string) fs.FS {
-		counter = &countingFS{FS: os.DirFS(dir)}
+	stubGlobBaseFS(t, func(dir string, budget *globBudget) fs.FS {
+		counter = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget}}
 		return counter
 	})
 
@@ -114,8 +177,8 @@ func TestGlobTruncatesAtTheMatchCap(t *testing.T) {
 	root := globBudgetFixture(t, fileCount)
 
 	var full *countingFS
-	stubGlobBaseFS(t, func(dir string) fs.FS {
-		full = &countingFS{FS: os.DirFS(dir)}
+	stubGlobBaseFS(t, func(dir string, budget *globBudget) fs.FS {
+		full = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget}}
 		return full
 	})
 	fullMatches, _, fullTruncatedAt, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.txt", root, true)
@@ -129,8 +192,8 @@ func TestGlobTruncatesAtTheMatchCap(t *testing.T) {
 	stubMaxGlobMatches(t, 5)
 
 	var capped *countingFS
-	stubGlobBaseFS(t, func(dir string) fs.FS {
-		capped = &countingFS{FS: os.DirFS(dir)}
+	stubGlobBaseFS(t, func(dir string, budget *globBudget) fs.FS {
+		capped = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget}}
 		return capped
 	})
 	matches, _, truncatedAt, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.txt", root, true)
@@ -170,6 +233,90 @@ func TestGlobBudgetIsSharedAcrossBraceExpandedPatterns(t *testing.T) {
 	}
 	if truncatedAt != 5 {
 		t.Fatalf("brace-expanded glob reported truncatedAt=%d, want 5 (the call-wide cap)", truncatedAt)
+	}
+}
+
+// TestGlobStopsOnADirectoryWithTooManyEntries is the unit-scale reproduction
+// of #497's other half (roborev High): the listing budget and match cap only
+// ever get a say once a directory's ReadDir call returns, and os.DirFS's
+// ReadDir is os.ReadDir, which reads every entry before handing any of them
+// back — so one directory with millions of entries can exhaust memory before
+// either bound is ever consulted. pacedDirEntriesFS paces what a chunked
+// reader gets per call, the same short-read shape a real filesystem can hand
+// back, so a small fixture can still show a listing stopping after a few
+// chunks instead of needing a directory too large to build here. The read
+// counter and peakDirEntries are what tell a fix that stops early apart from
+// one that reads the whole directory and only then reports the refusal — a
+// result-only assertion cannot tell the two apart, but the OOM only the
+// former avoids.
+func TestGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
+	const fileCount = 30
+	root := t.TempDir()
+	for i := range fileCount {
+		p := filepath.Join(root, fmt.Sprintf("leaf%03d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const budget = 10
+	stubMaxGlobDirEntries(t, budget)
+
+	var read int
+	var seenBudget *globBudget
+	stubGlobBaseFS(t, func(dir string, callBudget *globBudget) fs.FS {
+		seenBudget = callBudget
+		return boundedDirFS{FS: pacedDirEntriesFS{FS: os.DirFS(dir), read: &read, pace: 5}, budget: callBudget}
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "*.txt", root, true)
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Glob over a %d-entry directory with an entry budget of %d = (%v, %v), want a *globBudgetError; nothing bounds how many entries one listing may materialize", fileCount, budget, matches, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "glob" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "glob")
+	}
+	if read > fileCount {
+		t.Fatalf("paced double reported %d entries read out of %d total in the directory, which is impossible", read, fileCount)
+	}
+	if read == fileCount {
+		t.Fatalf("listing read all %d entries before refusing; it must stop near the entry budget of %d instead of materializing the whole directory", read, budget)
+	}
+	if seenBudget.peakDirEntries < budget || seenBudget.peakDirEntries >= fileCount {
+		t.Fatalf("globBudget.peakDirEntries = %d, want at least the entry budget of %d but strictly less than the directory's %d entries (a listing that materializes everything before refusing must not pass this)", seenBudget.peakDirEntries, budget, fileCount)
+	}
+}
+
+// TestGrepWalkIsChargedToTheBudget proves grepNative's own directory walk has
+// no bound of its own, distinct from the ignore-discovery bound
+// TestGrepIgnoreDiscoveryIsChargedToTheBudget already covers: grepWalk is a
+// plain fs.WalkDir with nothing charging its listings to a budget, so a huge
+// tree grepNative walks after ignore discovery completes still costs
+// unbounded work. The tree here has no .gitignore and is small enough that
+// ignore discovery alone stays well under the lowered listing budget, so a
+// refusal can only be attributed to the walk grepNative runs over the tree it
+// is grepping, not to the ignore-discovery pass that already has its own
+// test above.
+func TestGrepWalkIsChargedToTheBudget(t *testing.T) {
+	const dirCount = 30
+	const budget = 40
+	root := globBudgetFixture(t, dirCount)
+	stubMaxGlobDirListings(t, budget)
+
+	_, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("grepNative's own walk over a %d-directory tree with a listing budget of %d = (_, %v), want a *globBudgetError; grepWalk charges nothing to the budget", dirCount, budget, err)
+	}
+	if budgetErr.kind != budgetListings {
+		t.Fatalf("globBudgetError.kind = %v, want budgetListings", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
 	}
 }
 
@@ -244,8 +391,8 @@ func TestGlobIgnoreDiscoveryIsChargedToTheBudget(t *testing.T) {
 	stubMaxGlobDirListings(t, budget)
 
 	var counter *countingFS
-	stubGlobBaseFS(t, func(dir string) fs.FS {
-		counter = &countingFS{FS: os.DirFS(dir)}
+	stubGlobBaseFS(t, func(dir string, budget *globBudget) fs.FS {
+		counter = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget}}
 		return counter
 	})
 
@@ -453,5 +600,77 @@ func TestGlobMatchesReportsCancellationAfterTheCapTripped(t *testing.T) {
 	matches, err := globMatches(ctx, fstest.MapFS{}, "*.txt", budget)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("globMatches with a tripped cap and a cancelled context = (%v, %v), want context.Canceled", matches, err)
+	}
+}
+
+// flatEntriesFixture builds a t.TempDir() holding n files and no
+// subdirectories, so a test can force one directory listing to read past the
+// per-directory entry budget without building a tree.
+func flatEntriesFixture(t *testing.T, n int) string {
+	t.Helper()
+	root := t.TempDir()
+	for i := range n {
+		p := filepath.Join(root, fmt.Sprintf("leaf%03d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// TestGlobIgnoreDiscoveryStopsOnADirectoryWithTooManyEntries covers the arm
+// the pattern-walk entry test cannot reach: loadIgnoreSet walks the base with
+// fs.WalkDir, whose callback treats every error it is handed as an unreadable
+// entry to skip. A per-directory entry refusal handed to that callback is not
+// an unreadable entry — it is the bound doing its job — so swallowing it both
+// lets the oversized directory be read again by whatever walks next and
+// leaves ignore discovery reporting a set it never finished collecting, which
+// silently under-excludes the rest of the tree.
+//
+// The pattern is metacharacter-free and matches nothing, so doublestar
+// resolves it with a stat and lists no directory at all: the only walk that
+// can reach the entry bound here is ignore discovery's.
+func TestGlobIgnoreDiscoveryStopsOnADirectoryWithTooManyEntries(t *testing.T) {
+	const fileCount = 30
+	const budget = 10
+	root := flatEntriesFixture(t, fileCount)
+	stubMaxGlobDirEntries(t, budget)
+	stubGlobDirChunk(t, 5)
+
+	matches, _, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "does-not-exist.txt", root, false)
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("GlobWithExclusions(include_ignored=false) over a %d-entry directory with an entry budget of %d = (%v, %v), want a *globBudgetError; ignore discovery's walk is swallowing the refusal as if it were an unreadable entry", fileCount, budget, matches, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "glob" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "glob")
+	}
+}
+
+// TestGrepWalkStopsOnADirectoryWithTooManyEntries is the same contract for
+// grep's two best-effort walks. Both loadIgnoreSet's callback and grepNative's
+// own walk callback skip past any error they are handed, so an oversized
+// directory would be read in full by each of them in turn and the call would
+// come back reporting no matches and no error at all.
+func TestGrepWalkStopsOnADirectoryWithTooManyEntries(t *testing.T) {
+	const fileCount = 30
+	const budget = 10
+	root := flatEntriesFixture(t, fileCount)
+	stubMaxGlobDirEntries(t, budget)
+	stubGlobDirChunk(t, 5)
+
+	out, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("grepNative over a %d-entry directory with an entry budget of %d = (%q, %v), want a *globBudgetError; grep's walks are swallowing the refusal as if it were an unreadable entry", fileCount, budget, out, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
 	}
 }

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -17,8 +17,7 @@ import (
 
 // stubMaxGlobDirListings lowers the directory-listing budget for a test and
 // restores it when the test ends, so a budget test can use a tree small
-// enough for t.TempDir() rather than one large enough to trip the real
-// (100,000) bound.
+// enough for t.TempDir() rather than one large enough to trip the real bound.
 func stubMaxGlobDirListings(t *testing.T, n int) {
 	t.Helper()
 	orig := maxGlobDirListings
@@ -193,7 +192,7 @@ func TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked(t *testing.T) {
 	const siblingCount = 30
 	root := globBudgetFixture(t, siblingCount)
 
-	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: &globBudget{}}
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: newGlobBudget("glob")}
 	if _, err := w.ReadDir("."); err != nil {
 		t.Fatalf("listing the root: %v", err)
 	}
@@ -233,21 +232,80 @@ func TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked(t *testing.T) {
 // pattern walk. include_ignored skips ignore discovery entirely, so the
 // identical call must not trip the same budget: that is the control that
 // proves the failure is ignore discovery's, not some other unbounded walk.
+// The error must name "glob" as the operation that spent the budget — the
+// counterpart grep test proves the same budget names "grep" instead, which is
+// how a caller told the two apart at all — and the countingFS proves the walk
+// actually stopped at the budget rather than finishing and reporting a
+// failure afterward.
 func TestGlobIgnoreDiscoveryIsChargedToTheBudget(t *testing.T) {
 	const dirCount = 40
+	const budget = 8
 	root := globBudgetFixture(t, dirCount)
-	stubMaxGlobDirListings(t, 8)
+	stubMaxGlobDirListings(t, budget)
+
+	var counter *countingFS
+	stubGlobBaseFS(t, func(dir string) fs.FS {
+		counter = &countingFS{FS: os.DirFS(dir)}
+		return counter
+	})
 
 	matches, _, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "does-not-exist.txt", root, false)
 	if err == nil {
-		t.Fatalf("GlobWithExclusions(include_ignored=false) over a %d-directory tree with a listing budget of 8 returned no error and %d matches; ignore discovery is not charged to the budget", dirCount, len(matches))
+		t.Fatalf("GlobWithExclusions(include_ignored=false) over a %d-directory tree with a listing budget of %d returned no error and %d matches; ignore discovery is not charged to the budget", dirCount, budget, len(matches))
 	}
 	if errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the glob visibly instead", err)
 	}
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("GlobWithExclusions(include_ignored=false) error = %v (%T), want a *globBudgetError", err, err)
+	}
+	if budgetErr.op != "glob" {
+		t.Fatalf("globBudgetError.op = %q, want %q (this is glob's own call, not grep's)", budgetErr.op, "glob")
+	}
+	if counter.calls > budget+1 {
+		t.Fatalf("ignore discovery made %d directory listings against a budget of %d, want at most %d", counter.calls, budget, budget+1)
+	}
+	if counter.calls >= dirCount+1 {
+		t.Fatalf("ignore discovery listed all %d directories instead of stopping early (%d listings made)", dirCount+1, counter.calls)
+	}
 
 	if _, _, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "does-not-exist.txt", root, true); err != nil {
 		t.Fatalf("GlobWithExclusions(include_ignored=true) = %v, want nil (ignore discovery is skipped entirely, so it cannot trip the budget)", err)
+	}
+}
+
+// TestGrepIgnoreDiscoveryIsChargedToTheBudget proves the same ignore-discovery
+// budget applies on grep's native fallback, not only glob's: grepNative loads
+// its own ignore set with a fresh budget before it ever walks the tree it
+// greps, so an over-budget tree must fail the grep call, not silently glob
+// past its bound. grepNative is called directly, rather than through a tool
+// dispatch, because that is the "return \"\", err" path a native grep takes
+// when loadIgnoreSet refuses — existing tests such as
+// TestGrep_FallbackWithoutRipgrep reach the same native arm the same way,
+// without needing to defeat ripgrep detection. The error must name "grep" as
+// the operation that spent the budget: the budget is shared code with glob's,
+// so nothing about the failure itself distinguishes the two callers unless
+// the operation name does.
+func TestGrepIgnoreDiscoveryIsChargedToTheBudget(t *testing.T) {
+	const dirCount = 40
+	const budget = 8
+	root := globBudgetFixture(t, dirCount)
+	stubMaxGlobDirListings(t, budget)
+
+	_, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	if err == nil {
+		t.Fatalf("grepNative over a %d-directory tree with a listing budget of %d returned no error; ignore discovery is not charged to the budget", dirCount, budget)
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the grep visibly instead", err)
+	}
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("grepNative error = %v (%T), want a *globBudgetError", err, err)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q (grepNative's ignore discovery, not glob's)", budgetErr.op, "grep")
 	}
 }
 
@@ -272,7 +330,7 @@ func TestGlobWalkRefusesACycleThroughAnUnlistedAncestor(t *testing.T) {
 		t.Skipf("directory symlinks unavailable on this platform: %v", err)
 	}
 
-	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: &globBudget{}}
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: newGlobBudget("glob")}
 	_, err := w.ReadDir("a/loop")
 	if !errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("ReadDir(a/loop) as the walk's first-ever listing = %v, want an fs.ErrNotExist PathError (the ancestor cycle back to root, caught via a fresh stat rather than the chain)", err)
@@ -293,7 +351,7 @@ func TestGlobBudgetErrorRecordsWhetherTheWalkCouldDetectCycles(t *testing.T) {
 	stubMaxGlobDirListings(t, 1)
 
 	mapTree := fstest.MapFS{"dir00/leaf.txt": &fstest.MapFile{Data: []byte("x")}}
-	mw := &globWalkFS{FS: mapTree, ctx: t.Context(), budget: &globBudget{}}
+	mw := &globWalkFS{FS: mapTree, ctx: t.Context(), budget: newGlobBudget("glob")}
 	if _, err := mw.ReadDir("."); err != nil {
 		t.Fatalf("listing the MapFS root: %v", err)
 	}
@@ -310,7 +368,7 @@ func TestGlobBudgetErrorRecordsWhetherTheWalkCouldDetectCycles(t *testing.T) {
 	}
 
 	root := globBudgetFixture(t, 1)
-	ow := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: &globBudget{}}
+	ow := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: newGlobBudget("glob")}
 	if _, err := ow.ReadDir("."); err != nil {
 		t.Fatalf("listing the os.DirFS root: %v", err)
 	}
@@ -387,7 +445,8 @@ func TestSandboxedGlobTruncatesToAStablePrefix(t *testing.T) {
 // call cancelled right after the cap tripped comes back reporting truncated
 // success instead of the cancellation the caller actually asked for.
 func TestGlobMatchesReportsCancellationAfterTheCapTripped(t *testing.T) {
-	budget := &globBudget{truncated: true}
+	budget := newGlobBudget("glob")
+	budget.truncated = true
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 

--- a/agent/execenv/glob_budget_toctou_unix_test.go
+++ b/agent/execenv/glob_budget_toctou_unix_test.go
@@ -1,0 +1,190 @@
+//go:build linux || darwin
+
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/agent/sandbox"
+)
+
+// growDirWithFiles adds n more files to dir, named apart from any fixture's
+// own files so growth never collides with them. It exists so the TOCTOU
+// probes below can turn a directory that was under the entry budget when
+// ignore discovery listed it into one that is over budget by the time the
+// grep walk under test lists it a second time — the concurrent-growth shape
+// the per-directory guard exists for, which no fixture built up front can
+// produce (ignore discovery's skip set is always a subset of the walk's, so
+// it always reaches an oversized directory first on a static tree).
+func growDirWithFiles(t *testing.T, dir string, n int) {
+	t.Helper()
+	for i := range n {
+		p := filepath.Join(dir, fmt.Sprintf("grown%04d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+// forces the concurrent-growth case that no static fixture can produce.
+// grepNative runs two independent passes over the same tree under the same
+// budget: loadIgnoreSet's fs.WalkDir first, then grepWalk's own. Ignore
+// discovery's skip set (dot-prefixed directories only) is always a subset of
+// grepWalk's (which also skips gitignored ones), so on any fixture built up
+// front ignore discovery always reaches an oversized directory first and
+// grepWalk's own callback guard never gets a turn — that guard exists only
+// for a directory that grows past maxGlobDirEntries in the gap between the
+// two passes. This stubs grepWalk itself to open that exact gap: the stub
+// grows the walk root only once grepWalk is invoked, which is after
+// loadIgnoreSet has already listed the same root at its original, in-budget
+// size, and only then delegates to the real fs.WalkDir. The now-oversized
+// root's ReadDir raises the entries refusal from inside grepWalk's own
+// listing, so a pass here can only mean grepNative's own callback guard — not
+// ignore discovery's — carried it out instead of swallowing it as an
+// unreadable entry.
+func TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery(t *testing.T) {
+	const fileCount = 3
+	root := flatEntriesFixture(t, fileCount)
+
+	const budget = 8
+	stubMaxGlobDirEntries(t, budget)
+
+	walk := grepWalk
+	grepWalk = func(fsys fs.FS, name string, fn fs.WalkDirFunc) error {
+		growDirWithFiles(t, root, 20)
+		return walk(fsys, name, fn)
+	}
+	t.Cleanup(func() { grepWalk = walk })
+
+	_, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	budgetErr, refused := errors.AsType[*globBudgetError](err)
+	if !refused {
+		t.Fatalf("grepNative over a directory that grows past the entry budget of %d between ignore discovery's pass and grepWalk's own = %v, want a *globBudgetError from grepWalk's own callback guard", budget, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}
+
+// TestSandboxedGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+// is the sandboxed counterpart: sandboxFS.grepNative runs the same two-pass
+// shape as the off-sandbox arm — loadIgnoreSet walks the base once, then
+// secureBrowseWalkDir walks it again under the same budget — so the same
+// concurrent-growth gap exists and is just as unreachable from a static
+// fixture. This stubs secureBrowseWalkDir the way the off-sandbox probe above
+// stubs grepWalk: it grows the sandboxed worktree only once
+// secureBrowseWalkDir is invoked, after loadIgnoreSet has already listed it
+// at its original, in-budget size, then delegates to the real fs.WalkDir.
+// Growing the tree through the os.WriteFile calls below reaches the
+// filesystem directly, the same way the test's own fixture setup does; it is
+// not an operation the sandboxed environment under test performs.
+func TestSandboxedGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const fileCount = 3
+	for i := range fileCount {
+		p := filepath.Join(worktree, fmt.Sprintf("leaf%03d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const budget = 8
+	stubMaxGlobDirEntries(t, budget)
+
+	walk := secureBrowseWalkDir
+	secureBrowseWalkDir = func(fsys fs.FS, name string, fn fs.WalkDirFunc) error {
+		growDirWithFiles(t, worktree, 20)
+		return walk(fsys, name, fn)
+	}
+	t.Cleanup(func() { secureBrowseWalkDir = walk })
+
+	_, err := env.Grep(t.Context(), "needle", worktree, "", false, 100, "")
+	budgetErr, refused := errors.AsType[*globBudgetError](err)
+	if !refused {
+		t.Fatalf("sandboxed Grep over a directory that grows past the entry budget of %d between ignore discovery's pass and the walk's own = %v, want a *globBudgetError from grepNative's own callback guard", budget, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}
+
+// TestSandboxedGrepWalkDoesNotChargeSkippedDirectories is the sandboxed
+// counterpart to TestGrepWalkDoesNotChargeSkippedDirectories: sandboxFS's own
+// walk charges budget.listing(true) once per directory it actually descends
+// into, after the masked/dot/gitignore fs.SkipDir checks earlier in the same
+// callback, not before them. The fixture and budget here are the same
+// arithmetic as the off-sandbox test, because loadIgnoreSet is the identical
+// shared code on both arms: it does not yet know a directory is gitignored
+// while it is still collecting the .gitignore rules that would exclude it, so
+// it charges the base plus every real and gitignored directory (1 + 3 + 10 =
+// 14 listings here) but skips only the dot-prefixed ones for free. The
+// sandboxed walk then adds 4 more of its own — the base plus the 3 real
+// directories it actually descends into — for a total of 18, comfortably
+// under the budget of 25 and comfortably above ignore discovery's 14-listing
+// cost alone, so headroom cannot hide a regression here. Moving the charge
+// above the skip checks would instead start charging the 20 dot and 10
+// gitignored directories the walk was about to skip anyway, which on their
+// own are more than enough to cross the budget of 25 partway through (the
+// walk gives up as soon as the running total does, well short of a
+// legitimate 18): that is the only way this test can fail.
+func TestSandboxedGrepWalkDoesNotChargeSkippedDirectories(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const realCount = 3
+	for i := range realCount {
+		if err := os.MkdirAll(filepath.Join(worktree, fmt.Sprintf("dir%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "dir00", "leaf.txt"), []byte("needle\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const dotCount = 20
+	for i := range dotCount {
+		if err := os.MkdirAll(filepath.Join(worktree, fmt.Sprintf(".excluded%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const gitignoredCount = 10
+	gitignoreLines := make([]string, 0, gitignoredCount)
+	for i := range gitignoredCount {
+		dir := fmt.Sprintf("ignored%02d", i)
+		if err := os.MkdirAll(filepath.Join(worktree, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		gitignoreLines = append(gitignoreLines, dir+"/")
+	}
+	if err := os.WriteFile(filepath.Join(worktree, ".gitignore"), []byte(strings.Join(gitignoreLines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const budget = 25
+	stubMaxGlobDirListings(t, budget)
+
+	out, err := env.Grep(t.Context(), "needle", worktree, "", false, 100, "")
+	if budgetErr, refused := errors.AsType[*globBudgetError](err); refused {
+		t.Fatalf("sandboxed grepNative over a tree with %d dot-excluded and %d gitignored directories against only %d listed directories, with a listing budget of %d well above ignore discovery's own cost, refused: %v; the walk is charging directories it is about to skip toward the budget instead of only the ones it actually descends into", dotCount, gitignoredCount, realCount, budget, budgetErr)
+	}
+	if err != nil {
+		t.Fatalf("sandboxed Grep: %v", err)
+	}
+	if !strings.Contains(out, "needle") {
+		t.Fatalf("sandboxed Grep(%q) = %q, want a match for the needle in dir00/leaf.txt", "needle", out)
+	}
+}

--- a/agent/execenv/glob_budget_unix_test.go
+++ b/agent/execenv/glob_budget_unix_test.go
@@ -63,7 +63,7 @@ func TestSandboxedGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 	defer func() { _ = unix.Close(baseFd) }()
 
 	callBudget := newGlobBudget("glob")
-	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs, budget: callBudget}
+	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs, budget: callBudget, ctx: t.Context()}
 
 	entries, err := fsys.ReadDir(".")
 	var budgetErr *globBudgetError

--- a/agent/execenv/glob_budget_unix_test.go
+++ b/agent/execenv/glob_budget_unix_test.go
@@ -1,0 +1,82 @@
+//go:build linux || darwin
+
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"primeradiant.com/evener/agent/sandbox"
+)
+
+// TestSandboxedGlobStopsOnADirectoryWithTooManyEntries is
+// TestGlobStopsOnADirectoryWithTooManyEntries's sandboxed counterpart:
+// secureDirFS.ReadDir also collects a directory in one df.ReadDir(-1) call
+// before the budget or match cap get a say, so the same OOM shape exists on
+// the sandboxed arm. sandboxFS.glob builds its secureDirFS internally, with no
+// seam over its directory reads the way stubGlobBaseFS gives the plain path,
+// so this constructs a secureDirFS directly instead — the same shape
+// TestLoadIgnoreSetSkipsMaskedSubtree drives loadIgnoreSet through — over a
+// budget the test owns, and reads peakDirEntries off it once the call
+// returns. A bare errors.As/result check would also pass a listing that
+// materializes the whole directory and only then reports the refusal, which
+// is exactly the shape the OOM this bound exists for takes; peakDirEntries
+// is what tells the two apart.
+func TestSandboxedGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
+	env, home, _ := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	// A fresh subdirectory of its own, rather than home itself, so the
+	// sandboxedEnv-created "project" worktree isn't an extra entry the
+	// listing has to account for.
+	bucket := filepath.Join(home, "bucket")
+	if err := os.MkdirAll(bucket, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const fileCount = 30
+	for i := range fileCount {
+		p := filepath.Join(bucket, fmt.Sprintf("leaf%03d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const budget = 10
+	stubMaxGlobDirEntries(t, budget)
+	stubGlobDirChunk(t, 5)
+
+	sfs := env.sandbox()
+	if sfs == nil {
+		t.Fatal("expected a sandboxed environment")
+	}
+	// sandbox() hands back a held layer; the ReadDir call below runs on it, so
+	// the release goes at the end of the operation, not here.
+	defer sfs.release()
+	baseFd, canonical, err := sfs.openReadBaseFd("glob", bucket)
+	if err != nil {
+		t.Fatalf("openReadBaseFd: %v", err)
+	}
+	defer func() { _ = unix.Close(baseFd) }()
+
+	callBudget := newGlobBudget("glob")
+	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs, budget: callBudget}
+
+	entries, err := fsys.ReadDir(".")
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("secureDirFS.ReadDir over a %d-entry directory with an entry budget of %d = (%d entries, %v), want a *globBudgetError; nothing bounds how many entries one listing may materialize", fileCount, budget, len(entries), err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != callBudget.op {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, callBudget.op)
+	}
+	if callBudget.peakDirEntries < budget || callBudget.peakDirEntries >= fileCount {
+		t.Fatalf("globBudget.peakDirEntries = %d, want at least the entry budget of %d but strictly less than the directory's %d entries (a listing that materializes everything before refusing must not pass this)", callBudget.peakDirEntries, budget, fileCount)
+	}
+}

--- a/agent/execenv/glob_budget_unix_test.go
+++ b/agent/execenv/glob_budget_unix_test.go
@@ -80,3 +80,48 @@ func TestSandboxedGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
 		t.Fatalf("globBudget.peakDirEntries = %d, want at least the entry budget of %d but strictly less than the directory's %d entries (a listing that materializes everything before refusing must not pass this)", callBudget.peakDirEntries, budget, fileCount)
 	}
 }
+
+// TestSandboxedGrepWalkIsChargedToTheBudget is TestGrepWalkIsChargedToTheBudget's
+// sandboxed counterpart: sfs.grepNative's own directory walk charges every
+// directory it visits to the shared budget, on top of whatever ignore
+// discovery already charged for the same tree, so a huge tree grepNative
+// walks after ignore discovery completes still costs unbounded work. The tree
+// here has no .gitignore and is small enough that ignore discovery alone
+// stays well under the lowered listing budget, so a refusal can only be
+// attributed to grepNative's own walk over the tree it is grepping, not to
+// ignore discovery's separate pass over the same tree. Sandboxed sessions
+// always use native grep — LocalExecutionEnvironment.Grep routes to
+// sfs.grepNative whenever e.sandbox() is non-nil, even with ripgrep present —
+// so env.Grep is enough to reach this arm without defeating ripgrep
+// detection.
+//
+// This is a characterization pin, not a red test: it already passes on the
+// current tree.
+func TestSandboxedGrepWalkIsChargedToTheBudget(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const dirCount = 30
+	const budget = 40
+	for i := range dirCount {
+		dir := filepath.Join(worktree, fmt.Sprintf("dir%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "leaf.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stubMaxGlobDirListings(t, budget)
+
+	_, err := env.Grep(t.Context(), "needle", worktree, "", false, 100, "")
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("sandboxed grep's own walk over a %d-directory tree with a listing budget of %d = (_, %v), want a *globBudgetError; sfs.grepNative's walk charges nothing to the budget", dirCount, budget, err)
+	}
+	if budgetErr.kind != budgetListings {
+		t.Fatalf("globBudgetError.kind = %v, want budgetListings", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}

--- a/agent/execenv/glob_cancel_test.go
+++ b/agent/execenv/glob_cancel_test.go
@@ -152,7 +152,7 @@ func TestGlobWithExclusionsStopsMidWalk(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	stubGlobBaseFS(t, func(string) fs.FS {
+	stubGlobBaseFS(t, func(string, *globBudget) fs.FS {
 		return &countingFS{FS: globCancelTree(), cancelOn: 3, cancel: cancel}
 	})
 
@@ -250,7 +250,7 @@ func TestSortPathsByMtimeDescStopsOnCancellation(t *testing.T) {
 // stubGlobBaseFS interposes on the fs.FS the off-sandbox glob walks, so a test
 // can drive the exported entry point over a filesystem it controls, and
 // restores the seam when the test ends.
-func stubGlobBaseFS(t *testing.T, open func(dir string) fs.FS) {
+func stubGlobBaseFS(t *testing.T, open func(dir string, budget *globBudget) fs.FS) {
 	t.Helper()
 	orig := globBaseFS
 	globBaseFS = open

--- a/agent/execenv/glob_cancel_test.go
+++ b/agent/execenv/glob_cancel_test.go
@@ -63,7 +63,7 @@ func TestGlobMatchesStopsOnContextCancellation(t *testing.T) {
 	tree := globCancelTree()
 
 	full := &countingFS{FS: cancelFS{ctx: t.Context(), fsys: tree}}
-	if _, err := globMatches(t.Context(), full, "**/needle.txt"); err != nil {
+	if _, err := globMatches(t.Context(), full, "**/needle.txt", &globBudget{}); err != nil {
 		t.Fatalf("uncancelled globMatches: %v", err)
 	}
 	if full.calls < 20 {
@@ -74,7 +74,7 @@ func TestGlobMatchesStopsOnContextCancellation(t *testing.T) {
 	defer cancel()
 	counter := &countingFS{FS: cancelFS{ctx: ctx, fsys: tree}, cancelOn: 3, cancel: cancel}
 
-	matches, err := globMatches(ctx, counter, "**/needle.txt")
+	matches, err := globMatches(ctx, counter, "**/needle.txt", &globBudget{})
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("globMatches after mid-walk cancellation = (%v, %v), want context.Canceled", matches, err)
 	}
@@ -133,7 +133,7 @@ func TestGlobWithExclusionsReportsCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	matches, excluded, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(ctx, "**/needle.txt", root, true)
+	matches, excluded, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(ctx, "**/needle.txt", root, true)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GlobWithExclusions with a cancelled context = (%v, %d, %v), want context.Canceled", matches, excluded, err)
 	}
@@ -157,7 +157,7 @@ func TestGlobWithExclusionsStopsMidWalk(t *testing.T) {
 	})
 
 	root := t.TempDir()
-	matches, excluded, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(ctx, "**/needle.txt", root, true)
+	matches, excluded, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(ctx, "**/needle.txt", root, true)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("GlobWithExclusions cancelled mid-walk = (%v, %d, %v), want context.Canceled", matches, excluded, err)
 	}
@@ -182,14 +182,14 @@ func TestSandboxedGlobReportsCancellation(t *testing.T) {
 
 	// Sanity: the same glob finds the file when nobody cancels it, so a
 	// cancelled empty result cannot be mistaken for "there was nothing here".
-	found, _, err := env.GlobWithExclusions(t.Context(), "**/needle.txt", worktree, true)
+	found, _, _, err := env.GlobWithExclusions(t.Context(), "**/needle.txt", worktree, true)
 	if err != nil || len(found) != 1 {
 		t.Fatalf("sandboxed glob = (%v, %v), want the one needle", found, err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	matches, excluded, err := env.GlobWithExclusions(ctx, "**/needle.txt", worktree, true)
+	matches, excluded, _, err := env.GlobWithExclusions(ctx, "**/needle.txt", worktree, true)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("sandboxed GlobWithExclusions with a cancelled context = (%v, %d, %v), want context.Canceled", matches, excluded, err)
 	}

--- a/agent/execenv/glob_cancel_test.go
+++ b/agent/execenv/glob_cancel_test.go
@@ -152,7 +152,7 @@ func TestGlobWithExclusionsStopsMidWalk(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	stubGlobBaseFS(t, func(string, *globBudget) fs.FS {
+	stubGlobBaseFS(t, func(context.Context, string, *globBudget) fs.FS {
 		return &countingFS{FS: globCancelTree(), cancelOn: 3, cancel: cancel}
 	})
 
@@ -250,7 +250,7 @@ func TestSortPathsByMtimeDescStopsOnCancellation(t *testing.T) {
 // stubGlobBaseFS interposes on the fs.FS the off-sandbox glob walks, so a test
 // can drive the exported entry point over a filesystem it controls, and
 // restores the seam when the test ends.
-func stubGlobBaseFS(t *testing.T, open func(dir string, budget *globBudget) fs.FS) {
+func stubGlobBaseFS(t *testing.T, open func(ctx context.Context, dir string, budget *globBudget) fs.FS) {
 	t.Helper()
 	orig := globBaseFS
 	globBaseFS = open

--- a/agent/execenv/glob_cancel_test.go
+++ b/agent/execenv/glob_cancel_test.go
@@ -63,7 +63,7 @@ func TestGlobMatchesStopsOnContextCancellation(t *testing.T) {
 	tree := globCancelTree()
 
 	full := &countingFS{FS: cancelFS{ctx: t.Context(), fsys: tree}}
-	if _, err := globMatches(t.Context(), full, "**/needle.txt", &globBudget{}); err != nil {
+	if _, err := globMatches(t.Context(), full, "**/needle.txt", newGlobBudget("glob")); err != nil {
 		t.Fatalf("uncancelled globMatches: %v", err)
 	}
 	if full.calls < 20 {
@@ -74,7 +74,7 @@ func TestGlobMatchesStopsOnContextCancellation(t *testing.T) {
 	defer cancel()
 	counter := &countingFS{FS: cancelFS{ctx: ctx, fsys: tree}, cancelOn: 3, cancel: cancel}
 
-	matches, err := globMatches(ctx, counter, "**/needle.txt", &globBudget{})
+	matches, err := globMatches(ctx, counter, "**/needle.txt", newGlobBudget("glob"))
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("globMatches after mid-walk cancellation = (%v, %v), want context.Canceled", matches, err)
 	}

--- a/agent/execenv/glob_grep_scoping_test.go
+++ b/agent/execenv/glob_grep_scoping_test.go
@@ -198,7 +198,7 @@ func TestGlobWithExclusions_ReportsExcludedCountWhenFullyFiltered(t *testing.T) 
 	dir := writeScopingFixture(t)
 	env := NewLocalExecutionEnvironment(dir)
 
-	matches, excluded, err := env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", dir, false)
+	matches, excluded, _, err := env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", dir, false)
 	if err != nil {
 		t.Fatalf("GlobWithExclusions: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestGlobWithExclusions_ReportsExcludedCountWhenFullyFiltered(t *testing.T) 
 		t.Fatal("expected a non-zero excluded count for a fully-filtered glob")
 	}
 
-	matches, excluded, err = env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", dir, true)
+	matches, excluded, _, err = env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", dir, true)
 	if err != nil {
 		t.Fatalf("GlobWithExclusions include_ignored: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestSandboxedGlobWithExclusions_ReportsExcludedCountWhenFullyFiltered(t *te
 	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
 	writeScopingFixtureAt(t, worktree)
 
-	matches, excluded, err := env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", worktree, false)
+	matches, excluded, _, err := env.GlobWithExclusions(t.Context(), "node_modules/**/*.js", worktree, false)
 	if err != nil {
 		t.Fatalf("GlobWithExclusions: %v", err)
 	}

--- a/agent/execenv/glob_stat_unix_test.go
+++ b/agent/execenv/glob_stat_unix_test.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGlobMatchesAStatableUnreadableFile proves boundedDirFS does not hide the
+// fs.StatFS fast path os.DirFS provides underneath it. boundedDirFS embeds
+// fs.FS as a bare interface value, which exposes only Open, so fs.Stat on a
+// boundedDirFS can never find a Stat method and falls back to Open plus
+// File.Stat instead of reaching os.DirFS's own Stat the way it would if
+// boundedDirFS forwarded it. A file that can be stat'ed but not opened (mode
+// 0000) fails that fallback, so it is missed where it used to be found —
+// globWalkFS.Stat and cancelFS.Stat both reach the walk's underlying
+// filesystem through fs.Stat, so the loss shows up in an ordinary literal-name
+// glob. File permissions are meaningless outside Unix, hence the build tag.
+func TestGlobMatchesAStatableUnreadableFile(t *testing.T) {
+	root := t.TempDir()
+	const name = "secret.txt"
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("os.Stat(%q) = %v, want the file to remain stat-able at mode 0000 (else this test proves nothing)", path, err)
+	}
+	if _, err := os.Open(path); err == nil {
+		t.Skip("this user can open a 0000 file; cannot stage a stat-able-but-unreadable file")
+	}
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), name, root, true)
+	if err != nil {
+		t.Fatalf("Glob(%q): %v", name, err)
+	}
+	want := []string{path}
+	if len(matches) != 1 || matches[0] != want[0] {
+		t.Fatalf("Glob(%q) = %v, want %v; the stat-able file was not matched because boundedDirFS hides fs.StatFS, so fs.Stat falls back to Open, which a mode-0000 file fails", name, matches, want)
+	}
+}

--- a/agent/execenv/glob_walk_test.go
+++ b/agent/execenv/glob_walk_test.go
@@ -161,11 +161,11 @@ func TestGlobWalkFSBoundsAFilesystemWithoutFileIdentity(t *testing.T) {
 		t.Fatalf("fstest.MapFS should carry no file identity: (%v, %v)", info, err)
 	}
 
-	w := &globWalkFS{FS: tree, ctx: t.Context(), listed: map[string]fs.FileInfo{}}
+	w := &globWalkFS{FS: tree, ctx: t.Context(), budget: &globBudget{}}
 	if _, err := w.ReadDir("dir"); err != nil {
 		t.Fatalf("first listing: %v", err)
 	}
-	w.unidentified = maxUnidentifiedGlobDirs
+	w.budget.listings = maxGlobDirListings
 	_, err := w.ReadDir("dir")
 	if err == nil {
 		t.Fatal("listing past the bound succeeded, want a refusal")
@@ -176,19 +176,29 @@ func TestGlobWalkFSBoundsAFilesystemWithoutFileIdentity(t *testing.T) {
 }
 
 // TestGlobWalkFSKnowsWhenIdentityIsAvailable pins the discrimination the
-// backstop turns on: an os-backed filesystem carries file identity and is
-// bounded by the cycle check, so it must never be counted against the bound.
+// backstop turns on: identity decides how running out of budget is EXPLAINED,
+// not whether a listing counts toward it. An os-backed filesystem is bounded
+// by the cycle check too, so its listings are charged to the budget exactly
+// like an identity-less filesystem's — only the message a refusal gives once
+// the bound trips differs.
 func TestGlobWalkFSKnowsWhenIdentityIsAvailable(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), listed: map[string]fs.FileInfo{}}
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: &globBudget{}}
 	if _, err := w.ReadDir("sub"); err != nil {
 		t.Fatalf("listing an os-backed directory: %v", err)
 	}
-	if w.unidentified != 0 {
-		t.Fatalf("os-backed listing counted %d unidentified directories, want 0", w.unidentified)
+	if w.budget.listings != 1 {
+		t.Fatalf("os-backed listing charged %d to the budget, want 1", w.budget.listings)
+	}
+	info, err := fs.Stat(w.FS, "sub")
+	if err != nil {
+		t.Fatalf("stat sub: %v", err)
+	}
+	if !hasFileIdentity(info) {
+		t.Fatalf("an os-backed directory must carry file identity")
 	}
 }
 

--- a/agent/execenv/glob_walk_test.go
+++ b/agent/execenv/glob_walk_test.go
@@ -161,7 +161,7 @@ func TestGlobWalkFSBoundsAFilesystemWithoutFileIdentity(t *testing.T) {
 		t.Fatalf("fstest.MapFS should carry no file identity: (%v, %v)", info, err)
 	}
 
-	w := &globWalkFS{FS: tree, ctx: t.Context(), budget: &globBudget{}}
+	w := &globWalkFS{FS: tree, ctx: t.Context(), budget: newGlobBudget("glob")}
 	if _, err := w.ReadDir("dir"); err != nil {
 		t.Fatalf("first listing: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestGlobWalkFSKnowsWhenIdentityIsAvailable(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: &globBudget{}}
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: newGlobBudget("glob")}
 	if _, err := w.ReadDir("sub"); err != nil {
 		t.Fatalf("listing an os-backed directory: %v", err)
 	}

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1710,9 +1710,10 @@ func (e *LocalExecutionEnvironment) Glob(ctx context.Context, pattern string, ba
 // globBaseFS opens the filesystem the off-sandbox glob walks, rooted at the
 // resolved base directory; a variable so tests can drive the exported entry
 // point over a filesystem they control. budget is threaded through so a
-// bounded implementation can charge what it reads while listing.
-var globBaseFS = func(dir string, budget *globBudget) fs.FS {
-	return boundedDirFS{FS: os.DirFS(dir), budget: budget}
+// bounded implementation can charge what it reads while listing, and ctx down
+// to boundedDirFS so its chunk loop can observe cancellation.
+var globBaseFS = func(ctx context.Context, dir string, budget *globBudget) fs.FS {
+	return boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}
 }
 
 // GlobWithExclusions implements GlobExcluder: same matching as Glob, but also
@@ -1741,7 +1742,7 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 		return sfs.glob(ctx, "glob", base, pattern, includeIgnored)
 	}
 	budget := newGlobBudget("glob")
-	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(base, budget)}
+	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(ctx, base, budget)}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// No masking concept off the sandboxed path: no-op skip.
@@ -1942,13 +1943,13 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 	// secureDirFS policy on the sandboxed arm while retaining file-symlink
 	// behavior for the unsandboxed fallback.
 	budget := newGlobBudget("grep")
-	fsys := cancelFS{ctx: ctx, fsys: boundedDirFS{FS: os.DirFS(path), budget: budget}}
+	fsys := cancelFS{ctx: ctx, fsys: boundedDirFS{FS: os.DirFS(path), budget: budget, ctx: ctx}}
 	// No masking concept off the sandboxed path: no-op skip.
 	ignoreFS := fsys
 	if singleFile {
 		// Preserve the old single-file behavior: ignore rules are rooted at the
 		// file argument, which cannot contain a .gitignore tree of its own.
-		ignoreFS = cancelFS{ctx: ctx, fsys: boundedDirFS{FS: os.DirFS(filepath.Join(path, walkRoot)), budget: budget}}
+		ignoreFS = cancelFS{ctx: ctx, fsys: boundedDirFS{FS: os.DirFS(filepath.Join(path, walkRoot)), budget: budget, ctx: ctx}}
 	}
 	ignores, err := loadIgnoreSet(ignoreFS, nil, budget)
 	if err != nil {
@@ -1968,7 +1969,9 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 			// set (dot-prefixed directories only) is a strict subset of this
 			// walk's (which also skips gitignored ones) — so it normally
 			// raises this refusal first. This guard is for the case where a
-			// directory grows past the bound between the two passes.
+			// directory grows past the bound between the two passes, which
+			// TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+			// forces.
 			if _, refused := errors.AsType[*globBudgetError](err); refused {
 				return err
 			}

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1738,15 +1738,19 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 		return sfs.glob(ctx, "glob", base, pattern, includeIgnored)
 	}
 	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(base)}
+	budget := &globBudget{}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// No masking concept off the sandboxed path: no-op skip.
-		ignores = loadIgnoreSet(fsys, nil)
+		var err error
+		ignores, err = loadIgnoreSet(fsys, nil, budget)
+		if err != nil {
+			return nil, 0, 0, err
+		}
 	}
 	seen := make(map[string]struct{})
 	var abs []string
 	excluded := 0
-	budget := &globBudget{}
 	for _, pattern := range patterns {
 		matches, err := globMatches(ctx, fsys, pattern, budget)
 		if err != nil {
@@ -1774,11 +1778,7 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 	if err := sortPathsByMtimeDesc(ctx, abs); err != nil {
 		return nil, 0, 0, err
 	}
-	truncatedAt := 0
-	if budget.full() {
-		truncatedAt = maxGlobMatches
-	}
-	return abs, excluded, truncatedAt, nil
+	return abs, excluded, budget.truncatedAt(), nil
 }
 
 // Grep searches for pattern under path (defaulting to RootDir), using ripgrep
@@ -1946,7 +1946,10 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 		// file argument, which cannot contain a .gitignore tree of its own.
 		ignoreFS = cancelFS{ctx: ctx, fsys: os.DirFS(filepath.Join(path, walkRoot))}
 	}
-	ignores := loadIgnoreSet(ignoreFS, nil)
+	ignores, err := loadIgnoreSet(ignoreFS, nil, &globBudget{})
+	if err != nil {
+		return "", err
+	}
 	excludedByIgnore := 0
 
 	err = grepWalk(fsys, walkRoot, func(p string, d fs.DirEntry, err error) error {

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1703,7 +1703,7 @@ func (e *LocalExecutionEnvironment) ListDirectory(path string, depth int) ([]Dir
 // (The sandboxed walk is stricter: it never follows a symlink at all, which is
 // a policy boundary rather than a termination measure.)
 func (e *LocalExecutionEnvironment) Glob(ctx context.Context, pattern string, basePath string, includeIgnored ...bool) ([]string, error) {
-	matches, _, err := e.GlobWithExclusions(ctx, pattern, basePath, len(includeIgnored) > 0 && includeIgnored[0])
+	matches, _, _, err := e.GlobWithExclusions(ctx, pattern, basePath, len(includeIgnored) > 0 && includeIgnored[0])
 	return matches, err
 }
 
@@ -1719,10 +1719,10 @@ var globBaseFS = os.DirFS
 // count never includes matches dropped by sandbox masking — that's a
 // separate security boundary, not something to describe to the caller as
 // "gitignored".
-func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, pattern string, basePath string, includeIgnored bool) ([]string, int, error) {
+func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, pattern string, basePath string, includeIgnored bool) ([]string, int, int, error) {
 	patterns, err := expandSearchPattern(pattern)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
 	base := strings.TrimSpace(basePath)
 	if base == "" {
@@ -1746,16 +1746,17 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 	seen := make(map[string]struct{})
 	var abs []string
 	excluded := 0
+	budget := &globBudget{}
 	for _, pattern := range patterns {
-		matches, err := globMatches(ctx, fsys, pattern)
+		matches, err := globMatches(ctx, fsys, pattern, budget)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, 0, err
 		}
 		for _, m := range matches {
 			if !includeIgnored {
 				drop, err := globMatchExcluded(ctx, fsys, ignores, m)
 				if err != nil {
-					return nil, 0, err
+					return nil, 0, 0, err
 				}
 				if drop {
 					excluded++
@@ -1771,9 +1772,13 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 		}
 	}
 	if err := sortPathsByMtimeDesc(ctx, abs); err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
-	return abs, excluded, nil
+	truncatedAt := 0
+	if budget.full() {
+		truncatedAt = maxGlobMatches
+	}
+	return abs, excluded, truncatedAt, nil
 }
 
 // Grep searches for pattern under path (defaulting to RootDir), using ripgrep

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1963,20 +1963,16 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 		if err != nil {
 			// A budget refusal ends the grep with its reason; skipping it the
 			// way an unreadable entry is skipped would let the walk carry on
-			// past the bound it just hit.
+			// past the bound it just hit. In practice, loadIgnoreSet's walk
+			// above already visits every directory this one would — its skip
+			// set (dot-prefixed directories only) is a strict subset of this
+			// walk's (which also skips gitignored ones) — so it normally
+			// raises this refusal first. This guard is for the case where a
+			// directory grows past the bound between the two passes.
 			if _, refused := errors.AsType[*globBudgetError](err); refused {
 				return err
 			}
 			return nil //nolint:nilerr // best-effort grep: skip unreadable entries and keep walking
-		}
-		if d.IsDir() {
-			// fs.WalkDir never follows a directory symlink, so this walk
-			// cannot cycle back into itself the way the glob pattern walk's
-			// ancestor check has to guard against — the same reason ignore
-			// discovery's own budget charge is always cycleSafe.
-			if berr := budget.listing(true); berr != nil {
-				return berr
-			}
 		}
 		relPath := filepath.FromSlash(p)
 		if singleFile {
@@ -1992,6 +1988,15 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 					excludedByIgnore++
 					return filepath.SkipDir
 				}
+			}
+			// fs.WalkDir never follows a directory symlink, so this walk
+			// cannot cycle back into itself the way the glob pattern walk's
+			// ancestor check has to guard against — the same reason ignore
+			// discovery's own budget charge is always cycleSafe. Charged only
+			// here, once the dot/gitignore skips above have already passed,
+			// so a directory the walk is about to skip anyway costs nothing.
+			if berr := budget.listing(true); berr != nil {
+				return berr
 			}
 			return nil
 		}

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1738,7 +1738,7 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 		return sfs.glob(ctx, "glob", base, pattern, includeIgnored)
 	}
 	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(base)}
-	budget := &globBudget{}
+	budget := newGlobBudget("glob")
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// No masking concept off the sandboxed path: no-op skip.
@@ -1946,7 +1946,7 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 		// file argument, which cannot contain a .gitignore tree of its own.
 		ignoreFS = cancelFS{ctx: ctx, fsys: os.DirFS(filepath.Join(path, walkRoot))}
 	}
-	ignores, err := loadIgnoreSet(ignoreFS, nil, &globBudget{})
+	ignores, err := loadIgnoreSet(ignoreFS, nil, newGlobBudget("grep"))
 	if err != nil {
 		return "", err
 	}

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1709,8 +1709,11 @@ func (e *LocalExecutionEnvironment) Glob(ctx context.Context, pattern string, ba
 
 // globBaseFS opens the filesystem the off-sandbox glob walks, rooted at the
 // resolved base directory; a variable so tests can drive the exported entry
-// point over a filesystem they control.
-var globBaseFS = os.DirFS
+// point over a filesystem they control. budget is threaded through so a
+// bounded implementation can charge what it reads while listing.
+var globBaseFS = func(dir string, budget *globBudget) fs.FS {
+	return boundedDirFS{FS: os.DirFS(dir), budget: budget}
+}
 
 // GlobWithExclusions implements GlobExcluder: same matching as Glob, but also
 // reports how many candidate matches the default dotfile/gitignore exclusion
@@ -1737,8 +1740,8 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 		// traversal (no out-of-root match) and drops masked matches.
 		return sfs.glob(ctx, "glob", base, pattern, includeIgnored)
 	}
-	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(base)}
 	budget := newGlobBudget("glob")
+	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(base, budget)}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// No masking concept off the sandboxed path: no-op skip.
@@ -1938,15 +1941,16 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 	// fs.WalkDir does not descend through directory symlinks, matching the
 	// secureDirFS policy on the sandboxed arm while retaining file-symlink
 	// behavior for the unsandboxed fallback.
-	fsys := cancelFS{ctx: ctx, fsys: os.DirFS(path)}
+	budget := newGlobBudget("grep")
+	fsys := cancelFS{ctx: ctx, fsys: boundedDirFS{FS: os.DirFS(path), budget: budget}}
 	// No masking concept off the sandboxed path: no-op skip.
 	ignoreFS := fsys
 	if singleFile {
 		// Preserve the old single-file behavior: ignore rules are rooted at the
 		// file argument, which cannot contain a .gitignore tree of its own.
-		ignoreFS = cancelFS{ctx: ctx, fsys: os.DirFS(filepath.Join(path, walkRoot))}
+		ignoreFS = cancelFS{ctx: ctx, fsys: boundedDirFS{FS: os.DirFS(filepath.Join(path, walkRoot)), budget: budget}}
 	}
-	ignores, err := loadIgnoreSet(ignoreFS, nil, newGlobBudget("grep"))
+	ignores, err := loadIgnoreSet(ignoreFS, nil, budget)
 	if err != nil {
 		return "", err
 	}
@@ -1957,7 +1961,22 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 			return cancelErr
 		}
 		if err != nil {
+			// A budget refusal ends the grep with its reason; skipping it the
+			// way an unreadable entry is skipped would let the walk carry on
+			// past the bound it just hit.
+			if _, refused := errors.AsType[*globBudgetError](err); refused {
+				return err
+			}
 			return nil //nolint:nilerr // best-effort grep: skip unreadable entries and keep walking
+		}
+		if d.IsDir() {
+			// fs.WalkDir never follows a directory symlink, so this walk
+			// cannot cycle back into itself the way the glob pattern walk's
+			// ancestor check has to guard against — the same reason ignore
+			// discovery's own budget charge is always cycleSafe.
+			if berr := budget.listing(true); berr != nil {
+				return berr
+			}
 		}
 		relPath := filepath.FromSlash(p)
 		if singleFile {

--- a/agent/execenv/sandbox_tools_ignoreset_unix_test.go
+++ b/agent/execenv/sandbox_tools_ignoreset_unix_test.go
@@ -51,7 +51,7 @@ func TestLoadIgnoreSetSkipsMaskedSubtree(t *testing.T) {
 	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs}
 	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return sfs.underMasked(filepath.Join(canonical, relPath))
-	}, &globBudget{})
+	}, newGlobBudget("glob"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/execenv/sandbox_tools_ignoreset_unix_test.go
+++ b/agent/execenv/sandbox_tools_ignoreset_unix_test.go
@@ -49,9 +49,12 @@ func TestLoadIgnoreSetSkipsMaskedSubtree(t *testing.T) {
 	defer func() { _ = unix.Close(baseFd) }()
 
 	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs}
-	set := loadIgnoreSet(fsys, func(relPath string) bool {
+	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return sfs.underMasked(filepath.Join(canonical, relPath))
-	})
+	}, &globBudget{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, d := range set.dirs {
 		if d.rel == "vault" || strings.HasPrefix(d.rel, "vault/") {

--- a/agent/execenv/sandbox_tools_ignoreset_unix_test.go
+++ b/agent/execenv/sandbox_tools_ignoreset_unix_test.go
@@ -48,7 +48,7 @@ func TestLoadIgnoreSetSkipsMaskedSubtree(t *testing.T) {
 	}
 	defer func() { _ = unix.Close(baseFd) }()
 
-	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs, budget: newGlobBudget("glob")}
+	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs, budget: newGlobBudget("glob"), ctx: t.Context()}
 	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return sfs.underMasked(filepath.Join(canonical, relPath))
 	}, newGlobBudget("glob"))

--- a/agent/execenv/sandbox_tools_ignoreset_unix_test.go
+++ b/agent/execenv/sandbox_tools_ignoreset_unix_test.go
@@ -48,7 +48,7 @@ func TestLoadIgnoreSetSkipsMaskedSubtree(t *testing.T) {
 	}
 	defer func() { _ = unix.Close(baseFd) }()
 
-	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs}
+	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs, budget: newGlobBudget("glob")}
 	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return sfs.underMasked(filepath.Join(canonical, relPath))
 	}, newGlobBudget("glob"))

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -65,9 +65,12 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 // even where the cycle check works, an unbounded `**` over a huge tree (`/`)
 // still costs unbounded work.
 //
-// The value itself is a WORK bound, not a memory bound — the match cap and the
-// O(depth) ancestor chain already hold memory to a small constant, so this
-// only has to be large enough that a legitimate call doesn't pay for it. One
+// The value itself is a WORK bound rather than the memory bound. Memory is
+// held down by three other things: the match cap, the O(depth) ancestor chain,
+// and the per-directory entry cap. What those leave is maxGlobDirEntries times
+// the walk's depth, which is bounded but not small (see that constant), and
+// raising this number does not make it larger. So this one only has to be big
+// enough that a legitimate call never pays for it. One
 // call's listings are the sum of ignore discovery's walk plus every
 // brace-expanded pattern's walk (up to globpattern.MaxExpansions), so this one
 // number has to be large enough to cover all of them together. A
@@ -206,6 +209,19 @@ func (e *globBudgetError) advice() string {
 	return "narrow the pattern or its base directory"
 }
 
+// entryAdvice names the lever that gets a caller past one oversized directory,
+// which differs by operation the same way advice does. A glob can spell a
+// pattern that matches inside the directory without listing all of it; a grep
+// cannot, because its pattern is a regex matched against file contents after
+// the walk has already listed everything, so its only lever is a base that
+// does not contain the directory at all.
+func (e *globBudgetError) entryAdvice() string {
+	if e.op == "grep" {
+		return "that directory is too large to list, so point the base at a smaller directory that does not contain it"
+	}
+	return "that directory is too large to list, so match inside it more specifically or point the base elsewhere"
+}
+
 // where names the oversized directory the way a caller can act on it. The
 // walk's own root comes through as ".", which tells a model nothing, so it is
 // reported as the base it passed in instead of echoed back as a bare dot.
@@ -218,7 +234,7 @@ func (e *globBudgetError) where() string {
 
 func (e *globBudgetError) Error() string {
 	if e.kind == budgetEntries {
-		return fmt.Sprintf("%s walk read %d entries from %s, past the per-directory budget of %d: that directory is too large to list, so match inside it more specifically or point the base elsewhere", e.op, e.count, e.where(), e.budget)
+		return fmt.Sprintf("%s walk read %d entries from %s, past the per-directory budget of %d: %s", e.op, e.count, e.where(), e.budget, e.entryAdvice())
 	}
 	if !e.cycleSafe {
 		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.count, e.budget, e.advice())
@@ -265,6 +281,12 @@ func (b *globBudget) truncatedAt() int {
 // charged no matter what observes it from above.
 type boundedDirFS struct {
 	fs.FS
+	// ctx reaches readDirChunked, which checks it between chunks. A chunk
+	// loop reading from an already-open directory handle is invisible to
+	// cancelFS's Open/ReadDir/Stat checks: those see a listing starting, not
+	// the chunks inside one, so without this a cancelled call keeps reading a
+	// directory nobody is waiting for.
+	ctx    context.Context
 	budget *globBudget
 }
 
@@ -304,7 +326,7 @@ func (b boundedDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 		}
 		return entries, nil
 	}
-	return readDirChunked(rdf, name, b.budget)
+	return readDirChunked(b.ctx, rdf, name, b.budget)
 }
 
 // readDirChunked lists dir by pulling entries from rdf in globDirChunk-sized
@@ -322,9 +344,24 @@ func (b boundedDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 // boundary that fell in a different place change which entries end up in
 // that prefix, and the raw fd-backed listing secureDirFS builds this on top
 // of has no ordering guarantee of its own to begin with.
-func readDirChunked(rdf fs.ReadDirFile, dir string, budget *globBudget) ([]fs.DirEntry, error) {
+//
+// ctx is checked between chunks because cancelFS cannot help here: it guards
+// Open, ReadDir and Stat at the filesystem level, so it tests the context
+// once as a listing begins and never again while this loop holds the
+// directory handle. See boundedDirFS.ctx and secureDirFS.ctx for how it is
+// threaded this far down.
+func readDirChunked(ctx context.Context, rdf fs.ReadDirFile, dir string, budget *globBudget) ([]fs.DirEntry, error) {
 	var entries []fs.DirEntry
 	for {
+		// cancelFS guards Open, ReadDir and Stat, so it checks ctx once as a
+		// listing starts and never again; this loop then holds the directory
+		// handle for as many chunks as the entry cap allows. Checking here is
+		// what keeps a cancelled call from reading the rest of a huge
+		// directory nobody is waiting for any more, and it answers with the
+		// same cancellation the rest of the walk returns.
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
 		chunk, err := rdf.ReadDir(globDirChunk)
 		entries = append(entries, chunk...)
 		if berr := budget.tooManyEntries(dir, len(entries)); berr != nil {
@@ -343,6 +380,12 @@ func readDirChunked(rdf fs.ReadDirFile, dir string, budget *globBudget) ([]fs.Di
 			// forever.
 			break
 		}
+	}
+	// A cancellation that landed on the final chunk must not come back as a
+	// complete listing, so the answer is the cancellation however the loop
+	// happened to leave it.
+	if cerr := ctx.Err(); cerr != nil {
+		return nil, cerr
 	}
 	slices.SortFunc(entries, func(x, y fs.DirEntry) int { return strings.Compare(x.Name(), y.Name()) })
 	return entries, nil

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -75,6 +77,20 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 // the two.
 var maxGlobDirListings = 1_000_000
 
+// globDirChunk is how many entries one bounded listing pulls per syscall. A
+// variable, not a constant: it is the unit the per-listing entry bound is
+// enforced in, so a test has to be able to shrink it below a fixture's size
+// to see a listing stop after a few chunks instead of needing a directory too
+// large to build in a test.
+var globDirChunk = 4096
+
+// maxGlobDirEntries bounds how many entries a SINGLE directory listing may
+// materialize. It is per listing rather than cumulative because it bounds
+// peak memory: the walk frees each directory's slice when it moves on, so
+// what has to stay small is the largest one listing can hold, not the total
+// a legitimate walk reads across a whole tree.
+var maxGlobDirEntries = 200_000
+
 // maxGlobMatches bounds how many matches one glob call may accumulate.
 var maxGlobMatches = 10_000
 
@@ -88,6 +104,14 @@ type globBudget struct {
 	matches   int
 	truncated bool
 	op        string
+	// peakDirEntries is the largest number of entries tooManyEntries has ever
+	// been asked to charge to a single listing. The per-listing bound exists
+	// to cap peak memory, not merely to end in a refusal eventually, so this
+	// is what lets a test tell a listing that stopped after a few chunks
+	// apart from one that read a whole huge directory and only then reported
+	// the refusal — a result-only assertion cannot see the difference, but the
+	// OOM only the former avoids.
+	peakDirEntries int
 }
 
 // newGlobBudget constructs a globBudget for op, so every call site names the
@@ -110,21 +134,49 @@ func (b *globBudget) listing(cycleSafe bool) error {
 	if b.listings <= maxGlobDirListings {
 		return nil
 	}
-	return &globBudgetError{listings: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe, op: b.op}
+	return &globBudgetError{listings: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe, op: b.op, kind: budgetListings}
 }
 
+// tooManyEntries reports the refusal for a listing that has read more entries
+// than one directory may materialize, or nil while it is still under. It
+// records read against peakDirEntries on every call, not only the one that
+// finally trips, so peakDirEntries reflects how far a listing actually got
+// even on the chunks that stay under the bound.
+func (b *globBudget) tooManyEntries(read int) error {
+	if read > b.peakDirEntries {
+		b.peakDirEntries = read
+	}
+	if read <= maxGlobDirEntries {
+		return nil
+	}
+	return &globBudgetError{listings: read, budget: maxGlobDirEntries, cycleSafe: true, op: b.op, kind: budgetEntries}
+}
+
+// globBudgetKind tells apart the two things a globBudgetError can report:
+// too many directory listings across a whole call, or too many entries
+// materialized by a single one of them.
+type globBudgetKind int
+
+const (
+	budgetListings globBudgetKind = iota
+	budgetEntries
+)
+
 // globBudgetError reports that one glob or grep call ran past its
-// directory-listing budget. cycleSafe records whether the walk that gave up
+// directory-listing budget, or that one listing within it read past the
+// per-directory entry budget. cycleSafe records whether the walk that gave up
 // could have detected a symlink cycle on its own — the pattern walk can tell
 // only where the filesystem reports file identity, while ignore discovery
 // never follows symlinks and so always can — which picks which of Error's two
-// explanations applies; listings and budget are the values a caller can act
-// on without parsing either sentence.
+// explanations applies; a single oversized directory says nothing about cycle
+// detection, so an entries refusal is always cycleSafe. listings and budget
+// are the values a caller can act on without parsing either sentence.
 type globBudgetError struct {
 	listings  int
 	budget    int
 	cycleSafe bool
 	op        string
+	kind      globBudgetKind
 }
 
 // advice names the lever that actually makes the walk smaller, which differs
@@ -140,11 +192,23 @@ func (e *globBudgetError) advice() string {
 	return "narrow the pattern or its base directory"
 }
 
+// work names the unit of work e's kind bounds, so Error can report either
+// "made N directory listings" (one call ran past its listing budget) or
+// "read N directory entries from one directory" (one listing ran past the
+// per-directory entry budget) without duplicating the two sentences below for
+// each kind.
+func (e *globBudgetError) work() string {
+	if e.kind == budgetEntries {
+		return fmt.Sprintf("read %d directory entries from one directory", e.listings)
+	}
+	return fmt.Sprintf("made %d directory listings", e.listings)
+}
+
 func (e *globBudgetError) Error() string {
 	if !e.cycleSafe {
-		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.listings, e.budget, e.advice())
+		return fmt.Sprintf("%s walk %s on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.work(), e.budget, e.advice())
 	}
-	return fmt.Sprintf("%s walk made %d directory listings, past the budget of %d for one call: %s", e.op, e.listings, e.budget, e.advice())
+	return fmt.Sprintf("%s walk %s, past the budget of %d for one call: %s", e.op, e.work(), e.budget, e.advice())
 }
 
 // match reports whether the walk may keep the next match, so the caller can
@@ -172,6 +236,75 @@ func (b *globBudget) truncatedAt() int {
 		return maxGlobMatches
 	}
 	return 0
+}
+
+// boundedDirFS lists a directory in chunks instead of materializing it whole,
+// charging what it reads to budget after every chunk so one pathological
+// directory cannot exhaust memory before the listing budget or match cap ever
+// get a say — os.DirFS's own ReadDir, like the raw secureDirFS one it mirrors
+// on the sandboxed arm, reads a directory's entire contents before handing
+// any of it back, which is exactly the shape that lets a single huge
+// directory OOM the walk regardless of how tightly the other bounds are set.
+// It has to sit at the bottom of the plain path's stack, under any test
+// wrapper such as countingFS, so every listing that reaches the walk is
+// charged no matter what observes it from above.
+type boundedDirFS struct {
+	fs.FS
+	budget *globBudget
+}
+
+// ReadDir pulls name in globDirChunk-sized pieces, charging the running total
+// to budget after each one and returning its refusal the moment it trips
+// rather than waiting for the rest of the directory to come back. The pieces
+// are sorted by name only once the whole read is done, not per chunk: a
+// listing that stays under the bound has to come back byte-for-byte what
+// os.ReadDir would have produced, because the match cap downstream truncates
+// to a deterministic, lexically-first prefix of it — sorting mid-stream would
+// let a chunk boundary that fell in a different place change which entries
+// end up in that prefix.
+func (b boundedDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	f, err := b.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	rdf, ok := f.(fs.ReadDirFile)
+	if !ok {
+		// Not every fs.FS hands back a directory file that can list itself in
+		// pieces (a test fake, say); fall back to reading it whole rather than
+		// letting such a filesystem slip past the bound uncharged.
+		entries, err := fs.ReadDir(b.FS, name)
+		if err != nil {
+			return nil, err
+		}
+		if berr := b.budget.tooManyEntries(len(entries)); berr != nil {
+			return nil, berr
+		}
+		return entries, nil
+	}
+	var entries []fs.DirEntry
+	for {
+		chunk, err := rdf.ReadDir(globDirChunk)
+		entries = append(entries, chunk...)
+		if berr := b.budget.tooManyEntries(len(entries)); berr != nil {
+			return nil, berr
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		if len(chunk) == 0 {
+			// Defensive: a well-behaved ReadDirFile signals the end with
+			// io.EOF, but nothing here should trust that every fs.FS does, and
+			// a chunk that reads nothing without an error would otherwise spin
+			// forever.
+			break
+		}
+	}
+	slices.SortFunc(entries, func(x, y fs.DirEntry) int { return strings.Compare(x.Name(), y.Name()) })
+	return entries, nil
 }
 
 // listedDir is one entry on globWalkFS.chain: the identity of a directory on
@@ -233,6 +366,14 @@ func (w *globWalkFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	entries, err := fs.ReadDir(w.FS, name)
 	if err != nil {
+		// A per-directory entry-budget refusal has to reach the caller
+		// looking like itself, the same as the listing-count refusal admit
+		// already returns unhidden: folding it into the generic fs.ErrNotExist
+		// below would make doublestar quietly skip the very directory that
+		// tripped the bound instead of ending the walk with the reason why.
+		if _, refused := errors.AsType[*globBudgetError](err); refused {
+			return nil, err
+		}
 		return nil, w.hide("readdir", name)
 	}
 	return entries, nil

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -53,8 +53,8 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 	return fs.Stat(c.fsys, name)
 }
 
-// maxGlobDirListings bounds how many directory listings one glob call may
-// make, across ignore discovery and every brace-expanded pattern in it. It
+// maxGlobDirListings bounds how many directory listings one glob or grep call
+// may make, across ignore discovery and every brace-expanded pattern in it. It
 // counts directories listed rather than capping depth because a symlink cycle
 // costs unbounded *work*, not merely unbounded depth: one /proc/<pid>/root hop
 // re-enters the entire tree, so a shallow depth cap would still admit a
@@ -66,23 +66,34 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 // The value itself is a WORK bound, not a memory bound — the match cap and the
 // O(depth) ancestor chain already hold memory to a small constant, so this
 // only has to be large enough that a legitimate call doesn't pay for it. One
-// call can spend this budget several times over: once on ignore discovery,
-// then again on each brace-expanded pattern (up to
-// globpattern.MaxExpansions). A 60,000-directory monorepo globbed with a
-// 5-way brace expansion costs on the order of 360,000 listings and must not
-// error; `/` on a developer's machine is 500,000 to several million
-// directories and must. 1,000,000 sits between the two.
+// call's listings are the sum of ignore discovery's walk plus every
+// brace-expanded pattern's walk (up to globpattern.MaxExpansions), so this one
+// number has to be large enough to cover all of them together. A
+// 60,000-directory monorepo globbed with a 5-way brace expansion costs on the
+// order of 360,000 listings and must not error; `/` on a developer's machine
+// is 500,000 to several million directories and must. 1,000,000 sits between
+// the two.
 var maxGlobDirListings = 1_000_000
 
 // maxGlobMatches bounds how many matches one glob call may accumulate.
 var maxGlobMatches = 10_000
 
-// globBudget bounds the total work and memory one glob call may spend, shared
-// by every brace-expanded pattern the call walks.
+// globBudget bounds the total work and memory one glob or grep call may
+// spend, shared by every brace-expanded pattern the call walks. op names the
+// operation the budget was created for, "glob" or "grep": loadIgnoreSet is
+// shared by both tools, so a refusal from it has to name whichever the caller
+// actually invoked instead of always saying "glob".
 type globBudget struct {
 	listings  int
 	matches   int
 	truncated bool
+	op        string
+}
+
+// newGlobBudget constructs a globBudget for op, so every call site names the
+// operation its budget belongs to rather than leaving the field unset.
+func newGlobBudget(op string) *globBudget {
+	return &globBudget{op: op}
 }
 
 // listing charges one more directory listing to the budget regardless of
@@ -99,27 +110,28 @@ func (b *globBudget) listing(cycleSafe bool) error {
 	if b.listings <= maxGlobDirListings {
 		return nil
 	}
-	return &globBudgetError{listings: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe}
+	return &globBudgetError{listings: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe, op: b.op}
 }
 
-// globBudgetError reports that one glob call ran past its directory-listing
-// budget. cycleSafe records whether the walk that gave up could have detected
-// a symlink cycle on its own — the pattern walk can tell only where the
-// filesystem reports file identity, while ignore discovery never follows
-// symlinks and so always can — which picks which of Error's two explanations
-// applies; listings and budget are the values a caller can act on without
-// parsing either sentence.
+// globBudgetError reports that one glob or grep call ran past its
+// directory-listing budget. cycleSafe records whether the walk that gave up
+// could have detected a symlink cycle on its own — the pattern walk can tell
+// only where the filesystem reports file identity, while ignore discovery
+// never follows symlinks and so always can — which picks which of Error's two
+// explanations applies; listings and budget are the values a caller can act
+// on without parsing either sentence.
 type globBudgetError struct {
 	listings  int
 	budget    int
 	cycleSafe bool
+	op        string
 }
 
 func (e *globBudgetError) Error() string {
 	if !e.cycleSafe {
-		return fmt.Sprintf("glob walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; narrow the pattern or its base directory", e.listings, e.budget)
+		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; narrow the pattern or its base directory", e.op, e.listings, e.budget)
 	}
-	return fmt.Sprintf("glob walk made %d directory listings, past the budget of %d for one glob call: narrow the pattern or its base directory", e.listings, e.budget)
+	return fmt.Sprintf("%s walk made %d directory listings, past the budget of %d for one call: narrow the pattern or its base directory", e.op, e.listings, e.budget)
 }
 
 // match reports whether the walk may keep the next match, so the caller can

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -100,8 +100,25 @@ var globDirChunk = 4096
 // multiply by a plausible depth without exhausting memory on its own.
 var maxGlobDirEntries = 200_000
 
+// maxGlobLiveEntries bounds how many directory entries one call may hold live
+// at once, summed over every listing its walk still has open. maxGlobDirEntries
+// bounds a single listing, which does not bound the walk: fs.WalkDir and
+// doublestar both keep an ancestor's entry slice alive while they read a
+// child, so a walk N levels deep holds up to N listings at once. This is the
+// aggregate ceiling that makes that sum finite. At roughly 105 bytes per
+// os.dirEntry, 500,000 entries is about 52 MB — a couple of maximal
+// directories' worth, far above any real tree (a deep repository holds a few
+// thousand live entries) and far below what would threaten the process.
+var maxGlobLiveEntries = 500_000
+
 // maxGlobMatches bounds how many matches one glob call may accumulate.
 var maxGlobMatches = 10_000
+
+// liveDir is one directory whose listing the walk is still holding.
+type liveDir struct {
+	name string
+	n    int
+}
 
 // globBudget bounds the total work and memory one glob or grep call may
 // spend, shared by every brace-expanded pattern the call walks. op names the
@@ -121,6 +138,14 @@ type globBudget struct {
 	// the refusal — a result-only assertion cannot see the difference, but the
 	// OOM only the former avoids.
 	peakDirEntries int
+	// live holds one entry per directory listing the walk currently has open,
+	// pruned by holdEntries down to just the ancestors of whichever directory
+	// is being listed now.
+	live []liveDir
+	// peakLiveEntries is the largest live total holdEntries has ever computed
+	// across b.live, recorded on every call rather than only the one that
+	// trips, so a test can see how far a walk actually got.
+	peakLiveEntries int
 }
 
 // newGlobBudget constructs a globBudget for op, so every call site names the
@@ -162,29 +187,62 @@ func (b *globBudget) tooManyEntries(dir string, read int) error {
 	return &globBudgetError{count: read, dir: dir, budget: maxGlobDirEntries, cycleSafe: true, op: b.op, kind: budgetEntries}
 }
 
-// globBudgetKind tells apart the two things a globBudgetError can report:
-// too many directory listings across a whole call, or too many entries
-// materialized by a single one of them.
+// isGlobWalkAncestor reports whether dir is a proper ancestor of name in the
+// slash-separated paths a walk uses.
+func isGlobWalkAncestor(dir, name string) bool {
+	return dir != name && (dir == "." || strings.HasPrefix(name, dir+"/"))
+}
+
+// holdEntries records dir's listing of n entries as live and releases every
+// directory that is not one of dir's ancestors: to be listing dir at all the
+// walk must have left them, the same reasoning globWalkFS.push uses for
+// identity. It refuses once the live total crosses maxGlobLiveEntries.
+func (b *globBudget) holdEntries(dir string, n int) error {
+	kept := 0
+	total := n
+	for _, d := range b.live {
+		if isGlobWalkAncestor(d.name, dir) {
+			b.live[kept] = d
+			kept++
+			total += d.n
+		}
+	}
+	b.live = append(b.live[:kept], liveDir{name: dir, n: n})
+	if total > b.peakLiveEntries {
+		b.peakLiveEntries = total
+	}
+	if total > maxGlobLiveEntries {
+		return &globBudgetError{count: total, budget: maxGlobLiveEntries, cycleSafe: true, op: b.op, kind: budgetLiveEntries}
+	}
+	return nil
+}
+
+// globBudgetKind tells apart the three things a globBudgetError can report:
+// too many directory listings across a whole call, too many entries
+// materialized by a single one of them, or too many entries held live at once
+// across the listings a walk still has open.
 type globBudgetKind int
 
 const (
 	budgetListings globBudgetKind = iota
 	budgetEntries
+	budgetLiveEntries
 )
 
-// globBudgetError reports that one glob or grep call ran past its
-// directory-listing budget, or that one listing within it read past the
-// per-directory entry budget. cycleSafe records whether the walk that gave up
-// could have detected a symlink cycle on its own — the pattern walk can tell
-// only where the filesystem reports file identity, while ignore discovery
-// never follows symlinks and so always can — which picks which of the
-// listings kind's two explanations applies; a single oversized directory says
-// nothing about cycle detection, so an entries refusal is always cycleSafe.
-// count is the whole call's directory-listing tally for the listings kind, or
-// the entry count of the one oversized directory for the entries kind; dir
-// names that directory and is empty for the listings kind, which has no
-// single directory to blame. count, dir and budget are the values a caller
-// can act on without parsing either sentence.
+// globBudgetError reports that one glob or grep call ran past one of its
+// bounds: its directory-listing budget, the per-directory entry budget for a
+// single listing within it, or the call-wide ceiling on entries held live at
+// once. cycleSafe records whether the walk that gave up could have detected a
+// symlink cycle on its own — the pattern walk can tell only where the
+// filesystem reports file identity, while ignore discovery never follows
+// symlinks and so always can — which picks which of the listings kind's two
+// explanations applies; neither a single oversized directory nor an aggregate
+// live total says anything about cycle detection, so those kinds are always
+// cycleSafe. count is the whole call's directory-listing tally, the entry
+// count of the one oversized directory, or the live total, according to kind;
+// dir names the oversized directory and is empty for the other two kinds,
+// which have no single directory to blame. count, dir and budget are the
+// values a caller can act on without parsing any of the sentences.
 type globBudgetError struct {
 	count     int
 	dir       string
@@ -235,6 +293,9 @@ func (e *globBudgetError) where() string {
 func (e *globBudgetError) Error() string {
 	if e.kind == budgetEntries {
 		return fmt.Sprintf("%s walk read %d entries from %s, past the per-directory budget of %d: %s", e.op, e.count, e.where(), e.budget, e.entryAdvice())
+	}
+	if e.kind == budgetLiveEntries {
+		return fmt.Sprintf("%s walk is holding %d directory entries live across the listings it has open, past the call-wide budget of %d: %s", e.op, e.count, e.budget, e.advice())
 	}
 	if !e.cycleSafe {
 		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.count, e.budget, e.advice())
@@ -388,6 +449,9 @@ func readDirChunked(ctx context.Context, rdf fs.ReadDirFile, dir string, budget 
 		return nil, cerr
 	}
 	slices.SortFunc(entries, func(x, y fs.DirEntry) int { return strings.Compare(x.Name(), y.Name()) })
+	if berr := budget.holdEntries(dir, len(entries)); berr != nil {
+		return nil, berr
+	}
 	return entries, nil
 }
 
@@ -522,7 +586,7 @@ func (w *globWalkFS) identity(dir string) (fs.FileInfo, bool) {
 func (w *globWalkFS) push(name string, info fs.FileInfo) {
 	kept := 0
 	for _, d := range w.chain {
-		if d.name != name && (d.name == "." || strings.HasPrefix(name, d.name+"/")) {
+		if isGlobWalkAncestor(d.name, name) {
 			w.chain[kept] = d
 			kept++
 		}

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -54,15 +54,25 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 }
 
 // maxGlobDirListings bounds how many directory listings one glob call may
-// make, across every brace-expanded pattern in it. It counts directories
-// listed rather than capping depth because a symlink cycle costs unbounded
-// *work*, not merely unbounded depth: one /proc/<pid>/root hop re-enters the
-// entire tree, so a shallow depth cap would still admit a combinatorial
-// re-walk while a deep one would truncate real results. It bounds every
-// listing, not only ones on a filesystem without file identity: even where
-// the cycle check works, an unbounded `**` over a huge tree (`/`) still costs
-// unbounded work and memory.
-var maxGlobDirListings = 100_000
+// make, across ignore discovery and every brace-expanded pattern in it. It
+// counts directories listed rather than capping depth because a symlink cycle
+// costs unbounded *work*, not merely unbounded depth: one /proc/<pid>/root hop
+// re-enters the entire tree, so a shallow depth cap would still admit a
+// combinatorial re-walk while a deep one would truncate real results. It
+// bounds every listing, not only ones on a filesystem without file identity:
+// even where the cycle check works, an unbounded `**` over a huge tree (`/`)
+// still costs unbounded work.
+//
+// The value itself is a WORK bound, not a memory bound — the match cap and the
+// O(depth) ancestor chain already hold memory to a small constant, so this
+// only has to be large enough that a legitimate call doesn't pay for it. One
+// call can spend this budget several times over: once on ignore discovery,
+// then again on each brace-expanded pattern (up to
+// globpattern.MaxExpansions). A 60,000-directory monorepo globbed with a
+// 5-way brace expansion costs on the order of 360,000 listings and must not
+// error; `/` on a developer's machine is 500,000 to several million
+// directories and must. 1,000,000 sits between the two.
+var maxGlobDirListings = 1_000_000
 
 // maxGlobMatches bounds how many matches one glob call may accumulate.
 var maxGlobMatches = 10_000
@@ -76,19 +86,40 @@ type globBudget struct {
 }
 
 // listing charges one more directory listing to the budget regardless of
-// identified: an unbounded `**` over a huge tree costs unbounded work and
+// cycleSafe: an unbounded `**` over a huge tree costs unbounded work and
 // memory even where the cycle check works, so the bound has to apply whether
-// or not this filesystem can tell directories apart. identified only picks
-// which explanation the refusal gives once the bound trips.
-func (b *globBudget) listing(identified bool) error {
+// or not this filesystem can tell directories apart. cycleSafe only picks
+// which explanation the refusal gives once the bound trips — true when the
+// walk that hit the bound could have detected a symlink cycle on its own
+// (the pattern walk can, only where the filesystem reports file identity;
+// ignore discovery never follows symlinks and so always can), false when it
+// could not.
+func (b *globBudget) listing(cycleSafe bool) error {
 	b.listings++
 	if b.listings <= maxGlobDirListings {
 		return nil
 	}
-	if !identified {
-		return fmt.Errorf("glob walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking", b.listings)
+	return &globBudgetError{listings: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe}
+}
+
+// globBudgetError reports that one glob call ran past its directory-listing
+// budget. cycleSafe records whether the walk that gave up could have detected
+// a symlink cycle on its own — the pattern walk can tell only where the
+// filesystem reports file identity, while ignore discovery never follows
+// symlinks and so always can — which picks which of Error's two explanations
+// applies; listings and budget are the values a caller can act on without
+// parsing either sentence.
+type globBudgetError struct {
+	listings  int
+	budget    int
+	cycleSafe bool
+}
+
+func (e *globBudgetError) Error() string {
+	if !e.cycleSafe {
+		return fmt.Sprintf("glob walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; narrow the pattern or its base directory", e.listings, e.budget)
 	}
-	return fmt.Errorf("glob walk made %d directory listings, past the budget for one glob call: narrow the pattern or its base directory", b.listings)
+	return fmt.Sprintf("glob walk made %d directory listings, past the budget of %d for one glob call: narrow the pattern or its base directory", e.listings, e.budget)
 }
 
 // match reports whether the walk may keep the next match, so the caller can
@@ -108,6 +139,16 @@ func (b *globBudget) full() bool {
 	return b.truncated
 }
 
+// truncatedAt reports the match cap that cut a glob call short, or 0 when
+// every match was reported, so a caller can hand the cap value to the model
+// without duplicating the truncated check at every call site that needs it.
+func (b *globBudget) truncatedAt() int {
+	if b.truncated {
+		return maxGlobMatches
+	}
+	return 0
+}
+
 // listedDir is one entry on globWalkFS.chain: the identity of a directory on
 // the path currently being walked.
 type listedDir struct {
@@ -125,7 +166,13 @@ type listedDir struct {
 // already reachable at a shorter path, so refusing costs no matches. A
 // directory symlink pointing anywhere other than at its own ancestors
 // (node_modules/lib -> ../packages/lib, or /etc -> /private/etc on macOS) is
-// walked normally and its files match under both names.
+// walked normally and its files match under both names. The check
+// deliberately admits one case: two sibling names for the same directory,
+// neither an ancestor of the other (a bind mount, or two symlinks pointing at
+// one shared target), are both listed and so walked twice. That case has no
+// unbounded recursion to catch — a sibling can't be its own ancestor — so it
+// is left to cost two listings against the budget rather than being detected
+// and refused.
 //
 // Abort. doublestar propagates a filesystem error only under
 // WithFailOnIOErrors; without it a cancelled walk keeps grinding through every
@@ -217,11 +264,11 @@ func (w *globWalkFS) identity(dir string) (fs.FileInfo, bool) {
 }
 
 // push records name's identity as the innermost entry on the chain, first
-// dropping every entry that is not a proper ancestor of name. Nothing listed
-// under name can ever be compared against a non-ancestor, and retaining those
-// entries anyway is what made the walk hold one FileInfo for every directory
-// it had ever listed instead of only the ones on the path currently being
-// walked.
+// dropping every entry that is not a proper ancestor of name. Only name's own
+// ancestors are ever consulted by the cycle check, so pruning everything else
+// loses nothing: the chain stays sized to the depth of the path currently
+// being walked rather than growing with the number of directories the walk
+// has listed in total.
 func (w *globWalkFS) push(name string, info fs.FileInfo) {
 	kept := 0
 	for _, d := range w.chain {
@@ -232,12 +279,6 @@ func (w *globWalkFS) push(name string, info fs.FileInfo) {
 	}
 	w.chain = append(w.chain[:kept], listedDir{name: name, info: info})
 }
-
-// retained reports how many directory identities this walk is holding, which
-// is the walk's own memory cost: the cycle check consults only the ancestors
-// of the directory it is admitting, so this must track the depth of the path
-// being walked, not the number of directories the walk has ever listed.
-func (w *globWalkFS) retained() int { return len(w.chain) }
 
 // hide answers with the walk's cancellation when there is one — the walk runs
 // under WithFailOnIOErrors so that ends it immediately — and otherwise with
@@ -279,6 +320,13 @@ var errGlobMatchesFull = errors.New("glob match cap reached")
 // being noticed only after the tree runs out.
 func globMatches(ctx context.Context, fsys fs.FS, pattern string, budget *globBudget) ([]string, error) {
 	if budget.full() {
+		// A cancelled walk must not come back as a plausible-looking short
+		// list: a cap that is already tripped when a cancellation lands must
+		// still answer with the cancellation, not with the truncated result
+		// the cap alone would produce.
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
 		return nil, nil
 	}
 	walk := &globWalkFS{FS: fsys, ctx: ctx, budget: budget}

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -86,9 +86,15 @@ var globDirChunk = 4096
 
 // maxGlobDirEntries bounds how many entries a SINGLE directory listing may
 // materialize. It is per listing rather than cumulative because it bounds
-// peak memory: the walk frees each directory's slice when it moves on, so
-// what has to stay small is the largest one listing can hold, not the total
-// a legitimate walk reads across a whole tree.
+// peak memory — but the peak one listing being small does not mean the
+// walk's peak is: both fs.WalkDir and doublestar hold a directory's entry
+// slice live for as long as they are recursing into one of its children, so a
+// walk currently N levels deep is holding up to N listings at once, one per
+// ancestor on the path, and only frees a sibling's slice once it moves on to
+// the next one. The real peak is this cap times the walk's depth. An
+// os.dirEntry is roughly 105 bytes including its name, so one listing at the
+// cap costs on the order of 21 to 25 MB, which has to stay small enough to
+// multiply by a plausible depth without exhausting memory on its own.
 var maxGlobDirEntries = 200_000
 
 // maxGlobMatches bounds how many matches one glob call may accumulate.
@@ -134,22 +140,23 @@ func (b *globBudget) listing(cycleSafe bool) error {
 	if b.listings <= maxGlobDirListings {
 		return nil
 	}
-	return &globBudgetError{listings: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe, op: b.op, kind: budgetListings}
+	return &globBudgetError{count: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe, op: b.op, kind: budgetListings}
 }
 
 // tooManyEntries reports the refusal for a listing that has read more entries
-// than one directory may materialize, or nil while it is still under. It
-// records read against peakDirEntries on every call, not only the one that
-// finally trips, so peakDirEntries reflects how far a listing actually got
-// even on the chunks that stay under the bound.
-func (b *globBudget) tooManyEntries(read int) error {
+// than one directory may materialize, or nil while it is still under. dir is
+// the directory being listed, named in the refusal so a caller knows which
+// one to act on. It records read against peakDirEntries on every call, not
+// only the one that finally trips, so peakDirEntries reflects how far a
+// listing actually got even on the chunks that stay under the bound.
+func (b *globBudget) tooManyEntries(dir string, read int) error {
 	if read > b.peakDirEntries {
 		b.peakDirEntries = read
 	}
 	if read <= maxGlobDirEntries {
 		return nil
 	}
-	return &globBudgetError{listings: read, budget: maxGlobDirEntries, cycleSafe: true, op: b.op, kind: budgetEntries}
+	return &globBudgetError{count: read, dir: dir, budget: maxGlobDirEntries, cycleSafe: true, op: b.op, kind: budgetEntries}
 }
 
 // globBudgetKind tells apart the two things a globBudgetError can report:
@@ -167,24 +174,31 @@ const (
 // per-directory entry budget. cycleSafe records whether the walk that gave up
 // could have detected a symlink cycle on its own — the pattern walk can tell
 // only where the filesystem reports file identity, while ignore discovery
-// never follows symlinks and so always can — which picks which of Error's two
-// explanations applies; a single oversized directory says nothing about cycle
-// detection, so an entries refusal is always cycleSafe. listings and budget
-// are the values a caller can act on without parsing either sentence.
+// never follows symlinks and so always can — which picks which of the
+// listings kind's two explanations applies; a single oversized directory says
+// nothing about cycle detection, so an entries refusal is always cycleSafe.
+// count is the whole call's directory-listing tally for the listings kind, or
+// the entry count of the one oversized directory for the entries kind; dir
+// names that directory and is empty for the listings kind, which has no
+// single directory to blame. count, dir and budget are the values a caller
+// can act on without parsing either sentence.
 type globBudgetError struct {
-	listings  int
+	count     int
+	dir       string
 	budget    int
 	cycleSafe bool
 	op        string
 	kind      globBudgetKind
 }
 
-// advice names the lever that actually makes the walk smaller, which differs
-// by operation. A glob's pattern decides how much of the tree gets listed, so
-// tightening it is the first thing to try. A grep's pattern is a regex matched
-// against file contents after the walk has already listed everything, so
-// narrowing it changes nothing about the listings; only a smaller base
-// directory does.
+// advice names the lever that actually makes a whole call's listing count
+// smaller, which differs by operation. A glob's pattern decides how much of
+// the tree gets listed, so tightening it is the first thing to try. A grep's
+// pattern is a regex matched against file contents after the walk has already
+// listed everything, so narrowing it changes nothing about the listings; only
+// a smaller base directory does. The entries kind names a single directory
+// instead of using this: the lever there is that one directory, not the call
+// as a whole.
 func (e *globBudgetError) advice() string {
 	if e.op == "grep" {
 		return "narrow the base directory"
@@ -192,23 +206,24 @@ func (e *globBudgetError) advice() string {
 	return "narrow the pattern or its base directory"
 }
 
-// work names the unit of work e's kind bounds, so Error can report either
-// "made N directory listings" (one call ran past its listing budget) or
-// "read N directory entries from one directory" (one listing ran past the
-// per-directory entry budget) without duplicating the two sentences below for
-// each kind.
-func (e *globBudgetError) work() string {
-	if e.kind == budgetEntries {
-		return fmt.Sprintf("read %d directory entries from one directory", e.listings)
+// where names the oversized directory the way a caller can act on it. The
+// walk's own root comes through as ".", which tells a model nothing, so it is
+// reported as the base it passed in instead of echoed back as a bare dot.
+func (e *globBudgetError) where() string {
+	if e.dir == "" || e.dir == "." {
+		return "the base directory"
 	}
-	return fmt.Sprintf("made %d directory listings", e.listings)
+	return "directory " + e.dir
 }
 
 func (e *globBudgetError) Error() string {
-	if !e.cycleSafe {
-		return fmt.Sprintf("%s walk %s on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.work(), e.budget, e.advice())
+	if e.kind == budgetEntries {
+		return fmt.Sprintf("%s walk read %d entries from %s, past the per-directory budget of %d: that directory is too large to list, so match inside it more specifically or point the base elsewhere", e.op, e.count, e.where(), e.budget)
 	}
-	return fmt.Sprintf("%s walk %s, past the budget of %d for one call: %s", e.op, e.work(), e.budget, e.advice())
+	if !e.cycleSafe {
+		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.count, e.budget, e.advice())
+	}
+	return fmt.Sprintf("%s walk made %d directory listings, past the budget of %d for one call: %s", e.op, e.count, e.budget, e.advice())
 }
 
 // match reports whether the walk may keep the next match, so the caller can
@@ -253,15 +268,25 @@ type boundedDirFS struct {
 	budget *globBudget
 }
 
-// ReadDir pulls name in globDirChunk-sized pieces, charging the running total
-// to budget after each one and returning its refusal the moment it trips
-// rather than waiting for the rest of the directory to come back. The pieces
-// are sorted by name only once the whole read is done, not per chunk: a
-// listing that stays under the bound has to come back byte-for-byte what
-// os.ReadDir would have produced, because the match cap downstream truncates
-// to a deterministic, lexically-first prefix of it — sorting mid-stream would
-// let a chunk boundary that fell in a different place change which entries
-// end up in that prefix.
+// Stat forwards to the wrapped fs.FS's own Stat rather than letting fs.Stat
+// fall back to Open plus File.Stat. boundedDirFS embeds fs.FS as a bare
+// interface value, which exposes only Open, so without this forward
+// os.DirFS's fs.StatFS fast path is invisible here and a file that can be
+// stat'ed but not opened (mode 0000) fails a call that used to succeed.
+// fs.ReadFile and fs.Sub lose the same fast path and are deliberately not
+// forwarded: their fallbacks (Open plus ReadAll, and a path-prefixing
+// wrapper) are functionally identical to the fast path, and ReadFile's
+// fallback fails on exactly the unreadable file its fast path would have
+// failed on too, so only Stat's fallback actually changes behavior.
+func (b boundedDirFS) Stat(name string) (fs.FileInfo, error) {
+	return fs.Stat(b.FS, name)
+}
+
+// ReadDir lists name through readDirChunked once Open hands back an
+// fs.ReadDirFile, falling back to reading it whole only for a filesystem that
+// cannot list itself in pieces (a test fake, say) — a fallback that still
+// charges what it reads to budget so such a filesystem cannot slip past the
+// bound uncharged.
 func (b boundedDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	f, err := b.Open(name)
 	if err != nil {
@@ -270,23 +295,39 @@ func (b boundedDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	defer func() { _ = f.Close() }()
 	rdf, ok := f.(fs.ReadDirFile)
 	if !ok {
-		// Not every fs.FS hands back a directory file that can list itself in
-		// pieces (a test fake, say); fall back to reading it whole rather than
-		// letting such a filesystem slip past the bound uncharged.
 		entries, err := fs.ReadDir(b.FS, name)
 		if err != nil {
 			return nil, err
 		}
-		if berr := b.budget.tooManyEntries(len(entries)); berr != nil {
+		if berr := b.budget.tooManyEntries(name, len(entries)); berr != nil {
 			return nil, berr
 		}
 		return entries, nil
 	}
+	return readDirChunked(rdf, name, b.budget)
+}
+
+// readDirChunked lists dir by pulling entries from rdf in globDirChunk-sized
+// pieces, charging the running total to budget after each one and returning
+// its refusal the moment it trips rather than waiting for the rest of the
+// directory to come back. A single unchunked ReadDir(-1) call — the shape
+// both os.DirFS's ReadDir and a raw *os.File's ReadDir take — materializes a
+// directory's entire contents before the entry budget or match cap ever get
+// a say, which is exactly what lets one huge directory OOM the walk no
+// matter how tightly the other bounds are set. The pieces are sorted by name
+// only once the whole read is done, not per chunk: a listing that stays
+// under the bound has to come back byte-for-byte what os.ReadDir would have
+// produced, because the match cap downstream truncates to a deterministic,
+// lexically-first prefix of it — sorting mid-stream would let a chunk
+// boundary that fell in a different place change which entries end up in
+// that prefix, and the raw fd-backed listing secureDirFS builds this on top
+// of has no ordering guarantee of its own to begin with.
+func readDirChunked(rdf fs.ReadDirFile, dir string, budget *globBudget) ([]fs.DirEntry, error) {
 	var entries []fs.DirEntry
 	for {
 		chunk, err := rdf.ReadDir(globDirChunk)
 		entries = append(entries, chunk...)
-		if berr := b.budget.tooManyEntries(len(entries)); berr != nil {
+		if berr := budget.tooManyEntries(dir, len(entries)); berr != nil {
 			return nil, berr
 		}
 		if err != nil {

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -2,6 +2,7 @@ package execenv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -52,16 +53,67 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 	return fs.Stat(c.fsys, name)
 }
 
-// maxUnidentifiedGlobDirs bounds a walk over a filesystem whose directories
-// carry no file identity, where globWalkFS's cycle check cannot work. The
-// bound counts directories listed rather than capping depth because a symlink
-// cycle costs unbounded *work*, not merely unbounded depth: one
-// /proc/<pid>/root hop re-enters the entire tree, so a shallow depth cap would
-// still admit a combinatorial re-walk while a deep one would truncate real
-// results. os-backed filesystems never reach this — the cycle check bounds
-// them — so exceeding it means the walk has lost its footing, and it is
-// reported as an error rather than as a short list.
-const maxUnidentifiedGlobDirs = 100_000
+// maxGlobDirListings bounds how many directory listings one glob call may
+// make, across every brace-expanded pattern in it. It counts directories
+// listed rather than capping depth because a symlink cycle costs unbounded
+// *work*, not merely unbounded depth: one /proc/<pid>/root hop re-enters the
+// entire tree, so a shallow depth cap would still admit a combinatorial
+// re-walk while a deep one would truncate real results. It bounds every
+// listing, not only ones on a filesystem without file identity: even where
+// the cycle check works, an unbounded `**` over a huge tree (`/`) still costs
+// unbounded work and memory.
+var maxGlobDirListings = 100_000
+
+// maxGlobMatches bounds how many matches one glob call may accumulate.
+var maxGlobMatches = 10_000
+
+// globBudget bounds the total work and memory one glob call may spend, shared
+// by every brace-expanded pattern the call walks.
+type globBudget struct {
+	listings  int
+	matches   int
+	truncated bool
+}
+
+// listing charges one more directory listing to the budget regardless of
+// identified: an unbounded `**` over a huge tree costs unbounded work and
+// memory even where the cycle check works, so the bound has to apply whether
+// or not this filesystem can tell directories apart. identified only picks
+// which explanation the refusal gives once the bound trips.
+func (b *globBudget) listing(identified bool) error {
+	b.listings++
+	if b.listings <= maxGlobDirListings {
+		return nil
+	}
+	if !identified {
+		return fmt.Errorf("glob walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking", b.listings)
+	}
+	return fmt.Errorf("glob walk made %d directory listings, past the budget for one glob call: narrow the pattern or its base directory", b.listings)
+}
+
+// match reports whether the walk may keep the next match, so the caller can
+// end the walk itself rather than letting it run to completion and truncating
+// the result afterward — the cap has to bound the work a glob call spends,
+// not only the length of the answer it hands back.
+func (b *globBudget) match() bool {
+	if b.matches >= maxGlobMatches {
+		b.truncated = true
+		return false
+	}
+	b.matches++
+	return true
+}
+
+func (b *globBudget) full() bool {
+	return b.truncated
+}
+
+// listedDir is one entry on globWalkFS.chain: the identity of a directory on
+// the path currently being walked.
+type listedDir struct {
+	name string
+	info fs.FileInfo
+}
 
 // globWalkFS is the view of the filesystem a single doublestar walk runs over.
 // It supplies the two properties doublestar itself cannot:
@@ -85,13 +137,14 @@ const maxUnidentifiedGlobDirs = 100_000
 type globWalkFS struct {
 	fs.FS
 	ctx context.Context
-	// listed holds the identity of every directory already listed, keyed by
-	// the path it was listed under, so the ancestor check costs a map lookup
-	// per level instead of a stat per level.
-	listed map[string]fs.FileInfo
-	// unidentified counts listed directories whose FileInfo carries no file
-	// identity — the only case maxUnidentifiedGlobDirs bounds.
-	unidentified int
+	// chain holds the identity of every directory on the path currently being
+	// walked, root first, so the ancestor check in admit can compare against
+	// them without retaining one FileInfo for every directory the walk has
+	// ever listed. See push for how it stays pruned to that path.
+	chain []listedDir
+	// budget bounds the directory listings and matches this walk may spend,
+	// shared with the rest of the glob call's brace-expanded patterns.
+	budget *globBudget
 }
 
 func (w *globWalkFS) Stat(name string) (fs.FileInfo, error) {
@@ -120,11 +173,11 @@ func (w *globWalkFS) admit(name string) error {
 	if err != nil {
 		return w.hide("stat", name)
 	}
-	if !hasFileIdentity(info) {
-		w.unidentified++
-		if w.unidentified > maxUnidentifiedGlobDirs {
-			return fmt.Errorf("glob walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking", w.unidentified)
-		}
+	identified := hasFileIdentity(info)
+	if err := w.budget.listing(identified); err != nil {
+		return err
+	}
+	if !identified {
 		return nil
 	}
 	// The walk root is skipped: it has no ancestors to cycle back to, and
@@ -132,7 +185,7 @@ func (w *globWalkFS) admit(name string) error {
 	// entry and refuse the second listing doublestar makes of every directory.
 	if name != "." {
 		for dir := path.Dir(name); ; dir = path.Dir(dir) {
-			if ancestor, ok := w.listed[dir]; ok && os.SameFile(ancestor, info) {
+			if ancestor, ok := w.identity(dir); ok && os.SameFile(ancestor, info) {
 				return w.hide("readdir", name)
 			}
 			if dir == "." {
@@ -140,9 +193,51 @@ func (w *globWalkFS) admit(name string) error {
 			}
 		}
 	}
-	w.listed[name] = info
+	w.push(name, info)
 	return nil
 }
+
+// identity answers dir's FileInfo from the chain of directories currently
+// being walked, falling back to a fresh stat on a miss. The chain is only a
+// cache of the path being walked — push prunes it down to that path on every
+// listing — so a walk that jumps between subtrees still compares admit's
+// candidate against every real ancestor by re-stat'ing it, and pruning the
+// chain can never let a cycle slip past the check that costs nothing extra.
+func (w *globWalkFS) identity(dir string) (fs.FileInfo, bool) {
+	for _, d := range w.chain {
+		if d.name == dir {
+			return d.info, true
+		}
+	}
+	info, err := fs.Stat(w.FS, dir)
+	if err != nil {
+		return nil, false
+	}
+	return info, true
+}
+
+// push records name's identity as the innermost entry on the chain, first
+// dropping every entry that is not a proper ancestor of name. Nothing listed
+// under name can ever be compared against a non-ancestor, and retaining those
+// entries anyway is what made the walk hold one FileInfo for every directory
+// it had ever listed instead of only the ones on the path currently being
+// walked.
+func (w *globWalkFS) push(name string, info fs.FileInfo) {
+	kept := 0
+	for _, d := range w.chain {
+		if d.name != name && (d.name == "." || strings.HasPrefix(name, d.name+"/")) {
+			w.chain[kept] = d
+			kept++
+		}
+	}
+	w.chain = append(w.chain[:kept], listedDir{name: name, info: info})
+}
+
+// retained reports how many directory identities this walk is holding, which
+// is the walk's own memory cost: the cycle check consults only the ancestors
+// of the directory it is admitting, so this must track the depth of the path
+// being walked, not the number of directories the walk has ever listed.
+func (w *globWalkFS) retained() int { return len(w.chain) }
 
 // hide answers with the walk's cancellation when there is one — the walk runs
 // under WithFailOnIOErrors so that ends it immediately — and otherwise with
@@ -162,21 +257,38 @@ func hasFileIdentity(info fs.FileInfo) bool {
 	return os.SameFile(info, info)
 }
 
+// errGlobMatchesFull signals the GlobWalk callback's own cap trip back out to
+// globMatches: doublestar has no way to end a walk early other than the
+// callback returning an error, so the cap has to speak in that vocabulary and
+// then be told apart from a real failure once GlobWalk returns.
+var errGlobMatchesFull = errors.New("glob match cap reached")
+
 // globMatches runs one expanded glob pattern against fsys, which must already
 // observe ctx (see cancelFS), through a fresh globWalkFS — fresh per pattern,
 // because the directories one pattern listed say nothing about whether another
-// pattern's walk is re-entering itself.
+// pattern's walk is re-entering itself. budget is shared across every pattern
+// in the call: it is checked before the walk starts, so a pattern that runs
+// after the cap has already tripped does not re-walk the tree just to
+// discover it can keep nothing, and it is checked on every match the walk
+// finds, so a `**` with millions of hits stops there instead of accumulating
+// all of them before the caller gets a chance to see any.
 //
 // GlobWalk rather than Glob: it ends the walk the moment the callback returns
-// an error, so a cancellation that lands between two filesystem calls stops
-// the walk at the next match instead of being noticed only after the tree runs
-// out.
-func globMatches(ctx context.Context, fsys fs.FS, pattern string) ([]string, error) {
-	walk := &globWalkFS{FS: fsys, ctx: ctx, listed: map[string]fs.FileInfo{}}
+// an error, so a cancellation — or the match cap tripping — that lands
+// between two filesystem calls stops the walk at the next match instead of
+// being noticed only after the tree runs out.
+func globMatches(ctx context.Context, fsys fs.FS, pattern string, budget *globBudget) ([]string, error) {
+	if budget.full() {
+		return nil, nil
+	}
+	walk := &globWalkFS{FS: fsys, ctx: ctx, budget: budget}
 	var matches []string
 	err := doublestar.GlobWalk(walk, pattern, func(p string, _ fs.DirEntry) error {
 		if cerr := ctx.Err(); cerr != nil {
 			return cerr
+		}
+		if !budget.match() {
+			return errGlobMatchesFull
 		}
 		matches = append(matches, p)
 		return nil
@@ -185,6 +297,12 @@ func globMatches(ctx context.Context, fsys fs.FS, pattern string) ([]string, err
 	// so answer with the cancellation however the walk happened to unwind.
 	if cerr := ctx.Err(); cerr != nil {
 		return nil, cerr
+	}
+	// The match cap ending the walk is not a failure: it is the mechanism by
+	// which the cap bounds the work rather than only the result, so the
+	// matches collected before it tripped are the answer, not an error.
+	if errors.Is(err, errGlobMatchesFull) {
+		return matches, nil
 	}
 	if err != nil {
 		return nil, err

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -127,11 +127,24 @@ type globBudgetError struct {
 	op        string
 }
 
+// advice names the lever that actually makes the walk smaller, which differs
+// by operation. A glob's pattern decides how much of the tree gets listed, so
+// tightening it is the first thing to try. A grep's pattern is a regex matched
+// against file contents after the walk has already listed everything, so
+// narrowing it changes nothing about the listings; only a smaller base
+// directory does.
+func (e *globBudgetError) advice() string {
+	if e.op == "grep" {
+		return "narrow the base directory"
+	}
+	return "narrow the pattern or its base directory"
+}
+
 func (e *globBudgetError) Error() string {
 	if !e.cycleSafe {
-		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; narrow the pattern or its base directory", e.op, e.listings, e.budget)
+		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.listings, e.budget, e.advice())
 	}
-	return fmt.Sprintf("%s walk made %d directory listings, past the budget of %d for one call: narrow the pattern or its base directory", e.op, e.listings, e.budget)
+	return fmt.Sprintf("%s walk made %d directory listings, past the budget of %d for one call: %s", e.op, e.listings, e.budget, e.advice())
 }
 
 // match reports whether the walk may keep the next match, so the caller can

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -38,6 +38,9 @@ type secureDirFS struct {
 	// budget bounds the entries a single ReadDir call may materialize, shared
 	// with the rest of the glob or grep call's directory-listing budget.
 	budget *globBudget
+	// ctx is threaded down to readDirChunked the same way boundedDirFS.ctx is
+	// on the off-sandbox path; see that field for why.
+	ctx context.Context
 }
 
 func (f *secureDirFS) Open(name string) (fs.File, error) {
@@ -60,7 +63,7 @@ func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	defer func() { _ = df.Close() }()
 	// df is listed through readDirChunked the same as boundedDirFS on the
 	// plain path, so a huge directory here cannot OOM the walk either.
-	return readDirChunked(df, name, f.budget)
+	return readDirChunked(f.ctx, df, name, f.budget)
 }
 
 func (f *secureDirFS) Stat(name string) (fs.FileInfo, error) {
@@ -108,7 +111,7 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 	defer func() { _ = unix.Close(baseFd) }()
 
 	budget := newGlobBudget("glob")
-	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s, budget: budget}}
+	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s, budget: budget, ctx: ctx}}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// Never list or read into a masked subtree while collecting
@@ -182,7 +185,7 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 		return "", err
 	}
 	budget := newGlobBudget("grep")
-	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s, budget: budget}}
+	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s, budget: budget, ctx: ctx}}
 	// Never list or read into a masked subtree while collecting .gitignore
 	// rules — see the matching comment in glob above.
 	ignores, err := loadIgnoreSet(fsys, func(relPath string) bool {
@@ -205,7 +208,9 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 			// is a strict subset of this walk's (which also skips gitignored
 			// ones) — so it normally raises this refusal first. This guard is
 			// for the case where a directory grows past the bound between the
-			// two passes.
+			// two passes, which
+			// TestSandboxedGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+			// forces.
 			if _, refused := errors.AsType[*globBudgetError](walkErr); refused {
 				return walkErr
 			}

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -7,11 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -60,33 +58,9 @@ func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	df := os.NewFile(uintptr(fd), name)
 	defer func() { _ = df.Close() }()
-	// Pulled in globDirChunk-sized pieces and charged to budget after each
-	// one, the same as boundedDirFS on the plain path: a single df.ReadDir(-1)
-	// materializes the whole directory before the entry budget or match cap
-	// ever get a say, which is exactly the shape that lets one huge directory
-	// OOM the walk no matter how tightly the other bounds are set.
-	var entries []fs.DirEntry
-	for {
-		chunk, err := df.ReadDir(globDirChunk)
-		entries = append(entries, chunk...)
-		if berr := f.budget.tooManyEntries(len(entries)); berr != nil {
-			return nil, berr
-		}
-		if err != nil {
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			return nil, err
-		}
-		if len(chunk) == 0 {
-			break
-		}
-	}
-	// os.DirFS sorts by name; the glob walk's match cap depends on that order
-	// to truncate to the same prefix every time, so this arm has to match it
-	// rather than hand back whatever order the kernel gave the readdir call.
-	slices.SortFunc(entries, func(a, b fs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) })
-	return entries, nil
+	// df is listed through readDirChunked the same as boundedDirFS on the
+	// plain path, so a huge directory here cannot OOM the walk either.
+	return readDirChunked(df, name, f.budget)
 }
 
 func (f *secureDirFS) Stat(name string) (fs.FileInfo, error) {
@@ -225,20 +199,17 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 		if walkErr != nil {
 			// A budget refusal ends the grep with its reason; skipping it the
 			// way an unreadable or symlink-refused entry is skipped would let
-			// the walk carry on past the bound it just hit.
+			// the walk carry on past the bound it just hit. In practice,
+			// loadIgnoreSet's walk above already visits every directory this
+			// one would — its skip set (dot-prefixed and masked directories)
+			// is a strict subset of this walk's (which also skips gitignored
+			// ones) — so it normally raises this refusal first. This guard is
+			// for the case where a directory grows past the bound between the
+			// two passes.
 			if _, refused := errors.AsType[*globBudgetError](walkErr); refused {
 				return walkErr
 			}
 			return nil //nolint:nilerr // skip unreadable / symlink-refused entries and keep walking
-		}
-		if d.IsDir() {
-			// fs.WalkDir never follows a directory symlink, so this walk
-			// cannot cycle back into itself the way the glob pattern walk's
-			// ancestor check has to guard against — the same reason ignore
-			// discovery's own budget charge above is always cycleSafe.
-			if berr := budget.listing(true); berr != nil {
-				return berr
-			}
 		}
 		abs := filepath.Join(canonical, rel)
 		if s.underMasked(abs) {
@@ -256,6 +227,16 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 					excludedByIgnore++
 					return fs.SkipDir
 				}
+			}
+			// fs.WalkDir never follows a directory symlink, so this walk
+			// cannot cycle back into itself the way the glob pattern walk's
+			// ancestor check has to guard against — the same reason ignore
+			// discovery's own budget charge above is always cycleSafe.
+			// Charged only here, once the masked/dot/gitignore skips above
+			// have already passed, so a directory the walk is about to skip
+			// anyway costs nothing.
+			if berr := budget.listing(true); berr != nil {
+				return berr
 			}
 			return nil
 		}

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -36,6 +37,9 @@ type secureDirFS struct {
 	baseFd   int
 	basePath string
 	fs       *sandboxFS
+	// budget bounds the entries a single ReadDir call may materialize, shared
+	// with the rest of the glob or grep call's directory-listing budget.
+	budget *globBudget
 }
 
 func (f *secureDirFS) Open(name string) (fs.File, error) {
@@ -56,9 +60,27 @@ func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	df := os.NewFile(uintptr(fd), name)
 	defer func() { _ = df.Close() }()
-	entries, err := df.ReadDir(-1)
-	if err != nil {
-		return nil, err
+	// Pulled in globDirChunk-sized pieces and charged to budget after each
+	// one, the same as boundedDirFS on the plain path: a single df.ReadDir(-1)
+	// materializes the whole directory before the entry budget or match cap
+	// ever get a say, which is exactly the shape that lets one huge directory
+	// OOM the walk no matter how tightly the other bounds are set.
+	var entries []fs.DirEntry
+	for {
+		chunk, err := df.ReadDir(globDirChunk)
+		entries = append(entries, chunk...)
+		if berr := f.budget.tooManyEntries(len(entries)); berr != nil {
+			return nil, berr
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		if len(chunk) == 0 {
+			break
+		}
 	}
 	// os.DirFS sorts by name; the glob walk's match cap depends on that order
 	// to truncate to the same prefix every time, so this arm has to match it
@@ -111,8 +133,8 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 	}
 	defer func() { _ = unix.Close(baseFd) }()
 
-	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
 	budget := newGlobBudget("glob")
+	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s, budget: budget}}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// Never list or read into a masked subtree while collecting
@@ -185,12 +207,13 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 	if err != nil {
 		return "", err
 	}
-	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
+	budget := newGlobBudget("grep")
+	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s, budget: budget}}
 	// Never list or read into a masked subtree while collecting .gitignore
 	// rules — see the matching comment in glob above.
 	ignores, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return s.underMasked(filepath.Join(canonical, relPath))
-	}, newGlobBudget("grep"))
+	}, budget)
 	if err != nil {
 		return "", err
 	}
@@ -200,7 +223,22 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 			return cancelErr
 		}
 		if walkErr != nil {
+			// A budget refusal ends the grep with its reason; skipping it the
+			// way an unreadable or symlink-refused entry is skipped would let
+			// the walk carry on past the bound it just hit.
+			if _, refused := errors.AsType[*globBudgetError](walkErr); refused {
+				return walkErr
+			}
 			return nil //nolint:nilerr // skip unreadable / symlink-refused entries and keep walking
+		}
+		if d.IsDir() {
+			// fs.WalkDir never follows a directory symlink, so this walk
+			// cannot cycle back into itself the way the glob pattern walk's
+			// ancestor check has to guard against — the same reason ignore
+			// discovery's own budget charge above is always cycleSafe.
+			if berr := budget.listing(true); berr != nil {
+				return berr
+			}
 		}
 		abs := filepath.Join(canonical, rel)
 		if s.underMasked(abs) {

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -91,14 +91,14 @@ func toFsErr(err error) error {
 //
 // Dotfiles/dirs and gitignored paths are excluded by default (matching the
 // off path's Glob), unless includeIgnored is set.
-func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool) ([]string, int, error) {
+func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool) ([]string, int, int, error) {
 	patterns, err := expandSearchPattern(pattern)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
 	baseFd, canonical, err := s.openReadBaseFd(tool, base)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
 	defer func() { _ = unix.Close(baseFd) }()
 
@@ -115,16 +115,17 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 	seen := make(map[string]struct{})
 	var abs []string
 	excluded := 0
+	budget := &globBudget{}
 	for _, pattern := range patterns {
-		matches, err := globMatches(ctx, fsys, pattern)
+		matches, err := globMatches(ctx, fsys, pattern, budget)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, 0, err
 		}
 		for _, m := range matches {
 			if !includeIgnored {
 				drop, err := globMatchExcluded(ctx, fsys, ignores, m)
 				if err != nil {
-					return nil, 0, err
+					return nil, 0, 0, err
 				}
 				if drop {
 					excluded++
@@ -143,9 +144,13 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 		}
 	}
 	if err := sortPathsByMtimeDesc(ctx, abs); err != nil {
-		return nil, 0, err
+		return nil, 0, 0, err
 	}
-	return abs, excluded, nil
+	truncatedAt := 0
+	if budget.full() {
+		truncatedAt = maxGlobMatches
+	}
+	return abs, excluded, truncatedAt, nil
 }
 
 // grepNative runs the native (ripgrep-absent) grep beneath a policy-checked base,

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -112,7 +112,7 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 	defer func() { _ = unix.Close(baseFd) }()
 
 	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
-	budget := &globBudget{}
+	budget := newGlobBudget("glob")
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// Never list or read into a masked subtree while collecting
@@ -190,7 +190,7 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 	// rules — see the matching comment in glob above.
 	ignores, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return s.underMasked(filepath.Join(canonical, relPath))
-	}, &globBudget{})
+	}, newGlobBudget("grep"))
 	if err != nil {
 		return "", err
 	}

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -55,7 +56,15 @@ func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	df := os.NewFile(uintptr(fd), name)
 	defer func() { _ = df.Close() }()
-	return df.ReadDir(-1)
+	entries, err := df.ReadDir(-1)
+	if err != nil {
+		return nil, err
+	}
+	// os.DirFS sorts by name; the glob walk's match cap depends on that order
+	// to truncate to the same prefix every time, so this arm has to match it
+	// rather than hand back whatever order the kernel gave the readdir call.
+	slices.SortFunc(entries, func(a, b fs.DirEntry) int { return strings.Compare(a.Name(), b.Name()) })
+	return entries, nil
 }
 
 func (f *secureDirFS) Stat(name string) (fs.FileInfo, error) {
@@ -103,19 +112,22 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 	defer func() { _ = unix.Close(baseFd) }()
 
 	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
+	budget := &globBudget{}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// Never list or read into a masked subtree while collecting
 		// .gitignore rules — secureDirFS enforces symlink-refusal and root
 		// confinement but not masking, so the skip must be supplied here.
-		ignores = loadIgnoreSet(fsys, func(relPath string) bool {
+		ignores, err = loadIgnoreSet(fsys, func(relPath string) bool {
 			return s.underMasked(filepath.Join(canonical, relPath))
-		})
+		}, budget)
+		if err != nil {
+			return nil, 0, 0, err
+		}
 	}
 	seen := make(map[string]struct{})
 	var abs []string
 	excluded := 0
-	budget := &globBudget{}
 	for _, pattern := range patterns {
 		matches, err := globMatches(ctx, fsys, pattern, budget)
 		if err != nil {
@@ -146,11 +158,7 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 	if err := sortPathsByMtimeDesc(ctx, abs); err != nil {
 		return nil, 0, 0, err
 	}
-	truncatedAt := 0
-	if budget.full() {
-		truncatedAt = maxGlobMatches
-	}
-	return abs, excluded, truncatedAt, nil
+	return abs, excluded, budget.truncatedAt(), nil
 }
 
 // grepNative runs the native (ripgrep-absent) grep beneath a policy-checked base,
@@ -180,9 +188,12 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
 	// Never list or read into a masked subtree while collecting .gitignore
 	// rules — see the matching comment in glob above.
-	ignores := loadIgnoreSet(fsys, func(relPath string) bool {
+	ignores, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return s.underMasked(filepath.Join(canonical, relPath))
-	})
+	}, &globBudget{})
+	if err != nil {
+		return "", err
+	}
 	excludedByIgnore := 0
 	err = secureBrowseWalkDir(fsys, ".", func(rel string, d fs.DirEntry, walkErr error) error {
 		if cancelErr := ctx.Err(); cancelErr != nil {

--- a/agent/execenv/securepath_edge_program_fuzz_test.go
+++ b/agent/execenv/securepath_edge_program_fuzz_test.go
@@ -302,7 +302,7 @@ func runSecurePathEdgeContractProgram(t *testing.T, program []byte) securePathEd
 
 	// secureDirFS rejects invalid virtual paths and invalid root fds with ordinary
 	// fs.PathError values rather than allowing a browse escape.
-	dirFS := &secureDirFS{baseFd: -1, basePath: worktree, fs: s, budget: newGlobBudget("glob")}
+	dirFS := &secureDirFS{baseFd: -1, basePath: worktree, fs: s, budget: newGlobBudget("glob"), ctx: t.Context()}
 	if _, err := dirFS.Open("../escape"); !errors.Is(err, fs.ErrInvalid) {
 		t.Fatalf("secureDirFS invalid Open = %v", err)
 	}

--- a/agent/execenv/securepath_edge_program_fuzz_test.go
+++ b/agent/execenv/securepath_edge_program_fuzz_test.go
@@ -336,10 +336,10 @@ func runSecurePathEdgeContractProgram(t *testing.T, program []byte) securePathEd
 	// Browsing preserves the same denied-base/error contracts as direct reads.
 	// A masked file, hidden file, and binary file are all absent from native grep,
 	// while a visible text hit remains discoverable.
-	if _, _, err := s.glob(t.Context(), "glob", filepath.Join(worktree, "missing-glob-base"), "*", false); err == nil {
+	if _, _, _, err := s.glob(t.Context(), "glob", filepath.Join(worktree, "missing-glob-base"), "*", false); err == nil {
 		t.Fatal("sandbox glob missing base unexpectedly succeeded")
 	}
-	if _, _, err := s.glob(t.Context(), "glob", worktree, "[", false); err == nil {
+	if _, _, _, err := s.glob(t.Context(), "glob", worktree, "[", false); err == nil {
 		t.Fatal("sandbox glob malformed pattern unexpectedly succeeded")
 	}
 	if _, err := s.grepNative(context.Background(), "[", worktree, "", false, 10, ""); err == nil {

--- a/agent/execenv/securepath_edge_program_fuzz_test.go
+++ b/agent/execenv/securepath_edge_program_fuzz_test.go
@@ -302,7 +302,7 @@ func runSecurePathEdgeContractProgram(t *testing.T, program []byte) securePathEd
 
 	// secureDirFS rejects invalid virtual paths and invalid root fds with ordinary
 	// fs.PathError values rather than allowing a browse escape.
-	dirFS := &secureDirFS{baseFd: -1, basePath: worktree, fs: s}
+	dirFS := &secureDirFS{baseFd: -1, basePath: worktree, fs: s, budget: newGlobBudget("glob")}
 	if _, err := dirFS.Open("../escape"); !errors.Is(err, fs.ErrInvalid) {
 		t.Fatalf("secureDirFS invalid Open = %v", err)
 	}

--- a/agent/execenv/securepath_other.go
+++ b/agent/execenv/securepath_other.go
@@ -79,8 +79,8 @@ func (s *sandboxFS) listDir(tool, abs string, depth int) ([]DirEntry, error) {
 	return nil, errSandboxUnsupported()
 }
 
-func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool) ([]string, int, error) {
-	return nil, 0, errSandboxUnsupported()
+func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool) ([]string, int, int, error) {
+	return nil, 0, 0, errSandboxUnsupported()
 }
 
 func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter string, caseInsensitive bool, maxResults int, outputMode string, contextLines ...int) (string, error) {

--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -238,22 +238,36 @@ func registerShellTools(reg *tool.Registry, s *Session, deps *toolDeps) error {
 			}
 			var matches []string
 			var excluded int
+			var truncatedAt int
 			var err error
 			if ge, ok := env.(execenv.GlobExcluder); ok {
-				matches, excluded, err = ge.GlobWithExclusions(ctx, pat, path, includeIgnored)
+				matches, excluded, truncatedAt, err = ge.GlobWithExclusions(ctx, pat, path, includeIgnored)
 			} else {
 				matches, err = env.Glob(ctx, pat, path, includeIgnored)
 			}
 			if err != nil {
 				return "", err
 			}
+			result := strings.Join(matches, "\n")
 			// Silent-empty is the enemy: a bare "" here is indistinguishable
 			// from "genuinely no matches" when it's actually "every match was
 			// filtered out by the default dotfile/gitignore exclusion" (D2).
 			if len(matches) == 0 && excluded > 0 {
-				return fmt.Sprintf("0 matches after excluding %d dotfile/gitignored path(s); set include_ignored to include them", excluded), nil
+				result = fmt.Sprintf("0 matches after excluding %d dotfile/gitignored path(s); set include_ignored to include them", excluded)
 			}
-			return strings.Join(matches, "\n"), nil
+			if truncatedAt > 0 {
+				// Silent truncation is the same enemy: the matches collected
+				// before the cap tripped look exactly like the whole answer,
+				// and a fully-excluded or fully-masked capped walk would
+				// otherwise report its emptiness as if the walk had finished.
+				note := fmt.Sprintf("The glob stopped after reaching its cap of %d matches; results may be incomplete. Narrow the pattern or point path at a smaller directory to see the rest.", truncatedAt)
+				if result == "" {
+					result = note
+				} else {
+					result += "\n\n" + note
+				}
+			}
+			return result, nil
 		},
 	}); err != nil {
 		return err

--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -260,7 +260,10 @@ func registerShellTools(reg *tool.Registry, s *Session, deps *toolDeps) error {
 				// before the cap tripped look exactly like the whole answer,
 				// and a fully-excluded or fully-masked capped walk would
 				// otherwise report its emptiness as if the walk had finished.
-				note := fmt.Sprintf("The glob stopped after reaching its cap of %d matches; results may be incomplete. Narrow the pattern or point path at a smaller directory to see the rest.", truncatedAt)
+				// The cap counts candidate matches, before the dotfile/
+				// gitignore exclusion above drops any of them, so the number
+				// of paths actually shown can be smaller than the cap itself.
+				note := fmt.Sprintf("The glob stopped after considering its cap of %d candidate matches; fewer may be shown above once excluded paths are dropped, and there may be more beyond the cap. Narrow the pattern or point path at a smaller directory to see the rest.", truncatedAt)
 				if result == "" {
 					result = note
 				} else {


### PR DESCRIPTION
## What was wrong

A `find_files` call with a `**` pattern rooted at `/` could exhaust memory and OOM-kill the agent process (#497). The walk *terminated* — the ancestor/SameFile cycle check added for #369 catches `/proc/<pid>/root` re-entering the tree — but nothing bounded what it spent getting there. Five separate holes, found in that order:

1. **The directory-listing budget was unreachable.** The only counter incremented inside `if !hasFileIdentity(info)`. Every file on ext4, APFS and HFS+ carries `(device, inode)` identity, so on the filesystems agents actually run on that branch was never taken.
2. **`globMatches` accumulated matches with no cap.** A `**` over `/` is millions of paths.
3. **The walk retained one `fs.FileInfo` per listed directory**, though the cycle check only consults *ancestors* of the directory being admitted.
4. **Ignore discovery was unbounded and ran first.** `loadIgnoreSet` walked the entire base collecting `.gitignore` rules before the first `globMatches` existed, so the default `include_ignored: false` traversed all of `/` before any bound applied. Native grep had the identical walk.
5. **Every listing materialized its whole directory before any bound was consulted.** `os.DirFS`'s `ReadDir` is `os.ReadDir`, and `secureDirFS` ended in `df.ReadDir(-1)`, so one directory holding millions of entries exhausted memory before the listing budget or match cap ever ran.

## What changed

A `globBudget`, created once per glob or grep call and shared across ignore discovery and every brace-expanded pattern, now bounds four things: directory listings (1,000,000 per call), matches (10,000 per call), entries materialized by a single listing (200,000), and entries held live at once across every listing the walk still has open (500,000, roughly 52 MB at ~105 bytes per entry). The last one matters because a per-directory cap does not bound a walk: `fs.WalkDir` and doublestar both keep an ancestor's entry slice alive while reading a child, so peak is otherwise the per-directory cap times depth. Release is free — to be listing a directory at all, the walk must have left every non-ancestor, which is the same rule the ancestor chain already uses. Listings are pulled in 4,096-entry chunks and charged after each one, so the walk stops instead of finishing and then complaining, and the chunk loop checks the context between chunks — `cancelFS` only sees a listing start, not the chunks inside it.

Refusals are a typed `globBudgetError` carrying the operation, the bound, the count, the offending directory, and whether the walk could have detected a symlink cycle at all, so callers and tests read fields rather than parse sentences. The advice names the lever that actually helps: a glob can narrow its pattern, a grep cannot, because its pattern is a regex applied after the walk has already listed everything.

`listed` became an ancestor chain pruned to the path being walked, so retention is O(depth) rather than O(listings). The chain is only a cache: an ancestor it does not hold is re-stat'ed, so a walk that jumps between subtrees still cannot miss a cycle. No configuration knobs were added.

## Caller-visible changes

- **Grep is budgeted on both arms** and can now fail where it used to return partial output. `grepWalk` and `secureBrowseWalkDir` were unbudgeted; both now charge the same budget their ignore discovery spends, and only for directories they actually descend into, not ones they skip.
- **A single directory over 200,000 entries now fails glob and grep outright**, naming that directory, rather than being read into memory.
- **A walk holding more than 500,000 entries live at once fails**, which a deep tree of large directories can reach even when no single directory is over the per-directory cap. A wide, flat repository is unaffected: the bound is on entries held simultaneously, not a cumulative count.
- **Ignore discovery can now fail a call.** It stays best-effort for I/O errors, but a budget refusal propagates: a partial ignoreSet reported as complete would silently under-exclude the rest of a huge tree.
- **Sandboxed listings are lexically sorted** where they came back in raw directory order, which changes sandboxed match order and grep visit order. `os.DirFS` already sorted; the two arms now agree, and the match cap truncates to the same prefix on both.
- The glob tool tells the model when the match cap cut a listing short, naming the cap and saying it counts *candidate* matches, before dotfile/gitignore exclusion drops any.
- `GlobExcluder.GlobWithExclusions` gained a fourth return, `truncatedAt`. `*LocalExecutionEnvironment` is its only implementation in this repo.

## How it is tested

Every bound was written test-first and each new test was confirmed failing for its stated reason before the fix. The tests assert *work done*, not just results — entries actually read, directory listings actually made, `peakDirEntries` — because a fix that reads a whole directory and then reports a refusal would satisfy a result-only assertion while still doing exactly the thing that OOMs. Sample first failures:

- `Glob over a 40-directory tree with a listing budget of 8 returned no error and 40 matches; the listing budget was not enforced`
- `walk retained 31 directory identities after listing 30 sibling directories`
- `Glob over a 30-entry directory with an entry budget of 10 = (...30 matches..., <nil>), want a *globBudgetError`
- `grepNative's own walk over a 30-directory tree with a listing budget of 40 = (_, <nil>), want a *globBudgetError`
- `listing kept reading after cancellation: read 40 of 40 entries in the directory, want at most 15`

Two guards cannot be reached by any static tree, because ignore discovery prunes a subset of what the walks prune and runs first over the same filesystem; probes force the concurrent-growth case by growing a directory inside a stubbed walk. Termination stays pinned by the #369 regression tests, and a characterization test proves the ancestor check still catches a cycle reached through a never-listed ancestor.

Gates run per round, all foreground: `gofmt`; `make vet` and `GOOS=windows make vet`; `go vet -tags evenerfuzz ./...`; `make lint-golangci`; `make lint-evenerfuzz lint-eval lint-gofmt lint-internal`; `go test -race` on `./agent/execenv/` and `./agent/`; `-tags evenerfuzz -run Fuzz` on both; and the full `go test ./agent/`.

Closes #497
Closes #938

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
