### PR TITLE
fix(web): preserve transcript text across page merges

### DIFF
--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -2512,6 +2512,76 @@ test("an even older omitted fragment does not erase an older provided text", () 
   expect(result.turns[0]?.items[0]?.text).toBe("A");
 });
 
+test.each([
+  ["omitted text recovers history", undefined, "settled"],
+  ["explicit empty text stays empty", "", ""],
+])("item/completed preserves text presence for later pagination: %s", (_case, text, expectedText) => {
+  let model = testHydrate({
+    turns: [
+      {
+        id: "shared-turn",
+        status: "inProgress",
+        itemsView: "fragment",
+        items: [
+          {
+            id: "item-1",
+            transcriptKey: "shared-key",
+            position: { entry: 2, item: 0 },
+            turnId: "shared-turn",
+            type: "agentMessage",
+          },
+        ],
+      },
+    ],
+  });
+  model = applyNotification(
+    model,
+    {
+      method: "item/completed",
+      params: {
+        threadId: "thr_t",
+        ref: "ref_t",
+        turnId: "shared-turn",
+        item: {
+          id: "item-1",
+          turnId: "shared-turn",
+          type: "agentMessage",
+          status: "completed",
+          ...(text === undefined ? {} : { text }),
+        },
+      },
+    },
+    1001,
+  );
+  expect(model.turns[0]?.items[0]).toMatchObject({
+    transcriptKey: "shared-key",
+    position: { entry: 2, item: 0 },
+    status: "completed",
+  });
+
+  const result = mergeOlderItemPage(model, {
+    data: [
+      {
+        id: "shared-turn",
+        status: "completed",
+        itemsView: "full",
+        items: [
+          {
+            id: "settled-item",
+            transcriptKey: "shared-key",
+            turnId: "shared-turn",
+            type: "agentMessage",
+            text: "settled",
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(result.turns[0]?.items).toHaveLength(1);
+  expect(result.turns[0]?.items[0]?.text).toBe(expectedText);
+});
+
 test("agent message delta clone preserves omitted text presence for later pagination", () => {
   let model = testHydrate({
     turns: [

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -2582,6 +2582,70 @@ test.each([
   expect(result.turns[0]?.items[0]?.text).toBe(expectedText);
 });
 
+for (const method of ["item/completed", "turn/completed"] as const) {
+  for (const chunks of [[], ["chunk-1", "chunk-2"]]) {
+    test.each([
+      ["omitted", undefined, `prefix${chunks.join("")}`],
+      ["explicit empty", "", ""],
+      ["explicit nonempty", "replacement", "replacement"],
+    ])(`${method} settles streamed text with ${chunks.length} pending chunks: %s`, (_case, text, expected) => {
+      let model = testHydrate({
+        turns: [
+          {
+            id: "shared-turn",
+            status: "inProgress",
+            itemsView: "full",
+            items: [
+              {
+                id: "item-1",
+                turnId: "shared-turn",
+                type: "agentMessage",
+                text: "prefix",
+                status: "inProgress",
+              },
+            ],
+          },
+        ],
+      });
+      expect(model.activeTurnId).toBe("shared-turn");
+      for (const delta of chunks) {
+        model = applyNotification(
+          model,
+          {
+            method: "item/agentMessage/delta",
+            params: { threadId: "thr_t", ref: "ref_t", turnId: "shared-turn", itemId: "item-1", delta },
+          },
+          1001,
+        );
+      }
+      const item: ThreadItem = {
+        id: "item-1",
+        turnId: "shared-turn",
+        type: "agentMessage",
+        status: "completed",
+        ...(text === undefined ? {} : { text }),
+      };
+      const params = { threadId: "thr_t", ref: "ref_t", turnId: "shared-turn" };
+      model = applyNotification(
+        model,
+        method === "item/completed"
+          ? { method, params: { ...params, item } }
+          : {
+              method,
+              params: {
+                ...params,
+                turn: { id: "shared-turn", status: "completed", itemsView: "full", items: [item] },
+              },
+            },
+        1002,
+      );
+      expect(model.turns[0]?.items[0]?.text).toBe(expected);
+      expect(model.turns[0]?.items[0]?.pendingText).toBeUndefined();
+      expect(model.turns[0]?.items[0]?.status).toBe("completed");
+    });
+  }
+}
+
 test("agent message delta clone preserves omitted text presence for later pagination", () => {
   let model = testHydrate({
     turns: [

--- a/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.test.ts
@@ -2336,6 +2336,277 @@ test("mergeOlderItemPage preserves older settled payload and usage when the curr
   });
 });
 
+test.each([
+  ["omitted text falls back to the older settled text", undefined, "settled text"],
+  ["explicit empty text remains empty", "", ""],
+  ["explicit nonempty text remains the newer text", "newer text", "newer text"],
+])("mergeOlderItemPage preserves same-key text presence semantics: %s", (_case, newerText, expectedText) => {
+  const model = hydrateThread(
+    {
+      thread: testThread({
+        turns: [
+          {
+            id: "shared-turn",
+            status: "completed",
+            itemsView: "fragment",
+            items: [
+              {
+                id: "newer-item",
+                transcriptKey: "shared-key",
+                position: { entry: 2, item: 0 },
+                turnId: "shared-turn",
+                type: "agentMessage",
+                ...(newerText === undefined ? {} : { text: newerText }),
+                status: "completed",
+              },
+              {
+                id: "newer-after",
+                transcriptKey: "after-key",
+                position: { entry: 2, item: 1 },
+                turnId: "shared-turn",
+                type: "agentMessage",
+                text: "after",
+                status: "completed",
+              },
+            ],
+          },
+        ],
+      }),
+    },
+    "ref_t",
+    1000,
+  );
+
+  const result = mergeOlderItemPage(model, {
+    data: [
+      {
+        id: "shared-turn",
+        status: "completed",
+        itemsView: "full",
+        items: [
+          {
+            id: "settled-item",
+            transcriptKey: "shared-key",
+            position: { entry: 2, item: 0 },
+            turnId: "shared-turn",
+            type: "agentMessage",
+            text: "settled text",
+            output: "settled output",
+            status: "completed",
+          },
+        ],
+      },
+    ],
+    nextCursor: "cursor_0",
+  });
+
+  expect(result.turns[0]?.items.map((item) => item.transcriptKey)).toEqual(["shared-key", "after-key"]);
+  expect(result.turns[0]?.items[0]).toMatchObject({
+    id: "newer-item",
+    text: expectedText,
+    output: "settled output",
+    position: { entry: 2, item: 0 },
+  });
+  expect(result.olderCursor).toBe("cursor_0");
+});
+
+test("mergeOlderItemPage keeps omitted text absent across repeated same-key merges", () => {
+  const model = hydrateThread(
+    {
+      thread: testThread({
+        turns: [
+          {
+            id: "shared-turn",
+            status: "completed",
+            itemsView: "fragment",
+            items: [{ id: "newer-item", transcriptKey: "shared-key", turnId: "shared-turn", type: "agentMessage" }],
+          },
+        ],
+      }),
+    },
+    "ref_t",
+    1000,
+  );
+  const page = {
+    data: [
+      {
+        id: "shared-turn",
+        status: "completed" as const,
+        itemsView: "full" as const,
+        items: [
+          {
+            id: "settled-item",
+            transcriptKey: "shared-key",
+            turnId: "shared-turn",
+            type: "agentMessage" as const,
+            text: "settled text",
+            status: "completed" as const,
+          },
+        ],
+      },
+    ],
+    nextCursor: "cursor_0",
+  };
+
+  const first = mergeOlderItemPage(model, page);
+  const second = mergeOlderItemPage(first, page);
+
+  expect(first.turns[0]?.items[0]?.text).toBe("settled text");
+  expect(second.turns[0]?.items[0]?.text).toBe("settled text");
+  expect(second.turns[0]?.items).toHaveLength(1);
+});
+
+test("an even older omitted fragment does not erase an older provided text", () => {
+  const model = hydrateThread(
+    {
+      thread: testThread({
+        turns: [
+          {
+            id: "shared-turn",
+            status: "completed",
+            itemsView: "fragment",
+            items: [{ id: "newer-item", transcriptKey: "shared-key", turnId: "shared-turn", type: "agentMessage" }],
+          },
+        ],
+      }),
+    },
+    "ref_t",
+    1000,
+  );
+  const provided = mergeOlderItemPage(model, {
+    data: [
+      {
+        id: "shared-turn",
+        status: "completed",
+        itemsView: "full",
+        items: [
+          {
+            id: "provided-item",
+            transcriptKey: "shared-key",
+            turnId: "shared-turn",
+            type: "agentMessage",
+            text: "A",
+          },
+        ],
+      },
+    ],
+  });
+  const result = mergeOlderItemPage(provided, {
+    data: [
+      {
+        id: "shared-turn",
+        status: "completed",
+        itemsView: "fragment",
+        items: [
+          {
+            id: "omitted-item",
+            transcriptKey: "shared-key",
+            turnId: "shared-turn",
+            type: "agentMessage",
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(result.turns[0]?.items[0]?.text).toBe("A");
+});
+
+test("agent message delta clone preserves omitted text presence for later pagination", () => {
+  let model = testHydrate({
+    turns: [
+      {
+        id: "shared-turn",
+        status: "inProgress",
+        itemsView: "fragment",
+        items: [{ id: "item-1", transcriptKey: "shared-key", turnId: "shared-turn", type: "agentMessage" }],
+      },
+    ],
+  });
+  model = applyNotification(
+    model,
+    {
+      method: "item/agentMessage/delta",
+      params: { threadId: "thr_t", ref: "ref_t", turnId: "shared-turn", itemId: "item-1", delta: "chunk" },
+    },
+    1001,
+  );
+  const result = mergeOlderItemPage(model, {
+    data: [
+      {
+        id: "shared-turn",
+        status: "completed",
+        itemsView: "full",
+        items: [
+          {
+            id: "settled-item",
+            transcriptKey: "shared-key",
+            turnId: "shared-turn",
+            type: "agentMessage",
+            text: "settled",
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(result.turns[0]?.items[0]?.text).toBe("settled");
+});
+
+test("settling nonempty pending text marks its fresh text as provided", () => {
+  let model = testHydrate({
+    turns: [
+      {
+        id: "shared-turn",
+        status: "inProgress",
+        itemsView: "fragment",
+        items: [{ id: "item-1", transcriptKey: "shared-key", turnId: "shared-turn", type: "agentMessage" }],
+      },
+    ],
+  });
+  model = applyNotification(
+    model,
+    {
+      method: "item/agentMessage/delta",
+      params: { threadId: "thr_t", ref: "ref_t", turnId: "shared-turn", itemId: "item-1", delta: "live" },
+    },
+    1001,
+  );
+  model = applyNotification(
+    model,
+    {
+      method: "turn/completed",
+      params: {
+        threadId: "thr_t",
+        ref: "ref_t",
+        turnId: "shared-turn",
+        turn: { id: "shared-turn", status: "completed", itemsView: "" },
+      },
+    },
+    1002,
+  );
+  const result = mergeOlderItemPage(model, {
+    data: [
+      {
+        id: "shared-turn",
+        status: "completed",
+        itemsView: "full",
+        items: [
+          {
+            id: "settled-item",
+            transcriptKey: "shared-key",
+            turnId: "shared-turn",
+            type: "agentMessage",
+            text: "historical",
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(result.turns[0]?.items[0]?.text).toBe("live");
+});
+
 test("mergeOlderItemPage retains the older status when an equal-rank newer item omits status", () => {
   const thread = testThread({
     turns: [

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -590,13 +590,13 @@ function mergePageItem(older: ItemModel, newer: ItemModel): ItemModel {
 
 function mergeItemIdentityMetadata(existing: ItemModel, incoming: ItemModel): ItemModel {
   const transcriptKey = incoming.transcriptKey || existing.transcriptKey;
-  return {
+  return copyItemTextPresence(incoming, {
     ...incoming,
     ...(transcriptKey ? { transcriptKey } : {}),
     ...(incoming.position !== undefined || existing.position !== undefined
       ? { position: incoming.position ?? existing.position }
       : {}),
-  };
+  });
 }
 
 function itemIdentityMatches(left: ItemModel, right: ItemModel): boolean {

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -335,6 +335,24 @@ function outputImagesToItemImages(images: OutputImage[] | undefined): ItemImage[
 // live in-flight chunks accumulated via item/reasoning/summaryTextDelta are
 // preserved separately by the item/completed and turn/completed handlers
 // (mergeReasoning), since they are more complete than this seed.
+const ITEM_TEXT_PRESENCE = Symbol("itemTextPresence");
+type ItemTextPresence = "omitted" | "provided";
+type InternalItemModel = ItemModel & { [ITEM_TEXT_PRESENCE]?: ItemTextPresence };
+
+function setItemTextPresence(item: ItemModel, presence: ItemTextPresence): ItemModel {
+  Object.defineProperty(item, ITEM_TEXT_PRESENCE, { value: presence, enumerable: false, configurable: true });
+  return item;
+}
+
+function copyItemTextPresence(source: ItemModel, target: ItemModel): ItemModel {
+  const presence = (source as InternalItemModel)[ITEM_TEXT_PRESENCE];
+  return presence === undefined ? target : setItemTextPresence(target, presence);
+}
+
+function itemTextPresence(item: ItemModel): ItemTextPresence {
+  return (item as InternalItemModel)[ITEM_TEXT_PRESENCE] ?? "provided";
+}
+
 function wireItemToModel(item: ThreadItem): ItemModel {
   const model: ItemModel & { clientMutationId?: string } = {
     id: item.id,
@@ -359,6 +377,7 @@ function wireItemToModel(item: ThreadItem): ItemModel {
     startedAt: epochMsToISO(item.startedAt),
     completedAt: epochMsToISO(item.completedAt),
   };
+  setItemTextPresence(model, item.text === undefined ? "omitted" : "provided");
   if (item.transcriptKey !== undefined) model.transcriptKey = item.transcriptKey;
   if (item.position !== undefined) model.position = { ...item.position };
   // Set only when the wire carried one (like clientMutationId below, and
@@ -379,7 +398,7 @@ function wireItemToModel(item: ThreadItem): ItemModel {
 // seeded from the settled wire item's own (usually empty) text.
 function mergeReasoning(settled: ItemModel, existing: ItemModel | undefined): ItemModel {
   if (existing?.reasoningSummaries) {
-    return { ...settled, reasoningSummaries: existing.reasoningSummaries };
+    return copyItemTextPresence(settled, { ...settled, reasoningSummaries: existing.reasoningSummaries });
   }
   return settled;
 }
@@ -394,11 +413,11 @@ function mergeReasoning(settled: ItemModel, existing: ItemModel | undefined): It
 // only ever from the now argument, never a clock read).
 function mergeObservedTiming(settled: ItemModel, existing: ItemModel | undefined, now: number): ItemModel {
   if (existing?.observedStartedAt === undefined) return settled;
-  return {
+  return copyItemTextPresence(settled, {
     ...settled,
     observedStartedAt: existing.observedStartedAt,
     observedCompletedAt: existing.observedCompletedAt ?? epochMsToISO(now),
-  };
+  });
 }
 
 // The live tool-settle site drops ArgumentsJSON: EventToolCallEnd
@@ -414,7 +433,7 @@ function mergeObservedTiming(settled: ItemModel, existing: ItemModel | undefined
 function mergeArguments(settled: ItemModel, existing: ItemModel | undefined): ItemModel {
   if (settled.argumentsJSON !== undefined) return settled;
   if (existing?.argumentsJSON === undefined) return settled;
-  return { ...settled, argumentsJSON: existing.argumentsJSON };
+  return copyItemTextPresence(settled, { ...settled, argumentsJSON: existing.argumentsJSON });
 }
 
 // Folds a PRESERVED item (one carried over from before settlement, not
@@ -438,13 +457,14 @@ function settleItem(item: ItemModel, now: number): ItemModel {
   const stale = item.status === "inProgress";
   const needsObservedCompletion = item.observedStartedAt !== undefined && item.observedCompletedAt === undefined;
   if (pending === undefined && !stale && !needsObservedCompletion) return item;
-  return {
+  const settled = copyItemTextPresence(item, {
     ...item,
     text: pending === undefined ? item.text : item.text + pendingTextJoined(pending),
     pendingText: undefined,
     status: stale ? "completed" : item.status,
     observedCompletedAt: needsObservedCompletion ? epochMsToISO(now) : item.observedCompletedAt,
-  };
+  });
+  return pending === undefined ? settled : setItemTextPresence(settled, "provided");
 }
 
 // The turn-level (non-items) fields wireToTurnModel maps — split out so the
@@ -504,17 +524,19 @@ function mergeToolCallsByCallId(turns: TurnModel[]): TurnModel[] {
       if (item.callId && isToolCallId(item.id)) {
         const result = resultByCallId.get(item.callId);
         if (result) {
-          items.push({
-            ...item,
-            output: result.output,
-            error: result.error,
-            prevalOnly: result.prevalOnly,
-            exitCode: result.exitCode,
-            completedAt: result.completedAt,
-            status: result.status,
-            outputImages: result.outputImages ?? item.outputImages,
-            raw: result.raw ?? item.raw,
-          });
+          items.push(
+            copyItemTextPresence(item, {
+              ...item,
+              output: result.output,
+              error: result.error,
+              prevalOnly: result.prevalOnly,
+              exitCode: result.exitCode,
+              completedAt: result.completedAt,
+              status: result.status,
+              outputImages: result.outputImages ?? item.outputImages,
+              raw: result.raw ?? item.raw,
+            }),
+          );
           continue;
         }
       }
@@ -532,34 +554,38 @@ const statusRank: Record<string, number> = {
 };
 
 function mergePageItem(older: ItemModel, newer: ItemModel): ItemModel {
-  return mergeItemIdentityMetadata(older, {
-    ...older,
-    ...newer,
-    text: newer.text ?? older.text,
-    toolName: newer.toolName ?? older.toolName,
-    callId: newer.callId ?? older.callId,
-    argumentsJSON: newer.argumentsJSON ?? older.argumentsJSON,
-    description: newer.description ?? older.description,
-    eventKind: newer.eventKind ?? older.eventKind,
-    steeringKind: newer.steeringKind ?? older.steeringKind,
-    raw: newer.raw ?? older.raw,
-    output: newer.output ?? older.output,
-    error: newer.error ?? older.error,
-    prevalOnly: newer.prevalOnly ?? older.prevalOnly,
-    exitCode: newer.exitCode ?? older.exitCode,
-    images: newer.images ?? older.images,
-    outputImages: newer.outputImages ?? older.outputImages,
-    source: newer.source ?? older.source,
-    reasoningSummaries: newer.reasoningSummaries ?? older.reasoningSummaries,
-    startedAt: newer.startedAt ?? older.startedAt,
-    completedAt: newer.completedAt ?? older.completedAt,
-    observedStartedAt: newer.observedStartedAt ?? older.observedStartedAt,
-    observedCompletedAt: newer.observedCompletedAt ?? older.observedCompletedAt,
-    status:
-      newer.status === undefined || (statusRank[newer.status] ?? 0) < (statusRank[older.status ?? ""] ?? 0)
-        ? older.status
-        : newer.status,
-  });
+  const textSource = itemTextPresence(newer) === "omitted" && itemTextPresence(older) === "provided" ? older : newer;
+  return copyItemTextPresence(
+    textSource,
+    mergeItemIdentityMetadata(older, {
+      ...older,
+      ...newer,
+      text: textSource.text,
+      toolName: newer.toolName ?? older.toolName,
+      callId: newer.callId ?? older.callId,
+      argumentsJSON: newer.argumentsJSON ?? older.argumentsJSON,
+      description: newer.description ?? older.description,
+      eventKind: newer.eventKind ?? older.eventKind,
+      steeringKind: newer.steeringKind ?? older.steeringKind,
+      raw: newer.raw ?? older.raw,
+      output: newer.output ?? older.output,
+      error: newer.error ?? older.error,
+      prevalOnly: newer.prevalOnly ?? older.prevalOnly,
+      exitCode: newer.exitCode ?? older.exitCode,
+      images: newer.images ?? older.images,
+      outputImages: newer.outputImages ?? older.outputImages,
+      source: newer.source ?? older.source,
+      reasoningSummaries: newer.reasoningSummaries ?? older.reasoningSummaries,
+      startedAt: newer.startedAt ?? older.startedAt,
+      completedAt: newer.completedAt ?? older.completedAt,
+      observedStartedAt: newer.observedStartedAt ?? older.observedStartedAt,
+      observedCompletedAt: newer.observedCompletedAt ?? older.observedCompletedAt,
+      status:
+        newer.status === undefined || (statusRank[newer.status] ?? 0) < (statusRank[older.status ?? ""] ?? 0)
+          ? older.status
+          : newer.status,
+    }),
+  );
 }
 
 function mergeItemIdentityMetadata(existing: ItemModel, incoming: ItemModel): ItemModel {
@@ -947,7 +973,11 @@ function appendReasoningDelta(item: ItemModel, summaryIndex: number, delta: stri
   while (summaries.length <= summaryIndex) summaries.push([]);
   const chunks = summaries[summaryIndex] ?? [];
   summaries[summaryIndex] = appendChunk(chunks, delta);
-  return { ...item, reasoningSummaries: summaries, observedStartedAt: item.observedStartedAt ?? epochMsToISO(now) };
+  return copyItemTextPresence(item, {
+    ...item,
+    reasoningSummaries: summaries,
+    observedStartedAt: item.observedStartedAt ?? epochMsToISO(now),
+  });
 }
 
 // Appends `incoming` to pendingEscalations, or — if an entry with the same
@@ -1144,11 +1174,13 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
         ...model,
         turns: mapTurn(model.turns, targetTurnId, (turn) => ({
           ...turn,
-          items: mapItem(turn.items, params.itemId, (item) => ({
-            ...item,
-            // O(1) — see appendChunk's doc comment.
-            pendingText: appendChunk(item.pendingText, params.delta),
-          })),
+          items: mapItem(turn.items, params.itemId, (item) =>
+            copyItemTextPresence(item, {
+              ...item,
+              // O(1) — see appendChunk's doc comment.
+              pendingText: appendChunk(item.pendingText, params.delta),
+            }),
+          ),
         })),
         lastFrameAt: now,
       };
@@ -1195,10 +1227,12 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
         ...model,
         turns: mapTurn(model.turns, targetTurnId, (turn) => ({
           ...turn,
-          items: mapItem(turn.items, params.itemId, (item) => ({
-            ...item,
-            output: (item.output ?? "") + params.delta,
-          })),
+          items: mapItem(turn.items, params.itemId, (item) =>
+            copyItemTextPresence(item, {
+              ...item,
+              output: (item.output ?? "") + params.delta,
+            }),
+          ),
         })),
         lastFrameAt: now,
       };

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -403,6 +403,18 @@ function mergeReasoning(settled: ItemModel, existing: ItemModel | undefined): It
   return settled;
 }
 
+// Omission is not a replacement: finalize the text already observed locally.
+// Explicit wire text, including empty text, remains authoritative.
+function mergeCompletedText(settled: ItemModel, existing: ItemModel | undefined): ItemModel {
+  if (!existing || itemTextPresence(settled) === "provided") return settled;
+  const pending = existing.pendingText;
+  const merged = copyItemTextPresence(existing, {
+    ...settled,
+    text: existing.text + (pending === undefined ? "" : pendingTextJoined(pending)),
+  });
+  return pending === undefined ? merged : setItemTextPresence(merged, "provided");
+}
+
 // item/completed's settled wire item never carries observedStartedAt/
 // observedCompletedAt — those are model-only client observations (see
 // ItemModel's doc comment in model.ts), never present on a wire ThreadItem,
@@ -1064,8 +1076,8 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
       let settledTurn: TurnModel;
       if (stamp.itemsView === "full") {
         settledTurn = wireToTurnModel(stamp);
-        // Same three-helper composition as item/completed's existing-item
-        // branch below (mergeReasoning/mergeArguments/mergeObservedTiming
+        // Same helper composition as item/completed's existing-item branch
+        // below (mergeCompletedText/mergeReasoning/mergeArguments/mergeObservedTiming
         // read/write disjoint fields off the same `old` reference, so
         // composition order is free) — this branch has its own settled
         // items rather than item/completed's single one, so it maps instead
@@ -1073,7 +1085,11 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
         settledTurn.items = settledTurn.items.map((item) => {
           const old = oldTurn?.items.find((o) => itemIdentityMatches(o, item));
           const identitySettled = old ? mergeItemIdentityMetadata(old, item) : item;
-          return mergeObservedTiming(mergeArguments(mergeReasoning(identitySettled, old), old), old, now);
+          return mergeObservedTiming(
+            mergeArguments(mergeReasoning(mergeCompletedText(identitySettled, old), old), old),
+            old,
+            now,
+          );
         });
       } else {
         // The live wire's settle stamp never carries items — every live
@@ -1136,7 +1152,10 @@ function applyNotificationToThread(model: ThreadModel, n: AnyNotification, now: 
             ...turn,
             items: mapItemByIdentity(turn.items, incoming, (old) =>
               mergeObservedTiming(
-                mergeArguments(mergeReasoning(mergeItemIdentityMetadata(old, incoming), old), old),
+                mergeArguments(
+                  mergeReasoning(mergeCompletedText(mergeItemIdentityMetadata(old, incoming), old), old),
+                  old,
+                ),
                 old,
                 now,
               ),


### PR DESCRIPTION
## Summary
Follow-up to merged #822, kept separate as requested.

- Preserve settled item text when a newer page fragment omits text, while honoring explicit empty text.
- Carry text-presence metadata through reducer clones and repeated older-page merges.
- Keep materialized live text authoritative after settlement.

## Verification
- 151 focused reducer tests passed, including seven independently replayed regression sequences.
- Typecheck and touched-file Biome passed.
- `make test-web` passed.
- `make test-web-browser` passed all five guards.
- Independent scoped review approved; integrated blobs exactly match the reviewed implementation.

Only two frontend reducer files change. Backend admission/cursor fixes and issue #922 are separate.
