### PR TITLE
agent: claim the child for the whole committed attention start

### DIFF
--- a/agent/delegate_resource_supervision_test.go
+++ b/agent/delegate_resource_supervision_test.go
@@ -144,6 +144,77 @@ func TestDelegateResourceSupervision_AttentionFollowUpRequiresReport(t *testing.
 	}
 }
 
+// TestDelegateResourceSupervision_CommittedAttentionStartRefusesASecondTurn
+// pins the attention start hand-off. Between the committed start and the run
+// goroutine that takes the generation over, sub.running is still false, the
+// reservation is consumed, and the attention id is no longer pending -- so a
+// wake-edge drive arriving in that gap declines the attention drive (nothing
+// left to dispatch) and falls through to driveSubagentNotificationTurn, which
+// reads the child as idle and launches a second, UNLEASED EntryNotification
+// turn on the very session the generation is about to run.
+//
+// The two turns then share one session: whichever reaches its drain ladder
+// first pops the follow-up the attention turn queued, and when that is the
+// unleased turn the run never admits report-requiring work. The generation
+// settles attention-only/no-action instead of report-required, which is the
+// load-sensitive failure this pins:
+//
+//	attention follow-up evidence = {requirement:0x0 outcome:0x1 terminalSeen:false}
+func TestDelegateResourceSupervision_CommittedAttentionStartRefusesASecondTurn(t *testing.T) {
+	fixture := newColdStableDelegateFixture(t, "")
+	bare := func(llm.Request) llm.Response {
+		return llm.Response{Message: llm.Assistant("bare without communicate")}
+	}
+	var root *Session
+	fixture.adapter.steps = []func(llm.Request) llm.Response{
+		func(llm.Request) llm.Response { return finalResponse("warm result") },
+		func(llm.Request) llm.Response {
+			root.subagents.get(fixture.childID).sess.FollowUp("queued follow-up work")
+			return llm.Response{Message: llm.Assistant("attention requires no action")}
+		},
+		bare, bare, bare, bare,
+		func(llm.Request) llm.Response { return finalResponse("follow-up report") },
+	}
+	root = restoreSupervisionRoot(t, fixture, nil)
+	sub := warmStableSupervisionDelegate(t, root, fixture)
+	snapshots := make(chan delegateCompletionSnapshot, 1)
+	updateSessionTestConfig(sub.sess, func(cfg *testConfig) {
+		cfg.subagentBeforeSettlement = captureStableCompletionSnapshot(snapshots)
+	})
+	var handoffMu sync.Mutex
+	var handoffSeen, secondTurnLaunched bool
+	updateSessionTestConfig(root, func(cfg *testConfig) {
+		cfg.delegateAttentionStartCommitted = func(committed *subagent) {
+			launched := root.driveSubagentNotificationTurn(committed)
+			handoffMu.Lock()
+			defer handoffMu.Unlock()
+			if handoffSeen {
+				return
+			}
+			handoffSeen, secondTurnLaunched = true, launched
+		}
+	})
+	armStableSupervisionAttention(t, sub, "attention:committed-start", "inspect before follow-up")
+	waitForStableSupervisionRun(t, root, fixture.childID)
+
+	handoffMu.Lock()
+	seen, launched := handoffSeen, secondTurnLaunched
+	handoffMu.Unlock()
+	if !seen {
+		t.Fatal("the committed attention start hand-off was never observed")
+	}
+	if launched {
+		t.Fatal("a committed attention start left the child drivable as a plain notification turn")
+	}
+	snapshot := <-snapshots
+	if snapshot.requirement != delegateCompletionReportRequired || !snapshot.terminalSeen {
+		t.Fatalf("committed-start attention evidence = %#v, want report-required terminal", snapshot)
+	}
+	if got := supervisionRequestCount(fixture.adapter); got != 7 {
+		t.Fatalf("provider requests = %d, want warm, attention, four follow-up attempts, and recovery report", got)
+	}
+}
+
 func TestDelegateResourceSupervision_AttentionGoalContinuationRequiresReport(t *testing.T) {
 	fixture := newColdStableDelegateFixture(t, "")
 	bare := func(llm.Request) llm.Response {

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -336,12 +336,38 @@ func (s *Session) driveStableDelegateAttention(sub *subagent) bool {
 	if len(ids) == 0 {
 		return false
 	}
+	// Claim the child for the WHOLE start, not just for this check. Everything
+	// between here and launchAcceptedDelegateAttention is durable work
+	// (ReserveAttention, acceptDelegateAttention's transcript append,
+	// CommitStart, the delegate update emit), and the run goroutine only sets
+	// running at the far end of it. Without the claim a wake-edge drive landing
+	// in that gap reads an idle child: the reservation is already consumed and
+	// the attention is no longer pending, so driveStableDelegateAttention itself
+	// declines, and driveChildIfNotStopGated falls through to
+	// driveSubagentNotificationTurn, which starts a second, UNLEASED turn on the
+	// session this generation is about to run. The two turns then share one
+	// drain ladder and the unleased one can pop the run's follow-up, leaving the
+	// generation to settle attention-only instead of report-required. The claim
+	// is the drive flag every other guard already reads, and it is handed over
+	// under the same sub.mu hold that sets running.
 	sub.mu.Lock()
 	blocked := sub.closed || sub.running || sub.driving || sub.disposeGated || sub.fatalRunGated || sub.finalizing
+	if !blocked {
+		sub.driving = true
+	}
 	sub.mu.Unlock()
 	if blocked {
 		return true
 	}
+	launched := false
+	defer func() {
+		if launched {
+			return
+		}
+		sub.mu.Lock()
+		sub.driving = false
+		sub.mu.Unlock()
+	}()
 	s.mu.Lock()
 	closed := s.closingOrClosedLocked()
 	s.mu.Unlock()
@@ -367,8 +393,13 @@ func (s *Session) driveStableDelegateAttention(sub *subagent) bool {
 		s.delegateController.retryDelegateAttentionLater()
 		return true
 	}
+	if observer := s.cfg.testOnly.delegateAttentionStartCommitted; observer != nil {
+		observer(sub)
+	}
 	s.delegateController.emitDelegateUpdate(started.plan)
-	if launchErr := s.launchAcceptedDelegateAttention(sub, started); launchErr != nil {
+	launchErr := s.launchAcceptedDelegateAttention(sub, started)
+	launched = launchErr == nil
+	if launchErr != nil {
 		plans, finishErr := s.delegateController.FailCommittedRestart(started.lease, delegatePermanentStartFailure(launchErr, "launch_failed"))
 		if executeErr := s.executeDelegateMutationPlans(plans); finishErr == nil {
 			finishErr = executeErr
@@ -395,6 +426,12 @@ func (s *Session) launchAcceptedDelegateAttention(sub *subagent, started delegat
 	sub.mu.Lock()
 	sub.fatalRunGated = false
 	resetSubagentForRunLocked(sub, runCancel, started.startedAt)
+	// Hand the start claim over to the run under one hold, so the child never
+	// reads idle between the committed start and the run that owns it. The
+	// clear is unconditional: the owed-attention bootstrap reaches here
+	// without having taken the claim, and clearing a flag it never set is
+	// harmless because running is already true under this same hold.
+	sub.driving = false
 	sub.mu.Unlock()
 	bindStableDelegateActivity(sub.sess, s.delegateController, started.lease)
 	s.launchSubagentRun(runCtx, sub, runCancel, "", descriptorProvenance(started.descriptor))

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -330,6 +330,10 @@ type testConfig struct {
 	// subagentBeforeSettlement observes the final unlocked boundary before a
 	// stable generation enters controller settlement.
 	subagentBeforeSettlement func(*subagent)
+	// delegateAttentionStartCommitted observes the start hand-off: the attention
+	// generation is committed and its run goroutine does not exist yet. Tests use
+	// it to drive the child from a second goroutine at exactly that point.
+	delegateAttentionStartCommitted func(*subagent)
 	// subagentAfterFinalStatePublish observes the interval after a retained child
 	// publishes terminal state and before it restores its parent notify callback.
 	subagentAfterFinalStatePublish func(*subagent)

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -109,7 +109,7 @@ type subagent struct {
 	stableDescriptor      *delegatestore.Descriptor // immutable committed identity/config for stable terminal evidence
 	closed                bool                      // session torn down; record retained as terminal history
 	closeTimedOut         bool                      // session-close wait exceeded its bound; close not confirmed
-	driving               bool                      // a drive-down notification turn (§3) is in flight on this idle child
+	driving               bool                      // a drive-down notification turn (§3), or a committed delegate start not yet handed to its run, is in flight on this idle child
 	fatalRunGated         bool                      // terminal run error freezes automatic drives until an explicit resume
 	finalizing            bool                      // the run accepts no input while owned work drains and terminal state/notify ownership are handed off
 	// disposeGated freezes a quiescent, retained TERMINAL child while a dispose op

--- a/docs/superpowers/specs/2026-06-13-recursion-validation-fixes.md
+++ b/docs/superpowers/specs/2026-06-13-recursion-validation-fixes.md
@@ -155,6 +155,13 @@ gate, and the whole-campaign sweep re-runs after the pass.
 - **Test (red, `-race`):** launch a drive turn, concurrently call
   `startOrSteerSubagentRun`; assert no second `ProcessInputKind` starts
   concurrently (no data race).
+- **Amendment (2026-09-06):** `sub.driving` also covers a committed delegate
+  attention start until its run takes ownership: `driveStableDelegateAttention`
+  takes the claim with its drivability check and holds it across the durable
+  start, released under the same hold that sets `running`, so a wake-edge
+  drive landing in that window steers or waits instead of launching a second,
+  unleased turn on the child (the once-seen
+  `TestDelegateResourceSupervision_AttentionFollowUpRequiresReport` flake).
 
 ### F1 [USABILITY, text-only] — allowance>0 on a non-delegating role silently accepted
 - **Symptom:** `delegate(agent_type:"subagent", delegation_allowance:1)` is


### PR DESCRIPTION
Fixes the load-dependent failure of `TestDelegateResourceSupervision_AttentionFollowUpRequiresReport` seen once during the PR #879 review, which turned out to be a real production race in the delegate attention start.

## The race

`driveStableDelegateAttention` checked whether the child was drivable, released that check, and then ran a long durable start (reserve the attention, append it to the child transcript, `CommitStart`, emit the update) before the run goroutine existed. Between `CommitStart` and `resetSubagentForRunLocked` the child read idle to every guard: `sub.running` was still false, the reservation had been consumed, and the attention id was already resolved in the child transcript. A wake-edge drive landing in that gap found nothing to dispatch and fell through `driveChildIfNotStopGated` to `driveSubagentNotificationTurn`, which launched a second, unleased `EntryNotification` turn on the very session the committed generation was about to run.

Two turns then shared one drain ladder, and `popFollowUp` is a destructive pop with no owner check. When the unleased turn won, it ran the queued follow-up as its own turn with no run lease in its context, so the completion requirement was never escalated; the attention run's own ladder found nothing to drain and settled the generation as attention-only/no-action, the reported snapshot verbatim. Load widens the gap (it is durable I/O plus an event emit) and decides which turn reaches the ladder first, which is why a saturated `make test` saw it once and 2,340 plain repetitions never did. One `notify()` injected into the gap reproduces it on the first try.

## The fix

Take the child's drive claim (`sub.driving`) atomically with the `blocked` check and hold it across the whole start: released on every pre-launch failure, and on success handed to the run inside `launchAcceptedDelegateAttention` under the same `sub.mu` hold that sets `running`, so the child is never momentarily idle. `sub.driving` is the flag every other guard already reads as "a turn is in flight on this idle child", so there is no new field and no new guard site.

## Tests

`TestDelegateResourceSupervision_CommittedAttentionStartRefusesASecondTurn`: the flaky scenario plus a `driveSubagentNotificationTurn` driven from a new test seam (`testConfig.delegateAttentionStartCommitted`) at the hand-off point. Before the fix it fails on "a committed attention start left the child drivable as a plain notification turn" and, with that assertion muted, on the exact reported snapshot. After the fix, the pair of tests passed 400 runs and 80 under the race detector; the whole `agent` package passed four times.

## Left out on purpose

The same committed-start gap exists on the `delegateRuntime.send` path. No failure has been observed there and its rollback shape differs at every exit, so it is not touched here; it should get its own issue.

Full investigation notes (attempts, ruled-out hypotheses, traces) are in the session.

https://claude.ai/code/session_01KqwE2HUhZDJvbqhmKPv5xz
