### PR TITLE
fix(appserver): fence read admission across unsubscribe

### DIFF
--- a/appwire/paging.go
+++ b/appwire/paging.go
@@ -30,7 +30,7 @@ func ValidateThreadReadParams(params ThreadReadParams) error {
 // ValidateThreadTurnsListParams validates the item-only transcript list cursor
 // and limit.
 func ValidateThreadTurnsListParams(params ThreadTurnsListParams) error {
-	if params.Cursor == "" {
+	if strings.TrimSpace(params.Cursor) == "" {
 		return InvalidParams("cursor is required for thread/turns/list")
 	}
 	if isLegacyNumericCursor(params.Cursor) {

--- a/appwire/paging_test.go
+++ b/appwire/paging_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestNormalizeTranscriptItemLimit(t *testing.T) {
@@ -75,7 +76,8 @@ func TestThreadTurnsListItemModeRequiresCursor(t *testing.T) {
 
 func TestThreadTurnsListItemModeRejectsWhitespaceOnlyCursor(t *testing.T) {
 	for _, cursor := range []string{" ", "\t", "\n", "\u2003", "\u00a0"} {
-		t.Run(fmt.Sprintf("%U", []rune(cursor)[0]), func(t *testing.T) {
+		first, _ := utf8.DecodeRuneInString(cursor)
+		t.Run(fmt.Sprintf("%U", first), func(t *testing.T) {
 			if err := ValidateThreadTurnsListParams(ThreadTurnsListParams{ItemLimit: 4, Cursor: cursor}); err == nil {
 				t.Fatalf("whitespace-only cursor %q accepted", cursor)
 			}

--- a/appwire/paging_test.go
+++ b/appwire/paging_test.go
@@ -73,6 +73,16 @@ func TestThreadTurnsListItemModeRequiresCursor(t *testing.T) {
 	}
 }
 
+func TestThreadTurnsListItemModeRejectsWhitespaceOnlyCursor(t *testing.T) {
+	for _, cursor := range []string{" ", "\t", "\n", "\u2003", "\u00a0"} {
+		t.Run(fmt.Sprintf("%U", []rune(cursor)[0]), func(t *testing.T) {
+			if err := ValidateThreadTurnsListParams(ThreadTurnsListParams{ItemLimit: 4, Cursor: cursor}); err == nil {
+				t.Fatalf("whitespace-only cursor %q accepted", cursor)
+			}
+		})
+	}
+}
+
 func TestThreadItemModeJSON(t *testing.T) {
 	position := &ThreadItemPosition{Entry: 12, Item: 4}
 	item := ThreadItem{Type: "agentMessage", ID: "display-1", TranscriptKey: "entry-12-item-4", Position: position}

--- a/cmd/evener-hub/admission_resolution_test.go
+++ b/cmd/evener-hub/admission_resolution_test.go
@@ -26,6 +26,14 @@ func TestSourceForThreadNilRegistryIsQuiet(t *testing.T) {
 	}
 }
 
+func TestSourceForThreadInvalidRefPreservesInvalidParams(t *testing.T) {
+	_, err := sourceForThread(appsource.NewRegistry(), "bad-ref", "")
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("invalid ref error = %v, want InvalidParams", err)
+	}
+}
+
 func TestHubAdmissionStableOwnerChangeSucceeds(t *testing.T) {
 	testHubAdmissionInventoryChange(t, true)
 }

--- a/cmd/evener-hub/admission_resolution_test.go
+++ b/cmd/evener-hub/admission_resolution_test.go
@@ -20,6 +20,12 @@ func TestHubAdmissionInventoryChangeRejected(t *testing.T) {
 	testHubAdmissionInventoryChange(t, false)
 }
 
+func TestSourceForThreadNilRegistryIsQuiet(t *testing.T) {
+	if _, err := sourceForThread(nil, "", "thread"); err == nil {
+		t.Fatal("nil source registry unexpectedly resolved a thread")
+	}
+}
+
 func TestHubAdmissionStableOwnerChangeSucceeds(t *testing.T) {
 	testHubAdmissionInventoryChange(t, true)
 }

--- a/cmd/evener-hub/admission_resolution_test.go
+++ b/cmd/evener-hub/admission_resolution_test.go
@@ -1,0 +1,169 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestHubAdmissionInventoryChangeRejected(t *testing.T) {
+	testHubAdmissionInventoryChange(t, false)
+}
+
+func TestHubAdmissionStableOwnerChangeSucceeds(t *testing.T) {
+	testHubAdmissionInventoryChange(t, true)
+}
+
+func testHubAdmissionInventoryChange(t *testing.T, sameOwner bool) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	var swapped atomic.Bool
+	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, p appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		id := "current"
+		if sameOwner && swapped.Load() {
+			id = "next"
+		}
+		appserver.Subscribe(ctx, id)
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: id, SessionID: id, Evener: appwire.EvenerThread{Ref: "local:" + id}}}, nil
+	})
+	upstream := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+	defer upstream.Close()
+	entered, release := make(chan struct{}), make(chan struct{})
+	var lookups atomic.Int32
+	source := appsource.NewLocalDaemonSourceWithEntries("local", func() []appsource.LocalDaemonEntry {
+		// First inventory lookup is ResolveSubscriptionAdmission at ingress;
+		// second is ResolveRelaySession in the concurrent read handler.
+		if lookups.Add(1) == 2 {
+			close(entered)
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+		}
+		stable := "old-workspace"
+		current := "current"
+		if swapped.Load() && !sameOwner {
+			stable = "new-workspace"
+		} else if swapped.Load() {
+			current = "next"
+		}
+		return []appsource.LocalDaemonEntry{{Entry: rendezvous.Entry{SourceID: "local", ThreadID: stable, SessionID: current, WorkspaceRef: "local:" + stable, Endpoint: upstream.URL, Protocol: appwire.ProtocolVersion}}}
+	}, http.DefaultClient)
+	sources := appsource.NewRegistry()
+	sources.Add(source)
+	server := newHubAppServer(hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}, sources)
+	wire := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer wire.Close()
+	client := dialHubRPC(t, wire)
+	defer client.Close()
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	ref := "local:current"
+	if sameOwner {
+		ref = "local:old-workspace"
+	}
+	go func() {
+		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: ref, Subscribe: true})
+		done <- err
+	}()
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("inventory barrier not reached")
+	}
+	swapped.Store(true)
+	if !sameOwner {
+		if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{Ref: ref}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(release)
+	select {
+	case err := <-done:
+		var wire appwire.WireError
+		if sameOwner && err != nil {
+			t.Fatalf("same-owner read rejected: %v", err)
+		} else if !sameOwner && (!errors.As(err, &wire) || wire.Code != appwire.CodeUnavailable) {
+			t.Errorf("changed-owner error=%v, want unavailable", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("read blocked")
+	}
+	if sameOwner {
+		if got := server.SubscriberCount(ref); got != 1 {
+			t.Fatalf("same-owner subscribers=%d, want 1", got)
+		}
+		awaitLiveHubSubscriptions(t, server, 1)
+		daemon.Broadcast("next", "test/same-owner", map[string]any{"threadId": "next"})
+		daemon.Broadcast("next", "test/alias-barrier", map[string]any{"threadId": "next"})
+		if got := aliasMethodCountUntilBarrier(t, client, "test/same-owner"); got != 1 {
+			t.Fatalf("same-owner delivery=%d, want 1", got)
+		}
+		return
+	}
+	if got := server.SubscriberCount("local:current"); got != 0 {
+		t.Errorf("stale registration=%d, want 0", got)
+	}
+	server.Broadcast("local:current", "test/stale-inventory", map[string]any{})
+	server.BroadcastAll("test/alias-barrier", map[string]any{})
+	if got := aliasMethodCountUntilBarrier(t, client, "test/stale-inventory"); got != 0 {
+		t.Errorf("stale inventory delivery=%d, want 0", got)
+	}
+}
+
+func TestHubUnsubscribeAcceptedExtraField(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, p appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		appserver.Subscribe(ctx, "current")
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "current", SessionID: "current", Evener: appwire.EvenerThread{Ref: "local:current"}}}, nil
+	})
+	upstream := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+	defer upstream.Close()
+	source := appsource.NewLocalDaemonSourceWithEntries("local", func() []appsource.LocalDaemonEntry {
+		return []appsource.LocalDaemonEntry{{Entry: rendezvous.Entry{SourceID: "local", ThreadID: "stable", SessionID: "current", WorkspaceRef: "local:stable", Endpoint: upstream.URL, Protocol: appwire.ProtocolVersion}}}
+	}, http.DefaultClient)
+	sources := appsource.NewRegistry()
+	sources.Add(source)
+	server := newHubAppServer(hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}, sources)
+	wire := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer wire.Close()
+	client := dialHubRPC(t, wire)
+	defer client.Close()
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	for _, ref := range []string{"local:stable", "local:current"} {
+		if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: ref, Subscribe: true}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var result appwire.EmptyResponse
+	if err := client.Request(ctx, appwire.MethodThreadUnsubscribe, map[string]any{"ref": "local:stable", "clientTag": "accepted-extra"}, &result); err != nil {
+		t.Fatalf("extra field unsubscribe rejected: %v", err)
+	}
+	for _, key := range []string{"local:stable", "local:current"} {
+		if got := server.SubscriberCount(key); got != 0 {
+			t.Errorf("accepted extra-field unsubscribe leaves %s=%d, want 0", key, got)
+		}
+		server.Broadcast(key, "test/stale-extra", map[string]any{})
+	}
+	server.BroadcastAll("test/alias-barrier", map[string]any{})
+	if got := aliasMethodCountUntilBarrier(t, client, "test/stale-extra"); got != 0 {
+		t.Errorf("stale extra-field delivery=%d, want 0", got)
+	}
+}

--- a/cmd/evener-hub/admission_resolution_test.go
+++ b/cmd/evener-hub/admission_resolution_test.go
@@ -20,6 +20,24 @@ func TestHubAdmissionInventoryChangeRejected(t *testing.T) {
 	testHubAdmissionInventoryChange(t, false)
 }
 
+func TestHubRPCSubscribedInvalidRefPreservesInvalidParams(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	server := newHubAppServer(hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}, appsource.NewRegistry())
+	wire := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer wire.Close()
+	client := dialHubRPC(t, wire)
+	defer client.Close()
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "bad-ref", Subscribe: true})
+	var wireErr appwire.WireError
+	if !errors.As(err, &wireErr) || wireErr.Code != appwire.CodeInvalidParams {
+		t.Fatalf("invalid subscribed ref error=%v, want InvalidParams", err)
+	}
+}
+
 func TestSourceForThreadNilRegistryIsQuiet(t *testing.T) {
 	if _, err := sourceForThread(nil, "", "thread"); err == nil {
 		t.Fatal("nil source registry unexpectedly resolved a thread")

--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -54,6 +54,8 @@ type relayKeyState struct {
 }
 
 type hubThreadReadResult struct {
+	// relayKey is the acquired delivery owner, not the response's session ID.
+	relayKey          string
 	response          appwire.ThreadReadResponse
 	itemCandidates    appsource.ItemCandidateResult
 	hasItemCandidates bool
@@ -301,14 +303,14 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 	if cfg.RelayHooks.RetryWait != nil {
 		retryClock = relayRetryClockFunc(cfg.RelayHooks.RetryWait)
 	}
-	registerSubscription := func(ctx context.Context, relayKey string, replace bool) bool {
+	registerSubscription := func(ctx context.Context, relayKey string, replace bool) error {
 		if cfg.RelayHooks.RegisterSubscription != nil {
-			return cfg.RelayHooks.RegisterSubscription(ctx, relayKey, replace)
+			if !cfg.RelayHooks.RegisterSubscription(ctx, relayKey, replace) {
+				return context.Canceled
+			}
+			return nil
 		}
-		if replace {
-			return appserver.ReplaceSubscriptions(ctx, relayKey)
-		}
-		return appserver.Subscribe(ctx, relayKey)
+		return appserver.SubscribeWithAdmission(ctx, relayKey, replace)
 	}
 	relayTarget := threadRelayTarget
 	var relayMu sync.Mutex
@@ -1139,7 +1141,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		if err := deletionFenceError(cfg, params.Ref, params.ThreadID, ""); err != nil {
 			return nil, err
 		}
-		handle, _, publish, release, err := acquireRelaySession(ctx, relaySource, source, params)
+		handle, state, publish, release, err := acquireRelaySession(ctx, relaySource, source, params)
 		if err != nil {
 			return nil, err
 		}
@@ -1161,6 +1163,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		result, err := handle.lease.ReadWithRoutePublication(ctx, readParams, publish)
 		if result.Handoff != nil {
 			read = &hubThreadReadResult{
+				relayKey: state.relayKey,
 				response: result.Response,
 				handoff:  result.Handoff,
 				release:  releaseCommand,
@@ -1195,20 +1198,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		if read == nil || read.handoff == nil {
 			return true
 		}
-		sourceID := strings.TrimSpace(read.response.Thread.Source)
-		if ref, err := appwire.ParseRef(params.Ref); err == nil {
-			sourceID = ref.SourceID
-		}
-		if sourceID == "" {
-			sourceID = "local"
-		}
-		// Keyed on the response's Thread.ID rather than the request's
-		// ref.ThreadID: the daemon maps a stable ref back to the live session
-		// id before answering (server/appwire_runtime.go appThreadIDForRead),
-		// so the two coincide on every reachable path, and thread/unsubscribe
-		// resolves through the same mapping. Kept explicit so a future source
-		// that lets them diverge shows exactly where to look.
-		relayKey := sourceID + ":" + read.response.Thread.ID
+		relayKey := read.relayKey
 		captured, err := withDeletionTargetOwnership(
 			cfg,
 			params.Ref,
@@ -1263,7 +1253,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 			return appwire.ThreadReadResponse{}, err
 		}
 		threadID := read.response.Thread.ID
-		relayKey := source.ID() + ":" + threadID
+		relayKey := read.relayKey
 		registered, err := withDeletionTargetOwnership(
 			cfg,
 			params.Ref,
@@ -1273,8 +1263,8 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				if !read.handoff.Prepare() {
 					return false, appwire.SessionUnavailable("relay handoff could not be prepared")
 				}
-				if !registerSubscription(ctx, relayKey, params.ReplaceSubscription) {
-					return false, nil
+				if err := registerSubscription(ctx, relayKey, params.ReplaceSubscription); err != nil {
+					return false, err
 				}
 				if !read.finish(true) {
 					return false, appwire.SessionUnavailable("relay handoff could not be committed")
@@ -1359,8 +1349,8 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				if cfg.RelayHooks.BeforeExistingRegistration != nil {
 					cfg.RelayHooks.BeforeExistingRegistration(threadID)
 				}
-				if !registerSubscription(ctx, relayKey, subscribeParams.ReplaceSubscription) {
-					return false, context.Canceled
+				if err := registerSubscription(ctx, relayKey, subscribeParams.ReplaceSubscription); err != nil {
+					return false, err
 				}
 				return true, nil
 			}
@@ -1424,9 +1414,8 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 			cancelRelay()
 			return err
 		}
-		if !registerSubscription(ctx, relayKey, subscribeParams.ReplaceSubscription) {
+		if err = registerSubscription(ctx, relayKey, subscribeParams.ReplaceSubscription); err != nil {
 			delete(relayedThreads, relayKey)
-			err = context.Canceled
 			finishHandleLocked(relayHandle, err)
 			relayMu.Unlock()
 			cancelRelay()

--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -235,9 +235,9 @@ var observeHubRelayFunctions func(hubRelayFunctions)
 var observeHubRelayWait func()
 
 // threadRelayTarget resolves the relay key (source.ID()+":"+threadID) and the
-// bare threadID for a read-shaped request. thread/read's relay, its recovery
-// paths, and thread/unsubscribe all derive the key here so a subscribe and
-// its unsubscribe can never disagree about which registry entry they name.
+// bare threadID for a read-shaped request. This is the delivery routing
+// identity, not the canonical session identity used to cancel pending reads.
+// thread/read's relay, its recovery paths, and thread/unsubscribe use it.
 func threadRelayTarget(source appsource.Source, params appwire.ThreadReadParams) (string, string, error) {
 	threadID := strings.TrimSpace(params.ThreadID)
 	if threadID == "" && params.Ref != "" {

--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -56,6 +56,7 @@ type relayKeyState struct {
 type hubThreadReadResult struct {
 	// relayKey is the acquired delivery owner, not the response's session ID.
 	relayKey          string
+	lifecycleKey      string
 	response          appwire.ThreadReadResponse
 	itemCandidates    appsource.ItemCandidateResult
 	hasItemCandidates bool
@@ -303,14 +304,14 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 	if cfg.RelayHooks.RetryWait != nil {
 		retryClock = relayRetryClockFunc(cfg.RelayHooks.RetryWait)
 	}
-	registerSubscription := func(ctx context.Context, relayKey string, replace bool) error {
+	registerSubscription := func(ctx context.Context, relayKey string, replace bool, expectedLifecycle ...string) error {
 		if cfg.RelayHooks.RegisterSubscription != nil {
 			if !cfg.RelayHooks.RegisterSubscription(ctx, relayKey, replace) {
 				return context.Canceled
 			}
 			return nil
 		}
-		return appserver.SubscribeWithAdmission(ctx, relayKey, replace)
+		return appserver.SubscribeWithAdmission(ctx, relayKey, replace, expectedLifecycle...)
 	}
 	relayTarget := threadRelayTarget
 	var relayMu sync.Mutex
@@ -770,12 +771,9 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		source appsource.RelaySessionSource,
 		base appsource.Source,
 		params appwire.ThreadReadParams,
+		canonicalRef appwire.Ref,
 	) (*hubRelayHandle, *relayKeyState, func(context.Context, appwire.Thread) error, func(), error) {
 		relayKey, _, err := relayTarget(base, params)
-		if err != nil {
-			return nil, nil, nil, nil, err
-		}
-		canonicalRef, err := source.ResolveRelaySession(params)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}
@@ -1141,9 +1139,25 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		if err := deletionFenceError(cfg, params.Ref, params.ThreadID, ""); err != nil {
 			return nil, err
 		}
-		handle, state, publish, release, err := acquireRelaySession(ctx, relaySource, source, params)
+		var canonicalRef appwire.Ref
+		var lifecycleKey string
+		var err error
+		if paired, ok := relaySource.(interface {
+			ResolveRelaySessionWithAdmission(appwire.ThreadReadParams) (appwire.Ref, string, error)
+		}); ok {
+			canonicalRef, lifecycleKey, err = paired.ResolveRelaySessionWithAdmission(params)
+		} else {
+			canonicalRef, err = relaySource.ResolveRelaySession(params)
+		}
 		if err != nil {
 			return nil, err
+		}
+		handle, state, publish, release, err := acquireRelaySession(ctx, relaySource, source, params, canonicalRef)
+		if err != nil {
+			return nil, err
+		}
+		if lifecycleKey == "" {
+			lifecycleKey = state.relayKey
 		}
 		var releaseOnce sync.Once
 		releaseCommand := func() { releaseOnce.Do(release) }
@@ -1163,10 +1177,11 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		result, err := handle.lease.ReadWithRoutePublication(ctx, readParams, publish)
 		if result.Handoff != nil {
 			read = &hubThreadReadResult{
-				relayKey: state.relayKey,
-				response: result.Response,
-				handoff:  result.Handoff,
-				release:  releaseCommand,
+				relayKey:     state.relayKey,
+				lifecycleKey: lifecycleKey,
+				response:     result.Response,
+				handoff:      result.Handoff,
+				release:      releaseCommand,
 			}
 		}
 		if err != nil {
@@ -1226,6 +1241,9 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 						Commit: func() { read.finish(true) },
 						Abort:  func() { read.finish(false) },
 					},
+					func() appserver.SubscriptionTarget {
+						return appserver.SubscriptionTarget{ThreadID: relayKey, LifecycleKey: read.lifecycleKey}
+					},
 				), nil
 			},
 		)
@@ -1263,7 +1281,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				if !read.handoff.Prepare() {
 					return false, appwire.SessionUnavailable("relay handoff could not be prepared")
 				}
-				if err := registerSubscription(ctx, relayKey, params.ReplaceSubscription); err != nil {
+				if err := registerSubscription(ctx, relayKey, params.ReplaceSubscription, read.lifecycleKey); err != nil {
 					return false, err
 				}
 				if !read.finish(true) {

--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -243,8 +243,9 @@ var observeHubRelayWait func()
 // thread/read's relay, its recovery paths, and thread/unsubscribe use it.
 func threadRelayTarget(source appsource.Source, params appwire.ThreadReadParams) (string, string, error) {
 	threadID := strings.TrimSpace(params.ThreadID)
-	if threadID == "" && params.Ref != "" {
-		ref, err := appwire.ParseRef(params.Ref)
+	refInput := strings.TrimSpace(params.Ref)
+	if threadID == "" && refInput != "" {
+		ref, err := appwire.ParseRef(refInput)
 		if err != nil {
 			return "", "", err
 		}

--- a/cmd/evener-hub/app_relay_alias_test.go
+++ b/cmd/evener-hub/app_relay_alias_test.go
@@ -174,6 +174,29 @@ func TestHubRelaySharedSessionAliasesDeliverEachNotificationOnce(t *testing.T) {
 	}
 }
 
+func TestHubRelayRealWireReadUnsubscribeAliases(t *testing.T) {
+	pool := &aliasRelayPool{}
+	source := &aliasRelaySource{canonicalRefs: map[string]appwire.Ref{
+		"root-thread": {SourceID: "local", ThreadID: "root-thread"},
+	}, pool: pool}
+	sources := appsource.NewRegistry()
+	sources.Add(source)
+	appServer := newHubAppServer(hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}, sources)
+	hub := httptest.NewServer(http.HandlerFunc(appServer.ServeWebSocket))
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: "local:root-thread"}); err != nil {
+		t.Fatalf("ref-only subscribe read: %v", err)
+	}
+	if _, err := client.ThreadUnsubscribe(t.Context(), appwire.ThreadUnsubscribeParams{ThreadID: "root-thread"}); err != nil {
+		t.Fatalf("mixed-alias unsubscribe: %v", err)
+	}
+}
+
 func TestHubRelaySharedSessionAliasesEnrichUntargetedOutputImages(t *testing.T) {
 	const (
 		rootRef  = "local:root-image"

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -450,17 +450,17 @@ func registerThreadHandlers(
 				return appwire.EmptyResponse{}, err
 			}
 			if parsed, parseErr := appwire.ParseRef(strings.TrimSpace(params.Ref)); parseErr == nil && parsed.SourceID != "" {
-				appserver.Unsubscribe(ctx, parsed.SourceID+":"+parsed.ThreadID)
+				appserver.UnsubscribeLifecycle(ctx, parsed.SourceID+":"+parsed.ThreadID)
 				return appwire.EmptyResponse{}, nil
 			}
-			appserver.Unsubscribe(ctx, "local:"+strings.TrimSpace(params.ThreadID))
+			appserver.UnsubscribeLifecycle(ctx, "local:"+strings.TrimSpace(params.ThreadID))
 			return appwire.EmptyResponse{}, nil
 		}
 		relayKey, _, keyErr := threadRelayTarget(source, appwire.ThreadReadParams{ThreadID: params.ThreadID, Ref: params.Ref})
 		if keyErr != nil {
 			return appwire.EmptyResponse{}, keyErr
 		}
-		appserver.Unsubscribe(ctx, relayKey)
+		appserver.UnsubscribeLifecycle(ctx, relayKey)
 		return appwire.EmptyResponse{}, nil
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadTurnsList, func(ctx context.Context, params appwire.ThreadTurnsListParams) (appwire.ThreadTurnsListResponse, error) {

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -223,7 +223,13 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 				return "", false
 			}
 			var params appwire.ThreadReadParams
-			if json.Unmarshal(msg.Request.Params, &params) != nil {
+			if msg.Request.Method == appwire.MethodThreadUnsubscribe {
+				var unsubscribe appwire.ThreadUnsubscribeParams
+				if json.Unmarshal(msg.Request.Params, &unsubscribe) != nil {
+					return "", false
+				}
+				params.Ref, params.ThreadID = unsubscribe.Ref, unsubscribe.ThreadID
+			} else if json.Unmarshal(msg.Request.Params, &params) != nil {
 				return "", false
 			}
 			source, err := sourceForThread(sources, params.Ref, params.ThreadID)

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -236,6 +236,21 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 			// Stable refs and current IDs name one pending admission, but
 			// must not rewrite the relay's notification delivery identity.
 			if daemon, ok := source.(*appsource.LocalDaemonSource); ok {
+				// Read-only descendants share the root's relay connection, not
+				// its downstream subscription. Keep their admission keys separate.
+				key, threadID, err := threadRelayTarget(source, params)
+				if err != nil {
+					return "", false
+				}
+				threads, err := daemon.ListThreads(context.Background(), appwire.ThreadListParams{})
+				if err != nil {
+					return "", false
+				}
+				for _, thread := range threads.Data {
+					if thread.Evener.Kind == "subagent" && thread.ID == threadID {
+						return key, true
+					}
+				}
 				ref, err := daemon.ResolveRelaySession(params)
 				return ref.String(), err == nil
 			}

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -266,6 +266,9 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 					}
 					return appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionUnresolved}
 				}
+				if delivery, _, deliveryErr := threadRelayTarget(source, params); deliveryErr == nil {
+					return appserver.SubscriptionAdmissionResolution{Key: ref.String(), SecondaryKey: delivery, Intent: appserver.SubscriptionAdmissionResolved}
+				}
 				return appserver.SubscriptionAdmissionResolution{Key: ref.String(), Intent: appserver.SubscriptionAdmissionResolved}
 			}
 			key, _, err := threadRelayTarget(source, params)

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -236,22 +236,7 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 			// Stable refs and current IDs name one pending admission, but
 			// must not rewrite the relay's notification delivery identity.
 			if daemon, ok := source.(*appsource.LocalDaemonSource); ok {
-				// Read-only descendants share the root's relay connection, not
-				// its downstream subscription. Keep their admission keys separate.
-				key, threadID, err := threadRelayTarget(source, params)
-				if err != nil {
-					return "", false
-				}
-				threads, err := daemon.ListThreads(context.Background(), appwire.ThreadListParams{})
-				if err != nil {
-					return "", false
-				}
-				for _, thread := range threads.Data {
-					if thread.Evener.Kind == "subagent" && thread.ID == threadID {
-						return key, true
-					}
-				}
-				ref, err := daemon.ResolveRelaySession(params)
+				ref, err := daemon.ResolveSubscriptionAdmission(params)
 				return ref.String(), err == nil
 			}
 			key, _, err := threadRelayTarget(source, params)

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -217,6 +218,30 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 		Navigation:           capability,
 		NavigationCapability: capabilityProvider,
 		Logf:                 hubLogf,
+		SubscriptionAdmissionResolver: func(msg appwire.Message) (string, bool) {
+			if msg.Request == nil || (msg.Request.Method != appwire.MethodThreadRead && msg.Request.Method != appwire.MethodThreadUnsubscribe) {
+				return "", false
+			}
+			var params appwire.ThreadReadParams
+			if json.Unmarshal(msg.Request.Params, &params) != nil {
+				return "", false
+			}
+			source, err := sourceForThread(sources, params.Ref, params.ThreadID)
+			if err != nil {
+				return "", false
+			}
+			if msg.Request.Method == appwire.MethodThreadRead && !params.Subscribe && !relayOnThreadRead(source) {
+				return "", false
+			}
+			// Stable refs and current IDs name one pending admission, but
+			// must not rewrite the relay's notification delivery identity.
+			if daemon, ok := source.(*appsource.LocalDaemonSource); ok {
+				ref, err := daemon.ResolveRelaySession(params)
+				return ref.String(), err == nil
+			}
+			key, _, err := threadRelayTarget(source, params)
+			return key, err == nil
+		},
 		Features: appwire.FeatureSet{
 			ThreadList:                true,
 			ThreadTurnsList:           true,

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -258,6 +258,12 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 					}
 				}
 				if err != nil {
+					if msg.Request.Method == appwire.MethodThreadUnsubscribe {
+						delivery, _, deliveryErr := threadRelayTarget(source, params)
+						if deliveryErr == nil {
+							return appserver.SubscriptionAdmissionResolution{Key: delivery, SecondaryKey: normalizedAdmissionRef(params), Intent: appserver.SubscriptionAdmissionUnresolved}
+						}
+					}
 					return appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionUnresolved}
 				}
 				return appserver.SubscriptionAdmissionResolution{Key: ref.String(), Intent: appserver.SubscriptionAdmissionResolved}
@@ -329,6 +335,16 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 	registerTranscriptDisplayHandlers(server, cfg.TranscriptDisplayStore)
 	registerKeybindingsHandlers(server, cfg.KeybindingsStore)
 	return server
+}
+
+func normalizedAdmissionRef(params appwire.ThreadReadParams) string {
+	if ref := strings.TrimSpace(params.Ref); ref != "" {
+		return ref
+	}
+	if threadID := strings.TrimSpace(params.ThreadID); threadID != "" {
+		return "local:" + threadID
+	}
+	return ""
 }
 
 // registerThreadHandlers registers the thread- and turn-lifecycle RPC handlers

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -218,31 +218,35 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 		Navigation:           capability,
 		NavigationCapability: capabilityProvider,
 		Logf:                 hubLogf,
-		SubscriptionAdmissionResolver: func(msg appwire.Message) (string, bool) {
+		SubscriptionAdmissionResolverV2: func(msg appwire.Message) appserver.SubscriptionAdmissionResolution {
+			notSubscribe := appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionNotSubscribe}
 			if msg.Request == nil || (msg.Request.Method != appwire.MethodThreadRead && msg.Request.Method != appwire.MethodThreadUnsubscribe) {
-				return "", false
+				return notSubscribe
 			}
 			var params appwire.ThreadReadParams
 			if msg.Request.Method == appwire.MethodThreadUnsubscribe {
 				var unsubscribe appwire.ThreadUnsubscribeParams
 				if json.Unmarshal(msg.Request.Params, &unsubscribe) != nil {
-					return "", false
+					return appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionInvalid}
 				}
 				params.Ref, params.ThreadID = unsubscribe.Ref, unsubscribe.ThreadID
 			} else if json.Unmarshal(msg.Request.Params, &params) != nil {
-				return "", false
+				return appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionInvalid}
 			}
 			source, err := sourceForThread(sources, params.Ref, params.ThreadID)
 			if err != nil {
+				if _, parseErr := appwire.ParseRef(strings.TrimSpace(params.Ref)); params.Ref != "" && parseErr != nil {
+					return appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionInvalid}
+				}
 				if msg.Request.Method == appwire.MethodThreadRead && params.Subscribe {
 					if past, ok := pastEntryForRead(cfg, params); ok && past.ID != "" {
-						return "local:" + past.ID, true
+						return appserver.SubscriptionAdmissionResolution{Key: "local:" + past.ID, Intent: appserver.SubscriptionAdmissionResolved}
 					}
 				}
-				return "", false
+				return appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionUnresolved}
 			}
 			if msg.Request.Method == appwire.MethodThreadRead && !params.Subscribe && !relayOnThreadRead(source) {
-				return "", false
+				return notSubscribe
 			}
 			// Stable refs and current IDs name one pending admission, but
 			// must not rewrite the relay's notification delivery identity.
@@ -250,13 +254,19 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 				ref, err := daemon.ResolveSubscriptionAdmission(params)
 				if err != nil && msg.Request.Method == appwire.MethodThreadRead && params.Subscribe {
 					if past, pastOK := pastEntryForRead(cfg, params); pastOK && past.ID != "" {
-						return "local:" + past.ID, true
+						return appserver.SubscriptionAdmissionResolution{Key: "local:" + past.ID, Intent: appserver.SubscriptionAdmissionResolved}
 					}
 				}
-				return ref.String(), err == nil
+				if err != nil {
+					return appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionUnresolved}
+				}
+				return appserver.SubscriptionAdmissionResolution{Key: ref.String(), Intent: appserver.SubscriptionAdmissionResolved}
 			}
 			key, _, err := threadRelayTarget(source, params)
-			return key, err == nil
+			if err != nil {
+				return appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionInvalid}
+			}
+			return appserver.SubscriptionAdmissionResolution{Key: key, Intent: appserver.SubscriptionAdmissionResolved}
 		},
 		Features: appwire.FeatureSet{
 			ThreadList:                true,

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -234,6 +234,11 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 			}
 			source, err := sourceForThread(sources, params.Ref, params.ThreadID)
 			if err != nil {
+				if msg.Request.Method == appwire.MethodThreadRead && params.Subscribe {
+					if past, ok := pastEntryForRead(cfg, params); ok && past.ID != "" {
+						return "local:" + past.ID, true
+					}
+				}
 				return "", false
 			}
 			if msg.Request.Method == appwire.MethodThreadRead && !params.Subscribe && !relayOnThreadRead(source) {
@@ -243,6 +248,11 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 			// must not rewrite the relay's notification delivery identity.
 			if daemon, ok := source.(*appsource.LocalDaemonSource); ok {
 				ref, err := daemon.ResolveSubscriptionAdmission(params)
+				if err != nil && msg.Request.Method == appwire.MethodThreadRead && params.Subscribe {
+					if past, pastOK := pastEntryForRead(cfg, params); pastOK && past.ID != "" {
+						return "local:" + past.ID, true
+					}
+				}
 				return ref.String(), err == nil
 			}
 			key, _, err := threadRelayTarget(source, params)

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -259,8 +259,13 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 				}
 				if err != nil {
 					if msg.Request.Method == appwire.MethodThreadUnsubscribe {
-						delivery, _, deliveryErr := threadRelayTarget(source, params)
-						if deliveryErr == nil {
+						delivery := normalizedAdmissionRef(params)
+						if source != nil {
+							if resolvedDelivery, _, deliveryErr := threadRelayTarget(source, params); deliveryErr == nil {
+								delivery = resolvedDelivery
+							}
+						}
+						if delivery != "" {
 							return appserver.SubscriptionAdmissionResolution{Key: delivery, SecondaryKey: normalizedAdmissionRef(params), Intent: appserver.SubscriptionAdmissionUnresolved}
 						}
 					}

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -2820,6 +2820,119 @@ func TestHubRPCThreadReadDoesNotMergeLocalPastIntoNonLocalLiveThread(t *testing.
 	}
 }
 
+// A stable workspace ref and its current session ID cancel the same pending
+// read, without changing the response identity used for notification delivery.
+func TestHubRPCStableCurrentAdmissionCancellation(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		read        appwire.ThreadReadParams
+		unsubscribe appwire.ThreadUnsubscribeParams
+	}{
+		{"stable_ref_current_id", appwire.ThreadReadParams{Ref: "local:stable"}, appwire.ThreadUnsubscribeParams{ThreadID: "current"}},
+		{"current_id_stable_ref", appwire.ThreadReadParams{ThreadID: "current"}, appwire.ThreadUnsubscribeParams{Ref: "local:stable"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			entered, release := make(chan struct{}), make(chan struct{})
+			var releaseOnce, firstRead sync.Once
+			unblock := func() { releaseOnce.Do(func() { close(release) }) }
+			defer unblock()
+			daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+				id := "current"
+				if params.Ref == "local:other" || params.ThreadID == "other" {
+					id = "other"
+				} else {
+					firstRead.Do(func() {
+						close(entered)
+						select {
+						case <-release:
+						case <-ctx.Done():
+						}
+					})
+				}
+				appserver.Subscribe(ctx, id)
+				return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: id, SessionID: id, Evener: appwire.EvenerThread{Ref: "local:" + id}}}, nil
+			})
+			daemonHTTP := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+			defer daemonHTTP.Close()
+			source := appsource.NewLocalDaemonSourceWithEntries("local", func() []appsource.LocalDaemonEntry {
+				return []appsource.LocalDaemonEntry{
+					{Entry: rendezvous.Entry{SourceID: "local", ThreadID: "stable", SessionID: "current", WorkspaceRef: "local:stable", Endpoint: daemonHTTP.URL, Protocol: appwire.ProtocolVersion}},
+					{Entry: rendezvous.Entry{SourceID: "local", ThreadID: "other", SessionID: "other", WorkspaceRef: "local:other", Endpoint: daemonHTTP.URL, Protocol: appwire.ProtocolVersion}},
+				}
+			}, http.DefaultClient)
+			sources := appsource.NewRegistry()
+			sources.Add(source)
+			appServer := newHubAppServer(hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}, sources)
+			hub := httptest.NewServer(http.HandlerFunc(appServer.ServeWebSocket))
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:other"}); err != nil {
+				t.Fatalf("unrelated read: %v", err)
+			}
+			readDone := make(chan error, 1)
+			go func() {
+				_, err := client.ThreadRead(ctx, tc.read)
+				readDone <- err
+			}()
+			select {
+			case <-entered:
+			case <-ctx.Done():
+				t.Fatal("read did not reach the pre-capture daemon barrier")
+			}
+			if _, err := client.ThreadUnsubscribe(ctx, tc.unsubscribe); err != nil {
+				t.Fatalf("unsubscribe before capture: %v", err)
+			}
+			unblock()
+			var readErr error
+			select {
+			case readErr = <-readDone:
+			case <-ctx.Done():
+				t.Fatal("read did not finish after barrier release")
+			}
+			if got := appServer.SubscriberCount("local:current"); got != 0 {
+				t.Fatalf("old stable/current read registered %d stale subscriptions after unsubscribe", got)
+			}
+			// The hub already reports an unavailable subscription when its
+			// handoff capture is rejected; cancellation preserves that contract.
+			var wire appwire.WireError
+			if !errors.As(readErr, &wire) || wire.Code != appwire.CodeUnavailable {
+				t.Fatalf("canceled read error = %v, want unavailable subscription", readErr)
+			}
+			data, ok := wire.Data.(map[string]any)
+			if !ok || data["evenerErrorInfo"] != string(appwire.ErrorSessionUnavailable) {
+				t.Fatalf("canceled read error data = %#v, want sessionUnavailable", wire.Data)
+			}
+			if got := appServer.SubscriberCount("local:other"); got != 1 {
+				t.Fatalf("unrelated subscriptions = %d, want 1", got)
+			}
+			appServer.Broadcast("local:current", "test/stale-admission", map[string]any{})
+			appServer.BroadcastAll("test/alias-barrier", map[string]any{})
+			if got := aliasMethodCountUntilBarrier(t, client, "test/stale-admission"); got != 0 {
+				t.Fatalf("canceled read delivered %d notifications", got)
+			}
+			if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:stable"}); err != nil {
+				t.Fatalf("later read: %v", err)
+			}
+			if got := appServer.SubscriberCount("local:current"); got != 1 {
+				t.Fatalf("later read subscriptions = %d, want 1", got)
+			}
+			awaitLiveHubSubscriptions(t, appServer, 2)
+			appServer.Broadcast("local:current", "test/later-admission", map[string]any{})
+			appServer.BroadcastAll("test/alias-barrier", map[string]any{})
+			if got := aliasMethodCountUntilBarrier(t, client, "test/later-admission"); got != 1 {
+				t.Fatalf("later read delivered %d notifications, want 1", got)
+			}
+		})
+	}
+}
+
 func TestHubRPCThreadReadRelaysDaemonNotifications(t *testing.T) {
 	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
 	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -2896,6 +2896,9 @@ func TestHubRPCStableCurrentAdmissionCancellation(t *testing.T) {
 			case <-ctx.Done():
 				t.Fatal("read did not finish after barrier release")
 			}
+			if got := appServer.SubscriberCount("local:stable"); got != 0 {
+				t.Fatalf("canceled stable subscriptions = %d", got)
+			}
 			if got := appServer.SubscriberCount("local:current"); got != 0 {
 				t.Fatalf("old stable/current read registered %d stale subscriptions after unsubscribe", got)
 			}
@@ -2912,6 +2915,7 @@ func TestHubRPCStableCurrentAdmissionCancellation(t *testing.T) {
 			if got := appServer.SubscriberCount("local:other"); got != 1 {
 				t.Fatalf("unrelated subscriptions = %d, want 1", got)
 			}
+			appServer.Broadcast("local:stable", "test/stale-admission", map[string]any{})
 			appServer.Broadcast("local:current", "test/stale-admission", map[string]any{})
 			appServer.BroadcastAll("test/alias-barrier", map[string]any{})
 			if got := aliasMethodCountUntilBarrier(t, client, "test/stale-admission"); got != 0 {
@@ -2920,12 +2924,12 @@ func TestHubRPCStableCurrentAdmissionCancellation(t *testing.T) {
 			if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:stable"}); err != nil {
 				t.Fatalf("later read: %v", err)
 			}
-			if got := appServer.SubscriberCount("local:current"); got != 1 {
+			if got := appServer.SubscriberCount("local:stable"); got != 1 {
 				t.Fatalf("later read subscriptions = %d, want 1", got)
 			}
 			awaitLiveHubSubscriptions(t, appServer, 2)
-			appServer.Broadcast("local:current", "test/later-admission", map[string]any{})
-			appServer.BroadcastAll("test/alias-barrier", map[string]any{})
+			daemon.Broadcast("current", "test/later-admission", map[string]any{"threadId": "current"})
+			daemon.Broadcast("current", "test/alias-barrier", map[string]any{"threadId": "current"})
 			if got := aliasMethodCountUntilBarrier(t, client, "test/later-admission"); got != 1 {
 				t.Fatalf("later read delivered %d notifications, want 1", got)
 			}
@@ -3013,15 +3017,19 @@ func TestHubRPCRootChildAdmissionIsolation(t *testing.T) {
 			if readErr != nil {
 				t.Fatalf("child unsubscribe canceled unrelated pending root read: %v", readErr)
 			}
-			if got := appServer.SubscriberCount("local:current"); got != 1 {
+			deliveryKey := "local:stable"
+			if tc.read.ThreadID != "" {
+				deliveryKey = "local:" + tc.read.ThreadID
+			}
+			if got := appServer.SubscriberCount(deliveryKey); got != 1 {
 				t.Fatalf("root subscriptions = %d, want 1", got)
 			}
 			if got := appServer.SubscriberCount("local:other"); got != 1 {
 				t.Fatalf("unrelated subscriptions = %d, want 1", got)
 			}
 			awaitLiveHubSubscriptions(t, appServer, 2)
-			appServer.Broadcast("local:current", "test/root-admission", map[string]any{})
-			appServer.BroadcastAll("test/alias-barrier", map[string]any{})
+			daemon.Broadcast("current", "test/root-admission", map[string]any{"threadId": "current"})
+			daemon.Broadcast("current", "test/alias-barrier", map[string]any{"threadId": "current"})
 			if got := aliasMethodCountUntilBarrier(t, client, "test/root-admission"); got != 1 {
 				t.Fatalf("root read delivered %d notifications, want 1", got)
 			}

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -2941,6 +2941,8 @@ func TestHubRPCRootChildAdmissionIsolation(t *testing.T) {
 	}{
 		{"child_ref", appwire.ThreadReadParams{Ref: "local:stable"}, appwire.ThreadUnsubscribeParams{Ref: "local:child"}},
 		{"child_id", appwire.ThreadReadParams{ThreadID: "current"}, appwire.ThreadUnsubscribeParams{ThreadID: "child"}},
+		{"unsubscribe_ref_precedence", appwire.ThreadReadParams{Ref: "local:stable"}, appwire.ThreadUnsubscribeParams{Ref: "local:child", ThreadID: "current"}},
+		{"read_ref_precedence", appwire.ThreadReadParams{Ref: "local:stable", ThreadID: "child"}, appwire.ThreadUnsubscribeParams{Ref: "local:child"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -2933,6 +2933,100 @@ func TestHubRPCStableCurrentAdmissionCancellation(t *testing.T) {
 	}
 }
 
+func TestHubRPCRootChildAdmissionIsolation(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		read        appwire.ThreadReadParams
+		unsubscribe appwire.ThreadUnsubscribeParams
+	}{
+		{"child_ref", appwire.ThreadReadParams{Ref: "local:stable"}, appwire.ThreadUnsubscribeParams{Ref: "local:child"}},
+		{"child_id", appwire.ThreadReadParams{ThreadID: "current"}, appwire.ThreadUnsubscribeParams{ThreadID: "child"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			entered, release := make(chan struct{}), make(chan struct{})
+			var releaseOnce, firstRead sync.Once
+			unblock := func() { releaseOnce.Do(func() { close(release) }) }
+			defer unblock()
+			daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+				id := "current"
+				if params.Ref == "local:other" || params.ThreadID == "other" {
+					id = "other"
+				} else {
+					firstRead.Do(func() {
+						close(entered)
+						select {
+						case <-release:
+						case <-ctx.Done():
+						}
+					})
+				}
+				appserver.Subscribe(ctx, id)
+				return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: id, SessionID: id, Evener: appwire.EvenerThread{Ref: "local:" + id}}}, nil
+			})
+			daemonHTTP := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+			defer daemonHTTP.Close()
+			source := appsource.NewLocalDaemonSourceWithEntries("local", func() []appsource.LocalDaemonEntry {
+				return []appsource.LocalDaemonEntry{
+					{Entry: rendezvous.Entry{SourceID: "local", ThreadID: "stable", SessionID: "current", WorkspaceRef: "local:stable", Endpoint: daemonHTTP.URL, Protocol: appwire.ProtocolVersion}},
+					{Entry: rendezvous.Entry{SourceID: "local", ThreadID: "stable", SessionID: "current", WorkspaceRef: "local:stable", Endpoint: daemonHTTP.URL, Protocol: appwire.ProtocolVersion}, SessionID: "child", OwnerSessionID: "current", ReadOnlyAlias: true},
+					{Entry: rendezvous.Entry{SourceID: "local", ThreadID: "other", SessionID: "other", WorkspaceRef: "local:other", Endpoint: daemonHTTP.URL, Protocol: appwire.ProtocolVersion}},
+				}
+			}, http.DefaultClient)
+			sources := appsource.NewRegistry()
+			sources.Add(source)
+			appServer := newHubAppServer(hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}, sources)
+			hub := httptest.NewServer(http.HandlerFunc(appServer.ServeWebSocket))
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:other"}); err != nil {
+				t.Fatalf("unrelated read: %v", err)
+			}
+			readDone := make(chan error, 1)
+			go func() {
+				_, err := client.ThreadRead(ctx, tc.read)
+				readDone <- err
+			}()
+			select {
+			case <-entered:
+			case <-ctx.Done():
+				t.Fatal("read did not reach the pre-capture daemon barrier")
+			}
+			if _, err := client.ThreadUnsubscribe(ctx, tc.unsubscribe); err != nil {
+				t.Fatalf("unsubscribe before capture: %v", err)
+			}
+			unblock()
+			var readErr error
+			select {
+			case readErr = <-readDone:
+			case <-ctx.Done():
+				t.Fatal("read did not finish after barrier release")
+			}
+			if readErr != nil {
+				t.Fatalf("child unsubscribe canceled unrelated pending root read: %v", readErr)
+			}
+			if got := appServer.SubscriberCount("local:current"); got != 1 {
+				t.Fatalf("root subscriptions = %d, want 1", got)
+			}
+			if got := appServer.SubscriberCount("local:other"); got != 1 {
+				t.Fatalf("unrelated subscriptions = %d, want 1", got)
+			}
+			awaitLiveHubSubscriptions(t, appServer, 2)
+			appServer.Broadcast("local:current", "test/root-admission", map[string]any{})
+			appServer.BroadcastAll("test/alias-barrier", map[string]any{})
+			if got := aliasMethodCountUntilBarrier(t, client, "test/root-admission"); got != 1 {
+				t.Fatalf("root read delivered %d notifications, want 1", got)
+			}
+		})
+	}
+}
+
 func TestHubRPCThreadReadRelaysDaemonNotifications(t *testing.T) {
 	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
 	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {

--- a/cmd/evener-hub/app_sources.go
+++ b/cmd/evener-hub/app_sources.go
@@ -14,7 +14,14 @@ func sourceForThread(sources *appsource.Registry, ref, threadID string) (appsour
 		return nil, errors.New("source registry unavailable")
 	}
 	if ref != "" {
-		return sources.SourceForRef(ref)
+		source, err := sources.SourceForRef(ref)
+		if err != nil {
+			if _, parseErr := appwire.ParseRef(ref); parseErr != nil {
+				return nil, appwire.InvalidParams(parseErr.Error())
+			}
+			return nil, err
+		}
+		return source, nil
 	}
 	source, ok := sources.Source("local")
 	if !ok {

--- a/cmd/evener-hub/app_sources.go
+++ b/cmd/evener-hub/app_sources.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
@@ -10,6 +11,8 @@ import (
 )
 
 func sourceForThread(sources *appsource.Registry, ref, threadID string) (appsource.Source, error) {
+	ref = strings.TrimSpace(ref)
+	threadID = strings.TrimSpace(threadID)
 	if sources == nil {
 		return nil, errors.New("source registry unavailable")
 	}

--- a/cmd/evener-hub/app_sources.go
+++ b/cmd/evener-hub/app_sources.go
@@ -10,6 +10,9 @@ import (
 )
 
 func sourceForThread(sources *appsource.Registry, ref, threadID string) (appsource.Source, error) {
+	if sources == nil {
+		return nil, errors.New("source registry unavailable")
+	}
 	if ref != "" {
 		return sources.SourceForRef(ref)
 	}

--- a/cmd/evener-hub/internal/appsource/admission_resolution_test.go
+++ b/cmd/evener-hub/internal/appsource/admission_resolution_test.go
@@ -1,0 +1,56 @@
+package appsource
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestPairedRelayAdmissionSingleInventorySnapshot(t *testing.T) {
+	for _, child := range []bool{false, true} {
+		reads := 0
+		entry := rendezvous.Entry{SourceID: "local", ThreadID: "stable", SessionID: "current", WorkspaceRef: "local:stable", Endpoint: "http://127.0.0.1", Protocol: appwire.ProtocolVersion}
+		source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry {
+			reads++
+			if reads > 1 {
+				return nil
+			}
+			return []LocalDaemonEntry{{Entry: entry}, {Entry: entry, SessionID: "child", OwnerSessionID: "current", ReadOnlyAlias: true}}
+		}, nil)
+		target, wantOwner := "current", "local:stable"
+		if child {
+			target, wantOwner = "child", "local:child"
+		}
+		canonical, owner, err := source.ResolveRelaySessionWithAdmission(appwire.ThreadReadParams{Ref: "local:" + target})
+		if err != nil || canonical.String() != "local:stable" || owner != wantOwner || reads != 1 {
+			t.Fatalf("paired canonical=%s owner=%s reads=%d err=%v", canonical.String(), owner, reads, err)
+		}
+	}
+}
+
+func TestCanonicalRelayRejectsReassociatedCurrentAlias(t *testing.T) {
+	entry := rendezvous.Entry{SourceID: "local", ThreadID: "stable", SessionID: "current", WorkspaceRef: "local:stable", Endpoint: "http://127.0.0.1", Protocol: appwire.ProtocolVersion}
+	source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry { return []LocalDaemonEntry{{Entry: entry}} }, nil)
+	canonical, _, err := source.ResolveRelaySessionWithAdmission(appwire.ThreadReadParams{Ref: "local:current"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The old canonical string now happens to be a current-ID alias for a
+	// different workspace. It must not redirect an already resolved request.
+	entry.ThreadID = "other"
+	entry.SessionID = "stable"
+	entry.WorkspaceRef = "local:other"
+	if lease, err := source.AcquireRelaySession(canonical); err == nil {
+		lease.Close()
+		t.Fatal("canonical lookup changed semantic owner")
+	}
+	entry.ThreadID = "stable"
+	entry.SessionID = "new-current"
+	entry.WorkspaceRef = "local:stable"
+	lease, err := source.AcquireRelaySession(canonical)
+	if err != nil {
+		t.Fatalf("same-owner refresh rejected: %v", err)
+	}
+	lease.Close()
+}

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -105,6 +105,23 @@ func (s *LocalDaemonSource) ResolveRelaySession(params appwire.ThreadReadParams)
 	if err != nil {
 		return appwire.Ref{}, err
 	}
+	return s.relaySessionRef(entry)
+}
+
+// ResolveSubscriptionAdmission preserves stable/current root aliases while
+// keeping read-only descendants distinct from their shared relay session.
+func (s *LocalDaemonSource) ResolveSubscriptionAdmission(params appwire.ThreadReadParams) (appwire.Ref, error) {
+	item, err := s.localEntryForRefMode(params.Ref, params.ThreadID, true)
+	if err != nil {
+		return appwire.Ref{}, err
+	}
+	if item.ReadOnlyAlias {
+		return appwire.Ref{SourceID: s.sourceID, ThreadID: localDaemonThreadID(item)}, nil
+	}
+	return s.relaySessionRef(localDaemonRendezvousEntry(item))
+}
+
+func (s *LocalDaemonSource) relaySessionRef(entry rendezvous.Entry) (appwire.Ref, error) {
 	threadID := entry.ThreadID
 	if entry.SessionID != "" {
 		threadID = entry.SessionID
@@ -800,14 +817,22 @@ func (s *LocalDaemonSource) entryForReadRef(rawRef, threadID string) (rendezvous
 }
 
 func (s *LocalDaemonSource) entryForRefMode(rawRef, threadID string, allowReadOnlyAlias bool) (rendezvous.Entry, error) {
+	item, err := s.localEntryForRefMode(rawRef, threadID, allowReadOnlyAlias)
+	if err != nil {
+		return rendezvous.Entry{}, err
+	}
+	return localDaemonRendezvousEntry(item), nil
+}
+
+func (s *LocalDaemonSource) localEntryForRefMode(rawRef, threadID string, allowReadOnlyAlias bool) (LocalDaemonEntry, error) {
 	requestedRef := strings.TrimSpace(rawRef)
 	if rawRef != "" {
 		ref, err := appwire.ParseRef(rawRef)
 		if err != nil {
-			return rendezvous.Entry{}, err
+			return LocalDaemonEntry{}, err
 		}
 		if ref.SourceID != s.sourceID {
-			return rendezvous.Entry{}, fmt.Errorf("source not found: %s", ref.SourceID)
+			return LocalDaemonEntry{}, fmt.Errorf("source not found: %s", ref.SourceID)
 		}
 		threadID = ref.ThreadID
 	}
@@ -817,13 +842,13 @@ func (s *LocalDaemonSource) entryForRefMode(rawRef, threadID string, allowReadOn
 		}
 		entry := localDaemonRendezvousEntry(item)
 		if requestedRef != "" && localDaemonWorkspaceRef(s.sourceID, entry, localDaemonThreadID(item)) == requestedRef {
-			return entry, nil
+			return item, nil
 		}
 		if localDaemonThreadID(item) == threadID || entry.SessionID == threadID {
-			return entry, nil
+			return item, nil
 		}
 	}
-	return rendezvous.Entry{}, appwire.SessionUnavailable("thread not found: " + threadID)
+	return LocalDaemonEntry{}, appwire.SessionUnavailable("thread not found: " + threadID)
 }
 
 func (s *LocalDaemonSource) liveEntries() []LocalDaemonEntry {

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -101,24 +101,53 @@ func (s *LocalDaemonSource) ID() string {
 }
 
 func (s *LocalDaemonSource) ResolveRelaySession(params appwire.ThreadReadParams) (appwire.Ref, error) {
-	entry, err := s.entryForReadRef(params.Ref, params.ThreadID)
+	canonical, _, err := s.ResolveRelaySessionWithAdmission(params)
+	return canonical, err
+}
+
+// ResolveRelaySessionWithAdmission derives both identities from one inventory
+// entry. A descendant owns its admission even when it shares the root relay.
+func (s *LocalDaemonSource) ResolveRelaySessionWithAdmission(params appwire.ThreadReadParams) (appwire.Ref, string, error) {
+	item, err := s.localEntryForRefMode(params.Ref, params.ThreadID, true)
 	if err != nil {
-		return appwire.Ref{}, err
+		return appwire.Ref{}, "", err
 	}
-	return s.relaySessionRef(entry)
+	canonical, err := s.relaySessionRef(localDaemonRendezvousEntry(item))
+	if err != nil {
+		return appwire.Ref{}, "", err
+	}
+	owner := canonical.String()
+	if item.ReadOnlyAlias {
+		owner = (appwire.Ref{SourceID: s.sourceID, ThreadID: localDaemonThreadID(item)}).String()
+	}
+	return canonical, owner, nil
 }
 
 // ResolveSubscriptionAdmission preserves stable/current root aliases while
 // keeping read-only descendants distinct from their shared relay session.
 func (s *LocalDaemonSource) ResolveSubscriptionAdmission(params appwire.ThreadReadParams) (appwire.Ref, error) {
-	item, err := s.localEntryForRefMode(params.Ref, params.ThreadID, true)
+	_, owner, err := s.ResolveRelaySessionWithAdmission(params)
 	if err != nil {
 		return appwire.Ref{}, err
 	}
-	if item.ReadOnlyAlias {
-		return appwire.Ref{SourceID: s.sourceID, ThreadID: localDaemonThreadID(item)}, nil
+	return appwire.ParseRef(owner)
+}
+
+// relayEntry may refresh an endpoint, but a canonical key cannot fall back to
+// a newly reassociated current-ID alias with a different semantic owner.
+func (s *LocalDaemonSource) relayEntry(ref appwire.Ref) (rendezvous.Entry, error) {
+	entry, err := s.entryForReadRef(ref.String(), "")
+	if err != nil {
+		return rendezvous.Entry{}, err
 	}
-	return s.relaySessionRef(localDaemonRendezvousEntry(item))
+	canonical, err := s.relaySessionRef(entry)
+	if err != nil {
+		return rendezvous.Entry{}, err
+	}
+	if canonical != ref {
+		return rendezvous.Entry{}, appwire.SessionUnavailable("relay session identity changed")
+	}
+	return entry, nil
 }
 
 func (s *LocalDaemonSource) relaySessionRef(entry rendezvous.Entry) (appwire.Ref, error) {
@@ -137,7 +166,7 @@ func (s *LocalDaemonSource) AcquireRelaySession(ref appwire.Ref) (RelaySessionRo
 	if ref.SourceID != s.sourceID || ref.String() == "" {
 		return nil, appwire.SessionUnavailable("invalid relay session ref")
 	}
-	_, err := s.entryForReadRef(ref.String(), "")
+	_, err := s.relayEntry(ref)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +185,7 @@ func (s *LocalDaemonSource) AcquireRelaySession(ref appwire.Ref) (RelaySessionRo
 	if session == nil {
 		created := newRelaySession(
 			func(ctx context.Context, epoch uint64, observe func(uint64, appwire.Message, error)) (*appwire.Client, appwire.Transport, error) {
-				currentEntry, resolveErr := s.entryForReadRef(key, "")
+				currentEntry, resolveErr := s.relayEntry(ref)
 				if resolveErr != nil {
 					return nil, nil, resolveErr
 				}

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -855,8 +855,8 @@ func (s *LocalDaemonSource) entryForRefMode(rawRef, threadID string, allowReadOn
 
 func (s *LocalDaemonSource) localEntryForRefMode(rawRef, threadID string, allowReadOnlyAlias bool) (LocalDaemonEntry, error) {
 	requestedRef := strings.TrimSpace(rawRef)
-	if rawRef != "" {
-		ref, err := appwire.ParseRef(rawRef)
+	if requestedRef != "" {
+		ref, err := appwire.ParseRef(requestedRef)
 		if err != nil {
 			return LocalDaemonEntry{}, err
 		}

--- a/cmd/evener-hub/internal/appsource/local_daemon_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_test.go
@@ -1022,3 +1022,53 @@ func TestLocalDaemonResolveRelaySessionCanonicalizesAliasesWithoutAcquiring(t *t
 		t.Fatalf("resolution acquired %d relay sessions, want none", acquired)
 	}
 }
+
+func TestLocalDaemonResolveSubscriptionAdmissionSingleSnapshot(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		params    appwire.ThreadReadParams
+		want      string
+		snapshots int
+	}{
+		{"stable_root", appwire.ThreadReadParams{Ref: "local:stable"}, "local:stable", 1},
+		{"current_root", appwire.ThreadReadParams{ThreadID: "current"}, "local:stable", 1},
+		{"current_root_ref", appwire.ThreadReadParams{Ref: "local:current"}, "local:stable", 1},
+		{"child_ref", appwire.ThreadReadParams{Ref: "local:child"}, "local:child", 1},
+		{"child_id", appwire.ThreadReadParams{ThreadID: "child"}, "local:child", 1},
+		{"root_ref_precedence", appwire.ThreadReadParams{Ref: "local:stable", ThreadID: "child"}, "local:stable", 1},
+		{"child_ref_precedence", appwire.ThreadReadParams{Ref: "local:child", ThreadID: "current"}, "local:child", 1},
+		{"missing_ref_precedence", appwire.ThreadReadParams{Ref: "local:missing", ThreadID: "current"}, "", 1},
+		{"missing_id", appwire.ThreadReadParams{ThreadID: "missing"}, "", 1},
+		{"invalid_ref_precedence", appwire.ThreadReadParams{Ref: "invalid", ThreadID: "current"}, "", 0},
+		{"foreign_ref_precedence", appwire.ThreadReadParams{Ref: "other:stable", ThreadID: "current"}, "", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := rendezvous.Entry{Protocol: appwire.ProtocolVersion, Endpoint: "ws://127.0.0.1/rpc", SourceID: "local", ThreadID: "stable", SessionID: "current", WorkspaceRef: "local:stable"}
+			snapshots := 0
+			source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry {
+				snapshots++
+				if snapshots > 1 {
+					return nil // A second inventory read cannot resolve this target.
+				}
+				return []LocalDaemonEntry{
+					{Entry: entry},
+					{Entry: entry, SessionID: "child", OwnerSessionID: "current", ReadOnlyAlias: true},
+				}
+			}, nil)
+			got, err := source.ResolveSubscriptionAdmission(tc.params)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatalf("invalid admission resolved as %q", got.String())
+				}
+			} else if err != nil || got.String() != tc.want {
+				t.Fatalf("admission = %q, %v; want %q", got.String(), err, tc.want)
+			}
+			if snapshots != tc.snapshots {
+				t.Fatalf("inventory snapshots = %d, want %d", snapshots, tc.snapshots)
+			}
+			if len(source.relaySessions) != 0 {
+				t.Fatal("admission resolution acquired a relay session")
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/relay_subscription_lifecycle_test.go
+++ b/cmd/evener-hub/relay_subscription_lifecycle_test.go
@@ -1,0 +1,191 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestHubRelayStableCompletedLifecycle(t *testing.T) {
+	for _, mode := range []string{"local:stable", "local:current"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, p appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+				appserver.Subscribe(ctx, "current")
+				return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "current", SessionID: "current", Evener: appwire.EvenerThread{Ref: "local:current"}}}, nil
+			})
+			upstream := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+			defer upstream.Close()
+			source := appsource.NewLocalDaemonSourceWithEntries("local", func() []appsource.LocalDaemonEntry {
+				return []appsource.LocalDaemonEntry{{Entry: rendezvous.Entry{SourceID: "local", ThreadID: "stable", SessionID: "current", WorkspaceRef: "local:stable", Endpoint: upstream.URL, Protocol: appwire.ProtocolVersion}}}
+			}, http.DefaultClient)
+			sources := appsource.NewRegistry()
+			sources.Add(source)
+			cfg := hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}
+			server := newHubAppServer(cfg, sources)
+			wire := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+			defer wire.Close()
+			client := dialHubRPC(t, wire)
+			defer client.Close()
+			if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatal(err)
+			}
+			response, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:stable", Subscribe: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			awaitLiveHubSubscriptions(t, server, 1)
+			t.Logf("request=local:stable response=%s subscribers stable=%d current=%d", response.Thread.ID, server.SubscriberCount("local:stable"), server.SubscriberCount("local:current"))
+			if got := server.SubscriberCount("local:stable"); got != 1 {
+				t.Errorf("relay delivery/idle owner stable count=%d want 1", got)
+			}
+			if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:current", Subscribe: true}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{Ref: mode}); err != nil {
+				t.Fatal(err)
+			}
+			for _, key := range []string{"local:stable", "local:current"} {
+				if got := server.SubscriberCount(key); got != 0 {
+					t.Errorf("unsubscribe %s leaves %s subscribers=%d", mode, key, got)
+				}
+				server.Broadcast(key, "test/stale-completed", map[string]any{})
+			}
+			server.BroadcastAll("test/alias-barrier", map[string]any{})
+			if got := aliasMethodCountUntilBarrier(t, client, "test/stale-completed"); got != 0 {
+				t.Errorf("stale deliveries=%d", got)
+			}
+
+		})
+	}
+}
+
+func TestHubRelayNonAtomicUnsubscribeGap(t *testing.T) {
+	for _, existing := range []bool{false, true} {
+		name := "initial"
+		if existing {
+			name = "existing"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			source := &relayBroadcastSource{thread: appwire.Thread{ID: "probe", SessionID: "probe", Source: "codex", Evener: appwire.EvenerThread{Ref: "codex:probe"}}, notifications: make(chan appwire.Notification), subscribed: make(chan struct{}, 2), canceled: make(chan struct{}, 2)}
+			entered, release := make(chan struct{}), make(chan struct{})
+			var once sync.Once
+			unblock := func() { once.Do(func() { close(release) }) }
+			defer unblock()
+			var gateOnce sync.Once
+			gate := func(string) {
+				gateOnce.Do(func() { close(entered) })
+				select {
+				case <-release:
+				case <-ctx.Done():
+				}
+			}
+			cfg := hubcore.WebConfig{HubStateRoot: t.TempDir(), Past: hubcore.NewPastIndex("")}
+			if existing {
+				cfg.RelayHooks.BeforeExistingRegistration = gate
+			} else {
+				cfg.RelayHooks.AfterPlaceholder = gate
+			}
+			sources := appsource.NewRegistry()
+			sources.Add(source)
+			server := newHubAppServer(cfg, sources)
+			wire := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+			defer wire.Close()
+			var verifyKeeper func()
+			if existing {
+				keeper := dialHubRPC(t, wire)
+				defer keeper.Close()
+				if _, err := keeper.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := keeper.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "codex:probe", Subscribe: true}); err != nil {
+					t.Fatal(err)
+				}
+				verifyKeeper = func() {
+					for _, method := range []string{"test/keeper-alive", "test/alias-barrier"} {
+						select {
+						case source.notifications <- appwire.Notification{Method: method, Params: []byte(`{"threadId":"probe"}`)}:
+						case <-ctx.Done():
+							t.Fatal("keeper transport stopped")
+						}
+					}
+					if got := aliasMethodCountUntilBarrier(t, keeper, "test/keeper-alive"); got != 1 {
+						t.Fatalf("keeper deliveries=%d, want 1", got)
+					}
+				}
+			}
+			client := dialHubRPC(t, wire)
+			defer client.Close()
+			if _, err := client.Initialize(ctx, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan error, 1)
+			go func() {
+				_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "codex:probe", Subscribe: true})
+				done <- err
+			}()
+			select {
+			case <-entered:
+			case <-ctx.Done():
+				t.Fatal("registration barrier not reached")
+			}
+			if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{Ref: "codex:probe"}); err != nil {
+				t.Fatal(err)
+			}
+			unblock()
+			select {
+			case err := <-done:
+				var wire appwire.WireError
+				if !errors.As(err, &wire) || wire.Code != appwire.CodeUnavailable {
+					t.Fatalf("canceled admission error=%v, want unavailable", err)
+				}
+				if data, ok := wire.Data.(map[string]any); !ok || data["evenerErrorInfo"] != string(appwire.ErrorSessionUnavailable) {
+					t.Fatalf("canceled admission data=%#v, want sessionUnavailable", wire.Data)
+				}
+			case <-ctx.Done():
+				t.Fatal("read did not finish")
+			}
+			want := 0
+			if existing {
+				want = 1
+			}
+			if got := server.SubscriberCount("codex:probe"); got != want {
+				t.Errorf("%s registration resurrected canceled admission: subscribers=%d want=%d", name, got, want)
+			}
+			if verifyKeeper != nil {
+				verifyKeeper()
+			} else {
+				select {
+				case <-source.canceled:
+				case <-ctx.Done():
+					t.Fatal("rejected initial transport was not canceled")
+				}
+			}
+			server.Broadcast("codex:probe", "test/stale-nonatomic", map[string]any{})
+			server.BroadcastAll("test/alias-barrier", map[string]any{})
+			if got := aliasMethodCountUntilBarrier(t, client, "test/stale-nonatomic"); got != 0 {
+				t.Errorf("canceled non-atomic request delivered %d stale frames; want 0", got)
+			}
+			if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "codex:probe", Subscribe: true}); err != nil {
+				t.Fatalf("later legitimate read failed (stale placeholder): %v", err)
+			}
+			if got := server.SubscriberCount("codex:probe"); got != want+1 {
+				t.Fatalf("later subscribers=%d, want %d", got, want+1)
+			}
+		})
+	}
+}

--- a/internal/appserver/admission_resolution_test.go
+++ b/internal/appserver/admission_resolution_test.go
@@ -22,6 +22,13 @@ func TestSubscriptionAdmissionResolverPanicIsContained(t *testing.T) {
 		}
 	}()
 	c.executeOrdered(context.Background(), msg)
+	response := <-c.send
+	if response.Error == nil || response.Error.Error.Code != appwire.CodeInternalError {
+		t.Fatalf("resolver panic response = %+v, want internal error", response)
+	}
+	if len(c.pendingAdmissions) != 0 || len(s.subs.byConn[c.id]) != 0 {
+		t.Fatal("resolver panic caused admission or subscription side effects")
+	}
 }
 
 func TestUnresolvedSubscribingReadFailsClosed(t *testing.T) {
@@ -42,6 +49,23 @@ func TestUnresolvedSubscribingReadFailsClosed(t *testing.T) {
 	}
 	if s.subs.IsSubscribed(c.id, "thread") {
 		t.Fatal("unresolved subscribe installed a subscription")
+	}
+}
+
+func TestInvalidSubscribingReadPreservesInvalidParams(t *testing.T) {
+	s := NewServer(ServerConfig{SubscriptionAdmissionResolver: func(appwire.Message) (string, bool) {
+		return "", false
+	}})
+	c := s.NewConnection("invalid")
+	c.setInitialized()
+	HandleTyped(s.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		return appwire.ThreadReadResponse{}, nil
+	})
+	msg := appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodThreadRead, json.RawMessage(`{"subscribe":true,"threadId":123}`))
+	c.executeOrdered(context.Background(), msg)
+	response := <-c.send
+	if response.Error == nil || response.Error.Error.Code != appwire.CodeInvalidParams {
+		t.Fatalf("invalid subscribing read response = %+v, want invalid params", response)
 	}
 }
 

--- a/internal/appserver/admission_resolution_test.go
+++ b/internal/appserver/admission_resolution_test.go
@@ -2,11 +2,48 @@ package appserver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
 	"primeradiant.com/evener/appwire"
 )
+
+func TestSubscriptionAdmissionResolverPanicIsContained(t *testing.T) {
+	s := NewServer(ServerConfig{SubscriptionAdmissionResolver: func(appwire.Message) (string, bool) {
+		panic("resolver boom")
+	}})
+	c := s.NewConnection("panic")
+	c.setInitialized()
+	msg := appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodThreadRead, json.RawMessage(`{"subscribe":true}`))
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("resolver panic escaped ordered dispatch: %v", recovered)
+		}
+	}()
+	c.executeOrdered(context.Background(), msg)
+}
+
+func TestUnresolvedSubscribingReadFailsClosed(t *testing.T) {
+	s := NewServer(ServerConfig{SubscriptionAdmissionResolver: func(appwire.Message) (string, bool) {
+		return "", false
+	}})
+	c := s.NewConnection("unresolved")
+	c.setInitialized()
+	HandleTyped(s.Router(), appwire.MethodThreadRead, func(ctx context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		Subscribe(ctx, "thread")
+		return appwire.ThreadReadResponse{}, nil
+	})
+	msg := appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodThreadRead, json.RawMessage(`{"subscribe":true}`))
+	c.executeOrdered(context.Background(), msg)
+	response := <-c.send
+	if response.Error == nil || response.Error.Error.Code != appwire.CodeUnavailable {
+		t.Fatalf("unresolved subscribe response = %+v, want unavailable", response)
+	}
+	if s.subs.IsSubscribed(c.id, "thread") {
+		t.Fatal("unresolved subscribe installed a subscription")
+	}
+}
 
 func TestResolvedAdmissionMismatchPreservesOwnership(t *testing.T) {
 	for _, immediate := range []bool{false, true} {

--- a/internal/appserver/admission_resolution_test.go
+++ b/internal/appserver/admission_resolution_test.go
@@ -1,0 +1,92 @@
+package appserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+)
+
+func TestResolvedAdmissionMismatchPreservesOwnership(t *testing.T) {
+	for _, immediate := range []bool{false, true} {
+		s := NewServer(ServerConfig{})
+		c := s.NewConnection("conn")
+		s.registerConnection(c)
+		t.Cleanup(func() { s.unregisterConnection(c) })
+		ctx := context.WithValue(t.Context(), connectionContextKey{}, c)
+		ctx = context.WithValue(ctx, requestIDContextKey{}, "keeper")
+		if !CaptureSubscription(ctx, false, func() string { return "keeper" }, func() uint64 { return 0 }, func() bool { return true }) {
+			t.Fatal("keeper capture")
+		}
+		keeper := c.hydrations["keeper"]
+		ctx = context.WithValue(ctx, requestIDContextKey{}, "read")
+		admission := c.beginSubscriptionAdmission("read", "old-owner")
+		if immediate {
+			err := SubscribeWithAdmission(ctx, "new-delivery", true, "new-owner")
+			var wire appwire.WireError
+			if !errors.As(err, &wire) || wire.Code != appwire.CodeUnavailable {
+				t.Fatalf("immediate mismatch=%v", err)
+			}
+		} else {
+			captured := CaptureSubscription(ctx, true, nil, func() uint64 { return 0 }, func() bool { t.Error("mismatch reached materialization"); return true }, func() SubscriptionTarget {
+				if s.projectionMu.TryLock() {
+					s.projectionMu.Unlock()
+					t.Error("resolution outside projection gate")
+				}
+				if s.deliveryMu.TryLock() {
+					s.deliveryMu.Unlock()
+					t.Error("resolution outside delivery gate")
+				}
+				if !c.admissionMu.TryLock() {
+					t.Error("resolution under admission lock")
+				} else {
+					c.admissionMu.Unlock()
+				}
+				return SubscriptionTarget{ThreadID: "new-delivery", LifecycleKey: "new-owner"}
+			})
+			if captured {
+				t.Fatal("capture accepted mismatched owner")
+			}
+		}
+		if c.hydrations["keeper"] != keeper || !s.subs.IsSubscribed(c.id, "keeper") {
+			t.Fatal("mismatch superseded keeper hydration")
+		}
+		if s.subs.IsSubscribed(c.id, "new-delivery") {
+			t.Fatal("mismatch installed delivery")
+		}
+		c.admissionMu.Lock()
+		_, pending := c.pendingAdmissions[admission]
+		unchanged := admission.threadID == "old-owner"
+		c.admissionMu.Unlock()
+		if !pending || !unchanged {
+			t.Fatal("mismatch consumed or changed ingress admission")
+		}
+	}
+}
+
+func TestResolvedImmediateAdmissionOptionalCompatibility(t *testing.T) {
+	s := NewServer(ServerConfig{})
+	c := s.NewConnection("conn")
+	s.registerConnection(c)
+	defer s.unregisterConnection(c)
+	ctx := context.WithValue(t.Context(), connectionContextKey{}, c)
+	// No admission: explicit expected owner does not change the default A=D.
+	if err := SubscribeWithAdmission(ctx, "delivery", false, "different"); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.subs.byConn[c.id]["delivery"].lifecycleKey; got != "delivery" {
+		t.Fatalf("default owner=%s", got)
+	}
+	ctx = context.WithValue(ctx, requestIDContextKey{}, "read")
+	admission := c.beginSubscriptionAdmission("read", "owner")
+	if err := SubscribeWithAdmission(ctx, "alias", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, pending := c.pendingAdmissions[admission]; pending {
+		t.Fatal("successful generic registration did not consume admission")
+	}
+	if got := s.subs.byConn[c.id]["alias"].lifecycleKey; got != "owner" {
+		t.Fatalf("admission owner=%s", got)
+	}
+}

--- a/internal/appserver/admission_resolution_test.go
+++ b/internal/appserver/admission_resolution_test.go
@@ -81,6 +81,25 @@ func TestUnresolvedSubscriptionUsesSessionUnavailableMetadata(t *testing.T) {
 	}
 }
 
+func TestUnresolvedUnsubscribeCancelsCanonicalAndDeliveryAdmissions(t *testing.T) {
+	s := NewServer(ServerConfig{SubscriptionAdmissionResolverV2: func(appwire.Message) SubscriptionAdmissionResolution {
+		return SubscriptionAdmissionResolution{Key: "local:delivery", SecondaryKey: "local:lifecycle", Intent: SubscriptionAdmissionUnresolved}
+	}})
+	c := s.NewConnection("dual")
+	c.setInitialized()
+	canonical := c.beginSubscriptionAdmission("read", "local:lifecycle")
+	delivery := c.beginSubscriptionAdmission("other", "local:delivery")
+	msg := appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodThreadUnsubscribe, json.RawMessage(`{"ref":"local:delivery"}`))
+	c.executeOrdered(context.Background(), msg)
+	c.admissionMu.Lock()
+	canonicalCanceled := canonical.canceled
+	deliveryCanceled := delivery.canceled
+	c.admissionMu.Unlock()
+	if !canonicalCanceled || !deliveryCanceled {
+		t.Fatal("unresolved unsubscribe did not cancel admissions under either identity")
+	}
+}
+
 func TestResolvedAdmissionMismatchPreservesOwnership(t *testing.T) {
 	for _, immediate := range []bool{false, true} {
 		s := NewServer(ServerConfig{})

--- a/internal/appserver/admission_resolution_test.go
+++ b/internal/appserver/admission_resolution_test.go
@@ -81,15 +81,6 @@ func TestUnresolvedSubscriptionUsesSessionUnavailableMetadata(t *testing.T) {
 	}
 }
 
-func TestCaptureWithoutConnectionKeepsLifecycleOnlyTarget(t *testing.T) {
-	captured := CaptureSubscription(context.Background(), false, nil, func() uint64 { return 0 }, func() bool { return true }, func() SubscriptionTarget {
-		return SubscriptionTarget{LifecycleKey: "local:past"}
-	})
-	if !captured {
-		t.Fatal("no-connection capture rejected a valid lifecycle-only target")
-	}
-}
-
 func TestResolvedAdmissionMismatchPreservesOwnership(t *testing.T) {
 	for _, immediate := range []bool{false, true} {
 		s := NewServer(ServerConfig{})

--- a/internal/appserver/admission_resolution_test.go
+++ b/internal/appserver/admission_resolution_test.go
@@ -69,6 +69,27 @@ func TestInvalidSubscribingReadPreservesInvalidParams(t *testing.T) {
 	}
 }
 
+func TestUnresolvedSubscriptionUsesSessionUnavailableMetadata(t *testing.T) {
+	s := NewServer(ServerConfig{SubscriptionAdmissionResolver: func(appwire.Message) (string, bool) { return "", false }})
+	c := s.NewConnection("metadata")
+	c.setInitialized()
+	msg := appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodThreadRead, json.RawMessage(`{"subscribe":true}`))
+	c.executeOrdered(context.Background(), msg)
+	response := <-c.send
+	if response.Error == nil || response.Error.Error.Data.(appwire.ErrorData).EvenerErrorInfo != appwire.ErrorSessionUnavailable {
+		t.Fatalf("unresolved metadata = %+v, want session unavailable", response)
+	}
+}
+
+func TestCaptureWithoutConnectionKeepsLifecycleOnlyTarget(t *testing.T) {
+	captured := CaptureSubscription(context.Background(), false, nil, func() uint64 { return 0 }, func() bool { return true }, func() SubscriptionTarget {
+		return SubscriptionTarget{LifecycleKey: "local:past"}
+	})
+	if !captured {
+		t.Fatal("no-connection capture rejected a valid lifecycle-only target")
+	}
+}
+
 func TestResolvedAdmissionMismatchPreservesOwnership(t *testing.T) {
 	for _, immediate := range []bool{false, true} {
 		s := NewServer(ServerConfig{})

--- a/internal/appserver/appstack_seqfuzz_test.go
+++ b/internal/appserver/appstack_seqfuzz_test.go
@@ -164,9 +164,13 @@ func (s *ctxTransport) Recv(ctx context.Context) (appwire.Message, error) {
 	return s.stackTransport.Recv(ctx)
 }
 
-type stackCloser struct{ closes int }
+type stackCloser struct {
+	closes    int
+	immediate int
+}
 
 func (s *stackCloser) Close(websocket.StatusCode, string) error { s.closes++; return nil }
+func (s *stackCloser) CloseNow() error                          { s.immediate++; return nil }
 
 func exerciseReceiveLoops(t rapidTB) {
 	s := NewServer(ServerConfig{})
@@ -184,12 +188,18 @@ func exerciseReceiveLoops(t rapidTB) {
 	if closer.closes != 1 {
 		t.Fatalf("abnormal receive close count = %d", closer.closes)
 	}
+	if closer.immediate != 0 {
+		t.Fatalf("noncancelled immediate close count = %d", closer.immediate)
+	}
 	c.closeSend()
 	ctx, cancel := context.WithCancel(context.Background())
 	c.setCancel(cancel)
 	transport := &ctxTransport{ctx: ctx}
 	transport.messages = []appwire.Message{appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodPing, nil)}
 	runWebSocketReceiveLoop(ctx, closer, transport, c, newWebSocketReadGate())
+	if closer.closes != 1 || closer.immediate != 1 {
+		t.Fatalf("cancelled close counts = graceful %d, immediate %d", closer.closes, closer.immediate)
+	}
 }
 
 type stackPinger struct {

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -1007,11 +1007,8 @@ func captureSubscription(
 	conn, ok := ctx.Value(connectionContextKey{}).(*Connection)
 	if !ok || conn == nil {
 		if handoff.Commit == nil && handoff.Abort == nil {
-			if len(resolveTarget) != 0 {
-				target := resolveTarget[0]()
-				if target.ThreadID == "" && target.LifecycleKey == "" {
-					return false
-				}
+			if len(resolveTarget) != 0 && resolveTarget[0]().ThreadID == "" {
+				return false
 			}
 			return snapshot()
 		}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -35,6 +35,11 @@ type ServerConfig struct {
 	// of the socket, including handler failures and connection lifecycle events.
 	// Nil means silent.
 	Logf func(format string, args ...any)
+	// SubscriptionAdmissionResolver returns the canonical pending-admission key
+	// for a subscribing thread/read or a thread/unsubscribe request. It must be
+	// pure and synchronous; ordered dispatch uses it before starting the read or
+	// invoking the unsubscribe handler. It does not determine delivery routing.
+	SubscriptionAdmissionResolver func(appwire.Message) (string, bool)
 }
 
 // requestQueueCap bounds each connection's inbound request queue. It must
@@ -109,6 +114,9 @@ type Server struct {
 	conns                          map[string]*Connection
 	afterUnregisterDelete          func()
 	beforeSubscriptionRegistration func()
+	// beforeSubscriptionBeginBuffered pins the short claim-to-registration
+	// admission section in package tests; production leaves it nil.
+	beforeSubscriptionBeginBuffered func()
 	// beforeHydrationCommit runs after a response removes its hydration
 	// finalizer and before that finalizer commits. Production leaves it nil;
 	// package tests use it to pin the response-visible activation boundary.
@@ -217,14 +225,60 @@ func (s *Server) NewConnection(id string) *Connection {
 	// (at 32 this side evicted live clients whose send loop napped through a
 	// turn-boundary burst on a loaded machine).
 	return &Connection{
-		id:               id,
-		server:           s,
-		send:             make(chan appwire.Message, appwire.NotificationBufferCap),
-		requests:         make(chan appwire.Message, s.requestQueueCapacity),
-		slowReadSlots:    make(chan struct{}, slowReadDispatchCap),
-		slowReadInflight: map[string]int{},
-		workerExited:     make(chan struct{}),
+		id:                id,
+		server:            s,
+		send:              make(chan appwire.Message, appwire.NotificationBufferCap),
+		requests:          make(chan appwire.Message, s.requestQueueCapacity),
+		slowReadSlots:     make(chan struct{}, slowReadDispatchCap),
+		slowReadInflight:  map[string]int{},
+		workerExited:      make(chan struct{}),
+		pendingAdmissions: map[*subscriptionAdmission]struct{}{},
 	}
+}
+
+type subscriptionAdmission struct {
+	requestID string
+	threadID  string
+	canceled  bool
+}
+
+func (c *Connection) beginSubscriptionAdmission(requestID, threadID string) *subscriptionAdmission {
+	admission := &subscriptionAdmission{requestID: requestID, threadID: threadID}
+	c.admissionMu.Lock()
+	if c.pendingAdmissions == nil {
+		c.pendingAdmissions = map[*subscriptionAdmission]struct{}{}
+	}
+	c.pendingAdmissions[admission] = struct{}{}
+	c.admissionMu.Unlock()
+	return admission
+}
+
+func (c *Connection) finishSubscriptionAdmission(admission *subscriptionAdmission) {
+	if admission == nil {
+		return
+	}
+	c.admissionMu.Lock()
+	delete(c.pendingAdmissions, admission)
+	c.admissionMu.Unlock()
+}
+
+func (c *Connection) cancelSubscriptionAdmissions(threadID string) {
+	c.admissionMu.Lock()
+	for admission := range c.pendingAdmissions {
+		if admission.threadID == threadID {
+			admission.canceled = true
+		}
+	}
+	c.admissionMu.Unlock()
+}
+
+func (c *Connection) claimSubscriptionAdmission(requestID string) (*subscriptionAdmission, bool) {
+	for admission := range c.pendingAdmissions {
+		if admission.requestID == requestID {
+			return admission, !admission.canceled
+		}
+	}
+	return nil, true
 }
 
 func (s *Server) logf(format string, args ...any) {
@@ -459,12 +513,17 @@ type Connection struct {
 	// workerExited closes when the serial worker returns; tests assert
 	// worker teardown against it instead of sleeping.
 	workerExited chan struct{}
-	mu           sync.RWMutex
-	initialized  bool
-	cancel       context.CancelFunc
-	responseMu   sync.Mutex
-	hydrationMu  sync.Mutex
-	hydrations   map[string]*hydrationResponseFinalizer
+	// pendingAdmissions covers the wire-admitted-to-capture interval. Entries
+	// are removed on claim or read completion, so cancellation leaves no
+	// unbounded tombstones.
+	admissionMu       sync.Mutex
+	pendingAdmissions map[*subscriptionAdmission]struct{}
+	mu                sync.RWMutex
+	initialized       bool
+	cancel            context.CancelFunc
+	responseMu        sync.Mutex
+	hydrationMu       sync.Mutex
+	hydrations        map[string]*hydrationResponseFinalizer
 }
 
 func (c *Connection) ID() string {
@@ -767,6 +826,7 @@ func Unsubscribe(ctx context.Context, threadID string) {
 		return
 	}
 	server := conn.server
+	conn.cancelSubscriptionAdmissions(threadID)
 	server.mu.Lock()
 	defer server.mu.Unlock()
 	if server.conns[conn.id] != conn {
@@ -893,6 +953,15 @@ func captureSubscription(
 		return abortAfterUnlock()
 	}
 	responseID, _ := ctx.Value(requestIDContextKey{}).(string)
+	conn.admissionMu.Lock()
+	admission, allowed := conn.claimSubscriptionAdmission(responseID)
+	if admission != nil && !allowed {
+		conn.admissionMu.Unlock()
+		return abortAfterUnlock()
+	}
+	if conn.server.beforeSubscriptionBeginBuffered != nil {
+		conn.server.beforeSubscriptionBeginBuffered()
+	}
 	superseded = conn.takeSupersededHydrations(responseID, targetThreadID, replace)
 	for _, finalizer := range superseded {
 		server.subs.withdrawBuffered(
@@ -905,6 +974,10 @@ func captureSubscription(
 	server.nextHydrationGeneration++
 	generation := server.nextHydrationGeneration
 	rollback := server.subs.beginBuffered(conn.id, targetThreadID, replace, generation)
+	if admission != nil {
+		delete(conn.pendingAdmissions, admission)
+	}
+	conn.admissionMu.Unlock()
 	if !snapshot() {
 		server.subs.withdrawBuffered(conn.id, targetThreadID, generation, rollback)
 		return abortAfterUnlock()
@@ -1193,15 +1266,32 @@ func formatTally(tally map[string]int) string {
 // canceling the shared context is enough — the worker exits at its next
 // dequeue and the receive loop's next Recv fails into normal close handling.
 func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
+	if msg.Request != nil && msg.Request.Method == appwire.MethodThreadUnsubscribe && c.isInitialized() {
+		if resolve := c.server.cfg.SubscriptionAdmissionResolver; resolve != nil {
+			if key, ok := resolve(msg); ok && key != "" {
+				c.cancelSubscriptionAdmissions(key)
+			}
+		}
+	}
 	if msg.Request != nil && concurrentDispatchMethod(msg.Request.Method) && c.isInitialized() {
 		method := msg.Request.Method
+		var admission *subscriptionAdmission
+		if method == appwire.MethodThreadRead {
+			if c.server.cfg.SubscriptionAdmissionResolver != nil {
+				if key, subscribes := c.server.cfg.SubscriptionAdmissionResolver(msg); subscribes && key != "" {
+					admission = c.beginSubscriptionAdmission(requestIDKey(msg.Request.ID), key)
+				}
+			}
+		}
 		if !c.acquireSlowReadSlot(ctx, method) {
+			c.finishSubscriptionAdmission(admission)
 			// Canceled while dequeued-awaiting-dispatch-capacity; the worker
 			// loop observes the same cancellation at its next select and
 			// exits without executing anything further.
 			return
 		}
 		go func() {
+			defer c.finishSubscriptionAdmission(admission)
 			defer c.releaseSlowReadSlot(method)
 			c.handleAndEnqueue(ctx, msg)
 		}()

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -835,6 +835,73 @@ func Unsubscribe(ctx context.Context, threadID string) {
 	server.subs.Unsubscribe(conn.id, threadID)
 }
 
+type subscriptionLifecycleContextKey struct{}
+
+// UnsubscribeLifecycle uses the identity resolved at ordered request ingress.
+// Without a resolved identity, preserve the caller's raw delivery-key fallback.
+func UnsubscribeLifecycle(ctx context.Context, threadID string) {
+	conn, _ := ctx.Value(connectionContextKey{}).(*Connection)
+	if conn == nil || threadID == "" {
+		return
+	}
+	key, _ := ctx.Value(subscriptionLifecycleContextKey{}).(string)
+	if key == "" {
+		Unsubscribe(ctx, threadID)
+		return
+	}
+	threadID = key
+	conn.cancelSubscriptionAdmissions(threadID)
+	conn.server.mu.Lock()
+	defer conn.server.mu.Unlock()
+	if conn.server.conns[conn.id] == conn {
+		conn.server.subs.UnsubscribeLifecycle(conn.id, threadID)
+	}
+}
+
+// SubscribeWithAdmission installs an immediate subscription and consumes the
+// request's admission at one boundary. Registration gates precede admissionMu,
+// matching capture; unsubscribe cannot pass eligibility before installation.
+func SubscribeWithAdmission(ctx context.Context, threadID string, replace bool) error {
+	conn, _ := ctx.Value(connectionContextKey{}).(*Connection)
+	if conn == nil {
+		return nil
+	}
+	if threadID == "" {
+		return context.Canceled
+	}
+	server := conn.server
+	if server.beforeSubscriptionRegistration != nil {
+		server.beforeSubscriptionRegistration()
+	}
+	conn.hydrationMu.Lock()
+	defer conn.hydrationMu.Unlock()
+	server.projectionMu.Lock()
+	defer server.projectionMu.Unlock()
+	server.deliveryMu.Lock()
+	defer server.deliveryMu.Unlock()
+	conn.admissionMu.Lock()
+	defer conn.admissionMu.Unlock()
+	responseID, _ := ctx.Value(requestIDContextKey{}).(string)
+	admission, allowed := conn.claimSubscriptionAdmission(responseID)
+	if !allowed {
+		return appwire.SessionUnavailable("thread subscription is unavailable")
+	}
+	server.mu.RLock()
+	defer server.mu.RUnlock()
+	if server.conns[conn.id] != conn {
+		return context.Canceled
+	}
+	owner := threadID
+	if admission != nil {
+		owner = admission.threadID
+	}
+	server.subs.subscribeOwned(conn.id, threadID, owner, replace)
+	if admission != nil {
+		delete(conn.pendingAdmissions, admission)
+	}
+	return nil
+}
+
 func ReplaceSubscriptions(ctx context.Context, threadID string) bool {
 	conn, ok := ctx.Value(connectionContextKey{}).(*Connection)
 	if !ok || conn == nil {
@@ -973,7 +1040,11 @@ func captureSubscription(
 	}
 	server.nextHydrationGeneration++
 	generation := server.nextHydrationGeneration
-	rollback := server.subs.beginBuffered(conn.id, targetThreadID, replace, generation)
+	owner := targetThreadID
+	if admission != nil {
+		owner = admission.threadID
+	}
+	rollback := server.subs.beginBuffered(conn.id, targetThreadID, replace, generation, owner)
 	if admission != nil {
 		delete(conn.pendingAdmissions, admission)
 	}
@@ -1270,6 +1341,7 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 		if resolve := c.server.cfg.SubscriptionAdmissionResolver; resolve != nil {
 			if key, ok := resolve(msg); ok && key != "" {
 				c.cancelSubscriptionAdmissions(key)
+				ctx = context.WithValue(ctx, subscriptionLifecycleContextKey{}, key)
 			}
 		}
 	}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -1379,7 +1379,7 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 		resolvedKey, resolved, resolverPanic = safeResolveAdmission(c.server, resolve, msg)
 		if resolverPanic {
 			ctx = context.WithValue(ctx, subscriptionAdmissionResolverPanicContextKey{}, true)
-		} else if msg.Request.Method == appwire.MethodThreadRead && threadReadSubscribes(msg.Request.Params) && (!resolved || resolvedKey == "") {
+		} else if msg.Request.Method == appwire.MethodThreadRead && threadReadAdmissionEligible(msg.Request.Params) && (!resolved || resolvedKey == "") {
 			ctx = context.WithValue(ctx, subscriptionAdmissionFailureContextKey{}, "subscription admission is unavailable")
 		}
 	}
@@ -1425,11 +1425,12 @@ func safeResolveAdmission(server *Server, resolve func(appwire.Message) (string,
 	return key, ok, false
 }
 
-func threadReadSubscribes(raw json.RawMessage) bool {
-	var params struct {
-		Subscribe bool `json:"subscribe"`
+func threadReadAdmissionEligible(raw json.RawMessage) bool {
+	var params appwire.ThreadReadParams
+	if json.Unmarshal(raw, &params) != nil || !params.Subscribe {
+		return false
 	}
-	return json.Unmarshal(raw, &params) == nil && params.Subscribe
+	return appwire.ValidateThreadReadParams(params) == nil
 }
 
 // acquireSlowReadSlot takes one slowReadDispatchCap slot on behalf of the

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -861,7 +861,9 @@ func UnsubscribeLifecycle(ctx context.Context, threadID string) {
 // SubscribeWithAdmission installs an immediate subscription and consumes the
 // request's admission at one boundary. Registration gates precede admissionMu,
 // matching capture; unsubscribe cannot pass eligibility before installation.
-func SubscribeWithAdmission(ctx context.Context, threadID string, replace bool) error {
+// An optional expectedLifecycle is the identity already resolved by the handler.
+// A mismatch rejects without consuming admission or changing subscriptions.
+func SubscribeWithAdmission(ctx context.Context, threadID string, replace bool, expectedLifecycle ...string) error {
 	conn, _ := ctx.Value(connectionContextKey{}).(*Connection)
 	if conn == nil {
 		return nil
@@ -883,7 +885,7 @@ func SubscribeWithAdmission(ctx context.Context, threadID string, replace bool) 
 	defer conn.admissionMu.Unlock()
 	responseID, _ := ctx.Value(requestIDContextKey{}).(string)
 	admission, allowed := conn.claimSubscriptionAdmission(responseID)
-	if !allowed {
+	if !allowed || (admission != nil && len(expectedLifecycle) != 0 && admission.threadID != expectedLifecycle[0]) {
 		return appwire.SessionUnavailable("thread subscription is unavailable")
 	}
 	server.mu.RLock()
@@ -924,16 +926,28 @@ func ReplaceSubscriptions(ctx context.Context, threadID string) bool {
 	return true
 }
 
+// SubscriptionTarget is one resolved delivery/lifecycle pair. Capture resolves
+// it under the projection and delivery gates, before taking admissionMu.
+// LifecycleKey is compared with ingress admission ownership, never substituted
+// for the delivery key or used to retarget a pending admission.
+type SubscriptionTarget struct {
+	ThreadID     string
+	LifecycleKey string
+}
+
 // CaptureSubscription registers a buffering hydration generation, captures the
 // authoritative snapshot under the projection gate, and arranges to release
 // only post-cut records after the matching response enters the connection's
 // send queue. A false snapshot result restores the previous ownership.
+// When supplied, resolveTarget replaces threadID and atomically resolves D+A1
+// under the registration gates, before admission validation or hydration changes.
 func CaptureSubscription(
 	ctx context.Context,
 	replace bool,
 	threadID func() string,
 	currentSequence func() uint64,
 	snapshot func() bool,
+	resolveTarget ...func() SubscriptionTarget,
 ) bool {
 	return captureSubscription(
 		ctx,
@@ -943,6 +957,7 @@ func CaptureSubscription(
 		snapshot,
 		CaptureSubscriptionHandoff{},
 		true,
+		resolveTarget...,
 	)
 }
 
@@ -957,6 +972,7 @@ func CaptureSubscriptionWithHandoff(
 	currentSequence func() uint64,
 	snapshot func() bool,
 	handoff CaptureSubscriptionHandoff,
+	resolveTarget ...func() SubscriptionTarget,
 ) bool {
 	return captureSubscription(
 		ctx,
@@ -966,6 +982,7 @@ func CaptureSubscriptionWithHandoff(
 		snapshot,
 		handoff,
 		false,
+		resolveTarget...,
 	)
 }
 
@@ -977,10 +994,14 @@ func captureSubscription(
 	snapshot func() bool,
 	handoff CaptureSubscriptionHandoff,
 	releaseOnErrorResponse bool,
+	resolveTarget ...func() SubscriptionTarget,
 ) bool {
 	conn, ok := ctx.Value(connectionContextKey{}).(*Connection)
 	if !ok || conn == nil {
 		if handoff.Commit == nil && handoff.Abort == nil {
+			if len(resolveTarget) != 0 && resolveTarget[0]().ThreadID == "" {
+				return false
+			}
 			return snapshot()
 		}
 		if handoff.Abort != nil {
@@ -1015,14 +1036,20 @@ func captureSubscription(
 	if !registered {
 		return abortAfterUnlock()
 	}
-	targetThreadID := threadID()
+	var target SubscriptionTarget
+	if len(resolveTarget) != 0 {
+		target = resolveTarget[0]()
+	} else {
+		target.ThreadID = threadID()
+	}
+	targetThreadID := target.ThreadID
 	if targetThreadID == "" {
 		return abortAfterUnlock()
 	}
 	responseID, _ := ctx.Value(requestIDContextKey{}).(string)
 	conn.admissionMu.Lock()
 	admission, allowed := conn.claimSubscriptionAdmission(responseID)
-	if admission != nil && !allowed {
+	if admission != nil && (!allowed || (len(resolveTarget) != 0 && admission.threadID != target.LifecycleKey)) {
 		conn.admissionMu.Unlock()
 		return abortAfterUnlock()
 	}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -40,6 +40,23 @@ type ServerConfig struct {
 	// pure and synchronous; ordered dispatch uses it before starting the read or
 	// invoking the unsubscribe handler. It does not determine delivery routing.
 	SubscriptionAdmissionResolver func(appwire.Message) (string, bool)
+	// SubscriptionAdmissionResolverV2 distinguishes invalid target requests from
+	// unresolved subscribing reads, so native handlers retain validation errors.
+	SubscriptionAdmissionResolverV2 func(appwire.Message) SubscriptionAdmissionResolution
+}
+
+type SubscriptionAdmissionIntent uint8
+
+const (
+	SubscriptionAdmissionNotSubscribe SubscriptionAdmissionIntent = iota
+	SubscriptionAdmissionResolved
+	SubscriptionAdmissionUnresolved
+	SubscriptionAdmissionInvalid
+)
+
+type SubscriptionAdmissionResolution struct {
+	Key    string
+	Intent SubscriptionAdmissionIntent
 }
 
 // requestQueueCap bounds each connection's inbound request queue. It must
@@ -1375,13 +1392,24 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 	var resolverPanic bool
 	var resolvedKey string
 	var resolved bool
-	if resolve := c.server.cfg.SubscriptionAdmissionResolver; resolve != nil && msg.Request != nil && c.isInitialized() && (msg.Request.Method == appwire.MethodThreadRead || msg.Request.Method == appwire.MethodThreadUnsubscribe) {
+	intent := SubscriptionAdmissionNotSubscribe
+	if resolve := c.server.cfg.SubscriptionAdmissionResolverV2; resolve != nil && msg.Request != nil && c.isInitialized() && (msg.Request.Method == appwire.MethodThreadRead || msg.Request.Method == appwire.MethodThreadUnsubscribe) {
+		var result SubscriptionAdmissionResolution
+		result, resolverPanic = safeResolveAdmissionV2(c.server, resolve, msg)
+		resolvedKey, resolved, intent = result.Key, result.Intent == SubscriptionAdmissionResolved, result.Intent
+	} else if resolve := c.server.cfg.SubscriptionAdmissionResolver; resolve != nil && msg.Request != nil && c.isInitialized() && (msg.Request.Method == appwire.MethodThreadRead || msg.Request.Method == appwire.MethodThreadUnsubscribe) {
 		resolvedKey, resolved, resolverPanic = safeResolveAdmission(c.server, resolve, msg)
-		if resolverPanic {
-			ctx = context.WithValue(ctx, subscriptionAdmissionResolverPanicContextKey{}, true)
-		} else if msg.Request.Method == appwire.MethodThreadRead && threadReadAdmissionEligible(msg.Request.Params) && (!resolved || resolvedKey == "") {
-			ctx = context.WithValue(ctx, subscriptionAdmissionFailureContextKey{}, "subscription admission is unavailable")
+		if msg.Request.Method == appwire.MethodThreadRead && threadReadAdmissionEligible(msg.Request.Params) {
+			intent = SubscriptionAdmissionResolved
+			if !resolved || resolvedKey == "" {
+				intent = SubscriptionAdmissionUnresolved
+			}
 		}
+	}
+	if resolverPanic {
+		ctx = context.WithValue(ctx, subscriptionAdmissionResolverPanicContextKey{}, true)
+	} else if intent == SubscriptionAdmissionUnresolved {
+		ctx = context.WithValue(ctx, subscriptionAdmissionFailureContextKey{}, "subscription admission is unavailable")
 	}
 	if msg.Request != nil && msg.Request.Method == appwire.MethodThreadUnsubscribe && c.isInitialized() {
 		if resolved && resolvedKey != "" {
@@ -1423,6 +1451,16 @@ func safeResolveAdmission(server *Server, resolve func(appwire.Message) (string,
 	}()
 	key, ok = resolve(msg)
 	return key, ok, false
+}
+
+func safeResolveAdmissionV2(server *Server, resolve func(appwire.Message) SubscriptionAdmissionResolution, msg appwire.Message) (result SubscriptionAdmissionResolution, panicked bool) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			server.panicLogf("appserver: panic resolving subscription admission for %s: %v\n%s", methodOf(msg), recovered, debug.Stack())
+			result, panicked = SubscriptionAdmissionResolution{}, true
+		}
+	}()
+	return resolve(msg), false
 }
 
 func threadReadAdmissionEligible(raw json.RawMessage) bool {

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -873,6 +873,16 @@ func UnsubscribeLifecycle(ctx context.Context, threadID string) {
 	}
 	key, _ := ctx.Value(subscriptionLifecycleContextKey{}).(string)
 	if keys, ok := ctx.Value(subscriptionLifecycleContextKeysKey{}).([]string); ok && len(keys) > 0 {
+		if len(keys) >= 2 && keys[0] != "" && keys[1] != "" {
+			conn.cancelSubscriptionAdmissions(keys[0])
+			conn.cancelSubscriptionAdmissions(keys[1])
+			conn.server.mu.Lock()
+			if conn.server.conns[conn.id] == conn {
+				conn.server.subs.UnsubscribeLifecycleAlias(conn.id, keys[0], keys[1])
+			}
+			conn.server.mu.Unlock()
+			return
+		}
 		for _, key := range keys {
 			if key == "" {
 				continue
@@ -1434,7 +1444,7 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 			ctx = context.WithValue(ctx, subscriptionLifecycleContextKey{}, resolvedKey)
 			if secondaryKey != "" && secondaryKey != resolvedKey {
 				c.cancelSubscriptionAdmissions(secondaryKey)
-				ctx = context.WithValue(ctx, subscriptionLifecycleContextKeysKey{}, []string{resolvedKey, secondaryKey})
+				ctx = context.WithValue(ctx, subscriptionLifecycleContextKeysKey{}, []string{secondaryKey, resolvedKey})
 			}
 		}
 	}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -55,8 +55,9 @@ const (
 )
 
 type SubscriptionAdmissionResolution struct {
-	Key    string
-	Intent SubscriptionAdmissionIntent
+	Key          string
+	SecondaryKey string
+	Intent       SubscriptionAdmissionIntent
 }
 
 // requestQueueCap bounds each connection's inbound request queue. It must
@@ -861,6 +862,7 @@ func Unsubscribe(ctx context.Context, threadID string) {
 }
 
 type subscriptionLifecycleContextKey struct{}
+type subscriptionLifecycleContextKeysKey struct{}
 
 // UnsubscribeLifecycle uses the identity resolved at ordered request ingress.
 // Without a resolved identity, preserve the caller's raw delivery-key fallback.
@@ -870,6 +872,20 @@ func UnsubscribeLifecycle(ctx context.Context, threadID string) {
 		return
 	}
 	key, _ := ctx.Value(subscriptionLifecycleContextKey{}).(string)
+	if keys, ok := ctx.Value(subscriptionLifecycleContextKeysKey{}).([]string); ok && len(keys) > 0 {
+		for _, key := range keys {
+			if key == "" {
+				continue
+			}
+			conn.cancelSubscriptionAdmissions(key)
+			conn.server.mu.Lock()
+			if conn.server.conns[conn.id] == conn {
+				conn.server.subs.UnsubscribeLifecycle(conn.id, key)
+			}
+			conn.server.mu.Unlock()
+		}
+		return
+	}
 	if key == "" {
 		Unsubscribe(ctx, threadID)
 		return
@@ -1391,12 +1407,13 @@ func formatTally(tally map[string]int) string {
 func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 	var resolverPanic bool
 	var resolvedKey string
+	var secondaryKey string
 	var resolved bool
 	intent := SubscriptionAdmissionNotSubscribe
 	if resolve := c.server.cfg.SubscriptionAdmissionResolverV2; resolve != nil && msg.Request != nil && c.isInitialized() && (msg.Request.Method == appwire.MethodThreadRead || msg.Request.Method == appwire.MethodThreadUnsubscribe) {
 		var result SubscriptionAdmissionResolution
 		result, resolverPanic = safeResolveAdmissionV2(c.server, resolve, msg)
-		resolvedKey, resolved, intent = result.Key, result.Intent == SubscriptionAdmissionResolved, result.Intent
+		resolvedKey, secondaryKey, resolved, intent = result.Key, result.SecondaryKey, result.Intent == SubscriptionAdmissionResolved, result.Intent
 	} else if resolve := c.server.cfg.SubscriptionAdmissionResolver; resolve != nil && msg.Request != nil && c.isInitialized() && (msg.Request.Method == appwire.MethodThreadRead || msg.Request.Method == appwire.MethodThreadUnsubscribe) {
 		resolvedKey, resolved, resolverPanic = safeResolveAdmission(c.server, resolve, msg)
 		if msg.Request.Method == appwire.MethodThreadRead && threadReadAdmissionEligible(msg.Request.Params) {
@@ -1412,9 +1429,13 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 		ctx = context.WithValue(ctx, subscriptionAdmissionFailureContextKey{}, "subscription admission is unavailable")
 	}
 	if msg.Request != nil && msg.Request.Method == appwire.MethodThreadUnsubscribe && c.isInitialized() {
-		if resolved && resolvedKey != "" {
+		if (resolved || intent == SubscriptionAdmissionUnresolved) && resolvedKey != "" {
 			c.cancelSubscriptionAdmissions(resolvedKey)
 			ctx = context.WithValue(ctx, subscriptionLifecycleContextKey{}, resolvedKey)
+			if secondaryKey != "" && secondaryKey != resolvedKey {
+				c.cancelSubscriptionAdmissions(secondaryKey)
+				ctx = context.WithValue(ctx, subscriptionLifecycleContextKeysKey{}, []string{resolvedKey, secondaryKey})
+			}
 		}
 	}
 	if msg.Request != nil && concurrentDispatchMethod(msg.Request.Method) && c.isInitialized() {

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -706,6 +706,12 @@ func (c *Connection) HandleMessage(ctx context.Context, msg appwire.Message) app
 		return appwire.ErrorMessage(appwire.NewIntID(0), appwire.InvalidRequest("request message required"))
 	}
 	req := *msg.Request
+	if _, ok := ctx.Value(subscriptionAdmissionResolverPanicContextKey{}).(bool); ok {
+		return appwire.ErrorMessage(req.ID, appwire.InternalError("internal error handling request"))
+	}
+	if reason, ok := ctx.Value(subscriptionAdmissionFailureContextKey{}).(string); ok {
+		return appwire.ErrorMessage(req.ID, appwire.WireError{Code: appwire.CodeUnavailable, Message: reason})
+	}
 	// ping is the browser's app-level heartbeat (browsers cannot send WS ping
 	// frames from JS). It bypasses the router and is answered here, before
 	// the initialize gate; the receive loop answers it inline, bypassing the
@@ -747,6 +753,8 @@ func (c *Connection) handleNotification(notification appwire.Notification) appwi
 
 type connectionContextKey struct{}
 type requestIDContextKey struct{}
+type subscriptionAdmissionFailureContextKey struct{}
+type subscriptionAdmissionResolverPanicContextKey struct{}
 
 // CaptureSubscriptionHandoff is the one-shot continuation paired with a
 // buffering subscription capture. Commit runs only after the matching response
@@ -1364,22 +1372,29 @@ func formatTally(tally map[string]int) string {
 // canceling the shared context is enough — the worker exits at its next
 // dequeue and the receive loop's next Recv fails into normal close handling.
 func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
+	var resolverPanic bool
+	var resolvedKey string
+	var resolved bool
+	if resolve := c.server.cfg.SubscriptionAdmissionResolver; resolve != nil && msg.Request != nil && c.isInitialized() && (msg.Request.Method == appwire.MethodThreadRead || msg.Request.Method == appwire.MethodThreadUnsubscribe) {
+		resolvedKey, resolved, resolverPanic = safeResolveAdmission(c.server, resolve, msg)
+		if resolverPanic {
+			ctx = context.WithValue(ctx, subscriptionAdmissionResolverPanicContextKey{}, true)
+		} else if msg.Request.Method == appwire.MethodThreadRead && threadReadSubscribes(msg.Request.Params) && (!resolved || resolvedKey == "") {
+			ctx = context.WithValue(ctx, subscriptionAdmissionFailureContextKey{}, "subscription admission is unavailable")
+		}
+	}
 	if msg.Request != nil && msg.Request.Method == appwire.MethodThreadUnsubscribe && c.isInitialized() {
-		if resolve := c.server.cfg.SubscriptionAdmissionResolver; resolve != nil {
-			if key, ok := resolve(msg); ok && key != "" {
-				c.cancelSubscriptionAdmissions(key)
-				ctx = context.WithValue(ctx, subscriptionLifecycleContextKey{}, key)
-			}
+		if resolved && resolvedKey != "" {
+			c.cancelSubscriptionAdmissions(resolvedKey)
+			ctx = context.WithValue(ctx, subscriptionLifecycleContextKey{}, resolvedKey)
 		}
 	}
 	if msg.Request != nil && concurrentDispatchMethod(msg.Request.Method) && c.isInitialized() {
 		method := msg.Request.Method
 		var admission *subscriptionAdmission
 		if method == appwire.MethodThreadRead {
-			if c.server.cfg.SubscriptionAdmissionResolver != nil {
-				if key, subscribes := c.server.cfg.SubscriptionAdmissionResolver(msg); subscribes && key != "" {
-					admission = c.beginSubscriptionAdmission(requestIDKey(msg.Request.ID), key)
-				}
+			if resolved && resolvedKey != "" {
+				admission = c.beginSubscriptionAdmission(requestIDKey(msg.Request.ID), resolvedKey)
 			}
 		}
 		if !c.acquireSlowReadSlot(ctx, method) {
@@ -1397,6 +1412,24 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 		return
 	}
 	c.handleAndEnqueue(ctx, msg)
+}
+
+func safeResolveAdmission(server *Server, resolve func(appwire.Message) (string, bool), msg appwire.Message) (key string, ok, panicked bool) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			server.panicLogf("appserver: panic resolving subscription admission for %s: %v\n%s", methodOf(msg), recovered, debug.Stack())
+			key, ok, panicked = "", false, true
+		}
+	}()
+	key, ok = resolve(msg)
+	return key, ok, false
+}
+
+func threadReadSubscribes(raw json.RawMessage) bool {
+	var params struct {
+		Subscribe bool `json:"subscribe"`
+	}
+	return json.Unmarshal(raw, &params) == nil && params.Subscribe
 }
 
 // acquireSlowReadSlot takes one slowReadDispatchCap slot on behalf of the

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -1408,7 +1408,7 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 	}
 	if resolverPanic {
 		ctx = context.WithValue(ctx, subscriptionAdmissionResolverPanicContextKey{}, true)
-	} else if intent == SubscriptionAdmissionUnresolved {
+	} else if msg.Request != nil && msg.Request.Method == appwire.MethodThreadRead && threadReadAdmissionEligible(msg.Request.Params) && intent == SubscriptionAdmissionUnresolved {
 		ctx = context.WithValue(ctx, subscriptionAdmissionFailureContextKey{}, "subscription admission is unavailable")
 	}
 	if msg.Request != nil && msg.Request.Method == appwire.MethodThreadUnsubscribe && c.isInitialized() {

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -710,7 +710,7 @@ func (c *Connection) HandleMessage(ctx context.Context, msg appwire.Message) app
 		return appwire.ErrorMessage(req.ID, appwire.InternalError("internal error handling request"))
 	}
 	if reason, ok := ctx.Value(subscriptionAdmissionFailureContextKey{}).(string); ok {
-		return appwire.ErrorMessage(req.ID, appwire.WireError{Code: appwire.CodeUnavailable, Message: reason})
+		return appwire.ErrorMessage(req.ID, appwire.SessionUnavailable(reason))
 	}
 	// ping is the browser's app-level heartbeat (browsers cannot send WS ping
 	// frames from JS). It bypasses the router and is answered here, before
@@ -1007,8 +1007,11 @@ func captureSubscription(
 	conn, ok := ctx.Value(connectionContextKey{}).(*Connection)
 	if !ok || conn == nil {
 		if handoff.Commit == nil && handoff.Abort == nil {
-			if len(resolveTarget) != 0 && resolveTarget[0]().ThreadID == "" {
-				return false
+			if len(resolveTarget) != 0 {
+				target := resolveTarget[0]()
+				if target.ThreadID == "" && target.LifecycleKey == "" {
+					return false
+				}
 			}
 			return snapshot()
 		}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -1453,7 +1453,7 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 			if secondaryKey != "" && secondaryKey != resolvedKey {
 				c.cancelSubscriptionAdmissions(secondaryKey)
 				if intent == SubscriptionAdmissionUnresolved {
-					ctx = context.WithValue(ctx, subscriptionLifecycleContextKeysKey{}, []string{secondaryKey, resolvedKey})
+					ctx = context.WithValue(ctx, subscriptionLifecycleContextKeysKey{}, []string{resolvedKey, secondaryKey})
 					ctx = context.WithValue(ctx, subscriptionUnresolvedContextKey{}, true)
 				}
 			}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -866,6 +866,7 @@ func Unsubscribe(ctx context.Context, threadID string) {
 
 type subscriptionLifecycleContextKey struct{}
 type subscriptionLifecycleContextKeysKey struct{}
+type subscriptionUnresolvedContextKey struct{}
 
 // UnsubscribeLifecycle uses the identity resolved at ordered request ingress.
 // Without a resolved identity, preserve the caller's raw delivery-key fallback.
@@ -881,7 +882,11 @@ func UnsubscribeLifecycle(ctx context.Context, threadID string) {
 			conn.cancelSubscriptionAdmissions(keys[1])
 			conn.server.mu.Lock()
 			if conn.server.conns[conn.id] == conn {
-				conn.server.subs.UnsubscribeLifecycleAlias(conn.id, keys[0], keys[1])
+				if unresolved, _ := ctx.Value(subscriptionUnresolvedContextKey{}).(bool); unresolved {
+					conn.server.subs.Unsubscribe(conn.id, keys[0])
+				} else {
+					conn.server.subs.UnsubscribeLifecycleAlias(conn.id, keys[0], keys[1])
+				}
 			}
 			conn.server.mu.Unlock()
 			return
@@ -1449,6 +1454,7 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 				c.cancelSubscriptionAdmissions(secondaryKey)
 				if intent == SubscriptionAdmissionUnresolved {
 					ctx = context.WithValue(ctx, subscriptionLifecycleContextKeysKey{}, []string{secondaryKey, resolvedKey})
+					ctx = context.WithValue(ctx, subscriptionUnresolvedContextKey{}, true)
 				}
 			}
 		}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -851,6 +851,9 @@ func Unsubscribe(ctx context.Context, threadID string) {
 	if !ok || conn == nil || threadID == "" {
 		return
 	}
+	if resolved, ok := ctx.Value(subscriptionLifecycleContextKey{}).(string); ok && resolved != "" {
+		threadID = resolved
+	}
 	server := conn.server
 	conn.cancelSubscriptionAdmissions(threadID)
 	server.mu.Lock()
@@ -1444,7 +1447,9 @@ func (c *Connection) executeOrdered(ctx context.Context, msg appwire.Message) {
 			ctx = context.WithValue(ctx, subscriptionLifecycleContextKey{}, resolvedKey)
 			if secondaryKey != "" && secondaryKey != resolvedKey {
 				c.cancelSubscriptionAdmissions(secondaryKey)
-				ctx = context.WithValue(ctx, subscriptionLifecycleContextKeysKey{}, []string{secondaryKey, resolvedKey})
+				if intent == SubscriptionAdmissionUnresolved {
+					ctx = context.WithValue(ctx, subscriptionLifecycleContextKeysKey{}, []string{secondaryKey, resolvedKey})
+				}
 			}
 		}
 	}

--- a/internal/appserver/subscription_admission_ordering_test.go
+++ b/internal/appserver/subscription_admission_ordering_test.go
@@ -1,0 +1,52 @@
+package appserver
+
+import "testing"
+
+func TestSubscriptionAdmissionExistsBeforeRefResolution(t *testing.T) {
+	server := NewServer(ServerConfig{})
+	conn := server.NewConnection("conn-ref-only")
+	admission := conn.beginSubscriptionAdmission(`1`, "")
+	if admission == nil {
+		t.Fatal("ref-only thread/read lost its admission before resolver preparation")
+	}
+}
+
+func TestSubscriptionAdmissionEarlyUnsubscribeSurvivesCanonicalPreparation(t *testing.T) {
+	server := NewServer(ServerConfig{})
+	conn := server.NewConnection("conn-alias")
+	admission := conn.beginSubscriptionAdmission(`1`, "canonical:stable")
+	if admission == nil {
+		t.Fatal("raw thread/read admission was not created")
+	}
+	conn.cancelSubscriptionAdmissions("canonical:stable")
+	conn.admissionMu.Lock()
+	_, allowed := conn.claimSubscriptionAdmission(`1`)
+	conn.admissionMu.Unlock()
+	if allowed {
+		t.Fatal("unsubscribe before canonical preparation did not cancel the read")
+	}
+}
+
+func TestSubscriptionAdmissionSameThreadPreAndPostUnsubscribe(t *testing.T) {
+	server := NewServer(ServerConfig{})
+	conn := server.NewConnection("conn-order")
+	first := conn.beginSubscriptionAdmission(`1`, "thread")
+	if first == nil {
+		t.Fatal("first admission missing")
+	}
+	conn.cancelSubscriptionAdmissions("thread")
+	second := conn.beginSubscriptionAdmission(`2`, "thread")
+	if second == nil {
+		t.Fatal("second admission missing")
+	}
+	conn.admissionMu.Lock()
+	_, firstAllowed := conn.claimSubscriptionAdmission(`1`)
+	_, secondAllowed := conn.claimSubscriptionAdmission(`2`)
+	conn.admissionMu.Unlock()
+	if firstAllowed {
+		t.Fatal("pre-unsubscribe admission was allowed")
+	}
+	if !secondAllowed {
+		t.Fatal("post-unsubscribe admission was canceled with the stale read")
+	}
+}

--- a/internal/appserver/subscription_rollback_lifecycle_test.go
+++ b/internal/appserver/subscription_rollback_lifecycle_test.go
@@ -1,0 +1,94 @@
+package appserver
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSubscriptionLifecycleUnsubscribeRawFallback(t *testing.T) {
+	s := NewServer(ServerConfig{})
+	c := &Connection{id: "conn", server: s}
+	s.conns[c.id] = c
+	s.subs.subscribeOwned(c.id, "current", "stable", false)
+	s.subs.subscribeOwned(c.id, "stable", "stable", false)
+	ctx := context.WithValue(t.Context(), connectionContextKey{}, c)
+	UnsubscribeLifecycle(ctx, "current")
+	if s.subs.IsSubscribed(c.id, "current") || !s.subs.IsSubscribed(c.id, "stable") {
+		t.Fatal("unresolved unsubscribe must retain raw-key semantics")
+	}
+	ctx = context.WithValue(ctx, subscriptionLifecycleContextKey{}, "stable")
+	UnsubscribeLifecycle(ctx, "current")
+	if s.subs.IsSubscribed(c.id, "stable") {
+		t.Fatal("resolved unsubscribe ignored ingress lifecycle identity")
+	}
+}
+
+// Unsubscribe during the snapshot (before a finalizer exists) must reach
+// subscriptions displaced by a replace capture, not just the live registry.
+func TestSubscriptionDisplacedUnsubscribeBeforeFinalizer(t *testing.T) {
+	s := NewSubscriptions()
+	s.Subscribe("conn", "root")
+	s.Subscribe("conn", "child")
+	rollback := s.beginBuffered("conn", "replacement", true, 1)
+	s.Unsubscribe("conn", "root")
+	if !s.withdrawBuffered("conn", "replacement", 1, rollback) {
+		t.Fatal("withdraw failed")
+	}
+	if s.IsSubscribed("conn", "root") {
+		t.Error("abort resurrected unsubscribed displaced root")
+	}
+	if !s.IsSubscribed("conn", "child") {
+		t.Error("abort lost unrelated child")
+	}
+	s.Subscribe("conn", "root")
+	if !s.IsSubscribed("conn", "root") {
+		t.Error("later legitimate subscription rejected")
+	}
+}
+
+func TestSubscriptionLifecycleWithdrawsDisplacedAliases(t *testing.T) {
+	for _, replace := range []bool{false, true} {
+		s := NewSubscriptions()
+		s.subscribeOwned("conn", "stable", "root", false)
+		s.subscribeOwned("conn", "current", "root", false)
+		s.subscribeOwned("conn", "child", "child", false)
+		s.subscribeOwned("other", "stable", "root", false)
+		rollback := s.beginBuffered("conn", "current", replace, 1, "root")
+		// No response finalizer has been installed: only the generation itself
+		// owns the displaced subscriptions at this point.
+		s.UnsubscribeLifecycle("conn", "root")
+		if !s.withdrawBuffered("conn", "current", 1, rollback) {
+			t.Fatal("withdraw failed")
+		}
+		for _, key := range []string{"stable", "current"} {
+			if s.IsSubscribed("conn", key) {
+				t.Fatalf("replace=%v restored canceled alias %s", replace, key)
+			}
+		}
+		if !s.IsSubscribed("conn", "child") || !s.IsSubscribed("other", "stable") {
+			t.Fatal("unsubscribe removed unrelated ownership")
+		}
+		s.subscribeOwned("conn", "current", "root", false)
+		if !s.IsSubscribed("conn", "current") {
+			t.Fatal("old withdrawal poisoned later registration")
+		}
+		if s.withdrawBuffered("conn", "current", 1, rollback) || !s.IsSubscribed("conn", "current") {
+			t.Fatal("old generation modified new subscription")
+		}
+	}
+}
+
+func TestSubscriptionLifecycleAbortPreservesDifferentOwner(t *testing.T) {
+	for _, replace := range []bool{false, true} {
+		s := NewSubscriptions()
+		s.subscribeOwned("conn", "delivery", "child", false)
+		rollback := s.beginBuffered("conn", "delivery", replace, 1, "root")
+		s.UnsubscribeLifecycle("conn", "root")
+		if !s.withdrawBuffered("conn", "delivery", 1, rollback) {
+			t.Fatal("withdraw failed")
+		}
+		if !s.IsSubscribed("conn", "delivery") {
+			t.Errorf("replace=%v: abort lost displaced child ownership", replace)
+		}
+	}
+}

--- a/internal/appserver/subscription_rollback_lifecycle_test.go
+++ b/internal/appserver/subscription_rollback_lifecycle_test.go
@@ -23,6 +23,16 @@ func TestSubscriptionLifecycleUnsubscribeRawFallback(t *testing.T) {
 	}
 }
 
+func TestSubscriptionLifecycleUnsubscribeDeliveryAliasMatchesLifecycle(t *testing.T) {
+	s := NewSubscriptions()
+	s.subscribeOwned("conn", "current", "stable", false)
+	s.subscribeOwned("conn", "other", "other", false)
+	s.UnsubscribeLifecycleAlias("conn", "current", "stable")
+	if s.IsSubscribed("conn", "current") || !s.IsSubscribed("conn", "other") {
+		t.Fatal("delivery/lifecycle unsubscribe did not isolate the requested owner")
+	}
+}
+
 // Unsubscribe during the snapshot (before a finalizer exists) must reach
 // subscriptions displaced by a replace capture, not just the live registry.
 func TestSubscriptionDisplacedUnsubscribeBeforeFinalizer(t *testing.T) {

--- a/internal/appserver/subscriptions.go
+++ b/internal/appserver/subscriptions.go
@@ -3,8 +3,15 @@ package appserver
 import "sync"
 
 type subscription struct {
-	connID     string
-	threadID   string
+	connID   string
+	threadID string
+	// lifecycleKey groups raw delivery aliases for connection-local unsubscribe.
+	lifecycleKey string
+	// rollback belongs to this buffering generation from beginBuffered onward,
+	// including the snapshot interval before a response finalizer exists. Its
+	// displaced entries share withdrawal marks with the finalizer's value copy.
+	// Release or replacement drops this metadata; no tombstones outlive it.
+	rollback   *subscriptionCaptureRollback
 	buffering  bool
 	generation uint64
 	cut        uint64
@@ -63,15 +70,47 @@ func (s *Subscriptions) Subscribe(connID, threadID string) {
 func (s *Subscriptions) Unsubscribe(connID, threadID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	sub, ok := s.byConn[connID][threadID]
-	if !ok {
-		return
+	s.unsubscribeMatchingLocked(connID, func(sub *subscription) bool { return sub.threadID == threadID })
+}
+
+// UnsubscribeLifecycle withdraws all delivery aliases owned by this lifecycle,
+// including subscriptions displaced into an unresolved capture's rollback.
+func (s *Subscriptions) UnsubscribeLifecycle(connID, lifecycleKey string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unsubscribeMatchingLocked(connID, func(sub *subscription) bool { return sub.lifecycleKey == lifecycleKey })
+}
+
+func (s *Subscriptions) unsubscribeMatchingLocked(connID string, matches func(*subscription) bool) {
+	var withdraw func(*subscription)
+	withdraw = func(sub *subscription) {
+		if matches(sub) {
+			sub.withdrawn = true
+		}
+		if r := sub.rollback; r != nil {
+			for i := range r.connection.subscriptions {
+				withdraw(&r.connection.subscriptions[i])
+			}
+			if r.threadPrevious != nil {
+				withdraw(r.threadPrevious)
+			}
+		}
 	}
-	if sub.buffering {
-		sub.withdrawn = true
-		return
+	for threadID, sub := range s.byConn[connID] {
+		withdraw(sub)
+		if sub.withdrawn && !sub.buffering {
+			s.removeThreadLocked(connID, threadID)
+		}
 	}
-	s.removeThreadLocked(connID, threadID)
+}
+
+func (s *Subscriptions) subscribeOwned(connID, threadID, lifecycleKey string, replace bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if replace {
+		s.removeConnectionLocked(connID)
+	}
+	s.subscribeLocked(&subscription{connID: connID, threadID: threadID, lifecycleKey: lifecycleKey})
 }
 
 func (s *Subscriptions) ReplaceConnectionSubscriptions(connID, threadID string) {
@@ -83,7 +122,7 @@ func (s *Subscriptions) ReplaceConnectionSubscriptions(connID, threadID string) 
 	}
 }
 
-func (s *Subscriptions) beginBuffered(connID, threadID string, replace bool, generation uint64) subscriptionCaptureRollback {
+func (s *Subscriptions) beginBuffered(connID, threadID string, replace bool, generation uint64, lifecycleKeys ...string) subscriptionCaptureRollback {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	rollback := subscriptionCaptureRollback{replace: replace}
@@ -98,11 +137,17 @@ func (s *Subscriptions) beginBuffered(connID, threadID string, replace bool, gen
 		}
 		s.removeThreadLocked(connID, threadID)
 	}
+	owner := threadID
+	if len(lifecycleKeys) != 0 {
+		owner = lifecycleKeys[0]
+	}
 	s.subscribeLocked(&subscription{
-		connID:     connID,
-		threadID:   threadID,
-		buffering:  true,
-		generation: generation,
+		lifecycleKey: owner,
+		rollback:     &rollback,
+		connID:       connID,
+		threadID:     threadID,
+		buffering:    true,
+		generation:   generation,
 	})
 	return rollback
 }
@@ -122,11 +167,10 @@ func (s *Subscriptions) withdrawBuffered(
 		s.removeConnectionLocked(connID)
 		for i := range rollback.connection.subscriptions {
 			sub := rollback.connection.subscriptions[i]
-			if sub.withdrawn || (current.withdrawn && sub.threadID == threadID) {
-				// The client explicitly unsubscribed this thread mid-capture;
-				// restoring it would resurrect a thread it asked to stop
-				// receiving. Everything else the capture displaced comes back
-				// unchanged.
+			if sub.withdrawn {
+				// Withdrawal marks reach displaced entries directly. The current
+				// generation may have a different lifecycle owner even when it
+				// shares this delivery key, so its mark cannot suppress this entry.
 				continue
 			}
 			s.subscribeLocked(&sub)
@@ -134,7 +178,7 @@ func (s *Subscriptions) withdrawBuffered(
 		return true
 	}
 	s.removeThreadLocked(connID, threadID)
-	if rollback.threadPrevious != nil && !current.withdrawn && !rollback.threadPrevious.withdrawn {
+	if rollback.threadPrevious != nil && !rollback.threadPrevious.withdrawn {
 		previous := *rollback.threadPrevious
 		s.subscribeLocked(&previous)
 	}
@@ -189,6 +233,7 @@ func (s *Subscriptions) Release(connID, threadID string, generation uint64) ([]S
 			release = append(release, record)
 		}
 	}
+	sub.rollback = nil
 	sub.buffering = false
 	sub.buffer = nil
 	return release, true
@@ -255,6 +300,9 @@ func (s *Subscriptions) RemoveConnection(connID string) {
 }
 
 func (s *Subscriptions) subscribeLocked(sub *subscription) {
+	if sub.lifecycleKey == "" {
+		sub.lifecycleKey = sub.threadID
+	}
 	if s.byConn[sub.connID] == nil {
 		s.byConn[sub.connID] = map[string]*subscription{}
 	}

--- a/internal/appserver/subscriptions.go
+++ b/internal/appserver/subscriptions.go
@@ -81,6 +81,17 @@ func (s *Subscriptions) UnsubscribeLifecycle(connID, lifecycleKey string) {
 	s.unsubscribeMatchingLocked(connID, func(sub *subscription) bool { return sub.lifecycleKey == lifecycleKey })
 }
 
+// UnsubscribeLifecycleAlias removes the requested delivery alias only when it
+// belongs to the resolved lifecycle. Other aliases sharing that delivery key
+// remain owned by their respective lifecycles.
+func (s *Subscriptions) UnsubscribeLifecycleAlias(connID, deliveryKey, lifecycleKey string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.unsubscribeMatchingLocked(connID, func(sub *subscription) bool {
+		return sub.threadID == deliveryKey && sub.lifecycleKey == lifecycleKey
+	})
+}
+
 func (s *Subscriptions) unsubscribeMatchingLocked(connID string, matches func(*subscription) bool) {
 	var withdraw func(*subscription)
 	withdraw = func(sub *subscription) {

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -39,6 +39,7 @@ type webSocketTransport interface {
 
 type webSocketCloser interface {
 	Close(websocket.StatusCode, string) error
+	CloseNow() error
 }
 
 // wsPinger is the subset of *websocket.Conn the keepalive loop needs. Ping
@@ -190,7 +191,12 @@ func runWebSocketReceiveLoop(ctx context.Context, ws webSocketCloser, transport 
 		msg, err := transport.Recv(ctx)
 		gate.readerUnavailable()
 		if err != nil {
-			if websocket.CloseStatus(err) != websocket.StatusNormalClosure {
+			if ctx.Err() != nil {
+				// Recv can observe cancellation before starting a socket read,
+				// so cancellation alone need not have closed the connection.
+				// Do not wait for a peer handshake during local teardown.
+				_ = ws.CloseNow()
+			} else if websocket.CloseStatus(err) != websocket.StatusNormalClosure {
 				_ = ws.Close(websocket.StatusInternalError, err.Error())
 			}
 			return

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -186,17 +186,19 @@ func (s *Server) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
 // ping-inline-vs-enqueue decision), and stop when the transport or the
 // connection dies.
 func runWebSocketReceiveLoop(ctx context.Context, ws webSocketCloser, transport webSocketTransport, conn *Connection, gate *webSocketReadGate) {
+	defer func() {
+		// Both Recv and a full inbound queue can observe cancellation without
+		// closing the socket. Local teardown must not wait for a peer handshake.
+		if ctx.Err() != nil {
+			_ = ws.CloseNow()
+		}
+	}()
 	for {
 		gate.readerAvailable()
 		msg, err := transport.Recv(ctx)
 		gate.readerUnavailable()
 		if err != nil {
-			if ctx.Err() != nil {
-				// Recv can observe cancellation before starting a socket read,
-				// so cancellation alone need not have closed the connection.
-				// Do not wait for a peer handshake during local teardown.
-				_ = ws.CloseNow()
-			} else if websocket.CloseStatus(err) != websocket.StatusNormalClosure {
+			if ctx.Err() == nil && websocket.CloseStatus(err) != websocket.StatusNormalClosure {
 				_ = ws.Close(websocket.StatusInternalError, err.Error())
 			}
 			return

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -513,6 +513,146 @@ func TestServeWebSocketHydrationThenMutationDeliversEveryNotificationExactlyOnce
 	}
 }
 
+func TestServeWebSocketReadAdmissionCanceledByFollowingUnsubscribe(t *testing.T) {
+	const threadID = "th_admission"
+	server := NewServer(ServerConfig{ServerName: "test-server", Version: "test", SourceID: "local", SubscriptionAdmissionResolver: func(msg appwire.Message) (string, bool) {
+		if msg.Request != nil && msg.Request.Method == appwire.MethodThreadRead {
+			return threadID, true
+		}
+		return "", false
+	}})
+	notifier := NewNotifier(16)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	unsubStarted := make(chan struct{})
+	var once sync.Once
+	server.beforeSubscriptionRegistration = func() {
+		once.Do(func() { close(entered) })
+		<-release
+	}
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		if !Subscribe(ctx, "th_unrelated") {
+			return appwire.ThreadReadResponse{}, nil
+		}
+		if !CaptureSubscription(ctx, false, func() string { return params.ThreadID }, notifier.CurrentSequence, func() bool { return true }) {
+			return appwire.ThreadReadResponse{}, nil
+		}
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: params.ThreadID}}, nil
+	})
+	HandleTyped(server.Router(), appwire.MethodThreadUnsubscribe, func(ctx context.Context, params appwire.ThreadUnsubscribeParams) (appwire.EmptyResponse, error) {
+		close(unsubStarted)
+		Unsubscribe(ctx, params.ThreadID)
+		return appwire.EmptyResponse{}, nil
+	})
+	httpServer := serveWebSocketHTTP(t, server)
+	client := dialAppWireClient(t, httpServer)
+	ctx := context.Background()
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadRead(ctx, appwire.ThreadReadParams{ThreadID: threadID, Subscribe: true})
+		readDone <- err
+	}()
+	waitFor(t, "read admission barrier", entered)
+	unsubDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{ThreadID: threadID})
+		unsubDone <- err
+	}()
+	if err := waitFor(t, "following unsubscribe response", unsubDone); err != nil {
+		t.Fatalf("unsubscribe failed: %v", err)
+	}
+	close(release)
+	if err := waitFor(t, "older read response", readDone); err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	server.subs.mu.RLock()
+	if len(server.subs.byThread[threadID]) != 0 {
+		server.subs.mu.RUnlock()
+		t.Fatal("canceled older read registered a subscription")
+	}
+	if len(server.subs.byThread["th_unrelated"]) != 1 {
+		server.subs.mu.RUnlock()
+		t.Fatal("unrelated subscription was removed")
+	}
+	server.subs.mu.RUnlock()
+
+	server.beforeSubscriptionRegistration = nil
+	if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{ThreadID: threadID, Subscribe: true}); err != nil {
+		t.Fatalf("later read failed: %v", err)
+	}
+	server.subs.mu.RLock()
+	defer server.subs.mu.RUnlock()
+	if len(server.subs.byThread[threadID]) != 1 {
+		t.Fatalf("later read subscription count = %d, want 1", len(server.subs.byThread[threadID]))
+	}
+}
+
+func TestServeWebSocketUnsubscribeWaitsThroughSubscriptionRegistration(t *testing.T) {
+	const threadID = "th_registration_barrier"
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	unsubStarted := make(chan struct{})
+	server := NewServer(ServerConfig{
+		ServerName: "test-server", SourceID: "local",
+		SubscriptionAdmissionResolver: func(msg appwire.Message) (string, bool) {
+			if msg.Request != nil && msg.Request.Method == appwire.MethodThreadRead {
+				return threadID, true
+			}
+			return "", false
+		},
+	})
+	server.beforeSubscriptionBeginBuffered = func() {
+		select {
+		case <-entered:
+		default:
+			close(entered)
+		}
+		<-release
+	}
+	HandleTyped(server.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		if !CaptureSubscription(ctx, false, func() string { return params.ThreadID }, func() uint64 { return 0 }, func() bool { return true }) {
+			return appwire.ThreadReadResponse{}, nil
+		}
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: params.ThreadID}}, nil
+	})
+	HandleTyped(server.Router(), appwire.MethodThreadUnsubscribe, func(ctx context.Context, params appwire.ThreadUnsubscribeParams) (appwire.EmptyResponse, error) {
+		close(unsubStarted)
+		Unsubscribe(ctx, params.ThreadID)
+		return appwire.EmptyResponse{}, nil
+	})
+	httpServer := serveWebSocketHTTP(t, server)
+	client := dialAppWireClient(t, httpServer)
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{ThreadID: threadID, Subscribe: true})
+		readDone <- err
+	}()
+	waitFor(t, "claim/register barrier", entered)
+	unsubDone := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadUnsubscribe(context.Background(), appwire.ThreadUnsubscribeParams{ThreadID: threadID})
+		unsubDone <- err
+	}()
+	waitFor(t, "unsubscribe handler", unsubStarted)
+	select {
+	case err := <-unsubDone:
+		t.Fatalf("unsubscribe completed before registration release: %v", err)
+	default:
+	}
+	close(release)
+	if err := waitFor(t, "unsubscribe after registration", unsubDone); err != nil {
+		t.Fatalf("unsubscribe failed: %v", err)
+	}
+	if err := waitFor(t, "read after registration", readDone); err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	server.subs.mu.RLock()
+	defer server.subs.mu.RUnlock()
+	if len(server.subs.byThread[threadID]) != 0 {
+		t.Fatal("unsubscribe left a stale registered subscription")
+	}
+}
+
 // seenMarkers sorts the delivered markers for stable failure messages.
 func seenMarkers(seen map[string]bool) []string {
 	markers := make([]string, 0, len(seen))

--- a/internal/appserver/websocket_trace_test.go
+++ b/internal/appserver/websocket_trace_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"primeradiant.com/evener/appwire"
 )
 
 type decodedWebSocketTraceRecord struct {
@@ -273,6 +274,36 @@ func groupWebSocketTraceRecordsByConnection(records []decodedWebSocketTraceRecor
 }
 
 func TestServerShutdownDrainsOpenTracedWebSocket(t *testing.T) {
+	testServerShutdownDrainsOpenTracedWebSocket(t, false)
+}
+
+func TestServerShutdownBeforeTracedWebSocketReceive(t *testing.T) {
+	testServerShutdownDrainsOpenTracedWebSocket(t, true)
+}
+
+func TestWebSocketReceiveCloseModes(t *testing.T) {
+	exerciseReceiveLoops(t)
+}
+
+// A canceled receive may return before entering the socket read (for example,
+// while acquiring coder/websocket's read lock), leaving the socket open. Keep
+// the real initialization exchange, then deterministically select that boundary.
+type shutdownBeforeReceiveTransport struct {
+	webSocketTransport
+	initialized bool
+}
+
+func (w *shutdownBeforeReceiveTransport) Recv(ctx context.Context) (appwire.Message, error) {
+	if !w.initialized {
+		w.initialized = true
+		return w.webSocketTransport.Recv(ctx)
+	}
+	<-ctx.Done()
+	return appwire.Message{}, ctx.Err()
+}
+
+func testServerShutdownDrainsOpenTracedWebSocket(t *testing.T, beforeReceive bool) {
+	t.Helper()
 	path := filepath.Join(t.TempDir(), "trace.jsonl")
 	trace, err := NewWebSocketTrace(path)
 	if err != nil {
@@ -284,10 +315,17 @@ func TestServerShutdownDrainsOpenTracedWebSocket(t *testing.T) {
 		SourceID:       "local",
 		WebSocketTrace: trace,
 	})
+	if beforeReceive {
+		server.wrapWebSocketTransport = func(inner webSocketTransport) webSocketTransport {
+			return &shutdownBeforeReceiveTransport{webSocketTransport: inner}
+		}
+	}
 	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer httpServer.Close()
 
 	ctx := context.Background()
 	conn := dialTraceWebSocket(ctx, t, "ws"+strings.TrimPrefix(httpServer.URL, "http"), httpServer.Client())
+	defer conn.CloseNow()
 	request := []byte(`{"id":51,"method":"initialize","params":{"protocolVersion":"evener-appwire-v4"}}`)
 	if err := conn.Write(ctx, websocket.MessageText, request); err != nil {
 		t.Fatalf("write initialize: %v", err)
@@ -300,6 +338,9 @@ func TestServerShutdownDrainsOpenTracedWebSocket(t *testing.T) {
 	defer cancel()
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		t.Fatalf("Shutdown: %v", err)
+	}
+	if _, _, err := conn.Read(shutdownCtx); err == nil || errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("peer read after shutdown = %v, want closed socket", err)
 	}
 	conn.CloseNow()
 	httpServer.Close()

--- a/internal/appserver/websocket_trace_test.go
+++ b/internal/appserver/websocket_trace_test.go
@@ -285,6 +285,74 @@ func TestWebSocketReceiveCloseModes(t *testing.T) {
 	exerciseReceiveLoops(t)
 }
 
+type shutdownQueueTransport struct {
+	webSocketTransport
+	overflowReceived chan struct{}
+}
+
+func (w *shutdownQueueTransport) Recv(ctx context.Context) (appwire.Message, error) {
+	msg, err := w.webSocketTransport.Recv(ctx)
+	if msg.Request != nil && msg.Request.Method == "test/overflow" {
+		close(w.overflowReceived)
+	}
+	return msg, err
+}
+
+func TestServerShutdownWithFullWebSocketRequestQueue(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test-server", SourceID: "local"})
+	server.requestQueueCapacity = 1
+	entered, release := make(chan struct{}), make(chan struct{})
+	server.Router().Handle("test/block", func(context.Context, json.RawMessage) (any, error) {
+		close(entered)
+		<-release
+		return nil, nil
+	})
+	overflowReceived := make(chan struct{})
+	server.wrapWebSocketTransport = func(inner webSocketTransport) webSocketTransport {
+		return &shutdownQueueTransport{webSocketTransport: inner, overflowReceived: overflowReceived}
+	}
+	httpServer := httptest.NewServer(http.HandlerFunc(server.ServeWebSocket))
+	defer httpServer.Close()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	conn := dialTraceWebSocket(ctx, t, "ws"+strings.TrimPrefix(httpServer.URL, "http"), httpServer.Client())
+	defer conn.CloseNow()
+	defer close(release)
+	write := func(frame string) {
+		t.Helper()
+		if err := conn.Write(ctx, websocket.MessageText, []byte(frame)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(`{"id":1,"method":"initialize","params":{"protocolVersion":"evener-appwire-v4"}}`)
+	if _, _, err := conn.Read(ctx); err != nil {
+		t.Fatal(err)
+	}
+	write(`{"id":2,"method":"test/block"}`)
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("worker did not enter blocking request")
+	}
+	write(`{"id":3,"method":"test/queued"}`)
+	write(`{"id":4,"method":"test/overflow"}`)
+	select {
+	case <-overflowReceived:
+	case <-ctx.Done():
+		t.Fatal("receive loop did not reach full queue")
+	}
+	// The serial worker remains blocked and the preceding request fills its
+	// only queue slot. Cancellation must end enqueueRequest without another Recv.
+	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer shutdownCancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if _, _, err := conn.Read(shutdownCtx); err == nil || errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("peer read after shutdown = %v, want closed socket", err)
+	}
+}
+
 // A canceled receive may return before entering the socket read (for example,
 // while acquiring coder/websocket's read lock), leaving the socket open. Keep
 // the real initialization exchange, then deterministically select that boundary.

--- a/server/admission_resolution_test.go
+++ b/server/admission_resolution_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/appserver"
+)
+
+func TestAdmissionStableOwnerSwapCancellation(t *testing.T) {
+	probeAdmissionIdentitySwap(t, true, true)
+}
+
+func TestAdmissionChangedRootRejected(t *testing.T) {
+	probeAdmissionIdentitySwap(t, false, true)
+}
+
+func TestAdmissionStableOwnerSwapSucceeds(t *testing.T) { probeAdmissionIdentitySwap(t, true, false) }
+
+func probeAdmissionIdentitySwap(t *testing.T, sameOwner, unsubscribe bool) {
+	srv := NewServer(ServerConfig{})
+	oldRef, newRef := "local:stable", "local:stable"
+	params := appwire.ThreadReadParams{Ref: oldRef, Subscribe: true}
+	if !sameOwner {
+		oldRef, newRef = "local:old-workspace", "local:new-workspace"
+		params.Ref = "" // A supported implicit-root request follows the root.
+	}
+	prepared, err := PrepareAppIdentityForRef("local", "old", oldRef, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.ReplaceAppIdentity(prepared, nil)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	entered, release := make(chan struct{}), make(chan struct{})
+	// Ordered ingress has created its admission before dispatch reaches this
+	// wrapper. Everything after the barrier is the real production handler.
+	appserver.HandleTyped(srv.AppServer().Router(), appwire.MethodThreadRead, func(ctx context.Context, p appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		close(entered)
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return srv.handleAppThreadRead(ctx, p)
+	})
+	client := dialServerAppWire(t, srv)
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadRead(ctx, params)
+		done <- err
+	}()
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("handler barrier not reached")
+	}
+	prepared, err = PrepareAppIdentityForRef("local", "new", newRef, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.ReplaceAppIdentity(prepared, nil)
+	if unsubscribe {
+		if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{Ref: newRef}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(release)
+	select {
+	case err := <-done:
+		if unsubscribe || !sameOwner {
+			var wire appwire.WireError
+			if !errors.As(err, &wire) || wire.Code != appwire.CodeUnavailable {
+				t.Errorf("stale read error=%v, want unavailable", err)
+			}
+		} else if err != nil {
+			t.Fatalf("same-owner read rejected: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("read blocked")
+	}
+	want := 0
+	if sameOwner && !unsubscribe {
+		want = 1
+	}
+	if got := srv.AppSubscriberCount("new"); got != want {
+		t.Errorf("new-identity registration=%d, want %d", got, want)
+	}
+	if got := srv.AppSubscriberCount("old"); got != 0 {
+		t.Errorf("stale old-identity registration=%d, want 0", got)
+	}
+}

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1166,7 +1166,7 @@ func (s *Server) appThreadReadSnapshotForTarget(params appwire.ThreadReadParams,
 // form and the bare thread ID, and Unsubscribe is idempotent, so trying both
 // costs nothing and leaks nothing.
 func (s *Server) handleAppThreadUnsubscribe(ctx context.Context, params appwire.ThreadUnsubscribeParams) (appwire.EmptyResponse, error) {
-	threadID := s.appThreadIDForRead(appwire.ThreadReadParams{ThreadID: params.ThreadID, Ref: params.Ref})
+	threadID, target := s.appReadTarget(appwire.ThreadReadParams{ThreadID: params.ThreadID, Ref: params.Ref})
 	if threadID == "" {
 		// Teardown finding nothing is a success; still try the raw identities
 		// so a pre-swap key does not linger until connection close.
@@ -1179,7 +1179,7 @@ func (s *Server) handleAppThreadUnsubscribe(ctx context.Context, params appwire.
 		}
 		return appwire.EmptyResponse{}, nil
 	}
-	appserver.Unsubscribe(ctx, s.appNotificationTarget(threadID))
+	appserver.Unsubscribe(ctx, target)
 	return appwire.EmptyResponse{}, nil
 }
 

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1076,20 +1076,25 @@ func (s *Server) handleAppThreadRead(ctx context.Context, params appwire.ThreadR
 	if !params.Subscribe {
 		return s.appThreadReadSnapshotChecked(params)
 	}
-	threadID := s.appThreadIDForRead(params)
-	if threadID == "" {
-		return appwire.ThreadReadResponse{}, appwire.SessionUnavailable("thread is unavailable")
-	}
+	var threadID string
 	var response appwire.ThreadReadResponse
 	var readErr error
 	captured := appserver.CaptureSubscription(
 		ctx,
 		params.ReplaceSubscription,
-		func() string { return s.appNotificationTarget(threadID) },
+		nil,
 		s.appNotifier.CurrentSequence,
 		func() bool {
-			response, readErr = s.appThreadReadSnapshotChecked(params)
+			response, readErr = s.appThreadReadSnapshotForTarget(params, threadID)
 			return true
+		},
+		func() appserver.SubscriptionTarget {
+			threadID = s.appThreadIDForRead(params)
+			if threadID == "" {
+				return appserver.SubscriptionTarget{}
+			}
+			key := s.appNotificationTarget(threadID)
+			return appserver.SubscriptionTarget{ThreadID: key, LifecycleKey: key}
 		},
 	)
 	if !captured {
@@ -1125,7 +1130,12 @@ func (s *Server) appThreadReadSnapshot(params appwire.ThreadReadParams) appwire.
 }
 
 func (s *Server) appThreadReadSnapshotChecked(params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
-	threadID := s.appThreadIDForRead(params)
+	return s.appThreadReadSnapshotForTarget(params, s.appThreadIDForRead(params))
+}
+
+// appThreadReadSnapshotForTarget materializes the exact target selected under
+// the subscription projection gate, without resolving mutable request aliases.
+func (s *Server) appThreadReadSnapshotForTarget(params appwire.ThreadReadParams, threadID string) (appwire.ThreadReadResponse, error) {
 	thread, ok := s.appThreadForID(threadID)
 	if !ok {
 		return appwire.ThreadReadResponse{}, nil

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -1089,11 +1089,11 @@ func (s *Server) handleAppThreadRead(ctx context.Context, params appwire.ThreadR
 			return true
 		},
 		func() appserver.SubscriptionTarget {
-			threadID = s.appThreadIDForRead(params)
+			var key string
+			threadID, key = s.appReadTarget(params)
 			if threadID == "" {
 				return appserver.SubscriptionTarget{}
 			}
-			key := s.appNotificationTarget(threadID)
 			return appserver.SubscriptionTarget{ThreadID: key, LifecycleKey: key}
 		},
 	)
@@ -1184,6 +1184,22 @@ func (s *Server) handleAppThreadUnsubscribe(ctx context.Context, params appwire.
 }
 
 func (s *Server) appThreadIDForRead(params appwire.ThreadReadParams) string {
+	threadID, _ := s.appReadTarget(params)
+	return threadID
+}
+
+// appReadTarget takes one identity snapshot for both the requested thread and
+// its admission/delivery key. Ingress must not recompute the key after releasing
+// this lock: a same-workspace identity replacement could turn the saved root ID
+// into a stale bare key between those two reads.
+func (s *Server) appReadTarget(params appwire.ThreadReadParams) (string, string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.appReadTargetLocked(params)
+}
+
+// appReadTargetLocked requires s.mu and calls no lock-taking helpers.
+func (s *Server) appReadTargetLocked(params appwire.ThreadReadParams) (string, string) {
 	threadID := strings.TrimSpace(params.ThreadID)
 	rawRef := strings.TrimSpace(params.Ref)
 	if threadID == "" && rawRef != "" {
@@ -1194,25 +1210,29 @@ func (s *Server) appThreadIDForRead(params appwire.ThreadReadParams) string {
 		// else entirely (ledger #110/#111).
 		ref, err := appwire.ParseRef(rawRef)
 		if err != nil || ref.SourceID != "local" {
-			return ""
+			return "", ""
 		}
-		s.mu.RLock()
-		stableRef := s.appRef
-		currentThreadID := s.appThreadID
-		s.mu.RUnlock()
-		if rawRef == stableRef {
-			threadID = currentThreadID
+		if rawRef == s.appRef {
+			threadID = s.appThreadID
 		} else {
 			threadID = ref.ThreadID
 		}
 	}
+	rootID := s.appThreadID
+	if rootID == "" {
+		rootID = s.status.SessionID
+	}
 	if threadID == "" {
-		threadID = s.appProjectionThreadID()
+		threadID = rootID
 	}
-	if _, ok := s.appThreadForID(threadID); !ok {
-		return ""
+	if threadID == "" || (threadID != rootID && s.appDescendants[threadID] == nil) {
+		return "", ""
 	}
-	return threadID
+	target := threadID
+	if threadID == s.appThreadID && s.appRef != "" {
+		target = s.appRef
+	}
+	return threadID, target
 }
 
 func (s *Server) appThreadForID(threadID string) (appwire.Thread, bool) {

--- a/server/appwire_runtime_test.go
+++ b/server/appwire_runtime_test.go
@@ -855,6 +855,27 @@ func TestHandleAppThreadReadUnknownThreadRemainsEmpty(t *testing.T) {
 	}
 }
 
+func TestSubscribedThreadReadWithoutConnectionPreservesSnapshotTarget(t *testing.T) {
+	srv := seedTranscriptServer(t, 1)
+	srv.mu.Lock()
+	childTurns := &appTurnSnapshot{threadID: "child"}
+	childTurns.Seed(srv.appTurns.Snapshot())
+	childThread := srv.appThreadLocked()
+	childThread.ID, childThread.SessionID = "child", "child"
+	childThread.Evener.Ref = "local:child"
+	srv.appDescendants["child"] = &appDescendantProjection{turns: childTurns, thread: childThread}
+	srv.mu.Unlock()
+	for _, ref := range []string{"local:th_1", "local:child"} {
+		response, err := srv.handleAppThreadRead(context.Background(), appwire.ThreadReadParams{Ref: ref, Subscribe: true, IncludeTurns: true})
+		if err != nil {
+			t.Fatalf("subscribed thread/read without connection (%s): %v", ref, err)
+		}
+		if len(response.Thread.Turns) == 0 {
+			t.Fatalf("subscribed no-connection response (%s) = %+v, want seeded snapshot", ref, response)
+		}
+	}
+}
+
 func TestPrepareAppIdentityUsesPersistedItemIndexIncarnation(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.transcript.jsonl")
 	tw, err := transcript.NewWriter(path, transcript.Header{SessionID: "th_index"})

--- a/server/appwire_server_test.go
+++ b/server/appwire_server_test.go
@@ -34,6 +34,40 @@ func requireTranscriptFileTurns(t testing.TB, path string) []appwire.Turn {
 	return turns
 }
 
+func dialServerAppWire(t *testing.T, srv *Server) *appwire.Client {
+	t.Helper()
+	httpServer := httptest.NewServer(srv)
+	t.Cleanup(httpServer.Close)
+	transport, err := appwire.DialWebSocket(context.Background(), "ws"+httpServer.URL[len("http"):]+"/rpc", httpServer.Client())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = transport.Close() })
+	client := appwire.NewClient(transport)
+	client.Start(context.Background())
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	return client
+}
+
+func TestServerAppWireRealWireReadUnsubscribeAliases(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "th_1")
+	installProjectedMutationCallbacksForTest(srv)
+	client := dialServerAppWire(t, srv)
+	ctx := context.Background()
+	if _, err := client.ThreadRead(ctx, appwire.ThreadReadParams{Ref: "local:th_1", Subscribe: true}); err != nil {
+		t.Fatalf("ref-only subscribe read: %v", err)
+	}
+	if _, err := client.ThreadUnsubscribe(ctx, appwire.ThreadUnsubscribeParams{ThreadID: "th_1"}); err != nil {
+		t.Fatalf("mixed-alias unsubscribe: %v", err)
+	}
+	if got := srv.AppSubscriberCount("th_1"); got != 0 {
+		t.Fatalf("subscriber count after mixed aliases = %d, want 0", got)
+	}
+}
+
 func TestServerAppWireTurnStartQueuesInput(t *testing.T) {
 	srv := NewServer(ServerConfig{})
 	srv.SetAppIdentity("local", "th_1")

--- a/server/ingress_identity_test.go
+++ b/server/ingress_identity_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+)
+
+func TestAppReadTargetAtomicSnapshot(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	old, err := PrepareAppIdentityForRef("local", "old", "local:stable", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.ReplaceAppIdentity(old, nil)
+	params := appwire.ThreadReadParams{Ref: "local:stable", Subscribe: true}
+	// Exercise the actual shared resolver with a caller-held write lock: this
+	// deterministically verifies it requires no nested lock-taking helpers.
+	srv.mu.Lock()
+	result := make(chan [2]string, 1)
+	go func() { thread, target := srv.appReadTargetLocked(params); result <- [2]string{thread, target} }()
+	var before [2]string
+	select {
+	case before = <-result:
+		srv.mu.Unlock()
+	case <-time.After(5 * time.Second):
+		srv.mu.Unlock()
+		t.Fatal("locked resolver attempted nested locking")
+	}
+	if before != [2]string{"old", "local:stable"} {
+		t.Fatalf("locked snapshot=%q", before)
+	}
+	next, err := PrepareAppIdentityForRef("local", "new", "local:stable", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.ReplaceAppIdentity(next, nil)
+	thread, target := srv.appReadTarget(params)
+	if thread != "new" || target != before[1] {
+		t.Fatalf("same-owner snapshot=(%q,%q), previous=%q", thread, target, before)
+	}
+	// The saved ingress target is a value: replacement cannot reinterpret it as
+	// a stale bare thread ID. This is what the former two-call composition lost.
+	if before[1] != "local:stable" {
+		t.Fatalf("snapshot owner changed=%q", before[1])
+	}
+}
+
+func TestAppReadTargetPreservesResolutionSemantics(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		params                 appwire.ThreadReadParams
+		root, status, ref      string
+		child                  bool
+		wantThread, wantTarget string
+	}{
+		{name: "stable", params: appwire.ThreadReadParams{Ref: "local:stable"}, root: "current", ref: "local:stable", wantThread: "current", wantTarget: "local:stable"},
+		{name: "explicit id precedes invalid ref", params: appwire.ThreadReadParams{ThreadID: "current", Ref: "invalid"}, root: "current", ref: "local:stable", wantThread: "current", wantTarget: "local:stable"},
+		{name: "explicit child precedes root ref", params: appwire.ThreadReadParams{ThreadID: "child", Ref: "local:stable"}, root: "current", ref: "local:stable", child: true, wantThread: "child", wantTarget: "child"},
+		{name: "child ref", params: appwire.ThreadReadParams{Ref: "local:child"}, root: "current", ref: "local:stable", child: true, wantThread: "child", wantTarget: "child"},
+		{name: "missing child", params: appwire.ThreadReadParams{ThreadID: "child"}, root: "current", ref: "local:stable"},
+		{name: "invalid ref", params: appwire.ThreadReadParams{Ref: "invalid"}, root: "current", ref: "local:stable"},
+		{name: "foreign ref", params: appwire.ThreadReadParams{Ref: "remote:current"}, root: "current", ref: "local:stable"},
+		{name: "implicit root", root: "current", ref: "local:stable", wantThread: "current", wantTarget: "local:stable"},
+		{name: "status fallback", status: "status-root", wantThread: "status-root", wantTarget: "status-root"},
+		{name: "explicit status fallback", params: appwire.ThreadReadParams{ThreadID: "status-root"}, status: "status-root", ref: "local:stable", wantThread: "status-root", wantTarget: "status-root"},
+		{name: "empty root"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewServer(ServerConfig{})
+			srv.mu.Lock()
+			srv.appThreadID, srv.appRef, srv.status.SessionID = tc.root, tc.ref, tc.status
+			if tc.child {
+				srv.appDescendants["child"] = &appDescendantProjection{}
+			}
+			srv.mu.Unlock()
+			thread, target := srv.appReadTarget(tc.params)
+			if thread != tc.wantThread || target != tc.wantTarget {
+				t.Fatalf("target=(%q,%q), want (%q,%q)", thread, target, tc.wantThread, tc.wantTarget)
+			}
+			if got := srv.appThreadIDForRead(tc.params); got != thread {
+				t.Fatalf("read resolver diverged=%q, want %q", got, thread)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -443,11 +443,11 @@ func NewServer(cfg ServerConfig) *Server {
 				if json.Unmarshal(msg.Request.Params, &params) != nil || !params.Subscribe {
 					return "", false
 				}
-				threadID := runtime.appThreadIDForRead(params)
+				threadID, target := runtime.appReadTarget(params)
 				if threadID == "" {
 					return "", false
 				}
-				return runtime.appNotificationTarget(threadID), true
+				return target, true
 			},
 			Features: appwire.FeatureSet{
 				ThreadList:        true,

--- a/server/server.go
+++ b/server/server.go
@@ -429,11 +429,26 @@ func NewServer(cfg ServerConfig) *Server {
 		replaySize = 1000
 	}
 
+	var runtime *Server
 	s := &Server{
 		mux: http.NewServeMux(),
 		appServer: appserver.NewServer(appserver.ServerConfig{
 			ServerName: "evener-serve",
 			SourceID:   "local",
+			SubscriptionAdmissionResolver: func(msg appwire.Message) (string, bool) {
+				if msg.Request == nil || msg.Request.Method != appwire.MethodThreadRead {
+					return "", false
+				}
+				var params appwire.ThreadReadParams
+				if json.Unmarshal(msg.Request.Params, &params) != nil || !params.Subscribe {
+					return "", false
+				}
+				threadID := runtime.appThreadIDForRead(params)
+				if threadID == "" {
+					return "", false
+				}
+				return runtime.appNotificationTarget(threadID), true
+			},
 			Features: appwire.FeatureSet{
 				ThreadList:        true,
 				ThreadTurnsList:   true,
@@ -462,6 +477,7 @@ func NewServer(cfg ServerConfig) *Server {
 		hubToken:            strings.TrimSpace(cfg.HubToken),
 		sameOrigin:          httpguard.NewSameOriginPolicy(cfg.AllowedHost),
 	}
+	runtime = s
 	s.clearRecords, s.clearJournalErr = loadThreadClearJournal(s.clearJournalPath)
 	if s.clearRecords == nil {
 		s.clearRecords = make(map[string]threadClearRecord)

--- a/server/server.go
+++ b/server/server.go
@@ -436,12 +436,20 @@ func NewServer(cfg ServerConfig) *Server {
 			ServerName: "evener-serve",
 			SourceID:   "local",
 			SubscriptionAdmissionResolver: func(msg appwire.Message) (string, bool) {
-				if msg.Request == nil || msg.Request.Method != appwire.MethodThreadRead {
+				if msg.Request == nil || (msg.Request.Method != appwire.MethodThreadRead && msg.Request.Method != appwire.MethodThreadUnsubscribe) {
 					return "", false
 				}
 				var params appwire.ThreadReadParams
-				if json.Unmarshal(msg.Request.Params, &params) != nil || !params.Subscribe {
-					return "", false
+				if msg.Request.Method == appwire.MethodThreadUnsubscribe {
+					var unsubscribe appwire.ThreadUnsubscribeParams
+					if json.Unmarshal(msg.Request.Params, &unsubscribe) != nil {
+						return "", false
+					}
+					params.ThreadID, params.Ref = unsubscribe.ThreadID, unsubscribe.Ref
+				} else {
+					if json.Unmarshal(msg.Request.Params, &params) != nil || !params.Subscribe {
+						return "", false
+					}
 				}
 				threadID, target := runtime.appReadTarget(params)
 				if threadID == "" {

--- a/server/server.go
+++ b/server/server.go
@@ -446,10 +446,8 @@ func NewServer(cfg ServerConfig) *Server {
 						return "", false
 					}
 					params.ThreadID, params.Ref = unsubscribe.ThreadID, unsubscribe.Ref
-				} else {
-					if json.Unmarshal(msg.Request.Params, &params) != nil || !params.Subscribe {
-						return "", false
-					}
+				} else if json.Unmarshal(msg.Request.Params, &params) != nil || !params.Subscribe {
+					return "", false
 				}
 				threadID, target := runtime.appReadTarget(params)
 				if threadID == "" {


### PR DESCRIPTION
## Summary

Follow-up to merged #822; independent of frontend #931 and issue #922.

- Admit subscribing reads in wire order before asynchronous dispatch, so a following unsubscribe cancels reads that have not registered their subscription yet.
- Match each capture to its exact request and protect the claim-to-registration interval. Retire admission tokens on capture or completion rather than retaining cancellation tombstones.
- Canonicalize stable-ref/current-session aliases for pending cancellation without changing notification delivery routing or unresolved-unsubscribe behavior.
- Reject whitespace-only transcript list cursors without normalizing nonempty opaque cursors.

## Verification

- All four affected Go package suites passed: `./appwire`, `./internal/appserver`, `./server`, `./cmd/evener-hub`.
- Focused admission, alias, existing relay, and cursor tests passed under the race detector five times.
- Vet of all four packages, formatting, and staged diff checks passed.
- Real-wire regression covers both stable-ref/current-ID cancellation directions, the unavailable-subscription response, no stale delivery, unrelated subscriptions, and later reads.
- Existing daemon notification delivery, unresolved unsubscribe, shared aliases, and claim/register barrier controls remain intact.
- Full repository tests and races were not run locally, as requested; repository-wide verification belongs to CI.
