### PR TITLE
test(agent): pin close-during-start on virtual time

### DIFF
--- a/agent/job_shell_test.go
+++ b/agent/job_shell_test.go
@@ -439,6 +439,10 @@ func TestRunShellBackgroundWaitErrorFinalizesFailed(t *testing.T) {
 func TestRunShellBackgroundCloseDuringStartDoesNotCommitJob(t *testing.T) {
 	t.Parallel()
 	jm := newTestJM(t)
+	// Virtual time never advances, so closeRuntimeState's grace timer never
+	// expires on its own: close waits on the released start's real
+	// completion instead of racing a wall-clock window.
+	jm.clock = agenttest.NewFakeClock()
 	se := newBlockingStartStreamingExecutor()
 
 	resultCh := make(chan shellResult, 1)


### PR DESCRIPTION
## What was wrong

`TestRunShellBackgroundCloseDuringStartDoesNotCommitJob` (agent/job_shell_test.go) blocks a shell inside `StreamCommand`, runs `jm.close()` concurrently, polls `jm.closing`, then releases the start. `closeRuntimeState` snapshots the in-flight start and signals it **before** it arms the grace timer (`deadline := jm.clock.NewTimer(jm.closeGrace)`, agent/jobs.go:768), so the entire post-release tail — `setShellSignal`, `commitDelayedShell` refusing with `errJobManagerClosing`, `handle.Signal()`, `discardDelayedShell` closing the output store and removing the artifact, `run.closeDone()` — has to land inside what is left of the grace.

The test grace is `testCloseGrace` = 200 ms on non-race builds (3 s under `-race`). On a loaded runner the tail overruns it, close takes `<-deadline.C()`, `abandonRunningJobs()` runs, and `close()` returns `job manager close timed out waiting for running jobs`. Only the non-race jobs (`tests`, `fuzz`) can hit it; the most visible sighting is through the coverage wrapper `FuzzCovJobShellSeed100`, which just re-runs this test as the `close_during_start` subtest.

Production is unaffected. A start released after close abandoned it still cannot commit, which `TestCommitDelayedShellAfterCloseAbandonmentFails` already covers. The bug was the test's dependence on a wall-clock window it started before the release.

## What changed

Test-only, four lines. The test's job manager gets `agenttest.NewFakeClock()`. Virtual time never advances, so the grace timer never expires on its own and `closeRuntimeState` waits on the released start's real completion. Same shape as the fixes for #852 and #896.

`observerDeadline` (agent/jobs.go:785) uses the same clock and also never fires, but its wait still returns immediately: this test schedules no observer links, so `observerLinkWG` is empty and `observerLinkDone` closes at once. `MaxRuntimeMS` is 0 and the job is background, so `runShell` arms no clock timer of its own. Every existing assertion is unchanged.

## How it is tested

Reproduced by construction first. With the fake clock installed, forcing the interleaving with `clk.BlockUntil(1)` (close has armed its grace timer) and `clk.Advance(jm.closeGrace)` before releasing the start made it fail 3/3 on the exact CI message:

```
--- FAIL: TestRunShellBackgroundCloseDuringStartDoesNotCommitJob (0.00s)
    job_shell_test.go:486: close: job manager close timed out waiting for running jobs
```

Dropping those two forcing lines — the committed state — makes it pass.

## Gates

| Gate | Result |
| --- | --- |
| `gofmt -l agent/job_shell_test.go`, `make lint-gofmt` | clean |
| `go vet ./...` and `go vet -tags evenerfuzz ./...` (agent module) | exit 0 |
| `make lint-golangci` | PASS (61s) |
| `make lint-evenerfuzz lint-eval lint-fuzz-registry` | PASS |
| `GOMAXPROCS=4 go test -race ./agent/... -count=1` | 0 FAIL (agent ok 1168s, 41 subpackages ok) |
| `GOMAXPROCS=4 go test -tags evenerfuzz -run Fuzz ./agent/ -count=1` | 0 FAIL (ok 155s) |
| `GOMAXPROCS=4 go test ./agent/ -count=1` | 0 FAIL (ok 409s) |
| `GOMAXPROCS=4 go test ./agent/ -run '^TestRunShellBackgroundCloseDuringStartDoesNotCommitJob$' -count=30 -p 4` under load | 0 FAIL |
| same test, `-race -count=5` | 0 FAIL |

Closes #922

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT