### PR TITLE
Keep incompatible running sessions visible and reject undeliverable messages

### DIFF
--- a/agent/apilog_envelope_size_test.go
+++ b/agent/apilog_envelope_size_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAPILogSummarySizerMatchesTrimmedEnvelope(t *testing.T) {
+	envelope := apiLogReadEnvelope{TranscriptRef: "session", Source: "api-log", Records: []apiLogRecordSummary{
+		{RecordNumber: 1, Kind: "request", RequestModel: "model"},
+		{RecordNumber: 2, Kind: "response", ErrorClass: "multi\nline"},
+		{RecordNumber: 3, Kind: "request"},
+	}}
+	full, err := json.MarshalIndent(envelope, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sizer, err := newAPILogSummaryEnvelopeSizer(envelope, len(full))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		envelope.Meta.RecordsReturned = len(envelope.Records)
+		envelope.Meta.Truncated = len(envelope.Records) < 3
+		actual, err := json.MarshalIndent(envelope, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		size, err := sizer.envelopeSize(envelope)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if size != len(actual) {
+			t.Fatalf("%d records: predicted=%d actual=%d", len(envelope.Records), size, len(actual))
+		}
+		if len(envelope.Records) == 0 {
+			break
+		}
+		envelope.Records = envelope.Records[1:]
+	}
+}

--- a/agent/delegate_resume_ownership_test.go
+++ b/agent/delegate_resume_ownership_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/llm"
+)
+
+func TestRetainedDelegateReservesSessionUntilOwnerReleases(t *testing.T) {
+	root, client, _ := newDelegateResourceBootstrapSession(t)
+	logger, err := llm.NewSessionAPILogger(root.stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = logger.Close() })
+	root.cfg.AcquireSessionOwnership = logger.ReserveSession
+	adapter := newTask6FrozenDescriptorAdapter()
+	client.Register(adapter)
+	t.Cleanup(adapter.releaseRun)
+	result := root.createDelegate(context.Background(), delegateArgs{Task: "finish the assigned work", DelegationAllowance: new(0)})
+	if result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	select {
+	case <-adapter.entered:
+	case <-time.After(10 * time.Second): // TRIPWIRE: the scripted provider must receive the child request.
+		t.Fatal("child never reached provider")
+	}
+	child := root.subagents.get(result.ChildSessionID)
+	child.mu.Lock()
+	done := child.done
+	child.mu.Unlock()
+	contender, err := llm.NewSessionAPILogger(root.stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = contender.Close() })
+	if err := contender.ReserveSession(result.ChildSessionID); !errors.Is(err, llm.ErrAPILogTargetLocked) {
+		t.Fatalf("running child ownership = %v", err)
+	}
+	adapter.releaseRun()
+	drainDone := make(chan struct{})
+	defer close(drainDone)
+	go func() {
+		for {
+			select {
+			case <-adapter.entered:
+			case <-drainDone:
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second): // TRIPWIRE: await the actual child completion.
+		t.Fatal("child never completed")
+	}
+	if err := contender.ReserveSession(result.ChildSessionID); !errors.Is(err, llm.ErrAPILogTargetLocked) {
+		t.Fatalf("retained child ownership = %v", err)
+	}
+	root.Close()
+	if err := logger.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := contender.ReserveSession(result.ChildSessionID); err != nil {
+		t.Fatalf("released child ownership = %v", err)
+	}
+}

--- a/agent/internal/jobstore/output_snapshot.go
+++ b/agent/internal/jobstore/output_snapshot.go
@@ -47,6 +47,7 @@ type outputSnapshotObservation struct {
 	outputObserved  bool
 	outputExists    bool
 	retainedBytes   int64
+	outputInfo      os.FileInfo
 	pendingObserved bool
 	pendingExists   bool
 	pending         string
@@ -287,6 +288,7 @@ func observeOutputSnapshot(fs afero.Fs, path string) (outputSnapshotObservation,
 	observation.outputObserved = true
 	observation.outputExists = true
 	observation.retainedBytes = info.Size()
+	observation.outputInfo = info
 
 	metaPath := outputMetaPath(path)
 	// OutputStore publishes pending metadata before rewriting a capped file and
@@ -307,6 +309,18 @@ func observeOutputSnapshot(fs afero.Fs, path string) (outputSnapshotObservation,
 }
 
 func (after outputSnapshotObservation) changedFrom(before outputSnapshotObservation) bool {
+	// A prune can return to the same retained size while the reader still holds
+	// a hash of the expanded file. Metadata publication need not advance during
+	// that interval, so also fence the file generation and in-place appends.
+	if before.outputInfo != nil && after.outputInfo != nil {
+		if !before.outputInfo.ModTime().Equal(after.outputInfo.ModTime()) {
+			return true
+		}
+		if before.outputInfo.Sys() != nil && after.outputInfo.Sys() != nil && !os.SameFile(before.outputInfo, after.outputInfo) {
+			return true
+		}
+	}
+
 	if after.outputObserved && (after.outputExists != before.outputExists || after.retainedBytes != before.retainedBytes) {
 		return true
 	}

--- a/agent/internal/jobstore/output_snapshot_test.go
+++ b/agent/internal/jobstore/output_snapshot_test.go
@@ -1030,3 +1030,79 @@ func (f *snapshotCloseHookFile) Close() error {
 	}
 	return err
 }
+
+// The file size returns to its cap while pending/final metadata remain unchanged
+// across both observations. The hash in between belongs to the expanded inode.
+func TestReadOutputWindowSnapshotDetectsReplacementDuringHash(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "job.log")
+	fs := &snapshotHashReplacementFS{snapshotAppendPruneFS: newSnapshotAppendPruneFS(path), finalPublication: make(chan struct{}), allowFinalPublication: make(chan struct{})}
+	store, err := createOutputFsWithSync(fs, path, 4, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appendOutput(t, store, "AAAA")
+	fs.armInitialRetainedSize()
+	fs.fencePublication.Store(true)
+	type result struct {
+		snapshot OutputWindowSnapshot
+		err      error
+	}
+	snapshotDone := make(chan result, 1)
+	go func() {
+		snapshot, err := readOutputWindowSnapshotFs(fs, path, 4, 4)
+		snapshotDone <- result{snapshot, err}
+	}()
+	<-fs.initialRetainedSizeCaptured
+	appendDone := make(chan error, 1)
+	go func() { _, err := store.Append([]byte("BBBB")); appendDone <- err }()
+	defer func() {
+		fs.releaseInitialMetadataValidation()
+		fs.releaseOutputReplacement()
+		close(fs.allowFinalPublication)
+		if err := <-appendDone; err != nil {
+			t.Error(err)
+		}
+		if err := store.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	<-fs.pendingPublished
+	fs.captureHash.Store(true)
+	fs.releaseInitialMetadataValidation()
+	got := <-snapshotDone
+	if got.err != nil {
+		t.Fatalf("snapshot across replacement: %v", got.err)
+	}
+	if string(got.snapshot.Content) != "BBBB" || got.snapshot.Start != 4 || got.snapshot.TotalBytes != 8 {
+		t.Fatalf("snapshot=%+v", got.snapshot)
+	}
+}
+
+type snapshotHashReplacementFS struct {
+	*snapshotAppendPruneFS
+	captureHash           atomic.Bool
+	fencePublication      atomic.Bool
+	finalPublication      chan struct{}
+	allowFinalPublication chan struct{}
+	finalOnce             sync.Once
+}
+
+func (fs *snapshotHashReplacementFS) Open(name string) (afero.File, error) {
+	file, err := fs.snapshotAppendPruneFS.Open(name)
+	if err == nil && name == fs.path && fs.captureHash.Swap(false) {
+		return &snapshotCloseHookFile{File: file, afterClose: func() error {
+			fs.releaseOutputReplacement()
+			<-fs.finalPublication
+			return nil
+		}}, nil
+	}
+	return file, err
+}
+
+func (fs *snapshotHashReplacementFS) Rename(oldpath, newpath string) error {
+	if newpath == outputMetaPath(fs.path) && fs.fencePublication.Load() {
+		fs.finalOnce.Do(func() { close(fs.finalPublication) })
+		<-fs.allowFinalPublication
+	}
+	return fs.snapshotAppendPruneFS.Rename(oldpath, newpath)
+}

--- a/agent/session_active_turn_test.go
+++ b/agent/session_active_turn_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/spf13/afero"
 
@@ -32,11 +31,6 @@ func TestGoalContinuationTurnCarriesItsNameOnTheOpeningEvent(t *testing.T) {
 
 	var mu sync.Mutex
 	var continuations []events.GoalContinuationData
-	// The drain ConsumeEventsLossless registers delivers on its own goroutine
-	// (session_events.go), so nothing guarantees it has run by the time
-	// ProcessInputKind returns. Wait for the event rather than asserting on a
-	// slice the consumer may not have appended to yet.
-	sawContinuation := make(chan struct{}, 1)
 	drained := make(chan struct{})
 	s.ConsumeEventsLossless(func(ev events.SessionEvent) {
 		if ev.Kind != events.EventGoalContinuation {
@@ -49,26 +43,16 @@ func TestGoalContinuationTurnCarriesItsNameOnTheOpeningEvent(t *testing.T) {
 		mu.Lock()
 		continuations = append(continuations, data)
 		mu.Unlock()
-		select {
-		case sawContinuation <- struct{}{}:
-		default:
-		}
 	}, func() { close(drained) })
 
 	if _, err := s.ProcessInputKind(context.Background(), "keep going", nil, EntryContinuation); err != nil {
 		t.Fatalf("ProcessInputKind(EntryContinuation): %v", err)
 	}
 
-	select {
-	case <-sawContinuation:
-	// TRIPWIRE: the event is emitted synchronously by ProcessInputKind above
-	// and delivered by the in-process drain goroutine, so it normally arrives
-	// in well under a second. 30s only fires on a genuine delivery hang, not
-	// scheduler contention under a loaded suite.
-	case <-time.After(30 * time.Second):
-		t.Fatalf("timed out waiting for the EventGoalContinuation opening event")
-	}
-
+	// ProcessInputKind finishes the turn before the asynchronous consumer
+	// necessarily sees its events. Join the drain before inspecting them.
+	s.Close()
+	<-drained
 	mu.Lock()
 	defer mu.Unlock()
 	if len(continuations) != 1 {

--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"primeradiant.com/evener/agent/internal/jobstore"
@@ -208,6 +209,10 @@ func TestDrainIdleBackoffWakeResetsToFullRate(t *testing.T) {
 // exactly one notification turn for it.
 func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, testDrainBackoffFinalKickDeliversUnreachableChildPending)
+}
+
+func testDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 	sess := newSession(t)
 	seedWatchSendResidue(t, sess)
 	jm := sess.jobManager
@@ -248,7 +253,7 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 		_, _ = sess.drainJobTreeWith(ctx, recheck, kick, process)
 	}()
 
-	// Phase 1: drive passes 0..drainIdleBackoffFullRatePasses (17 sends).
+	// Phase 1: finish the full-rate prefix and one skipped-kick pass.
 	// The drain runs its first pass (pass 0) before parking, so 17 sends
 	// release passes 1..17: passes 0..16 kick at full rate (17 kicks) and
 	// pass 17 (quietPasses=17, 17%4!=0) is the first pass that SKIPS its
@@ -262,19 +267,19 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 			t.Fatal("drain returned before reaching a skipped-kick pass")
 		}
 	}
-	// Await the 17 full-rate kicks before seeding: this proves passes 0..16
-	// all ran their kick gates, so the loop is parked awaiting pass 17 (or
-	// running it) and Phase 2's seeding cannot land in an earlier pass's
-	// scan. Without the fix this wait still terminates — the prefix always
-	// kicks — and the turn assertion below still fails.
-	waitDrainBackoffKicks(t, done, &kicks, int32(drainIdleBackoffFullRatePasses)+1, "full-rate prefix")
-	// Phase 2: while the loop is parked awaiting pass 17, seed a forwarded
+	// The last recheck send only releases the pass. Wait until that pass has
+	// parked so it cannot inspect the fixture halfway through seeding.
+	synctest.Wait()
+	if got, want := kicks.Load(), int32(drainIdleBackoffFullRatePasses)+1; got != want {
+		t.Fatalf("full-rate prefix kicks = %d, want %d", got, want)
+	}
+	// Phase 2: while the loop is parked awaiting pass 18, seed a forwarded
 	// terminal pending owned by a child that is nowhere in the live tree —
 	// not a live direct subagent, no delegate descriptor, so childResumable
 	// is false and the next kick renders it onto this session's rail — and
 	// clear the residue. Both are pure store/flag writes (appendEvent is
 	// store.Append: no enqueue, no wake), so the wake edge stays clear and
-	// pass 17 still skips its kick deterministically.
+	// pass 18 still skips its kick deterministically.
 	const childID = "child-gone"
 	now := jm.now()
 	gen := "gen-job_unreachable_tail"
@@ -294,34 +299,12 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 	jm.mu.Lock()
 	jm.stableWatchSettlementRetrying = false
 	jm.mu.Unlock()
-	// The scan excludes the forwarded copy by design, so the tree now reads
-	// quiescent apart from the kick-only render — the hole under test. Poll
-	// read-only (no recheck ticks: every tick releases another parked pass
-	// and disturbs the kick count asserted at the tail) until the quiet scan
-	// is observable. A quiet scan here cannot be a stale read racing pass
-	// 17's own verdict: the loop is parked awaiting it, and the seeding
-	// above raised no wake, so the next pass still skips its kick.
-	quietDeadline := time.Now().Add(30 * time.Second)
-	for {
-		outstanding, err := sess.treeHasOutstandingWork()
-		if err != nil {
-			t.Fatalf("quiescence poll: %v", err)
-		}
-		if !outstanding {
-			break
-		}
-		if time.Now().After(quietDeadline) {
-			t.Fatalf("precondition: tree must read quiescent after residue clear, got outstanding=true after 30s")
-		}
-		select {
-		case <-done:
-			t.Fatalf("drain returned during quiescence poll with turns = %d, want the skipped-kick pass to run first", turns.Load())
-		// TRIPWIRE: not a completion-signal wait — a quiet scan above is
-		// the signal; 10ms only yields instead of busy-spinning.
-		case <-time.After(10 * time.Millisecond):
-		}
+	// The parked drain cannot change the fixture. Clearing the residue is
+	// synchronous, and the scan excludes the forwarded copy by design.
+	if outstanding, err := sess.treeHasOutstandingWork(); err != nil || outstanding {
+		t.Fatalf("precondition: tree must read quiescent after residue clear, got outstanding=%v err=%v", outstanding, err)
 	}
-	// Phase 3: release pass 17. Without the fix it returns quiescent with
+	// Phase 3: release pass 18. Without the fix it returns quiescent with
 	// the pending undelivered (turns stays 0 and done closes); with the fix
 	// the final kick renders it onto the rail and the loop runs exactly one
 	// notification turn for it.

--- a/agent/status.go
+++ b/agent/status.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"path/filepath"
 	"sort"
 	"time"
 
@@ -233,6 +235,50 @@ func (s *Session) DetailedStatus() DetailedStatus {
 	ds.TurnSlots = turnSlotOccupancyOf(s)
 
 	return ds
+}
+
+// SessionOwnsDelegate verifies a direct parent-child edge in the root-owned
+// delegate journal without projecting transcript attention.
+func SessionOwnsDelegate(ctx context.Context, stateDir, parentSessionID, childSessionID string) (bool, error) {
+	if err := schema.ValidateSessionID(parentSessionID); err != nil {
+		return false, err
+	}
+	if err := schema.ValidateSessionID(childSessionID); err != nil {
+		return false, err
+	}
+	meta, err := schema.LoadSessionMeta(stateDir, parentSessionID)
+	if err != nil {
+		return false, err
+	}
+	rootID := activityRootIDFromMeta(parentSessionID, meta)
+	if err := schema.ValidateSessionID(rootID); err != nil {
+		return false, err
+	}
+	path := filepath.Join(jobsDir(stateDir, rootID), "delegates.jsonl")
+	result, err := historicalDelegateFoldCache.Get(ctx, path, extendHistoricalDelegateFold)
+	if err != nil {
+		return false, err
+	}
+	parentDelegateID := ""
+	parentFound := parentSessionID == rootID
+	if !parentFound {
+		for delegateID, aggregate := range result.Value.state {
+			if aggregate != nil && aggregate.Descriptor.OwnerSessionID == rootID && aggregate.Descriptor.ChildSessionID == parentSessionID {
+				parentDelegateID, parentFound = delegateID, true
+				break
+			}
+		}
+	}
+	for _, aggregate := range result.Value.state {
+		if parentFound && aggregate != nil && aggregate.Descriptor.OwnerSessionID == rootID &&
+			aggregate.Descriptor.ChildSessionID == childSessionID && aggregate.Descriptor.ParentDelegateID == parentDelegateID {
+			return true, nil
+		}
+	}
+	if result.Value.tornTail {
+		return false, fmt.Errorf("delegate ownership journal has an incomplete trailing batch: %s", path)
+	}
+	return false, nil
 }
 
 // LoadSessionDelegateStatus projects a cold session's stable delegate rows

--- a/agent/status_test.go
+++ b/agent/status_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"primeradiant.com/evener/agent/execenv"
@@ -865,5 +867,72 @@ func TestLoadSessionDelegateStatus_OversizedDelegateJournalLineDegradesWithDiagn
 	}
 	if !found {
 		t.Fatalf("diagnostics = %v, want one identifying the oversized delegates.jsonl line (file + line info), visible rather than silently dropped", diagnostics)
+	}
+}
+
+func TestSessionOwnsDelegateCancellationDuringJournalFold(t *testing.T) {
+	stateDir := t.TempDir()
+	ownerID := "02wMz5Txv1C3Hut0M8GCeC"
+	childID := "02wMz5Txv1C3Hut0M8GCeD"
+	writePastStableDelegates(t, stateDir, ownerID, pastStableDescriptor(ownerID, childID, "inspect ownership"))
+	savePastActivityMeta(t, stateDir, ownerID, "Owner")
+	synctest.Test(t, func(t *testing.T) {
+		started, release := make(chan struct{}), make(chan struct{})
+		original := scanDelegateJournal
+		scanDelegateJournal = func(ctx context.Context, path string, fromOffset int64, limits delegatestore.ScanLimits) ([]delegatestore.Event, int64, delegatestore.ReadDiagnostics, error) {
+			close(started)
+			<-release
+			return original(ctx, path, fromOffset, limits)
+		}
+		defer func() { scanDelegateJournal = original }()
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { _, err := SessionOwnsDelegate(ctx, stateDir, ownerID, childID); done <- err }()
+		<-started
+		cancel()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("ownership error=%v, want cancellation", err)
+			}
+		default:
+			t.Error("ownership caller still waits for the journal fold after cancellation")
+		}
+		close(release)
+		synctest.Wait()
+		owned, err := SessionOwnsDelegate(context.Background(), stateDir, ownerID, childID)
+		if err != nil || !owned {
+			t.Errorf("shared fold lost healthy caller's result: owned=%v, err=%v", owned, err)
+		}
+	})
+}
+
+func TestSessionOwnsDelegateVerifiesRootOwnerAndImmediateParent(t *testing.T) {
+	const rootID = "02wMz5Txv1C3Hut0M8GCeC"
+	const parentID = "02wMz5Txv1C3Hut0M8GCeD"
+	const childID = "02wMz5Txv1C3Hut0M8GCeE"
+	const siblingID = "02wMz5Txv1C3Hut0M8GCeF"
+	stateDir := t.TempDir()
+	parent := pastStableDescriptor(rootID, parentID, "parent task")
+	child := pastStableDescriptor(rootID, childID, "nested task")
+	child.ParentDelegateID = "dlg_" + parentID
+	sibling := pastStableDescriptor(rootID, siblingID, "sibling task")
+	writePastStableDelegates(t, stateDir, rootID, parent, child, sibling)
+	savePastActivityMeta(t, stateDir, rootID, "root")
+	savePastActivityMetaWithTreeRevision(t, stateDir, parentID, "parent", rootID, 1)
+	savePastActivityMetaWithTreeRevision(t, stateDir, siblingID, "sibling", rootID, 1)
+	for _, tc := range []struct {
+		parent, child string
+		want          bool
+	}{
+		{rootID, parentID, true}, {parentID, childID, true}, {rootID, childID, false}, {siblingID, childID, false},
+	} {
+		t.Run(tc.parent+"/"+tc.child, func(t *testing.T) {
+			got, err := SessionOwnsDelegate(t.Context(), stateDir, tc.parent, tc.child)
+			if err != nil || got != tc.want {
+				t.Fatalf("owned=%v error=%v, want %v", got, err, tc.want)
+			}
+		})
 	}
 }

--- a/appwire/flagday_contract_test.go
+++ b/appwire/flagday_contract_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestFlagDayProtocolVersion(t *testing.T) {
-	if ProtocolVersion != "evener-appwire-v4" {
-		t.Fatalf("protocol = %q, want %q", ProtocolVersion, "evener-appwire-v4")
+	if ProtocolVersion != "evener-appwire-v5" {
+		t.Fatalf("protocol = %q, want %q", ProtocolVersion, "evener-appwire-v5")
 	}
 }
 

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -10,7 +10,9 @@ import (
 // ProtocolVersion is compared exactly at the handshake
 // (internal/appserver/server.go), so bumping it makes a mixed pair of binaries
 // fail once, loudly, at initialize -- rather than agreeing there and then
-// disagreeing on every request.
+// disagreeing on every request. Daemon reads must identify authoritative
+// mutation state: a client cannot safely release uncertain sends from a peer
+// that does not supply that evidence.
 //
 // v4 makes transcript reads item-only and rejects retired paging fields. v3
 // dropped expectedTurnId from turn/steer, turn/queue, turn/interrupt,
@@ -20,7 +22,11 @@ import (
 // "Steer and Stop are broken again" instead of as a version skew. The pair is
 // reachable in ordinary operation because daemons outlive the hub that spawned
 // them, so an operator who rebuilds and restarts the hub has one.
-const ProtocolVersion = "evener-appwire-v4"
+const ProtocolVersion = "evener-appwire-v5"
+
+// ThreadStatusRestartRequired identifies a live daemon that cannot serve this
+// hub's protocol. Its current activity is unavailable until explicitly restarted.
+const ThreadStatusRestartRequired = "restartRequired"
 
 const (
 	MethodInitialize                  = "initialize"
@@ -613,6 +619,9 @@ type EvenerThread struct {
 	// value (Depth==0, Preview==nil) means "no queued messages".
 	Queue            QueueState        `json:"queue"`
 	PendingMutations []PendingMutation `json:"pendingMutations,omitempty"`
+	// MutationStateAuthoritative identifies a daemon snapshot that can settle
+	// uncertain sends. Saved transcript data cannot prove a mutation absent.
+	MutationStateAuthoritative bool `json:"mutationStateAuthoritative,omitempty"`
 	// Tasks carries the task-list progress for a session snapshot. It is nil
 	// when the source cannot authoritatively read task state, including an old
 	// daemon or a missing persisted task file; a present zero is real zero.

--- a/cmd/evener-hub/app_compact.go
+++ b/cmd/evener-hub/app_compact.go
@@ -46,7 +46,7 @@ func compactThreadWithResume(ctx context.Context, cfg hubcore.WebConfig, sources
 }
 
 func compactThreadOnce(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadCompactStartParams) error {
-	_, err := withDeletionTargetOwnership(cfg, params.Ref, "", "", func() (struct{}, error) {
+	_, err := withSessionActionOwnership(ctx, cfg, params.Ref, "", func() (struct{}, error) {
 		source, err := sourceForThread(sources, params.Ref, "")
 		if err != nil {
 			return struct{}{}, err

--- a/cmd/evener-hub/app_model.go
+++ b/cmd/evener-hub/app_model.go
@@ -26,7 +26,7 @@ func setThreadModelWithResume(ctx context.Context, cfg hubcore.WebConfig, source
 }
 
 func setThreadModelOnce(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadModelSetParams) error {
-	_, err := withDeletionTargetOwnership(cfg, params.Ref, "", "", func() (struct{}, error) {
+	_, err := withSessionActionOwnership(ctx, cfg, params.Ref, "", func() (struct{}, error) {
 		source, err := sourceForThread(sources, params.Ref, "")
 		if err != nil {
 			return struct{}{}, err

--- a/cmd/evener-hub/app_relay.go
+++ b/cmd/evener-hub/app_relay.go
@@ -596,7 +596,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				if cfg.RelayHooks.AfterCanonicalPublishEntry != nil {
 					cfg.RelayHooks.AfterCanonicalPublishEntry(target.relayKey, notification)
 				}
-				_, publicationErr := withDeletionTargetOwnership(cfg, target.ref, target.threadID, "", func() (struct{}, error) {
+				_, publicationErr := withDeletionTargetOwnership(context.Background(), cfg, target.ref, target.threadID, "", func() (struct{}, error) {
 					server.Broadcast(target.relayKey, notification.Method, notification.Params)
 					return struct{}{}, nil
 				})
@@ -1216,7 +1216,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		}
 		relayKey := read.relayKey
 		captured, err := withDeletionTargetOwnership(
-			cfg,
+			ctx, cfg,
 			params.Ref,
 			read.response.Thread.ID,
 			"",
@@ -1274,7 +1274,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 		threadID := read.response.Thread.ID
 		relayKey := read.relayKey
 		registered, err := withDeletionTargetOwnership(
-			cfg,
+			ctx, cfg,
 			params.Ref,
 			threadID,
 			"",
@@ -1373,7 +1373,7 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 				}
 				return true, nil
 			}
-			registered, err := withDeletionTargetOwnership(cfg, subscribeParams.Ref, threadID, "", registerExisting)
+			registered, err := withDeletionTargetOwnership(ctx, cfg, subscribeParams.Ref, threadID, "", registerExisting)
 			if err != nil {
 				return err
 			}
@@ -1706,9 +1706,14 @@ func newHubRelayFunctions(server *appserver.Server, cfg hubcore.WebConfig, sourc
 					return appwire.TurnStartResponse{}, fenceErr
 				}
 			}
+			if daemonOwnershipMayHaveChanged(err) {
+				if restartErr := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, params.ThreadID, params.ClientMutationID); restartErr != nil {
+					return appwire.TurnStartResponse{}, restartErr
+				}
+			}
 			return appwire.TurnStartResponse{}, err
 		}
-		return withDeletionTargetOwnership(cfg, params.Ref, params.ThreadID, params.ClientMutationID, func() (appwire.TurnStartResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, params.ThreadID, params.ClientMutationID, func() (appwire.TurnStartResponse, error) {
 			return source.StartTurn(ctx, params)
 		})
 	}

--- a/cmd/evener-hub/app_rename.go
+++ b/cmd/evener-hub/app_rename.go
@@ -38,7 +38,10 @@ func setThreadName(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 		return appwire.EmptyResponse{}, appwire.InvalidParams("name is required")
 	}
 
-	mutation, err := withDeletionTargetOwnership(cfg, params.Ref, "", "", func() (threadNameMutation, error) {
+	mutation, err := withDeletionTargetOwnership(ctx, cfg, params.Ref, "", "", func() (threadNameMutation, error) {
+		if err := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, "", ""); err != nil {
+			return threadNameMutation{}, err
+		}
 		return mutateThreadName(ctx, cfg, sources, ref, params)
 	})
 	if err != nil {
@@ -128,6 +131,6 @@ func threadNameIsLive(cfg hubcore.WebConfig, threadID string) bool {
 	if cfg.Roster == nil {
 		return false
 	}
-	_, live := cfg.Roster.Find(threadID)
+	_, live := liveDaemonForThread(cfg.Roster, threadID)
 	return live
 }

--- a/cmd/evener-hub/app_rename_test.go
+++ b/cmd/evener-hub/app_rename_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -394,5 +395,42 @@ func assertRenameTargets(t *testing.T, events []appwire.NavigationInvalidatedPay
 		if got.Kind == appwire.NavigationTargetAllLoadedProjects && got.Revision != 0 {
 			t.Fatalf("rename wildcard target[%d] revision=%d, want 0", i, got.Revision)
 		}
+	}
+}
+
+func TestRenameLiveWorkspaceAliasReachesDaemon(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "project-0123456789")
+	const savedID = "02wMz5Txv1C3Hut0M8GCeB"
+	const instanceID = "02wMz5Txv1C3Hut0M8GCeC"
+	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{ID: savedID, Name: "saved name"}); err != nil {
+		t.Fatal(err)
+	}
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := past.Find(savedID); !ok {
+		t.Fatal("saved session missing from index")
+	}
+	live := &renameNavigationSource{scriptedAppSource: &scriptedAppSource{id: "local", thread: appwire.Thread{ID: instanceID, Evener: appwire.EvenerThread{Ref: "local:" + savedID, Capabilities: appwire.ThreadCapabilities{Rename: true}}}}}
+	sources := appsource.NewRegistry()
+	sources.Add(live)
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: os.Getpid(), Protocol: appwire.ProtocolVersion, ThreadID: instanceID, SessionID: instanceID, WorkspaceRef: "local:" + savedID})
+	cfg := hubcore.WebConfig{Past: past, Roster: hubcore.NewRoster(runDir, nil)}
+	server := newHubAppServerWithNavigation(cfg, sources, nil, nil)
+	if err := dispatchThreadNameSet(t, server, appwire.ThreadNameSetParams{Ref: "local:" + savedID, Name: "new name"}); err != nil {
+		t.Fatal(err)
+	}
+	if live.got.Name != "new name" || live.got.Ref != "local:"+savedID {
+		t.Fatalf("daemon rename=%+v", live.got)
+	}
+	meta, err := schema.LoadSessionMeta(stateDir, savedID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Name != "saved name" {
+		t.Fatalf("hub bypassed daemon and wrote metadata: %q", meta.Name)
 	}
 }

--- a/cmd/evener-hub/app_restart_required.go
+++ b/cmd/evener-hub/app_restart_required.go
@@ -1,0 +1,326 @@
+package hub
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+// daemonDiscoveryError describes uncertainty outside the requested ownership
+// chain. Saved projections remain readable, but cannot grant mutation authority.
+type daemonDiscoveryError struct {
+	err error
+}
+
+func (e *daemonDiscoveryError) Error() string {
+	return fmt.Sprintf("daemon ownership discovery failed: %v", e.err)
+}
+func (e *daemonDiscoveryError) Unwrap() error { return e.err }
+
+func isDaemonDiscoveryError(err error) bool {
+	var discovery *daemonDiscoveryError
+	return errors.As(err, &discovery)
+}
+
+// restartRequiredDaemon only uses an authenticated probe's mismatch verdict.
+// A rendezvous file or a live PID alone cannot establish daemon identity.
+func restartRequiredDaemon(ctx context.Context, cfg hubcore.WebConfig, ref, threadID string) (hubcore.LiveEntry, bool, error) {
+	return lookupDaemonOwner(ctx, cfg, ref, threadID, false)
+}
+
+func lookupDaemonOwner(ctx context.Context, cfg hubcore.WebConfig, ref, threadID string, verifyCompatibleAncestry bool) (hubcore.LiveEntry, bool, error) {
+	if ref != "" {
+		parsed, err := appwire.ParseRef(ref)
+		if err != nil {
+			return hubcore.LiveEntry{}, false, err
+		}
+		if parsed.SourceID != "local" {
+			return hubcore.LiveEntry{}, false, nil
+		}
+		threadID = parsed.ThreadID
+	}
+	if cfg.Roster == nil || threadID == "" {
+		return hubcore.LiveEntry{}, false, nil
+	}
+	type ownershipEdge struct {
+		stateDir, ownerID, childID string
+		isSubagent                 bool
+	}
+	var edges []ownershipEdge
+	verifyOwner := func(entry hubcore.LiveEntry, unconfirmed bool) (hubcore.LiveEntry, bool, error) {
+		if entry.Status != appwire.ThreadStatusRestartRequired && !unconfirmed && !verifyCompatibleAncestry {
+			return entry, false, nil
+		}
+		for _, edge := range edges {
+			owned, err := agent.SessionOwnsDelegate(ctx, edge.stateDir, edge.ownerID, edge.childID)
+			if err != nil {
+				return hubcore.LiveEntry{}, false, fmt.Errorf("read daemon ownership for %s: %w", edge.childID, err)
+			}
+			if !owned {
+				if edge.isSubagent {
+					return hubcore.LiveEntry{}, false, fmt.Errorf("cannot verify delegate %s ownership: descriptor for parent %s is missing", edge.childID, edge.ownerID)
+				}
+				return hubcore.LiveEntry{}, false, nil
+			}
+		}
+		if unconfirmed {
+			return hubcore.LiveEntry{}, false, fmt.Errorf("cannot verify daemon ownership for session %s", entry.SessionID)
+		}
+		return entry, entry.Status == appwire.ThreadStatusRestartRequired, nil
+	}
+	var jobTreeRootID string
+	var subagentAncestry, reachedRoot bool
+	seen := make(map[string]bool)
+	for !seen[threadID] {
+		seen[threadID] = true
+		if unconfirmedDaemonForThread(cfg.Roster, threadID) {
+			return verifyOwner(hubcore.LiveEntry{SessionID: threadID}, true)
+		}
+		findOwner := liveDaemonForThread
+		if len(edges) != 0 {
+			findOwner = liveDaemonForSession
+		}
+		if entry, ok := findOwner(cfg.Roster, threadID); ok {
+			return verifyOwner(entry, false)
+		}
+		// Ancestry locates a possible daemon. Every edge must have a persisted
+		// delegate descriptor before that daemon can be classified as the owner.
+		child, ok, err := ownershipEntry(ctx, cfg, threadID)
+		if err != nil {
+			return hubcore.LiveEntry{}, false, fmt.Errorf("read session ownership for %s: %w", threadID, err)
+		}
+		if !ok {
+			break
+		}
+		// A fork's parent records provenance, not daemon ownership. An
+		// independent activity root does not require its parent's metadata.
+		if !child.Meta.IsSubagent && (child.Meta.JobTreeRootSessionID == "" || child.Meta.JobTreeRootSessionID == threadID) {
+			reachedRoot = true
+			break
+		}
+		subagentAncestry = subagentAncestry || child.Meta.IsSubagent
+		if jobTreeRootID == "" {
+			jobTreeRootID = child.Meta.JobTreeRootSessionID
+		}
+		if child.Meta.ParentSessionID == "" {
+			reachedRoot = !child.Meta.IsSubagent
+			break
+		}
+		parentID := child.Meta.ParentSessionID
+		stateDir := child.StateDir
+		if parent, ok := pastEntryForRead(cfg, appwire.ThreadReadParams{ThreadID: parentID}); ok {
+			stateDir = parent.StateDir
+		}
+		// Missing indexed metadata cannot hide a known live parent. The next
+		// iteration checks the roster first; verifying its descriptor then
+		// reports unreadable ownership instead of permitting a delegate write.
+		edges = append(edges, ownershipEdge{stateDir: stateDir, ownerID: parentID, childID: threadID, isSubagent: child.Meta.IsSubagent})
+		threadID = parentID
+	}
+
+	if subagentAncestry && !reachedRoot && !cfg.Roster.DaemonOwnershipAbsent() {
+		return hubcore.LiveEntry{}, false, fmt.Errorf("cannot verify incomplete subagent ancestry at session %s", threadID)
+	}
+
+	// An incomplete ancestry chain cannot establish that an incompatible
+	// job-tree owner has released this descendant. Report uncertainty until
+	// its metadata and descriptor chain can be verified.
+	if owner, ok := liveDaemonForSession(cfg.Roster, jobTreeRootID); ok && owner.Status == appwire.ThreadStatusRestartRequired {
+		return hubcore.LiveEntry{}, false, fmt.Errorf("cannot verify delegate ownership at session %s in incompatible job tree %s", threadID, jobTreeRootID)
+	}
+	if unconfirmedDaemonForThread(cfg.Roster, jobTreeRootID) {
+		return hubcore.LiveEntry{}, false, fmt.Errorf("cannot verify daemon ownership in job tree %s", jobTreeRootID)
+	}
+	if err := cfg.Roster.OwnershipError(); err != nil {
+		return hubcore.LiveEntry{}, false, &daemonDiscoveryError{err: err}
+	}
+	return hubcore.LiveEntry{}, false, nil
+}
+
+// Indexed entries carry their project directory. Without one, inspect only the
+// requested metadata across configured projects; a failed read is not absence.
+func ownershipEntry(ctx context.Context, cfg hubcore.WebConfig, threadID string) (hubcore.PastEntry, bool, error) {
+	if entry, ok := pastEntryForRead(cfg, appwire.ThreadReadParams{ThreadID: threadID}); ok {
+		return entry, true, nil
+	}
+	if cfg.StateDir == "" {
+		return hubcore.PastEntry{}, false, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return hubcore.PastEntry{}, false, err
+	}
+	dirs := []string{cfg.StateDir}
+	projects, err := os.ReadDir(filepath.Join(cfg.StateDir, "projects"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return hubcore.PastEntry{}, false, err
+	}
+	for _, project := range projects {
+		if project.IsDir() {
+			dirs = append(dirs, filepath.Join(cfg.StateDir, "projects", project.Name()))
+		}
+	}
+	var found hubcore.PastEntry
+	for _, dir := range dirs {
+		if err := ctx.Err(); err != nil {
+			return hubcore.PastEntry{}, false, err
+		}
+		meta, err := schema.LoadSessionMeta(dir, threadID)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return hubcore.PastEntry{}, false, err
+		}
+		if found.ID != "" {
+			return hubcore.PastEntry{}, false, fmt.Errorf("session %s has ambiguous project ownership", threadID)
+		}
+		found = hubcore.PastEntry{ID: threadID, Meta: meta, StateDir: dir}
+	}
+	if found.ID == "" && cfg.Roster != nil && !cfg.Roster.DaemonOwnershipAbsent() {
+		return hubcore.PastEntry{}, false, fmt.Errorf("cannot locate ownership metadata for session %s", threadID)
+	}
+	return found, found.ID != "", nil
+}
+
+// A workspace route can survive clear while its former session's journal and
+// delegates are released. An ancestor must match the daemon's current session.
+func liveDaemonForSession(roster *hubcore.Roster, sessionID string) (hubcore.LiveEntry, bool) {
+	if sessionID == "" {
+		return hubcore.LiveEntry{}, false
+	}
+	for _, entry := range roster.List() {
+		if !entry.Crashed && cmp.Or(entry.SessionID, entry.Entry.SessionID, entry.ThreadID) == sessionID {
+			return entry, true
+		}
+	}
+	return hubcore.LiveEntry{}, false
+}
+
+func liveDaemonForThread(roster *hubcore.Roster, threadID string) (hubcore.LiveEntry, bool) {
+	if threadID == "" {
+		return hubcore.LiveEntry{}, false
+	}
+	if entry, ok := roster.Find(threadID); ok && !entry.Crashed {
+		return entry, true
+	}
+	workspaceRef := localAppRef(threadID)
+	for _, entry := range roster.List() {
+		if !entry.Crashed && localSpawnWorkspaceRef(entry.Entry) == workspaceRef {
+			return entry, true
+		}
+	}
+	return hubcore.LiveEntry{}, false
+}
+
+// Refresh ownership before a local metadata write or before treating a missing
+// daemon as proof that a mutation was not accepted. Successful delivery uses
+// the live source directly and does not wait for an unrelated roster probe.
+func refreshDaemonRestartRequiredError(ctx context.Context, cfg hubcore.WebConfig, ref, threadID, mutationID string) error {
+	if ref != "" {
+		parsed, err := appwire.ParseRef(ref)
+		if err != nil {
+			return appwire.InvalidParams(err.Error())
+		}
+		if parsed.SourceID != "local" {
+			return nil
+		}
+	}
+	if cfg.Roster != nil {
+		if err := hubRosterRefresh(ctx, cfg.Roster); err != nil {
+			wire := appwire.Unavailable(err.Error())
+			if mutationID != "" {
+				return restartRequiredMutationError(wire, mutationID)
+			}
+			return wire
+		}
+	}
+	return daemonRestartRequiredError(ctx, cfg, ref, threadID, mutationID)
+}
+
+func daemonRestartRequiredError(ctx context.Context, cfg hubcore.WebConfig, ref, threadID, mutationID string) error {
+	if ref != "" {
+		if _, err := appwire.ParseRef(ref); err != nil {
+			return appwire.InvalidParams(err.Error())
+		}
+	}
+
+	entry, ok, err := restartRequiredDaemon(ctx, cfg, ref, threadID)
+	if err != nil {
+		wire := appwire.Unavailable(err.Error())
+		if mutationID != "" {
+			return restartRequiredMutationError(wire, mutationID)
+		}
+		return wire
+	}
+	if !ok {
+		return nil
+	}
+	wire := appwire.WireError{Code: appwire.CodeConflict, Message: fmt.Sprintf("Session restart required: daemon pid %d uses an incompatible protocol; this hub requires %s. Stop the daemon, then resume this session. Stopping interrupts active work.", entry.PID, appwire.ProtocolVersion), Data: appwire.ErrorData{EvenerErrorInfo: appwire.ErrorConflict, Cause: "daemonRestartRequired"}}
+	if mutationID != "" {
+		return restartRequiredMutationError(wire, mutationID)
+	}
+	return wire
+}
+
+func isDaemonRestartRequiredError(err error) bool {
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		return false
+	}
+	switch data := wire.Data.(type) {
+	case appwire.ErrorData:
+		return data.Cause == "daemonRestartRequired"
+	case map[string]any:
+		return data["cause"] == "daemonRestartRequired"
+	default:
+		return false
+	}
+}
+
+// A retry may name a mutation accepted before the protocol upgrade. Without
+// its daemon's receipt history, the hub cannot claim that ID was rejected.
+func restartRequiredMutationError(err error, mutationID string) error {
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		return err
+	}
+	switch data := wire.Data.(type) {
+	case appwire.ErrorData:
+		data.ClientMutationID = mutationID
+		data.MutationOutcome = appwire.MutationOutcomeUnknown
+		data.RetryDisposition = appwire.RetryDispositionBlocked
+		wire.Data = data
+	case map[string]any:
+		updated := maps.Clone(data)
+		updated["clientMutationId"] = mutationID
+		updated["mutationOutcome"] = string(appwire.MutationOutcomeUnknown)
+		updated["retryDisposition"] = string(appwire.RetryDispositionBlocked)
+		wire.Data = updated
+	}
+	return wire
+}
+
+func unconfirmedDaemonForThread(roster *hubcore.Roster, threadID string) bool {
+	if threadID == "" {
+		return false
+	}
+	for _, entry := range roster.UnconfirmedEntries() {
+		// A live claim without a usable identity cannot exclude this target.
+		if _, err := appwire.ParseRef(localSpawnWorkspaceRef(entry)); err != nil {
+			return true
+		}
+		if entry.SessionID == threadID || entry.ThreadID == threadID || localSpawnWorkspaceRef(entry) == localAppRef(threadID) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/evener-hub/app_restart_required_test.go
+++ b/cmd/evener-hub/app_restart_required_test.go
@@ -1,0 +1,1712 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/hubapi"
+	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestHubProtocolUpgradePreservesTranscriptAndRejectsUndeliverableMessages(t *testing.T) {
+	for _, protocol := range []string{"evener-appwire-v3", "evener-appwire-v4"} {
+		for _, cleared := range []bool{false, true} {
+			for _, cached := range []bool{false, true} {
+				t.Run(fmt.Sprintf("%s/cleared=%v/cached=%v", protocol, cleared, cached), func(t *testing.T) { testHubProtocolUpgrade(t, protocol, cleared, cached) })
+			}
+		}
+	}
+}
+
+func testHubProtocolUpgrade(t *testing.T, protocol string, cleared, cached bool) {
+	root := t.TempDir()
+	sessionID := buildRPCParentSession(t, filepath.Join(root, "projects", "upgrade-0000000000"))
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	runDir := t.TempDir()
+	daemonSessionID := sessionID
+	if cleared {
+		daemonSessionID = "02wMz5Txv1C3Hut0M8GCeC"
+	}
+	entry := rendezvous.Entry{PID: 1001, Protocol: protocol, ThreadID: daemonSessionID, SessionID: daemonSessionID, WorkspaceRef: "local:" + sessionID, Endpoint: protocolMismatchPeer(t)}
+	roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+	if cached {
+		writeRendezvous(t, runDir, entry)
+		roster.Refresh()
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Past: past, Roster: roster})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	if !cached {
+		writeRendezvous(t, runDir, entry)
+	}
+	ref := "local:" + sessionID
+	t.Run("saved transcript remains readable with explicit restart state", func(t *testing.T) {
+		read, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: ref, IncludeTurns: true, Subscribe: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if read.Thread.Status.Type != "restartRequired" {
+			t.Errorf("status=%q", read.Thread.Status.Type)
+		}
+		if read.Thread.Evener.Capabilities.Send || read.Thread.Evener.Capabilities.Queue || read.Thread.Evener.Capabilities.Rename {
+			t.Error("incompatible session advertises unsupported mutations")
+		}
+		if len(read.Thread.Turns) != 2 {
+			t.Errorf("saved turns=%d", len(read.Thread.Turns))
+		}
+	})
+	for _, method := range []string{appwire.MethodTurnStart, appwire.MethodTurnQueue, appwire.MethodTurnSteer} {
+		t.Run(method, func(t *testing.T) {
+			var response any
+			err := client.Request(context.Background(), method, map[string]any{"ref": ref, "clientMutationId": "upgrade-message", "expectedInstanceId": sessionID, "expectedTurnId": "turn-active", "input": []appwire.InputItem{{Type: "text", Text: "sentinel"}}}, &response)
+			var wire appwire.WireError
+			if !errors.As(err, &wire) {
+				t.Fatalf("error=%v", err)
+			}
+			data, ok := wire.Data.(map[string]any)
+			if !ok || data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["clientMutationId"] != "upgrade-message" || data["cause"] != "daemonRestartRequired" {
+				t.Fatalf("rejection=%+v", wire)
+			}
+		})
+	}
+	for _, request := range []struct {
+		method string
+		params any
+	}{
+		{appwire.MethodThreadReasoningEffortSet, appwire.ThreadReasoningEffortSetParams{Ref: ref, ReasoningEffort: "high"}},
+		{appwire.MethodEvenerSandboxEscalationResolve, appwire.SandboxEscalationResolveParams{Ref: ref, EscalationID: "escalation", Approve: true}},
+	} {
+		t.Run(request.method, func(t *testing.T) {
+			var response any
+			err := client.Request(context.Background(), request.method, request.params, &response)
+			if !isDaemonRestartRequiredError(err) {
+				t.Fatalf("error=%v", err)
+			}
+		})
+	}
+	t.Run("rename refuses while incompatible daemon owns metadata", func(t *testing.T) {
+		var response any
+		err := client.Request(context.Background(), appwire.MethodEvenerThreadNameSet, appwire.ThreadNameSetParams{Ref: ref, Name: "sentinel"}, &response)
+		if !isDaemonRestartRequiredError(err) {
+			t.Fatalf("error=%v", err)
+		}
+	})
+	t.Run("resume refuses before replacement spawn", func(t *testing.T) {
+		_, err := client.ThreadResume(context.Background(), appwire.ThreadResumeParams{Ref: ref})
+		var wire appwire.WireError
+		if !errors.As(err, &wire) {
+			t.Fatalf("error=%v", err)
+		}
+		data, ok := wire.Data.(map[string]any)
+		if !ok || data["cause"] != "daemonRestartRequired" {
+			t.Fatalf("rejection=%+v", wire)
+		}
+	})
+	t.Run("shutdown does not pretend incompatible daemon exited", func(t *testing.T) {
+		err := client.ThreadShutdown(context.Background(), appwire.ThreadShutdownParams{Ref: ref})
+		if !isDaemonRestartRequiredError(err) {
+			t.Fatalf("error=%v", err)
+		}
+	})
+	t.Run("shutdown accepts a completed explicit stop", func(t *testing.T) {
+		if err := rendezvous.Remove(runDir, 1001); err != nil {
+			t.Fatal(err)
+		}
+		read, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: ref, IncludeTurns: true, Subscribe: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if read.Thread.Status.Type == appwire.ThreadStatusRestartRequired || !read.Thread.Evener.Capabilities.Send {
+			t.Fatalf("stopped daemon still blocks refreshed session: %+v", read.Thread)
+		}
+		if err := client.ThreadShutdown(context.Background(), appwire.ThreadShutdownParams{Ref: ref}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+}
+
+func protocolMismatchPeer(t *testing.T) string {
+	t.Helper()
+	peer := httptest.NewServer(http.HandlerFunc(serveProtocolMismatch))
+	t.Cleanup(peer.Close)
+	return "ws" + strings.TrimPrefix(peer.URL, "http") + "/rpc"
+}
+
+func serveProtocolMismatch(w http.ResponseWriter, r *http.Request) {
+	serveInitializeResponse(w, r, map[string]any{"error": map[string]any{"code": appwire.CodeInvalidRequest, "message": "incompatible protocol"}})
+}
+
+func serveTypedProtocolMismatch(w http.ResponseWriter, r *http.Request) {
+	serveInitializeResponse(w, r, map[string]any{"result": appwire.InitializeResponse{ProtocolVersion: "evener-appwire-v4"}})
+}
+
+func serveInitializeResponse(w http.ResponseWriter, r *http.Request, response map[string]any) {
+	conn, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.CloseNow()
+	var request struct {
+		ID any `json:"id"`
+	}
+	if err := wsjson.Read(r.Context(), conn, &request); err != nil {
+		return
+	}
+	response["id"] = request.ID
+	_ = wsjson.Write(r.Context(), conn, response)
+}
+
+func TestHubResumeRefreshesProtocolStateBeforeDeciding(t *testing.T) {
+	endpoint := protocolMismatchPeer(t)
+	for _, stopped := range []bool{false, true} {
+		t.Run(fmt.Sprint("stopped=", stopped), func(t *testing.T) {
+			dir := t.TempDir()
+			entry := rendezvous.Entry{PID: 1001, SessionID: "upgrade", ThreadID: "upgrade", Protocol: "evener-appwire-v3", Endpoint: endpoint}
+			roster := hubcore.NewRoster(dir, &hubcore.StatusProber{})
+			writeRendezvous(t, dir, entry)
+			if stopped {
+				roster.Refresh()
+				if err := rendezvous.Remove(dir, entry.PID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			spawned := false
+			cfg := hubcore.WebConfig{Roster: roster, ResumeLocks: hubcore.NewResumeLocks(), Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				spawned = true
+				return rendezvous.Entry{}, errors.New("spawn sentinel")
+			}}}
+			_, err := hubThreadResume(context.Background(), cfg, nil, appwire.ThreadResumeParams{Session: "upgrade"})
+			if spawned != stopped {
+				t.Fatalf("spawned=%v stopped=%v error=%v", spawned, stopped, err)
+			}
+			if !stopped {
+				var wire appwire.WireError
+				if !errors.As(err, &wire) || wire.Data.(appwire.ErrorData).Cause != "daemonRestartRequired" {
+					t.Fatalf("error=%v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestHubTurnStartDiscoversRestartRequiredDuringRecovery(t *testing.T) {
+	root := t.TempDir()
+	sessionID := buildRPCParentSession(t, filepath.Join(root, "projects", "upgrade-0000000000"))
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: sessionID, SessionID: sessionID, Endpoint: protocolMismatchPeer(t)})
+	roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{RunDir: runDir, Past: past, Roster: roster, ResumeLocks: hubcore.NewResumeLocks()})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := client.TurnStart(context.Background(), appwire.TurnStartParams{Ref: "local:" + sessionID, ClientMutationID: "upgrade-recovery", ExpectedInstanceID: sessionID, Input: []appwire.InputItem{{Type: "text", Text: "sentinel"}}})
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("error=%v", err)
+	}
+	data, ok := wire.Data.(map[string]any)
+	if !ok || data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["cause"] != "daemonRestartRequired" || data["clientMutationId"] != "upgrade-recovery" {
+		t.Fatalf("rejection=%+v data=%+v", wire, wire.Data)
+	}
+}
+
+func TestHubUpgradeKeepsLostAcceptedReceiptUnknown(t *testing.T) {
+	accepted := make(chan string, 1)
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		var request struct {
+			ID     any            `json:"id"`
+			Params map[string]any `json:"params"`
+		}
+		if err := wsjson.Read(r.Context(), conn, &request); err != nil {
+			return
+		}
+		if request.Params["protocolVersion"] != "evener-appwire-v3" {
+			_ = wsjson.Write(r.Context(), conn, map[string]any{"id": request.ID, "error": map[string]any{"code": appwire.CodeInvalidRequest, "message": "incompatible protocol"}})
+			return
+		}
+		if err := wsjson.Write(r.Context(), conn, map[string]any{"id": request.ID, "result": map[string]any{}}); err != nil {
+			return
+		}
+		if err := wsjson.Read(r.Context(), conn, &request); err != nil {
+			return
+		}
+		accepted <- request.Params["clientMutationId"].(string)
+		// The peer accepts the mutation, then loses the connection before its receipt.
+	}))
+	defer peer.Close()
+	endpoint := "ws" + strings.TrimPrefix(peer.URL, "http") + "/rpc"
+	ctx := t.Context()
+	transport, err := appwire.DialWebSocketWithHeaders(ctx, endpoint, peer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := appwire.NewClient(transport)
+	old.Start(ctx)
+	defer old.Close()
+	var response any
+	if err := old.Request(ctx, appwire.MethodInitialize, appwire.InitializeParams{ProtocolVersion: "evener-appwire-v3"}, &response); err != nil {
+		t.Fatal(err)
+	}
+	mutationID := "accepted-before-upgrade"
+	if err := old.Request(ctx, appwire.MethodTurnStart, appwire.TurnStartParams{ClientMutationID: mutationID}, &response); err == nil {
+		t.Fatal("expected lost receipt")
+	}
+	if got := <-accepted; got != mutationID {
+		t.Fatalf("accepted=%q", got)
+	}
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: "upgrade", SessionID: "upgrade", Endpoint: endpoint})
+	roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+	roster.Refresh()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Roster: roster})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(ctx, appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err = client.TurnStart(ctx, appwire.TurnStartParams{Ref: "local:upgrade", ClientMutationID: mutationID, ExpectedInstanceID: "upgrade", Input: []appwire.InputItem{{Type: "text", Text: "sentinel"}}})
+	var wire appwire.WireError
+	if !errors.As(err, &wire) {
+		t.Fatalf("error=%v", err)
+	}
+	data, ok := wire.Data.(map[string]any)
+	if !ok || data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["retryDisposition"] != string(appwire.RetryDispositionBlocked) || data["cause"] != "daemonRestartRequired" {
+		t.Fatalf("receipt=%+v", wire.Data)
+	}
+}
+
+func TestRestartRequiredRecoveryPreservesDecodedWireData(t *testing.T) {
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		var request struct {
+			ID any `json:"id"`
+		}
+		if err := wsjson.Read(r.Context(), conn, &request); err != nil {
+			return
+		}
+		_ = wsjson.Write(r.Context(), conn, map[string]any{"id": request.ID, "error": map[string]any{"code": appwire.CodeConflict, "message": "restart required", "data": map[string]any{"cause": "daemonRestartRequired", "evenerErrorInfo": "conflict", "detail": "preserved"}}})
+	}))
+	defer peer.Close()
+	transport, err := appwire.DialWebSocketWithHeaders(t.Context(), "ws"+strings.TrimPrefix(peer.URL, "http"), peer.Client(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := appwire.NewClient(transport)
+	client.Start(t.Context())
+	defer client.Close()
+	var response any
+	err = client.Request(t.Context(), appwire.MethodThreadResume, appwire.ThreadResumeParams{Ref: "local:upgrade"}, &response)
+	var wire appwire.WireError
+	if !errors.As(blockedUnknownMutationError("retry-id", err), &wire) {
+		t.Fatalf("error=%v", err)
+	}
+	data, ok := wire.Data.(map[string]any)
+	if !ok || data["cause"] != "daemonRestartRequired" || data["evenerErrorInfo"] != "conflict" || data["detail"] != "preserved" || data["clientMutationId"] != "retry-id" || data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) {
+		t.Fatalf("data=%+v", wire.Data)
+	}
+}
+
+func TestNavigationDisablesRenameForRestartRequiredDaemon(t *testing.T) {
+	tree := hubcore.Tree{Live: []hubcore.TreeNode{{ID: "02wMz5Txv1C3Hut0M8GCeB"}, {ID: "local:02wMz5Txv1C3Hut0M8GCeB"}, {ID: "02wMz5Txv1C3Hut0M8GCeC"}}}
+	live := []hubcore.LiveEntry{{SessionID: "02wMz5Txv1C3Hut0M8GCeB", Status: appwire.ThreadStatusRestartRequired}, {SessionID: "02wMz5Txv1C3Hut0M8GCeC", Status: appwire.ThreadStatusIdle}}
+	live[0].WorkspaceRef = "local:02wMz5Txv1C3Hut0M8GCeD"
+	tree.Live = append(tree.Live, hubcore.TreeNode{ID: "02wMz5Txv1C3Hut0M8GCeD"}, hubcore.TreeNode{ID: "local:02wMz5Txv1C3Hut0M8GCeD"})
+	inputs := navigationBuildInputsFromTreeSnapshot("generation", 1, tree, nil, hubapi.AttentionSummary{}, live, nil, nil, nil, nil)
+	if inputs.Renameable["02wMz5Txv1C3Hut0M8GCeB"] || inputs.Renameable["local:02wMz5Txv1C3Hut0M8GCeB"] || inputs.Renameable["02wMz5Txv1C3Hut0M8GCeD"] || inputs.Renameable["local:02wMz5Txv1C3Hut0M8GCeD"] {
+		t.Fatal("navigation advertises rename for incompatible owner")
+	}
+	if !inputs.Renameable["02wMz5Txv1C3Hut0M8GCeC"] {
+		t.Fatal("compatible session lost rename")
+	}
+}
+
+func TestNavigationCrashRecordCannotEnableRenameForIncompatibleReplacement(t *testing.T) {
+	const workspaceID = "02wMz5Txv1C3Hut0M8GCeB"
+	const currentID = "02wMz5Txv1C3Hut0M8GCeC"
+	roster := hubcore.NewRosterWithEntries(
+		hubcore.LiveEntry{PID: 2, StartedAt: time.Unix(2, 0), WorkspaceRef: "local:" + workspaceID, SessionID: currentID, Status: appwire.ThreadStatusRestartRequired},
+		hubcore.LiveEntry{PID: 1, StartedAt: time.Unix(1, 0), WorkspaceRef: "local:" + workspaceID, SessionID: "02wMz5Txv1C3Hut0M8GCeD", Status: "errored", Crashed: true},
+	)
+	tree := hubcore.Tree{Live: []hubcore.TreeNode{{ID: workspaceID, State: appwire.ThreadStatusRestartRequired}}}
+	inputs := navigationBuildInputsFromTreeSnapshot("generation", 1, tree, nil, hubapi.AttentionSummary{}, roster.List(), nil, nil, nil, nil)
+	projection, err := buildNavigationProjection(inputs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := projection.LivePage(0, 50).Sessions
+	if len(rows) != 1 || rows[0].Ref != "local:"+workspaceID || rows[0].Rename {
+		t.Fatalf("incompatible replacement must remain unrenameable: %+v", rows)
+	}
+}
+
+func TestHubUpgradeClassifiesUncachedDaemonOwnership(t *testing.T) {
+	for _, method := range []string{appwire.MethodThreadRead, appwire.MethodTurnQueue, appwire.MethodEvenerThreadNameSet, appwire.MethodThreadReasoningEffortSet, appwire.MethodEvenerSandboxEscalationResolve} {
+		t.Run(method, func(t *testing.T) {
+			root := t.TempDir()
+			sessionID := buildRPCParentSession(t, filepath.Join(root, "projects", "upgrade-0000000000"))
+			past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+			if _, err := past.Rebuild(); err != nil {
+				t.Fatal(err)
+			}
+			runDir := t.TempDir()
+			roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+			roster.Refresh()
+			writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: sessionID, SessionID: sessionID, WorkspaceRef: "local:" + sessionID, Endpoint: protocolMismatchPeer(t)})
+			hub := newHubRPCTestServer(t, hubcore.WebConfig{Past: past, Roster: roster, RunDir: runDir})
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(context.Background(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			if method == appwire.MethodThreadRead {
+				read, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: "local:" + sessionID, IncludeTurns: true, Subscribe: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if read.Thread.Status.Type != appwire.ThreadStatusRestartRequired || read.Thread.Evener.Capabilities.Send || read.Thread.Evener.Capabilities.Queue || read.Thread.Evener.Capabilities.Rename {
+					t.Fatalf("undiscovered incompatible owner was not reflected: %+v", read.Thread)
+				}
+				return
+			}
+			var response any
+			err := client.Request(context.Background(), method, map[string]any{"ref": "local:" + sessionID, "clientMutationId": "uncertain", "expectedInstanceId": sessionID, "input": []appwire.InputItem{{Type: "text", Text: "sentinel"}}, "name": "renamed", "reasoningEffort": "high", "escalationId": "escalation", "approve": true}, &response)
+			if !isDaemonRestartRequiredError(err) {
+				t.Fatalf("error=%v", err)
+			}
+			if method == appwire.MethodTurnQueue {
+				var wire appwire.WireError
+				if !errors.As(err, &wire) {
+					t.Fatal(err)
+				}
+				data, ok := wire.Data.(map[string]any)
+				if !ok || data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["retryDisposition"] != string(appwire.RetryDispositionBlocked) {
+					t.Fatalf("outcome=%+v", wire)
+				}
+			}
+		})
+	}
+}
+
+func TestHubUpgradeRestrictsPersistedDelegate(t *testing.T) {
+	for _, scenario := range []struct{ delegated, unreadableSibling bool }{{false, false}, {true, false}, {true, true}} {
+		delegated := scenario.delegated
+		t.Run(fmt.Sprint(scenario), func(t *testing.T) {
+			root := t.TempDir()
+			stateDir := filepath.Join(root, "projects", "upgrade-0000000000")
+			parentID := buildRPCParentSession(t, stateDir)
+			childID := "02wMz5Txv1C3Hut0M8GCeC"
+			writer, err := transcript.NewWriter(filepath.Join(stateDir, "sessions", childID+".transcript.jsonl"), transcript.Header{SessionID: childID, ParentSessionID: parentID, ProfileID: "openai", Model: "gpt-5"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{ID: childID, ParentSessionID: parentID, IsSubagent: delegated, JobTreeRootSessionID: parentID, ProfileID: "openai", Model: "gpt-5"}); err != nil {
+				t.Fatal(err)
+			}
+			if delegated {
+				path := filepath.Join(stateDir, "sessions", parentID, "delegates.jsonl")
+				if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+					t.Fatal(err)
+				}
+				descriptor := map[string]any{"child_session_id": childID, "transcript_ref": "local:" + childID, "owner_session_id": parentID, "task": "sentinel", "agent_type": "explorer", "tool_name_ceiling": []string{"communicate"}, "resumable": true, "config": map[string]any{}}
+				events := []map[string]any{{"kind": "delegate_created", "seq": 1, "delegate_id": "dlg_upgrade", "created": map[string]any{"descriptor": descriptor}}}
+				if scenario.unreadableSibling {
+					sibling := maps.Clone(descriptor)
+					siblingID := "02wMz5Txv1C3Hut0M8GCeD"
+					sibling["child_session_id"] = siblingID
+					sibling["transcript_ref"] = "local:" + siblingID
+					events = append(events, map[string]any{"kind": "delegate_created", "seq": 2, "delegate_id": "dlg_sibling", "created": map[string]any{"descriptor": sibling}})
+					if err := os.Mkdir(filepath.Join(stateDir, "sessions", siblingID+".transcript.jsonl"), 0700); err != nil {
+						t.Fatal(err)
+					}
+				}
+				batch, err := json.Marshal(map[string]any{"events": events})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := os.WriteFile(path, append(append([]byte("{\"version\":1}\n"), batch...), '\n'), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+			if _, err := past.Rebuild(); err != nil {
+				t.Fatal(err)
+			}
+			runDir := t.TempDir()
+			writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: parentID, SessionID: parentID, Endpoint: protocolMismatchPeer(t)})
+			roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+			roster.Refresh()
+			hub := newHubRPCTestServer(t, hubcore.WebConfig{Past: past, Roster: roster})
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+
+			web := &WebServer{cfg: hubcore.WebConfig{Past: past, Roster: roster}}
+			snapshot := web.navigationSnapshotInputs(t.Context())
+			tree := hubBuildNavigationTree(snapshot.metas, snapshot.live, nil, snapshot.projects)
+			inputs := navigationBuildInputsFromTreeSnapshot("generation", 1, tree, nil, hubapi.AttentionSummary{}, snapshot.live, nil, nil, nil, nil)
+			if delegated && inputs.Renameable[childID] {
+				t.Error("navigation advertises delegate rename")
+			}
+			childRestart := false
+			for _, live := range snapshot.live {
+				if live.SessionID == childID && live.Status == appwire.ThreadStatusRestartRequired {
+					childRestart = true
+				}
+			}
+			if childRestart != delegated {
+				t.Errorf("navigation child restart=%v, delegated=%v", childRestart, delegated)
+			}
+			if delegated && !scenario.unreadableSibling {
+				t.Run("canceled ownership check", func(t *testing.T) {
+					ctx, cancel := context.WithCancel(context.Background())
+					cancel()
+					_, err := withDeletionTargetOwnership(ctx, web.cfg, localAppRef(childID), "", "canceled-send", func() (struct{}, error) {
+						t.Error("canceled ownership check ran the mutation")
+						return struct{}{}, nil
+					})
+					wire, ok := errors.AsType[appwire.WireError](err)
+					if !ok || !strings.Contains(wire.Message, context.Canceled.Error()) {
+						t.Errorf("ownership check ignored cancellation: %v", err)
+					}
+					if snapshot := web.navigationSnapshotInputs(ctx); !errors.Is(snapshot.ownershipErr, context.Canceled) {
+						t.Errorf("navigation ownership error=%v, want cancellation", snapshot.ownershipErr)
+					}
+				})
+			}
+			ref := "local:" + childID
+			read, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := read.Thread.Status.Type == "restartRequired"; got != delegated {
+				t.Errorf("restartRequired=%v, delegated=%v", got, delegated)
+			}
+			if !delegated {
+				return
+			}
+			if read.Thread.Evener.Capabilities.Rename || read.Thread.Evener.Capabilities.Queue {
+				t.Error("delegate advertises mutations")
+			}
+			for _, method := range []string{appwire.MethodEvenerThreadNameSet, appwire.MethodTurnQueue} {
+				var response any
+				err := client.Request(t.Context(), method, map[string]any{"ref": ref, "name": "changed", "clientMutationId": "child-retry", "expectedInstanceId": childID, "input": []appwire.InputItem{{Type: "text", Text: "sentinel"}}}, &response)
+				if !isDaemonRestartRequiredError(err) {
+					t.Errorf("%s error=%v", method, err)
+				}
+				if method == appwire.MethodTurnQueue {
+					if wire, ok := errors.AsType[appwire.WireError](err); ok {
+						data, _ := wire.Data.(map[string]any)
+						if data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) {
+							t.Errorf("receipt=%+v", data)
+						}
+					}
+				}
+			}
+			if !scenario.unreadableSibling {
+				for _, rootHint := range []bool{true, false} {
+					t.Run(fmt.Sprint("unreadable intermediate metadata/root hint=", rootHint), func(t *testing.T) {
+						journalPath := filepath.Join(stateDir, "sessions", parentID, "delegates.jsonl")
+						journalBefore, err := os.ReadFile(journalPath)
+						if err != nil {
+							t.Fatal(err)
+						}
+						t.Cleanup(func() {
+							if err := os.WriteFile(journalPath, journalBefore, 0600); err != nil {
+								t.Error(err)
+							}
+						})
+
+						grandchildID := "02wMz5Txv1C3Hut0M8GCeD"
+						t.Cleanup(func() {
+							for _, suffix := range []string{".meta.json", ".transcript.jsonl"} {
+								if err := os.Remove(filepath.Join(stateDir, "sessions", grandchildID+suffix)); err != nil {
+									t.Error(err)
+								}
+							}
+							if _, err := past.Rebuild(); err != nil {
+								t.Error(err)
+							}
+						})
+
+						if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{ID: grandchildID, ParentSessionID: childID, IsSubagent: true, JobTreeRootSessionID: parentID, ProfileID: "openai", Model: "gpt-5"}); err != nil {
+							t.Fatal(err)
+						}
+						writer, err := transcript.NewWriter(filepath.Join(stateDir, "sessions", grandchildID+".transcript.jsonl"), transcript.Header{SessionID: grandchildID, ParentSessionID: childID, ProfileID: "openai", Model: "gpt-5"})
+						if err != nil {
+							t.Fatal(err)
+						}
+						if err := writer.Close(); err != nil {
+							t.Fatal(err)
+						}
+						descriptor := map[string]any{"child_session_id": grandchildID, "transcript_ref": localAppRef(grandchildID), "owner_session_id": parentID, "parent_delegate_id": "dlg_upgrade", "task": "nested sentinel", "agent_type": "explorer", "tool_name_ceiling": []string{"communicate"}, "resumable": true, "config": map[string]any{}}
+						batch, err := json.Marshal(map[string]any{"events": []map[string]any{{"kind": "delegate_created", "seq": 2, "delegate_id": "dlg_nested", "created": map[string]any{"descriptor": descriptor}}}})
+						if err != nil {
+							t.Fatal(err)
+						}
+						journal, err := os.OpenFile(filepath.Join(stateDir, "sessions", parentID, "delegates.jsonl"), os.O_APPEND|os.O_WRONLY, 0600)
+						if err != nil {
+							t.Fatal(err)
+						}
+						_, writeErr := journal.Write(append(batch, '\n'))
+						if err := journal.Close(); err != nil {
+							t.Fatal(err)
+						}
+						if writeErr != nil {
+							t.Fatal(writeErr)
+						}
+						if _, err := past.Rebuild(); err != nil {
+							t.Fatal(err)
+						}
+						grandRef := localAppRef(grandchildID)
+						if err := daemonRestartRequiredError(t.Context(), web.cfg, grandRef, "", ""); !isDaemonRestartRequiredError(err) {
+							t.Fatalf("nested fixture has no incompatible owner: %v", err)
+						}
+						if !rootHint {
+							meta, err := schema.LoadSessionMeta(stateDir, grandchildID)
+							if err != nil {
+								t.Fatal(err)
+							}
+							meta.JobTreeRootSessionID = ""
+							if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+								t.Fatal(err)
+							}
+						}
+						childPath := filepath.Join(stateDir, "sessions", childID+".meta.json")
+						original, err := os.ReadFile(childPath)
+						if err != nil {
+							t.Fatal(err)
+						}
+						t.Cleanup(func() {
+							if err := os.WriteFile(childPath, original, 0600); err != nil {
+								t.Error(err)
+							}
+							if _, err := past.Rebuild(); err != nil {
+								t.Error(err)
+							}
+						})
+						if err := os.WriteFile(childPath, []byte("{"), 0600); err != nil {
+							t.Fatal(err)
+						}
+						if _, err := past.Rebuild(); err != nil {
+							t.Fatal(err)
+						}
+						if _, ok := past.Find(childID); ok {
+							t.Fatal("unreadable intermediate remained indexed")
+						}
+						for _, method := range []string{appwire.MethodEvenerThreadNameSet, appwire.MethodTurnQueue} {
+							var response any
+							err := client.Request(t.Context(), method, map[string]any{"ref": grandRef, "name": "unsafe nested", "clientMutationId": "nested-owner", "expectedInstanceId": grandchildID, "input": []appwire.InputItem{{Type: "text", Text: "sentinel"}}}, &response)
+							wire, ok := errors.AsType[appwire.WireError](err)
+							if !ok {
+								t.Errorf("%s bypassed unresolved nested ownership: %v", method, err)
+								continue
+							}
+							if method == appwire.MethodTurnQueue {
+								data, _ := wire.Data.(map[string]any)
+								if data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["retryDisposition"] != string(appwire.RetryDispositionBlocked) {
+									t.Errorf("receipt=%+v", data)
+								}
+							}
+						}
+						meta, err := schema.LoadSessionMeta(stateDir, grandchildID)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if meta.Name != "" {
+							t.Errorf("nested delegate renamed through unreadable ownership: %q", meta.Name)
+						}
+						assertNavigationOwnershipReadOnly(t, web)
+					})
+				}
+			}
+			t.Run("unreadable parent metadata blocks delegate mutations", func(t *testing.T) {
+				parentPath := filepath.Join(stateDir, "sessions", parentID+".meta.json")
+				original, err := os.ReadFile(parentPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() {
+					if err := os.WriteFile(parentPath, original, 0600); err != nil {
+						t.Error(err)
+					}
+					if _, err := past.Rebuild(); err != nil {
+						t.Error(err)
+					}
+				})
+				if err := os.WriteFile(parentPath, []byte("{"), 0600); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := past.Rebuild(); err != nil {
+					t.Fatal(err)
+				}
+				if _, ok := past.Find(parentID); ok {
+					t.Fatal("unreadable parent remained in past index")
+				}
+				before, err := schema.LoadSessionMeta(stateDir, childID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, method := range []string{appwire.MethodEvenerThreadNameSet, appwire.MethodTurnQueue} {
+					var response any
+					err := client.Request(t.Context(), method, map[string]any{"ref": ref, "name": "unsafe", "clientMutationId": "unreadable-parent", "expectedInstanceId": childID, "input": []appwire.InputItem{{Type: "text", Text: "sentinel"}}}, &response)
+					wire, ok := errors.AsType[appwire.WireError](err)
+					if !ok {
+						t.Errorf("%s bypassed unreadable ownership: %v", method, err)
+						continue
+					}
+					if method == appwire.MethodTurnQueue {
+						data, _ := wire.Data.(map[string]any)
+						if data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["retryDisposition"] != string(appwire.RetryDispositionBlocked) {
+							t.Errorf("receipt=%+v", data)
+						}
+					}
+				}
+				after, err := schema.LoadSessionMeta(stateDir, childID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if after.Name != before.Name {
+					t.Errorf("delegate renamed despite unreadable ownership: %q", after.Name)
+				}
+				assertNavigationOwnershipReadOnly(t, web)
+			})
+			for _, fault := range []string{"missing", "unreadable", "torn"} {
+				t.Run("ownership journal "+fault, func(t *testing.T) {
+					journal := filepath.Join(stateDir, "sessions", parentID, "delegates.jsonl")
+					original, err := os.ReadFile(journal)
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() {
+						if err := os.RemoveAll(journal); err != nil {
+							t.Error(err)
+						}
+						if err := os.WriteFile(journal, original, 0600); err != nil {
+							t.Error(err)
+						}
+					})
+					if err := os.Remove(journal); err != nil {
+						t.Fatal(err)
+					}
+					if fault == "unreadable" {
+						if err := os.Mkdir(journal, 0700); err != nil {
+							t.Fatal(err)
+						}
+					}
+					if fault == "torn" {
+						if err := os.WriteFile(journal, append(original, '{'), 0600); err != nil {
+							t.Fatal(err)
+						}
+					}
+					before, err := schema.LoadSessionMeta(stateDir, childID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					beforeMetas, err := schema.ListSessionMetas(stateDir)
+					if err != nil {
+						t.Fatal(err)
+					}
+					for _, method := range []string{appwire.MethodEvenerThreadNameSet, appwire.MethodTurnQueue, appwire.MethodThreadFork} {
+						params := map[string]any{"ref": ref, "name": "unsafe", "clientMutationId": "unreadable-owner", "expectedInstanceId": childID, "input": []appwire.InputItem{{Type: "text", Text: "sentinel"}}}
+						if method == appwire.MethodThreadFork {
+							params = map[string]any{"ref": ref, "aside": true}
+						}
+						var response any
+						err := client.Request(t.Context(), method, params, &response)
+						wire, ok := errors.AsType[appwire.WireError](err)
+						if !ok {
+							t.Errorf("%s error=%v", method, err)
+							continue
+						}
+						if method == appwire.MethodTurnQueue {
+							data, _ := wire.Data.(map[string]any)
+							if data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["retryDisposition"] != string(appwire.RetryDispositionBlocked) {
+								t.Errorf("receipt=%+v", data)
+							}
+						}
+					}
+					after, err := schema.LoadSessionMeta(stateDir, childID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if after.Name != before.Name {
+						t.Errorf("renamed delegate without ownership journal: %q", after.Name)
+					}
+					afterMetas, err := schema.ListSessionMetas(stateDir)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if len(afterMetas) != len(beforeMetas) {
+						t.Error("fork created metadata without ownership journal")
+					}
+					_, navigationErr := (webNavigationSource{web: web}).Capture(t.Context(), "generation", time.Now())
+					if fault == "torn" {
+						// A complete matching descriptor still establishes a restriction:
+						// the caller blocks mutations rather than permitting them.
+						if navigationErr != nil {
+							t.Errorf("known owner lost restart projection: %v", navigationErr)
+						}
+					} else {
+						assertNavigationOwnershipReadOnly(t, web)
+					}
+				})
+			}
+
+		})
+	}
+}
+
+func TestThreadReadRejectsMalformedRefWithoutRoster(t *testing.T) {
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: "malformed"})
+	wire, ok := errors.AsType[appwire.WireError](err)
+	if !ok || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestMalformedMutationRefsAreNotReportedAsUncertain(t *testing.T) {
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, method := range []string{appwire.MethodTurnStart, appwire.MethodTurnQueue, appwire.MethodTurnSteer} {
+		t.Run(method, func(t *testing.T) {
+			var response any
+			err := client.Request(t.Context(), method, map[string]any{"ref": "malformed", "clientMutationId": "invalid-" + method, "expectedInstanceId": "session", "expectedTurnId": "turn", "input": []appwire.InputItem{{Type: "text", Text: "sentinel"}}}, &response)
+			wire, ok := errors.AsType[appwire.WireError](err)
+			if !ok || wire.Code != appwire.CodeInvalidParams {
+				t.Fatalf("error=%v", err)
+			}
+			data, _ := wire.Data.(map[string]any)
+			if data["mutationOutcome"] == string(appwire.MutationOutcomeUnknown) {
+				t.Fatalf("invalid request reported as uncertain: %+v", data)
+			}
+		})
+	}
+}
+
+type canceledOwnershipProber struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *canceledOwnershipProber) Probe(entry rendezvous.Entry) hubcore.ProbeResult {
+	close(p.started)
+	<-p.release
+	return hubcore.ProbeResult{SessionID: entry.ThreadID, Status: appwire.ThreadStatusIdle, OK: true}
+}
+
+func TestHubMutationOwnershipCancellationPreservesUnknownReceipt(t *testing.T) {
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, ThreadID: webTestSessionID})
+	synctest.Test(t, func(t *testing.T) {
+		prober := &canceledOwnershipProber{started: make(chan struct{}), release: make(chan struct{})}
+		cfg := hubcore.WebConfig{Roster: hubcore.NewRoster(runDir, prober)}
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() {
+			_, err := withDeletionTargetOwnership(ctx, cfg, localAppRef(webTestSessionID), "", "pending-send", func() (struct{}, error) {
+				return struct{}{}, appwire.SessionUnavailable("daemon unavailable")
+			})
+			done <- err
+		}()
+		<-prober.started
+		cancel()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			wire, ok := errors.AsType[appwire.WireError](err)
+			if !ok {
+				t.Errorf("expected wire error, got %v", err)
+			} else {
+				data, ok := wire.Data.(appwire.ErrorData)
+				if !ok || data.MutationOutcome != appwire.MutationOutcomeUnknown || data.RetryDisposition != appwire.RetryDispositionBlocked || data.ClientMutationID != "pending-send" {
+					t.Errorf("canceled ownership refresh must preserve the blocked unknown receipt: %+v", wire.Data)
+				}
+			}
+		default:
+			t.Error("mutation still waits for probe after cancellation")
+		}
+		close(prober.release)
+		synctest.Wait()
+	})
+}
+
+func TestHubUpgradeBlocksForkWritesUntilParentStops(t *testing.T) {
+	for _, scenario := range []struct{ cached, delegate bool }{{false, false}, {true, false}, {false, true}, {true, true}} {
+		for _, mode := range []string{"aside", "edit", "defer"} {
+			t.Run(fmt.Sprintf("cached=%v/delegate=%v/%s", scenario.cached, scenario.delegate, mode), func(t *testing.T) {
+				stateDir := t.TempDir()
+				rootID := buildRPCParentSession(t, stateDir)
+				parentID := rootID
+				expectedMetas := 1
+				if scenario.delegate {
+					parentID = buildUpgradeDelegate(t, stateDir, rootID)
+					expectedMetas++
+				}
+				runDir := t.TempDir()
+				writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: rootID, SessionID: rootID, Endpoint: protocolMismatchPeer(t)})
+				roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+				if scenario.cached {
+					roster.Refresh()
+				}
+				hub := newHubRPCTestServer(t, hubcore.WebConfig{StateDir: stateDir, Roster: roster})
+				defer hub.Close()
+				client := dialHubRPC(t, hub)
+				defer client.Close()
+				if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+					t.Fatal(err)
+				}
+				params := appwire.ThreadForkParams{Ref: localAppRef(parentID)}
+				if mode == "aside" {
+					params.Aside = true
+				} else {
+					params.SourceTurnID = "1"
+					params.Label = "parent branch"
+					if mode == "defer" {
+						params.DeferInput = true
+					} else {
+						params.EditedInput = "replacement"
+					}
+				}
+				_, err := client.ThreadFork(t.Context(), params)
+				if !isDaemonRestartRequiredError(err) {
+					t.Errorf("fork bypassed incompatible owner: %v", err)
+				}
+				metas, err := schema.ListSessionMetas(stateDir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(metas) != expectedMetas {
+					t.Errorf("fork created session metadata: count=%d, want %d", len(metas), expectedMetas)
+				}
+				parent, err := schema.LoadSessionMeta(stateDir, parentID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if parent.ForkLabel != "" {
+					t.Errorf("fork changed live parent label: %q", parent.ForkLabel)
+				}
+				if err := rendezvous.Remove(runDir, 1001); err != nil {
+					t.Fatal(err)
+				}
+				forked, err := client.ThreadFork(t.Context(), params)
+				if err != nil {
+					t.Fatalf("fork after owner stopped: %v", err)
+				}
+				child, err := schema.LoadSessionMeta(stateDir, forked.Thread.ID)
+				if err != nil || child.ParentSessionID != parentID {
+					t.Errorf("fork after stop did not create child: %+v, err=%v", child, err)
+				}
+			})
+		}
+	}
+}
+
+func buildUpgradeDelegate(t *testing.T, stateDir, ownerID string) string {
+	t.Helper()
+	childID, err := agent.ForkSession(stateDir, ownerID, 1, "delegate prompt", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, err := schema.LoadSessionMeta(stateDir, childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.IsSubagent = true
+	meta.JobTreeRootSessionID = ownerID
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatal(err)
+	}
+	descriptor := map[string]any{"child_session_id": childID, "transcript_ref": localAppRef(childID), "owner_session_id": ownerID, "task": "sentinel", "agent_type": "explorer", "tool_name_ceiling": []string{"communicate"}, "resumable": true, "config": map[string]any{}}
+	batch, err := json.Marshal(map[string]any{"events": []map[string]any{{"kind": "delegate_created", "seq": 1, "delegate_id": "dlg_upgrade", "created": map[string]any{"descriptor": descriptor}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(stateDir, "sessions", ownerID, "delegates.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(append([]byte("{\"version\":1}\n"), batch...), '\n'), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return childID
+}
+
+func TestHubUpgradeDoesNotTreatFailedProbeAsAbsentOwner(t *testing.T) {
+	for _, fault := range []string{"probe", "unidentified", "changed-identity", "malformed", "unreadable", "missing-directory"} {
+		for _, delegate := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/delegate=%v", fault, delegate), func(t *testing.T) {
+				stateDir := filepath.Join(t.TempDir(), "projects", "upgrade-0000000000")
+				rootID := buildRPCParentSession(t, stateDir)
+				targetID := rootID
+				if delegate {
+					targetID = buildUpgradeDelegate(t, stateDir, rootID)
+				}
+				before, err := schema.LoadSessionMeta(stateDir, targetID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				metas, err := schema.ListSessionMetas(stateDir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				runDir := t.TempDir()
+				hiddenRunDir := filepath.Join(t.TempDir(), "hidden")
+				entry := rendezvous.Entry{PID: os.Getpid(), Protocol: "evener-appwire-v3", ThreadID: rootID, SessionID: rootID}
+				if fault == "unidentified" {
+					entry.ThreadID = ""
+					entry.SessionID = ""
+				}
+				writeRendezvous(t, runDir, entry)
+				roster := hubcore.NewRoster(runDir, failedRPCProber{})
+				if fault == "changed-identity" {
+					entry.Protocol = appwire.ProtocolVersion
+					writeRendezvous(t, runDir, entry)
+					prober := &changedOwnershipProber{sessionID: rootID}
+					roster = hubcore.NewRoster(runDir, prober)
+					roster.Refresh()
+					entry.InstanceID = "replacement"
+					entry.Protocol = "evener-appwire-v3"
+					writeRendezvous(t, runDir, entry)
+					prober.fail = true
+				}
+				if fault != "probe" && fault != "unidentified" && fault != "changed-identity" {
+					roster = hubcore.NewRoster(runDir, fakeProber{sessionID: rootID, status: appwire.ThreadStatusRestartRequired})
+					roster.Refresh()
+					path := filepath.Join(runDir, fmt.Sprintf("%d.json", os.Getpid()))
+					switch fault {
+					case "malformed":
+						if err := os.WriteFile(path, []byte("{"), 0600); err != nil {
+							t.Fatal(err)
+						}
+					case "missing-directory":
+						if err := os.Rename(runDir, hiddenRunDir); err != nil {
+							t.Fatal(err)
+						}
+					default:
+						if err := os.Remove(path); err != nil {
+							t.Fatal(err)
+						}
+						if err := os.Mkdir(path, 0700); err != nil {
+							t.Fatal(err)
+						}
+					}
+				}
+
+				past := hubcore.NewPastIndex(stateDir)
+				if _, err := past.Rebuild(); err != nil {
+					t.Fatal(err)
+				}
+				hub := newHubRPCTestServer(t, hubcore.WebConfig{StateDir: stateDir, Past: past, Roster: roster})
+				defer hub.Close()
+				client := dialHubRPC(t, hub)
+				defer client.Close()
+				if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+					t.Fatal(err)
+				}
+				ref := localAppRef(targetID)
+				var response any
+				if err := client.Request(t.Context(), appwire.MethodEvenerThreadNameSet, appwire.ThreadNameSetParams{Ref: ref, Name: "must not write"}, &response); err == nil {
+					t.Error("rename bypassed unresolved owner")
+				}
+				if _, err := client.ThreadFork(t.Context(), appwire.ThreadForkParams{Ref: ref, Aside: true}); err == nil {
+					t.Error("fork bypassed unresolved owner")
+				}
+				err = client.Request(t.Context(), appwire.MethodTurnQueue, map[string]any{"ref": ref, "clientMutationId": "uncertain-upgrade", "expectedInstanceId": targetID, "input": []appwire.InputItem{{Type: "text", Text: "sentinel"}}}, &response)
+				var wire appwire.WireError
+				if !errors.As(err, &wire) {
+					t.Fatalf("queue error=%v", err)
+				}
+				data, ok := wire.Data.(map[string]any)
+				if !ok || data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["retryDisposition"] != string(appwire.RetryDispositionBlocked) {
+					t.Errorf("receipt=%+v", wire)
+				}
+				after, err := schema.LoadSessionMeta(stateDir, targetID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				afterMetas, err := schema.ListSessionMetas(stateDir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if after.Name != before.Name || len(afterMetas) != len(metas) {
+					t.Error("unresolved owner allowed metadata writes")
+				}
+				if fault == "probe" || fault == "unidentified" || fault == "changed-identity" {
+					web := &WebServer{cfg: hubcore.WebConfig{StateDir: stateDir, Past: past, Roster: roster}}
+					assertNavigationOwnershipReadOnly(t, web)
+				}
+				if fault == "missing-directory" {
+					if err := os.Rename(hiddenRunDir, runDir); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := rendezvous.Remove(runDir, os.Getpid()); err != nil {
+					t.Fatal(err)
+				}
+				if err := client.Request(t.Context(), appwire.MethodEvenerThreadNameSet, appwire.ThreadNameSetParams{Ref: ref, Name: "released"}, &response); err != nil {
+					t.Fatalf("rename after removal: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestRestartRequiredOwnershipSkipsUnspecifiedTarget(t *testing.T) {
+	cfg := hubcore.WebConfig{StateDir: t.TempDir(), Roster: hubcore.NewRoster(t.TempDir(), nil)}
+	_, required, err := restartRequiredDaemon(t.Context(), cfg, "", "")
+	if err != nil || required {
+		t.Fatalf("unspecified ownership: required=%v error=%v", required, err)
+	}
+}
+
+type changedOwnershipProber struct {
+	sessionID string
+	fail      bool
+}
+
+func (p *changedOwnershipProber) Probe(rendezvous.Entry) hubcore.ProbeResult {
+	return hubcore.ProbeResult{SessionID: p.sessionID, Status: appwire.ThreadStatusIdle, OK: !p.fail}
+}
+
+func TestHubRPCListShowsIncompatibleDaemonWithoutPastIndex(t *testing.T) {
+	const sessionID = "unindexed-owner"
+	runDir := t.TempDir()
+	entry := rendezvous.Entry{PID: os.Getpid(), Protocol: "evener-appwire-v4", Endpoint: protocolMismatchPeer(t), SourceID: "local", ThreadID: sessionID, SessionID: sessionID, WorkspaceRef: "local:unindexed-saved"}
+	writeRendezvous(t, runDir, entry)
+	roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+	roster.Refresh()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Roster: roster})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	list, err := client.ThreadList(t.Context(), appwire.ThreadListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Data) != 1 {
+		t.Fatalf("threads=%+v", list.Data)
+	}
+	thread := list.Data[0]
+	if thread.ID != sessionID || thread.Status.Type != appwire.ThreadStatusRestartRequired || thread.Evener.Capabilities != (appwire.ThreadCapabilities{}) {
+		t.Fatalf("thread=%+v", thread)
+	}
+	for _, params := range []appwire.ThreadReadParams{
+		{Ref: "local:" + sessionID, IncludeTurns: true},
+		{Ref: entry.WorkspaceRef, IncludeTurns: true, Subscribe: true},
+		{ThreadID: sessionID, IncludeTurns: true, Subscribe: true},
+	} {
+		read, err := client.ThreadRead(t.Context(), params)
+		if err != nil {
+			t.Fatalf("read visible incompatible owner (%+v): %v", params, err)
+		}
+		if read.Thread.ID != sessionID || read.Thread.Evener.Ref != entry.WorkspaceRef || read.Thread.Status.Type != appwire.ThreadStatusRestartRequired || read.Thread.Evener.Capabilities != (appwire.ThreadCapabilities{}) || len(read.Thread.Turns) != 0 {
+			t.Fatalf("read=%+v", read)
+		}
+	}
+	if err := client.ThreadShutdown(t.Context(), appwire.ThreadShutdownParams{Ref: "local:" + sessionID}); !isDaemonRestartRequiredError(err) {
+		t.Fatalf("shutdown error=%v", err)
+	}
+}
+
+func TestHubRPCListDeduplicatesIncompatibleWorkspaceAlias(t *testing.T) {
+	root := t.TempDir()
+	sessionID := buildRPCParentSession(t, filepath.Join(root, "projects", "upgrade-0000000000"))
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	const instanceID = "02wMz5Txv1C3Hut0M8GCeC"
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: os.Getpid(), Protocol: "evener-appwire-v4", Endpoint: protocolMismatchPeer(t), SourceID: "local", ThreadID: instanceID, SessionID: instanceID, WorkspaceRef: "local:" + sessionID})
+	roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+	roster.Refresh()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Roster: roster, Past: past})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	list, err := client.ThreadList(t.Context(), appwire.ThreadListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Data) != 1 {
+		t.Fatalf("threads=%+v", list.Data)
+	}
+	thread := list.Data[0]
+	if thread.ID != instanceID || thread.Evener.Ref != "local:"+sessionID || thread.Status.Type != appwire.ThreadStatusRestartRequired {
+		t.Fatalf("thread=%+v", thread)
+	}
+	search, err := client.ThreadList(t.Context(), appwire.ThreadListParams{SearchTerm: "second task"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(search.Data) != 1 || search.Data[0].ID != instanceID || search.Data[0].Name != "second task" {
+		t.Fatalf("search=%+v", search.Data)
+	}
+}
+
+func TestDaemonRejectionSurvivesDiscoveryFailure(t *testing.T) {
+	for _, mutationID := range []string{"", "rejected-message"} {
+		t.Run("mutation="+mutationID, func(t *testing.T) {
+			runDir := filepath.Join(t.TempDir(), "run")
+			if err := os.Mkdir(runDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			cfg := hubcore.WebConfig{Roster: hubcore.NewRoster(runDir, &hubcore.StatusProber{})}
+			cfg.Roster.Refresh()
+			rejection := appwire.WireError{Code: appwire.CodeInvalidRequest, Message: "mutation ID already used for another payload", Data: appwire.ErrorData{ClientMutationID: mutationID, MutationOutcome: appwire.MutationOutcomeNotAccepted, RetryDisposition: appwire.RetryDispositionNone}}
+			action := func() (struct{}, error) {
+				if err := os.Remove(runDir); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(runDir, []byte("unreadable roster"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				return struct{}{}, rejection
+			}
+			var err error
+			if mutationID == "" {
+				_, err = withSessionActionOwnership(t.Context(), cfg, localAppRef(webTestSessionID), "", action)
+			} else {
+				_, err = withDeletionTargetOwnership(t.Context(), cfg, localAppRef(webTestSessionID), "", mutationID, action)
+			}
+			var wire appwire.WireError
+			if !errors.As(err, &wire) || wire.Code != rejection.Code || wire.Message != rejection.Message {
+				t.Fatalf("rejection changed: %v", err)
+			}
+			data, ok := wire.Data.(appwire.ErrorData)
+			if !ok || data.MutationOutcome != appwire.MutationOutcomeNotAccepted || data.ClientMutationID != mutationID {
+				t.Fatalf("rejection data=%+v", wire.Data)
+			}
+		})
+	}
+}
+
+func TestHubRejectsMutationForPreviousPIDIdentity(t *testing.T) {
+	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+	var mutations atomic.Int32
+	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: "before", SessionID: "before", Evener: appwire.EvenerThread{Ref: "local:before", Capabilities: appwire.ThreadCapabilities{Compact: true}}}}, nil
+	})
+	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadCompactStart, func(context.Context, appwire.ThreadCompactStartParams) (appwire.EmptyResponse, error) {
+		mutations.Add(1)
+		return appwire.EmptyResponse{}, nil
+	})
+	peer := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+	defer peer.Close()
+	runDir := t.TempDir()
+	entry := rendezvous.Entry{PID: os.Getpid(), SessionID: "before", ThreadID: "before", Protocol: appwire.ProtocolVersion, Endpoint: "ws" + strings.TrimPrefix(peer.URL, "http"), SourceID: "local"}
+	writeRendezvous(t, runDir, entry)
+	prober := &changedOwnershipProber{sessionID: "before"}
+	roster := hubcore.NewRoster(runDir, prober)
+	roster.Refresh()
+	entry.SessionID, entry.ThreadID = "after", "after"
+	writeRendezvous(t, runDir, entry)
+	prober.fail = true
+	roster.Refresh()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Roster: roster, StateDir: t.TempDir()})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	var response appwire.EmptyResponse
+	err := client.Request(t.Context(), appwire.MethodThreadCompactStart, appwire.ThreadCompactStartParams{Ref: "local:before"}, &response)
+	if err == nil || mutations.Load() != 0 {
+		t.Fatalf("previous identity mutation error=%v, deliveries=%d", err, mutations.Load())
+	}
+}
+
+func TestHubResumeRetainedChildWaitsForOwnerRelease(t *testing.T) {
+	for _, delegate := range []bool{true, false} {
+		t.Run(fmt.Sprint("delegate=", delegate), func(t *testing.T) {
+			stateDir := t.TempDir()
+			rootID := buildRPCParentSession(t, stateDir)
+			var childID string
+			if delegate {
+				childID = buildUpgradeDelegate(t, stateDir, rootID)
+			} else {
+				var err error
+				childID, err = agent.ForkSession(stateDir, rootID, 1, "independent fork", "")
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			runDir := t.TempDir()
+			entry := rendezvous.Entry{PID: 1001, Protocol: appwire.ProtocolVersion, ThreadID: rootID, SessionID: rootID, Endpoint: "ws://unused"}
+			writeRendezvous(t, runDir, entry)
+			roster := hubcore.NewRoster(runDir, &changedOwnershipProber{sessionID: rootID})
+			spawned := 0
+			cfg := hubcore.WebConfig{StateDir: stateDir, Roster: roster, ResumeLocks: hubcore.NewResumeLocks(), Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				spawned++
+				return rendezvous.Entry{}, errors.New("spawn sentinel")
+			}}}
+			_, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(childID)})
+			if delegate && spawned != 0 {
+				t.Fatalf("retained child launched replacement: %v", err)
+			}
+			if !delegate && spawned != 1 {
+				t.Fatalf("independent fork did not reach launcher: %v", err)
+			}
+			if delegate {
+				wire, ok := errors.AsType[appwire.WireError](err)
+				if !ok || wire.Code != appwire.CodeUnavailable || wire.Data.(appwire.ErrorData).EvenerErrorInfo != appwire.ErrorActionUnavailable {
+					t.Fatalf("expected unavailable owner refusal, got %v", err)
+				}
+			}
+			if delegate {
+				_, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(rootID), Session: childID})
+				if spawned != 0 || err == nil {
+					t.Fatalf("explicit child target lost ownership fence: spawned=%d err=%v", spawned, err)
+				}
+			}
+
+			if err := rendezvous.Remove(runDir, entry.PID); err != nil {
+				t.Fatal(err)
+			}
+			before := spawned
+			_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(childID)})
+			if spawned != before+1 {
+				t.Fatalf("released child did not reach launcher: %v", err)
+			}
+		})
+	}
+}
+
+func TestHubResumeWithoutRosterReturnsUnavailable(t *testing.T) {
+	_, err := hubThreadResume(t.Context(), hubcore.WebConfig{}, nil, appwire.ThreadResumeParams{Session: "saved"})
+	wire, ok := errors.AsType[appwire.WireError](err)
+	if !ok || wire.Code != appwire.CodeUnavailable {
+		t.Fatalf("resume without roster = %v", err)
+	}
+}
+
+func TestHubOwnershipUsesProjectStateLayout(t *testing.T) {
+	for _, indexed := range []bool{false, true} {
+		for _, retained := range []bool{false, true} {
+			t.Run(fmt.Sprintf("indexed=%v/retained=%v", indexed, retained), func(t *testing.T) {
+				root := t.TempDir()
+				project := filepath.Join(root, "projects", "project-owner-0000000000")
+				rootID := buildRPCParentSession(t, project)
+				childID := buildUpgradeDelegate(t, project, rootID)
+				if !retained {
+					var err error
+					childID, err = agent.ForkSession(project, rootID, 1, "independent fork", "")
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				runDir := t.TempDir()
+				writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: rootID, SessionID: rootID, Endpoint: protocolMismatchPeer(t)})
+				spawned := 0
+				cfg := hubcore.WebConfig{StateDir: root, Roster: hubcore.NewRoster(runDir, &hubcore.StatusProber{}), ResumeLocks: hubcore.NewResumeLocks(), Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+					spawned++
+					return rendezvous.Entry{}, errors.New("spawn sentinel")
+				}}}
+				if indexed {
+					cfg.Past = hubcore.NewPastIndex(filepath.Join(root, "missing", "*"))
+				}
+				_, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(childID)})
+				if retained && (err == nil || spawned != 0) {
+					t.Fatalf("retained child resume err=%v launches=%d", err, spawned)
+				}
+				if !retained && spawned != 1 {
+					t.Fatalf("independent fork refused: %v", err)
+				}
+				err = daemonRestartRequiredError(t.Context(), cfg, localAppRef(childID), "", "pending-input")
+				if retained {
+					wire, ok := errors.AsType[appwire.WireError](err)
+					if !ok {
+						t.Fatalf("mutation not blocked: %v", err)
+					}
+					data := wire.Data.(appwire.ErrorData)
+					if data.MutationOutcome != appwire.MutationOutcomeUnknown || data.RetryDisposition != appwire.RetryDispositionBlocked {
+						t.Fatalf("unsafe mutation receipt: %+v", data)
+					}
+				} else if err != nil {
+					t.Fatalf("independent mutation refused: %v", err)
+				}
+				live, ownershipErr := projectSessionOwnership(t.Context(), cfg, childID)
+				if ownershipErr != nil || live != retained {
+					t.Fatalf("deletion ownership live=%v err=%v, retained=%v", live, ownershipErr, retained)
+				}
+				if err := rendezvous.Remove(runDir, 1001); err != nil {
+					t.Fatal(err)
+				}
+				before := spawned
+				_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(childID)})
+				if spawned != before+1 {
+					t.Fatalf("released child refused: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestHubOwnershipProjectDiscoveryPreservesUncertainty(t *testing.T) {
+	for _, fault := range []string{"missing", "malformed", "duplicate", "unreadable-projects"} {
+		t.Run(fault, func(t *testing.T) {
+			root := t.TempDir()
+			project := filepath.Join(root, "projects", "project-owner-0000000000")
+			rootID := buildRPCParentSession(t, project)
+			childID := buildUpgradeDelegate(t, project, rootID)
+			path := filepath.Join(project, "sessions", childID+".meta.json")
+			switch fault {
+			case "missing":
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+			case "malformed":
+				if err := os.WriteFile(path, []byte("{"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "duplicate":
+				meta, err := schema.LoadSessionMeta(project, childID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := schema.SaveSessionMeta(filepath.Join(root, "projects", "project-other-0000000000"), meta); err != nil {
+					t.Fatal(err)
+				}
+			case "unreadable-projects":
+				if err := os.Rename(filepath.Join(root, "projects"), filepath.Join(root, "held-projects")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(root, "projects"), []byte("obstruction"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			runDir := t.TempDir()
+			writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: rootID, SessionID: rootID, Endpoint: protocolMismatchPeer(t)})
+			roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+			roster.Refresh()
+			cfg := hubcore.WebConfig{StateDir: root, Roster: roster}
+			_, _, err := restartRequiredDaemon(t.Context(), cfg, localAppRef(childID), "")
+			if err == nil {
+				t.Fatal("uncertain project ownership reported as absent")
+			}
+			if fault == "missing" {
+				if err := rendezvous.Remove(runDir, 1001); err != nil {
+					t.Fatal(err)
+				}
+				roster.Refresh()
+				_, owned, err := restartRequiredDaemon(t.Context(), cfg, localAppRef(childID), "")
+				if err != nil || owned {
+					t.Fatalf("confirmed owner absence lost: owned=%v err=%v", owned, err)
+				}
+			}
+		})
+	}
+}
+
+func TestIndependentForkSurvivesDeletedParentWithUnrelatedDaemon(t *testing.T) {
+	stateDir := t.TempDir()
+	parentID := buildRPCParentSession(t, stateDir)
+	childID, err := agent.ForkSession(stateDir, parentID, 1, "independent fork", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(stateDir, "sessions", parentID+".meta.json")); err != nil {
+		t.Fatal(err)
+	}
+	unrelatedID := "02wMz5Txv1C3Hut0M8GCec"
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: unrelatedID, SessionID: unrelatedID, Endpoint: protocolMismatchPeer(t)})
+	spawned := 0
+	cfg := hubcore.WebConfig{StateDir: stateDir, Roster: hubcore.NewRoster(runDir, &hubcore.StatusProber{}), ResumeLocks: hubcore.NewResumeLocks(), Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		spawned++
+		return rendezvous.Entry{}, errors.New("spawn sentinel")
+	}}}
+	_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(childID)})
+	if spawned != 1 {
+		t.Fatalf("fork resume blocked: %v", err)
+	}
+	if err := daemonRestartRequiredError(t.Context(), cfg, localAppRef(childID), "", "input"); err != nil {
+		t.Fatal(err)
+	}
+	live, err := projectSessionOwnership(t.Context(), cfg, childID)
+	if live || err != nil {
+		t.Fatalf("fork deletion blocked: live=%v err=%v", live, err)
+	}
+}
+
+func TestResumeChecksExplicitSessionTargetForIncompatibleOwner(t *testing.T) {
+	stateDir := t.TempDir()
+	ownerID := buildRPCParentSession(t, stateDir)
+	forkID, err := agent.ForkSession(stateDir, ownerID, 1, "independent fork", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v3", ThreadID: ownerID, SessionID: ownerID, Endpoint: protocolMismatchPeer(t)})
+	spawned := 0
+	cfg := hubcore.WebConfig{StateDir: stateDir, Roster: hubcore.NewRoster(runDir, &hubcore.StatusProber{}), ResumeLocks: hubcore.NewResumeLocks(), Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		spawned++
+		return rendezvous.Entry{}, errors.New("spawn sentinel")
+	}}}
+	_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(forkID), Session: ownerID})
+	if err == nil || spawned != 0 {
+		t.Fatalf("incompatible explicit target reached launcher: spawned=%d err=%v", spawned, err)
+	}
+}
+
+func TestHubClearedOwnerReleasesHistoricalDelegate(t *testing.T) {
+	for _, compatible := range []bool{true, false} {
+		t.Run(fmt.Sprint("compatible=", compatible), func(t *testing.T) {
+			root := t.TempDir()
+			stateDir := filepath.Join(root, "projects", "clear-owner-0000000000")
+			oldID := buildRPCParentSession(t, stateDir)
+			oldChildID := buildUpgradeDelegate(t, stateDir, oldID)
+			newID, err := agent.ForkSession(stateDir, oldID, 1, "replacement root", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			newChildID := buildUpgradeDelegate(t, stateDir, newID)
+			past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+			if _, err := past.Rebuild(); err != nil {
+				t.Fatal(err)
+			}
+			runDir := t.TempDir()
+			entry := rendezvous.Entry{PID: 1001, Protocol: appwire.ProtocolVersion, ThreadID: oldID, SessionID: oldID, WorkspaceRef: localAppRef(oldID), Endpoint: "ws://unused"}
+			prober := &changedOwnershipProber{sessionID: oldID}
+			roster := hubcore.NewRoster(runDir, prober)
+			if !compatible {
+				entry.Protocol = "evener-appwire-v4"
+				entry.Endpoint = protocolMismatchPeer(t)
+				roster = hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+			}
+			writeRendezvous(t, runDir, entry)
+			roster.Refresh()
+			spawned := 0
+			cfg := hubcore.WebConfig{StateDir: root, Past: past, Roster: roster, RunDir: runDir, ResumeLocks: hubcore.NewResumeLocks(), Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				spawned++
+				return rendezvous.Entry{}, errors.New("spawn sentinel")
+			}}}
+			if live, err := projectSessionOwnership(t.Context(), cfg, oldChildID); err != nil || !live {
+				t.Fatalf("old root must initially retain its child: live=%v err=%v", live, err)
+			}
+			oldOwner, err := llm.NewSessionAPILogger(stateDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = oldOwner.Close() })
+			if err := oldOwner.ReserveSession(oldChildID); err != nil {
+				t.Fatal(err)
+			}
+			// Clear closes the old session tree and republishes the replacement
+			// session ID while retaining its workspace route and saved journals.
+			entry.SessionID, entry.ThreadID = newID, newID
+			prober.sessionID = newID
+			writeRendezvous(t, runDir, entry)
+			roster.Refresh()
+			hub, web := newHubRPCTestServerWithWeb(t, cfg)
+			defer hub.Close()
+			if owner, _, err := lookupDaemonOwner(t.Context(), cfg, localAppRef(oldID), "", true); err != nil || owner.SessionID != newID {
+				t.Fatalf("stable workspace route lost replacement: owner=%+v err=%v", owner, err)
+			}
+			_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(newChildID)})
+			if err == nil || spawned != 0 {
+				t.Fatalf("current child escaped owner: spawned=%d err=%v", spawned, err)
+			}
+			blocked, err := web.sessionDelete(t.Context(), appwire.SessionDeleteParams{Ref: localAppRef(newChildID)})
+			if err != nil || len(blocked.Deleted) != 0 || len(blocked.Skipped) != 1 {
+				t.Fatalf("current child deletion = %+v err=%v", blocked, err)
+			}
+			// Publication precedes oldSess.Close during clear. The old child's
+			// reservation must still prevent deletion in that interval.
+			closing, err := web.sessionDelete(t.Context(), appwire.SessionDeleteParams{Ref: localAppRef(oldChildID)})
+			if err != nil || len(closing.Deleted) != 0 || len(closing.Skipped) != 1 {
+				t.Fatalf("still-reserved historical child deletion = %+v err=%v", closing, err)
+			}
+			if _, err := schema.LoadSessionMeta(stateDir, oldChildID); err != nil {
+				t.Fatalf("still-reserved historical child metadata changed: %v", err)
+			}
+			if err := oldOwner.Close(); err != nil {
+				t.Fatal(err)
+			}
+			_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: localAppRef(oldChildID)})
+			if spawned != 1 {
+				t.Errorf("released child did not reach launcher: spawned=%d err=%v", spawned, err)
+			}
+			deleted, err := web.sessionDelete(t.Context(), appwire.SessionDeleteParams{Ref: localAppRef(oldChildID)})
+			if err != nil || len(deleted.Deleted) != 1 || deleted.Deleted[0] != oldChildID || len(deleted.Skipped) != 0 {
+				t.Errorf("released child deletion = %+v err=%v", deleted, err)
+			}
+		})
+	}
+}
+
+func TestHubColdReadFindsIncompatibleDaemonByStableThreadID(t *testing.T) {
+	runDir := t.TempDir()
+	roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{Roster: roster})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	// The owner appears after hub initialization. Its current session differs
+	// from the stable workspace, and no past index can supply an alias row.
+	entry := rendezvous.Entry{PID: os.Getpid(), Protocol: "evener-appwire-v4", Endpoint: protocolMismatchPeer(t), SourceID: "local", ThreadID: "current", SessionID: "current", WorkspaceRef: "local:stable"}
+	writeRendezvous(t, runDir, entry)
+	for _, subscribe := range []bool{false, true} {
+		read, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{ThreadID: "stable", IncludeTurns: true, Subscribe: subscribe})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if read.Thread.ID != "current" || read.Thread.Evener.Ref != "local:stable" || read.Thread.Status.Type != appwire.ThreadStatusRestartRequired || read.Thread.Evener.Capabilities != (appwire.ThreadCapabilities{}) || len(read.Thread.Turns) != 0 {
+			t.Fatalf("stable-ID read lost the incompatible owner: %+v", read.Thread)
+		}
+	}
+}
+
+func TestSavedReadsSurviveUnrelatedDiscoveryFailure(t *testing.T) {
+	for _, incompatible := range []bool{false, true} {
+		t.Run(fmt.Sprintf("incompatible=%v", incompatible), func(t *testing.T) {
+			testSavedReadsSurviveUnrelatedDiscoveryFailure(t, incompatible)
+		})
+	}
+}
+
+func testSavedReadsSurviveUnrelatedDiscoveryFailure(t *testing.T, incompatible bool) {
+	stateDir := filepath.Join(t.TempDir(), "saved-0000000000")
+	sessionID := buildRPCParentSession(t, stateDir)
+	past := hubcore.NewPastIndex(stateDir)
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	runDir := t.TempDir()
+	if incompatible {
+		writeRendezvous(t, runDir, rendezvous.Entry{PID: 1001, Protocol: "evener-appwire-v4", SessionID: sessionID, ThreadID: sessionID, Endpoint: protocolMismatchPeer(t)})
+	}
+	roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+	roster.Refresh()
+	if incompatible {
+		if _, required, err := restartRequiredDaemon(t.Context(), hubcore.WebConfig{Roster: roster}, localAppRef(sessionID), ""); err != nil || !required {
+			t.Fatalf("fixture did not establish incompatible ownership: required=%v err=%v", required, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(runDir, fmt.Sprintf("%d.json", os.Getpid())), []byte("{"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	roster.Refresh()
+	if roster.OwnershipError() == nil {
+		t.Fatal("fixture did not establish incomplete discovery")
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{StateDir: stateDir, Past: past, Roster: roster})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	assertReadOnly := func(t *testing.T, thread appwire.Thread) {
+		t.Helper()
+		if incompatible && thread.Status.Type != appwire.ThreadStatusRestartRequired {
+			t.Fatalf("confirmed incompatible daemon lost restart status: %+v", thread.Status)
+		}
+		if thread.ID != sessionID || thread.Evener.MutationStateAuthoritative || thread.Evener.Capabilities != (appwire.ThreadCapabilities{}) {
+			t.Fatalf("saved snapshot grants authority or changes identity: %+v", thread)
+		}
+	}
+	t.Run("read", func(t *testing.T) {
+		read, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: localAppRef(sessionID), IncludeTurns: true, Subscribe: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertReadOnly(t, read.Thread)
+		if len(read.Thread.Turns) != 2 {
+			t.Fatalf("saved turns=%d", len(read.Thread.Turns))
+		}
+	})
+	t.Run("list", func(t *testing.T) {
+		var listed appwire.ThreadListResponse
+		if err := client.Request(t.Context(), appwire.MethodThreadList, appwire.ThreadListParams{}, &listed); err != nil {
+			t.Fatal(err)
+		}
+		if len(listed.Data) != 1 {
+			t.Fatalf("saved rows=%d", len(listed.Data))
+		}
+		assertReadOnly(t, listed.Data[0])
+	})
+	t.Run("mutation remains blocked", func(t *testing.T) {
+		var response any
+		if err := client.Request(t.Context(), appwire.MethodEvenerThreadNameSet, appwire.ThreadNameSetParams{Ref: localAppRef(sessionID), Name: "must not write"}, &response); err == nil {
+			t.Fatal("rename bypassed discovery uncertainty")
+		}
+	})
+}

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -155,6 +156,9 @@ func listItemTurns(
 }
 
 func blockedUnknownMutationError(clientMutationID string, err error) error {
+	if isDaemonRestartRequiredError(err) {
+		return restartRequiredMutationError(err, clientMutationID)
+	}
 	return appwire.WireError{
 		Code:    appwire.CodeInternalError,
 		Message: err.Error(),
@@ -271,6 +275,11 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 					if past, pastOK := pastEntryForRead(cfg, params); pastOK && past.ID != "" {
 						return appserver.SubscriptionAdmissionResolution{Key: "local:" + past.ID, Intent: appserver.SubscriptionAdmissionResolved}
 					}
+					if cfg.Roster != nil {
+						if key, ok := cfg.Roster.RestartRequiredRootRef(normalizedAdmissionRef(params)); ok {
+							return appserver.SubscriptionAdmissionResolution{Key: key, Intent: appserver.SubscriptionAdmissionResolved}
+						}
+					}
 				}
 				if err != nil {
 					if msg.Request.Method == appwire.MethodThreadUnsubscribe {
@@ -386,12 +395,29 @@ func registerThreadHandlers(
 		if err != nil {
 			return appwire.ThreadReadResponse{}, err
 		}
+		if params.Ref != "" {
+			if _, err := appwire.ParseRef(params.Ref); err != nil {
+				return appwire.ThreadReadResponse{}, appwire.InvalidParams(err.Error())
+			}
+		}
+		if cfg.Roster != nil {
+			if _, required, ownershipErr := restartRequiredDaemon(ctx, cfg, params.Ref, params.ThreadID); required || ownershipErr != nil {
+				if err := hubRosterRefresh(ctx, cfg.Roster); err != nil {
+					// Refresh may fail on an unrelated marker. Recheck the target
+					// before allowing its saved, non-authoritative projection.
+					_, required, ownershipErr = restartRequiredDaemon(ctx, cfg, params.Ref, params.ThreadID)
+					if ctx.Err() != nil || (!required && !isDaemonDiscoveryError(ownershipErr)) {
+						return appwire.ThreadReadResponse{}, appwire.Unavailable(err.Error())
+					}
+				}
+			}
+		}
 		source, err := sourceForThreadWithDeletionFence(cfg, sources, params.Ref, params.ThreadID)
 		if err != nil {
 			if isTargetDeletedError(err) {
 				return appwire.ThreadReadResponse{}, err
 			}
-			resp, ok, pastErr := pastThreadReadResponse(ctx, cfg, params)
+			resp, ok, pastErr := unavailableThreadReadResponse(ctx, cfg, sources, params)
 			if pastErr != nil {
 				return appwire.ThreadReadResponse{}, pastErr
 			}
@@ -402,8 +428,29 @@ func registerThreadHandlers(
 		}
 		read, err := relays.readThread(ctx, source, params)
 		if err != nil {
-			if allowsPastFallbackAfterLiveReadFailure(source, params, err) {
-				saved, ok, pastErr := pastThreadReadResponse(ctx, cfg, params)
+			allowPast := allowsPastFallbackAfterLiveReadFailure(source, params, err)
+			if _, local := localPastThreadID(params); local && cfg.Roster != nil && daemonOwnershipMayHaveChanged(err) {
+				refreshErr := hubRosterRefresh(ctx, cfg.Roster)
+				_, required, ownershipErr := restartRequiredDaemon(ctx, cfg, params.Ref, params.ThreadID)
+				if ctx.Err() != nil {
+					return appwire.ThreadReadResponse{}, ctx.Err()
+				}
+				if required {
+					allowPast = true
+					err = daemonRestartRequiredError(ctx, cfg, params.Ref, params.ThreadID, "")
+				} else if isDaemonDiscoveryError(ownershipErr) {
+					allowPast = true
+				} else {
+					if refreshErr != nil {
+						return appwire.ThreadReadResponse{}, appwire.Unavailable(refreshErr.Error())
+					}
+					if ownershipErr != nil {
+						return appwire.ThreadReadResponse{}, appwire.Unavailable(ownershipErr.Error())
+					}
+				}
+			}
+			if allowPast {
+				saved, ok, pastErr := unavailableThreadReadResponse(ctx, cfg, sources, params)
 				if pastErr != nil {
 					return appwire.ThreadReadResponse{}, pastErr
 				}
@@ -639,7 +686,7 @@ func registerThreadHandlers(
 		}
 		resolved := false
 		attemptStart := func() (appwire.TurnStartResponse, error) {
-			source, err := withDeletionTargetOwnership(cfg, params.Ref, params.ThreadID, params.ClientMutationID, func() (appsource.Source, error) {
+			source, err := withDeletionTargetOwnership(ctx, cfg, params.Ref, params.ThreadID, params.ClientMutationID, func() (appsource.Source, error) {
 				return resolveTurnStartSource(sources, params.Ref, params.ThreadID)
 			})
 			if err != nil {
@@ -653,7 +700,10 @@ func registerThreadHandlers(
 			return resp, nil
 		}
 		if !resolved {
-			if isTargetDeletedError(err) {
+			if wire, ok := errors.AsType[appwire.WireError](err); ok && wire.Code == appwire.CodeInvalidParams {
+				return appwire.TurnStartResponse{}, err
+			}
+			if isTargetDeletedError(err) || isDaemonRestartRequiredError(err) {
 				return appwire.TurnStartResponse{}, err
 			}
 			if _, resumeErr := resumeTurnStartThread(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref, Session: params.ThreadID}); resumeErr != nil {
@@ -681,7 +731,7 @@ func registerThreadHandlers(
 		if strings.TrimSpace(params.ClientMutationID) == "" {
 			return appwire.TurnSteerResponse{}, appwire.InvalidParams("clientMutationId is required")
 		}
-		return withDeletionTargetOwnership(cfg, params.Ref, params.ThreadID, params.ClientMutationID, func() (appwire.TurnSteerResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, params.ThreadID, params.ClientMutationID, func() (appwire.TurnSteerResponse, error) {
 			source, err := sourceForThread(sources, params.Ref, params.ThreadID)
 			if err != nil {
 				return appwire.TurnSteerResponse{}, err
@@ -693,7 +743,7 @@ func registerThreadHandlers(
 		if strings.TrimSpace(params.ClientMutationID) == "" {
 			return appwire.TurnInterruptResponse{}, appwire.InvalidParams("clientMutationId is required")
 		}
-		return withDeletionTargetOwnership(cfg, params.Ref, params.ThreadID, params.ClientMutationID, func() (appwire.TurnInterruptResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, params.ThreadID, params.ClientMutationID, func() (appwire.TurnInterruptResponse, error) {
 			source, err := sourceForThread(sources, params.Ref, params.ThreadID)
 			if err != nil {
 				return appwire.TurnInterruptResponse{}, err
@@ -702,7 +752,10 @@ func registerThreadHandlers(
 		})
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSandboxEscalationResolve, func(ctx context.Context, params appwire.SandboxEscalationResolveParams) (appwire.EmptyResponse, error) {
-		return withDeletionTargetOwnership(cfg, params.Ref, params.ThreadID, "", func() (appwire.EmptyResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, params.ThreadID, "", func() (appwire.EmptyResponse, error) {
+			if err := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, params.ThreadID, ""); err != nil {
+				return appwire.EmptyResponse{}, err
+			}
 			source, err := sourceForThread(sources, params.Ref, params.ThreadID)
 			if err != nil {
 				return appwire.EmptyResponse{}, err
@@ -717,7 +770,7 @@ func registerThreadHandlers(
 		if strings.TrimSpace(params.ClientMutationID) == "" {
 			return appwire.TurnQueueResponse{}, appwire.InvalidParams("clientMutationId is required")
 		}
-		return withDeletionTargetOwnership(cfg, params.Ref, "", params.ClientMutationID, func() (appwire.TurnQueueResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, "", params.ClientMutationID, func() (appwire.TurnQueueResponse, error) {
 			source, err := sourceForThread(sources, params.Ref, "")
 			if err != nil {
 				return appwire.TurnQueueResponse{}, err
@@ -732,7 +785,7 @@ func registerThreadHandlers(
 		if strings.TrimSpace(params.ClientMutationID) == "" {
 			return appwire.TurnDrainAsSteerResponse{}, appwire.InvalidParams("clientMutationId is required")
 		}
-		return withDeletionTargetOwnership(cfg, params.Ref, "", params.ClientMutationID, func() (appwire.TurnDrainAsSteerResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, "", params.ClientMutationID, func() (appwire.TurnDrainAsSteerResponse, error) {
 			source, err := sourceForThread(sources, params.Ref, "")
 			if err != nil {
 				return appwire.TurnDrainAsSteerResponse{}, err
@@ -750,7 +803,7 @@ func registerThreadHandlers(
 		if strings.TrimSpace(params.ExpectedEntryID) == "" {
 			return appwire.TurnPromoteQueuedAsSteerResponse{}, appwire.InvalidParams("expectedEntryId is required")
 		}
-		return withDeletionTargetOwnership(cfg, params.Ref, "", params.ClientMutationID, func() (appwire.TurnPromoteQueuedAsSteerResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, "", params.ClientMutationID, func() (appwire.TurnPromoteQueuedAsSteerResponse, error) {
 			source, err := sourceForThread(sources, params.Ref, "")
 			if err != nil {
 				return appwire.TurnPromoteQueuedAsSteerResponse{}, err
@@ -768,7 +821,7 @@ func registerThreadHandlers(
 		if strings.TrimSpace(params.ExpectedEntryID) == "" {
 			return appwire.TurnCancelQueuedResponse{}, appwire.InvalidParams("expectedEntryId is required")
 		}
-		return withDeletionTargetOwnership(cfg, params.Ref, "", params.ClientMutationID, func() (appwire.TurnCancelQueuedResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, "", params.ClientMutationID, func() (appwire.TurnCancelQueuedResponse, error) {
 			source, err := sourceForThread(sources, params.Ref, "")
 			if err != nil {
 				return appwire.TurnCancelQueuedResponse{}, err
@@ -798,7 +851,10 @@ func registerThreadHandlers(
 		return appwire.EmptyResponse{}, setThreadVisionModelWithResume(ctx, cfg, sources, params)
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadReasoningEffortSet, func(ctx context.Context, params appwire.ThreadReasoningEffortSetParams) (appwire.EmptyResponse, error) {
-		return withDeletionTargetOwnership(cfg, params.Ref, "", "", func() (appwire.EmptyResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, "", "", func() (appwire.EmptyResponse, error) {
+			if err := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, "", ""); err != nil {
+				return appwire.EmptyResponse{}, err
+			}
 			source, err := sourceForThread(sources, params.Ref, "")
 			if err != nil {
 				return appwire.EmptyResponse{}, err

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -684,6 +684,12 @@ func TestHubRPCThreadListUsesAppWireRendezvous(t *testing.T) {
 }
 
 func TestHubRPCSteersSurvivingDaemonAfterHubRestart(t *testing.T) {
+	for _, cleared := range []bool{false, true} {
+		t.Run(fmt.Sprint("cleared=", cleared), func(t *testing.T) { testHubSteersSurvivingDaemon(t, cleared) })
+	}
+}
+
+func testHubSteersSurvivingDaemon(t *testing.T, cleared bool) {
 	const (
 		daemonProtocol = appwire.ProtocolVersion
 		threadID       = "th_compatible"
@@ -705,6 +711,18 @@ func TestHubRPCSteersSurvivingDaemonAfterHubRestart(t *testing.T) {
 	})
 	defer daemonHTTP.Close()
 
+	resumeID := threadID
+	if cleared {
+		resumeID = "workspace_before_clear"
+		entries, err := rendezvous.List(runDir)
+		if err != nil || len(entries) != 1 {
+			t.Fatalf("rendezvous entries=%+v error=%v", entries, err)
+		}
+		entry := entries[0]
+		entry.WorkspaceRef = "local:" + resumeID
+		writeRendezvous(t, runDir, entry)
+	}
+
 	roster := hubcore.NewRoster(runDir, fakeProber{sessionID: threadID, status: appwire.ThreadStatusActive})
 	roster.Refresh()
 
@@ -725,11 +743,11 @@ func TestHubRPCSteersSurvivingDaemonAfterHubRestart(t *testing.T) {
 	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
 		t.Fatalf("Initialize: %v", err)
 	}
-	resumed, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Session: threadID})
+	resumed, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + resumeID})
 	if err != nil {
 		t.Fatalf("ThreadResume: %v", err)
 	}
-	if resumed.Thread.ID != threadID || resumeCalls != 0 {
+	if resumed.Thread.ID != threadID || resumed.Thread.Evener.Ref != "local:"+threadID || resumeCalls != 0 {
 		t.Fatalf("resume = %+v, replacement calls = %d", resumed.Thread, resumeCalls)
 	}
 
@@ -8493,7 +8511,7 @@ func TestHubRPCModelListReportsEvenerLaunchDiagnostics(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-	  printf '{"protocol":"evener-appwire-v4","models":[{"provider":"ollama","model":"local"}],"diagnostics":[{"provider":"openai","source":"provider","title":"Provider error","message":"HTTP 403"}]}\n'
+	  printf '{"protocol":"evener-appwire-v5","models":[{"provider":"ollama","model":"local"}],"diagnostics":[{"provider":"openai","source":"provider","title":"Provider error","message":"HTTP 403"}]}\n'
   exit 0
 fi
 exit 2
@@ -8571,78 +8589,147 @@ func TestHubRPCThreadStartKeepsProviderForModelIDsWithSlashes(t *testing.T) {
 }
 
 func TestHubRPCThreadStartDeliversPromptWhenFirstRosterProbeFails(t *testing.T) {
-	const sessionID = "033snFBSHFr78ZbQQMAeBD"
-	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
-	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
-		return appwire.ThreadReadResponse{Thread: appwire.Thread{
-			ID:        sessionID,
-			SessionID: sessionID,
-			Source:    "local",
-			Evener: appwire.EvenerThread{
-				Ref:          params.Ref,
-				Capabilities: appwire.ThreadCapabilities{Send: true},
-			},
-		}}, nil
-	})
-	var gotPrompt string
-	appserver.HandleTyped(daemon.Router(), appwire.MethodTurnStart, func(_ context.Context, params appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
-		gotPrompt = inputTextForTest(params.Input)
-		return appwire.TurnStartResponse{Turn: appwire.Turn{ID: "turn_1"}}, nil
-	})
-	daemonHTTP := httptest.NewUnstartedServer(http.HandlerFunc(daemon.ServeWebSocket))
-	dropper := &dropFirstConnectionListener{
-		Listener: daemonHTTP.Listener,
-		dropped:  make(chan struct{}),
-	}
-	daemonHTTP.Listener = dropper
-	daemonHTTP.Start()
-	defer daemonHTTP.Close()
+	for _, fault := range []string{"probe", "listing", "status", "stale-instance"} {
+		t.Run(fault, func(t *testing.T) {
+			const sessionID = "033snFBSHFr78ZbQQMAeBD"
+			daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+				return appwire.ThreadReadResponse{Thread: appwire.Thread{
+					ID:        sessionID,
+					SessionID: sessionID,
+					Source:    "local",
+					Evener: appwire.EvenerThread{
+						Ref:          params.Ref,
+						Capabilities: appwire.ThreadCapabilities{Send: true},
+						Diagnostics: &appwire.EvenerDiagnostics{Delegates: []appwire.EvenerDelegateInfo{
+							{ChildSessionID: "active-child", Lifecycle: "running", Status: "running"},
+							{ChildSessionID: "idle-child", Lifecycle: "idle", Status: "completed", Resumable: true},
+							{ChildSessionID: "closed-child", Lifecycle: "closed", Status: "completed", Terminal: true},
+						}},
+					},
+				}}, nil
+			})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+				if fault == "status" {
+					return appwire.ThreadListResponse{}, appwire.Unavailable("status temporarily unavailable")
+				}
+				return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: sessionID, SessionID: sessionID, Status: appwire.ThreadStatus{Type: appwire.ThreadStatusIdle}}}}, nil
+			})
+			var gotPrompt string
+			var turns int
+			appserver.HandleTyped(daemon.Router(), appwire.MethodTurnStart, func(_ context.Context, params appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
+				gotPrompt = inputTextForTest(params.Input)
+				turns++
+				return appwire.TurnStartResponse{Turn: appwire.Turn{ID: "turn_1"}}, nil
+			})
+			daemonHTTP := httptest.NewUnstartedServer(http.HandlerFunc(daemon.ServeWebSocket))
+			dropper := &dropFirstConnectionListener{
+				Listener: daemonHTTP.Listener,
+				dropped:  make(chan struct{}),
+			}
+			if fault == "probe" {
+				daemonHTTP.Listener = dropper
+			}
+			daemonHTTP.Start()
+			defer daemonHTTP.Close()
 
-	runDir := t.TempDir()
-	entry := rendezvous.Entry{
-		PID:       os.Getpid(),
-		Protocol:  appwire.ProtocolVersion,
-		Endpoint:  "ws" + strings.TrimPrefix(daemonHTTP.URL, "http"),
-		SourceID:  "local",
-		ThreadID:  sessionID,
-		SessionID: sessionID,
-	}
-	spawner := &fakeRPCSpawner{spawn: func(context.Context, hubcore.SpawnRequest) (rendezvous.Entry, error) {
-		writeRendezvous(t, runDir, entry)
-		return entry, nil
-	}}
-	roster := hubcore.NewRoster(runDir, failedRPCProber{})
-	hub := newHubRPCTestServer(t, hubcore.WebConfig{
-		RunDir:  runDir,
-		Roster:  roster,
-		Spawner: spawner,
-		Past:    hubcore.NewPastIndex(""),
-	})
-	defer hub.Close()
-	client := dialHubRPC(t, hub)
-	defer client.Close()
+			runDir := t.TempDir()
+			entry := rendezvous.Entry{
+				PID:       os.Getpid(),
+				Protocol:  appwire.ProtocolVersion,
+				Endpoint:  "ws" + strings.TrimPrefix(daemonHTTP.URL, "http"),
+				SourceID:  "local",
+				ThreadID:  sessionID,
+				SessionID: sessionID,
+			}
+			if fault == "stale-instance" {
+				entry.InstanceID = "fresh-instance"
+			}
+			var spawns int
+			spawner := &fakeRPCSpawner{spawn: func(context.Context, hubcore.SpawnRequest) (rendezvous.Entry, error) {
+				spawns++
+				writeRendezvous(t, runDir, entry)
+				if fault == "listing" || fault == "stale-instance" {
+					if err := os.WriteFile(filepath.Join(runDir, "1.json"), []byte("{"), 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return entry, nil
+			}}
+			roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+			if fault == "stale-instance" {
+				old := entry
+				old.InstanceID = "previous-instance"
+				writeRendezvous(t, runDir, old)
+				roster.Refresh()
+			}
+			hub := newHubRPCTestServer(t, hubcore.WebConfig{
+				RunDir:  runDir,
+				Roster:  roster,
+				Spawner: spawner,
+				Past:    hubcore.NewPastIndex(""),
+			})
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
 
-	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
-		t.Fatalf("Initialize: %v", err)
-	}
-	resp, err := client.ThreadStart(context.Background(), appwire.ThreadStartParams{
-		Model: "openai/gpt-5",
-		CWD:   "/tmp",
-		Input: []appwire.InputItem{{Type: "text", Text: "review the open PRs"}},
-	})
-	if err != nil {
-		t.Fatalf("ThreadStart: %v", err)
-	}
-	select {
-	case <-dropper.dropped:
-	default:
-		t.Fatal("startup test did not drop the first daemon connection")
-	}
-	if gotPrompt != "review the open PRs" {
-		t.Fatalf("prompt=%q, want review the open PRs", gotPrompt)
-	}
-	if resp.Thread.Evener.Ref != "local:"+sessionID || resp.Turn.ID != "turn_1" {
-		t.Fatalf("response=%+v", resp)
+			if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			resp, err := client.ThreadStart(context.Background(), appwire.ThreadStartParams{
+				Model: "openai/gpt-5",
+				CWD:   "/tmp",
+				Input: []appwire.InputItem{{Type: "text", Text: "review the open PRs"}},
+			})
+			if err != nil {
+				t.Fatalf("ThreadStart: %v", err)
+			}
+			if fault == "probe" {
+				select {
+				case <-dropper.dropped:
+				default:
+					t.Fatal("startup test did not drop the first daemon connection")
+				}
+			}
+			if gotPrompt != "review the open PRs" {
+				t.Fatalf("prompt=%q, want review the open PRs", gotPrompt)
+			}
+			if resp.Thread.Evener.Ref != "local:"+sessionID || resp.Turn.ID != "turn_1" {
+				t.Fatalf("response=%+v", resp)
+			}
+
+			if spawns != 1 || turns != 1 {
+				t.Fatalf("spawns=%d turns=%d", spawns, turns)
+			}
+			if live, ok := roster.Find(sessionID); !ok || live.PID != entry.PID || live.Crashed {
+				t.Errorf("spawned daemon is not registered: %+v, present=%v", live, ok)
+			}
+			if live, _ := roster.Find(sessionID); live.InstanceID != entry.InstanceID {
+				t.Errorf("registered instance=%q, want %q", live.InstanceID, entry.InstanceID)
+			}
+			if state, ok := roster.SubagentState("active-child"); !ok || state != appwire.ThreadStatusActive {
+				t.Errorf("active child projection: state=%q live=%v", state, ok)
+			}
+			if state, ok := roster.SubagentState("idle-child"); !ok || state != appwire.ThreadStatusIdle {
+				t.Errorf("idle child projection: state=%q live=%v", state, ok)
+			}
+			if roster.IsSubagentActive("closed-child") {
+				t.Error("closed child published as live")
+			}
+			if _, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: resp.Thread.Evener.Ref}); err != nil {
+				t.Fatalf("subsequent ThreadRead: %v", err)
+			}
+			if _, err := client.TurnStart(context.Background(), appwire.TurnStartParams{
+				Ref: resp.Thread.Evener.Ref, ClientMutationID: "follow-up", ExpectedInstanceID: sessionID,
+				Input: []appwire.InputItem{{Type: "text", Text: "continue review"}},
+			}); err != nil {
+				t.Fatalf("subsequent TurnStart: %v", err)
+			}
+			if spawns != 1 || turns != 2 || gotPrompt != "continue review" {
+				t.Fatalf("follow-up delivery: spawns=%d turns=%d prompt=%q", spawns, turns, gotPrompt)
+			}
+
+		})
 	}
 }
 
@@ -9312,6 +9399,259 @@ func TestHubRPCThreadResumeSpawnsAndReadsDaemon(t *testing.T) {
 	}
 	if resp.Thread.ID != "th_resumed" || resp.Thread.Evener.Ref != "local:th_resumed" {
 		t.Fatalf("thread=%+v", resp.Thread)
+	}
+}
+
+func TestHubRPCThreadResumeConfirmsSpawnAfterDiscoveryFailure(t *testing.T) {
+	for _, fault := range []string{"status", "listing", "confirmed", "read", "identity"} {
+		t.Run(fault, func(t *testing.T) {
+			const sessionID = "resumed-owner"
+			daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+				if fault == "confirmed" {
+					return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: sessionID, SessionID: sessionID, Status: appwire.ThreadStatus{Type: appwire.ThreadStatusIdle}}}}, nil
+				}
+				return appwire.ThreadListResponse{}, appwire.Unavailable("inventory unavailable")
+			})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+				if fault == "read" {
+					return appwire.ThreadReadResponse{}, appwire.Unavailable("read unavailable")
+				}
+				id := sessionID
+				if fault == "identity" {
+					id = "different-owner"
+				}
+				return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: id, SessionID: id, Status: appwire.ThreadStatus{Type: appwire.ThreadStatusIdle}}}, nil
+			})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodTurnStart, func(context.Context, appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
+				return appwire.TurnStartResponse{Turn: appwire.Turn{ID: "delivered"}}, nil
+			})
+			peer := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+			defer peer.Close()
+			runDir := t.TempDir()
+			roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+			entry := rendezvous.Entry{PID: os.Getpid(), Protocol: appwire.ProtocolVersion, Endpoint: "ws" + strings.TrimPrefix(peer.URL, "http"), SourceID: "local", ThreadID: sessionID, SessionID: sessionID}
+			spawns := 0
+			spawner := &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				spawns++
+				writeRendezvous(t, runDir, entry)
+				if fault == "confirmed" {
+					roster.Refresh()
+				}
+				if fault == "listing" || fault == "confirmed" {
+					if err := os.WriteFile(filepath.Join(runDir, "1.json"), []byte("{"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return entry, nil
+			}}
+			hub := newHubRPCTestServer(t, hubcore.WebConfig{RunDir: runDir, Roster: roster, Spawner: spawner, ResumeLocks: hubcore.NewResumeLocks()})
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatal(err)
+			}
+			response, err := client.ThreadResume(context.Background(), appwire.ThreadResumeParams{Session: sessionID})
+			if spawns != 1 {
+				t.Fatalf("spawns=%d", spawns)
+			}
+			if fault == "read" || fault == "identity" {
+				if err == nil || roster.HasConfirmedEntry(entry) {
+					t.Fatalf("unverified owner admitted: error=%v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.Thread.ID != sessionID || !roster.HasConfirmedEntry(entry) {
+				t.Fatalf("resume did not publish owner: %+v", response.Thread)
+			}
+			if _, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: "local:" + sessionID}); err != nil {
+				t.Fatal(err)
+			}
+			turn, err := client.TurnStart(context.Background(), appwire.TurnStartParams{Ref: "local:" + sessionID, ClientMutationID: "resume-followup", ExpectedInstanceID: sessionID, Input: []appwire.InputItem{{Type: "text", Text: "continue"}}})
+			if err != nil || turn.Turn.ID != "delivered" {
+				t.Fatalf("followup=%+v error=%v", turn, err)
+			}
+		})
+	}
+}
+
+func TestHubRPCSubscribedReadRefreshesReplacedDaemonOwnership(t *testing.T) {
+	for _, sameEndpoint := range []bool{false, true} {
+		t.Run(fmt.Sprint("same endpoint=", sameEndpoint), func(t *testing.T) {
+			testHubSubscribedReadReplacedOwner(t, sameEndpoint, appwire.MethodThreadRead, serveProtocolMismatch)
+		})
+	}
+}
+
+func TestHubRPCSessionActionsRefreshReplacedDaemonOwnership(t *testing.T) {
+	for _, method := range []string{appwire.MethodThreadShutdown, appwire.MethodThreadModelSet, appwire.MethodThreadVisionModelSet, appwire.MethodThreadCompactStart, appwire.MethodGoalSet} {
+		t.Run(method, func(t *testing.T) { testHubSubscribedReadReplacedOwner(t, true, method, serveProtocolMismatch) })
+	}
+}
+
+func TestHubRPCTurnStartRefreshesReplacedDaemonBeforeRelay(t *testing.T) {
+	testHubSubscribedReadReplacedOwner(t, true, appwire.MethodTurnStart, serveProtocolMismatch)
+}
+
+func TestHubRPCCachedRouteRefreshesTypedProtocolMismatch(t *testing.T) {
+	for _, method := range []string{appwire.MethodThreadRead, appwire.MethodTurnStart, appwire.MethodThreadModelSet} {
+		t.Run(method, func(t *testing.T) { testHubSubscribedReadReplacedOwner(t, true, method, serveTypedProtocolMismatch) })
+	}
+}
+
+func testHubSubscribedReadReplacedOwner(t *testing.T, sameEndpoint bool, method string, replacement http.HandlerFunc) {
+	root := t.TempDir()
+	sessionID := buildRPCParentSession(t, filepath.Join(root, "projects", "upgrade-0000000000"))
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: sessionID, SessionID: sessionID, Status: appwire.ThreadStatus{Type: appwire.ThreadStatusIdle}}}}, nil
+	})
+	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: sessionID, SessionID: sessionID, Status: appwire.ThreadStatus{Type: appwire.ThreadStatusIdle}}}, nil
+	})
+	var handlerMu sync.RWMutex
+	serve := http.HandlerFunc(daemon.ServeWebSocket)
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerMu.RLock()
+		handler := serve
+		handlerMu.RUnlock()
+		handler(w, r)
+	}))
+	defer peer.Close()
+	runDir := t.TempDir()
+	entry := rendezvous.Entry{PID: os.Getpid(), Protocol: appwire.ProtocolVersion, Endpoint: "ws" + strings.TrimPrefix(peer.URL, "http"), SourceID: "local", ThreadID: sessionID, SessionID: sessionID}
+	writeRendezvous(t, runDir, entry)
+	roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+	roster.Refresh()
+	if !roster.HasConfirmedEntry(entry) {
+		t.Fatal("owner not confirmed")
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{RunDir: runDir, Roster: roster, Past: past})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	entry.Protocol = "evener-appwire-v4"
+	if sameEndpoint {
+		handlerMu.Lock()
+		serve = replacement
+		handlerMu.Unlock()
+	} else {
+		peer.Close()
+		entry.Endpoint = protocolMismatchPeer(t)
+	}
+	writeRendezvous(t, runDir, entry)
+	if method != appwire.MethodThreadRead {
+		params := map[string]any{"ref": "local:" + sessionID}
+		switch method {
+		case appwire.MethodTurnStart:
+			params["clientMutationId"] = "replacement-send"
+			params["expectedInstanceId"] = sessionID
+			params["input"] = []appwire.InputItem{{Type: "text", Text: "keep this message"}}
+		case appwire.MethodThreadModelSet:
+			params["modelProvider"], params["model"] = "test", "test-model"
+		case appwire.MethodThreadVisionModelSet:
+			params["visionModel"] = "test/vision"
+		case appwire.MethodGoalSet:
+			params["objective"] = "test goal"
+		}
+		var response any
+		err := client.Request(context.Background(), method, params, &response)
+		if !isDaemonRestartRequiredError(err) {
+			t.Fatalf("error=%v", err)
+		}
+		if method == appwire.MethodTurnStart {
+			var wire appwire.WireError
+			if !errors.As(err, &wire) {
+				t.Fatal(err)
+			}
+			data, ok := wire.Data.(map[string]any)
+			if !ok || data["clientMutationId"] != "replacement-send" || data["mutationOutcome"] != "unknown" || data["retryDisposition"] != "blocked" {
+				t.Fatalf("mutation outcome=%+v", wire.Data)
+			}
+		}
+		return
+	}
+	response, err := client.ThreadRead(context.Background(), appwire.ThreadReadParams{Ref: "local:" + sessionID, IncludeTurns: true, Subscribe: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.Thread.Status.Type != appwire.ThreadStatusRestartRequired {
+		t.Fatalf("status=%s", response.Thread.Status.Type)
+	}
+	if response.Thread.Evener.Capabilities.Send || len(response.Thread.Turns) != 2 {
+		t.Fatalf("thread=%+v", response.Thread)
+	}
+}
+
+func TestHubRPCThreadResumeVerifiesExistingOwnerWhenDiscoveryFails(t *testing.T) {
+	for _, state := range []string{"healthy", "unreachable", "absent"} {
+		t.Run(state, func(t *testing.T) {
+			const sessionID = "confirmed-owner"
+			daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+			thread := appwire.Thread{ID: sessionID, SessionID: sessionID, Status: appwire.ThreadStatus{Type: appwire.ThreadStatusIdle}}
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+				return appwire.ThreadListResponse{Data: []appwire.Thread{thread}}, nil
+			})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+				return appwire.ThreadReadResponse{Thread: thread}, nil
+			})
+			peer := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+			defer peer.Close()
+			runDir := t.TempDir()
+			roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+			if state != "absent" {
+				writeRendezvous(t, runDir, rendezvous.Entry{PID: os.Getpid(), Protocol: appwire.ProtocolVersion, Endpoint: "ws" + strings.TrimPrefix(peer.URL, "http"), SourceID: "local", ThreadID: sessionID, SessionID: sessionID})
+				roster.Refresh()
+				if _, ok := roster.Find(sessionID); !ok {
+					t.Fatal("owner was not confirmed")
+				}
+			}
+			if state == "unreachable" {
+				peer.Close()
+			}
+			if err := os.WriteFile(filepath.Join(runDir, "1.json"), []byte("{"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			spawned := false
+			hub := newHubRPCTestServer(t, hubcore.WebConfig{RunDir: runDir, Roster: roster, ResumeLocks: hubcore.NewResumeLocks(), Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				spawned = true
+				return rendezvous.Entry{}, errors.New("unexpected replacement")
+			}}})
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatal(err)
+			}
+			response, err := client.ThreadResume(context.Background(), appwire.ThreadResumeParams{Session: sessionID})
+			if spawned {
+				t.Fatal("spawned despite incomplete ownership discovery")
+			}
+			if state == "healthy" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if response.Thread.ID != sessionID {
+					t.Fatalf("thread=%+v", response.Thread)
+				}
+			} else if err == nil {
+				t.Fatal("resume succeeded without a verified owner")
+			}
+			if roster.OwnershipError() == nil {
+				t.Fatal("partial confirmation cleared the discovery failure")
+			}
+		})
 	}
 }
 
@@ -10031,100 +10371,111 @@ func TestHubRPCTurnStartResumesPastThreadAndRelaysNotifications(t *testing.T) {
 }
 
 func TestHubRPCTurnStartResumesPastThreadAfterLocalTransportError(t *testing.T) {
-	root := t.TempDir()
-	workingDir := t.TempDir()
-	stateDir := filepath.Join(root, "projects", "project-past-0000000000")
-	sessionID := buildRPCParentSessionWithWorkingDir(t, stateDir, workingDir)
-	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
-	if _, err := past.Rebuild(); err != nil {
-		t.Fatal(err)
-	}
-
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	staleAddress := ln.Addr().String()
-	staleEndpoint := "ws://" + ln.Addr().String() + "/rpc"
-	if err := ln.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
-	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
-		appserver.Subscribe(ctx, sessionID)
-		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: sessionID, SessionID: sessionID, Source: "local", Evener: appwire.EvenerThread{Ref: params.Ref, Capabilities: appwire.ThreadCapabilities{Send: true}}}}, nil
-	})
-	appserver.HandleTyped(daemon.Router(), appwire.MethodTurnStart, func(context.Context, appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
-		return appwire.TurnStartResponse{Turn: appwire.Turn{ID: "turn_recovered"}}, nil
-	})
-	daemonHTTP := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
-	defer daemonHTTP.Close()
-
-	runDir := t.TempDir()
-	writeRendezvous(t, runDir, rendezvous.Entry{
-		PID:       -1,
-		Address:   staleAddress,
-		Protocol:  appwire.ProtocolVersion,
-		Endpoint:  staleEndpoint,
-		SourceID:  "local",
-		ThreadID:  sessionID,
-		SessionID: sessionID,
-		StartedAt: time.Now().UTC(), // fresh crash: within the roster's crash-retention window
-	})
-	prober := perAddrProber{byAddr: map[string]struct{ SessionID, Status string }{}}
-	roster := hubcore.NewRoster(runDir, prober)
-	roster.Refresh()
-	if stale, ok := roster.Find(sessionID); !ok || stale.Status != "errored" || !stale.Crashed {
-		t.Fatalf("stale roster entry = %+v, %v; want retained crash marker", stale, ok)
-	}
-	resumeCalled := false
-	spawner := &fakeRPCSpawner{
-		resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
-			if req.WorkingDir != workingDir {
-				t.Fatalf("resume request=%+v", req)
+	for _, refreshFailure := range []bool{false, true} {
+		t.Run(fmt.Sprint("refresh failure=", refreshFailure), func(t *testing.T) {
+			root := t.TempDir()
+			workingDir := t.TempDir()
+			stateDir := filepath.Join(root, "projects", "project-past-0000000000")
+			sessionID := buildRPCParentSessionWithWorkingDir(t, stateDir, workingDir)
+			past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+			if _, err := past.Rebuild(); err != nil {
+				t.Fatal(err)
 			}
-			resumeCalled = true
-			entry := rendezvous.Entry{
-				PID:        110,
-				Address:    daemonHTTP.Listener.Addr().String(),
-				Protocol:   appwire.ProtocolVersion,
-				Endpoint:   "ws" + daemonHTTP.URL[len("http"):],
-				SourceID:   "local",
-				ThreadID:   sessionID,
-				SessionID:  sessionID,
-				WorkingDir: workingDir,
-				StartedAt:  time.Now().UTC(), // a real spawn stamps StartedAt; it must outrank the stale crashed entry
+
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
 			}
-			prober.byAddr[entry.Address] = struct{ SessionID, Status string }{SessionID: sessionID, Status: "idle"}
-			writeRendezvous(t, runDir, entry)
+			staleAddress := ln.Addr().String()
+			staleEndpoint := "ws://" + ln.Addr().String() + "/rpc"
+			if err := ln.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+				appserver.Subscribe(ctx, sessionID)
+				return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: sessionID, SessionID: sessionID, Source: "local", Evener: appwire.EvenerThread{Ref: params.Ref, Capabilities: appwire.ThreadCapabilities{Send: true}}}}, nil
+			})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodTurnStart, func(context.Context, appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
+				return appwire.TurnStartResponse{Turn: appwire.Turn{ID: "turn_recovered"}}, nil
+			})
+			daemonHTTP := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+			defer daemonHTTP.Close()
+
+			runDir := t.TempDir()
+			writeRendezvous(t, runDir, rendezvous.Entry{
+				PID:       -1,
+				Address:   staleAddress,
+				Protocol:  appwire.ProtocolVersion,
+				Endpoint:  staleEndpoint,
+				SourceID:  "local",
+				ThreadID:  sessionID,
+				SessionID: sessionID,
+				StartedAt: time.Now().UTC(), // fresh crash: within the roster's crash-retention window
+			})
+			prober := perAddrProber{byAddr: map[string]struct{ SessionID, Status string }{}}
+			roster := hubcore.NewRoster(runDir, prober)
 			roster.Refresh()
-			return entry, nil
-		},
-	}
-	hub := newHubRPCTestServer(t, hubcore.WebConfig{
-		RunDir:      runDir,
-		Roster:      roster,
-		Spawner:     spawner,
-		Past:        past,
-		ResumeLocks: hubcore.NewResumeLocks(),
-	})
-	defer hub.Close()
-	client := dialHubRPC(t, hub)
-	defer client.Close()
+			if stale, ok := roster.Find(sessionID); !ok || stale.Status != "errored" || !stale.Crashed {
+				t.Fatalf("stale roster entry = %+v, %v; want retained crash marker", stale, ok)
+			}
+			resumeCalled := false
+			spawner := &fakeRPCSpawner{
+				resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+					if req.WorkingDir != workingDir {
+						t.Fatalf("resume request=%+v", req)
+					}
+					resumeCalled = true
+					entry := rendezvous.Entry{
+						PID:        110,
+						Address:    daemonHTTP.Listener.Addr().String(),
+						Protocol:   appwire.ProtocolVersion,
+						Endpoint:   "ws" + daemonHTTP.URL[len("http"):],
+						SourceID:   "local",
+						ThreadID:   sessionID,
+						SessionID:  sessionID,
+						WorkingDir: workingDir,
+						StartedAt:  time.Now().UTC(), // a real spawn stamps StartedAt; it must outrank the stale crashed entry
+					}
+					prober.byAddr[entry.Address] = struct{ SessionID, Status string }{SessionID: sessionID, Status: "idle"}
+					writeRendezvous(t, runDir, entry)
+					if refreshFailure {
+						if err := os.WriteFile(filepath.Join(runDir, "1.json"), []byte("{"), 0600); err != nil {
+							t.Fatal(err)
+						}
+					}
 
-	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
-		t.Fatalf("Initialize: %v", err)
-	}
-	resp, err := client.TurnStart(context.Background(), appwire.TurnStartParams{ClientMutationID: "test-mutation", ExpectedInstanceID: sessionID, Ref: "local:" + sessionID, Input: []appwire.InputItem{{Type: "text", Text: "resume work"}}})
-	if err != nil {
-		t.Fatalf("TurnStart: %v", err)
-	}
-	if !resumeCalled {
-		t.Fatal("resume was not called after local transport error")
-	}
-	if resp.Turn.ID != "turn_recovered" {
-		t.Fatalf("turn=%+v", resp.Turn)
+					roster.Refresh()
+					return entry, nil
+				},
+			}
+			hub := newHubRPCTestServer(t, hubcore.WebConfig{
+				RunDir:      runDir,
+				Roster:      roster,
+				Spawner:     spawner,
+				Past:        past,
+				ResumeLocks: hubcore.NewResumeLocks(),
+			})
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+
+			if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatalf("Initialize: %v", err)
+			}
+			resp, err := client.TurnStart(context.Background(), appwire.TurnStartParams{ClientMutationID: "test-mutation", ExpectedInstanceID: sessionID, Ref: "local:" + sessionID, Input: []appwire.InputItem{{Type: "text", Text: "resume work"}}})
+			if err != nil {
+				t.Fatalf("TurnStart: %v", err)
+			}
+			if !resumeCalled {
+				t.Fatal("resume was not called after local transport error")
+			}
+			if resp.Turn.ID != "turn_recovered" {
+				t.Fatalf("turn=%+v", resp.Turn)
+			}
+
+		})
 	}
 }
 
@@ -11301,5 +11652,37 @@ func TestHubRPCThreadStartEmptyModelRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "model is required") {
 		t.Fatalf("error = %v, want error containing \"model is required\"", err)
+	}
+}
+
+func TestHubRPCSavedDelegateReadDoesNotClaimMutationAuthority(t *testing.T) {
+	for _, status := range []string{appwire.ThreadStatusActive, appwire.ThreadStatusIdle} {
+		t.Run(status, func(t *testing.T) {
+			cfg, childID := runningSubagentProjectionConfigWithState(t, status)
+			entries := cfg.Roster.List()
+			entries[0].Protocol = appwire.ProtocolVersion
+			entries[0].Endpoint = "ws://unused.invalid/appwire"
+			cfg.Roster = hubcore.NewRosterWithEntries(entries...)
+			sources := appsource.NewRegistry()
+			sources.Add(&pastFallbackRelaySource{
+				thread:  appwire.Thread{ID: childID, Evener: appwire.EvenerThread{Ref: "local:" + childID}},
+				readErr: errors.New("delegate transport failed"),
+			})
+			app := newHubAppServer(cfg, sources)
+			hub := httptest.NewServer(http.HandlerFunc(app.ServeWebSocket))
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+				t.Fatal(err)
+			}
+			response, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: "local:" + childID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.Thread.Status.Type != status || response.Thread.Evener.MutationStateAuthoritative {
+				t.Fatalf("saved delegate status=%q mutation authority=%v", response.Thread.Status.Type, response.Thread.Evener.MutationStateAuthoritative)
+			}
+		})
 	}
 }

--- a/cmd/evener-hub/app_session_delete.go
+++ b/cmd/evener-hub/app_session_delete.go
@@ -53,7 +53,7 @@ func (s *WebServer) sessionDelete(ctx context.Context, params appwire.SessionDel
 	target := hubcore.DeletionTarget{Ref: localAppRef(threadID), ThreadID: threadID}
 	record := hubcore.DeletionRecord{Targets: []hubcore.DeletionTarget{target}}
 	stateDirs := map[string]string{threadID: pe.StateDir}
-	release, ownerErr := s.acquireProjectDeletionOwnership(record, stateDirs)
+	release, ownerErr := s.acquireProjectDeletionOwnership(ctx, record, stateDirs)
 	if ownerErr != nil {
 		var skipped []projectDeleteSkip
 		if errors.Is(ownerErr.Err, llm.ErrAPILogTargetLocked) || ownerErr.Live {
@@ -78,9 +78,7 @@ func (s *WebServer) sessionDelete(ctx context.Context, params appwire.SessionDel
 	if err != nil {
 		decisionErrors = append(decisionErrors, "past index rebuild error: "+err.Error())
 	}
-	if s.cfg.Roster != nil {
-		hubRosterRefresh(s.cfg.Roster)
-	}
+	s.refreshRosterAfterDeletion(ctx)
 	if s.cfg.Inputs != nil {
 		s.cfg.Inputs.Bump()
 	}
@@ -123,10 +121,6 @@ func (s *WebServer) sessionDeleteResponse(
 	if s.navigation == nil {
 		return appwire.SessionDeleteResponse{}, appwire.Unavailable("navigation unavailable")
 	}
-	navigation, err := s.navigation.Refresh(ctx, hint)
-	if err != nil {
-		return appwire.SessionDeleteResponse{}, appwire.Unavailable(err.Error())
-	}
-	response.Navigation = navigation
+	response.Navigation = s.navigationAfterDeletion(ctx, hint)
 	return response, nil
 }

--- a/cmd/evener-hub/app_session_delete_test.go
+++ b/cmd/evener-hub/app_session_delete_test.go
@@ -1,13 +1,18 @@
 package hub
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/identifier"
@@ -389,7 +394,7 @@ func TestSessionDeleteFailsWithoutPastIndex(t *testing.T) {
 	}
 }
 
-func TestSessionDeleteReportsNavigationFailureAfterCommittedCleanup(t *testing.T) {
+func TestSessionDeletePreservesSuccessAfterNavigationFailure(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "project")
 	if err := os.MkdirAll(projectDir, 0o755); err != nil {
@@ -410,14 +415,9 @@ func TestSessionDeleteReportsNavigationFailureAfterCommittedCleanup(t *testing.T
 	failingSource.err = errors.New("capture failed")
 	web.navigation = newTestNavigationService(t, failingSource)
 
-	_, err = dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: "local:" + webTestSessionID})
-	var wireErr appwire.WireError
-	if !errors.As(err, &wireErr) || wireErr.Code != appwire.CodeUnavailable {
-		t.Fatalf("navigation failure error = %v, want action unavailable", err)
-	}
-	data, ok := wireErr.Data.(appwire.ErrorData)
-	if !ok || data.EvenerErrorInfo != appwire.ErrorActionUnavailable {
-		t.Fatalf("navigation failure data = %#v, want actionUnavailable", wireErr.Data)
+	response, err := dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: "local:" + webTestSessionID})
+	if err != nil || len(response.Deleted) != 1 || response.Deleted[0] != webTestSessionID || len(response.Skipped) != 0 {
+		t.Fatalf("committed deletion outcome: response=%+v error=%v", response, err)
 	}
 	if _, err := os.Stat(filepath.Join(stateDir, "sessions", webTestSessionID+".meta.json")); !os.IsNotExist(err) {
 		t.Fatalf("cleanup must remain committed when the navigation receipt fails: %v", err)
@@ -575,9 +575,9 @@ func TestSessionDeleteRefreshesRosterAndBustsTreeMemo(t *testing.T) {
 
 	var events []string
 	prevRefresh := hubRosterRefresh
-	hubRosterRefresh = func(r *hubcore.Roster) {
+	hubRosterRefresh = func(ctx context.Context, r *hubcore.Roster) error {
 		events = append(events, "roster-refresh")
-		prevRefresh(r)
+		return prevRefresh(ctx, r)
 	}
 	t.Cleanup(func() { hubRosterRefresh = prevRefresh })
 
@@ -601,5 +601,242 @@ func TestSessionDeleteRefreshesRosterAndBustsTreeMemo(t *testing.T) {
 	}
 	if len(events) < 2 || events[0] != "roster-refresh" || events[1] != "poke" {
 		t.Fatalf("events=%v, want the roster refreshed before PokeAttention", events)
+	}
+}
+
+func TestSessionDeletePreservesUnconfirmedDaemonState(t *testing.T) {
+	for _, identity := range []string{"known", "unidentified"} {
+		t.Run(identity, func(t *testing.T) {
+			root := t.TempDir()
+			stateDir := filepath.Join(root, "projects", "delete-uncertain-0123456789")
+			writeSession(t, stateDir, webTestSessionID, root)
+			past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+			if _, err := past.Rebuild(); err != nil {
+				t.Fatal(err)
+			}
+			runDir := t.TempDir()
+			entry := rendezvous.Entry{PID: os.Getpid(), SessionID: webTestSessionID, ThreadID: webTestSessionID}
+			if identity == "unidentified" {
+				entry.SessionID = ""
+				entry.ThreadID = ""
+			}
+			writeRendezvous(t, runDir, entry)
+			roster := hubcore.NewRoster(runDir, &fakeProber{shouldFail: true})
+			roster.Refresh()
+			if len(roster.UnconfirmedEntries()) != 1 {
+				t.Fatal("missing unconfirmed claim")
+			}
+			web := NewWebServer(hubcore.WebConfig{Past: past, Roster: roster, RunDir: runDir})
+			response, err := dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(webTestSessionID)})
+			if len(response.Deleted) > 0 {
+				t.Fatalf("deleted an unconfirmed live session: %+v", response)
+			}
+			if _, statErr := os.Stat(filepath.Join(stateDir, "sessions", webTestSessionID+".meta.json")); statErr != nil {
+				t.Fatalf("session state removed despite unconfirmed owner: %v (response error: %v)", statErr, err)
+			}
+			if err := rendezvous.Remove(runDir, entry.PID); err != nil {
+				t.Fatal(err)
+			}
+			roster.Refresh()
+			response, err = dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(webTestSessionID)})
+			if err != nil || len(response.Deleted) != 1 {
+				t.Fatalf("deletion stayed blocked after ownership cleared: response=%+v error=%v", response, err)
+			}
+		})
+	}
+}
+
+func TestFailedInitialRosterScanBlocksNavigationAndDeletion(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "delete-uncertain-0123456789")
+	writeSession(t, stateDir, webTestSessionID, root)
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	runDir := t.TempDir()
+	claim := filepath.Join(runDir, "1.json")
+	if err := os.WriteFile(claim, []byte("{"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	roster := hubcore.NewRoster(runDir, &fakeProber{})
+	roster.Refresh()
+	web := NewWebServer(hubcore.WebConfig{Past: past, Roster: roster, RunDir: runDir})
+	assertNavigationOwnershipReadOnly(t, web)
+	response, deleteErr := dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(webTestSessionID)})
+	if len(response.Deleted) > 0 {
+		t.Error("deleted session after failed discovery")
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", webTestSessionID+".meta.json")); err != nil {
+		t.Fatalf("state removed after failed discovery: %v (delete error: %v)", err, deleteErr)
+	}
+	if err := os.Remove(claim); err != nil {
+		t.Fatal(err)
+	}
+	roster.Refresh()
+	if _, err := (webNavigationSource{web: web}).Capture(t.Context(), "generation", time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	response, err := dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(webTestSessionID)})
+	if err != nil || len(response.Deleted) != 1 {
+		t.Fatalf("recovered deletion=%+v error=%v", response, err)
+	}
+}
+
+func TestSessionDeletePreservesDaemonOwnedDelegates(t *testing.T) {
+	for _, status := range []string{appwire.ThreadStatusActive, appwire.ThreadStatusRestartRequired, "unconfirmed"} {
+		for _, nested := range []bool{false, true} {
+			name := status + "/direct"
+			if nested {
+				name = status + "/nested"
+			}
+			t.Run(name, func(t *testing.T) {
+				root := t.TempDir()
+				projectDir := filepath.Join(root, "project")
+				if err := os.MkdirAll(projectDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				stateDir := filepath.Join(root, "projects", "session-delete-0123456789")
+				rootID, parentID, childID := projectDeleteCanonicalSessionIDs[0], projectDeleteCanonicalSessionIDs[1], projectDeleteCanonicalSessionIDs[2]
+				writeSession(t, stateDir, rootID, projectDir)
+				events := []map[string]any{}
+				addChild := func(id, parent, parentDelegate, delegate string) {
+					writeSession(t, stateDir, id, projectDir)
+					meta, err := schema.LoadSessionMeta(stateDir, id)
+					if err != nil {
+						t.Fatal(err)
+					}
+					meta.ParentSessionID, meta.JobTreeRootSessionID, meta.IsSubagent = parent, rootID, true
+					if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+						t.Fatal(err)
+					}
+					descriptor := map[string]any{"owner_session_id": rootID, "child_session_id": id, "parent_delegate_id": parentDelegate, "transcript_ref": localAppRef(id), "task": "delete ownership", "agent_type": "explorer", "tool_name_ceiling": []string{"communicate"}, "resumable": true, "config": map[string]any{}}
+					events = append(events, map[string]any{"kind": "delegate_created", "seq": len(events) + 1, "delegate_id": delegate, "created": map[string]any{"descriptor": descriptor}})
+				}
+				if nested {
+					addChild(parentID, rootID, "", "dlg_parent")
+					addChild(childID, parentID, "dlg_parent", "dlg_child")
+				} else {
+					addChild(childID, rootID, "", "dlg_child")
+				}
+				batch, err := json.Marshal(map[string]any{"events": events})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(stateDir, "sessions", rootID, "delegates.jsonl"), append(append([]byte("{\"version\":1}\n"), batch...), '\n'), 0600); err != nil {
+					t.Fatal(err)
+				}
+				past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+				if _, err := past.Rebuild(); err != nil {
+					t.Fatal(err)
+				}
+				roster := hubcore.NewRosterWithEntries(hubcore.LiveEntry{SessionID: rootID, Status: status})
+				if status == "unconfirmed" {
+					peer := httptest.NewServer(http.NotFoundHandler())
+					defer peer.Close()
+					runDir := t.TempDir()
+					writeRendezvous(t, runDir, rendezvous.Entry{PID: os.Getpid(), SessionID: rootID, ThreadID: rootID, Protocol: appwire.ProtocolVersion, Endpoint: "ws" + strings.TrimPrefix(peer.URL, "http")})
+					roster = hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+					roster.Refresh()
+					if !unconfirmedDaemonForThread(roster, rootID) {
+						t.Fatal("fixture has no unresolved owner")
+					}
+				}
+				web := NewWebServer(hubcore.WebConfig{Past: past, Roster: roster})
+				response, err := dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(childID)})
+				if len(response.Deleted) != 0 {
+					t.Errorf("deleted owned child: %+v", response)
+				}
+				if err == nil && len(response.Skipped) != 1 {
+					t.Errorf("missing ownership refusal: %+v", response)
+				}
+				if status != "unconfirmed" && (err != nil || len(response.Skipped) != 1 || response.Skipped[0].Reason != "resumed live") {
+					t.Errorf("verified owner not classified live: response=%+v error=%v", response, err)
+				}
+				for _, suffix := range []string{".meta.json", ".transcript.jsonl", ".api.jsonl"} {
+					if _, err := os.Stat(filepath.Join(stateDir, "sessions", childID+suffix)); err != nil {
+						t.Errorf("owned child artifact %s: %v", suffix, err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestSessionDeleteAllowsIndependentForkOfLiveDaemon(t *testing.T) {
+	for _, status := range []string{appwire.ThreadStatusActive, appwire.ThreadStatusRestartRequired} {
+		t.Run(status, func(t *testing.T) {
+			root := t.TempDir()
+			projectDir := filepath.Join(root, "project")
+			if err := os.MkdirAll(projectDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			stateDir := filepath.Join(root, "projects", "session-delete-0123456789")
+			rootID, forkID := projectDeleteCanonicalSessionIDs[0], projectDeleteCanonicalSessionIDs[1]
+			writeSession(t, stateDir, rootID, projectDir)
+			writeSession(t, stateDir, forkID, projectDir)
+			meta, err := schema.LoadSessionMeta(stateDir, forkID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			meta.ParentSessionID = rootID
+			if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+				t.Fatal(err)
+			}
+			past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+			if _, err := past.Rebuild(); err != nil {
+				t.Fatal(err)
+			}
+			roster := hubcore.NewRosterWithEntries(hubcore.LiveEntry{SessionID: rootID, Status: status})
+			web := NewWebServer(hubcore.WebConfig{Past: past, Roster: roster})
+			response, err := dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(forkID)})
+			if err != nil || len(response.Deleted) != 1 || response.Deleted[0] != forkID {
+				t.Fatalf("fork deletion=%+v error=%v", response, err)
+			}
+			if _, err := os.Stat(filepath.Join(stateDir, "sessions", rootID+".meta.json")); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestSessionDeleteRetainedDelegateAfterParentDeletion(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "projects", "upgrade-0000000000")
+	parentID := buildRPCParentSession(t, stateDir)
+	childID := buildUpgradeDelegate(t, stateDir, parentID)
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	roster := hubcore.NewRoster(t.TempDir(), &hubcore.StatusProber{})
+	roster.Refresh()
+	spawned := false
+	cfg := hubcore.WebConfig{Past: past, Roster: roster, ResumeLocks: hubcore.NewResumeLocks(), Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		spawned = true
+		return rendezvous.Entry{}, errors.New("spawn sentinel")
+	}}}
+	web := NewWebServer(cfg)
+	response, err := dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(parentID)})
+	if err != nil || len(response.Deleted) != 1 {
+		t.Fatalf("delete parent: %+v %v", response, err)
+	}
+	hub := newHubRPCTestServer(t, cfg)
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: localAppRef(childID), IncludeTurns: true}); err != nil {
+		t.Fatalf("read retained child: %v", err)
+	}
+	_, _ = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Session: childID})
+	if !spawned {
+		t.Fatal("retained child could not reach resume launcher")
+	}
+	response, err = dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(childID)})
+	if err != nil || len(response.Deleted) != 1 {
+		t.Fatalf("delete child: %+v %v", response, err)
 	}
 }

--- a/cmd/evener-hub/app_session_resume.go
+++ b/cmd/evener-hub/app_session_resume.go
@@ -27,7 +27,10 @@ func withSessionResume[R any](
 	once func() (R, error),
 ) (R, error) {
 	attempt := func() (R, error) {
-		return withDeletionTargetOwnership(cfg, ref, "", clientMutationID, once)
+		if clientMutationID == "" {
+			return withSessionActionOwnership(ctx, cfg, ref, "", once)
+		}
+		return withDeletionTargetOwnership(ctx, cfg, ref, "", clientMutationID, once)
 	}
 	resp, err := attempt()
 	if err == nil {
@@ -52,7 +55,7 @@ func withSessionResume[R any](
 // we must NOT resurrect it just to kill it (kata qp94 carve-out). An unknown
 // ref or any non-session-unavailable failure is still returned unchanged.
 func shutdownThreadTolerateExited(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadShutdownParams) error {
-	_, err := withDeletionTargetOwnership(cfg, params.Ref, "", "", func() (struct{}, error) {
+	_, err := withSessionActionOwnership(ctx, cfg, params.Ref, "", func() (struct{}, error) {
 		source, err := sourceForThread(sources, params.Ref, "")
 		if err != nil {
 			return struct{}{}, err
@@ -63,6 +66,14 @@ func shutdownThreadTolerateExited(ctx context.Context, cfg hubcore.WebConfig, so
 		return struct{}{}, source.ShutdownThread(ctx, params)
 	})
 	if err != nil && params.Ref != "" && hubKnowsRef(cfg, params.Ref) && isSessionUnavailableError(err) {
+		if cfg.Roster != nil {
+			if err := hubRosterRefresh(ctx, cfg.Roster); err != nil {
+				return appwire.Unavailable(err.Error())
+			}
+		}
+		if restartErr := daemonRestartRequiredError(ctx, cfg, params.Ref, "", ""); restartErr != nil {
+			return restartErr
+		}
 		return nil
 	}
 	return err

--- a/cmd/evener-hub/app_sources.go
+++ b/cmd/evener-hub/app_sources.go
@@ -37,12 +37,13 @@ func sourceForThread(sources *appsource.Registry, ref, threadID string) (appsour
 }
 
 func sourceForThreadWithDeletionFence(cfg hubcore.WebConfig, sources *appsource.Registry, ref, threadID string) (appsource.Source, error) {
-	return withDeletionTargetOwnership(cfg, ref, threadID, "", func() (appsource.Source, error) {
+	return withDeletionTargetOwnership(context.Background(), cfg, ref, threadID, "", func() (appsource.Source, error) {
 		return sourceForThread(sources, ref, threadID)
 	})
 }
 
 func withDeletionTargetOwnership[R any](
+	ctx context.Context,
 	cfg hubcore.WebConfig,
 	ref, threadID, clientMutationID string,
 	action func() (R, error),
@@ -53,7 +54,45 @@ func withDeletionTargetOwnership[R any](
 		var zero R
 		return zero, err
 	}
-	return action()
+	if clientMutationID != "" {
+		if err := daemonRestartRequiredError(ctx, cfg, ref, threadID, clientMutationID); err != nil {
+			var zero R
+			return zero, err
+		}
+	}
+	result, err := action()
+	if clientMutationID != "" && daemonOwnershipMayHaveChanged(err) {
+		if restartErr := refreshDaemonRestartRequiredError(ctx, cfg, ref, threadID, clientMutationID); restartErr != nil {
+			var zero R
+			return zero, restartErr
+		}
+	}
+	return result, err
+}
+
+// withSessionActionOwnership guards actions that have no durable mutation ID.
+// Reads share deletion locking but must remain available for incompatible owners.
+func withSessionActionOwnership[R any](ctx context.Context, cfg hubcore.WebConfig, ref, threadID string, action func() (R, error)) (R, error) {
+	return withDeletionTargetOwnership(ctx, cfg, ref, threadID, "", func() (R, error) {
+		if err := daemonRestartRequiredError(ctx, cfg, ref, threadID, ""); err != nil {
+			var zero R
+			return zero, err
+		}
+		result, err := action()
+		if daemonOwnershipMayHaveChanged(err) {
+			if restartErr := refreshDaemonRestartRequiredError(ctx, cfg, ref, threadID, ""); restartErr != nil {
+				var zero R
+				return zero, restartErr
+			}
+		}
+		return result, err
+	})
+}
+
+func daemonOwnershipMayHaveChanged(err error) bool {
+	var initialization appsource.DaemonInitializeError
+	var mismatch appwire.ProtocolVersionMismatchError
+	return isSessionUnavailableError(err) || errors.As(err, &mismatch) || errors.As(err, &initialization)
 }
 
 func lockDeletionTarget(cfg hubcore.WebConfig, ref, threadID string) func() {

--- a/cmd/evener-hub/app_threadlifecycle.go
+++ b/cmd/evener-hub/app_threadlifecycle.go
@@ -32,7 +32,7 @@ var (
 	hubCanonicalizeDir = fspaths.CanonicalizeDir
 	hubResolveLaunch   = launchconfig.Resolve
 	hubParseModelRef   = cmdutil.ParseModelRef
-	hubRosterRefresh   = func(r *hubcore.Roster) { r.Refresh() }
+	hubRosterRefresh   = func(ctx context.Context, r *hubcore.Roster) error { return r.RefreshAndWait(ctx) }
 	hubRosterList      = func(r *hubcore.Roster) []hubcore.LiveEntry { return r.List() }
 	hubForkSession     = agent.ForkSession
 	hubForkSessionAt   = agent.ForkSessionAtUserTurn
@@ -163,8 +163,16 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 	if err != nil {
 		return appwire.ThreadStartResponse{}, appwire.HubLaunchError(err.Error())
 	}
+	canUseSpawnEntry := entry.Protocol == appwire.ProtocolVersion && entry.Endpoint != "" && entry.ThreadID != ""
 	if cfg.Roster != nil {
-		hubRosterRefresh(cfg.Roster)
+		if err := hubRosterRefresh(ctx, cfg.Roster); err != nil {
+			if !canUseSpawnEntry {
+				return appwire.ThreadStartResponse{}, appwire.Unavailable(err.Error())
+			}
+			// Spawning already established this daemon's identity. An unrelated
+			// discovery failure must not hide its identity or discard initial input.
+			fmt.Fprintf(os.Stderr, "[hub] spawned session %s; roster refresh failed: %v\n", entry.ThreadID, err)
+		}
 		if entry.ThreadID == "" || entry.SessionID == "" {
 			for _, live := range hubRosterList(cfg.Roster) {
 				if live.PID == entry.PID {
@@ -181,7 +189,7 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 	}
 	ref := localSpawnWorkspaceRef(entry)
 	var source appsource.Source
-	if entry.Protocol == appwire.ProtocolVersion && entry.Endpoint != "" && entry.ThreadID != "" {
+	if canUseSpawnEntry {
 		// SpawnDaemon already returned this exact, freshly published rendezvous
 		// entry. Route the initial read and turn through it directly instead of
 		// depending on a concurrent roster status probe to admit the new daemon.
@@ -208,7 +216,22 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 		annotateThreadProjects([]appwire.Thread{thread})
 		return appwire.ThreadStartResponse{Thread: thread}, nil
 	}
-	threadResp, err := source.ReadThread(ctx, appwire.ThreadReadParams{Ref: ref})
+	read := func(ctx context.Context) (appwire.ThreadReadResponse, error) {
+		return source.ReadThread(ctx, appwire.ThreadReadParams{Ref: ref})
+	}
+	var threadResp appwire.ThreadReadResponse
+	if cfg.Roster != nil && canUseSpawnEntry {
+		if !cfg.Roster.HasConfirmedEntry(entry) {
+			threadResp, err = cfg.Roster.ReadSpawnedThread(ctx, entry, read)
+			if err != nil && threadResp.Thread.ID != "" {
+				return appwire.ThreadStartResponse{}, appwire.Unavailable(err.Error())
+			}
+		} else {
+			threadResp, err = read(ctx)
+		}
+	} else {
+		threadResp, err = read(ctx)
+	}
 	if err != nil {
 		threadResp.Thread = appwire.Thread{
 			ID: entry.ThreadID, SessionID: entry.SessionID, CWD: workingDir,
@@ -304,6 +327,34 @@ func hubThreadResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsou
 	if err := deletionFenceError(cfg, params.Ref, sessionID, ""); err != nil {
 		return appwire.ThreadResumeResponse{}, err
 	}
+	var discoveryErr error
+	if cfg.Roster != nil {
+		discoveryErr = hubRosterRefresh(ctx, cfg.Roster)
+	}
+	if err := daemonRestartRequiredError(ctx, cfg, "", sessionID, ""); err != nil {
+		return appwire.ThreadResumeResponse{}, err
+	}
+	if discoveryErr != nil {
+		// Incomplete discovery cannot authorize a replacement, but a direct
+		// probe can establish that a previously confirmed owner still serves
+		// this session. Keep the global discovery failure for other owners.
+		if owner, ok := liveDaemonForThread(cfg.Roster, sessionID); ok && owner.Protocol == appwire.ProtocolVersion {
+			if err := cfg.Roster.RefreshEntry(ctx, owner.Entry); err != nil {
+				return appwire.ThreadResumeResponse{}, appwire.Unavailable(errors.Join(discoveryErr, err).Error())
+			}
+			return hubResumedThreadResponse(ctx, sources, owner.SessionID, owner.ThreadID)
+		}
+		return appwire.ThreadResumeResponse{}, appwire.Unavailable(discoveryErr.Error())
+	}
+	owner, _, err := lookupDaemonOwner(ctx, cfg, "", sessionID, true)
+	if err != nil {
+		return appwire.ThreadResumeResponse{}, appwire.Unavailable(err.Error())
+	}
+	if owner.SessionID != "" {
+		if _, directlyOwned := liveDaemonForThread(cfg.Roster, sessionID); !directlyOwned {
+			return appwire.ThreadResumeResponse{}, appwire.Unavailable("session is retained by " + localAppRef(owner.SessionID) + "; open the owning session or refresh after it stops")
+		}
+	}
 	if cfg.Spawner == nil {
 		return appwire.ThreadResumeResponse{}, appwire.Unavailable("spawner not configured")
 	}
@@ -320,13 +371,10 @@ func hubThreadResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsou
 		// has already put the session in the roster, so reuse it instead of
 		// spawning again. Only this Hub's exact flag-day protocol establishes
 		// ownership; an older daemon can be healthy while remaining unroutable
-		// through the current local source. Refresh also preserves a dead daemon
-		// as a crash marker for diagnostics. Both cases must fall through
-		// to spawning.
+		// through the current local source. A dead daemon may remain as a
+		// crash marker and must fall through to spawning.
 		if cfg.Roster != nil {
-			hubRosterRefresh(cfg.Roster)
-			if le, ok := cfg.Roster.Find(sessionID); ok &&
-				!le.Crashed &&
+			if le, ok := liveDaemonForThread(cfg.Roster, sessionID); ok &&
 				le.Protocol == appwire.ProtocolVersion {
 				return hubResumedThreadResponse(ctx, sources, le.SessionID, le.ThreadID)
 			}
@@ -334,10 +382,29 @@ func hubThreadResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsou
 	}
 	entry, err := cfg.Spawner.Resume(ctx, resumeReq)
 	if err != nil {
-		return appwire.ThreadResumeResponse{}, appwire.HubLaunchError(resumeFailureError(cfg, sessionID, err).Error())
+		return appwire.ThreadResumeResponse{}, appwire.HubLaunchError(resumeFailureError(ctx, cfg, sessionID, err).Error())
 	}
 	if cfg.Roster != nil {
-		hubRosterRefresh(cfg.Roster)
+		refreshErr := hubRosterRefresh(ctx, cfg.Roster)
+		if entry.Protocol == appwire.ProtocolVersion && entry.Endpoint != "" && entry.ThreadID != "" && !cfg.Roster.HasConfirmedEntry(entry) {
+			// A successful scan can still miss an owner whose status probe
+			// failed. Confirm the exact spawned endpoint through its read before
+			// relying on the shared roster for subsequent requests.
+			source := appsource.NewLocalDaemonSource("local", func() []rendezvous.Entry {
+				return []rendezvous.Entry{entry}
+			}, nil)
+			read, err := cfg.Roster.ReadSpawnedThread(ctx, entry, func(ctx context.Context) (appwire.ThreadReadResponse, error) {
+				return source.ReadThread(ctx, appwire.ThreadReadParams{Ref: localSpawnWorkspaceRef(entry)})
+			})
+			if err != nil {
+				return appwire.ThreadResumeResponse{}, appwire.Unavailable(errors.Join(refreshErr, err).Error())
+			}
+			annotateThreadProjects([]appwire.Thread{read.Thread})
+			return appwire.ThreadResumeResponse{Thread: read.Thread}, nil
+		}
+		if refreshErr != nil && !cfg.Roster.HasConfirmedEntry(entry) {
+			return appwire.ThreadResumeResponse{}, appwire.Unavailable(refreshErr.Error())
+		}
 	}
 	return hubResumedThreadResponse(ctx, sources, entry.SessionID, entry.ThreadID)
 }
@@ -361,11 +428,13 @@ func hubThreadResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsou
 // The roster is re-read rather than reused from the pre-spawn check: the spawn
 // attempt takes seconds, and naming a pid that has since exited would send the
 // operator after a process that is not there.
-func resumeFailureError(cfg hubcore.WebConfig, sessionID string, err error) error {
+func resumeFailureError(ctx context.Context, cfg hubcore.WebConfig, sessionID string, err error) error {
 	if cfg.Roster == nil {
 		return err
 	}
-	hubRosterRefresh(cfg.Roster)
+	if refreshErr := hubRosterRefresh(ctx, cfg.Roster); refreshErr != nil {
+		return errors.Join(err, refreshErr)
+	}
 	blocker, ok := cfg.Roster.Find(sessionID)
 	if !ok || blocker.Crashed || blocker.Protocol == appwire.ProtocolVersion {
 		return err
@@ -438,7 +507,7 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 		if params.Aside {
 			return appwire.ThreadForkResponse{}, appwire.Unavailable("aside is only supported for local evener threads")
 		}
-		return withDeletionTargetOwnership(cfg, params.Ref, "", "", func() (appwire.ThreadForkResponse, error) {
+		return withDeletionTargetOwnership(ctx, cfg, params.Ref, "", "", func() (appwire.ThreadForkResponse, error) {
 			source, err := sourceForThread(sources, params.Ref, "")
 			if err != nil {
 				return appwire.ThreadForkResponse{}, err
@@ -468,6 +537,9 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 		}
 		if stateDir == "" {
 			return appwire.ThreadForkResponse{}, appwire.Unavailable("state dir not resolvable for parent thread")
+		}
+		if err := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, ref.ThreadID, ""); err != nil {
+			return appwire.ThreadForkResponse{}, err
 		}
 		childID, err := hubAsideSession(stateDir, ref.ThreadID)
 		if err != nil {
@@ -502,6 +574,9 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 	}
 	if stateDir == "" {
 		return appwire.ThreadForkResponse{}, appwire.Unavailable("state dir not resolvable for parent thread")
+	}
+	if err := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, ref.ThreadID, ""); err != nil {
+		return appwire.ThreadForkResponse{}, err
 	}
 	var childID, originalInput string
 	if params.DeferInput {

--- a/cmd/evener-hub/app_threadlist.go
+++ b/cmd/evener-hub/app_threadlist.go
@@ -28,7 +28,7 @@ func hubThreadList(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 		}
 		for _, thread := range resp.Data {
 			sourceID := threadListSourceID(source.ID(), thread)
-			for _, id := range []string{thread.ID, thread.SessionID} {
+			for _, id := range threadListIDs(sourceID, thread) {
 				if key := threadListSourceKey(sourceID, id); key != "" {
 					liveIDs[key] = struct{}{}
 				}
@@ -110,6 +110,14 @@ func threadListSourceID(defaultSourceID string, thread appwire.Thread) string {
 	return defaultSourceID
 }
 
+func threadListIDs(sourceID string, thread appwire.Thread) []string {
+	ids := []string{thread.ID, thread.SessionID}
+	if ref, err := appwire.ParseRef(thread.Evener.Ref); err == nil && ref.SourceID == sourceID {
+		ids = append(ids, ref.ThreadID)
+	}
+	return ids
+}
+
 func threadListSourceKey(sourceID, threadID string) string {
 	return appwire.Ref{SourceID: sourceID, ThreadID: threadID}.String()
 }
@@ -139,7 +147,7 @@ func mergePastMetadataForList(ctx context.Context, cfg hubcore.WebConfig, source
 	}
 	var entry hubcore.PastEntry
 	var ok bool
-	for _, id := range []string{live.ID, live.SessionID} {
+	for _, id := range threadListIDs("local", live) {
 		if id == "" {
 			continue
 		}

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -17,6 +17,7 @@ import (
 	taskpkg "primeradiant.com/evener/agent/task"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/envvars/userdirs"
 	"primeradiant.com/evener/internal/appitempaging"
@@ -65,6 +66,35 @@ func pastThreadForRead(ctx context.Context, cfg hubcore.WebConfig, params appwir
 	// One combined scan answers both figures; two separate ones would read and
 	// decode the same immutable bytes twice.
 	return stampDerivedTotals(cfg, entry, thread), true, nil
+}
+
+// unavailableThreadReadResponse prefers saved turns, but a confirmed incompatible
+// owner remains readable from roster metadata even before it has a past entry.
+func unavailableThreadReadResponse(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, bool, error) {
+	if response, ok, err := pastThreadReadResponse(ctx, cfg, params); ok || err != nil {
+		return response, ok, err
+	}
+	if _, required, err := restartRequiredDaemon(ctx, cfg, params.Ref, params.ThreadID); err != nil || !required {
+		return appwire.ThreadReadResponse{}, false, err
+	}
+	source, ok := sources.Source("local")
+	if !ok {
+		return appwire.ThreadReadResponse{}, false, nil
+	}
+	listed, err := source.ListThreads(ctx, appwire.ThreadListParams{})
+	if err != nil {
+		return appwire.ThreadReadResponse{}, false, err
+	}
+	for _, thread := range listed.Data {
+		matches := thread.ID == params.ThreadID || thread.Evener.Ref == localAppRef(params.ThreadID)
+		if params.Ref != "" {
+			matches = thread.Evener.Ref == params.Ref || localAppRef(thread.ID) == params.Ref
+		}
+		if matches && thread.Status.Type == appwire.ThreadStatusRestartRequired {
+			return appwire.ThreadReadResponse{Thread: thread}, true, nil
+		}
+	}
+	return appwire.ThreadReadResponse{}, false, nil
 }
 
 func pastThreadReadResponse(ctx context.Context, cfg hubcore.WebConfig, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, bool, error) {
@@ -490,6 +520,15 @@ func pastEntryThread(ctx context.Context, cfg hubcore.WebConfig, entry hubcore.P
 			// ActiveTurnStartedAt stays 0 because the parent status payload does not
 			// expose the in-process child's turn start time.
 		},
+	}
+	if _, required, ownershipErr := restartRequiredDaemon(ctx, cfg, ref, entry.Meta.ID); ownershipErr != nil {
+		if !isDaemonDiscoveryError(ownershipErr) {
+			return appwire.Thread{}, ownershipErr
+		}
+		thread.Evener.Capabilities = appwire.ThreadCapabilities{}
+	} else if required {
+		thread.Status.Type = appwire.ThreadStatusRestartRequired
+		thread.Evener.Capabilities = appwire.ThreadCapabilities{}
 	}
 	thread.Evener.VisionModel = entry.Meta.VisionModel
 	delegates, delegateDiagnostics, err := pastEntryDelegateStatus(ctx, entry)

--- a/cmd/evener-hub/app_threadread_test.go
+++ b/cmd/evener-hub/app_threadread_test.go
@@ -1046,6 +1046,9 @@ func TestPastThreadReadProjectsRunningSubagentActive(t *testing.T) {
 	if !ok {
 		t.Fatal("running subagent not found in past index")
 	}
+	if thread.Evener.MutationStateAuthoritative {
+		t.Fatal("saved delegate data cannot prove mutation absence")
+	}
 	if thread.Status.Type != appwire.ThreadStatusActive {
 		t.Fatalf("running subagent status = %q, want %q", thread.Status.Type, appwire.ThreadStatusActive)
 	}

--- a/cmd/evener-hub/app_transcripts_test.go
+++ b/cmd/evener-hub/app_transcripts_test.go
@@ -11,6 +11,7 @@ import (
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/rendezvous"
 )
 
 func TestHubRPCTranscriptTargetsUseEvenerParentRefs(t *testing.T) {
@@ -62,6 +63,34 @@ func TestHubRPCTranscriptTargetsUseEvenerParentRefs(t *testing.T) {
 	}
 	if resp.Data[1].Kind != "subagent" || resp.Data[1].Ref != "local:"+subID || resp.Data[1].TurnsUsed != 1 {
 		t.Fatalf("subagent target=%+v", resp.Data[1])
+	}
+}
+
+func TestHubTranscriptTargetsIncludeRestartRequiredChildOfStableWorkspace(t *testing.T) {
+	root := t.TempDir()
+	stableID := buildRPCParentSession(t, filepath.Join(root, "projects", "project-repo-0000000000"))
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	entry := rendezvous.Entry{Protocol: "evener-appwire-v4", Endpoint: "ws://unused.test/rpc", ThreadID: stableID, SessionID: "current", WorkspaceRef: "local:" + stableID}
+	sources := appsource.NewRegistry()
+	sources.Add(appsource.NewLocalDaemonSourceWithEntries("local", func() []appsource.LocalDaemonEntry {
+		return []appsource.LocalDaemonEntry{
+			{Entry: entry, Status: appwire.ThreadStatusRestartRequired},
+			{Entry: entry, SessionID: "child", OwnerSessionID: "current", ReadOnlyAlias: true, Status: appwire.ThreadStatusRestartRequired},
+		}
+	}, nil))
+	response, err := hubThreadTranscriptList(context.Background(), hubcore.WebConfig{Past: past}, sources, appwire.ThreadTranscriptListParams{Ref: entry.WorkspaceRef})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Data) != 2 {
+		t.Fatalf("want main and child transcript targets: %+v", response.Data)
+	}
+	child := response.Data[1]
+	if child.Ref != "local:child" || child.ThreadID != "child" || child.Kind != "subagent" || child.Status != appwire.ThreadStatusRestartRequired {
+		t.Fatalf("child transcript target = %+v", child)
 	}
 }
 

--- a/cmd/evener-hub/app_vision_model.go
+++ b/cmd/evener-hub/app_vision_model.go
@@ -26,7 +26,7 @@ func setThreadVisionModelWithResume(ctx context.Context, cfg hubcore.WebConfig, 
 }
 
 func setThreadVisionModelOnce(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadVisionModelSetParams) error {
-	_, err := withDeletionTargetOwnership(cfg, params.Ref, "", "", func() (struct{}, error) {
+	_, err := withSessionActionOwnership(ctx, cfg, params.Ref, "", func() (struct{}, error) {
 		source, err := sourceForThread(sources, params.Ref, "")
 		if err != nil {
 			return struct{}{}, err

--- a/cmd/evener-hub/cov_exact_lifecycle_tree_fuzz_test.go
+++ b/cmd/evener-hub/cov_exact_lifecycle_tree_fuzz_test.go
@@ -73,7 +73,7 @@ func FuzzExactLifecycleTree(f *testing.F) {
 		_, _ = hubThreadStart(ctx, localCfg, appsource.NewRegistry(), appwire.ThreadStartParams{})
 		roster := hubcore.NewRosterWithEntries()
 		localCfg.Roster = roster
-		hubRosterRefresh = func(*hubcore.Roster) {}
+		hubRosterRefresh = func(context.Context, *hubcore.Roster) error { return nil }
 		hubRosterList = func(*hubcore.Roster) []hubcore.LiveEntry {
 			return []hubcore.LiveEntry{{Entry: rendezvous.Entry{PID: 44, SessionID: "r"}, SessionID: "r"}}
 		}

--- a/cmd/evener-hub/frontend/src/App.test.tsx
+++ b/cmd/evener-hub/frontend/src/App.test.tsx
@@ -291,7 +291,7 @@ test("initiates and settles the welcome navigation load without an error", async
   const client = new FakeClient("ready");
   client.scriptConnect(() => ({
     serverInfo: { name: "fake", version: "1" },
-    protocolVersion: "evener-appwire-v4",
+    protocolVersion: "evener-appwire-v5",
     sourceId: "fake",
     features: {} as never,
     navigation: { version: 1, generationId: "test-generation", sequence: 0, readVersions: [2] },
@@ -310,7 +310,7 @@ test("AppShell's injected v2 handshake selects navigation through AppWire", asyn
   const client = new FakeClient("ready");
   client.scriptConnect(() => ({
     serverInfo: { name: "fake", version: "1" },
-    protocolVersion: "evener-appwire-v4",
+    protocolVersion: "evener-appwire-v5",
     sourceId: "fake",
     features: {} as never,
     navigation: { version: 1, generationId: "app-generation", sequence: 0, readVersions: [2] },

--- a/cmd/evener-hub/frontend/src/dev/DevHarness.test.tsx
+++ b/cmd/evener-hub/frontend/src/dev/DevHarness.test.tsx
@@ -175,7 +175,7 @@ describe("DevHarness", () => {
     const fake = new FakeClient("ready");
     const scripted: InitializeResponse = {
       serverInfo: { name: "dev-harness-hub", version: "2.0.0" },
-      protocolVersion: "evener-appwire-v4",
+      protocolVersion: "evener-appwire-v5",
       sourceId: "dev-harness-test",
       features: {
         threadList: false,

--- a/cmd/evener-hub/frontend/src/dev/shellguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/shellguard-entry.tsx
@@ -362,7 +362,7 @@ async function boot(): Promise<void> {
   shellClient = fake;
   fake.scriptConnect(() => ({
     serverInfo: { name: "fake-evener-hub", version: "0.0.0" },
-    protocolVersion: "evener-appwire-v4",
+    protocolVersion: "evener-appwire-v5",
     sourceId: "fake",
     features: {
       threadList: true,

--- a/cmd/evener-hub/frontend/src/notifications/attention.test.ts
+++ b/cmd/evener-hub/frontend/src/notifications/attention.test.ts
@@ -115,3 +115,10 @@ describe("detectFires", () => {
     ).toEqual(["local:b", "local:c"]);
   });
 });
+
+test("restart-required sessions enter attention and preserve notification baseline", () => {
+  const next = snapshotFromNavigation([row({ ref: "local:upgrade", state: "restartRequired" })]);
+  expect(next.get("local:upgrade")?.level).toBe("needs_you");
+  expect(detectFires(new Map(), next, "all").map((entry) => entry.ref)).toEqual(["local:upgrade"]);
+  expect(detectFires(next, next, "all")).toEqual([]);
+});

--- a/cmd/evener-hub/frontend/src/notifications/attention.ts
+++ b/cmd/evener-hub/frontend/src/notifications/attention.ts
@@ -9,6 +9,7 @@ export function levelFromState(state: string): AttentionLevel {
       return "working";
     case "awaiting":
     case "warning":
+    case "restartRequired":
       return "needs_you";
     case "errored":
       return "error";

--- a/cmd/evener-hub/frontend/src/notifications/index.test.ts
+++ b/cmd/evener-hub/frontend/src/notifications/index.test.ts
@@ -20,7 +20,7 @@ const navigationCapability = capability;
 const navigationManifest = (generationId = "generation_test") => manifest({ generation_id: generationId });
 const navigationInitialize = (generationId = "generation_test"): InitializeResponse => ({
   serverInfo: { name: "fake", version: "1" },
-  protocolVersion: "evener-appwire-v4",
+  protocolVersion: "evener-appwire-v5",
   sourceId: "fake",
   features: {
     threadList: false,
@@ -227,7 +227,7 @@ async function boot(baseline: {
     client = new FakeClient("ready");
     client.scriptConnect(() => ({
       serverInfo: { name: "fake", version: "1" },
-      protocolVersion: "evener-appwire-v4",
+      protocolVersion: "evener-appwire-v5",
       sourceId: "fake",
       features: {} as never,
       navigation: navigationCapability(),
@@ -257,7 +257,7 @@ describe("initNotifications lifecycle", () => {
     scriptNavigationManifest(client);
     client.scriptConnect(() => ({
       serverInfo: { name: "fake", version: "1" },
-      protocolVersion: "evener-appwire-v4",
+      protocolVersion: "evener-appwire-v5",
       sourceId: "fake",
       features: {} as never,
       navigation: navigationCapability(),
@@ -287,7 +287,7 @@ describe("initNotifications lifecycle", () => {
     const client = new FakeClient("ready");
     client.scriptConnect(() => ({
       serverInfo: { name: "fake", version: "1" },
-      protocolVersion: "evener-appwire-v4",
+      protocolVersion: "evener-appwire-v5",
       sourceId: "fake",
       features: {} as never,
       navigation: navigationCapability("generation_test", 2),
@@ -576,7 +576,7 @@ describe("reconnect re-baselines silently", () => {
         releaseOld = resolve;
       }).then((cap) => ({
         serverInfo: { name: "old", version: "1" },
-        protocolVersion: "evener-appwire-v4",
+        protocolVersion: "evener-appwire-v5",
         sourceId: "old",
         features: {} as never,
         navigation: cap,
@@ -606,7 +606,7 @@ describe("reconnect re-baselines silently", () => {
     const fake = new FakeClient("ready");
     fake.scriptConnect(() => ({
       serverInfo: { name: "fake", version: "1" },
-      protocolVersion: "evener-appwire-v4",
+      protocolVersion: "evener-appwire-v5",
       sourceId: "fake",
       features: {} as never,
       navigation: navigationCapability(),
@@ -649,7 +649,7 @@ describe("reconnect re-baselines silently", () => {
     const fake = new FakeClient("ready");
     fake.scriptConnect(() => ({
       serverInfo: { name: "fake", version: "1" },
-      protocolVersion: "evener-appwire-v4",
+      protocolVersion: "evener-appwire-v5",
       sourceId: "fake",
       features: {} as never,
       navigation: navigationCapability(),
@@ -738,7 +738,7 @@ describe("reconnect re-baselines silently", () => {
     scriptNavigationManifest(client);
     client.scriptConnect(() => ({
       serverInfo: { name: "fake", version: "1" },
-      protocolVersion: "evener-appwire-v4",
+      protocolVersion: "evener-appwire-v5",
       sourceId: "fake",
       features: {} as never,
       navigation: navigationCapability(),
@@ -758,7 +758,7 @@ describe("reconnect re-baselines silently", () => {
     const fake = new FakeClient("ready");
     fake.scriptConnect(() => ({
       serverInfo: { name: "fake", version: "1" },
-      protocolVersion: "evener-appwire-v4",
+      protocolVersion: "evener-appwire-v5",
       sourceId: "fake",
       features: {} as never,
       navigation: navigationCapability(),

--- a/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
@@ -3,7 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { IDBFactory } from "fake-indexeddb";
+import { IDBFactory, IDBObjectStore } from "fake-indexeddb";
 import { StrictMode } from "react";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { WireError } from "../../protocol/errors";
@@ -15,6 +15,7 @@ import { connectionStore } from "../../stores/connection";
 import { MutationOutboxIndexedDB } from "../../stores/mutationOutboxIndexedDB";
 import { navigationStore, resetNavigationStoreForTests } from "../../stores/navigation/store";
 import { keyID } from "../../stores/navigation/types";
+import { holdIndexedDBEvent } from "../../stores/testing/stalledIndexedDB";
 import { resetThreadsStoreForTests, setMutationStorageForTests, threadsStore } from "../../stores/threads";
 import { transcriptDisplayStore } from "../../stores/transcriptDisplay";
 import { makeTranscriptDisplayConfig } from "../../transcriptDisplay/config";
@@ -2026,4 +2027,236 @@ test("a pending ask counts the dock row in the scroll coordinator's rendered row
   } finally {
     spy.mockRestore();
   }
+});
+
+test("explains that an incompatible daemon needs an explicit restart", async () => {
+  const fake = connectFakeClient();
+  fake.on("thread/read", () => readResponse("ref_a", { status: { type: "restartRequired" } }));
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  expect((await screen.findByRole("alert")).textContent).toContain("Session restart required");
+  expect(fake.calls.filter((call) => call.method === "thread/resume" || call.method === "turn/start")).toHaveLength(0);
+});
+
+test("refreshes a restarted session without closing its pane", async () => {
+  const fake = connectFakeClient();
+  let replaced = false;
+  fake.on("thread/read", () => readResponse("ref_a", { status: { type: replaced ? "idle" : "restartRequired" } }));
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  await screen.findByRole("alert");
+  const refresh = vi.spyOn(threadsStore.getState(), "refreshThread");
+  replaced = true;
+  fireEvent.click(screen.getByRole("button", { name: "Refresh session" }));
+  expect(refresh).toHaveBeenCalledOnce();
+  await act(async () => {
+    await refresh.mock.results[0]?.value;
+  });
+  expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("idle");
+  expect(screen.queryByRole("alert")).toBeNull();
+  expect(fake.calls.filter((call) => call.method === "thread/resume" || call.method === "turn/start")).toHaveLength(0);
+});
+
+test("shows an explicit session refresh failure", async () => {
+  const fake = connectFakeClient();
+  let failRefresh = false;
+  fake.on("thread/read", () => {
+    if (failRefresh) throw new Error("refresh rejected");
+    return readResponse("ref_a", { status: { type: "restartRequired" } });
+  });
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  await screen.findByRole("alert");
+  failRefresh = true;
+  fireEvent.click(screen.getByRole("button", { name: "Refresh session" }));
+  expect(await screen.findByText("refresh rejected")).toBeTruthy();
+  expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("restartRequired");
+});
+
+test.each([false, true])("restart-required empty transcript suppresses first-send UI (pending=%s)", async (pending) => {
+  const fake = connectFakeClient();
+  fake.on("thread/read", () => readResponse("ref_a", { status: { type: "restartRequired" } }));
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  await screen.findByRole("alert");
+  if (pending) await seedPendingSend();
+  expect(screen.queryByText(/send the first message/i)).toBeNull();
+  expect(screen.queryByTestId("cold-start-skeleton")).toBeNull();
+  expect(screen.getByText("Session unavailable until restart")).toBeTruthy();
+});
+
+test("offers explicit resume after restart even without pending messages", async () => {
+  const fake = connectFakeClient();
+  let status = "restartRequired";
+  fake.on("thread/read", () => readResponse("ref_a", { status: { type: status } }));
+  fake.on("thread/resume", () => {
+    status = "idle";
+    return readResponse("ref_a", { status: { type: "idle" } });
+  });
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  const refresh = await screen.findByRole("button", { name: "Refresh session" });
+  status = "notLoaded";
+  fireEvent.click(refresh);
+  const resume = await screen.findByRole("button", { name: "Resume session" });
+  await waitFor(() => expect((resume as HTMLButtonElement).disabled).toBe(false));
+  fireEvent.click(resume);
+  await waitFor(() => expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("idle"));
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(1);
+});
+
+test.each(["notLoaded", "active", "idle"])(
+  "explicitly resumes a %s session before reconciling its uncertain send",
+  async (recoveryStatus) => {
+    const fake = connectFakeClient();
+    let status = "restartRequired";
+    let mutationId = "";
+    let resumed = false;
+    fake.on("thread/read", () =>
+      readResponse("ref_a", {
+        status: { type: status },
+        evener: {
+          ref: "ref_a",
+          capabilities: CAPABILITIES,
+          mutationStateAuthoritative: resumed,
+          queue: { revision: 1, clientMutationIds: resumed ? [mutationId] : [] },
+        },
+      }),
+    );
+    fake.on("thread/resume", () => {
+      resumed = true;
+      status = "idle";
+      return readResponse("ref_a", { status: { type: "idle" } });
+    });
+    render(
+      <ClientProvider client={fake}>
+        <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+      </ClientProvider>,
+    );
+    await screen.findByRole("alert");
+    await act(async () => {
+      mutationId = await seedPendingSend();
+      await mutationStorage.markUnknown(mutationId, "blockedUnknown");
+      await refreshPendingTurnsProjection("ref_a");
+      await flushPendingTurnsProjectionForTests();
+    });
+    const holds: ReturnType<typeof holdIndexedDBEvent>[] = [];
+    let announceRead: (() => void) | undefined;
+    const readHeld = new Promise<void>((resolve) => {
+      announceRead = resolve;
+    });
+    const getAll = IDBObjectStore.prototype.getAll;
+    const reads = vi.spyOn(IDBObjectStore.prototype, "getAll").mockImplementation(function (
+      this: IDBObjectStore,
+      ...args
+    ) {
+      const request = getAll.apply(this, args);
+      if (this.name === "outbox" && threadsStore.getState().threads.get("ref_a")?.status.type === recoveryStatus) {
+        const hold = holdIndexedDBEvent(request, "success");
+        holds.push(hold);
+        void hold.reached.then(() => announceRead?.());
+      }
+      return request;
+    });
+    const releaseReads = () => {
+      reads.mockRestore();
+      for (const hold of holds.splice(0)) hold.release();
+    };
+    try {
+      status = recoveryStatus;
+      fireEvent.click(screen.getByRole("button", { name: "Refresh session" }));
+      await readHeld;
+      const resume = await screen.findByRole("button", { name: "Resume session" });
+      expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
+      expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+      expect((resume as HTMLButtonElement).disabled).toBe(true);
+      releaseReads();
+      await waitFor(() => expect((resume as HTMLButtonElement).disabled).toBe(false));
+      fireEvent.click(resume);
+      await waitFor(async () => expect(await mutationStorage.getOutbox(mutationId)).toBeUndefined());
+      expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(1);
+      expect(fake.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
+    } finally {
+      releaseReads();
+    }
+  },
+);
+
+test("keeps recovery failure visible on a compatible session until reconciliation succeeds", async () => {
+  const fake = connectFakeClient();
+  fake.on("thread/read", () => readResponse("ref_a", { status: { type: "idle" } }));
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  await waitFor(() => expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("idle"));
+  act(() => threadsStore.setState({ mutationReconciliationFailures: new Set(["ref_a"]) }));
+  expect(await screen.findByRole("alert")).toBeTruthy();
+  act(() => threadsStore.setState({ mutationReconciliationFailures: new Set() }));
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+test.each(["active", "idle"])("retained %s child preserves uncertainty until its owner releases it", async (status) => {
+  const mutationId = await seedPendingSend();
+  await mutationStorage.markUnknown(mutationId, "blockedUnknown");
+  const fake = connectFakeClient();
+  let resumed = false;
+  let owned = true;
+  fake.on("thread/read", () =>
+    readResponse("ref_a", {
+      status: { type: resumed ? "idle" : owned ? status : "notLoaded" },
+      evener: {
+        ref: "ref_a",
+        capabilities: CAPABILITIES,
+        kind: "subagent",
+        parentRef: owned ? "local:parent" : undefined,
+        mutationStateAuthoritative: resumed,
+        queue: { revision: 1, clientMutationIds: resumed ? [mutationId] : [] },
+      },
+    }),
+  );
+  fake.on("thread/resume", () => {
+    resumed = true;
+    return readResponse("ref_a", { status: { type: status } });
+  });
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  const refresh = await screen.findByRole("button", { name: "Refresh session" });
+  expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
+  expect(screen.getByRole("link", { name: "Open owning session" }).getAttribute("href")).toContain("parent");
+  expect(threadsStore.getState().restartBlockingObligations.size).toBe(0);
+  expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(false);
+  expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
+  expect(fake.calls.filter((call) => call.method === "thread/resume" || call.method === "turn/start")).toHaveLength(0);
+  fireEvent.click(refresh);
+  await waitFor(() => expect((refresh as HTMLButtonElement).disabled).toBe(false));
+  expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+  owned = false;
+  fireEvent.click(refresh);
+  const resume = await screen.findByRole("button", { name: "Resume session" });
+  await waitFor(() => expect((resume as HTMLButtonElement).disabled).toBe(false));
+  fireEvent.click(resume);
+  await waitFor(async () => expect(await mutationStorage.getOutbox(mutationId)).toBeUndefined());
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(1);
+  expect(fake.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/Session.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.tsx
@@ -37,6 +37,7 @@ import { VisuallyHidden } from "../../widgets/internal/VisuallyHidden";
 import { ColdStartSkeleton, useColdStartSkeleton } from "./coldStart";
 import { AskDock, AskDockAnnouncements, useAskDockActivationEpoch, useAskDockPending } from "./composer/askDock";
 import { Composer } from "./composer/Composer";
+import { useBlockedMutationEntries } from "./composer/queue/pendingTurnsStore";
 import { requestQuoteInsert } from "./composer/quoteInsert";
 import { cadenceStateForStatus, NOW_TICK_MS, SessionNowContext, useNowTick } from "./liveness";
 import { PendingChips } from "./pending/PendingChips";
@@ -84,9 +85,12 @@ const EMPTY_THREADS = new Map<string, ThreadModel>();
 //
 // `status.type === "active"` is the wire vocabulary's word for "a turn is
 // running right now" (appwire's ThreadStatus, mapped in ./liveness), which is
-// exactly the mid-first-turn window. Every other status with zero turns -
-// idle, notLoaded, closed, "" - has nothing running, so the invitation holds.
-function EmptyTranscript({ active }: { active: boolean }) {
+// exactly the mid-first-turn window. An incompatible session needs a restart;
+// other empty sessions invite their first message.
+function EmptyTranscript({ active, restartRequired }: { active: boolean; restartRequired: boolean }) {
+  if (restartRequired) {
+    return <EmptyState title="Session unavailable until restart" hint="Stop the daemon, then resume this session." />;
+  }
   if (active) {
     return <EmptyState title="Waiting for the first reply" hint="The agent has your message." />;
   }
@@ -100,8 +104,52 @@ function EmptyTranscript({ active }: { active: boolean }) {
 // actions) follows that shape. Automatic older-turn paging is the deliberate
 // exception: nobody pressed anything, so its failure reports inline at the top
 // of the transcript instead (useTranscript's olderError -> LoadOlderRow).
+function RestartRequiredNotice({
+  sessionRef,
+  resumeRequired = false,
+  ownerRef,
+}: {
+  sessionRef: string;
+  resumeRequired?: boolean;
+  ownerRef?: string;
+}) {
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const refresh = async () => {
+    setRefreshing(true);
+    setError(null);
+    try {
+      if (resumeRequired) {
+        const { client, state } = connectionStore.getState();
+        if (!client || state !== "ready") throw new Error("Connect to the hub before resuming this session.");
+        await client.request("thread/resume", { ref: sessionRef });
+      }
+      await threadsStore.getState().refreshThread(sessionRef);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRefreshing(false);
+    }
+  };
+  return (
+    <div role="alert">
+      {ownerRef
+        ? "This session is retained by its owning session. Its uncertain messages cannot be checked here until the owner releases it."
+        : resumeRequired
+          ? "Resume this session to check whether its uncertain messages were delivered."
+          : "Session restart required. Stop the older daemon, then refresh this session. Stopping interrupts active work."}
+      {ownerRef && <a href={paneToURL("session", { ref: ownerRef }) ?? undefined}>Open owning session</a>}
+      <Button disabled={refreshing} onClick={() => void refresh()}>
+        {resumeRequired ? "Resume session" : "Refresh session"}
+      </Button>
+      {error && <span>{error}</span>}
+    </div>
+  );
+}
+
 export default function Session({ params, paneId, focused: paneFocused }: PaneProps<SessionPaneParams>) {
   const { ref } = params;
+  const blockedMutations = useBlockedMutationEntries(ref);
 
   // One ensureThread(ref) claim on mount, one matching releaseThread(ref) on
   // unmount. AppShell mounts DockHost (and therefore this pane)
@@ -168,6 +216,9 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
   // lets this pane render an honest terminal state instead of "Loading
   // transcript…" forever.
   const deletedRef = useThreadsStore((s) => !model && s.deletedRefs.has(ref));
+  const restartPending = useThreadsStore((s) => s.restartBlockingObligations.has(ref));
+  const mutationStateAuthoritative = useThreadsStore((s) => s.mutationAuthorityRefs.has(ref));
+  const reconciliationFailed = useThreadsStore((s) => s.mutationReconciliationFailures.has(ref));
   const navigation = useNavigationStore();
 
   const frameTimes = useThreadsStore((s) => s.frameTimes.get(ref) ?? EMPTY_FRAME_TIMES);
@@ -293,6 +344,14 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
     );
   }
 
+  const recoveryOwnerRef =
+    !mutationStateAuthoritative &&
+    model.status.type !== "notLoaded" &&
+    model.status.type !== "restartRequired" &&
+    model.parentRef?.startsWith("local:")
+      ? model.parentRef
+      : undefined;
+
   const cadence = <Cadence state={cadenceStateForStatus(model.status.type)} frameTimes={frameTimes} now={now} />;
 
   const transcriptContent = (
@@ -379,6 +438,18 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
               retry={model.modelRetry}
               primaryModel={model.model}
             />
+            {(model.status.type === "restartRequired" ||
+              restartPending ||
+              (blockedMutations.length > 0 && (model.status.type === "notLoaded" || !mutationStateAuthoritative))) && (
+              <RestartRequiredNotice
+                sessionRef={ref}
+                ownerRef={recoveryOwnerRef}
+                resumeRequired={model.status.type !== "restartRequired" && !recoveryOwnerRef}
+              />
+            )}
+            {reconciliationFailed && (
+              <div role="alert">Message recovery has not completed. Sending will resume after recovery succeeds.</div>
+            )}
             <PendingChips sessionRef={ref} />
             <Composer ref={ref} />
           </div>
@@ -389,7 +460,10 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
       {showColdStartSkeleton && isDormantTranscript(model.turns) ? (
         <ColdStartSkeleton />
       ) : isDormantTranscript(model.turns) ? (
-        <EmptyTranscript active={model.status.type === "active"} />
+        <EmptyTranscript
+          active={model.status.type === "active"}
+          restartRequired={model.status.type === "restartRequired"}
+        />
       ) : (
         transcript
       )}

--- a/cmd/evener-hub/frontend/src/panes/session/coldStart.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/coldStart.tsx
@@ -23,7 +23,7 @@ function hasAuthoritativeFrame(turn: TurnModel): boolean {
 }
 
 function shouldShowColdStart(model: ThreadModel, hasPendingSend: boolean, awaitingFirstFrame: boolean): boolean {
-  if (isThreadTerminalStatus(model.status.type)) return false;
+  if (model.status.type === "restartRequired" || isThreadTerminalStatus(model.status.type)) return false;
 
   const turns = realTurns(model.turns);
   if (turns.length === 0) return hasPendingSend || awaitingFirstFrame;

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
@@ -145,7 +145,13 @@ function testThread(ref: string, overrides: Partial<Thread> = {}): Thread {
     cwd: "/tmp/project",
     cliVersion: "1.0.0",
     source: "evener",
-    evener: { ref, capabilities: FULL_CAPABILITIES, queue: { revision: 0 }, activeTurnId: "turn_1" },
+    evener: {
+      ref,
+      mutationStateAuthoritative: true,
+      capabilities: FULL_CAPABILITIES,
+      queue: { revision: 0 },
+      activeTurnId: "turn_1",
+    },
     turns: [{ id: "turn_1", status: "inProgress", itemsView: "full", items: [] }],
     ...overrides,
   };
@@ -229,14 +235,21 @@ function composerSteerButton(): HTMLButtonElement {
 
 test("an unconfirmed storage commit stays visible and repeated Steer clicks cannot duplicate it", async () => {
   const fake = await mountComposer("ref_a");
-  fake.on("turn/steer", (params) => ({
-    receipt: {
-      clientMutationId: params.clientMutationId,
-      disposition: "applied",
-      threadId: "thr_ref_a",
-      projectionState: "reflected",
-    },
-  }));
+  let deliveryObserved: (() => void) | undefined;
+  const delivered = new Promise<void>((resolve) => {
+    deliveryObserved = resolve;
+  });
+  fake.on("turn/steer", (params) => {
+    deliveryObserved?.();
+    return {
+      receipt: {
+        clientMutationId: params.clientMutationId,
+        disposition: "applied",
+        threadId: "thr_ref_a",
+        projectionState: "reflected",
+      },
+    };
+  });
   await flushPendingTurnsProjectionForTests();
   let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
   let commitObserved: (() => void) | undefined;
@@ -272,19 +285,27 @@ test("an unconfirmed storage commit stays visible and repeated Steer clicks cann
   }
   expect(textarea()?.value).toBe("");
   expect(screen.queryByRole("status", { name: "Message storage" })).toBeNull();
+  await act(async () => delivered);
   expect(fake.calls.filter((call) => call.method === "turn/steer")).toHaveLength(1);
 });
 
 test("a cancelled storage stall keeps the draft, reports the problem, and allows one safe retry", async () => {
   const fake = await mountComposer("ref_a");
-  fake.on("turn/steer", (params) => ({
-    receipt: {
-      clientMutationId: params.clientMutationId,
-      disposition: "applied",
-      threadId: "thr_ref_a",
-      projectionState: "reflected",
-    },
-  }));
+  let deliveryObserved: (() => void) | undefined;
+  const delivered = new Promise<void>((resolve) => {
+    deliveryObserved = resolve;
+  });
+  fake.on("turn/steer", (params) => {
+    deliveryObserved?.();
+    return {
+      receipt: {
+        clientMutationId: params.clientMutationId,
+        disposition: "applied",
+        threadId: "thr_ref_a",
+        projectionState: "reflected",
+      },
+    };
+  });
   await flushPendingTurnsProjectionForTests();
   const get = IDBObjectStore.prototype.get;
   let hold: ReturnType<typeof holdIndexedDBEvent> | undefined;
@@ -326,6 +347,7 @@ test("a cancelled storage stall keeps the draft, reports the problem, and allows
   fireEvent.click(composerSteerButton());
   await flushPendingTurnsProjectionForTests();
   expect(textarea()?.value).toBe("");
+  await act(async () => delivered);
   expect(fake.calls.filter((call) => call.method === "turn/steer")).toHaveLength(1);
 });
 
@@ -1092,7 +1114,13 @@ test("queuing a message end to end: queue -> strip renders -> edit restores text
   const user = userEvent.setup();
   const fake = await mountComposer("ref_a", {
     status: { type: "active" },
-    evener: { ref: "ref_a", capabilities: FULL_CAPABILITIES, queue: { revision: 0 }, activeTurnId: "turn_1" },
+    evener: {
+      ref: "ref_a",
+      mutationStateAuthoritative: true,
+      capabilities: FULL_CAPABILITIES,
+      queue: { revision: 0 },
+      activeTurnId: "turn_1",
+    },
   });
   fake.on("turn/queue", (params) => ({
     receipt: {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -142,7 +142,7 @@ function testThread(ref: string, overrides: Partial<Thread> = {}): Thread {
     cwd: "/tmp/project",
     cliVersion: "1.0.0",
     source: "evener",
-    evener: { ref, capabilities: FULL_CAPABILITIES, queue: { revision: 0 } },
+    evener: { ref, mutationStateAuthoritative: true, capabilities: FULL_CAPABILITIES, queue: { revision: 0 } },
     ...overrides,
   };
 }
@@ -2079,6 +2079,7 @@ test("sending recovered text uses current Composer routing and consumes the reco
       ref: "ref_a",
       capabilities: FULL_CAPABILITIES,
       activeTurnId: "turn-current",
+      mutationStateAuthoritative: true,
       queue: { revision: 4 },
     },
   });

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/QueueStrip.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/QueueStrip.test.tsx
@@ -50,7 +50,13 @@ function testThread(ref: string, overrides: Partial<Thread> = {}): Thread {
     cwd: "/tmp/project",
     cliVersion: "1.0.0",
     source: "evener",
-    evener: { ref, capabilities: CAPABILITIES, queue: { revision: 0 }, activeTurnId: "turn_1" },
+    evener: {
+      ref,
+      mutationStateAuthoritative: true,
+      capabilities: CAPABILITIES,
+      queue: { revision: 0 },
+      activeTurnId: "turn_1",
+    },
     turns: [{ id: "turn_1", status: "inProgress", itemsView: "full", items: [] }],
     ...overrides,
   };
@@ -274,6 +280,15 @@ describe("durable recovery rows", () => {
     // It still needs a way off the strip: with no action at all its recovery
     // record is permanent and keeps being counted as queued.
     expect(within(row).getByRole("button", { name: "Dismiss" })).toBeTruthy();
+  });
+
+  test.each(["restartRequired", "notLoaded"] as const)("Retry stays blocked for %s sessions", async (type) => {
+    const fake = connectFakeClient();
+    await hydrate(fake, "ref_a", { status: { type } });
+    await seedBlockedUnknown("uncertain");
+    renderStrip(defaultProps());
+    const retry = await screen.findByRole("button", { name: "Retry" });
+    expect(isDisabled(retry)).toBe(true);
   });
 
   test("blocked unknown has Retry but no sendable action", async () => {
@@ -1039,4 +1054,15 @@ describe("drain-as-steer affordance", () => {
     fireEvent.click(drainButton);
     expect(fake.calls.filter((c) => c.method === "turn/drainAsSteer")).toHaveLength(0);
   });
+});
+
+test.each(["active", "idle"])("Retry stays disabled for saved %s delegate data", async (type) => {
+  const fake = connectFakeClient();
+  const thread = testThread("ref_a", { status: { type } });
+  thread.evener.mutationStateAuthoritative = false;
+  await hydrate(fake, "ref_a", thread);
+  await seedBlockedUnknown("uncertain");
+  renderStrip(defaultProps());
+  const retry = await screen.findByRole("button", { name: "Retry" });
+  expect(isDisabled(retry)).toBe(true);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/QueueStrip.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/QueueStrip.tsx
@@ -140,6 +140,7 @@ export function QueueStrip({
   onDrainBusyChange,
 }: QueueStripProps): ReactNode {
   const model = useThreadsStore((s) => s.threads.get(sessionRef));
+  const mutationAuthority = useThreadsStore((s) => s.mutationAuthorityRefs.has(sessionRef));
   const pendingQueueEntries = usePendingTurnEntries(sessionRef, "queue").filter(
     (entry) => entry.state !== "blockedUnknown",
   );
@@ -393,7 +394,18 @@ export function QueueStrip({
                   <span>{recordPreview(record)}</span>
                 </span>
                 <div className={CLASS.rowActions}>
-                  <Button size="sm" variant="quiet" disabled={rowBusy} onClick={() => void handleRetry(record)}>
+                  <Button
+                    size="sm"
+                    variant="quiet"
+                    disabled={
+                      rowBusy ||
+                      !mutationAuthority ||
+                      !model ||
+                      model.status.type === "restartRequired" ||
+                      model.status.type === "notLoaded"
+                    }
+                    onClick={() => void handleRetry(record)}
+                  >
                     Retry
                   </Button>
                 </div>

--- a/cmd/evener-hub/frontend/src/panes/session/liveness.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/liveness.ts
@@ -36,6 +36,7 @@ export function cadenceStateForStatus(type: string): CadenceState {
       return "failed";
     case "awaiting":
     case "warning":
+    case "restartRequired":
       return "needs-you";
     case "active":
       return "working";

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
@@ -1061,31 +1061,34 @@ describe("the error anchor (failed turn)", () => {
 });
 
 describe("the needs-you upgrade", () => {
-  test("the pill upgrades to needs-you in place when the status flip lands in a LATER render than the content that produced it", () => {
-    const { ref } = makeListHandle();
-    const { measure } = makeMeasure(SCROLLED_AWAY);
-    const { result, rerender } = renderHook(
-      ({ m }) =>
-        useTranscriptScroll({
-          ref: "ref_a",
-          model: m,
-          listRef: ref,
-          loadOlder: vi.fn(() => Promise.resolve()),
-          measure,
-        }),
-      { initialProps: { m: model([turn("t1", ["i1"])], { status: { type: "idle" } }) } },
-    );
+  test.each(["awaiting", "warning", "restartRequired"] as const)(
+    "the %s pill upgrades to needs-you in place when the status flip lands in a LATER render than the content that produced it",
+    (statusType) => {
+      const { ref } = makeListHandle();
+      const { measure } = makeMeasure(SCROLLED_AWAY);
+      const { result, rerender } = renderHook(
+        ({ m }) =>
+          useTranscriptScroll({
+            ref: "ref_a",
+            model: m,
+            listRef: ref,
+            loadOlder: vi.fn(() => Promise.resolve()),
+            measure,
+          }),
+        { initialProps: { m: model([turn("t1", ["i1"])], { status: { type: "idle" } }) } },
+      );
 
-    rerender({ m: model([turn("t1", ["i1"]), turn("t2", ["i2"])], { status: { type: "idle" } }) });
-    expect(result.current.pillCount).toBe(1);
-    expect(result.current.pillNeedsYou).toBe(false);
+      rerender({ m: model([turn("t1", ["i1"]), turn("t2", ["i2"])], { status: { type: "idle" } }) });
+      expect(result.current.pillCount).toBe(1);
+      expect(result.current.pillNeedsYou).toBe(false);
 
-    // Same content, later render: status alone flips to awaiting.
-    rerender({ m: model([turn("t1", ["i1"]), turn("t2", ["i2"])], { status: { type: "awaiting" } }) });
+      // Same content, later render: status alone requires attention.
+      rerender({ m: model([turn("t1", ["i1"]), turn("t2", ["i2"])], { status: { type: statusType } }) });
 
-    expect(result.current.pillCount).toBe(1); // unchanged - no new content in this render
-    expect(result.current.pillNeedsYou).toBe(true);
-  });
+      expect(result.current.pillCount).toBe(1); // unchanged - no new content in this render
+      expect(result.current.pillNeedsYou).toBe(true);
+    },
+  );
 
   test("askPending alone (independent of status.type) also upgrades the pill", () => {
     const { ref } = makeListHandle();

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
@@ -589,7 +589,7 @@ function totalItemCount(model: ThreadModel | undefined): number {
   return total;
 }
 
-// Mirrors Session.tsx's own cadenceStateForStatus mapping (awaiting/warning
+// Mirrors Session.tsx's own cadenceStateForStatus mapping (awaiting/warning/restartRequired
 // -> needs-you) rather than importing it: flow/ is composed BY Session.tsx,
 // not the other way around (same "deliberately separate, parallel small
 // mapping function" precedent Session.tsx itself follows relative to
@@ -597,7 +597,12 @@ function totalItemCount(model: ThreadModel | undefined): number {
 // is checked independently since it need not always coincide with status.type.
 function isAttentionWorthy(model: ThreadModel | undefined): boolean {
   if (!model) return false;
-  return model.askPending || model.status.type === "awaiting" || model.status.type === "warning";
+  return (
+    model.askPending ||
+    model.status.type === "awaiting" ||
+    model.status.type === "warning" ||
+    model.status.type === "restartRequired"
+  );
 }
 
 // The error-anchor's failure signal is TURN-level (this rewrite's own

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -328,10 +328,19 @@ test("successful keyless testing refreshes availability without an auth notifica
   });
   connectionStore.getState().connect(client);
   renderSpawn(client);
-  await user.click(await screen.findByRole("button", { name: "Connect provider" }));
+  const connectProvider = await screen.findByRole("button", { name: "Connect provider" });
+  // Finish the lazy dialog's mount and catalog refresh before retaining a button
+  // reference: the refresh replaces the initially cached instance rows.
+  await act(async () => {
+    await user.click(connectProvider);
+    await vi.dynamicImportSettled();
+  });
   const testConnection = await screen.findByRole("button", { name: "Test connection" });
   available = true;
   await user.click(testConnection);
+  expect(client.calls.filter((call) => call.method === "evener/auth/test")).toEqual([
+    { method: "evener/auth/test", params: { provider: "ollama" } },
+  ]);
   await waitFor(() => expect(screen.queryByRole("button", { name: "Connect provider" })).toBeNull());
   await user.click(modelTrigger());
   expect(await screen.findByRole("option", { name: /local-model/ })).toBeTruthy();

--- a/cmd/evener-hub/frontend/src/protocol/client.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.test.ts
@@ -96,21 +96,21 @@ describe("AppwireClient", () => {
   test("connect advertises v4 and rejects a v3 daemon", async () => {
     // Keep this assertion first so the pre-cutover client fails immediately,
     // rather than waiting on a handshake that it still considers compatible.
-    expect(APPWIRE_PROTOCOL_VERSION).toBe("evener-appwire-v4");
+    expect(APPWIRE_PROTOCOL_VERSION).toBe("evener-appwire-v5");
 
     const fake = new FakeSocket();
     const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: () => fake });
     const connecting = connectReady(fake, client);
     await flushUntil(() => fake.sent.length > 0);
     const frame = lastSentFrame(fake);
-    expect(frame.params).toMatchObject({ protocolVersion: "evener-appwire-v4" });
+    expect(frame.params).toMatchObject({ protocolVersion: "evener-appwire-v5" });
     fake.receive({
       id: frame.id,
       result: { ...FAKE_INITIALIZE_RESULT, protocolVersion: "evener-appwire-v3" },
     });
 
     await expect(connecting).rejects.toThrow(
-      "AppwireClient: expected protocol evener-appwire-v4, received evener-appwire-v3",
+      "AppwireClient: expected protocol evener-appwire-v5, received evener-appwire-v3",
     );
     expect(client.terminalReason).toBe("protocol");
   });

--- a/cmd/evener-hub/frontend/src/protocol/client.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.ts
@@ -22,7 +22,7 @@ export interface AppwireClientOptions {
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
-export const APPWIRE_PROTOCOL_VERSION = "evener-appwire-v4";
+export const APPWIRE_PROTOCOL_VERSION = "evener-appwire-v5";
 const DEFAULT_CLIENT_INFO = { name: "evener-web", version: "0.1.0" };
 const DEFAULT_CAPABILITIES = { experimentalApi: false };
 

--- a/cmd/evener-hub/frontend/src/protocol/model.ts
+++ b/cmd/evener-hub/frontend/src/protocol/model.ts
@@ -210,6 +210,7 @@ export interface ThreadDiagnostics {
 
 export interface ThreadModel {
   ref: string;
+  parentRef?: string;
   threadId: string;
   // The serving session image bytes belong to (the wire Thread.sessionId at
   // hydrate, falling back to the thread id exactly as the hub's

--- a/cmd/evener-hub/frontend/src/protocol/reducer.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reducer.ts
@@ -758,6 +758,7 @@ export function hydrateThread(resp: ThreadReadResponse, ref: string, now: number
   return {
     ref,
     threadId: thread.id,
+    ...(thread.evener.parentRef === undefined ? {} : { parentRef: thread.evener.parentRef }),
     imageSessionId,
     ...(thread.evener.instanceId === undefined ? {} : { instanceId: thread.evener.instanceId }),
     name: thread.name ?? "",

--- a/cmd/evener-hub/frontend/src/protocol/sendQueueAvailability.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/sendQueueAvailability.test.ts
@@ -213,3 +213,9 @@ describe("deriveSendQueueAvailability", () => {
     ).toEqual({ canSend: false, canQueue: false });
   });
 });
+
+test("an incompatible daemon cannot receive another message even with an outstanding send", () => {
+  expect(
+    deriveSendQueueAvailability({ statusType: "restartRequired", capabilities: caps(), hasPendingSend: true }),
+  ).toEqual({ canSend: false, canQueue: false });
+});

--- a/cmd/evener-hub/frontend/src/protocol/sendQueueAvailability.ts
+++ b/cmd/evener-hub/frontend/src/protocol/sendQueueAvailability.ts
@@ -82,6 +82,7 @@ export function deriveSendQueueAvailability({
   capabilities,
   hasPendingSend,
 }: SendQueueAvailabilityInput): SendQueueAvailability {
+  if (statusType === "restartRequired") return BOTH_UNAVAILABLE;
   // Tier 6 (below) reaches inside this tier rather than being shadowed by it. A
   // finished session is resumable - turn/start alone carries the hub's
   // auto-resume (app_rpc.go's resumeTurnStartThread) - so a first message wakes

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -384,6 +384,7 @@ export interface EvenerThread {
   diagnostics?: EvenerDiagnostics;
   queue: QueueState;
   pendingMutations?: PendingMutation[];
+  mutationStateAuthoritative?: boolean;
   tasks?: TaskAggregate;
   goal?: GoalState;
   usage?: EvenerUsage;

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -175,7 +175,7 @@ function navClient(initialState: ConnectionState = "ready"): FakeClient {
   client.on("evener/navigation/read", navigationRead);
   client.scriptConnect(() => ({
     serverInfo: { name: "fake", version: "1" },
-    protocolVersion: "evener-appwire-v4",
+    protocolVersion: "evener-appwire-v5",
     sourceId: "fake",
     features: {} as never,
     navigation: { version: 1, generationId: "generation_test", sequence: 0, readVersions: [2] },

--- a/cmd/evener-hub/frontend/src/shell/DockRegion.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/DockRegion.test.tsx
@@ -142,7 +142,7 @@ test("a rejected DockHost chunk degrades the dock region, never the whole shell"
   scriptNavigationManifest(client);
   client.scriptConnect(() => ({
     serverInfo: { name: "fake", version: "1" },
-    protocolVersion: "evener-appwire-v4",
+    protocolVersion: "evener-appwire-v5",
     sourceId: "fake",
     features: {} as never,
     navigation: { version: 1, generationId: "test-generation", sequence: 0, readVersions: [2] },

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -216,6 +216,8 @@ async function openMenu(name: RegExp | string) {
 
 function normalizedRailResource(
   key: Extract<ResourceKey, { kind: "project_page" | "pin_section" }>,
+  parentOverrides: Partial<RailSession> = {},
+  childOverrides: Partial<RailSession> = {},
 ): NormalizedResource {
   const parentKey = `${navigationViewScope(key)}/entity/${"1".repeat(64)}`;
   const childKey = `${navigationViewScope(key)}/entity/${"2".repeat(64)}`;
@@ -224,8 +226,16 @@ function normalizedRailResource(
     graph: normalizedGraphFromSnapshot({
       metadata: {},
       entities: [
-        { key: parentKey, kind: "session", value: apiNode({ ref: "parent", title: "Parent", children: [] }) },
-        { key: childKey, kind: "session", value: apiNode({ ref: "child", title: "Child", children: [] }) },
+        {
+          key: parentKey,
+          kind: "session",
+          value: apiNode({ ref: "parent", title: "Parent", children: [], ...parentOverrides }),
+        },
+        {
+          key: childKey,
+          kind: "session",
+          value: apiNode({ ref: "child", title: "Child", children: [], ...childOverrides }),
+        },
       ],
       containers: [
         {
@@ -2042,4 +2052,53 @@ describe("pin star follows the same scoping as the pin action", () => {
       expect(screen.queryByTestId("favorite-star")).toBeNull();
     });
   }
+});
+
+test("an incompatible daemon has an attention signal and restart instruction", () => {
+  renderRow({ state: "restartRequired", live: true, branch: "" });
+  expect(screen.getByRole("img", { name: "Needs you" })).toBeTruthy();
+  expect(screen.getByTestId("rail-row-activity").textContent).toContain("restart required");
+});
+
+test.each([
+  ["own activity", { state: "active" }, { state: "idle" }, "working"],
+  ["subagent activity", { state: "idle" }, { state: "active" }, "1 subagent working"],
+  [
+    "job activity",
+    { state: "idle", running_jobs: [{ job_id: "job-a", job_type: "shell", status: "running" }] },
+    { state: "idle" },
+    "1 job running",
+  ],
+] as const)("normalized navigation preserves %s in the rendered sidebar", (_name, parentState, childState, gloss) => {
+  const resource = normalizedRailResource(
+    { kind: "project_page", projectKey: "project", tier: "current", offset: 0, limit: 50 },
+    { ...parentState, running_jobs: "running_jobs" in parentState ? [...parentState.running_jobs] : [] },
+    childState,
+  );
+  const parent = [...selectRailModel(resource).sessions.values()].find((session) => session.ref === "parent");
+  if (!parent) throw new Error("missing parent");
+  render(<RailRow node={sessionRailNode(parent)} info={info()} actions={actions()} />);
+  expect(screen.getByRole("img", { name: "Working" })).toBeTruthy();
+  expect(screen.getByTestId("rail-row-activity").textContent).toContain(gloss);
+});
+
+test("restart-required navigation disables daemon actions in the sidebar menu", async () => {
+  renderRow({ state: "restartRequired", rename: false, live: true });
+  await openMenu(/actions for/i);
+  expect(screen.getByRole("menuitem", { name: "Shut down" }).getAttribute("aria-disabled")).toBe("true");
+  expect(screen.getByRole("menuitem", { name: "Rename" }).getAttribute("aria-disabled")).toBe("true");
+});
+
+test.each(["subagent", "job"] as const)("restart explanation survives %s activity", (kind) => {
+  renderRow({
+    state: "restartRequired",
+    live: true,
+    branch: "",
+    children: kind === "subagent" ? [apiNode({ state: "active" })] : [],
+    running_jobs: kind === "job" ? [{ job_id: "job-a", job_type: "shell", status: "running" }] : [],
+  });
+  expect(screen.getByRole("img", { name: "Needs you" })).toBeTruthy();
+  const gloss = screen.getByTestId("rail-row-activity").textContent;
+  expect(gloss).toContain("restart required");
+  expect(gloss).toContain(kind === "subagent" ? "1 subagent working" : "1 job running");
 });

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -114,6 +114,7 @@ export function cadenceStateFor(wireState: string): CadenceState {
       return "failed";
     case "awaiting":
     case "warning":
+    case "restartRequired":
       return "needs-you";
     case "active":
       return "working";
@@ -153,6 +154,8 @@ function humanizeState(wireState: string, askPending: boolean): string {
       return "working";
     case "awaiting":
       return askPending ? "question waiting" : "your move";
+    case "restartRequired":
+      return "restart required";
     case "warning":
       return "warning";
     case "errored":
@@ -242,9 +245,10 @@ export function activityGloss(session: RailSession, activity = activeWorkSummary
   const workingCount = activity.workingSubagents;
   const jobCount = activity.runningJobs;
   const parts: string[] = [];
+  if (session.state === "restartRequired") parts.push(humanizeState(session.state, session.ask_pending === true));
   if (workingCount > 0) {
     parts.push(`${workingCount} subagent${workingCount === 1 ? "" : "s"} working`);
-  } else if (jobCount === 0 || session.state === "active") {
+  } else if (session.state !== "restartRequired" && (jobCount === 0 || session.state === "active")) {
     parts.push(humanizeState(session.state, session.ask_pending === true));
   }
   if (jobCount > 0) parts.push(`${jobCount} job${jobCount === 1 ? "" : "s"} running`);
@@ -482,7 +486,7 @@ function SessionMenuRow({ session, actions }: { session: RailSession; actions: R
       title={session.title}
       triggerLabel={`Actions for ${session.title}`}
       canRename={session.rename === true}
-      canShutdown={session.live}
+      canShutdown={session.live && session.state !== "restartRequired"}
       treeNode={session}
       panesOpen={{ details: detailsOpen, tasks: tasksOpen, activity: activityOpen }}
       actions={{
@@ -522,7 +526,7 @@ function SessionRow({ node, info, actions }: { node: SessionRailNode; info: Tree
   // failed session still wins over that rollup so an error cannot disappear
   // behind a green child.
   let effectiveState = presented;
-  if (effectiveState !== "errored" && hasActiveWork) effectiveState = "active";
+  if (effectiveState !== "errored" && effectiveState !== "restartRequired" && hasActiveWork) effectiveState = "active";
   const showsGloss = SIGNAL_STATES.has(cadenceStateFor(effectiveState));
   // kata hxjn: a row at depth 0 is a top-level entry in a flat, cross-project
   // tier (Live/Pinned - see toSessionNode/sessionNodes; a Projects/Test-runs/

--- a/cmd/evener-hub/frontend/src/shell/rail/railNodes.ts
+++ b/cmd/evener-hub/frontend/src/shell/rail/railNodes.ts
@@ -254,7 +254,13 @@ export function overrideLookup(overrides: ReadonlyMap<string, boolean>): IsExpan
 // child is settled work - it would otherwise sit in the current list forever.
 // A child that picks work back up (a drive turn, job_send) reports active and
 // surfaces again.
-const CURRENT_SUBAGENT_STATES: ReadonlySet<string> = new Set(["active", "awaiting", "warning", "notLoaded"]);
+const CURRENT_SUBAGENT_STATES: ReadonlySet<string> = new Set([
+  "active",
+  "awaiting",
+  "warning",
+  "restartRequired",
+  "notLoaded",
+]);
 
 // Namespaced the same way projectNodeExpansionKey is, and off the PARENT's row_id, so
 // every parent's fold is its own key at every nesting depth - expanding one
@@ -401,7 +407,7 @@ export function pinSectionDisclosureID(sectionID: string): string {
 // railNodes for its node types). Same two wire states RailRow's own
 // cadenceStateFor maps to Cadence's "needs-you" family.
 function stateNeedsYou(state: string): boolean {
-  return state === "awaiting" || state === "warning";
+  return state === "awaiting" || state === "warning" || state === "restartRequired";
 }
 
 // The state a row PRESENTS, which is not always the wire state. "awaiting"

--- a/cmd/evener-hub/frontend/src/stores/mutationDispatcher.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationDispatcher.test.ts
@@ -352,13 +352,9 @@ describe("MutationDispatcher", () => {
     expect(await outbox.getRecovery(record.clientMutationId)).toBeUndefined();
   });
 
-  // The daemon's own contract for a blocked-unknown outcome is "retry must
-  // remain blocked until persistence recovers" (NormalizeClientMutationError).
-  // The authoritative thread read is how recovery is proven: an id absent from
-  // every authoritative set (pending, queue, transcript items) was never
-  // journaled, so re-dispatching it is safe — the daemon's journal replays a
-  // receipt if a race ever makes it a duplicate. Without this restore, a
-  // blocked head parks the whole FIFO forever, across reloads (kata gwea).
+  // Live reconciliation reopens unresolved records without changing their
+  // payloads. The daemon's durable journal and original instance fence own
+  // replay safety; omission from the snapshot does not prove non-delivery.
   test("restoreProvenAbsent returns a blocked head to submitting and the next dispatch drains it", async () => {
     const indexedDB = new IDBFactory();
     const outbox = storage(indexedDB, "restore-absent", ["mutation-a", "mutation-b"]);
@@ -529,4 +525,83 @@ describe("MutationDispatcher", () => {
 
     expect(await outbox.getOutbox(record.clientMutationId)).toBeUndefined();
   });
+});
+
+test("attempt evidence is visible to another tab before transport and survives an unknown outcome", async () => {
+  const indexedDB = new IDBFactory();
+  const writer = storage(indexedDB, "attempt-evidence", ["attempted", "unsent"]);
+  const inspector = new MutationOutboxIndexedDB({ indexedDB, databaseName: "attempt-evidence" });
+  const record = await writer.enqueueIntent(queueIntent());
+  const fake = new FakeClient("ready");
+  fake.on("turn/queue", async () => {
+    expect((await inspector.getOutbox(record.clientMutationId))?.attempted).toBe(true);
+    throw new Error("reply lost");
+  });
+  const dispatcher = new MutationDispatcher(writer, { getClient: () => fake });
+  await dispatcher.dispatchTargets([record.targetRef]);
+  writer.close();
+  const fresh = await inspector.enqueueIntent(queueIntent());
+  await inspector.markUnknown(record.clientMutationId, "blockedUnknown", { onlyAttempted: true });
+  await inspector.markUnknown(fresh.clientMutationId, "blockedUnknown", { onlyAttempted: true });
+  expect((await inspector.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+  expect((await inspector.getOutbox(fresh.clientMutationId))?.state).toBe("submitting");
+  inspector.close();
+});
+
+test("failed attempt commit prevents transport", async () => {
+  const store = new MutationOutboxIndexedDB({
+    indexedDB: new IDBFactory(),
+    databaseName: "attempt-commit-failure",
+    beforeCommit: (operation) => {
+      if (operation === "markAttempted") throw new Error("attempt commit failed");
+    },
+  });
+  const record = await store.enqueueIntent(queueIntent());
+  const fake = new FakeClient("ready");
+  const dispatcher = new MutationDispatcher(store, { getClient: () => fake });
+  await expect(dispatcher.dispatchTargets([record.targetRef])).rejects.toThrow("attempt commit failed");
+  expect(fake.calls).toHaveLength(0);
+  expect((await store.getOutbox(record.clientMutationId))?.attempted).toBe(false);
+  store.close();
+});
+
+test("a client replacement during attempt commit retains evidence and recovers the same mutation", async () => {
+  const indexedDB = new IDBFactory();
+  const retired = new FakeClient("ready");
+  const replacement = new FakeClient("ready");
+  let current = retired;
+  const writer = new MutationOutboxIndexedDB({
+    indexedDB,
+    databaseName: "rewire-attempt-evidence",
+    createMutationId: () => "mutation-a",
+    beforeCommit: (operation) => {
+      if (operation === "markAttempted") current = replacement;
+    },
+  });
+  const inspector = new MutationOutboxIndexedDB({ indexedDB, databaseName: "rewire-attempt-evidence" });
+  const record = await writer.enqueueIntent(queueIntent());
+  const dispatcher = new MutationDispatcher(writer, { getClient: () => current });
+
+  await dispatcher.dispatchTargets([record.targetRef]);
+
+  expect(retired.calls).toHaveLength(0);
+  expect(replacement.calls).toHaveLength(0);
+  expect(await inspector.getOutbox(record.clientMutationId)).toMatchObject({
+    attempted: true,
+    payload: record.payload,
+  });
+  // A saved read cannot distinguish this interrupted attempt from delivery
+  // by another tab, so it retains the shared write-ahead evidence.
+  await inspector.markUnknown(record.clientMutationId, "blockedUnknown", { onlyAttempted: true });
+  await dispatcher.dispatchTargets([record.targetRef]);
+  expect(replacement.calls).toHaveLength(0);
+
+  replacement.on("turn/queue", (params) => ({ receipt: receipt(params.clientMutationId, "replayed") }));
+  await dispatcher.restoreProvenAbsent(record.targetRef, new Set());
+  await dispatcher.dispatchTargets([record.targetRef]);
+
+  expect(replacement.calls).toEqual([{ method: "turn/queue", params: record.payload }]);
+  expect(await inspector.getOutbox(record.clientMutationId)).toBeUndefined();
+  inspector.close();
+  writer.close();
 });

--- a/cmd/evener-hub/frontend/src/stores/mutationDispatcher.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationDispatcher.ts
@@ -7,6 +7,7 @@ import type { MutationOutboxIndexedDB } from "./mutationOutboxIndexedDB";
 export interface MutationDispatcherOptions {
   getClient: (targetRef: string) => AppwireClientLike | null | undefined;
   onStorageChange?: (targetRefs: string[]) => void;
+  onBlockedMutation?: (targetRef: string, client: AppwireClientLike) => void;
   onClearResponse?: (targetRef: string, response: ThreadClearResponse) => void;
 }
 
@@ -14,6 +15,7 @@ export class MutationDispatcher {
   readonly #storage: MutationOutboxIndexedDB;
   readonly #getClient: MutationDispatcherOptions["getClient"];
   readonly #onStorageChange: NonNullable<MutationDispatcherOptions["onStorageChange"]>;
+  readonly #onBlockedMutation: NonNullable<MutationDispatcherOptions["onBlockedMutation"]>;
   readonly #onClearResponse: NonNullable<MutationDispatcherOptions["onClearResponse"]>;
   readonly #dispatching = new Map<string, Promise<void>>();
   readonly #requestedRuns = new Map<string, number>();
@@ -22,6 +24,7 @@ export class MutationDispatcher {
     this.#storage = storage;
     this.#getClient = options.getClient;
     this.#onStorageChange = options.onStorageChange ?? (() => undefined);
+    this.#onBlockedMutation = options.onBlockedMutation ?? (() => undefined);
     this.#onClearResponse = options.onClearResponse ?? (() => undefined);
   }
 
@@ -29,11 +32,9 @@ export class MutationDispatcher {
     await Promise.all([...new Set(targetRefs)].map((targetRef) => this.#dispatchTarget(targetRef)));
   }
 
-  // restoreProvenAbsent reopens dispatch for blockedUnknown records the
-  // authoritative read proved the daemon never accepted (see the storage
-  // method's comment for why absence is proof). Runs beside
-  // reconcileIdentities on the hydration publish path: reconcile settles what
-  // the authority knows, this restores what it provably does not.
+  // Reopen unresolved records beside receipt reconciliation. A live snapshot
+  // may omit accepted work, so dispatch preserves each original mutation ID
+  // and payload for journal replay and instance-fence validation.
   async restoreProvenAbsent(targetRef: string, authoritativeIds: ReadonlySet<string>): Promise<void> {
     const restored = await this.#storage.restoreProvenAbsent(targetRef, authoritativeIds);
     if (restored.length > 0) this.#onStorageChange([targetRef]);
@@ -89,6 +90,11 @@ export class MutationDispatcher {
       if (current?.state !== "submitting") continue;
       if (this.#getClient(targetRef) !== client) return false;
 
+      if (!(await this.#storage.markAttempted(current.clientMutationId))) continue;
+      // Keep the committed attempt evidence if this client was retired: another
+      // tab may have dispatched the same record, so absence of this send is not
+      // proof of non-delivery. Live recovery retries the original payload.
+      if (this.#getClient(targetRef) !== client) return false;
       const outcome = await this.#attempt(client, current);
       if (outcome === "stop") return false;
     }
@@ -156,8 +162,12 @@ export class MutationDispatcher {
         data?.mutationOutcome === "unknown" &&
         (data.cause === "persistenceUnavailable" || data.retryDisposition === "blocked")
       ) {
-        await this.#storage.markUnknown(record.clientMutationId, "blockedUnknown");
-        this.#onStorageChange([record.targetRef]);
+        try {
+          await this.#storage.markUnknown(record.clientMutationId, "blockedUnknown");
+          this.#onStorageChange([record.targetRef]);
+        } finally {
+          this.#onBlockedMutation(record.targetRef, client);
+        }
       }
       // Request timeouts, transport failures, and automatically retryable
       // unknown outcomes retain submitting. A later ready/discovery event

--- a/cmd/evener-hub/frontend/src/stores/mutationOutbox.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutbox.test.ts
@@ -87,6 +87,7 @@ describe("MutationOutboxIndexedDB", () => {
       attachments: [],
       optimisticDisplay: { text: "survive reload" },
       state: "submitting",
+      attempted: false,
     });
   });
 
@@ -735,7 +736,10 @@ describe("MutationOutbox discovery", () => {
     });
     await survivingTab.start();
     await survivingTab.connectionReady();
-    expect(discoveries).toEqual([]);
+    expect(discoveries).toEqual([
+      { targets: [], reason: "startup" },
+      { targets: [], reason: "ready" },
+    ]);
 
     await new MutationOutboxIndexedDB({
       indexedDB,
@@ -745,7 +749,11 @@ describe("MutationOutbox discovery", () => {
     intervals[0]?.();
     await survivingTab.stop();
 
-    expect(discoveries).toEqual([{ targets: [TARGET], reason: "interval" }]);
+    expect(discoveries).toEqual([
+      { targets: [], reason: "startup" },
+      { targets: [], reason: "ready" },
+      { targets: [TARGET], reason: "interval" },
+    ]);
     expect(await storage.listOutbox(TARGET)).toHaveLength(1);
   });
 

--- a/cmd/evener-hub/frontend/src/stores/mutationOutbox.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutbox.ts
@@ -48,6 +48,7 @@ export interface MutationRecord extends MutationIntent {
 
 export interface MutationOutboxRecord extends MutationRecord {
   state: MutationOutboxState;
+  attempted?: boolean;
 }
 
 export interface MutationOptimisticRecord extends MutationRecord {
@@ -223,7 +224,7 @@ export class MutationOutbox {
   }
 
   async #discover(targetRefs: string[], reason: MutationDiscoveryReason): Promise<void> {
-    if (targetRefs.length === 0) return;
+    // The consumer may still own failed reconciliation after its last durable record settled.
     await this.#onDiscover(targetRefs, reason);
   }
 }

--- a/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
+++ b/cmd/evener-hub/frontend/src/stores/mutationOutboxIndexedDB.ts
@@ -11,6 +11,7 @@ import type {
 import { createSecureUUID } from "./secureUUID";
 
 type MutationOutboxOperation =
+  | "markAttempted"
   | "enqueueIntent"
   | "settleReceipt"
   | "transferToRecovery"
@@ -121,6 +122,7 @@ export class MutationOutboxIndexedDB {
         intentSequence,
         createdAt: this.#now(),
         state: "submitting",
+        attempted: false,
       };
       await requestResult(transaction.objectStore(OUTBOX_STORE).add(record));
       return record;
@@ -230,25 +232,38 @@ export class MutationOutboxIndexedDB {
     });
   }
 
-  async markUnknown(clientMutationId: string, state: MutationOutboxState): Promise<boolean> {
+  // Commit attempt evidence before transport so another tab or a reload cannot
+  // mistake a possibly delivered mutation for an unsent intent.
+  async markAttempted(clientMutationId: string): Promise<boolean> {
+    return this.#write(OUTBOX_STORE, "markAttempted", async (transaction) => {
+      const store = transaction.objectStore(OUTBOX_STORE);
+      const record = await requestResult<MutationOutboxRecord | undefined>(store.get(clientMutationId));
+      if (record?.state !== "submitting") return false;
+      await requestResult(store.put({ ...record, attempted: true }));
+      return true;
+    });
+  }
+
+  async markUnknown(
+    clientMutationId: string,
+    state: MutationOutboxState,
+    options?: { onlyAttempted: boolean },
+  ): Promise<boolean> {
     return this.#write(OUTBOX_STORE, undefined, async (transaction) => {
       const store = transaction.objectStore(OUTBOX_STORE);
       const record = await requestResult<MutationOutboxRecord | undefined>(store.get(clientMutationId));
-      if (!record) return false;
+      if (!record || (options?.onlyAttempted && record.attempted === false)) return false;
       if (record.state !== state) await requestResult(store.put({ ...record, state }));
       return true;
     });
   }
 
-  // restoreProvenAbsent is markUnknown's exit. A blockedUnknown record waits
-  // for its outcome to become provable ("retry must remain blocked until
-  // persistence recovers" — the daemon's NormalizeClientMutationError); a
-  // successful authoritative read is that proof. An id absent from every
-  // authoritative set was never journaled, so it returns to "submitting" for
-  // the normal dispatch path — the daemon's journal replays a receipt if a
-  // race ever makes the resend a duplicate. Ids the authority DOES report are
-  // left alone: reconcileIdentities or a replayed dispatch owns their
-  // settlement. Returns the restored ids.
+  // Reopen unresolved records after a live authoritative read. Missing IDs
+  // are not proof of non-delivery: bounded transcripts omit older work.
+  // Preserve the original mutation ID and entire payload so the daemon's
+  // durable journal can replay its receipt, or the original instance fence
+  // can reject a retry after a clear. Known IDs stay on the receipt path.
+  // Returns the restored IDs.
   async restoreProvenAbsent(targetRef: string, authoritativeIds: ReadonlySet<string>): Promise<string[]> {
     return this.#write(OUTBOX_STORE, undefined, async (transaction) => {
       const store = transaction.objectStore(OUTBOX_STORE);
@@ -358,6 +373,7 @@ export class MutationOutboxIndexedDB {
         intentSequence,
         createdAt: this.#now(),
         state: "submitting",
+        attempted: false,
       };
       await requestResult(transaction.objectStore(OUTBOX_STORE).add(record));
       await requestResult(recoveryStore.delete(clientMutationId));

--- a/cmd/evener-hub/frontend/src/stores/navigation/store.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/navigation/store.test.ts
@@ -61,7 +61,7 @@ const init = async (script: NavigationScript) => {
 };
 const initialize = (navigation: NavigationCapability): InitializeResponse => ({
   serverInfo: { name: "fake", version: "1" },
-  protocolVersion: "evener-appwire-v4",
+  protocolVersion: "evener-appwire-v5",
   sourceId: "fake",
   features: {
     threadList: false,
@@ -1029,7 +1029,7 @@ test("same-generation reconnect during manifest load continues booting resources
   });
   client.scriptConnect(() => ({
     serverInfo: { name: "fake", version: "1" },
-    protocolVersion: "evener-appwire-v4",
+    protocolVersion: "evener-appwire-v5",
     sourceId: "fake",
     features: {} as never,
     navigation: capability(),
@@ -1200,7 +1200,7 @@ test("sequence gaps revalidate demanded locations", async () => {
   const client = new FakeClient("ready");
   client.scriptConnect(() => ({
     serverInfo: { name: "fake", version: "1" },
-    protocolVersion: "evener-appwire-v4",
+    protocolVersion: "evener-appwire-v5",
     sourceId: "fake",
     features: {} as never,
     navigation: capability(),

--- a/cmd/evener-hub/frontend/src/stores/threads.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.test.ts
@@ -42,6 +42,7 @@ import {
   readMutationPersistence,
   resendRecoveryMutation,
   resetThreadsStoreForTests,
+  retryBlockedMutation,
   setMutationStorageForTests,
   subscribeMutationPersistence,
   threadRoutingIndexesForTests,
@@ -131,6 +132,7 @@ function testThread(ref: string, overrides: TestThreadOverrides = {}): Thread {
     evener: {
       ref,
       instanceId: threadID,
+      mutationStateAuthoritative: true,
       capabilities: CAPABILITIES,
       ...evener,
       queue: { revision: 0, ...evener?.queue },
@@ -7182,6 +7184,40 @@ describe("useThreadsStore read-only ready-gating (requireReadyClient)", () => {
     vi.useRealTimers();
   });
 
+  test("explicit refresh keeps one readiness deadline across ready-to-rewire races", async () => {
+    let client = connectFakeClient("reconnecting");
+    const clients = [client];
+    let outcome: unknown;
+    const refreshing = threadsStore
+      .getState()
+      .refreshThread("ref_a")
+      .then(
+        () => {
+          outcome = "resolved";
+        },
+        (error: unknown) => {
+          outcome = error;
+        },
+      );
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await vi.advanceTimersByTimeAsync(5_000);
+      client.emitReady();
+      // Ready resolves the helper; the connection changes before the refresh
+      // continuation captures the current client and its ready epoch.
+      await Promise.resolve();
+      client = new FakeClient("reconnecting");
+      clients.push(client);
+      connectionStore.getState().connect(client);
+    }
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(outcome).toBeInstanceOf(ClientNotReadyError);
+    expect(errorKind(outcome)).toBe("hub-unreachable");
+    await refreshing;
+    expect(clients.flatMap((candidate) => candidate.calls)).toHaveLength(0);
+  });
+
   test("a read call times out with a classified ClientNotReadyError if the client never becomes ready", async () => {
     connectFakeClient("reconnecting"); // never reaches ready in this test
     const pending = threadsStore.getState().listJobs("ref_a");
@@ -7209,17 +7245,17 @@ describe("useThreadsStore read-only ready-gating (requireReadyClient)", () => {
   });
 });
 
-describe("retry-safe mutation outbox integration", () => {
-  function deferred<T>() {
-    let resolve!: (value: T) => void;
-    let reject!: (error: unknown) => void;
-    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-      resolve = resolvePromise;
-      reject = rejectPromise;
-    });
-    return { promise, resolve, reject };
-  }
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
+describe("retry-safe mutation outbox integration", () => {
   test("send resolves from the local commit while a lost response leaves one durable intent", async () => {
     const response = deferred<TurnStartResponse>();
     const called = deferred<void>();
@@ -7274,38 +7310,70 @@ describe("retry-safe mutation outbox integration", () => {
     expect(fake.calls.map((call) => call.method)).toEqual(["thread/read", "turn/queue"]);
   });
 
-  // A blockedUnknown record parks until its outcome is provable. The
-  // authoritative read this rejoin performs IS the proof: readResponse's
-  // authoritative sets don't contain the id, so the daemon never journaled
-  // it, and the record must return to dispatch instead of sitting parked
-  // forever — across reloads, with the composer showing it queued and no
-  // recovery affordance (kata gwea, observed live 2026-07-31).
-  test("restores and replays a blocked-unknown intent once the authoritative read proves it absent", async () => {
-    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "mutation-a" });
-    const record = await storage.enqueueIntent({
-      targetRef: "ref_a",
-      method: "turn/queue",
-      payload: {
+  test.each(["bounded transcript", "cleared instance"])(
+    "retries an unresolved %s mutation with its original identity and payload",
+    async (snapshot) => {
+      const storage = new MutationOutboxIndexedDB({ createMutationId: () => "mutation-a" });
+      const record = await storage.enqueueIntent({
+        targetRef: "ref_a",
+        method: "turn/queue",
+        payload: {
+          ref: "ref_a",
+          expectedInstanceId: "original-instance",
+          expectedQueueRevision: 3,
+          input: [{ type: "text", text: "queued before the outage" }],
+        },
+        attachments: [],
+        optimisticDisplay: { text: "queued before the outage" },
+      });
+      await storage.markAttempted(record.clientMutationId);
+      await storage.markUnknown(record.clientMutationId, "blockedUnknown");
+      storage.close();
+      const fake = connectFakeClient("connecting");
+      fake.on("thread/read", () => ({
+        olderCursor: snapshot === "bounded transcript" ? "older-transcript" : undefined,
+        ...readResponse("ref_a", {
+          evener: {
+            ref: "ref_a",
+            capabilities: CAPABILITIES,
+            instanceId: snapshot === "bounded transcript" ? "original-instance" : "cleared-instance",
+            mutationStateAuthoritative: true,
+            queue: { revision: 9, clientMutationIds: [] },
+          },
+        }),
+      }));
+      const retried = nextHandledRequest(fake, "turn/queue", (params) => {
+        if (snapshot === "cleared instance") {
+          throw new WireError("instance changed", -32014, {
+            clientMutationId: params.clientMutationId,
+            mutationOutcome: "notAccepted",
+          });
+        }
+        return { receipt: { ...mutationReceipt(params.clientMutationId), disposition: "replayed" } };
+      });
+
+      fake.emitReady();
+      expect(await retried).toEqual({
         ref: "ref_a",
+        expectedInstanceId: "original-instance",
+        expectedQueueRevision: 3,
         input: [{ type: "text", text: "queued before the outage" }],
-      },
-      attachments: [],
-      optimisticDisplay: { text: "queued before the outage" },
-    });
-    await storage.markUnknown(record.clientMutationId, "blockedUnknown");
-    storage.close();
-    const fake = connectFakeClient("connecting");
-    fake.on("thread/read", () => readResponse("ref_a"));
-    fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
-
-    fake.emitReady();
-    await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
-
-    expect(fake.calls.map((call) => call.method)).toEqual(["thread/read", "turn/queue"]);
-    const inspector = new MutationOutboxIndexedDB();
-    expect(await inspector.getOutbox(record.clientMutationId)).toBeUndefined();
-    inspector.close();
-  });
+        clientMutationId: "mutation-a",
+      });
+      await threadsStore.getState().refreshThread("ref_a");
+      const inspector = new MutationOutboxIndexedDB();
+      expect(await inspector.getOutbox(record.clientMutationId)).toBeUndefined();
+      if (snapshot === "cleared instance") {
+        expect(await inspector.getRecovery(record.clientMutationId)).toMatchObject({
+          recoveryKind: "rejected",
+          payload: record.payload,
+        });
+      } else {
+        expect(await inspector.getRecovery(record.clientMutationId)).toBeUndefined();
+      }
+      inspector.close();
+    },
+  );
 
   test("hydrates a durable optimistic ref without redispatching its settled transport intent", async () => {
     const storage = new MutationOutboxIndexedDB({ createMutationId: () => "mutation-a" });
@@ -7895,4 +7963,975 @@ describe("putThreadModel ref invariant (map key === model.ref)", () => {
     putThreadModel("ref_a", model);
     expect(threadsStore.getState().threads.get("ref_a")?.ref).toBe("ref_a");
   });
+});
+
+test("explicit refresh captures the replacement client with its ready epoch", async () => {
+  const oldClient = connectFakeClient();
+  oldClient.on("thread/read", () => ({ thread: testThread("ref_a", { status: { type: "restartRequired" } }) }));
+  await threadsStore.getState().ensureThread("ref_a");
+  const refreshing = threadsStore.getState().refreshThread("ref_a");
+  const replacement = new FakeClient("ready");
+  replacement.on("thread/read", () => ({ thread: testThread("ref_a", { status: { type: "idle" } }) }));
+  connectionStore.getState().connect(replacement);
+  await refreshing;
+  await settleCallerContinuations();
+  expect(oldClient.calls.filter((call) => call.method === "thread/read")).toHaveLength(1);
+  expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("idle");
+});
+
+test("a new message composed after a saved snapshot can still dispatch", async () => {
+  const fake = connectFakeClient("connecting");
+  fake.on("thread/read", () => readResponse("ref_a", { status: { type: "notLoaded" } }));
+  fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+  fake.emitReady();
+  await threadsStore.getState().ensureThread("ref_a");
+  await threadsStore.getState().queue("ref_a", "new message");
+  await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
+  expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+});
+
+test("a message composed during a saved read dispatches its first delivery", async () => {
+  const fake = connectFakeClient("connecting");
+  const saved = deferred<ThreadReadResponse>();
+  fake.on("thread/read", () => saved.promise);
+  const delivered = deferred<void>();
+  fake.on("turn/queue", (params) => {
+    delivered.resolve();
+    return { receipt: mutationReceipt(params.clientMutationId) };
+  });
+  fake.emitReady();
+  const hydration = threadsStore.getState().ensureThread("ref_a");
+  await threadsStore.getState().queue("ref_a", "new message during hydration");
+  expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+  saved.resolve(readResponse("ref_a", { status: { type: "notLoaded" } }));
+  await hydration;
+  await delivered.promise;
+  expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+});
+
+test("reload after a failed restart write reconciles persisted uncertainty with the resumed daemon", async () => {
+  const storage = new MutationOutboxIndexedDB({ createMutationId: () => "reload-uncertain" });
+  const record = await storage.enqueueIntent({
+    targetRef: "ref_a",
+    method: "turn/queue",
+    payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+    attachments: [],
+    optimisticDisplay: { text: "sentinel" },
+  });
+  await storage.markAttempted(record.clientMutationId);
+  setMutationStorageForTests(storage);
+  vi.spyOn(storage, "markUnknown").mockRejectedValue(new DOMException("storage unavailable", "AbortError"));
+  const old = connectFakeClient("connecting");
+  old.on("thread/read", () => readResponse("ref_a", { status: { type: "restartRequired" } }));
+  old.emitReady();
+  await threadsStore
+    .getState()
+    .ensureThread("ref_a")
+    .catch(() => undefined);
+  expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("submitting");
+  resetThreadsStoreForTests();
+  const reloadedStorage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(reloadedStorage);
+  const reloaded = connectFakeClient("connecting");
+  let resumed = false;
+  reloaded.on("thread/read", () =>
+    readResponse("ref_a", {
+      status: { type: resumed ? "idle" : "notLoaded" },
+      evener: {
+        ref: "ref_a",
+        capabilities: CAPABILITIES,
+        queue: { revision: 1, clientMutationIds: resumed ? [record.clientMutationId] : [] },
+      },
+    }),
+  );
+  reloaded.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+  reloaded.emitReady();
+  await threadsStore.getState().ensureThread("ref_a");
+  expect((await reloadedStorage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+  expect(reloaded.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+  resumed = true;
+  await threadsStore.getState().refreshThread("ref_a");
+  expect(await reloadedStorage.getOutbox(record.clientMutationId)).toBeUndefined();
+  expect(reloaded.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+});
+
+test("saved snapshots retain restart protection for subsequently discovered outbox records", async () => {
+  const storage = new MutationOutboxIndexedDB({ createMutationId: () => "late-upgrade-record" });
+  setMutationStorageForTests(storage);
+  const fake = connectFakeClient("connecting");
+  let status = "restartRequired";
+  fake.on("thread/read", () => readResponse("ref_a", { status: { type: status } }));
+  fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+  fake.emitReady();
+  await threadsStore.getState().ensureThread("ref_a");
+  status = "notLoaded";
+  await threadsStore.getState().refreshThread("ref_a");
+  const record = await storage.enqueueIntent({
+    targetRef: "ref_a",
+    method: "turn/queue",
+    payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+    attachments: [],
+    optimisticDisplay: { text: "sentinel" },
+  });
+  await storage.markAttempted(record.clientMutationId);
+  await threadsStore.getState().refreshThread("ref_a");
+  expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+  expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+  status = "idle";
+  await threadsStore.getState().refreshThread("ref_a");
+  await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
+  expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+});
+
+for (const state of ["blockedUnknown", "submitting"] as const) {
+  test(`incompatible refresh preserves ${state} until a compatible snapshot arrives`, async () => {
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "upgrade-pending" });
+    const record = await storage.enqueueIntent({
+      targetRef: "ref_a",
+      method: "turn/queue",
+      payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+      attachments: [],
+      optimisticDisplay: { text: "sentinel" },
+    });
+    await storage.markAttempted(record.clientMutationId);
+    if (state === "blockedUnknown") await storage.markUnknown(record.clientMutationId, state);
+    storage.close();
+    const fake = connectFakeClient("connecting");
+    let status = "restartRequired";
+    fake.on("thread/read", () => readResponse("ref_a", { status: { type: status } }));
+    fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+    fake.emitReady();
+    await threadsStore.getState().ensureThread("ref_a");
+    await threadsStore.getState().refreshThread("ref_a");
+    const inspector = new MutationOutboxIndexedDB();
+    expect(await retryBlockedMutation(record.clientMutationId)).toBe(false);
+    expect((await inspector.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+    status = "notLoaded";
+    await threadsStore.getState().refreshThread("ref_a");
+    expect(await retryBlockedMutation(record.clientMutationId)).toBe(false);
+    expect((await inspector.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+    status = "idle";
+    await threadsStore.getState().refreshThread("ref_a");
+    await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+    inspector.close();
+  });
+}
+
+test("compatible refresh wins over a delayed incompatible receipt write", async () => {
+  const storage = new MutationOutboxIndexedDB({ createMutationId: () => "delayed-upgrade" });
+  const record = await storage.enqueueIntent({
+    targetRef: "ref_a",
+    method: "turn/queue",
+    payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+    attachments: [],
+    optimisticDisplay: { text: "sentinel" },
+  });
+  await storage.markAttempted(record.clientMutationId);
+  const writeStarted = deferred<void>();
+  const releaseWrite = deferred<void>();
+  const markUnknown = storage.markUnknown.bind(storage);
+  vi.spyOn(storage, "markUnknown").mockImplementation(async (id, state) => {
+    writeStarted.resolve();
+    await releaseWrite.promise;
+    return markUnknown(id, state);
+  });
+  const settled = deferred<void>();
+  const settleReceipt = storage.settleReceipt.bind(storage);
+  vi.spyOn(storage, "settleReceipt").mockImplementation(async (id, projectionState) => {
+    const result = await settleReceipt(id, projectionState);
+    if (id === record.clientMutationId) settled.resolve();
+    return result;
+  });
+  setMutationStorageForTests(storage);
+  const fake = connectFakeClient("connecting");
+  let status = "restartRequired";
+  fake.on("thread/read", () => readResponse("ref_a", { status: { type: status } }));
+  const receipt = deferred<{ receipt: ReturnType<typeof mutationReceipt> }>();
+  fake.on("turn/queue", () => receipt.promise);
+  fake.emitReady();
+  const firstRead = threadsStore.getState().ensureThread("ref_a");
+  await writeStarted.promise;
+  status = "idle";
+  const refresh = threadsStore.getState().refreshThread("ref_a");
+  await flushIndexedDBUntil(() => threadsStore.getState().threads.get("ref_a")?.status.type === "idle");
+  expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("idle");
+  releaseWrite.resolve();
+  await Promise.all([firstRead, refresh]);
+  await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
+  expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("submitting");
+  expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+  receipt.resolve({ receipt: mutationReceipt(record.clientMutationId) });
+  await settled.promise;
+});
+
+test.each([false, true])(
+  "stopped refresh retains an overlapping blocking obligation (reconnect=%s)",
+  async (reconnect) => {
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "overlapping-stop" });
+    const record = await storage.enqueueIntent({
+      targetRef: "ref_a",
+      method: "turn/queue",
+      payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+      attachments: [],
+      optimisticDisplay: { text: "sentinel" },
+    });
+    await storage.markAttempted(record.clientMutationId);
+    const scanStarted = deferred<void>();
+    const releaseScan = deferred<void>();
+    const listOutbox = storage.listOutbox.bind(storage);
+    let held = false;
+    vi.spyOn(storage, "listOutbox").mockImplementation(async (ref) => {
+      const records = await listOutbox(ref);
+      if (ref && !held && threadsStore.getState().threads.get(ref)?.status.type === "restartRequired") {
+        held = true;
+        scanStarted.resolve();
+        await releaseScan.promise;
+      }
+      return records;
+    });
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient("connecting");
+    let status = "restartRequired";
+    fake.on("thread/read", () => readResponse("ref_a", { status: { type: status } }));
+    fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+    fake.emitReady();
+    const firstRead = threadsStore.getState().ensureThread("ref_a");
+    await scanStarted.promise;
+    status = "notLoaded";
+    if (reconnect) {
+      fake.emitStateChange("reconnecting");
+      fake.emitReady();
+    }
+    const refresh = threadsStore.getState().refreshThread("ref_a");
+    await flushIndexedDBUntil(() => threadsStore.getState().threads.get("ref_a")?.status.type === "notLoaded");
+    expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("notLoaded");
+    releaseScan.resolve();
+    await Promise.all([firstRead, refresh]);
+    expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+    status = "idle";
+    await threadsStore.getState().refreshThread("ref_a");
+    await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+  },
+);
+
+for (const failure of ["listOutbox", "markUnknown"] as const) {
+  test.each([false, true])(
+    `restart blocking survives ${failure} failure and stopped refresh (overlap=%s)`,
+    async (overlap) => {
+      const storage = new MutationOutboxIndexedDB({ createMutationId: () => "failed-restart-block" });
+      const record = await storage.enqueueIntent({
+        targetRef: "ref_a",
+        method: "turn/queue",
+        payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+        attachments: [],
+        optimisticDisplay: { text: "sentinel" },
+      });
+      await storage.markAttempted(record.clientMutationId);
+      const blockingStarted = deferred<void>();
+      const releaseFailure = deferred<void>();
+      let faultEnabled = true;
+      let held = false;
+      const failStorage = async () => {
+        if (!held) {
+          held = true;
+          blockingStarted.resolve();
+          await releaseFailure.promise;
+        }
+        throw new DOMException("IndexedDB transaction aborted", "AbortError");
+      };
+      if (failure === "listOutbox") {
+        const listOutbox = storage.listOutbox.bind(storage);
+        vi.spyOn(storage, "listOutbox").mockImplementation(async (ref) => {
+          if (
+            faultEnabled &&
+            ref &&
+            (held || threadsStore.getState().threads.get(ref)?.status.type === "restartRequired")
+          )
+            await failStorage();
+          return listOutbox(ref);
+        });
+      } else {
+        const markUnknown = storage.markUnknown.bind(storage);
+        vi.spyOn(storage, "markUnknown").mockImplementation(async (id, state) => {
+          if (faultEnabled && state === "blockedUnknown") await failStorage();
+          return markUnknown(id, state);
+        });
+      }
+      setMutationStorageForTests(storage);
+      const fake = connectFakeClient("connecting");
+      let status = "restartRequired";
+      fake.on("thread/read", () => readResponse("ref_a", { status: { type: status } }));
+      fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+      fake.emitReady();
+      const firstRead = threadsStore
+        .getState()
+        .ensureThread("ref_a")
+        .catch(() => undefined);
+      await blockingStarted.promise;
+      let stopped: Promise<unknown> | undefined;
+      if (overlap) {
+        status = "notLoaded";
+        stopped = threadsStore
+          .getState()
+          .refreshThread("ref_a")
+          .catch(() => undefined);
+        await flushIndexedDBUntil(() => threadsStore.getState().threads.get("ref_a")?.status.type === "notLoaded");
+      }
+      releaseFailure.resolve();
+      await firstRead;
+      status = "notLoaded";
+      await (stopped ??
+        threadsStore
+          .getState()
+          .refreshThread("ref_a")
+          .catch(() => undefined));
+      expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("submitting");
+      expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+      faultEnabled = false;
+      await threadsStore.getState().refreshThread("ref_a");
+      expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+      expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+      status = "idle";
+      await threadsStore.getState().refreshThread("ref_a");
+      await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
+      expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+    },
+  );
+}
+
+test("periodic discovery recovers failed compatible reconciliation after storage returns", async () => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  try {
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "recovery-after-storage" });
+    await storage.enqueueIntent({
+      targetRef: "ref_a",
+      method: "turn/queue",
+      payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+      attachments: [],
+      optimisticDisplay: { text: "sentinel" },
+    });
+    let faultEnabled = false;
+    let failures = 0;
+    const listOutbox = storage.listOutbox.bind(storage);
+    vi.spyOn(storage, "listOutbox").mockImplementation(async (ref) => {
+      if (
+        faultEnabled &&
+        ref &&
+        (failures > 0 || threadsStore.getState().threads.get(ref)?.status.type === "restartRequired")
+      ) {
+        failures += 1;
+        throw new DOMException("IndexedDB transaction aborted", "AbortError");
+      }
+      return listOutbox(ref);
+    });
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient("connecting");
+    let status = "restartRequired";
+    fake.on("thread/read", () => readResponse("ref_a", { status: { type: status } }));
+    fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+    fake.emitReady();
+    await threadsStore.getState().ensureThread("ref_a");
+    await settleCallerContinuations();
+    faultEnabled = true;
+    await threadsStore
+      .getState()
+      .refreshThread("ref_a")
+      .catch(() => undefined);
+    expect(failures).toBeGreaterThan(0);
+    status = "idle";
+    await threadsStore
+      .getState()
+      .refreshThread("ref_a")
+      .catch(() => undefined);
+    expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("idle");
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+    expect(failures).toBeGreaterThan(1);
+    expect(threadsStore.getState().mutationReconciliationFailures.has("ref_a")).toBe(true);
+    faultEnabled = false;
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushIndexedDBUntil(() => fake.calls.some((call) => call.method === "turn/queue"));
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+    expect(threadsStore.getState().mutationReconciliationFailures.has("ref_a")).toBe(false);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("periodic discovery recovers reconciliation after the final durable record settles", async () => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  try {
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "last-record" });
+    await storage.enqueueIntent({
+      targetRef: "ref_a",
+      method: "turn/queue",
+      payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+      attachments: [],
+      optimisticDisplay: { text: "sentinel" },
+    });
+    let faultEnabled = false;
+    const listOutbox = storage.listOutbox.bind(storage);
+    vi.spyOn(storage, "listOutbox").mockImplementation(async (ref) => {
+      const records = await listOutbox(ref);
+      if (faultEnabled && ref && records.length === 0)
+        throw new DOMException("IndexedDB transaction aborted", "AbortError");
+      return records;
+    });
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient("connecting");
+    let compatible = false;
+    fake.on("thread/read", () =>
+      readResponse("ref_a", {
+        status: { type: compatible ? "idle" : "restartRequired" },
+        evener: {
+          ref: "ref_a",
+          capabilities: CAPABILITIES,
+          queue: { revision: 1, clientMutationIds: compatible ? ["last-record"] : [] },
+        },
+      }),
+    );
+    fake.emitReady();
+    await threadsStore.getState().ensureThread("ref_a");
+    await settleCallerContinuations();
+    compatible = true;
+    faultEnabled = true;
+    await threadsStore
+      .getState()
+      .refreshThread("ref_a")
+      .catch(() => undefined);
+    expect(await storage.listTargetRefs()).toEqual([]);
+    expect(threadsStore.getState().mutationReconciliationFailures.has("ref_a")).toBe(true);
+    faultEnabled = false;
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushIndexedDBUntil(() => !threadsStore.getState().mutationReconciliationFailures.has("ref_a"));
+    expect(threadsStore.getState().mutationReconciliationFailures.has("ref_a")).toBe(false);
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test.each(["active", "idle"])(
+  "recovered %s descendant without uncertain messages permits new sends",
+  async (status) => {
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "fresh-descendant-send" });
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient("connecting");
+    let snapshot = readResponse("ref_a", { status: { type: "restartRequired" } });
+    fake.on("thread/read", () => snapshot);
+    const delivered = deferred<void>();
+    fake.on("turn/queue", (params) => {
+      delivered.resolve();
+      return { receipt: mutationReceipt(params.clientMutationId) };
+    });
+    fake.emitReady();
+    await threadsStore.getState().ensureThread("ref_a");
+    await threadsStore.getState().refreshThread("ref_a");
+    expect(threadsStore.getState().restartBlockingObligations.has("ref_a")).toBe(true);
+    snapshot = readResponse("ref_a", { status: { type: status } });
+    Object.assign(snapshot.thread.evener, { mutationStateAuthoritative: false, kind: "subagent" });
+    await threadsStore.getState().refreshThread("ref_a");
+    expect(threadsStore.getState().restartBlockingObligations.has("ref_a")).toBe(false);
+    expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(false);
+    await threadsStore.getState().queue("ref_a", "new message after restart");
+    await delivered.promise;
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+  },
+);
+test.each(["active", "idle"])(
+  "recovered %s descendant with a never-attempted intent permits delivery",
+  async (status) => {
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "unsent-descendant-send" });
+    await storage.enqueueIntent({
+      targetRef: "ref_a",
+      method: "turn/queue",
+      payload: { ref: "ref_a", input: [{ type: "text", text: "unsent" }] },
+      attachments: [],
+      optimisticDisplay: { text: "unsent" },
+    });
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient("connecting");
+    let snapshot = readResponse("ref_a", { status: { type: "restartRequired" } });
+    fake.on("thread/read", () => snapshot);
+    const delivered = deferred<void>();
+    fake.on("turn/queue", (params) => {
+      delivered.resolve();
+      return { receipt: mutationReceipt(params.clientMutationId) };
+    });
+    fake.emitReady();
+    await threadsStore.getState().ensureThread("ref_a");
+    await threadsStore.getState().refreshThread("ref_a");
+    expect(threadsStore.getState().restartBlockingObligations.has("ref_a")).toBe(true);
+    snapshot = readResponse("ref_a", { status: { type: status } });
+    Object.assign(snapshot.thread.evener, { mutationStateAuthoritative: false, kind: "subagent" });
+    await threadsStore.getState().refreshThread("ref_a");
+    expect(threadsStore.getState().restartBlockingObligations.has("ref_a")).toBe(false);
+    expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(false);
+
+    await delivered.promise;
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+  },
+);
+
+for (const status of ["active", "idle"]) {
+  test(`saved ${status} delegate snapshots do not release uncertain mutations`, async () => {
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "delegate-uncertain" });
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient("connecting");
+    let snapshot = readResponse("ref_a", { status: { type: "restartRequired" } });
+    fake.on("thread/read", () => snapshot);
+    fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+    fake.emitReady();
+    await threadsStore.getState().ensureThread("ref_a");
+    const record = await storage.enqueueIntent({
+      targetRef: "ref_a",
+      method: "turn/queue",
+      payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+      attachments: [],
+      optimisticDisplay: { text: "sentinel" },
+    });
+    await storage.markAttempted(record.clientMutationId);
+    snapshot = readResponse("ref_a", { status: { type: status } });
+    Object.assign(snapshot.thread.evener, { mutationStateAuthoritative: false, kind: "subagent" });
+    await threadsStore.getState().refreshThread("ref_a");
+    expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+    expect(threadsStore.getState().restartBlockingObligations.has("ref_a")).toBe(true);
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+    snapshot = readResponse("ref_a", {
+      evener: {
+        ref: "ref_a",
+        capabilities: CAPABILITIES,
+        queue: { revision: 1, clientMutationIds: [record.clientMutationId] },
+      },
+    });
+    await threadsStore.getState().refreshThread("ref_a");
+    expect(await storage.getOutbox(record.clientMutationId)).toBeUndefined();
+    expect(threadsStore.getState().restartBlockingObligations.has("ref_a")).toBe(false);
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+  });
+}
+
+test.each(["active", "idle"])("manual retry stays blocked after reload of a saved %s delegate", async (status) => {
+  const storage = new MutationOutboxIndexedDB({ createMutationId: () => "saved-manual-retry" });
+  const record = await storage.enqueueIntent({
+    targetRef: "ref_a",
+    method: "turn/queue",
+    payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+    attachments: [],
+    optimisticDisplay: { text: "sentinel" },
+  });
+  await storage.markUnknown(record.clientMutationId, "blockedUnknown");
+  setMutationStorageForTests(storage);
+  const fake = connectFakeClient("connecting");
+  const saved = readResponse("ref_a", { status: { type: status } });
+  saved.thread.evener.mutationStateAuthoritative = false;
+  fake.on("thread/read", () => saved);
+  fake.emitReady();
+  await threadsStore.getState().ensureThread("ref_a");
+  await settleCallerContinuations();
+  expect(threadsStore.getState().restartBlockingObligations.size).toBe(0);
+  expect(await retryBlockedMutation(record.clientMutationId)).toBe(false);
+  expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+});
+
+test.each(["active", "idle"].flatMap((status) => [true, false].map((accepted) => ({ status, accepted }))))(
+  "periodic discovery resumes authority checks for saved $status delegates, accepted=$accepted",
+  async ({ status, accepted }) => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    try {
+      const storage = new MutationOutboxIndexedDB({ createMutationId: () => "delegate-periodic" });
+      const record = await storage.enqueueIntent({
+        targetRef: "ref_a",
+        method: "turn/queue",
+        payload: { ref: "ref_a", input: [{ type: "text", text: "sentinel" }] },
+        attachments: [],
+        optimisticDisplay: { text: "sentinel" },
+      });
+      await storage.markAttempted(record.clientMutationId);
+      const settled = deferred<void>();
+      const settleApplied = storage.settleApplied.bind(storage);
+      vi.spyOn(storage, "settleApplied").mockImplementation(async (...args) => {
+        const result = await settleApplied(...args);
+        if (args[0] === record.clientMutationId && result) settled.resolve();
+        return result;
+      });
+      const settleReceipt = storage.settleReceipt.bind(storage);
+      vi.spyOn(storage, "settleReceipt").mockImplementation(async (...args) => {
+        const result = await settleReceipt(...args);
+        if (args[0] === record.clientMutationId) settled.resolve();
+        return result;
+      });
+      setMutationStorageForTests(storage);
+      const fake = connectFakeClient("connecting");
+      let recovered = false;
+      fake.on("thread/read", () => {
+        const response = readResponse("ref_a", { status: { type: status } });
+        response.thread.evener.mutationStateAuthoritative = recovered;
+        if (recovered && accepted) response.thread.evener.queue.clientMutationIds = [record.clientMutationId];
+        return response;
+      });
+      fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+      fake.emitReady();
+      await threadsStore.getState().ensureThread("ref_a");
+      // ensureThread resolves on model publication; refreshThread also waits
+      // for durable reconciliation before the single simulated recovery tick.
+      await threadsStore.getState().refreshThread("ref_a");
+      expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+      recovered = true;
+      await vi.advanceTimersByTimeAsync(2000);
+      await settled.promise;
+      expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(true);
+      expect(await storage.getOutbox(record.clientMutationId)).toBeUndefined();
+      expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(accepted ? 0 : 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  },
+);
+
+test.each(["daemonRestartRequired", "persistenceUnavailable"])(
+  "blocked %s mutation invalidates earlier authority on the same connection",
+  async (cause) => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    try {
+      const storage = new MutationOutboxIndexedDB({ createMutationId: () => "authority-lost" });
+      const blocked = deferred<void>();
+      const markUnknown = storage.markUnknown.bind(storage);
+      vi.spyOn(storage, "markUnknown").mockImplementation(async (...args) => {
+        const result = await markUnknown(...args);
+        blocked.resolve();
+        return result;
+      });
+      setMutationStorageForTests(storage);
+      const fake = connectFakeClient("connecting");
+      const fresh = deferred<ThreadReadResponse>();
+      let reads = 0;
+      fake.on("thread/read", () => {
+        reads++;
+        return reads === 1 ? readResponse("ref_a", { status: { type: "idle" } }) : fresh.promise;
+      });
+      fake.on("turn/queue", (params) => {
+        throw new WireError("owner unavailable", -32014, {
+          evenerErrorInfo: "mutationOutcome",
+          clientMutationId: params.clientMutationId,
+          mutationOutcome: "unknown",
+          retryDisposition: "blocked",
+          cause,
+        });
+      });
+      fake.emitReady();
+      await threadsStore.getState().ensureThread("ref_a");
+      expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(true);
+      await threadsStore.getState().queue("ref_a", "preserve this message");
+      await blocked.promise;
+      await settleCallerContinuations();
+      expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(false);
+      expect(await retryBlockedMutation("authority-lost")).toBe(false);
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushIndexedDBUntil(() => reads === 2);
+      expect(reads).toBe(2);
+      const response = readResponse("ref_a", { status: { type: "restartRequired" } });
+      response.thread.evener.mutationStateAuthoritative = false;
+      fresh.resolve(response);
+      await flushIndexedDBUntil(() => threadsStore.getState().threads.get("ref_a")?.status.type === "restartRequired");
+      expect((await storage.getOutbox("authority-lost"))?.state).toBe("blockedUnknown");
+      expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  },
+);
+
+test.each([true, false])(
+  "discovery reconciles another tab's blocked send with cached authority, accepted=%s",
+  async (accepted) => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "other-tab-blocked" });
+    const otherTab = new MutationOutboxIndexedDB({ createMutationId: () => "other-tab-blocked" });
+    const settled = deferred<void>();
+    const settleApplied = storage.settleApplied.bind(storage);
+    vi.spyOn(storage, "settleApplied").mockImplementation(async (...args) => {
+      const result = await settleApplied(...args);
+      settled.resolve();
+      return result;
+    });
+    const settleReceipt = storage.settleReceipt.bind(storage);
+    vi.spyOn(storage, "settleReceipt").mockImplementation(async (...args) => {
+      const result = await settleReceipt(...args);
+      settled.resolve();
+      return result;
+    });
+    try {
+      setMutationStorageForTests(storage);
+      const fake = connectFakeClient("connecting");
+      let reads = 0;
+      fake.on("thread/read", () => {
+        reads++;
+        const response = readResponse("ref_a", { status: { type: "idle" } });
+        if (reads > 1 && accepted)
+          response.thread.evener.queue = { revision: 1, clientMutationIds: ["other-tab-blocked"] };
+        return response;
+      });
+      let sends = 0;
+      fake.on("turn/queue", (params) => {
+        if (++sends === 1) throw new RequestTimeoutError("response lost");
+        return { receipt: mutationReceipt(params.clientMutationId) };
+      });
+      fake.emitReady();
+      await threadsStore.getState().ensureThread("ref_a");
+      expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(true);
+      await threadsStore.getState().queue("ref_a", "sentinel");
+      await flushIndexedDBUntil(() => sends === 1);
+      await settleCallerContinuations();
+      await otherTab.markUnknown("other-tab-blocked", "blockedUnknown");
+      otherTab.close();
+      expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(true);
+      await vi.advanceTimersByTimeAsync(2000);
+      await flushIndexedDBUntil(() => reads > 1);
+      expect(reads).toBe(2);
+      await flushIndexedDBUntil(() => accepted || sends === 2);
+      expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(accepted ? 1 : 2);
+      await settled.promise;
+      expect(await storage.getOutbox("other-tab-blocked")).toBeUndefined();
+    } finally {
+      otherTab.close();
+      vi.useRealTimers();
+    }
+  },
+);
+
+test.each(["accepted", "absent", "unavailable"])(
+  "manual retry refreshes authority after another tab blocks a send: %s",
+  async (outcome) => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "manual-other-tab" });
+    const otherTab = new MutationOutboxIndexedDB();
+    const fresh = deferred<ThreadReadResponse>();
+    try {
+      setMutationStorageForTests(storage);
+      const fake = connectFakeClient("connecting");
+      let reads = 0;
+      fake.on("thread/read", () =>
+        ++reads === 1 ? readResponse("ref_a", { status: { type: "idle" } }) : fresh.promise,
+      );
+      let sends = 0;
+      fake.on("turn/queue", (params) => {
+        if (++sends === 1) throw new RequestTimeoutError("response lost");
+        return { receipt: mutationReceipt(params.clientMutationId) };
+      });
+      fake.emitReady();
+      await threadsStore.getState().ensureThread("ref_a");
+      await threadsStore.getState().queue("ref_a", "sentinel");
+      await flushIndexedDBUntil(() => sends === 1);
+      await settleCallerContinuations();
+      await otherTab.markUnknown("manual-other-tab", "blockedUnknown");
+      otherTab.close();
+      expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(true);
+      const retry = retryBlockedMutation("manual-other-tab");
+      await flushIndexedDBUntil(() => reads === 2);
+      expect(reads).toBe(2);
+      expect((await storage.getOutbox("manual-other-tab"))?.state).toBe("blockedUnknown");
+      expect(sends).toBe(1);
+      expect(await retryBlockedMutation("manual-other-tab")).toBe(false);
+      const response = readResponse("ref_a", {
+        status: { type: outcome === "unavailable" ? "restartRequired" : "idle" },
+      });
+      if (outcome === "accepted")
+        response.thread.evener.queue = { revision: 1, clientMutationIds: ["manual-other-tab"] };
+      if (outcome === "unavailable") response.thread.evener.mutationStateAuthoritative = false;
+      fresh.resolve(response);
+      expect(await retry).toBe(outcome !== "unavailable");
+      if (outcome === "absent") await flushIndexedDBUntil(() => sends === 2);
+      expect(sends).toBe(outcome === "absent" ? 2 : 1);
+      if (outcome === "unavailable")
+        expect((await storage.getOutbox("manual-other-tab"))?.state).toBe("blockedUnknown");
+    } finally {
+      fresh.resolve(readResponse("ref_a", { status: { type: "restartRequired" } }));
+      otherTab.close();
+      vi.useRealTimers();
+    }
+  },
+);
+
+test("persistent journal failures wait for periodic recovery between attempts", async () => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  try {
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => "persistent-journal" });
+    let blocked = deferred<void>();
+    const markUnknown = storage.markUnknown.bind(storage);
+    vi.spyOn(storage, "markUnknown").mockImplementation(async (...args) => {
+      const result = await markUnknown(...args);
+      blocked.resolve();
+      return result;
+    });
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient("connecting");
+    fake.on("thread/read", () => readResponse("ref_a", { status: { type: "idle" } }));
+    fake.on("turn/queue", (params) => {
+      throw new WireError("journal unavailable", -32014, {
+        evenerErrorInfo: "mutationOutcome",
+        clientMutationId: params.clientMutationId,
+        mutationOutcome: "unknown",
+        retryDisposition: "blocked",
+        cause: "persistenceUnavailable",
+      });
+    });
+    fake.emitReady();
+    await threadsStore.getState().ensureThread("ref_a");
+    await threadsStore.getState().queue("ref_a", "keep until persistence recovers");
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      await blocked.promise;
+      await settleCallerContinuations();
+      expect(fake.calls.filter((call) => call.method === "thread/read")).toHaveLength(attempt);
+      expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(attempt);
+      expect(await retryBlockedMutation("persistent-journal")).toBe(false);
+      expect((await storage.getOutbox("persistent-journal"))?.state).toBe("blockedUnknown");
+      if (attempt < 3) {
+        blocked = deferred<void>();
+        await vi.advanceTimersByTimeAsync(2000);
+      }
+    }
+    const settled = deferred<void>();
+    const settleReceipt = storage.settleReceipt.bind(storage);
+    vi.spyOn(storage, "settleReceipt").mockImplementation(async (...args) => {
+      const result = await settleReceipt(...args);
+      settled.resolve();
+      return result;
+    });
+    fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+    await vi.advanceTimersByTimeAsync(2000);
+    await settled.promise;
+    expect(await storage.getOutbox("persistent-journal")).toBeUndefined();
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(4);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("failed blocking persistence prevents a new enqueue from retrying uncertain work", async () => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  try {
+    let nextID = 0;
+    const storage = new MutationOutboxIndexedDB({ createMutationId: () => `blocking-write-${++nextID}` });
+    const failed = deferred<void>();
+    vi.spyOn(storage, "markUnknown").mockImplementationOnce(async () => {
+      failed.resolve();
+      throw new DOMException("IndexedDB transaction aborted", "AbortError");
+    });
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient("connecting");
+    const fresh = deferred<ThreadReadResponse>();
+    let reads = 0;
+    fake.on("thread/read", () => (++reads === 1 ? readResponse("ref_a", { status: { type: "idle" } }) : fresh.promise));
+    fake.on("turn/queue", (params) => {
+      throw new WireError("owner unavailable", -32014, {
+        evenerErrorInfo: "mutationOutcome",
+        clientMutationId: params.clientMutationId,
+        mutationOutcome: "unknown",
+        retryDisposition: "blocked",
+      });
+    });
+    fake.emitReady();
+    await threadsStore.getState().ensureThread("ref_a");
+    await threadsStore.getState().queue("ref_a", "first");
+    await failed.promise;
+    await settleCallerContinuations();
+    expect((await storage.getOutbox("blocking-write-1"))?.state).toBe("submitting");
+    await threadsStore.getState().queue("ref_a", "second");
+    await settleCallerContinuations();
+    await storage.listOutbox("ref_a");
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+    fake.on("turn/queue", (params) => ({ receipt: mutationReceipt(params.clientMutationId) }));
+    fresh.resolve(readResponse("ref_a", { status: { type: "idle" } }));
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushIndexedDBUntil(() => fake.calls.filter((call) => call.method === "turn/queue").length === 3);
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(3);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("clear response fences goal responses from the previous instance", async () => {
+  const fake = connectFakeClient();
+  fake.on("thread/read", () => readResponse("ref_a"));
+  await threadsStore.getState().ensureThread("ref_a");
+  await threadsStore.getState().watchThread("ref_a");
+  const goalResponse = deferred<{ started: boolean }>();
+  const requested = nextHandledRequest(fake, "goal/set", () => goalResponse.promise);
+  const pending = threadsStore.getState().setGoal("ref_a", "old objective");
+  await requested;
+  fake.on("thread/clear", (params) =>
+    clearResponse(params, testThread("ref_a", { id: "cleared-instance", turns: [] })),
+  );
+  await threadsStore.getState().clearThread("ref_a");
+  expect(threadsStore.getState().threads.get("ref_a")?.threadId).toBe("cleared-instance");
+  goalResponse.resolve({ started: true });
+  await pending;
+  expect(threadsStore.getState().threads.get("ref_a")?.goal).toBeNull();
+  expect(threadsStore.getState().watchedThreads.get("ref_a")?.goal).toBeNull();
+  fake.on("goal/set", () => ({ started: true }));
+  await threadsStore.getState().setGoal("ref_a", "new objective");
+  expect(threadsStore.getState().threads.get("ref_a")?.goal?.objective).toBe("new objective");
+  expect(threadsStore.getState().watchedThreads.get("ref_a")?.goal?.objective).toBe("new objective");
+});
+
+test("clear permits explicit fresh recovery without replaying old-instance input", async () => {
+  const storage = new MutationOutboxIndexedDB();
+  setMutationStorageForTests(storage);
+  const fake = connectFakeClient("connecting");
+  const saved = readResponse("ref_a", { status: { type: "notLoaded" } });
+  saved.thread.evener.mutationStateAuthoritative = false;
+  const replacement = testThread("ref_a", { id: "replacement" });
+  let cleared = false;
+  fake.on("thread/read", () => (cleared ? { thread: replacement } : saved));
+  const started = deferred<void>();
+  const release = deferred<void>();
+  fake.on("thread/clear", async (params) => {
+    started.resolve();
+    await release.promise;
+    cleared = true;
+    return clearResponse(params, replacement);
+  });
+  fake.on("turn/queue", (params) => {
+    expect(params.expectedInstanceId).toBe("thr_ref_a");
+    throw new WireError("thread instance is stale", -32014, {
+      evenerErrorInfo: "mutationOutcome",
+      clientMutationId: params.clientMutationId,
+      mutationOutcome: "notAccepted",
+      retryDisposition: "none",
+    });
+  });
+  fake.emitReady();
+  await threadsStore.getState().ensureThread("ref_a");
+  const clearing = threadsStore.getState().clearThread("ref_a");
+  await started.promise;
+  // Another tab can contribute an uncertain old-instance intent while clear is in flight.
+  const record = await storage.enqueueIntent({
+    targetRef: "ref_a",
+    method: "turn/queue",
+    payload: { ref: "ref_a", expectedInstanceId: "thr_ref_a", input: [{ type: "text", text: "old input" }] },
+    attachments: [],
+    optimisticDisplay: { text: "old input" },
+  });
+  await storage.markAttempted(record.clientMutationId);
+  await storage.markUnknown(record.clientMutationId, "blockedUnknown");
+  release.resolve();
+  await clearing;
+  expect(threadsStore.getState().threads.get("ref_a")?.instanceId).toBe("replacement");
+  expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+  expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(0);
+  const reads = fake.calls.filter((call) => call.method === "thread/read").length;
+  expect(await retryBlockedMutation(record.clientMutationId)).toBe(true);
+  expect(fake.calls.filter((call) => call.method === "thread/read").length).toBeGreaterThan(reads);
+  await vi.waitFor(async () => {
+    expect(await storage.getRecovery(record.clientMutationId)).toMatchObject({
+      recoveryKind: "rejected",
+      payload: { expectedInstanceId: "thr_ref_a" },
+    });
+  });
+  expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
 });

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -103,6 +103,9 @@ export class ConflictError extends Error {
 export interface ThreadsStoreState {
   threads: Map<string, ThreadModel>;
   mutationWriteStalled: boolean;
+  mutationReconciliationFailures: ReadonlySet<string>;
+  restartBlockingObligations: ReadonlyMap<string, symbol>;
+  mutationAuthorityRefs: ReadonlySet<string>;
   // Per-ref ring of live-notification arrival timestamps, for
   // widgets/cadence's Cadence trace - see appendFrameTime below. Deliberately
   // NOT part of ThreadModel/the reducer: it is display-liveness bookkeeping
@@ -136,6 +139,7 @@ export interface ThreadsStoreState {
   // an ordinary transient one.
   deletedRefs: Set<string>;
   ensureThread(ref: string): Promise<void>;
+  refreshThread(ref: string): Promise<void>;
   releaseThread(ref: string): void;
   // Additive, leaner subscription to a child thread for a delegate card's
   // row's live view (see this file's own doc comment). opts.includeTurns
@@ -286,6 +290,7 @@ type PendingThreadHydration = {
 // response. Keep the newest hydration's notifications out of the old model,
 // then fold them onto the returned snapshot before publishing it.
 const pendingThreadHydrations = new Map<string, PendingThreadHydration>();
+const pendingMutationReconciliations = new Map<string, Promise<void>>();
 const pendingWatchedHydrations = new Map<string, PendingThreadHydration>();
 
 // --- Notification routing index ---------------------------------------------
@@ -597,6 +602,7 @@ function notifyMutationPersistence(targetRefs: Iterable<string>, committed?: Mut
 }
 
 function applyClearResponse(targetRef: string, response: ThreadClearResponse): void {
+  invalidateGoalResponseFallback(targetRef);
   const now = Date.now();
   const model = hydrateThread({ thread: response.thread }, targetRef, now);
   // A clear response is a newer authoritative cut than any thread/read that
@@ -613,16 +619,30 @@ function applyClearResponse(targetRef: string, response: ThreadClearResponse): v
     stateBefore.threads.has(targetRef) ? model : undefined,
     stateBefore.watchedThreads.has(targetRef) ? model : undefined,
   );
-  if (stateBefore.threads.has(targetRef)) {
-    threadsStore.setState((state) => ({
-      hydrations: new Map(state.hydrations).set(targetRef, (state.hydrations.get(targetRef) ?? 0) + 1),
-    }));
-  }
+  threadsStore.setState((state) => {
+    const mutationAuthorityRefs = new Set(state.mutationAuthorityRefs);
+    if (response.thread.evener.mutationStateAuthoritative === true) mutationAuthorityRefs.add(targetRef);
+    else mutationAuthorityRefs.delete(targetRef);
+    return {
+      mutationAuthorityRefs,
+      hydrations: stateBefore.threads.has(targetRef)
+        ? new Map(state.hydrations).set(targetRef, (state.hydrations.get(targetRef) ?? 0) + 1)
+        : state.hydrations,
+    };
+  });
 }
 
 function currentDispatchClient(targetRef?: string): AppwireClientLike | null {
   if (wiredClient !== dispatchReadyClient || readyEpoch !== dispatchReadyEpoch) return null;
   if (targetRef && !dispatchableMutationRefs.has(targetRef)) return null;
+  if (
+    targetRef &&
+    (pendingMutationReconciliations.has(targetRef) ||
+      threadsStore.getState().restartBlockingObligations.has(targetRef) ||
+      threadsStore.getState().mutationReconciliationFailures.has(targetRef))
+  )
+    return null;
+  if (targetRef && threadsStore.getState().threads.get(targetRef)?.status.type === "restartRequired") return null;
   return wiredClient?.state === "ready" ? wiredClient : null;
 }
 
@@ -684,7 +704,7 @@ function scheduleMutationDispatch(runtime: MutationRuntime, targetRefs: Iterable
 
 function handleDiscoveredMutations(runtime: MutationRuntime, targetRefs: Iterable<string>): void {
   if (!isCurrentMutationRuntime(runtime)) return;
-  const refs = [...new Set(targetRefs)];
+  const refs = [...new Set([...targetRefs, ...threadsStore.getState().mutationReconciliationFailures])];
   for (const targetRef of refs) pinnedMutationRefs.add(targetRef);
   notifyMutationPersistence(refs);
   scheduleMutationDispatch(runtime, refs);
@@ -693,11 +713,35 @@ function handleDiscoveredMutations(runtime: MutationRuntime, targetRefs: Iterabl
   if (!client) return;
   const epoch = dispatchReadyEpoch;
   for (const targetRef of refs) {
-    if (dispatchableMutationRefs.has(targetRef)) continue;
+    if (pendingMutationReconciliations.has(targetRef)) continue;
+    if (
+      dispatchableMutationRefs.has(targetRef) &&
+      !threadsStore.getState().mutationReconciliationFailures.has(targetRef)
+    ) {
+      // Another tab can block a shared record after this tab's snapshot.
+      // Cached authority cannot settle that newly uncertain send.
+      void refreshUncertainMutationAuthority(runtime, client, epoch, targetRef).catch(() => {
+        // The next discovery pass retries after storage or transport recovers.
+      });
+      continue;
+    }
     const pending = pendingThreadHydrations.get(targetRef);
     if (pending?.client === client && pending.epoch === epoch) continue;
     void handleReady(client, epoch, targetRef);
   }
+}
+
+async function refreshUncertainMutationAuthority(
+  runtime: MutationRuntime,
+  client: AppwireClientLike,
+  epoch: number,
+  targetRef: string,
+): Promise<void> {
+  const records = await runtime.storage.listOutbox(targetRef);
+  if (!records.some((record) => record.state === "blockedUnknown")) return;
+  if (!isCurrentMutationRuntime(runtime) || currentDispatchClient() !== client || dispatchReadyEpoch !== epoch) return;
+  if (pendingMutationReconciliations.has(targetRef) || pendingThreadHydrations.has(targetRef)) return;
+  await handleReady(client, epoch, targetRef);
 }
 
 function getMutationRuntime(): MutationRuntime | null {
@@ -716,6 +760,23 @@ function getMutationRuntime(): MutationRuntime | null {
     getClient: (targetRef) => (isCurrentMutationRuntime(runtime) ? currentDispatchClient(targetRef) : null),
     onStorageChange: (targetRefs) => {
       if (isCurrentMutationRuntime(runtime)) notifyMutationPersistence(targetRefs);
+    },
+    onBlockedMutation: (targetRef, client) => {
+      if (!isCurrentMutationRuntime(runtime) || currentDispatchClient() !== client) return;
+      threadsStore.setState((state) => {
+        const mutationAuthorityRefs = new Set(state.mutationAuthorityRefs);
+        mutationAuthorityRefs.delete(targetRef);
+        // The durable blocking write may have failed, leaving a submitting
+        // record. New enqueues must wait for successful reconciliation too.
+        return {
+          mutationAuthorityRefs,
+          mutationReconciliationFailures: new Set(state.mutationReconciliationFailures).add(targetRef),
+        };
+      });
+      // Let the periodic discovery pass refresh and reconcile. An immediate
+      // read can prove absence while journal writes still fail, creating a
+      // read/retry loop without giving persistence time to recover.
+      dispatchableMutationRefs.delete(targetRef);
     },
     onClearResponse: applyClearResponse,
   });
@@ -773,10 +834,26 @@ export async function retryBlockedMutation(clientMutationId: string): Promise<bo
   await runtime.start;
   const record = await runtime.storage.getOutbox(clientMutationId);
   if (record?.state !== "blockedUnknown") return false;
-  await runtime.storage.markUnknown(clientMutationId, "submitting");
-  notifyMutationPersistence([record.targetRef]);
-  handleDiscoveredMutations(runtime, [record.targetRef]);
-  return true;
+  if (!threadsStore.getState().mutationAuthorityRefs.has(record.targetRef)) return false;
+  const status = threadsStore.getState().threads.get(record.targetRef)?.status.type;
+  if (!status || status === "restartRequired" || status === "notLoaded") return false;
+  if (
+    pendingMutationReconciliations.has(record.targetRef) ||
+    pendingThreadHydrations.has(record.targetRef) ||
+    threadsStore.getState().restartBlockingObligations.has(record.targetRef) ||
+    threadsStore.getState().mutationReconciliationFailures.has(record.targetRef)
+  )
+    return false;
+  const client = currentDispatchClient();
+  if (!client) return false;
+  const epoch = dispatchReadyEpoch;
+  // Shared storage can become blocked after this tab's authoritative snapshot.
+  // Only fresh reconciliation may settle it or restore it for dispatch.
+  await handleReady(client, epoch, record.targetRef);
+  if (!isCurrentMutationRuntime(runtime) || currentDispatchClient() !== client || dispatchReadyEpoch !== epoch)
+    return false;
+  const current = await runtime.storage.getOutbox(clientMutationId);
+  return current?.state !== "blockedUnknown";
 }
 
 export async function updateRecoveryMutation(
@@ -1354,16 +1431,11 @@ function replayHydrationNotifications(
   return { model: hydrated, appliedAt };
 }
 
-// A snapshot may only publish into the ready generation it was cut on, and the
-// epoch alone says that for the client too: rewireClient bumps readyEpoch
-// before it assigns wiredClient, the epoch only ever increases, and every
-// hydration captures its client and its epoch in the same synchronous step —
-// the one site that used to capture them either side of an await now re-reads
-// the client, and a test pins it there. So a hydration under a superseded
-// client necessarily carries a superseded epoch.
+// A snapshot may publish only for the client and ready generation that own
+// its hydration. Retired connections cannot overwrite replacement state.
 function publishThreadHydration(ref: string, pending: PendingThreadHydration, model: ThreadModel): ThreadModel | null {
   if (pendingThreadHydrations.get(ref) !== pending) return null;
-  if (readyEpoch !== pending.epoch) return null;
+  if (readyEpoch !== pending.epoch || wiredClient !== pending.client) return null;
   if ((refCounts.get(ref) ?? 0) <= 0 && !pinnedMutationRefs.has(ref)) {
     pendingThreadHydrations.delete(ref);
     return null;
@@ -1395,6 +1467,18 @@ async function publishAndReconcileThreadHydration(
 ): Promise<ThreadModel | null> {
   const published = publishThreadHydration(ref, pending, hydration.model);
   if (!published) return null;
+  threadsStore.setState((state) => {
+    const mutationAuthorityRefs = new Set(state.mutationAuthorityRefs);
+    if (hydration.response.thread.evener.mutationStateAuthoritative === true) mutationAuthorityRefs.add(ref);
+    else mutationAuthorityRefs.delete(ref);
+    return { mutationAuthorityRefs };
+  });
+  if (published.status.type === "restartRequired") {
+    threadsStore.setState((state) => ({
+      restartBlockingObligations: new Map(state.restartBlockingObligations).set(ref, Symbol()),
+    }));
+  }
+  const blockingObligation = threadsStore.getState().restartBlockingObligations.get(ref);
   // The authoritative read has succeeded, so the replay gate opens HERE — in
   // the same synchronous step publishThreadHydration deleted the ref's
   // pending-hydration entry — not after the storage hygiene below. Between
@@ -1406,14 +1490,101 @@ async function publishAndReconcileThreadHydration(
   if (pinnedMutationRefs.has(ref)) dispatchableMutationRefs.add(ref);
   const runtime = getMutationRuntime();
   if (runtime) {
-    const authoritativeIds = collectAuthoritativeMutationIds(hydration.response);
-    await runtime.dispatcher.reconcileIdentities(authoritativeIds);
-    // The same read that settles what the authority knows also proves what it
-    // does not: a blockedUnknown record absent from every authoritative set
-    // was never journaled, so it returns to dispatch here rather than parking
-    // forever behind an outage that has since recovered (kata gwea).
-    await runtime.dispatcher.restoreProvenAbsent(ref, authoritativeIds);
-    await refreshMutationPins(runtime, [ref]);
+    // A newer snapshot may publish while an older storage transaction is in
+    // flight. Serialize reconciliation and keep dispatch closed until the
+    // latest snapshot has reconciled; older writes then cannot undo recovery.
+    const previous = pendingMutationReconciliations.get(ref) ?? Promise.resolve();
+    const reconciliation: Promise<void> = previous
+      .catch(() => undefined)
+      .then(async () => {
+        // A published incompatibility remains a blocking obligation across
+        // later saved snapshots and reconnects. Process it in order; only a
+        // compatible snapshot afterward can prove that dispatch may resume.
+        const current = () =>
+          isCurrentMutationRuntime(runtime) &&
+          (published.status.type === "restartRequired" ||
+            (pending.epoch === readyEpoch && pending.client === wiredClient));
+        if (!current()) return;
+        const authoritativeIds = collectAuthoritativeMutationIds(hydration.response);
+        const mutationStateAuthoritative = hydration.response.thread.evener.mutationStateAuthoritative === true;
+        await runtime.dispatcher.reconcileIdentities(authoritativeIds);
+        if (!current()) return;
+        // A bounded transcript or a clear can omit an accepted mutation from
+        // the live projection. Retry unresolved records with their original
+        // mutation ID and payload: the daemon journal replays accepted work,
+        // and the original instance fence rejects a retry after a clear.
+        // Saved snapshots contain no authoritative daemon receipt history, even
+        // after an incompatible daemon has been stopped. Persist uncertainty so
+        // reopening that saved snapshot cannot release an already accepted send.
+        if (
+          !mutationStateAuthoritative ||
+          published.status.type === "restartRequired" ||
+          published.status.type === "notLoaded"
+        ) {
+          for (const record of await runtime.storage.listOutbox(ref)) {
+            if (!current()) return;
+            if (record.state === "submitting")
+              await runtime.storage.markUnknown(record.clientMutationId, "blockedUnknown", { onlyAttempted: true });
+          }
+          notifyMutationPersistence([ref]);
+        } else {
+          await runtime.dispatcher.restoreProvenAbsent(ref, authoritativeIds);
+        }
+        if (!current()) return;
+        await refreshMutationPins(runtime, [ref]);
+        // Descendant reads cannot prove an uncertain mutation absent. Explicitly
+        // never-attempted intents need no receipt authority before first delivery.
+        const mutationsReconciled =
+          mutationStateAuthoritative ||
+          (await runtime.storage.listOutbox(ref)).every((record) => record.attempted === false);
+        // A newer incompatible snapshot owns a different obligation. An older
+        // successful reconciliation cannot clear that newer restriction.
+        if (
+          current() &&
+          mutationsReconciled &&
+          published.status.type !== "restartRequired" &&
+          published.status.type !== "notLoaded" &&
+          threadsStore.getState().restartBlockingObligations.get(ref) === blockingObligation
+        ) {
+          threadsStore.setState((state) => {
+            const restartBlockingObligations = new Map(state.restartBlockingObligations);
+            restartBlockingObligations.delete(ref);
+            return { restartBlockingObligations };
+          });
+        }
+      });
+    pendingMutationReconciliations.set(ref, reconciliation);
+    try {
+      await reconciliation;
+      if (
+        pendingMutationReconciliations.get(ref) === reconciliation &&
+        isCurrentMutationRuntime(runtime) &&
+        pending.epoch === readyEpoch &&
+        pending.client === wiredClient
+      ) {
+        threadsStore.setState((state) => {
+          const mutationReconciliationFailures = new Set(state.mutationReconciliationFailures);
+          mutationReconciliationFailures.delete(ref);
+          return { mutationReconciliationFailures };
+        });
+      }
+    } catch (error) {
+      if (
+        pendingMutationReconciliations.get(ref) === reconciliation &&
+        isCurrentMutationRuntime(runtime) &&
+        pending.epoch === readyEpoch &&
+        pending.client === wiredClient
+      ) {
+        // Discovery retries the authoritative read after storage recovers.
+        // Keep the failure visible and dispatch closed until that succeeds.
+        threadsStore.setState((state) => ({
+          mutationReconciliationFailures: new Set(state.mutationReconciliationFailures).add(ref),
+        }));
+      }
+      throw error;
+    } finally {
+      if (pendingMutationReconciliations.get(ref) === reconciliation) pendingMutationReconciliations.delete(ref);
+    }
   }
   return published;
 }
@@ -1741,6 +1912,7 @@ async function refreshTrackedThread(
   epoch: number,
   ref: string,
   targetedResync: boolean,
+  reportFailure = false,
 ): Promise<void> {
   if ((refCounts.get(ref) ?? 0) <= 0 && !pinnedMutationRefs.has(ref)) return;
   const previous = pendingThreadHydrations.get(ref);
@@ -1783,7 +1955,8 @@ async function refreshTrackedThread(
   try {
     const model = await hydration;
     if (model && pinnedMutationRefs.has(ref)) dispatchableMutationRefs.add(ref);
-  } catch {
+  } catch (error) {
+    if (reportFailure) throw error;
     // The stale model stays published. Convergence is the owned hydration
     // lifecycle's job now (scheduleOwnedHydrationRetry, above).
   } finally {
@@ -1921,6 +2094,7 @@ async function handleReady(client: AppwireClientLike, epoch: number, targetRef?:
 function rewireClient(client: AppwireClientLike): void {
   if (client === wiredClient) return;
   readyEpoch += 1;
+  threadsStore.setState({ mutationAuthorityRefs: new Set() });
   // A different client is a different connection: every wire subscription
   // this generation tracked belongs to a socket that is gone, so drop the
   // whole set — handleReady's re-reads re-subscribe the still-tracked refs on
@@ -1936,6 +2110,7 @@ function rewireClient(client: AppwireClientLike): void {
   unwireNotification = client.onNotification(handleNotification);
   unwireReady = client.onReady(() => {
     readyEpoch += 1;
+    threadsStore.setState({ mutationAuthorityRefs: new Set() });
     // onReady is the SAME client reconnecting: its old connection's
     // subscriptions are server-side gone too, even though the client object
     // survives. handleReady re-subscribes the still-tracked refs.
@@ -1964,6 +2139,9 @@ function rewireClient(client: AppwireClientLike): void {
 // Registered once, at module load, same lifetime as this module's other
 // singleton bookkeeping (refCounts, wiredClient, ...).
 connectionStore.subscribe((state) => {
+  if (state.client?.state !== "ready" && threadsStore.getState().mutationAuthorityRefs.size > 0) {
+    threadsStore.setState({ mutationAuthorityRefs: new Set() });
+  }
   if (state.client) rewireClient(state.client);
 });
 
@@ -2086,6 +2264,9 @@ function replaceThread(
 export const threadsStore = createStore<ThreadsStoreState>(() => ({
   threads: new Map(),
   mutationWriteStalled: false,
+  mutationReconciliationFailures: new Set(),
+  restartBlockingObligations: new Map(),
+  mutationAuthorityRefs: new Set(),
   frameTimes: new Map(),
   hydrations: new Map(),
   watchedThreads: new Map(),
@@ -2374,6 +2555,22 @@ export const threadsStore = createStore<ThreadsStoreState>(() => ({
       sendThreadUnsubscribe(ref);
     }
     removeWatchedThreadModel(ref);
+  },
+
+  async refreshThread(ref): Promise<void> {
+    const deadline = Date.now() + REQUIRE_READY_TIMEOUT_MS;
+    let client: AppwireClientLike;
+    do {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        throw new ClientNotReadyError("threads store: timed out waiting for a ready client");
+      }
+      await requireReadyClient(remaining);
+      client = requireClient();
+    } while (client.state !== "ready");
+    await refreshTrackedThread(client, readyEpoch, ref, true, true);
+    const runtime = getMutationRuntime();
+    if (runtime) scheduleMutationDispatch(runtime, [ref]);
   },
 
   async loadOlderTurns(ref) {
@@ -2735,6 +2932,7 @@ export function resetThreadsStoreForTests(): void {
   inflightHydrateEpochs.clear();
   trackedHydrationCompletions.clear();
   pendingThreadHydrations.clear();
+  pendingMutationReconciliations.clear();
   watchRefCounts.clear();
   inflightWatchHydrates.clear();
   inflightWatchHydrateClients.clear();

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -242,7 +242,7 @@ func (s *LocalDaemonSource) acquireRelaySession(params appwire.ThreadReadParams)
 
 func (s *LocalDaemonSource) ListThreads(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
 	out := appwire.ThreadListResponse{}
-	for _, entry := range s.liveEntries() {
+	for _, entry := range s.listedEntries() {
 		out.Data = append(out.Data, s.threadFromEntry(entry))
 	}
 	sort.SliceStable(out.Data, func(i, j int) bool {
@@ -809,13 +809,22 @@ func localDaemonMutationEntryError(clientMutationID string, err error) error {
 	return wire
 }
 
+// DaemonInitializeError identifies failures before a daemon accepts session RPCs.
+// Its underlying wire error remains available for protocol error reporting.
+type DaemonInitializeError struct {
+	Err error
+}
+
+func (e DaemonInitializeError) Error() string { return e.Err.Error() }
+func (e DaemonInitializeError) Unwrap() error { return e.Err }
+
 func localDaemonInitializeError(err error) error {
 	mapped := localDaemonCallError(err)
 	var wire appwire.WireError
 	if errors.As(mapped, &wire) && wire.Code != appwire.CodeInternalError {
-		return mapped
+		return DaemonInitializeError{Err: mapped}
 	}
-	return localDaemonDialError(mapped)
+	return DaemonInitializeError{Err: localDaemonDialError(mapped)}
 }
 
 func localDaemonSubscribeReadError(err error) error {
@@ -881,6 +890,19 @@ func (s *LocalDaemonSource) localEntryForRefMode(rawRef, threadID string, allowR
 }
 
 func (s *LocalDaemonSource) liveEntries() []LocalDaemonEntry {
+	entries := s.listedEntries()
+	out := make([]LocalDaemonEntry, 0, len(entries))
+	for _, item := range entries {
+		if item.Entry.Protocol == appwire.ProtocolVersion && item.Status != appwire.ThreadStatusRestartRequired {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// listedEntries preserves confirmed incompatible owners for display, without
+// admitting them to the live RPC routes selected by liveEntries.
+func (s *LocalDaemonSource) listedEntries() []LocalDaemonEntry {
 	if s.entries == nil {
 		return nil
 	}
@@ -888,7 +910,7 @@ func (s *LocalDaemonSource) liveEntries() []LocalDaemonEntry {
 	out := make([]LocalDaemonEntry, 0, len(entries))
 	for _, item := range entries {
 		entry := item.Entry
-		if entry.Protocol != appwire.ProtocolVersion || entry.Endpoint == "" || entry.ThreadID == "" {
+		if entry.Endpoint == "" || localDaemonThreadID(item) == "" || (entry.Protocol != appwire.ProtocolVersion && item.Status != appwire.ThreadStatusRestartRequired) {
 			continue
 		}
 		sourceID := entry.SourceID
@@ -943,6 +965,9 @@ func (s *LocalDaemonSource) threadFromEntry(item LocalDaemonEntry) appwire.Threa
 		},
 		Status: appwire.ThreadStatus{Type: status},
 	}
+	if status == appwire.ThreadStatusRestartRequired {
+		thread.Evener.Capabilities = appwire.ThreadCapabilities{}
+	}
 	if !item.ReadOnlyAlias && (len(item.RunningJobs) > 0 || len(item.CompletedJobs) > 0) {
 		jobs := make([]appwire.EvenerJobInfo, 0, len(item.RunningJobs)+len(item.CompletedJobs))
 		jobs = append(jobs, item.RunningJobs...)
@@ -950,10 +975,11 @@ func (s *LocalDaemonSource) threadFromEntry(item LocalDaemonEntry) appwire.Threa
 		thread.Evener.Diagnostics = &appwire.EvenerDiagnostics{Jobs: cloneLocalDaemonJobs(jobs)}
 	}
 	if item.ReadOnlyAlias {
+		thread.Evener.Ref = appwire.Ref{SourceID: s.sourceID, ThreadID: threadID}.String()
 		thread.Evener.Capabilities = appwire.ThreadCapabilities{}
 		thread.Evener.Kind = "subagent"
 		if item.OwnerSessionID != "" {
-			thread.Evener.ParentRef = appwire.Ref{SourceID: s.sourceID, ThreadID: item.OwnerSessionID}.String()
+			thread.Evener.ParentRef = localDaemonWorkspaceRef(s.sourceID, item.Entry, item.OwnerSessionID)
 		}
 	}
 	return thread
@@ -990,7 +1016,7 @@ func localDaemonThreadID(item LocalDaemonEntry) string {
 	if item.SessionID != "" {
 		return item.SessionID
 	}
-	return item.Entry.ThreadID
+	return firstLocalNonEmpty(item.Entry.ThreadID, item.Entry.SessionID)
 }
 
 func localDaemonThreadStatus(status string) string {
@@ -1007,6 +1033,8 @@ func localDaemonThreadStatus(status string) string {
 		return appwire.ThreadStatusClosed
 	case appwire.ThreadStatusNotLoaded:
 		return appwire.ThreadStatusNotLoaded
+	case appwire.ThreadStatusRestartRequired:
+		return appwire.ThreadStatusRestartRequired
 	case appwire.ThreadStatusIdle:
 		return appwire.ThreadStatusIdle
 	default:

--- a/cmd/evener-hub/internal/appsource/local_daemon_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_test.go
@@ -1029,6 +1029,68 @@ func TestLocalDaemonResolveRelaySessionCanonicalizesAliasesWithoutAcquiring(t *t
 	}
 }
 
+func TestLocalDaemonListPreservesRestartRequiredStatus(t *testing.T) {
+	source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry {
+		return []LocalDaemonEntry{{
+			Entry:  rendezvous.Entry{Protocol: "evener-appwire-v4", Endpoint: "ws://daemon", SourceID: "local", ThreadID: "owner", SessionID: "owner"},
+			Status: appwire.ThreadStatusRestartRequired,
+		}}
+	}, nil)
+	dials := 0
+	source.dial = func(context.Context, string, *http.Client, http.Header) (appwire.Transport, error) {
+		dials++
+		return nil, errors.New("unexpected incompatible daemon dial")
+	}
+	response, err := source.ListThreads(t.Context(), appwire.ThreadListParams{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Data) != 1 {
+		t.Fatalf("threads=%d", len(response.Data))
+	}
+	thread := response.Data[0]
+	if thread.Status.Type != appwire.ThreadStatusRestartRequired {
+		t.Fatalf("status=%s", thread.Status.Type)
+	}
+	if thread.Evener.Capabilities != (appwire.ThreadCapabilities{}) {
+		t.Fatalf("capabilities=%+v", thread.Evener.Capabilities)
+	}
+	if _, err := source.ReadThread(t.Context(), appwire.ThreadReadParams{Ref: "local:owner"}); err == nil {
+		t.Fatal("incompatible daemon was readable through a live route")
+	}
+	if _, err := source.ListModels(t.Context(), appwire.ModelListParams{}); err != nil {
+		t.Fatal(err)
+	}
+	if dials != 0 {
+		t.Fatalf("incompatible daemon dials=%d", dials)
+	}
+
+}
+
+func TestLocalDaemonListsSessionOnlyRestartRequiredEntry(t *testing.T) {
+	for _, observedID := range []string{"", "owner"} {
+		t.Run("observed="+observedID, func(t *testing.T) {
+			source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry {
+				return []LocalDaemonEntry{{Entry: rendezvous.Entry{Protocol: "evener-appwire-v4", Endpoint: "ws://daemon", SourceID: "local", SessionID: "owner"}, SessionID: observedID, Status: appwire.ThreadStatusRestartRequired}}
+			}, nil)
+			response, err := source.ListThreads(t.Context(), appwire.ThreadListParams{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(response.Data) != 1 {
+				t.Fatalf("threads=%+v", response.Data)
+			}
+			thread := response.Data[0]
+			if thread.ID != "owner" || thread.Evener.Ref != "local:owner" || thread.Status.Type != appwire.ThreadStatusRestartRequired {
+				t.Fatalf("thread=%+v", thread)
+			}
+			if thread.Evener.Capabilities != (appwire.ThreadCapabilities{}) {
+				t.Fatalf("capabilities=%+v", thread.Evener.Capabilities)
+			}
+		})
+	}
+}
+
 func TestLocalDaemonResolveSubscriptionAdmissionSingleSnapshot(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
@@ -1074,6 +1136,46 @@ func TestLocalDaemonResolveSubscriptionAdmissionSingleSnapshot(t *testing.T) {
 			}
 			if len(source.relaySessions) != 0 {
 				t.Fatal("admission resolution acquired a relay session")
+			}
+		})
+	}
+}
+
+func TestLocalDaemonListKeepsChildReferencesDistinctFromOwnerWorkspace(t *testing.T) {
+	for _, workspaceRef := range []string{"local:stable", ""} {
+		t.Run(workspaceRef, func(t *testing.T) {
+			entry := rendezvous.Entry{Protocol: appwire.ProtocolVersion, Endpoint: "ws://127.0.0.1/rpc", SourceID: "local", ThreadID: "current", SessionID: "current", WorkspaceRef: workspaceRef}
+			source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry {
+				return []LocalDaemonEntry{
+					{Entry: entry},
+					{Entry: entry, SessionID: "child", OwnerSessionID: "current", ReadOnlyAlias: true},
+				}
+			}, nil)
+			response, err := source.ListThreads(context.Background(), appwire.ThreadListParams{IncludeSubagents: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			byRef := map[string]appwire.Thread{}
+			for _, thread := range response.Data {
+				byRef[thread.Evener.Ref] = thread
+			}
+			if len(byRef) != 2 {
+				t.Fatalf("root and child must have distinct references: %+v", response.Data)
+			}
+			rootRef := workspaceRef
+			if rootRef == "" {
+				rootRef = "local:current"
+			}
+			child, ok := byRef["local:child"]
+			if !ok || child.Evener.ParentRef != rootRef || child.Evener.Kind != "subagent" {
+				t.Fatalf("child must target its own transcript under %s: %+v", rootRef, child)
+			}
+			if child.Evener.Capabilities != (appwire.ThreadCapabilities{}) {
+				t.Fatalf("child alias must remain read-only: %+v", child.Evener.Capabilities)
+			}
+			admission, err := source.ResolveSubscriptionAdmission(appwire.ThreadReadParams{Ref: child.Evener.Ref})
+			if err != nil || admission.String() != child.Evener.Ref {
+				t.Fatalf("listed child reference must resolve to its own subscription: %v, %v", admission, err)
 			}
 		})
 	}

--- a/cmd/evener-hub/internal/hubcore/attention.go
+++ b/cmd/evener-hub/internal/hubcore/attention.go
@@ -10,7 +10,7 @@ func attentionLevel(normalized string) string {
 	switch normalized {
 	case "active":
 		return "working"
-	case "awaiting", "warning":
+	case "awaiting", "warning", appwire.ThreadStatusRestartRequired:
 		return "needs_you"
 	case "errored":
 		return "error"

--- a/cmd/evener-hub/internal/hubcore/prober.go
+++ b/cmd/evener-hub/internal/hubcore/prober.go
@@ -2,6 +2,7 @@ package hubcore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -52,6 +53,19 @@ func (p *StatusProber) Probe(entry rendezvous.Entry) ProbeResult {
 	appClient.SetLogf(hubConnectionLogf)
 	appClient.Start(ctx)
 	if _, err := appClient.Initialize(ctx, appwire.InitializeParams{ClientInfo: appwire.ClientInfo{Name: "evener-hub"}}); err != nil {
+		var wire appwire.WireError
+		var mismatch appwire.ProtocolVersionMismatchError
+		if errors.As(err, &mismatch) ||
+			(entry.Protocol != "" && entry.Protocol != appwire.ProtocolVersion &&
+				errors.As(err, &wire) && wire.Code == appwire.CodeInvalidRequest) {
+			id := entry.SessionID
+			if id == "" {
+				id = entry.ThreadID
+			}
+			if id != "" {
+				return ProbeResult{SessionID: id, Status: appwire.ThreadStatusRestartRequired, OK: true}
+			}
+		}
 		return ProbeResult{}
 	}
 	// Read descendants before the root diagnostics. A retained delegate can be

--- a/cmd/evener-hub/internal/hubcore/prober_upgrade_test.go
+++ b/cmd/evener-hub/internal/hubcore/prober_upgrade_test.go
@@ -1,0 +1,126 @@
+package hubcore
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/rendezvous"
+	"primeradiant.com/evener/server"
+)
+
+// The network peer models an older daemon's initialize rejection. No old
+// protocol is negotiated and no session mutation is sent to that daemon.
+func TestRosterReportsRestartRequiredAfterProtocolUpgrade(t *testing.T) {
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.CloseNow()
+		var request struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := wsjson.Read(r.Context(), conn, &request); err != nil {
+			return
+		}
+		if request.Method != appwire.MethodInitialize {
+			t.Errorf("method = %q, want initialize", request.Method)
+		}
+		if err := wsjson.Write(context.Background(), conn, map[string]any{
+			"id":    request.ID,
+			"error": map[string]any{"code": appwire.CodeInvalidRequest, "message": "incompatible protocol"},
+		}); err != nil {
+			t.Errorf("write rejection: %v", err)
+		}
+	}))
+	defer peer.Close()
+	dir := t.TempDir()
+	writeRendezvous(t, dir, rendezvous.Entry{
+		PID: 1001, SessionID: "session-upgrade", ThreadID: "session-upgrade",
+		Protocol: "evener-appwire-v3", Endpoint: "ws" + strings.TrimPrefix(peer.URL, "http") + "/rpc",
+	})
+	roster := NewRoster(dir, &StatusProber{client: peer.Client()})
+	roster.procAlive = func(int) bool { return true }
+	roster.Refresh()
+	entry, ok := roster.Find("session-upgrade")
+	if !ok {
+		t.Fatal("incompatible live daemon disappeared after hub upgrade")
+	}
+	if entry.Status != "restartRequired" {
+		t.Fatalf("status = %q, want restartRequired", entry.Status)
+	}
+	if len(entry.RunningSubagentIDs) != 0 || len(entry.RunningJobs) != 0 {
+		t.Fatal("unreadable activity must not be reported as current")
+	}
+
+	if NormalizeState(entry.Status) != "restartRequired" || attentionLevel(NormalizeState(entry.Status)) != "needs_you" {
+		t.Fatal("protocol mismatch must remain visible in navigation attention")
+	}
+	_, replacement := startProbeDaemon(t, probeDaemonConfig{
+		sessionID: "session-upgrade", state: appwire.ThreadStatusActive,
+		descendants: map[string]string{"child-working": appwire.ThreadStatusActive},
+		source:      wireProbeEnvelopeSource{detailed: server.DetailedStatus{Jobs: []server.JobStatusInfo{{JobID: "shell-running", JobType: "shell", Status: "running"}}}},
+	})
+	replacement.PID = 1001
+	replacement.Protocol = appwire.ProtocolVersion
+	replacement.SessionID = "session-upgrade"
+	replacement.ThreadID = "session-upgrade"
+	writeRendezvous(t, dir, replacement)
+	roster.Refresh()
+	recovered, ok := roster.Find("session-upgrade")
+	if !ok || recovered.Status != appwire.ThreadStatusActive || len(recovered.RunningSubagentIDs) != 1 || len(recovered.RunningJobs) != 1 {
+		t.Fatalf("replacement activity did not recover: %+v", recovered)
+	}
+}
+
+func TestStatusProberClassifiesProtocolMismatchWithoutMetadata(t *testing.T) {
+	for _, protocol := range []string{"", appwire.ProtocolVersion, "evener-appwire-v3"} {
+		for _, typed := range []bool{false, true} {
+			name := protocol + "/invalid-request"
+			if typed {
+				name = protocol + "/typed-mismatch"
+			}
+			t.Run(name, func(t *testing.T) {
+				peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					conn, err := websocket.Accept(w, r, nil)
+					if err != nil {
+						return
+					}
+					defer conn.CloseNow()
+					var request struct {
+						ID any `json:"id"`
+					}
+					if err := wsjson.Read(r.Context(), conn, &request); err != nil {
+						return
+					}
+					response := map[string]any{"id": request.ID}
+					if typed {
+						response["result"] = appwire.InitializeResponse{ProtocolVersion: "evener-appwire-v3"}
+					} else {
+						response["error"] = map[string]any{"code": appwire.CodeInvalidRequest, "message": "request rejected"}
+					}
+					if err := wsjson.Write(r.Context(), conn, response); err != nil {
+						t.Errorf("write initialize: %v", err)
+					}
+				}))
+				defer peer.Close()
+				prober := &StatusProber{client: peer.Client()}
+				got := prober.Probe(rendezvous.Entry{SessionID: "session-upgrade", ThreadID: "session-upgrade", Protocol: protocol, Endpoint: "ws" + strings.TrimPrefix(peer.URL, "http") + "/rpc"})
+				wantRestart := typed || protocol == "evener-appwire-v3"
+				if got.OK != wantRestart {
+					t.Fatalf("probe = %+v, want restart classification %v", got, wantRestart)
+				}
+				if wantRestart && (got.Status != appwire.ThreadStatusRestartRequired || got.SessionID != "session-upgrade") {
+					t.Fatalf("restart projection = %+v", got)
+				}
+			})
+		}
+	}
+}

--- a/cmd/evener-hub/internal/hubcore/roster.go
+++ b/cmd/evener-hub/internal/hubcore/roster.go
@@ -2,6 +2,7 @@ package hubcore
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"maps"
@@ -133,12 +134,17 @@ type Roster struct {
 	// an in-memory or sandboxed filesystem via SetFs.
 	fs afero.Fs
 
-	mu     sync.RWMutex
-	bySess map[string]LiveEntry // session_id -> entry
-	byPID  map[int]LiveEntry    // pid -> entry (for fsnotify event correlation)
-	// refreshGen rejects a completed probe pass that started before a newer
-	// refresh attempt, while allowing probes to run without holding mu.
-	refreshGen uint64
+	mu           sync.RWMutex
+	bySess       map[string]LiveEntry // session_id -> entry
+	byPID        map[int]LiveEntry    // pid -> entry (for fsnotify event correlation)
+	unconfirmed  []rendezvous.Entry   // live PIDs whose daemon ownership has not been established
+	ownershipErr error
+	// A completed pass may publish unless a newer pass already published.
+	refreshGen              uint64
+	publishedGen            uint64
+	entryPublishedGen       map[int]uint64
+	ownershipRefreshRunning bool
+	queuedOwnershipRefresh  *rosterRefreshBatch
 
 	// procAlive reports whether a daemon PID is still running. A failed AppWire
 	// probe to a live process means the daemon is busy, not gone, so its session
@@ -153,7 +159,7 @@ type Roster struct {
 	newTicker    func(time.Duration) rosterTicker
 
 	// onChange, when set via SetOnChange, is fired by Refresh only when the
-	// live set's membership, per-session status, or running-child set changes.
+	// live set's membership, per-session status, running-child set, or unresolved ownership changes.
 	onChange func()
 	// fingerprint is the live-set hash from the most recent Refresh (see
 	// rosterFingerprint), used to gate onChange against no-op refreshes.
@@ -173,12 +179,13 @@ type Roster struct {
 // If prober is nil, liveness is assumed (used for tests).
 func NewRoster(runDir string, prober Prober) *Roster {
 	return &Roster{
-		runDir:    runDir,
-		prober:    prober,
-		fs:        afero.NewOsFs(),
-		bySess:    make(map[string]LiveEntry),
-		byPID:     make(map[int]LiveEntry),
-		procAlive: processAlive,
+		runDir:            runDir,
+		prober:            prober,
+		fs:                afero.NewOsFs(),
+		bySess:            make(map[string]LiveEntry),
+		byPID:             make(map[int]LiveEntry),
+		entryPublishedGen: make(map[int]uint64),
+		procAlive:         processAlive,
 		newWatcher: func() (rosterWatcher, error) {
 			w, err := fsnotify.NewWatcher()
 			return fsnotifyWatcher{w}, err
@@ -297,23 +304,33 @@ func rosterFingerprint(bySess map[string]LiveEntry) uint64 {
 // probe miss (busy daemon, overloaded host) must not blank the session from the
 // UI. It is dropped only when its process is gone (a stale rendezvous file).
 func (r *Roster) Refresh() {
+	_ = r.refresh()
+}
+
+func (r *Roster) refresh() error {
 	r.mu.Lock()
 	r.refreshGen++
 	generation := r.refreshGen
 	r.mu.Unlock()
 
-	entries, err := rendezvous.List(r.runDir)
-	if err != nil {
-		return
+	var entries []rendezvous.Entry
+	// An unconfigured roster has no discovery directory. A configured path
+	// disappearing is an incomplete read and must preserve existing ownership.
+	if r.runDir != "" {
+		var err error
+		entries, err = rendezvous.ListStrict(r.runDir)
+		if err != nil {
+			r.recordOwnershipError(generation, err)
+			return err
+		}
 	}
 
-	// Snapshot the previous PID map for the keep-alive fallback, and the
-	// previous per-session map for the status-transition diff below. Reading
-	// them under a brief lock (rather than holding the lock across the
+	// Snapshot the previous PID map for the keep-alive fallback. Reading
+	// it under a brief lock (rather than holding the lock across the
 	// probes) keeps List() responsive while a slow probe pass runs.
 	r.mu.RLock()
 	prevByPID := r.byPID
-	prevBySess := r.bySess
+	previousUnconfirmed := slices.Clone(r.unconfirmed)
 	r.mu.RUnlock()
 
 	type probeResult struct {
@@ -337,21 +354,46 @@ func (r *Roster) Refresh() {
 
 	bySess := make(map[string]LiveEntry, len(entries))
 	byPID := make(map[int]LiveEntry, len(entries))
+	var unconfirmed []rendezvous.Entry
+	retainUnconfirmed := func(entry rendezvous.Entry) {
+		if !slices.Contains(unconfirmed, entry) {
+			unconfirmed = append(unconfirmed, entry)
+		}
+	}
 	for _, res := range results {
 		e := res.entry
 		if !res.OK {
-			// The rendezvous file plus a live PID are the authoritative "this
-			// session exists" signal; keep the previously-seen entry while its
-			// process is alive (a transient probe miss).
-			if prev, had := prevByPID[e.PID]; had && r.procAlive(e.PID) {
+			alive := r.procAlive(e.PID)
+			if alive {
+				for _, claim := range previousUnconfirmed {
+					if claim.PID == e.PID {
+						retainUnconfirmed(claim)
+					}
+				}
+			}
+			// A transient probe miss preserves a route only while the complete
+			// rendezvous identity is unchanged. PID liveness cannot confirm a
+			// replacement's ownership of either the old or the new session.
+			if prev, had := prevByPID[e.PID]; had && alive {
+				if !sameDaemonIdentity(prev.Entry, e) {
+					retainUnconfirmed(prev.Entry)
+					resolved := prev.Entry
+					resolved.SessionID = prev.SessionID
+					retainUnconfirmed(resolved)
+					retainUnconfirmed(e)
+					continue
+				}
 				byPID[e.PID] = prev
 				if prev.SessionID != "" {
-					bySess[prev.SessionID] = prev
+					if current, ok := bySess[prev.SessionID]; !ok || preferLiveEntry(prev, current) {
+						bySess[prev.SessionID] = prev
+					}
 				}
 				continue
 			}
-			if r.procAlive(e.PID) {
-				continue // never confirmed live before, and still can't reach it
+			if alive {
+				retainUnconfirmed(e)
+				continue // ownership is unresolved; do not publish it as a live daemon
 			}
 			// The process is confirmed GONE, yet its rendezvous file is still
 			// on disk. The rendezvous package writes that file on startup and
@@ -392,20 +434,12 @@ func (r *Roster) Refresh() {
 			crashed.Status = "errored"
 			crashed.Crashed = true
 			byPID[e.PID] = crashed
-			bySess[sessionID] = crashed
+			if current, ok := bySess[sessionID]; !ok || preferLiveEntry(crashed, current) {
+				bySess[sessionID] = crashed
+			}
 			continue
 		}
-		live := LiveEntry{
-			Entry:                 e,
-			SessionID:             res.SessionID,
-			Status:                res.Status,
-			PendingAsk:            res.PendingAsk,
-			PendingEscalation:     res.PendingEscalation,
-			RunningSubagentIDs:    append([]string(nil), res.RunningSubagentIDs...),
-			RunningSubagentStates: cloneSubagentStates(res.RunningSubagentStates),
-			RunningJobs:           cloneRunningJobs(res.RunningJobs),
-			CompletedJobs:         cloneRunningJobs(res.CompletedJobs),
-		}
+		live := liveEntryFromProbe(e, res.ProbeResult)
 		if res.SessionID != "" {
 			if prev, ok := bySess[res.SessionID]; !ok || preferLiveEntry(live, prev) {
 				bySess[res.SessionID] = live
@@ -416,13 +450,44 @@ func (r *Roster) Refresh() {
 
 	fp := rosterFingerprint(bySess)
 	r.mu.Lock()
-	if generation != r.refreshGen {
+	if generation < r.publishedGen {
 		r.mu.Unlock()
-		return
+		return nil
 	}
+	// A newer single-daemon confirmation supersedes only that daemon's
+	// observation. Keep the complete scan's findings for every other PID.
+	merged := false
+	for pid, confirmed := range r.entryPublishedGen {
+		if confirmed <= generation {
+			delete(r.entryPublishedGen, pid)
+			continue
+		}
+		if live, ok := r.byPID[pid]; ok {
+			byPID[pid] = live
+			merged = true
+		}
+		unconfirmed = slices.DeleteFunc(unconfirmed, func(claim rendezvous.Entry) bool { return claim.PID == pid })
+	}
+	if merged {
+		bySess = make(map[string]LiveEntry, len(byPID))
+		for _, live := range byPID {
+			if live.SessionID == "" {
+				continue
+			}
+			if previous, ok := bySess[live.SessionID]; !ok || preferLiveEntry(live, previous) {
+				bySess[live.SessionID] = live
+			}
+		}
+		fp = rosterFingerprint(bySess)
+	}
+	r.publishedGen = generation
+	prevBySess := r.bySess
 	r.bySess = bySess
 	r.byPID = byPID
-	changed := fp != r.fingerprint
+	ownershipChanged := r.ownershipErr != nil || !slices.Equal(r.unconfirmed, unconfirmed)
+	r.ownershipErr = nil
+	r.unconfirmed = unconfirmed
+	changed := fp != r.fingerprint || ownershipChanged
 	r.fingerprint = fp
 	statusChanges := make([]string, 0)
 	for id, cur := range bySess {
@@ -442,6 +507,96 @@ func (r *Roster) Refresh() {
 	}
 	if changed && onChange != nil {
 		onChange()
+	}
+	return nil
+}
+
+// OwnershipError reports an incomplete full scan. Individual daemon
+// confirmations cannot establish that the remaining ownership claims are absent.
+func (r *Roster) OwnershipError() error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.ownershipErr
+}
+
+// DaemonOwnershipAbsent reports whether the roster excludes every possible
+// daemon owner, including unresolved claims. This permits retained sessions
+// with deleted ancestry to recover without guessing which daemon owns them.
+func (r *Roster) DaemonOwnershipAbsent() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.ownershipErr != nil || len(r.unconfirmed) != 0 {
+		return false
+	}
+	for _, entry := range r.byPID {
+		if !entry.Crashed {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *Roster) recordOwnershipError(generation uint64, err error) {
+	r.mu.Lock()
+	if generation < r.publishedGen {
+		r.mu.Unlock()
+		return
+	}
+	changed := r.ownershipErr == nil || r.ownershipErr.Error() != err.Error()
+	r.publishedGen = generation
+	r.ownershipErr = err
+	onChange := r.onChange
+	r.mu.Unlock()
+	if changed && onChange != nil {
+		onChange()
+	}
+}
+
+type rosterRefreshBatch struct {
+	done chan struct{}
+	err  error
+}
+
+// RefreshAndWait waits for a scan that starts after this request. Requests
+// arriving during a scan share the next scan, so ongoing traffic cannot move
+// an existing caller's completion target. Cancellation releases the caller;
+// the shared scan continues for the other callers.
+func (r *Roster) RefreshAndWait(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	batch := r.queuedOwnershipRefresh
+	if batch == nil {
+		batch = &rosterRefreshBatch{done: make(chan struct{})}
+		r.queuedOwnershipRefresh = batch
+	}
+	if !r.ownershipRefreshRunning {
+		r.ownershipRefreshRunning = true
+		go r.refreshOwnership()
+	}
+	r.mu.Unlock()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-batch.done:
+		return batch.err
+	}
+}
+
+func (r *Roster) refreshOwnership() {
+	for {
+		r.mu.Lock()
+		batch := r.queuedOwnershipRefresh
+		r.queuedOwnershipRefresh = nil
+		if batch == nil {
+			r.ownershipRefreshRunning = false
+			r.mu.Unlock()
+			return
+		}
+		r.mu.Unlock()
+		batch.err = r.refresh()
+		close(batch.done)
 	}
 }
 
@@ -500,6 +655,9 @@ func (r *Roster) SubagentState(sessionID string) (string, bool) {
 }
 
 func preferLiveEntry(candidate, current LiveEntry) bool {
+	if candidate.Crashed != current.Crashed {
+		return !candidate.Crashed
+	}
 	candidateAppWire := candidate.Protocol == appwire.ProtocolVersion && candidate.Endpoint != "" && candidate.ThreadID != ""
 	currentAppWire := current.Protocol == appwire.ProtocolVersion && current.Endpoint != "" && current.ThreadID != ""
 	if candidateAppWire != currentAppWire {
@@ -509,6 +667,81 @@ func preferLiveEntry(candidate, current LiveEntry) bool {
 		return candidate.StartedAt.After(current.StartedAt)
 	}
 	return candidate.PID > current.PID
+}
+
+func sameDaemonIdentity(a, b rendezvous.Entry) bool {
+	return a.PID == b.PID && a.Protocol == b.Protocol && a.Endpoint == b.Endpoint && a.Address == b.Address &&
+		a.SourceID == b.SourceID && a.ThreadID == b.ThreadID && a.SessionID == b.SessionID &&
+		a.WorkspaceRef == b.WorkspaceRef && a.InstanceID == b.InstanceID && a.HubToken == b.HubToken && a.StartedAt.Equal(b.StartedAt)
+}
+
+// HasConfirmedEntry reports whether the exact daemon identity has a live route.
+func (r *Roster) HasConfirmedEntry(entry rendezvous.Entry) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.hasConfirmedEntry(entry)
+}
+
+func (r *Roster) hasConfirmedEntry(entry rendezvous.Entry) bool {
+	live, ok := r.byPID[entry.PID]
+	routed, found := r.bySess[live.SessionID]
+	return ok && found && !live.Crashed && routed.PID == entry.PID && sameDaemonIdentity(live.Entry, entry)
+}
+
+// RestartRequiredRootRef resolves metadata-only admission from one roster
+// snapshot. It never reads persisted ancestry or probes daemon endpoints.
+func (r *Roster) RestartRequiredRootRef(rawRef string) (string, bool) {
+	ref, err := appwire.ParseRef(rawRef)
+	if err != nil || ref.SourceID != "local" {
+		return "", false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.ownershipErr != nil || len(r.unconfirmed) != 0 {
+		return "", false
+	}
+	aliases := func(entry LiveEntry) []string {
+		refs := []string{entry.WorkspaceRef}
+		for _, id := range []string{entry.SessionID, entry.Entry.SessionID, entry.ThreadID} {
+			if id != "" {
+				refs = append(refs, appwire.Ref{SourceID: "local", ThreadID: id}.String())
+			}
+		}
+		return refs
+	}
+	var owner LiveEntry
+	found := false
+	for _, entry := range r.byPID {
+		if entry.Crashed || (entry.SourceID != "" && entry.SourceID != "local") {
+			continue
+		}
+		ids := aliases(entry)
+		if !slices.Contains(ids, rawRef) {
+			continue
+		}
+		if found || entry.Status != appwire.ThreadStatusRestartRequired {
+			return "", false
+		}
+		owner, found = entry, true
+	}
+	if !found {
+		return "", false
+	}
+	ownerAliases := aliases(owner)
+	for _, entry := range r.byPID {
+		if entry.PID == owner.PID || entry.Crashed {
+			continue
+		}
+		for _, alias := range aliases(entry) {
+			if alias != "" && slices.Contains(ownerAliases, alias) {
+				return "", false
+			}
+		}
+	}
+	if workspace, err := appwire.ParseRef(owner.WorkspaceRef); err == nil && workspace.SourceID == "local" {
+		return owner.WorkspaceRef, true
+	}
+	return appwire.Ref{SourceID: "local", ThreadID: owner.SessionID}.String(), true
 }
 
 // Find returns the entry with the given session_id, or false if not present.
@@ -567,4 +800,151 @@ func (r *Roster) Watch(ctx context.Context) error {
 			r.Refresh()
 		}
 	}
+}
+
+// UnconfirmedEntries returns rendezvous claims whose processes are alive but
+// whose daemon identity could not be established. They are not live sessions,
+// but callers must not treat their absence from List as proof of released ownership.
+func (r *Roster) UnconfirmedEntries() []rendezvous.Entry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return slices.Clone(r.unconfirmed)
+}
+
+func liveEntryFromProbe(e rendezvous.Entry, result ProbeResult) LiveEntry {
+	return LiveEntry{
+		Entry:                 e,
+		SessionID:             result.SessionID,
+		Status:                result.Status,
+		PendingAsk:            result.PendingAsk,
+		PendingEscalation:     result.PendingEscalation,
+		RunningSubagentIDs:    append([]string(nil), result.RunningSubagentIDs...),
+		RunningSubagentStates: cloneSubagentStates(result.RunningSubagentStates),
+		RunningJobs:           cloneRunningJobs(result.RunningJobs),
+		CompletedJobs:         cloneRunningJobs(result.CompletedJobs),
+	}
+}
+
+// RefreshEntry confirms one freshly spawned daemon without depending on other
+// rendezvous files. Publishing it makes the ordinary source and relay paths
+// available for the pending mutation after a successful resume.
+func (r *Roster) RefreshEntry(ctx context.Context, entry rendezvous.Entry) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if entry.Protocol != appwire.ProtocolVersion || entry.Endpoint == "" {
+		return errors.New("spawned daemon has no current protocol endpoint")
+	}
+	r.mu.Lock()
+	r.refreshGen++
+	generation := r.refreshGen
+	r.mu.Unlock()
+	results := make(chan ProbeResult, 1)
+	go func() {
+		if r.prober == nil {
+			results <- ProbeResult{OK: true, SessionID: envvars.FirstNonEmpty(entry.SessionID, entry.ThreadID)}
+		} else {
+			results <- r.prober.Probe(entry)
+		}
+	}()
+	var result ProbeResult
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case result = <-results:
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !result.OK || result.SessionID == "" {
+		return fmt.Errorf("cannot confirm spawned daemon %s", entry.SessionID)
+	}
+	return r.publishConfirmedEntry(entry, result, generation)
+}
+
+// ReadSpawnedThread confirms a fresh endpoint through the caller's direct read.
+// Initial delivery does not depend on collecting the full status inventory.
+func (r *Roster) ReadSpawnedThread(ctx context.Context, entry rendezvous.Entry, read func(context.Context) (appwire.ThreadReadResponse, error)) (appwire.ThreadReadResponse, error) {
+	r.mu.Lock()
+	r.refreshGen++
+	generation := r.refreshGen
+	r.mu.Unlock()
+	response, err := read(ctx)
+	if err != nil {
+		return response, err
+	}
+	if err := ctx.Err(); err != nil {
+		return response, err
+	}
+	root := response.Thread
+	if entry.Protocol != appwire.ProtocolVersion || entry.Endpoint == "" || root.ID != entry.ThreadID || statusThreadID(root) == "" || (entry.SessionID != "" && statusThreadID(root) != entry.SessionID) {
+		return response, errors.New("spawned daemon read did not confirm its identity")
+	}
+	runningJobs, completedJobs := splitNonAgentJobs(root.Evener.Diagnostics)
+	result := ProbeResult{OK: true, SessionID: statusThreadID(root), Status: root.Status.Type,
+		PendingAsk: root.Evener.AskPending, PendingEscalation: len(root.Evener.PendingEscalations) > 0,
+		RunningJobs: runningJobs, CompletedJobs: completedJobs}
+	if root.Evener.Diagnostics != nil {
+		result.RunningSubagentStates = make(map[string]string)
+		for _, delegate := range root.Evener.Diagnostics.Delegates {
+			if delegate.ChildSessionID == "" || delegate.Lifecycle == "closed" {
+				continue
+			}
+			state := ""
+			switch delegate.Lifecycle {
+			case "idle":
+				state = appwire.ThreadStatusIdle
+			case "running":
+				state = appwire.ThreadStatusActive
+				if delegate.NeedsAttention {
+					state = appwire.ThreadStatusAwaiting
+				}
+			}
+			result.RunningSubagentStates[delegate.ChildSessionID] = state
+		}
+		for childID := range result.RunningSubagentStates {
+			result.RunningSubagentIDs = append(result.RunningSubagentIDs, childID)
+		}
+		sort.Strings(result.RunningSubagentIDs)
+	}
+	return response, r.publishConfirmedEntry(entry, result, generation)
+}
+
+func (r *Roster) publishConfirmedEntry(entry rendezvous.Entry, result ProbeResult, generation uint64) error {
+	live := liveEntryFromProbe(entry, result)
+	r.mu.Lock()
+	if generation < r.publishedGen || generation < r.entryPublishedGen[entry.PID] {
+		confirmed := r.hasConfirmedEntry(entry)
+		r.mu.Unlock()
+		if !confirmed {
+			return fmt.Errorf("spawned daemon %s confirmation superseded without a route", live.SessionID)
+		}
+		return nil
+	}
+	previous, hadPrevious := r.bySess[live.SessionID]
+	bySess, byPID := maps.Clone(r.bySess), maps.Clone(r.byPID)
+	if old, ok := byPID[entry.PID]; ok && bySess[old.SessionID].PID == entry.PID {
+		delete(bySess, old.SessionID)
+	}
+	bySess[live.SessionID], byPID[entry.PID] = live, live
+	unconfirmed := make([]rendezvous.Entry, 0, len(r.unconfirmed))
+	for _, claim := range r.unconfirmed {
+		if claim.PID != entry.PID {
+			unconfirmed = append(unconfirmed, claim)
+		}
+	}
+	fp := rosterFingerprint(bySess)
+	changed := fp != r.fingerprint || !slices.Equal(unconfirmed, r.unconfirmed)
+	r.bySess, r.byPID, r.unconfirmed = bySess, byPID, unconfirmed
+	r.entryPublishedGen[entry.PID] = generation
+	r.fingerprint = fp
+	onChange, onStatusChange := r.onChange, r.onStatusChange
+	r.mu.Unlock()
+	if hadPrevious && previous.Status != live.Status && onStatusChange != nil {
+		onStatusChange(live.SessionID)
+	}
+	if changed && onChange != nil {
+		onChange()
+	}
+	return nil
 }

--- a/cmd/evener-hub/internal/hubcore/roster_admission_test.go
+++ b/cmd/evener-hub/internal/hubcore/roster_admission_test.go
@@ -1,0 +1,62 @@
+package hubcore
+
+import (
+	"errors"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestRestartRequiredRootRef(t *testing.T) {
+	owner := LiveEntry{Entry: rendezvous.Entry{PID: 1, SessionID: "current", ThreadID: "current", WorkspaceRef: "local:saved"}, SessionID: "current", Status: appwire.ThreadStatusRestartRequired}
+	for _, ref := range []string{"local:current", "local:saved"} {
+		roster := NewRosterWithEntries(owner)
+		if got, ok := roster.RestartRequiredRootRef(ref); !ok || got != "local:saved" {
+			t.Fatalf("%s: ref=%s ok=%v", ref, got, ok)
+		}
+	}
+	for _, scenario := range []string{"missing", "remote", "duplicate", "overlap", "cross-alias", "unconfirmed", "discovery", "compatible", "crashed", "descendant"} {
+		t.Run(scenario, func(t *testing.T) {
+			owner := owner
+			roster := NewRosterWithEntries(owner)
+			ref := "local:current"
+			switch scenario {
+			case "missing":
+				ref = "local:missing"
+			case "remote":
+				ref = "remote:current"
+			case "duplicate", "overlap", "cross-alias":
+				other := owner
+				other.PID = 2
+				if scenario == "overlap" {
+					other.SessionID = "other"
+					other.Entry.SessionID = "other"
+					other.ThreadID = "other"
+				}
+				if scenario == "cross-alias" {
+					other.SessionID, other.Entry.SessionID, other.ThreadID = "saved", "saved", "saved"
+					other.WorkspaceRef = "local:other"
+				}
+				roster.byPID[2] = other
+			case "unconfirmed":
+				roster.unconfirmed = []rendezvous.Entry{{PID: 2}}
+			case "discovery":
+				roster.ownershipErr = errors.New("unreadable discovery")
+			case "compatible":
+				owner.Status = appwire.ThreadStatusIdle
+				roster = NewRosterWithEntries(owner)
+			case "crashed":
+				owner.Crashed = true
+				roster = NewRosterWithEntries(owner)
+			case "descendant":
+				owner.RunningSubagentIDs = []string{"child"}
+				roster = NewRosterWithEntries(owner)
+				ref = "local:child"
+			}
+			if got, ok := roster.RestartRequiredRootRef(ref); ok {
+				t.Fatalf("unexpected root admission %s", got)
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/internal/hubcore/roster_test.go
+++ b/cmd/evener-hub/internal/hubcore/roster_test.go
@@ -2,12 +2,15 @@ package hubcore
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"primeradiant.com/evener/agent/schema"
@@ -613,6 +616,8 @@ type overlappingRefreshProber struct {
 	firstStarted  chan struct{}
 	secondStarted chan struct{}
 	releaseFirst  chan struct{}
+	releaseSecond chan struct{}
+	failSecond    bool
 }
 
 func (p *overlappingRefreshProber) Probe(rendezvous.Entry) ProbeResult {
@@ -623,6 +628,12 @@ func (p *overlappingRefreshProber) Probe(rendezvous.Entry) ProbeResult {
 		return ProbeResult{SessionID: "parent", Status: "old", RunningSubagentIDs: []string{"old-child"}, OK: true}
 	case 2:
 		close(p.secondStarted)
+		if p.releaseSecond != nil {
+			<-p.releaseSecond
+		}
+		if p.failSecond {
+			return ProbeResult{}
+		}
 		return ProbeResult{SessionID: "parent", Status: "new", RunningSubagentIDs: []string{"new-child"}, OK: true}
 	default:
 		return ProbeResult{SessionID: "parent", Status: "unexpected", OK: true}
@@ -646,9 +657,9 @@ func TestRoster_RefreshRejectsStaleConcurrentCommit(t *testing.T) {
 	newDone := make(chan struct{})
 	go func() { r.Refresh(); close(newDone) }()
 	<-prober.secondStarted
+	<-newDone
 	close(prober.releaseFirst)
 	<-oldDone
-	<-newDone
 
 	entry, ok := r.Find("parent")
 	if !ok || entry.Status != "new" || len(entry.RunningSubagentIDs) != 1 || entry.RunningSubagentIDs[0] != "new-child" {
@@ -956,5 +967,478 @@ func fuzzScenarioNewRosterWithEntries(t *testing.T) {
 	// NewRosterWithEntries keeps bySess free of empty keys.
 	if e, ok := r.Find(""); ok {
 		t.Fatalf("Find(\"\") = {PID:%d}, want not found", e.PID)
+	}
+}
+
+func TestRosterOwnershipRefreshPublishesDespiteLaterProbe(t *testing.T) {
+	dir := t.TempDir()
+	writeRendezvous(t, dir, rendezvous.Entry{PID: 1001})
+	synctest.Test(t, func(t *testing.T) {
+		prober := &overlappingRefreshProber{firstStarted: make(chan struct{}), secondStarted: make(chan struct{}), releaseFirst: make(chan struct{}), releaseSecond: make(chan struct{})}
+		r := NewRoster(dir, prober)
+		ownerDone := make(chan struct{})
+		go func() {
+			if err := r.RefreshAndWait(context.Background()); err != nil {
+				t.Error(err)
+			}
+			close(ownerDone)
+		}()
+		<-prober.firstStarted
+		backgroundDone := make(chan struct{})
+		go func() { r.Refresh(); close(backgroundDone) }()
+		<-prober.secondStarted
+		close(prober.releaseFirst)
+		synctest.Wait()
+		select {
+		case <-ownerDone:
+		default:
+			t.Error("ownership check waited for a later probe instead of publishing its own scan")
+		}
+		close(prober.releaseSecond)
+		<-ownerDone
+		<-backgroundDone
+		entry, ok := r.Find("parent")
+		if !ok || entry.Status != "new" {
+			t.Fatalf("ownership snapshot=%+v, found=%v", entry, ok)
+		}
+	})
+}
+
+type ownershipBatchProber struct {
+	calls   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *ownershipBatchProber) Probe(entry rendezvous.Entry) ProbeResult {
+	if p.calls.Add(1) == 1 {
+		close(p.started)
+	}
+	<-p.release
+	return ProbeResult{SessionID: entry.ThreadID, Status: appwire.ThreadStatusIdle, OK: true}
+}
+
+func TestRosterOwnershipRefreshesCoalesceWithoutLosingFreshness(t *testing.T) {
+	dir := t.TempDir()
+	writeRendezvous(t, dir, rendezvous.Entry{PID: 1001, ThreadID: "old"})
+	synctest.Test(t, func(t *testing.T) {
+		prober := &ownershipBatchProber{started: make(chan struct{}), release: make(chan struct{})}
+		roster := NewRoster(dir, prober)
+		done := make(chan struct{}, 17)
+		go func() {
+			if err := roster.RefreshAndWait(context.Background()); err != nil {
+				t.Error(err)
+			}
+			done <- struct{}{}
+		}()
+		<-prober.started
+		writeRendezvous(t, dir, rendezvous.Entry{PID: 1001, ThreadID: "new"})
+		for range 16 {
+			go func() {
+				if err := roster.RefreshAndWait(context.Background()); err != nil {
+					t.Error(err)
+				}
+				done <- struct{}{}
+			}()
+		}
+		synctest.Wait()
+		if got := prober.calls.Load(); got != 1 {
+			t.Errorf("started %d probes while the first was still running, want one", got)
+		}
+		close(prober.release)
+		for range 17 {
+			<-done
+		}
+		if got := prober.calls.Load(); got != 2 {
+			t.Errorf("probe passes=%d, want the active pass and one fresh coalesced pass", got)
+		}
+		if _, ok := roster.Find("new"); !ok {
+			t.Error("waiting callers did not receive a fresh rendezvous snapshot")
+		}
+	})
+}
+
+func TestRosterOwnershipRefreshCancellation(t *testing.T) {
+	dir := t.TempDir()
+	writeRendezvous(t, dir, rendezvous.Entry{PID: 1001, ThreadID: "owner"})
+	synctest.Test(t, func(t *testing.T) {
+		prober := &ownershipBatchProber{started: make(chan struct{}), release: make(chan struct{})}
+		roster := NewRoster(dir, prober)
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan error, 1)
+		go func() { done <- roster.RefreshAndWait(ctx) }()
+		<-prober.started
+		cancel()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("refresh error=%v, want cancellation", err)
+			}
+		default:
+			t.Error("canceled caller is still waiting for the probe")
+		}
+		close(prober.release)
+		synctest.Wait()
+	})
+}
+
+func TestRosterOwnershipRefreshReportsReadFailure(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	roster := NewRoster(path, nil)
+	if err := roster.RefreshAndWait(context.Background()); err == nil {
+		t.Fatal("ownership refresh succeeded without reading the rendezvous directory")
+	}
+}
+
+func TestRosterUnconfirmedOwnershipClearsOnProbeOrExit(t *testing.T) {
+	for _, resolvesByProbe := range []bool{false, true} {
+		t.Run(strconv.FormatBool(resolvesByProbe), func(t *testing.T) {
+			dir := t.TempDir()
+			writeRendezvous(t, dir, rendezvous.Entry{PID: 1001, SessionID: "owner", Protocol: "evener-appwire-v3"})
+			roster := NewRoster(dir, fakeProber{shouldFail: true})
+			alive := true
+			roster.procAlive = func(int) bool { return alive }
+			roster.Refresh()
+			claims := roster.UnconfirmedEntries()
+			if len(claims) != 1 || claims[0].SessionID != "owner" {
+				t.Fatalf("claims=%+v", claims)
+			}
+			if len(roster.List()) != 0 {
+				t.Fatal("unconfirmed process published as live daemon")
+			}
+			claims[0].SessionID = "modified"
+			if roster.UnconfirmedEntries()[0].SessionID != "owner" {
+				t.Fatal("caller modified roster ownership")
+			}
+			if resolvesByProbe {
+				roster.prober = fakeProber{sessionID: "owner", status: appwire.ThreadStatusRestartRequired}
+			} else {
+				alive = false
+			}
+			roster.Refresh()
+			if len(roster.UnconfirmedEntries()) != 0 {
+				t.Fatal("resolved ownership remained unconfirmed")
+			}
+		})
+	}
+}
+
+func TestRosterUnconfirmedOwnershipInvalidatesNavigation(t *testing.T) {
+	dir := t.TempDir()
+	roster := NewRoster(dir, fakeProber{shouldFail: true})
+	roster.procAlive = func(int) bool { return true }
+	roster.Refresh()
+	changes := 0
+	roster.SetOnChange(func() { changes++ })
+	entry := rendezvous.Entry{PID: 1001, SessionID: "owner"}
+	writeRendezvous(t, dir, entry)
+	roster.Refresh()
+	if changes != 1 {
+		t.Fatalf("new claim callbacks=%d, want 1", changes)
+	}
+	roster.Refresh()
+	if changes != 1 {
+		t.Fatal("unchanged claim invalidated navigation")
+	}
+	entry.WorkspaceRef = "local:workspace"
+	writeRendezvous(t, dir, entry)
+	roster.Refresh()
+	if changes != 2 {
+		t.Fatalf("changed identity callbacks=%d, want 2", changes)
+	}
+	roster.Refresh()
+	if changes != 2 {
+		t.Fatal("unchanged identity invalidated navigation")
+	}
+	if err := rendezvous.Remove(dir, entry.PID); err != nil {
+		t.Fatal(err)
+	}
+	roster.Refresh()
+	if changes != 3 {
+		t.Fatalf("removed claim callbacks=%d, want 3", changes)
+	}
+}
+
+func TestRosterRefreshEntryPreservesOtherOwnership(t *testing.T) {
+	otherEntry := rendezvous.Entry{PID: 1001}
+	roster := NewRosterWithEntries(LiveEntry{Entry: otherEntry, SessionID: "other", Status: "active"})
+	roster.runDir = t.TempDir()
+	roster.prober = fakeProber{sessionID: "resumed", status: "idle"}
+	roster.unconfirmed = []rendezvous.Entry{{PID: 1002, SessionID: "resumed"}, {PID: 1003, SessionID: "uncertain"}}
+	if err := os.WriteFile(filepath.Join(roster.runDir, "1.json"), []byte("{"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := roster.RefreshAndWait(t.Context()); err == nil {
+		t.Fatal("fixture did not fail discovery")
+	}
+	entry := rendezvous.Entry{PID: 1002, SessionID: "resumed", ThreadID: "resumed", Protocol: appwire.ProtocolVersion, Endpoint: "ws://daemon/rpc"}
+	if err := roster.RefreshEntry(t.Context(), entry); err != nil {
+		t.Fatal(err)
+	}
+	if live, ok := roster.Find("resumed"); !ok || live.PID != 1002 || live.Status != "idle" {
+		t.Fatalf("resumed=%+v, %v", live, ok)
+	}
+	if other, ok := roster.Find("other"); !ok || other.Status != "active" {
+		t.Fatal("other owner changed")
+	}
+	if claims := roster.UnconfirmedEntries(); len(claims) != 1 || claims[0].SessionID != "uncertain" {
+		t.Fatalf("claims=%+v", claims)
+	}
+	roster.prober = fakeProber{shouldFail: true}
+	if err := roster.RefreshEntry(t.Context(), entry); err == nil {
+		t.Fatal("unconfirmed entry accepted")
+	}
+	if len(roster.List()) != 2 {
+		t.Fatal("failed confirmation changed roster")
+	}
+}
+
+func TestRosterRefreshEntryDoesNotOverwriteNewerRefresh(t *testing.T) {
+	for _, fullScan := range []bool{false, true} {
+		t.Run(strconv.FormatBool(fullScan), func(t *testing.T) {
+			dir := t.TempDir()
+			entry := rendezvous.Entry{PID: 1001, SessionID: "parent", Protocol: appwire.ProtocolVersion, Endpoint: "ws://daemon/rpc"}
+			writeRendezvous(t, dir, entry)
+			prober := &overlappingRefreshProber{firstStarted: make(chan struct{}), secondStarted: make(chan struct{}), releaseFirst: make(chan struct{})}
+			roster := NewRoster(dir, prober)
+			done := make(chan error, 1)
+			go func() { done <- roster.RefreshEntry(t.Context(), entry) }()
+			<-prober.firstStarted
+			if fullScan {
+				roster.Refresh()
+			} else if err := roster.RefreshEntry(t.Context(), entry); err != nil {
+				t.Fatal(err)
+			}
+			close(prober.releaseFirst)
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			if live, ok := roster.Find("parent"); !ok || live.Status != "new" {
+				t.Fatalf("stale confirmation replaced newer snapshot: %+v", live)
+			}
+
+		})
+	}
+}
+
+func TestRosterRefreshEntryCancellation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		prober := &gateProber{sessionID: "parent", gate: make(chan struct{}), started: make(chan struct{}, 1)}
+		roster := NewRoster(t.TempDir(), prober)
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan error, 1)
+		go func() {
+			done <- roster.RefreshEntry(ctx, rendezvous.Entry{PID: 1001, Protocol: appwire.ProtocolVersion, Endpoint: "ws://daemon/rpc"})
+		}()
+		<-prober.started
+		cancel()
+		synctest.Wait()
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("error=%v", err)
+			}
+		default:
+			t.Fatal("cancellation waited for probe")
+		}
+		close(prober.gate)
+		synctest.Wait()
+		if len(roster.List()) != 0 {
+			t.Fatal("cancelled confirmation published")
+		}
+	})
+}
+
+type entryConfirmationProber struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (p *entryConfirmationProber) Probe(entry rendezvous.Entry) ProbeResult {
+	if entry.PID == 1001 {
+		close(p.started)
+		<-p.release
+	}
+	return ProbeResult{OK: true, SessionID: entry.SessionID, Status: "idle"}
+}
+
+func TestRosterConcurrentConfirmationPreservesEveryRoute(t *testing.T) {
+	for _, fullScan := range []bool{false, true} {
+		t.Run(strconv.FormatBool(fullScan), func(t *testing.T) {
+			dir := t.TempDir()
+			first := rendezvous.Entry{PID: 1001, SessionID: "first", Protocol: appwire.ProtocolVersion, Endpoint: "ws://first/rpc"}
+			second := rendezvous.Entry{PID: 1002, SessionID: "second", Protocol: appwire.ProtocolVersion, Endpoint: "ws://second/rpc"}
+			writeRendezvous(t, dir, first)
+			prober := &entryConfirmationProber{started: make(chan struct{}), release: make(chan struct{})}
+			roster := NewRoster(dir, prober)
+			done := make(chan error, 1)
+			go func() {
+				if fullScan {
+					done <- roster.RefreshAndWait(t.Context())
+				} else {
+					done <- roster.RefreshEntry(t.Context(), first)
+				}
+			}()
+			<-prober.started
+			writeRendezvous(t, dir, second)
+			if err := roster.RefreshEntry(t.Context(), second); err != nil {
+				t.Fatal(err)
+			}
+			close(prober.release)
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			for _, id := range []string{"first", "second"} {
+				if _, ok := roster.Find(id); !ok {
+					t.Errorf("confirmed session %s lost its route", id)
+				}
+			}
+		})
+	}
+}
+
+// A crash marker must not replace a surviving daemon's ownership or status.
+func TestRosterLiveOwnerWinsOverCrashMarker(t *testing.T) {
+	for _, livePID := range []int{1001, 1002} {
+		t.Run(strconv.Itoa(livePID), func(t *testing.T) {
+			dir := t.TempDir()
+			for _, pid := range []int{1001, 1002} {
+				protocol := appwire.ProtocolVersion
+				if pid == livePID {
+					protocol = "evener-appwire-v3"
+				}
+				writeRendezvous(t, dir, rendezvous.Entry{PID: pid, SessionID: "owner", ThreadID: "owner", Protocol: protocol, Endpoint: "ws://unused", StartedAt: time.Now().UTC()})
+			}
+			prober := &survivingOwnerProber{livePID: livePID}
+			r := NewRoster(dir, prober)
+			r.procAlive = func(pid int) bool { return pid == livePID }
+			for _, failProbe := range []bool{false, true} {
+				prober.fail = failProbe
+				r.Refresh()
+				got, ok := r.Find("owner")
+				if !ok || got.Crashed || got.PID != livePID || got.Status != "restartRequired" {
+					t.Errorf("Find after probe failure=%v: %+v, present=%v", failProbe, got, ok)
+				}
+				listed := r.List()
+				if len(listed) != 1 || listed[0].Crashed || listed[0].PID != livePID {
+					t.Errorf("List after probe failure=%v: %+v", failProbe, listed)
+				}
+			}
+		})
+	}
+}
+
+type survivingOwnerProber struct {
+	livePID int
+	fail    bool
+}
+
+func (p *survivingOwnerProber) Probe(e rendezvous.Entry) ProbeResult {
+	if e.PID != p.livePID || p.fail {
+		return ProbeResult{}
+	}
+	return ProbeResult{SessionID: e.SessionID, Status: "restartRequired", OK: true}
+}
+
+func TestRosterRefreshEntryDoesNotSucceedWithoutRouteAfterNewerMiss(t *testing.T) {
+	dir := t.TempDir()
+	entry := rendezvous.Entry{PID: 1001, SessionID: "parent", Protocol: appwire.ProtocolVersion, Endpoint: "ws://daemon/rpc"}
+	writeRendezvous(t, dir, entry)
+	prober := &overlappingRefreshProber{firstStarted: make(chan struct{}), secondStarted: make(chan struct{}), releaseFirst: make(chan struct{}), failSecond: true}
+	roster := NewRoster(dir, prober)
+	roster.procAlive = func(int) bool { return true }
+	done := make(chan error, 1)
+	go func() { done <- roster.RefreshEntry(t.Context(), entry) }()
+	<-prober.firstStarted
+	roster.Refresh()
+	close(prober.releaseFirst)
+	err := <-done
+	live, ok := roster.Find("parent")
+	if err == nil && (!ok || live.Crashed || live.PID != entry.PID) {
+		t.Fatalf("confirmation returned success without a route: %+v, present=%v", live, ok)
+	}
+}
+
+func TestRosterRetainsChangedClaimAfterProbeFailure(t *testing.T) {
+	dir := t.TempDir()
+	entry := rendezvous.Entry{PID: 1001, SessionID: "before", ThreadID: "before", Protocol: appwire.ProtocolVersion, Endpoint: "ws://daemon/rpc"}
+	writeRendezvous(t, dir, entry)
+	prober := &flakyProber{sessionID: "before"}
+	roster := NewRoster(dir, prober)
+	roster.procAlive = func(int) bool { return true }
+	roster.Refresh()
+	previous := entry
+	prober.fail = true
+	roster.Refresh()
+	if !roster.HasConfirmedEntry(previous) {
+		t.Fatal("unchanged identity lost its route during a transient probe failure")
+	}
+	entry.SessionID, entry.ThreadID = "after", "after"
+	writeRendezvous(t, dir, entry)
+	prober.fail = true
+	for range 2 {
+		roster.Refresh()
+		if _, ok := roster.Find("before"); ok || roster.HasConfirmedEntry(previous) {
+			t.Fatal("previous identity remains routable after its PID changed identity")
+		}
+		if len(roster.List()) != 0 {
+			t.Fatal("unconfirmed replacement published a live route")
+		}
+		claims := roster.UnconfirmedEntries()
+		if len(claims) != 2 || !slices.Contains(claims, previous) || !slices.Contains(claims, entry) {
+			t.Fatalf("old and changed claims must remain unresolved: %+v", claims)
+		}
+	}
+	prober.fail, prober.sessionID = false, "after"
+	roster.Refresh()
+	if _, ok := roster.Find("after"); !ok || !roster.HasConfirmedEntry(entry) {
+		t.Fatal("confirmed replacement did not acquire its route")
+	}
+	if _, ok := roster.Find("before"); ok || len(roster.UnconfirmedEntries()) != 0 {
+		t.Fatal("confirmed replacement retained previous ownership")
+	}
+}
+
+func TestRosterOwnershipErrorRequiresNewerCompleteScan(t *testing.T) {
+	dir := t.TempDir()
+	entry := rendezvous.Entry{PID: 1001, SessionID: "parent", Protocol: appwire.ProtocolVersion, Endpoint: "ws://daemon/rpc"}
+	writeRendezvous(t, dir, entry)
+	prober := &overlappingRefreshProber{firstStarted: make(chan struct{}), secondStarted: make(chan struct{}), releaseFirst: make(chan struct{})}
+	roster := NewRoster(dir, prober)
+	var changes atomic.Int32
+	roster.SetOnChange(func() { changes.Add(1) })
+	done := make(chan struct{})
+	go func() { roster.Refresh(); close(done) }()
+	<-prober.firstStarted
+	badClaim := filepath.Join(dir, "2.json")
+	if err := os.WriteFile(badClaim, []byte("{"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	roster.Refresh()
+	if roster.OwnershipError() == nil || changes.Load() != 1 {
+		t.Fatal("failed discovery did not publish uncertainty")
+	}
+	close(prober.releaseFirst)
+	<-done
+	if roster.OwnershipError() == nil {
+		t.Fatal("older successful scan cleared newer uncertainty")
+	}
+	if err := roster.RefreshEntry(t.Context(), entry); err != nil {
+		t.Fatal(err)
+	}
+	if roster.OwnershipError() == nil {
+		t.Fatal("individual confirmation cleared global uncertainty")
+	}
+	if err := os.Remove(badClaim); err != nil {
+		t.Fatal(err)
+	}
+	before := changes.Load()
+	roster.Refresh()
+	if roster.OwnershipError() != nil || changes.Load() <= before {
+		t.Fatal("complete scan did not publish recovered ownership")
 	}
 }

--- a/cmd/evener-hub/internal/hubcore/tree.go
+++ b/cmd/evener-hub/internal/hubcore/tree.go
@@ -548,6 +548,8 @@ func NormalizeState(s string) string {
 		return "active"
 	case appwire.ThreadStatusSystemError:
 		return "errored" // first-class red error lane (spec v5) — no longer grouped with awaiting
+	case appwire.ThreadStatusRestartRequired:
+		return appwire.ThreadStatusRestartRequired
 	case appwire.ThreadStatusWarning:
 		return "warning"
 	case appwire.ThreadStatusIdle:
@@ -1229,7 +1231,7 @@ func buildTreeAtWithProjects(metas []schema.SessionMeta, live []LiveEntry, decis
 				rollup = taskState
 			}
 			switch taskState {
-			case "awaiting", "warning", "errored":
+			case "awaiting", "warning", "errored", appwire.ThreadStatusRestartRequired:
 				rollupAttn++
 			case "active":
 				rollupLive++

--- a/cmd/evener-hub/main.go
+++ b/cmd/evener-hub/main.go
@@ -205,6 +205,11 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 	if runDir == "" {
 		runDir = rendezvous.DefaultDir()
 	}
+	// Initial ownership discovery must be ready before any request can resume
+	// a saved session; the background watcher is not a startup barrier.
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		return fmt.Errorf("prepare runtime directory: %w", err)
+	}
 	stateGlob := cfg.StateGlob
 	if stateGlob == "" {
 		stateGlob = DefaultStateGlob()

--- a/cmd/evener-hub/main_test.go
+++ b/cmd/evener-hub/main_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -542,4 +543,33 @@ func hubInstanceListOverRPC(t *testing.T, web *WebServer) (appwire.InstanceListR
 	}
 	resp, ok := raw.(appwire.InstanceListResponse)
 	return resp, ok
+}
+
+func TestRunMainPreparesRuntimeDirectoryBeforeRequests(t *testing.T) {
+	for _, blocked := range []bool{false, true} {
+		t.Run(strconv.FormatBool(blocked), func(t *testing.T) {
+			_, cfg, deps := newTraceMainTestDeps(t)
+			if blocked {
+				if err := os.WriteFile(cfg.RunDir, []byte("occupied"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			ready := false
+			deps.afterWeb = func(web *WebServer) {
+				ready = true
+				if err := web.cfg.Roster.RefreshAndWait(t.Context()); err != nil {
+					t.Errorf("initial ownership discovery: %v", err)
+				}
+			}
+			var stderr bytes.Buffer
+			err := runMain([]string{"-addr", cfg.Addr, "-evener", "/bin/evener"}, &stderr, deps)
+			if blocked {
+				if err == nil || ready {
+					t.Fatalf("unusable runtime directory reached requests: err=%v ready=%v", err, ready)
+				}
+			} else if err != nil || !ready {
+				t.Fatalf("fresh runtime directory: err=%v ready=%v", err, ready)
+			}
+		})
+	}
 }

--- a/cmd/evener-hub/navigation_ownership_test.go
+++ b/cmd/evener-hub/navigation_ownership_test.go
@@ -1,0 +1,88 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubtest"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestNavigationPreservesKnownFavoritesDuringOwnershipFailure(t *testing.T) {
+	runDir := t.TempDir()
+	id := hubtest.SessionID(t)
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: os.Getpid(), SessionID: id, ThreadID: id, WorkingDir: t.TempDir()})
+	roster := hubcore.NewRoster(runDir, fakeProber{sessionID: id, status: "idle"})
+	roster.Refresh()
+	favorites := hubcore.NewFavoriteStore(filepath.Join(t.TempDir(), "index.db"))
+	if err := favorites.Set("session", id, true, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	unresolved := hubtest.SessionID(t)
+	if err := favorites.Set("session", unresolved, true, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	web := NewWebServer(hubcore.WebConfig{Roster: roster, Favorite: favorites})
+	source := webNavigationSource{web: web}
+	check := func(rename bool) {
+		t.Helper()
+		snapshot, err := source.Capture(t.Context(), "generation", time.Now())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(snapshot.Inputs.LiveEntries) != 1 || snapshot.Inputs.LiveEntries[0].SessionID != id {
+			t.Fatalf("known live row lost: %+v", snapshot.Inputs.LiveEntries)
+		}
+		if !snapshot.Inputs.SessionFavorite[id] {
+			t.Fatal("known favorite lost")
+		}
+		if got := snapshot.Inputs.Renameable[id]; got != rename {
+			t.Fatalf("rename=%v want=%v", got, rename)
+		}
+	}
+	check(true)
+	bad := filepath.Join(runDir, "424242.json")
+	if err := os.WriteFile(bad, []byte("{"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	roster.Refresh()
+	if roster.OwnershipError() == nil || roster.DaemonOwnershipAbsent() {
+		t.Fatal("incomplete discovery claimed absent ownership")
+	}
+	check(false)
+	decisions, err := favorites.Favorites()
+	if err != nil || !decisions[hubcore.ArchiveKey{Kind: "session", ID: id}] || !decisions[hubcore.ArchiveKey{Kind: "session", ID: unresolved}] {
+		t.Fatalf("favorite decision changed: %v %v", decisions, err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := source.Capture(ctx, "generation", time.Now()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancel error=%v", err)
+	}
+	if err := os.Remove(bad); err != nil {
+		t.Fatal(err)
+	}
+	roster.Refresh()
+	if roster.OwnershipError() != nil {
+		t.Fatal(roster.OwnershipError())
+	}
+	check(true)
+}
+
+func assertNavigationOwnershipReadOnly(t *testing.T, web *WebServer) {
+	t.Helper()
+	snapshot, err := (webNavigationSource{web: web}).Capture(t.Context(), "generation", time.Now())
+	if err != nil {
+		t.Fatalf("navigation read unavailable during ownership uncertainty: %v", err)
+	}
+	for id, renameable := range snapshot.Inputs.Renameable {
+		if isLocalRouteID(id) && renameable {
+			t.Errorf("local rename enabled during ownership uncertainty: %s", id)
+		}
+	}
+}

--- a/cmd/evener-hub/navigation_service.go
+++ b/cmd/evener-hub/navigation_service.go
@@ -1330,6 +1330,9 @@ func (s webNavigationSource) Capture(ctx context.Context, generation string, now
 		return navigationSourceSnapshot{}, errors.New("navigation web source is unavailable")
 	}
 	snapshot := s.web.navigationSnapshot(ctx)
+	if err := ctx.Err(); err != nil {
+		return navigationSourceSnapshot{}, err
+	}
 	decisions := s.web.archiveDecisions()
 	// Keep the legacy adapter on the exact same seam as the established endpoint;
 	// in particular, test and compatibility fixtures replace these functions.
@@ -1352,6 +1355,15 @@ func (s webNavigationSource) Capture(ctx context.Context, generation string, now
 	pinView := classifySessionPins(assignments, authority)
 	assignments = canonicalPinAssignments(assignments, pinView)
 	inputs := navigationBuildInputsFromTreeSnapshot(generation, 0, tree, s.web.apiTreeSources(), hubAttentionSummaryFromCore(attention), snapshot.live, favoriteView, projectFavoritePresentation(favoriteView), sections, assignments)
+	// Retained rows and saved metadata remain positive read evidence during
+	// an incomplete ownership scan. They cannot authorize local daemon writes.
+	if snapshot.ownershipErr != nil {
+		for id := range inputs.Renameable {
+			if isLocalRouteID(id) {
+				inputs.Renameable[id] = false
+			}
+		}
+	}
 	return navigationSourceSnapshot{Inputs: inputs, NextBoundary: navigationSnapshotBoundary(tree, now)}, nil
 }
 

--- a/cmd/evener-hub/project_delete.go
+++ b/cmd/evener-hub/project_delete.go
@@ -14,6 +14,7 @@ import (
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/hubapi"
 	"primeradiant.com/evener/identifier"
 	"primeradiant.com/evener/llm"
 	"primeradiant.com/evener/rendezvous"
@@ -25,13 +26,29 @@ func (s *WebServer) projectDeleteResult(ctx context.Context, deleted []string, s
 	navigation := s.emptyNavigationMutation()
 	if changed {
 		hint := navigationChangeHint{Projects: []string{project}}
-		var err error
-		navigation, err = s.navigation.Refresh(ctx, hint)
-		if err != nil {
-			return appwire.ProjectDeleteResponse{}, appwire.Unavailable(err.Error())
-		}
+		navigation = s.navigationAfterDeletion(ctx, hint)
 	}
 	return appwire.ProjectDeleteResponse{Deleted: deleted, Skipped: skipped, Navigation: navigation}, nil
+}
+
+// Roster and navigation refreshes do not undo committed artifact removal.
+// Keep discovery errors visible in the roster and log stale projections while
+// returning the durable deletion outcome to the caller.
+func (s *WebServer) refreshRosterAfterDeletion(ctx context.Context) {
+	if s.cfg.Roster != nil {
+		if err := hubRosterRefresh(ctx, s.cfg.Roster); err != nil {
+			fmt.Fprintf(os.Stderr, "[hub] deletion completed with stale roster: %v\n", err)
+		}
+	}
+}
+
+func (s *WebServer) navigationAfterDeletion(ctx context.Context, hint navigationChangeHint) hubapi.NavigationMutation {
+	navigation, err := s.navigation.Refresh(ctx, hint)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[hub] deletion completed with stale navigation: %v\n", err)
+		return s.emptyNavigationMutation()
+	}
+	return navigation
 }
 
 var (
@@ -43,15 +60,31 @@ var (
 	// 8at6): a retained crash marker (LiveEntry.Crashed=true, written by
 	// hubcore.Roster.Refresh only once a daemon's PID is confirmed gone) is
 	// historical error state, not a live daemon, and must not block deletion.
-	// A reachable daemon and a live PID whose status probe merely timed out
-	// both carry Crashed=false, so they still block it. Used at both the
+	// Confirmed live daemons and unresolved live-process claims block it;
+	// a failed first probe cannot authorize deletion. Used at both the
 	// whole-project entry preflight and the per-session ownership re-check
 	// below, so the TOCTOU protection applies the same rule at both sites.
 	projectSessionLive = func(roster *hubcore.Roster, id string) bool {
-		entry, ok := roster.Find(id)
-		return ok && !entry.Crashed
+		if unconfirmedDaemonForThread(roster, id) {
+			return true
+		}
+		_, live := liveDaemonForThread(roster, id)
+		return live
 	}
 )
+
+// projectSessionOwnership checks direct ownership and persisted delegate
+// ancestry. Independent forks do not inherit their ancestor's live ownership.
+func projectSessionOwnership(ctx context.Context, cfg hubcore.WebConfig, id string) (bool, error) {
+	if cfg.Roster == nil {
+		return false, nil
+	}
+	if projectSessionLive(cfg.Roster, id) {
+		return true, nil
+	}
+	owner, _, err := lookupDaemonOwner(ctx, cfg, "", id, true)
+	return owner.SessionID != "" || owner.ThreadID != "", err
+}
 
 // projectDelete removes every session file under a project and scrubs only the
 // decision rows for artifacts it removed. It validates both the project key
@@ -81,7 +114,7 @@ func (s *WebServer) projectDelete(ctx context.Context, params appwire.ProjectDel
 		return appwire.ProjectDeleteResponse{}, appwire.InternalError("load deletion state: " + s.deletionStoreErr.Error())
 	}
 	if record, ok := s.cfg.DeletionStore.DeletingProject(project.ID); ok {
-		releaseOwnership, ownerErr := s.acquireProjectDeletionOwnership(record, nil)
+		releaseOwnership, ownerErr := s.acquireProjectDeletionOwnership(ctx, record, nil)
 		if ownerErr != nil {
 			skipped := []projectDeleteSkip{{ID: ownerErr.ThreadID, Reason: ownerErr.Error()}}
 			if errors.Is(ownerErr.Err, llm.ErrAPILogTargetLocked) || ownerErr.Live {
@@ -94,7 +127,7 @@ func (s *WebServer) projectDelete(ctx context.Context, params appwire.ProjectDel
 				releaseOwnership()
 			}
 		}()
-		result := s.cleanupProjectDeletion(record, nil)
+		result := s.cleanupProjectDeletion(ctx, record, nil)
 		if len(result.DecisionErrors) > 0 {
 			return appwire.ProjectDeleteResponse{}, appwire.InternalError(strings.Join(result.DecisionErrors, "; "))
 		}
@@ -141,9 +174,16 @@ func (s *WebServer) projectDelete(ctx context.Context, params appwire.ProjectDel
 
 	// Whole-project fast path: refuse when anything is live at entry.
 	if s.cfg.Roster != nil {
+		if err := s.cfg.Roster.OwnershipError(); err != nil {
+			return appwire.ProjectDeleteResponse{}, appwire.Unavailable(err.Error())
+		}
 		var liveNames []string
 		for _, e := range entries {
-			if projectSessionLive(s.cfg.Roster, e.ID) {
+			live, err := projectSessionOwnership(ctx, s.cfg, e.ID)
+			if err != nil {
+				return appwire.ProjectDeleteResponse{}, appwire.Unavailable(err.Error())
+			}
+			if live {
 				liveNames = append(liveNames, hubcore.ShortID(e.ID))
 			}
 		}
@@ -171,7 +211,7 @@ func (s *WebServer) projectDelete(ctx context.Context, params appwire.ProjectDel
 		})
 		stateDirs[entry.ID] = entry.StateDir
 	}
-	ownedTargets, skipped, releaseOwnership := s.acquireProjectDeletionCandidates(targets, stateDirs)
+	ownedTargets, skipped, releaseOwnership := s.acquireProjectDeletionCandidates(ctx, targets, stateDirs)
 	defer func() {
 		if releaseOwnership != nil {
 			releaseOwnership()
@@ -185,7 +225,7 @@ func (s *WebServer) projectDelete(ctx context.Context, params appwire.ProjectDel
 	if err != nil {
 		return appwire.ProjectDeleteResponse{}, appwire.InternalError("commit deletion fence: " + err.Error())
 	}
-	result := s.cleanupProjectDeletion(record, stateDirs)
+	result := s.cleanupProjectDeletion(ctx, record, stateDirs)
 	result.Skipped = append(skipped, result.Skipped...)
 	if len(result.DecisionErrors) > 0 {
 		return appwire.ProjectDeleteResponse{}, appwire.InternalError(strings.Join(result.DecisionErrors, "; "))
@@ -219,6 +259,7 @@ type projectDeletionCleanupResult struct {
 }
 
 func (s *WebServer) acquireProjectDeletionCandidates(
+	ctx context.Context,
 	targets []hubcore.DeletionTarget,
 	stateDirs map[string]string,
 ) ([]hubcore.DeletionTarget, []projectDeleteSkip, func()) {
@@ -235,7 +276,7 @@ func (s *WebServer) acquireProjectDeletionCandidates(
 	for _, target := range targets {
 		record := hubcore.DeletionRecord{ProjectID: "", Targets: []hubcore.DeletionTarget{target}}
 		stateDir := stateDirs[target.ThreadID]
-		releaseTarget, err := s.acquireProjectDeletionOwnership(record, map[string]string{target.ThreadID: stateDir})
+		releaseTarget, err := s.acquireProjectDeletionOwnership(ctx, record, map[string]string{target.ThreadID: stateDir})
 		if err == nil {
 			owned = append(owned, target)
 			releases = append(releases, releaseTarget)
@@ -256,14 +297,14 @@ func (s *WebServer) resumeProjectDeletions() error {
 	}
 	var firstErr error
 	for _, record := range s.cfg.DeletionStore.Deleting() {
-		release, err := s.acquireProjectDeletionOwnership(record, nil)
+		release, err := s.acquireProjectDeletionOwnership(context.Background(), record, nil)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
 			continue
 		}
-		result := s.cleanupProjectDeletion(record, nil)
+		result := s.cleanupProjectDeletion(context.Background(), record, nil)
 		release()
 		if len(result.Skipped) > 0 || len(result.DecisionErrors) > 0 {
 			if firstErr == nil {
@@ -275,6 +316,7 @@ func (s *WebServer) resumeProjectDeletions() error {
 }
 
 func (s *WebServer) acquireProjectDeletionOwnership(
+	ctx context.Context,
 	record hubcore.DeletionRecord,
 	stateDirs map[string]string,
 ) (func(), *projectDeletionOwnershipError) {
@@ -294,9 +336,16 @@ func (s *WebServer) acquireProjectDeletionOwnership(
 		lock := s.lockForSession(target.ThreadID)
 		lock.Lock()
 		locks = append(locks, lock)
-		if s.cfg.Roster != nil && projectSessionLive(s.cfg.Roster, target.ThreadID) {
+		if s.cfg.Roster != nil {
+			if err := s.cfg.Roster.OwnershipError(); err != nil {
+				release()
+				return nil, &projectDeletionOwnershipError{ThreadID: target.ThreadID, Err: err}
+			}
+		}
+		live, ownershipErr := projectSessionOwnership(ctx, s.cfg, target.ThreadID)
+		if live || ownershipErr != nil {
 			release()
-			return nil, &projectDeletionOwnershipError{ThreadID: target.ThreadID, Live: true}
+			return nil, &projectDeletionOwnershipError{ThreadID: target.ThreadID, Live: live, Err: ownershipErr}
 		}
 		stateDir := s.projectDeletionStateDir(record.ProjectID, target.ThreadID, stateDirs)
 		if stateDir == "" {
@@ -370,6 +419,7 @@ func (s *WebServer) sessionDecisionAuthority() hubcore.FavoriteAuthority {
 }
 
 func (s *WebServer) cleanupProjectDeletion(
+	ctx context.Context,
 	record hubcore.DeletionRecord,
 	stateDirs map[string]string,
 ) projectDeletionCleanupResult {
@@ -409,9 +459,7 @@ func (s *WebServer) cleanupProjectDeletion(
 		// UI's immediate follow-up navigation read is built from a roster that
 		// already dropped the deleted sessions (their rendezvous files were
 		// just unlinked) instead of showing ghost rows until the 5s tick.
-		if s.cfg.Roster != nil {
-			hubRosterRefresh(s.cfg.Roster)
-		}
+		s.refreshRosterAfterDeletion(ctx)
 		// Bust the tree memo unconditionally: a no-delta past rebuild plus a
 		// nil PokeAttention would otherwise leave InputsVersion unmoved and
 		// navigation serving the memoized pre-delete snapshot for its bucket.

--- a/cmd/evener-hub/project_delete_test.go
+++ b/cmd/evener-hub/project_delete_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -702,9 +703,9 @@ func TestProjectDeleteRefreshesRosterAndBustsTreeMemo(t *testing.T) {
 
 	var events []string
 	prevRefresh := hubRosterRefresh
-	hubRosterRefresh = func(r *hubcore.Roster) {
+	hubRosterRefresh = func(ctx context.Context, r *hubcore.Roster) error {
 		events = append(events, "roster-refresh")
-		prevRefresh(r)
+		return prevRefresh(ctx, r)
 	}
 	t.Cleanup(func() { hubRosterRefresh = prevRefresh })
 
@@ -1632,5 +1633,130 @@ func TestProjectDeleteDoesNotBroadcastWhenNothingRemoved(t *testing.T) {
 	}
 	if len(got.Deleted) != 0 {
 		t.Fatalf("expected nothing actually deleted (session skipped), got %+v", got.Deleted)
+	}
+}
+
+func TestProjectDeleteResumesAfterRemovingDelegateParent(t *testing.T) {
+	root := t.TempDir()
+	work := filepath.Join(root, "work")
+	if err := os.MkdirAll(work, 0755); err != nil {
+		t.Fatal(err)
+	}
+	project, err := identifier.ResolveProject(work)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateDir := filepath.Join(root, "projects", project.ID)
+	parentID, childID := projectDeleteCanonicalSessionIDs[0], projectDeleteCanonicalSessionIDs[1]
+	writeSession(t, stateDir, parentID, project.CanonicalPath)
+	writeSession(t, stateDir, childID, project.CanonicalPath)
+	meta, err := schema.LoadSessionMeta(stateDir, childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.ParentSessionID, meta.JobTreeRootSessionID, meta.IsSubagent = parentID, parentID, true
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatal(err)
+	}
+	past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	oldRemove := removeProjectSessionFile
+	t.Cleanup(func() { removeProjectSessionFile = oldRemove })
+	removeProjectSessionFile = func(path string) error {
+		if filepath.Base(path) == childID+".future-artifact" {
+			return errors.New("interrupted child cleanup")
+		}
+		return oldRemove(path)
+	}
+	web := NewWebServer(hubcore.WebConfig{HubStateRoot: root, StateDir: root, Past: past, Roster: hubcore.NewRosterWithEntries()})
+	if _, err := dispatchProjectDelete(t, web, appwire.ProjectDeleteParams{Key: project.ID, WorkingDir: project.CanonicalPath}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", parentID+".meta.json")); !os.IsNotExist(err) {
+		t.Fatalf("parent not removed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", childID+".meta.json")); err != nil {
+		t.Fatalf("child not retained: %v", err)
+	}
+	removeProjectSessionFile = oldRemove
+	restored := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+	if _, err := restored.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	_ = NewWebServer(hubcore.WebConfig{HubStateRoot: root, StateDir: root, Past: restored, Roster: hubcore.NewRosterWithEntries()})
+	if _, err := os.Stat(filepath.Join(stateDir, "sessions", childID+".meta.json")); !os.IsNotExist(err) {
+		t.Fatalf("recovery retained child: %v", err)
+	}
+}
+
+func TestDeletionPreservesSuccessWhenPostCleanupRosterScanFails(t *testing.T) {
+	for _, wholeProject := range []bool{false, true} {
+		t.Run(fmt.Sprint("project=", wholeProject), func(t *testing.T) {
+			root := t.TempDir()
+			work := filepath.Join(root, "work")
+			if err := os.MkdirAll(work, 0755); err != nil {
+				t.Fatal(err)
+			}
+			project, err := identifier.ResolveProject(work)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stateDir := filepath.Join(root, "projects", project.ID)
+			id := projectDeleteCanonicalSessionIDs[0]
+			writeSession(t, stateDir, id, project.CanonicalPath)
+			past := hubcore.NewPastIndex(filepath.Join(root, "projects", "*"))
+			if _, err := past.Rebuild(); err != nil {
+				t.Fatal(err)
+			}
+			runDir := filepath.Join(root, "run")
+			if err := os.MkdirAll(runDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			roster := hubcore.NewRoster(runDir, &hubcore.StatusProber{})
+			roster.Refresh()
+			web := NewWebServer(hubcore.WebConfig{HubStateRoot: root, StateDir: root, Past: past, Roster: roster})
+			oldRemove := removeProjectSessionFile
+			t.Cleanup(func() { removeProjectSessionFile = oldRemove })
+			removeProjectSessionFile = func(path string) error {
+				if err := oldRemove(path); err != nil {
+					return err
+				}
+				if filepath.Base(path) == id+".meta.json" {
+					if err := os.Remove(runDir); err != nil {
+						return err
+					}
+					return os.WriteFile(runDir, []byte("not a directory"), 0600)
+				}
+				return nil
+			}
+			var deleted []string
+			if wholeProject {
+				response, err := dispatchProjectDelete(t, web, appwire.ProjectDeleteParams{Key: project.ID, WorkingDir: project.CanonicalPath})
+				if err != nil {
+					t.Errorf("completed project deletion failed: %v", err)
+				}
+				deleted = response.Deleted
+				if _, deleting := web.cfg.DeletionStore.DeletingProject(project.ID); deleting {
+					t.Error("completed cleanup left deletion in progress")
+				}
+			} else {
+				response, err := dispatchSessionDelete(t, web, appwire.SessionDeleteParams{Ref: localAppRef(id)})
+				if err != nil {
+					t.Errorf("completed session deletion failed: %v", err)
+				}
+				deleted = response.Deleted
+			}
+			if len(deleted) != 1 || deleted[0] != id {
+				t.Errorf("deleted=%v", deleted)
+			}
+			if roster.OwnershipError() == nil {
+				t.Error("fixture did not preserve roster scan failure")
+			}
+			if _, err := os.Stat(filepath.Join(stateDir, "sessions", id+".meta.json")); !os.IsNotExist(err) {
+				t.Errorf("artifact was not removed: %v", err)
+			}
+		})
 	}
 }

--- a/cmd/evener-hub/sandbox_test.go
+++ b/cmd/evener-hub/sandbox_test.go
@@ -131,6 +131,9 @@ api_key = "sk-sandbox"
 		tb.Fatal(err)
 	}
 
+	if err := os.Mkdir(filepath.Join(root, "roster"), 0700); err != nil {
+		tb.Fatal(err)
+	}
 	spawner := &recordingSpawner{}
 	cfg := hubcore.WebConfig{
 		HubAddr:             "127.0.0.1:9180",

--- a/cmd/evener-hub/spawn_test.go
+++ b/cmd/evener-hub/spawn_test.go
@@ -156,7 +156,7 @@ func TestHubSpawnerResumeLaunchCheckOmitsAmbientModel(t *testing.T) {
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
   printf '%s\n' "$@" > "$ARGS_OUT"
-	  printf '{"protocol":"evener-appwire-v4"}\n'
+	  printf '{"protocol":"evener-appwire-v5"}\n'
   exit 0
 fi
 if [ "$1" = "serve" ]; then
@@ -664,7 +664,7 @@ func TestHubSpawnerSpawnPassesHubTokenToDaemon(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-	  printf '{"protocol":"evener-appwire-v4"}\n'
+	  printf '{"protocol":"evener-appwire-v5"}\n'
   exit 0
 fi
 if [ "$1" = "serve" ]; then
@@ -719,7 +719,7 @@ func TestHubSpawnerSpawnUsesConfiguredXDGStateHomeForStateDir(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-	  printf '{"protocol":"evener-appwire-v4"}\n'
+	  printf '{"protocol":"evener-appwire-v5"}\n'
   exit 0
 fi
 if [ "$1" = "serve" ]; then
@@ -789,7 +789,7 @@ func TestHubSpawnerListsModelsFromEvenerLaunchContract(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-	  printf '{"protocol":"evener-appwire-v4","models":[{"provider":"openai","model":"gpt-5.5"}]}\n'
+	  printf '{"protocol":"evener-appwire-v5","models":[{"provider":"openai","model":"gpt-5.5"}]}\n'
   exit 0
 fi
 exit 2
@@ -811,7 +811,7 @@ func TestValidateEvenerLaunchContractRejectsIncompatibleProtocolBinary(t *testin
 	evenerBinary := filepath.Join(t.TempDir(), "old-evener")
 	writeFakeEvener(t, evenerBinary, `#!/bin/sh
 case " $* " in
-	  *" --protocol evener-appwire-v4 "*)
+	  *" --protocol evener-appwire-v5 "*)
     printf '{"protocol":"evener-appwire-v2"}\n'
     exit 0
     ;;
@@ -1333,7 +1333,7 @@ func TestHubSpawnerResumeAcceptsCredentiallessOllamaConfig(t *testing.T) {
 	bin := filepath.Join(dir, "fake-evener")
 	script := `#!/bin/sh
 if [ "$1" = "launch-check" ]; then
-	  printf '{"protocol":"evener-appwire-v4"}\n'
+	  printf '{"protocol":"evener-appwire-v5"}\n'
   exit 0
 fi
 if [ "$1" = "serve" ]; then

--- a/cmd/evener-hub/web_api_tree.go
+++ b/cmd/evener-hub/web_api_tree.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -34,6 +35,7 @@ var (
 var _ = hubTreeAttentionRank
 
 type navigationSnapshot struct {
+	ownershipErr        error
 	metas               []schema.SessionMeta
 	live                []hubcore.LiveEntry
 	projects            map[string]identifier.Project
@@ -197,7 +199,6 @@ func navigationBuildInputsFromTreeSnapshot(generationID string, revision uint64,
 		if entry.SessionID != "" {
 			for _, alias := range favoriteSessionAliases(entry.SessionID) {
 				liveBySession[alias] = true
-				renameable[alias] = isLocalRouteID(alias)
 			}
 		}
 	}
@@ -230,6 +231,19 @@ func navigationBuildInputsFromTreeSnapshot(generationID string, revision uint64,
 			indexRenameable(rows)
 		}
 	}
+	// Live daemon constraints override every persisted navigation copy.
+	for _, entry := range live {
+		if entry.SessionID == "" || entry.Crashed {
+			continue
+		}
+		aliases := favoriteSessionAliases(entry.SessionID)
+		if entry.WorkspaceRef != "" {
+			aliases = append(aliases, favoriteSessionAliases(entry.WorkspaceRef)...)
+		}
+		for _, alias := range aliases {
+			renameable[alias] = isLocalRouteID(alias) && entry.Status != appwire.ThreadStatusRestartRequired
+		}
+	}
 	return navigationBuildInputs{
 		GenerationID:     generationID,
 		Revision:         revision,
@@ -248,8 +262,12 @@ func navigationBuildInputsFromTreeSnapshot(generationID string, revision uint64,
 
 func (s *WebServer) navigationSnapshotInputs(ctx context.Context) navigationSnapshot {
 	var live []hubcore.LiveEntry
+	var unconfirmedOwnership bool
+	var ownershipErr error
 	if s.cfg.Roster != nil {
+		ownershipErr = s.cfg.Roster.OwnershipError()
 		live = s.cfg.Roster.List()
+		unconfirmedOwnership = len(s.cfg.Roster.UnconfirmedEntries()) > 0
 	}
 	var metas []schema.SessionMeta
 	var pastEntries []hubcore.PastEntry
@@ -259,6 +277,32 @@ func (s *WebServer) navigationSnapshotInputs(ctx context.Context) navigationSnap
 		for _, entry := range pastEntries {
 			metas = append(metas, entry.Meta)
 		}
+	}
+	// Healthy navigation snapshots need no persisted ownership scan.
+	if unconfirmedOwnership || slices.ContainsFunc(live, func(entry hubcore.LiveEntry) bool {
+		return !entry.Crashed && entry.Status == appwire.ThreadStatusRestartRequired
+	}) {
+		// Persisted delegates have no rendezvous of their own. Preserve the
+		// authenticated owner's restart restriction in every navigation projection.
+		for _, past := range pastEntries {
+			owner, incompatible, err := restartRequiredDaemon(ctx, s.cfg, "", past.Meta.ID)
+			if err != nil {
+				if ownershipErr == nil {
+					ownershipErr = err
+				}
+				continue
+			}
+			if !incompatible || owner.SessionID == past.Meta.ID || localSpawnWorkspaceRef(owner.Entry) == localAppRef(past.Meta.ID) {
+				continue
+			}
+			entry := owner.Entry
+			entry.ThreadID = past.Meta.ID
+			entry.WorkspaceRef = localAppRef(past.Meta.ID)
+			entry.WorkingDir = hubcore.EffectiveWorkingDir(past.Meta)
+			child := hubcore.LiveEntry{Entry: entry, SessionID: past.Meta.ID, Status: owner.Status}
+			live = append(live, child)
+		}
+
 	}
 	fetch := s.remoteThreadFetch(ctx)
 	carriedProjectCandidates := make(map[string]map[string]identifier.Project)
@@ -324,6 +368,7 @@ func (s *WebServer) navigationSnapshotInputs(ctx context.Context) navigationSnap
 		}
 	}
 	return navigationSnapshot{
+		ownershipErr:        ownershipErr,
 		metas:               metas,
 		live:                live,
 		projects:            projects,

--- a/cmd/evener-tui/hub_dashboard_view.go
+++ b/cmd/evener-tui/hub_dashboard_view.go
@@ -147,7 +147,7 @@ func dashboardHeader(hubURL string, liveCount int, width int, badge string) stri
 }
 
 // needsYouCount reports how many live sessions are in a state that needs the
-// user's attention (awaiting input, warning, or errored). Only hubRowSession
+// user's attention (awaiting input, warning, errored, or restart required). Only hubRowSession
 // rows are counted; a project's rollup row carries the same aggregated state
 // as its children (see buildDashboardRows) and would double-count otherwise.
 func needsYouCount(rows []hubRow) int {
@@ -157,7 +157,7 @@ func needsYouCount(rows []hubRow) int {
 			continue
 		}
 		switch stateLabel(row.state) {
-		case "awaiting", "warning", "errored":
+		case "awaiting", "warning", "errored", "restartRequired":
 			count++
 		}
 	}
@@ -297,7 +297,7 @@ func stateColor(state string) lipgloss.Color {
 		return th.StateAwaiting
 	case "active":
 		return th.StateWorking
-	case "warning":
+	case "warning", "restartRequired":
 		return th.StateWarning
 	case "idle":
 		return th.StateIdle
@@ -534,7 +534,7 @@ func statusDot(state string) string {
 		return "●"
 	case "active":
 		return "●"
-	case "warning":
+	case "warning", "restartRequired":
 		return "●"
 	case "idle":
 		return "●"

--- a/cmd/evener-tui/hub_dashboard_view_test.go
+++ b/cmd/evener-tui/hub_dashboard_view_test.go
@@ -141,3 +141,21 @@ func TestDashboardSessionRow_AskPendingMarker(t *testing.T) {
 		t.Fatalf("an ask-pending row must show the ◆ question-waiting marker, got %q", rendered)
 	}
 }
+
+func TestRestartRequiredDashboardAttention(t *testing.T) {
+	state := appwire.ThreadStatusRestartRequired
+	rows := []hubRow{
+		{kind: hubRowProject, state: state, live: true},
+		{kind: hubRowSession, state: state, live: true},
+		{kind: hubRowSession, state: state, live: false},
+	}
+	if got := needsYouCount(rows); got != 1 {
+		t.Errorf("needs-you count = %d, want one live session", got)
+	}
+	if got := stateColor(state); got != tuitheme.ActiveTheme().StateWarning {
+		t.Errorf("restart color = %v, want warning", got)
+	}
+	if got := statusDot(state); got != "●" {
+		t.Errorf("restart marker = %q, want filled", got)
+	}
+}

--- a/cmd/evener/internal/launchcheck/launchcheck_test.go
+++ b/cmd/evener/internal/launchcheck/launchcheck_test.go
@@ -97,8 +97,8 @@ func TestLaunchCheckReportsProtocolAndValidatedModel(t *testing.T) {
 		t.Fatalf("launch check output=%+v", out)
 	}
 	// Literal check: catches a change to the ProtocolVersion constant value.
-	if out.Protocol != "evener-appwire-v4" {
-		t.Fatalf("out.Protocol=%q, want \"evener-appwire-v4\"", out.Protocol)
+	if out.Protocol != "evener-appwire-v5" {
+		t.Fatalf("out.Protocol=%q, want \"evener-appwire-v5\"", out.Protocol)
 	}
 }
 

--- a/cmd/evener/serve_state_test.go
+++ b/cmd/evener/serve_state_test.go
@@ -128,6 +128,14 @@ type sessionControlIdentityServer struct {
 	userInputOnce        sync.Once
 	interruptOnce        sync.Once
 	releaseOnce          sync.Once
+
+	terminalProjectionEntered chan struct{}
+	releaseTerminalProjection chan struct{}
+	terminalProjected         chan struct{}
+	holdTerminalProjection    bool
+	terminalEnteredOnce       sync.Once
+	terminalProjectedOnce     sync.Once
+	terminalReleaseOnce       sync.Once
 }
 
 func newSessionControlIdentityServer(cfg server.ServerConfig) *sessionControlIdentityServer {
@@ -138,6 +146,10 @@ func newSessionControlIdentityServer(cfg server.ServerConfig) *sessionControlIde
 		processingFinished: make(chan struct{}),
 		userInputProjected: make(chan struct{}),
 		interruptEntered:   make(chan struct{}),
+
+		terminalProjectionEntered: make(chan struct{}),
+		releaseTerminalProjection: make(chan struct{}),
+		terminalProjected:         make(chan struct{}),
 	}
 }
 
@@ -187,14 +199,14 @@ type sessionControlLifecycle struct {
 	ref    string
 }
 
-func startSessionControlLifecycle(t *testing.T) *sessionControlLifecycle {
+func startSessionControlLifecycle(t *testing.T, adapter llm.ProviderAdapter) *sessionControlLifecycle {
 	t.Helper()
 	deps := defaultServeDeps()
 	deps.ensureConfigDirs = func() error { return nil }
 	deps.seedMarketplaces = func(context.Context) error { return nil }
 	deps.newClient = func(string, io.Writer) (*llm.Client, func() error, error) {
 		client := llm.NewClient()
-		client.Register(&closedStreamAdapter{})
+		client.Register(adapter)
 		return client, func() error { return nil }, nil
 	}
 	deps.newSession = func(client *llm.Client, profile *provider.Profile, env execenv.ExecutionEnvironment, cfg agent.SessionConfig) (*agent.Session, error) {
@@ -208,7 +220,18 @@ func startSessionControlLifecycle(t *testing.T) *sessionControlLifecycle {
 	}
 	deps.bridge = func(_ serveServer, session *agent.Session, observer func(events.SessionEvent), onDrained func()) {
 		session.ConsumeEventsLossless(func(ev events.SessionEvent) {
+			terminal := ev.Kind == events.EventSessionEnd || ev.Kind == events.EventError
+			observedServer.mu.Lock()
+			holdTerminal := observedServer.holdTerminalProjection
+			observedServer.mu.Unlock()
+			if terminal && holdTerminal {
+				observedServer.terminalEnteredOnce.Do(func() { close(observedServer.terminalProjectionEntered) })
+				<-observedServer.releaseTerminalProjection
+			}
 			server.BridgeEvent(observedServer.Server, ev, observer)
+			if ev.Kind == events.EventSessionEnd {
+				observedServer.terminalProjectedOnce.Do(func() { close(observedServer.terminalProjected) })
+			}
 			if ev.Kind == events.EventUserInput {
 				observedServer.userInputOnce.Do(func() { close(observedServer.userInputProjected) })
 			}
@@ -255,6 +278,7 @@ func startSessionControlLifecycle(t *testing.T) *sessionControlLifecycle {
 	}
 	t.Cleanup(func() {
 		observedServer.release()
+		observedServer.terminalReleaseOnce.Do(func() { close(observedServer.releaseTerminalProjection) })
 		client.Close()
 		if err := shutdownServeTestDaemon(ctx, entry.Address, entry.SessionID); err != nil {
 			return
@@ -310,7 +334,7 @@ func readSessionControlThread(t *testing.T, lifecycle *sessionControlLifecycle, 
 
 func TestRunServeRetrySafeTurnPublishesControllableStableIdentity(t *testing.T) {
 	t.Run("steer and incorporate", func(t *testing.T) {
-		lifecycle := startSessionControlLifecycle(t)
+		lifecycle := startSessionControlLifecycle(t, &closedStreamAdapter{})
 		lifecycle.server.RecordAppEvent(events.SessionEvent{
 			Kind:      events.EventUserInput,
 			SessionID: strings.TrimPrefix(lifecycle.ref, "local:"),
@@ -362,11 +386,22 @@ func TestRunServeRetrySafeTurnPublishesControllableStableIdentity(t *testing.T) 
 	})
 
 	t.Run("stop", func(t *testing.T) {
-		lifecycle := startSessionControlLifecycle(t)
+		adapter := newStopParkAdapter()
+		lifecycle := startSessionControlLifecycle(t, adapter)
+		lifecycle.server.mu.Lock()
+		lifecycle.server.holdTerminalProjection = true
+		lifecycle.server.mu.Unlock()
 		start := startHeldClientMutationTurn(t, lifecycle, "stop-start", "stop this turn")
 		activeTurnID := readSessionControlThread(t, lifecycle, false).Evener.ActiveTurnID
 		if activeTurnID == "" {
 			t.Fatal("thread/read published no active turn while processing")
+		}
+		lifecycle.server.release()
+		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.userInputProjected, "user input projection")
+		select {
+		case <-adapter.modelCalls:
+		case <-lifecycle.ctx.Done():
+			t.Fatalf("provider start: %v", lifecycle.ctx.Err())
 		}
 		stopDone := make(chan error, 1)
 		go func() {
@@ -377,7 +412,6 @@ func TestRunServeRetrySafeTurnPublishesControllableStableIdentity(t *testing.T) 
 			})
 		}()
 		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.interruptEntered, "interrupt handler entry")
-		lifecycle.server.release()
 		select {
 		case err := <-stopDone:
 			if err != nil {
@@ -393,6 +427,13 @@ func TestRunServeRetrySafeTurnPublishesControllableStableIdentity(t *testing.T) 
 		if status := readSessionControlThread(t, lifecycle, false).Status.Type; status != appwire.ThreadStatusIdle {
 			t.Fatalf("thread status after Stop = %q, want idle", status)
 		}
+		// Runner completion does not drain the asynchronous event bridge.
+		// Hold terminal projection until Stop returns, then await the actual
+		// session-end commit before asserting the projected turn is closed.
+		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.terminalProjectionEntered, "terminal projection entry")
+		lifecycle.server.terminalReleaseOnce.Do(func() { close(lifecycle.server.releaseTerminalProjection) })
+		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.terminalProjected, "session end projection")
+
 		if activeTurnID := readSessionControlThread(t, lifecycle, false).Evener.ActiveTurnID; activeTurnID != "" {
 			t.Fatalf("active turn after Stop = %q, want empty", activeTurnID)
 		}

--- a/hubapi/attention.go
+++ b/hubapi/attention.go
@@ -18,7 +18,7 @@ func AttentionRank(state string) int {
 		return 4
 	case "active":
 		return 3
-	case "warning":
+	case "warning", "restartRequired":
 		return 2
 	case "idle":
 		return 1
@@ -38,7 +38,7 @@ func RollupRank(state string) int {
 		return 5
 	case "awaiting":
 		return 4
-	case "warning":
+	case "warning", "restartRequired":
 		return 3
 	case "active":
 		return 2
@@ -66,6 +66,8 @@ func StateWord(state string, askPending bool) string {
 		return "Your move"
 	case "active":
 		return "Working"
+	case "restartRequired":
+		return "Restart required"
 	case "warning":
 		return "Warning"
 	case "idle":

--- a/internal/appserver/websocket_trace_test.go
+++ b/internal/appserver/websocket_trace_test.go
@@ -177,8 +177,8 @@ func TestServeWebSocketTraceSeparatesConnections(t *testing.T) {
 	first := dialTraceWebSocket(ctx, t, url, httpServer.Client())
 	second := dialTraceWebSocket(ctx, t, url, httpServer.Client())
 	requests := []string{
-		`{"id":41,"method":"initialize","params":{"protocolVersion":"evener-appwire-v4"}}`,
-		`{"id":42,"method":"initialize","params":{"protocolVersion":"evener-appwire-v4"}}`,
+		`{"id":41,"method":"initialize","params":{"protocolVersion":"evener-appwire-v5"}}`,
+		`{"id":42,"method":"initialize","params":{"protocolVersion":"evener-appwire-v5"}}`,
 	}
 	for i, conn := range []*websocket.Conn{first, second} {
 		if err := conn.Write(ctx, websocket.MessageText, []byte(requests[i])); err != nil {
@@ -324,7 +324,7 @@ func TestServerShutdownWithFullWebSocketRequestQueue(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	write(`{"id":1,"method":"initialize","params":{"protocolVersion":"evener-appwire-v4"}}`)
+	write(`{"id":1,"method":"initialize","params":{"protocolVersion":"` + appwire.ProtocolVersion + `"}}`)
 	if _, _, err := conn.Read(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +394,7 @@ func testServerShutdownDrainsOpenTracedWebSocket(t *testing.T, beforeReceive boo
 	ctx := context.Background()
 	conn := dialTraceWebSocket(ctx, t, "ws"+strings.TrimPrefix(httpServer.URL, "http"), httpServer.Client())
 	defer conn.CloseNow()
-	request := []byte(`{"id":51,"method":"initialize","params":{"protocolVersion":"evener-appwire-v4"}}`)
+	request := []byte(`{"id":51,"method":"initialize","params":{"protocolVersion":"evener-appwire-v5"}}`)
 	if err := conn.Write(ctx, websocket.MessageText, request); err != nil {
 		t.Fatalf("write initialize: %v", err)
 	}

--- a/internal/apptranscript/turnsfromentries_parity_test.go
+++ b/internal/apptranscript/turnsfromentries_parity_test.go
@@ -1,0 +1,98 @@
+package apptranscript
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+func largeEntryProjectionFixture(t testing.TB) (string, transcript.Header, []transcript.Entry) {
+	t.Helper()
+	const entryCount = 20000
+	path := filepath.Join(t.TempDir(), "large.transcript.jsonl")
+	w, err := transcript.NewWriter(path, transcript.Header{
+		SessionID:    "th_large",
+		SystemPrompt: "You are Evener.",
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	// The measurement is the READ side; the fixture write only needs the
+	// bytes on disk, so skip the per-append fsync the durability default pays.
+	w.SyncInterval = time.Hour
+	for i := range entryCount {
+		turn := schema.NewTurn(schema.TurnUserInput, llm.User(fmt.Sprintf("message %d with some body text to make the line realistic", i)))
+		turn.Usage = llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}
+		turn.Timestamp = time.Unix(1_700_000_000+int64(i), 0).UTC()
+		if err := w.Append(turn); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	rw, entries, err := transcript.OpenWriterForSession(path, "th_large")
+	if err != nil {
+		t.Fatalf("OpenWriterForSession: %v", err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path, rw.Header(), entries
+}
+
+func largeEntryProjector(turn schema.Turn, turnID string, entryIndex int) []appwire.ThreadItem {
+	return []appwire.ThreadItem{{Type: "userMessage", ID: turnID, TurnID: turnID, Text: turn.Message.Content[0].Text}}
+}
+
+func TestItemTurnsFromEntriesLargeFixtureParity(t *testing.T) {
+	path, header, entries := largeEntryProjectionFixture(t)
+	fileTurns, err := ItemTurnsFromFile(path, 1<<30, largeEntryProjector)
+	if err != nil {
+		t.Fatalf("ItemTurnsFromFile: %v", err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	entryTurns, err := ItemTurnsFromEntries(header, entries, largeEntryProjector)
+	if err != nil {
+		t.Fatalf("ItemTurnsFromEntries: %v", err)
+	}
+	if len(entryTurns) != len(entries)+1 {
+		t.Fatalf("got %d turns for %d entries and system prelude", len(entryTurns), len(entries))
+	}
+	if !reflect.DeepEqual(fileTurns, entryTurns) {
+		t.Fatal("file and in-memory projections differ")
+	}
+}
+
+// Benchmark the saved-file scan and the already-decoded projection separately;
+// scheduler load can change their timing ratio without changing either contract.
+func BenchmarkItemTurnsLargeFixture(b *testing.B) {
+	path, header, entries := largeEntryProjectionFixture(b)
+	b.Run("file", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := ItemTurnsFromFile(path, 1<<30, largeEntryProjector); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("entries", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if _, err := ItemTurnsFromEntries(header, entries, largeEntryProjector); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/rendezvous/rendezvous.go
+++ b/rendezvous/rendezvous.go
@@ -122,31 +122,51 @@ func List(dir string) ([]Entry, error) {
 	return listFS(afero.NewOsFs(), dir)
 }
 
+// ListStrict requires every PID-named rendezvous entry to be readable and
+// valid. Ownership checks must not interpret a skipped claim as a stopped daemon.
+func ListStrict(dir string) ([]Entry, error) {
+	return listFSMode(afero.NewOsFs(), dir, true)
+}
+
 // listFS is List against an injected afero.Fs (see writeFS).
 func listFS(fs afero.Fs, dir string) ([]Entry, error) {
+	return listFSMode(fs, dir, false)
+}
+
+func listFSMode(fs afero.Fs, dir string, strict bool) ([]Entry, error) {
 	entries, err := afero.ReadDir(fs, dir)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if os.IsNotExist(err) && !strict {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("read rendezvous dir: %w", err)
 	}
 	var out []Entry
 	for _, de := range entries {
-		if de.IsDir() || !strings.HasSuffix(de.Name(), ".json") {
+		if (!strict && de.IsDir()) || !strings.HasSuffix(de.Name(), ".json") {
 			continue
 		}
 		base := strings.TrimSuffix(de.Name(), ".json")
-		if _, err := strconv.Atoi(base); err != nil {
+		pid, err := strconv.Atoi(base)
+		if err != nil {
 			continue
 		}
 		data, err := afero.ReadFile(fs, filepath.Join(dir, de.Name()))
 		if err != nil {
+			if strict {
+				return nil, fmt.Errorf("read rendezvous %s: %w", de.Name(), err)
+			}
 			continue
 		}
 		var e Entry
 		if err := json.Unmarshal(data, &e); err != nil {
+			if strict {
+				return nil, fmt.Errorf("decode rendezvous %s: %w", de.Name(), err)
+			}
 			continue
+		}
+		if strict && e.PID != pid {
+			return nil, fmt.Errorf("rendezvous %s has invalid process identity", de.Name())
 		}
 		out = append(out, e)
 	}

--- a/rendezvous/rendezvous_test.go
+++ b/rendezvous/rendezvous_test.go
@@ -269,3 +269,66 @@ func TestWrite_TargetIsDirectory(t *testing.T) {
 		t.Fatalf("expected error from the Rename branch, got %v", err)
 	}
 }
+
+func TestListStrictRejectsUnreadableOrInvalidClaims(t *testing.T) {
+	for _, fault := range []string{"malformed", "directory", "wrong-pid"} {
+		t.Run(fault, func(t *testing.T) {
+			dir := t.TempDir()
+			path, err := Write(dir, Entry{PID: 1001, SessionID: "owner"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			entries, err := ListStrict(dir)
+			if err != nil || len(entries) != 1 || entries[0].SessionID != "owner" {
+				t.Fatalf("list=%+v, %v", entries, err)
+			}
+			switch fault {
+			case "directory":
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(path, 0700); err != nil {
+					t.Fatal(err)
+				}
+			case "malformed":
+				if err := os.WriteFile(path, []byte("{"), 0600); err != nil {
+					t.Fatal(err)
+				}
+			case "wrong-pid":
+				data, err := json.Marshal(Entry{PID: 1002, SessionID: "owner"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err := ListStrict(dir); err == nil {
+				t.Fatal("invalid claim treated as complete ownership listing")
+			}
+			if err := os.Remove(path); err != nil {
+				t.Fatal(err)
+			}
+			entries, err = ListStrict(dir)
+			if err != nil || len(entries) != 0 {
+				t.Fatalf("after removal=%+v, %v", entries, err)
+			}
+		})
+	}
+}
+
+func TestListStrictRequiresExistingDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "missing")
+	if _, err := ListStrict(dir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("strict missing directory error=%v", err)
+	}
+	if entries, err := List(dir); err != nil || len(entries) != 0 {
+		t.Fatalf("ordinary discovery=%+v, %v", entries, err)
+	}
+	if err := os.Mkdir(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if entries, err := ListStrict(dir); err != nil || len(entries) != 0 {
+		t.Fatalf("existing empty directory=%+v, %v", entries, err)
+	}
+}

--- a/server/appwire_clear_test.go
+++ b/server/appwire_clear_test.go
@@ -2,12 +2,14 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
+	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/appwire"
 )
 
@@ -93,6 +95,9 @@ func TestServerAppWireThreadClearReplaysTheSameReplacement(t *testing.T) {
 	if first.Thread.ID != "new" || second.Thread.ID != "new" {
 		t.Fatalf("clear thread ids = (%q, %q), want replacement new", first.Thread.ID, second.Thread.ID)
 	}
+	if !first.Thread.Evener.MutationStateAuthoritative || !second.Thread.Evener.MutationStateAuthoritative {
+		t.Fatal("root clear snapshots must identify the authoritative replacement mutation state")
+	}
 	if first.Ref != params.Ref || second.Ref != params.Ref {
 		t.Fatalf("clear refs = (%q, %q), want stable %q", first.Ref, second.Ref, params.Ref)
 	}
@@ -121,6 +126,10 @@ func TestServerAppWireThreadClearReplaysTheSameReplacement(t *testing.T) {
 	}
 	if replayed.Thread.ID != "new" || replayed.Receipt.Disposition != appwire.MutationDispositionReplayed {
 		t.Fatalf("restart replay = (%q, %q), want (new, replayed)", replayed.Thread.ID, replayed.Receipt.Disposition)
+	}
+
+	if !replayed.Thread.Evener.MutationStateAuthoritative {
+		t.Fatal("persisted clear receipt lost replacement mutation authority")
 	}
 
 	wrongWorkspace := NewServer(ServerConfig{StateDir: stateDir})
@@ -580,5 +589,54 @@ func TestServerAppWireThreadClearRestoresReservationWhenRollbackPersistFails(t *
 	}
 	if response.Thread.ID != "new" || response.Receipt.Disposition != appwire.MutationDispositionApplied {
 		t.Fatalf("recovered retry = (%q, %q), want (new, applied)", response.Thread.ID, response.Receipt.Disposition)
+	}
+}
+
+func TestDescendantAfterClearUsesStableParentRef(t *testing.T) {
+	srv := NewServer(ServerConfig{StateDir: t.TempDir()})
+	srv.SetAppIdentity("local", "old")
+	setReplacingClearFunc(srv, "new")
+	if _, err := srv.handleAppThreadClear(t.Context(), appwire.ThreadClearParams{
+		Ref: "local:old", ClientMutationID: "clear-1", ExpectedInstanceID: "old",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, event := range []events.SessionEvent{
+		{Kind: events.EventUserInput, SessionID: "child", Data: events.UserInputData{Text: "child work"}},
+		{Kind: events.EventSessionStart, SessionID: "child", Data: events.SessionStartData{}},
+	} {
+		srv.RecordDescendantAppEvent("new", event)
+		child, err := srv.handleAppThreadRead(t.Context(), appwire.ThreadReadParams{Ref: "local:child"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if child.Thread.Evener.ParentRef != "local:old" {
+			t.Errorf("parent after %s = %q, want stable local:old", event.Kind, child.Thread.Evener.ParentRef)
+		}
+		parent, err := srv.handleAppThreadRead(t.Context(), appwire.ThreadReadParams{Ref: child.Thread.Evener.ParentRef})
+		if err != nil {
+			t.Errorf("resolve descendant parent after %s: %v", event.Kind, err)
+		} else if parent.Thread.ID != "new" || parent.Thread.Evener.Ref != "local:old" {
+			t.Errorf("parent after %s = %+v, want replacement new at local:old", event.Kind, parent.Thread)
+		}
+	}
+
+	started := false
+	for _, notification := range srv.AppNotificationsAfter(0, "child") {
+		if notification.Notification.Method != appwire.NotifyThreadStarted {
+			continue
+		}
+		var params appwire.ThreadStartedParams
+		if err := json.Unmarshal(notification.Notification.Params, &params); err != nil {
+			t.Fatal(err)
+		}
+		if params.Thread.Evener.ParentRef != "local:old" {
+			t.Errorf("started parent = %q, want stable local:old", params.Thread.Evener.ParentRef)
+		}
+		started = true
+	}
+	if !started {
+		t.Fatal("descendant start was not published")
 	}
 }

--- a/server/appwire_runtime.go
+++ b/server/appwire_runtime.go
@@ -518,6 +518,10 @@ func (s *Server) RecordDescendantAppEvent(ownerThreadID string, event events.Ses
 			s.mu.Unlock()
 			return nil
 		}
+		parentRef := s.appRef
+		if parentRef == "" {
+			parentRef = appwire.Ref{SourceID: sourceIDForProjection(s.appSourceID), ThreadID: ownerThreadID}.String()
+		}
 		projection := s.appDescendants[threadID]
 		if projection == nil {
 			sourceID := s.appSourceID
@@ -532,7 +536,7 @@ func (s *Server) RecordDescendantAppEvent(ownerThreadID string, event events.Ses
 					ID:        threadID,
 					SessionID: threadID,
 					Source:    sourceID,
-					Evener:    appwire.EvenerThread{Ref: ref, Kind: "subagent"},
+					Evener:    appwire.EvenerThread{Ref: ref, Kind: "subagent", ParentRef: parentRef},
 				},
 			}
 			s.installCostLookup(projection.projector)
@@ -567,6 +571,7 @@ func (s *Server) RecordDescendantAppEvent(ownerThreadID string, event events.Ses
 					startSeed = currentWorkSeedWithoutTasks(startSeed)
 				}
 				mergeStartCurrentWork(&params.Thread.Evener, cachedTasks, projection.thread.Evener.Goal, startSeed)
+				params.Thread.Evener.ParentRef = parentRef
 				projection.thread = params.Thread
 				projection.thread.Evener.Kind = "subagent"
 				projection.thread.Evener.Tasks = cloneTaskAggregate(params.Thread.Evener.Tasks)
@@ -1148,6 +1153,9 @@ func (s *Server) appThreadReadSnapshotForTarget(params appwire.ThreadReadParams,
 			return appwire.ThreadReadResponse{}, err
 		}
 	}
+	// Descendant projections carry events and transcript windows, but not the
+	// addressed child's durable queue and mutation receipts.
+	thread.Evener.MutationStateAuthoritative = threadID == s.appProjectionThreadID()
 	response := appwire.ThreadReadResponse{Thread: thread, OlderCursor: olderCursor}
 	if err := appwire.ValidateThreadReadItemResponse(response); err != nil {
 		return appwire.ThreadReadResponse{}, err
@@ -1810,6 +1818,7 @@ func (s *Server) clearBlockedReasonLocked() string {
 
 func (s *Server) threadClearResponse(clientMutationID string, disposition appwire.MutationDisposition) appwire.ThreadClearResponse {
 	thread := s.appThread()
+	thread.Evener.MutationStateAuthoritative = true
 	return appwire.ThreadClearResponse{
 		Thread: thread,
 		Ref:    thread.Evener.Ref,

--- a/server/appwire_runtime_test.go
+++ b/server/appwire_runtime_test.go
@@ -818,6 +818,9 @@ func TestAppWireItemPagingSubscriptionCut(t *testing.T) {
 	if len(response.Thread.Turns) == 0 || len(response.Thread.Turns[0].Items) != 1 {
 		t.Fatalf("item read response = %+v, want one positioned item fragment", response)
 	}
+	if !response.Thread.Evener.MutationStateAuthoritative {
+		t.Fatal("daemon read must carry authoritative mutation state")
+	}
 	item := response.Thread.Turns[0].Items[0]
 	if item.TranscriptKey == "" || item.Position == nil {
 		t.Fatalf("item metadata = %+v, want transcript key and position", item)
@@ -1423,5 +1426,69 @@ func TestPreparedResumeFirstLiveLifecycleUsesAuthoritativeTurnIdentity(t *testin
 		if turn.ID == "turn_1" && len(turn.Items) == 1 && turn.Items[0].Text == "live" {
 			t.Fatalf("live lifecycle recovery replaced historical turn item: %+v", turn.Items[0])
 		}
+	}
+}
+
+func TestDescendantReadDoesNotClaimDurableMutationAuthority(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "root")
+	srv.RecordDescendantAppEvent("root", events.SessionEvent{
+		Kind: events.EventUserInput, SessionID: "child", Data: events.UserInputData{Text: "child work"},
+	})
+	srv.RecordDescendantAppEvent("root", events.SessionEvent{
+		Kind: events.EventSessionStart, SessionID: "child", Data: events.SessionStartData{},
+	})
+	started := false
+	for _, notification := range srv.AppNotificationsAfter(0, "child") {
+		if notification.Notification.Method != appwire.NotifyThreadStarted {
+			continue
+		}
+		var params appwire.ThreadStartedParams
+		if err := json.Unmarshal(notification.Notification.Params, &params); err != nil {
+			t.Fatal(err)
+		}
+		if params.Thread.Evener.ParentRef != "local:root" {
+			t.Fatalf("started owner = %q", params.Thread.Evener.ParentRef)
+		}
+		started = true
+	}
+	if !started {
+		t.Fatal("child start was not published")
+	}
+	peer := httptest.NewServer(http.HandlerFunc(srv.AppServer().ServeWebSocket))
+	defer peer.Close()
+	transport, err := appwire.DialWebSocket(t.Context(), "ws"+strings.TrimPrefix(peer.URL, "http"), peer.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.Close()
+	client := appwire.NewClient(transport)
+	client.Start(t.Context())
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	for _, subscribe := range []bool{false, true} {
+		for _, includeTurns := range []bool{false, true} {
+			response, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: "local:child", IncludeTurns: includeTurns, Subscribe: subscribe, ItemLimit: 1})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if response.Thread.Evener.ParentRef != "local:root" {
+				t.Fatalf("descendant owner = %q", response.Thread.Evener.ParentRef)
+			}
+			if response.Thread.ID != "child" || response.Thread.Evener.MutationStateAuthoritative {
+				t.Fatalf("descendant subscribe=%v turns=%v thread=%+v", subscribe, includeTurns, response.Thread)
+			}
+			if includeTurns && len(response.Thread.Turns) == 0 {
+				t.Fatal("descendant transcript was lost")
+			}
+		}
+	}
+	root, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: "local:root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !root.Thread.Evener.MutationStateAuthoritative {
+		t.Fatal("root durable projection lost authority")
 	}
 }

--- a/server/appwire_server_test.go
+++ b/server/appwire_server_test.go
@@ -2767,3 +2767,22 @@ func TestServerAppWireDescendantThreadReadIncludesSeededTranscriptHistory(t *tes
 		t.Fatalf("second item text missing, want the seeded tail in the same logical turn")
 	}
 }
+
+// A cancelled input that never reached the projector has no SessionEnd event.
+func TestServerAppWireUnincorporatedTurnReleasesActiveIdentity(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	srv.SetAppIdentity("local", "root")
+	srv.SetProcessingTurn("durable-turn")
+	before := srv.appThreadReadSnapshot(appwire.ThreadReadParams{Ref: "local:root"})
+	if before.Thread.Evener.ActiveTurnID != "durable-turn" {
+		t.Fatalf("reserved active turn = %q", before.Thread.Evener.ActiveTurnID)
+	}
+	srv.SetProcessing(false)
+	after := srv.appThreadReadSnapshot(appwire.ThreadReadParams{Ref: "local:root"})
+	if after.Thread.Evener.ActiveTurnID != "" {
+		t.Fatalf("unincorporated active turn = %q", after.Thread.Evener.ActiveTurnID)
+	}
+	if after.Thread.Status.Type != appwire.ThreadStatusIdle {
+		t.Fatalf("unincorporated status = %q", after.Thread.Status.Type)
+	}
+}


### PR DESCRIPTION
The v4 flag day in 7d9939d506c72f27930b2e4e857c1cb081e36d4c (#822, September 6) left still-running v3 daemons unreachable. A cold hub dropped their sidebar activity after initialization failed, while message recovery tried to spawn a replacement over the live session. Existing tests used matching protocol versions and missed hub-only upgrades.

This fix negotiates AppWire v5 to make daemon mutation-receipt authority explicit. Surviving v3 and v4 daemons require an explicit restart. Authenticated mismatches appear as `restartRequired`, retain saved transcripts and list visibility, and disable unavailable actions. Typed initialize mismatches remain actionable even with missing or stale rendezvous protocol metadata and invalidate previously cached routes. The TUI includes restart-required sessions in its attention count and warning indicators. Ownership is refreshed for subscribed reads, initial relay setup, and session actions, including actions without mutation IDs and protocol replacement at the same endpoint. Initialization failures carry their phase so definite daemon RPC rejections retain their original reason and mutation outcome even when unrelated discovery fails.

Roster discovery retains unresolved live ownership claims and reports incomplete discovery rather than treating it as evidence that a session can be replaced or deleted. Session writes and deletion check ownership under locks, including persisted descendant relationships. Nested relationships are verified against root ownership and ParentDelegateID in the root journal; deletion checks compatible and incompatible ancestor daemons and preserves uncertain descendants while allowing independent forks. Concurrent full scans and individual confirmations preserve newer ownership evidence. A freshly spawned or resumed daemon is verified through its exact endpoint when broader discovery fails; previously confirmed compatible owners can still serve reads and messages. Navigation preserves root, subagent, and job activity and invalidates when ownership claims change. Thread listings deduplicate live workspace aliases against saved sessions and retain saved-title search. Rename routes workspace aliases to the owning daemon, and restart-required listings accept session-only daemon identities.

Browser recovery keeps uncertain messages in IndexedDB until current daemon receipts prove delivery or absence. A failed mutation invalidates earlier authority; periodic discovery retries reconciliation without an immediate retry loop. Saved and descendant transcript projections cannot authorize retries. A retained live descendant preserves uncertain messages and offers owner navigation and Refresh until the parent releases it; the hub refuses Resume before spawning over verified ancestor ownership. Once ownership is released, explicit Resume can obtain the child daemon state. Successful root clear snapshots establish mutation authority for explicit fresh reconciliation without replaying old-instance input. Storage failures remain visible and cannot silently release pending sends. A failed blocking write retains a reconciliation obligation in memory, so a later enqueue cannot retry an uncertain record before fresh daemon state is reconciled. Clear responses fence earlier goal updates before publishing the replacement instance.

Behavioral tests cover older peers and compatible replacements over real WebSockets, same-endpoint protocol changes, saved transcripts, lost accepted receipts, root/subagent/job sidebar activity, incomplete ownership metadata, concurrent roster publication, descendant receipt authority, and IndexedDB failures and recovery. Retained delegates remain recoverable after ancestor deletion when the roster excludes every possible daemon owner; interrupted project cleanup is tested across a hub restart. A post-cleanup discovery failure preserves committed deletion outcomes and records stale roster/navigation diagnostics separately. Default tests use scripted external boundaries. A job-output snapshot replacement race exposed by CI has a deterministic regression test; stale-refresh tests now synchronize publication, and transcript performance uses benchmarks alongside deterministic projection checks.

Validation: the rewritten head `25be21cad` has exactly the same Git tree as validated `cba6a0b14`. The confirmed-incompatible saved-read regression reproduced both incorrect read exits before the fix; broader upgrade, ownership, and admission tests then passed under race (24.212s). Local review221 found no issues, and all CI checks passed before consolidation. All CI checks, including snapshot artifacts, passed on `25be21cad`. Current-head hosted combined review6600 completed with both reviewers passing and no issues found.

Explicit out-of-band process termination is implemented separately in #977 for #934. This PR adds no old-protocol compatibility or automatic process termination.

History is consolidated into two logical commits: backend behavior and regression tests, followed by frontend behavior and regression tests. Consolidation changed no final file contents.
