### PR TITLE
feat(tui): paste a Google credential JSON from the credentials panel

### DIFF
--- a/cmd/evener-tui/credential_file_other.go
+++ b/cmd/evener-tui/credential_file_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package tui
+
+// nonblockingOpen has no equivalent outside unix: Windows has no O_NONBLOCK
+// for files, and the shapes it guards against (FIFOs opened by path, character
+// devices under /dev) are unix shapes. The descriptor is still judged after
+// the open, so a non-regular file is refused either way.
+const nonblockingOpen = 0

--- a/cmd/evener-tui/credential_file_unix.go
+++ b/cmd/evener-tui/credential_file_unix.go
@@ -1,0 +1,11 @@
+//go:build unix
+
+package tui
+
+import "syscall"
+
+// nonblockingOpen keeps opening a path from blocking on what it names. A
+// FIFO with no writer blocks an ordinary open until one arrives, which on the
+// update loop means the interface stops responding with no way out; with this
+// flag the open returns and the descriptor can be judged and refused.
+const nonblockingOpen = syscall.O_NONBLOCK

--- a/cmd/evener-tui/hub_credential_json_test.go
+++ b/cmd/evener-tui/hub_credential_json_test.go
@@ -87,7 +87,8 @@ func TestCredentialJsonResult_SendsThePasteAndReadsAPath(t *testing.T) {
 }
 
 // TestCredentialJsonResult_UnreadablePathIsReportedAndNotSent: a path that
-// cannot be read is the user's mistake to see, and nothing is stored.
+// cannot be read is the user's mistake to see — by its reason, since the
+// value itself is never repeated — and nothing is stored.
 func TestCredentialJsonResult_UnreadablePathIsReportedAndNotSent(t *testing.T) {
 	client, got, cleanup := credentialJSONHub(t)
 	defer cleanup()
@@ -99,11 +100,55 @@ func TestCredentialJsonResult_UnreadablePathIsReportedAndNotSent(t *testing.T) {
 		t.Fatalf("nothing should be sent for an unreadable path; got %+v", cmd())
 	}
 	err := updated.(hubModel).err
-	if err == nil || !strings.Contains(err.Error(), "no-such-credentials.json") {
-		t.Fatalf("err = %v, want one naming the path that could not be read", err)
+	if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
+		t.Fatalf("err = %v, want one giving the reason the read failed", err)
+	}
+	if strings.Contains(err.Error(), missing) {
+		t.Fatalf("err = %q, must not repeat what was submitted", err)
 	}
 	if got.Value != "" {
 		t.Fatalf("the hub must not be called; it received %q", got.Value)
+	}
+}
+
+// TestCredentialJsonResult_NeverEchoesWhatWasSubmitted: the error line is
+// rendered and persists after the panel closes, so a value that is neither a
+// document nor a readable path — the wrong secret pasted into this prompt —
+// must not put any of itself there. The reason it failed is what the user
+// needs.
+func TestCredentialJsonResult_NeverEchoesWhatWasSubmitted(t *testing.T) {
+	const wrongSecret = `sk-ant-api03-SECRET-MATERIAL-that-is-not-a-path-or-a-document`
+	for _, tt := range []struct {
+		name  string
+		value string
+	}{
+		{name: "wrong secret", value: wrongSecret},
+		{name: "secret with a path separator", value: "AQ.Ab8RN6Jz/SECRET+MATERIAL/x"},
+		{name: "mistyped path", value: "/tmp/definitely-not-here/SECRET-MATERIAL.json"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client, got, cleanup := credentialJSONHub(t)
+			defer cleanup()
+			m := newHubModel(client, "http://hub.test")
+			m.followupModal = &tuipick.TextInputModal{}
+			updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: tt.value})
+			if cmd != nil {
+				t.Fatalf("nothing should be sent; got %+v", cmd())
+			}
+			err := updated.(hubModel).err
+			if err == nil {
+				t.Fatal("the failure must be reported")
+			}
+			if strings.Contains(err.Error(), "SECRET") || strings.Contains(err.Error(), tt.value) {
+				t.Fatalf("err = %q, must not repeat what was submitted", err)
+			}
+			if !strings.Contains(err.Error(), "credential JSON") {
+				t.Fatalf("err = %q, want it to name what failed", err)
+			}
+			if got.Value != "" {
+				t.Fatalf("the hub must not be called; it received %q", got.Value)
+			}
+		})
 	}
 }
 

--- a/cmd/evener-tui/hub_credential_json_test.go
+++ b/cmd/evener-tui/hub_credential_json_test.go
@@ -5,8 +5,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"testing"
 
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-tui/internal/launchconfig"
 	"primeradiant.com/evener/cmd/evener-tui/internal/tuipick"
@@ -150,6 +153,54 @@ func TestCredentialJsonResult_NeverEchoesWhatWasSubmitted(t *testing.T) {
 			}
 		})
 	}
+}
+
+// assertCredentialPathRefused runs the credential-JSON result for a path the
+// prompt must refuse, on a goroutine with a deadline: the read happens on the
+// update loop, so a path that never returns has to be refused before it is
+// opened rather than hanging the interface.
+func assertCredentialPathRefused(t *testing.T, value, want string) {
+	t.Helper()
+	client, got, cleanup := credentialJSONHub(t)
+	defer cleanup()
+	m := newHubModel(client, "http://hub.test")
+	m.followupModal = &tuipick.TextInputModal{}
+	done := make(chan tea.Model, 1)
+	go func() {
+		updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: value})
+		if cmd != nil {
+			t.Errorf("nothing should be sent; got %+v", cmd())
+		}
+		done <- updated
+	}()
+	var updated tea.Model
+	select {
+	case updated = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handling blocked: the path was opened instead of being refused")
+	}
+	err := updated.(hubModel).err
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("err = %v, want one saying %q", err, want)
+	}
+	if got.Value != "" {
+		t.Fatalf("the hub must not be called; it received %q", got.Value)
+	}
+}
+
+// TestCredentialJsonResult_RefusesWhatIsNotAReadableFile covers the refusals
+// every platform can express; the pipe and device cases are in the unix file.
+func TestCredentialJsonResult_RefusesWhatIsNotAReadableFile(t *testing.T) {
+	dir := t.TempDir()
+	huge := filepath.Join(dir, "huge.json")
+	if err := os.WriteFile(huge, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(huge, maxCredentialFileBytes+1); err != nil {
+		t.Fatal(err)
+	}
+	t.Run("directory", func(t *testing.T) { assertCredentialPathRefused(t, dir, "not a regular file") })
+	t.Run("too large", func(t *testing.T) { assertCredentialPathRefused(t, huge, "too large") })
 }
 
 // TestCredentialJsonResult_CancelledOrEmptyStoresNothing mirrors the API-key

--- a/cmd/evener-tui/hub_credential_json_test.go
+++ b/cmd/evener-tui/hub_credential_json_test.go
@@ -1,0 +1,137 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-tui/internal/launchconfig"
+	"primeradiant.com/evener/cmd/evener-tui/internal/tuipick"
+	"primeradiant.com/evener/internal/appserver"
+)
+
+const testCredentialJSON = "{\n  \"type\": \"authorized_user\",\n  \"client_id\": \"a\",\n  \"client_secret\": \"b\",\n  \"refresh_token\": \"c\"\n}"
+
+// credentialJSONHub is a hub that records what evener/auth/credentialJson/set
+// received, so a test can prove the TUI sent the paste unaltered.
+func credentialJSONHub(t *testing.T) (*appwire.Client, *appwire.AuthCredentialJsonSetParams, func()) {
+	t.Helper()
+	got := &appwire.AuthCredentialJsonSetParams{}
+	client, cleanup := newTestHubClient(t, func(app *appserver.Server) {
+		appserver.HandleTyped(app.Router(), appwire.MethodEvenerAuthCredentialJsonSet, func(_ context.Context, params appwire.AuthCredentialJsonSetParams) (appwire.AuthStatusResponse, error) {
+			*got = params
+			return appwire.AuthStatusResponse{Provider: params.Provider, SignedIn: true, ActiveSource: "store"}, nil
+		})
+	})
+	return client, got, cleanup
+}
+
+// TestCredentialJsonAction_OpensAPasteModal: the panel's credential-JSON
+// action opens an input tagged for this instance, so the result routes back
+// to the credential-JSON store rather than the API-key one.
+func TestCredentialJsonAction_OpensAPasteModal(t *testing.T) {
+	client, _, cleanup := credentialJSONHub(t)
+	defer cleanup()
+	m := newHubModel(client, "http://hub.test")
+	updated, _ := m.handleCredentialsAction(launchconfig.CredentialsActionMsg{Action: "setCredentialJson", Instance: "google-vertex"})
+	modal := updated.(hubModel).followupModal
+	if modal == nil {
+		t.Fatal("the credential-JSON action must open an input modal")
+	}
+	view := modal.View()
+	if !strings.Contains(view, "google-vertex") || !strings.Contains(strings.ToLower(view), "credential json") {
+		t.Fatalf("modal view = %q, want it to name the instance and the credential JSON", view)
+	}
+}
+
+// TestCredentialJsonResult_SendsThePasteAndReadsAPath: the value is either the
+// JSON itself (a bracketed paste) or a path to a file holding it, which the
+// TUI reads on the machine the user typed it on.
+func TestCredentialJsonResult_SendsThePasteAndReadsAPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "application_default_credentials.json")
+	if err := os.WriteFile(path, []byte(testCredentialJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name  string
+		value string
+	}{
+		{name: "pasted json", value: testCredentialJSON},
+		{name: "path to the file", value: path},
+		{name: "path with surrounding space", value: "  " + path + "  "},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client, got, cleanup := credentialJSONHub(t)
+			defer cleanup()
+			m := newHubModel(client, "http://hub.test")
+			m.followupModal = &tuipick.TextInputModal{}
+			updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: tt.value})
+			if updated.(hubModel).followupModal != nil {
+				t.Fatal("the modal should be dismissed")
+			}
+			if cmd == nil {
+				t.Fatal("a credential-JSON result should produce a cmd")
+			}
+			res, ok := cmd().(launchconfig.AuthApiKeySetResultMsg)
+			if !ok || res.Err != nil || !res.Status.SignedIn {
+				t.Fatalf("result = %#v", cmd())
+			}
+			if got.Provider != "google-vertex" || got.Value != testCredentialJSON {
+				t.Fatalf("hub received provider=%q value=%q, want the credential JSON verbatim for google-vertex", got.Provider, got.Value)
+			}
+		})
+	}
+}
+
+// TestCredentialJsonResult_UnreadablePathIsReportedAndNotSent: a path that
+// cannot be read is the user's mistake to see, and nothing is stored.
+func TestCredentialJsonResult_UnreadablePathIsReportedAndNotSent(t *testing.T) {
+	client, got, cleanup := credentialJSONHub(t)
+	defer cleanup()
+	missing := filepath.Join(t.TempDir(), "no-such-credentials.json")
+	m := newHubModel(client, "http://hub.test")
+	m.followupModal = &tuipick.TextInputModal{}
+	updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: missing})
+	if cmd != nil {
+		t.Fatalf("nothing should be sent for an unreadable path; got %+v", cmd())
+	}
+	err := updated.(hubModel).err
+	if err == nil || !strings.Contains(err.Error(), "no-such-credentials.json") {
+		t.Fatalf("err = %v, want one naming the path that could not be read", err)
+	}
+	if got.Value != "" {
+		t.Fatalf("the hub must not be called; it received %q", got.Value)
+	}
+}
+
+// TestCredentialJsonResult_CancelledOrEmptyStoresNothing mirrors the API-key
+// path: a dismissed prompt is not a credential.
+func TestCredentialJsonResult_CancelledOrEmptyStoresNothing(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		msg  tuipick.TextInputResultMsg
+	}{
+		{name: "cancelled", msg: tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Cancelled: true}},
+		{name: "empty", msg: tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: "   "}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client, got, cleanup := credentialJSONHub(t)
+			defer cleanup()
+			m := newHubModel(client, "http://hub.test")
+			m.followupModal = &tuipick.TextInputModal{}
+			updated, cmd := m.handleTextInputResult(tt.msg)
+			if updated.(hubModel).followupModal != nil {
+				t.Fatal("the modal should be dismissed")
+			}
+			if cmd != nil {
+				t.Fatalf("nothing should be sent; got %+v", cmd())
+			}
+			if got.Value != "" {
+				t.Fatalf("the hub must not be called; it received %q", got.Value)
+			}
+		})
+	}
+}

--- a/cmd/evener-tui/hub_credential_json_test.go
+++ b/cmd/evener-tui/hub_credential_json_test.go
@@ -2,10 +2,11 @@ package tui
 
 import (
 	"context"
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
-
 	"testing"
 	"time"
 
@@ -136,8 +137,10 @@ func TestCredentialJsonFile_UnreadablePathIsReportedAndNotSent(t *testing.T) {
 		t.Fatal("want a cmd carrying the failure")
 	}
 	res, ok := cmd().(launchconfig.AuthApiKeySetResultMsg)
-	if !ok || res.Err == nil || !strings.Contains(res.Err.Error(), "no such file or directory") {
-		t.Fatalf("result = %#v, want one giving the reason the read failed", cmd())
+	// The reason travels as the wrapped sentinel rather than as words, so
+	// this holds wherever the test runs: every platform words it differently.
+	if !ok || !errors.Is(res.Err, fs.ErrNotExist) {
+		t.Fatalf("result = %#v, want one wrapping fs.ErrNotExist", cmd())
 	}
 	if strings.Contains(res.Err.Error(), missing) {
 		t.Fatalf("err = %q, must not repeat what was submitted", res.Err)

--- a/cmd/evener-tui/hub_credential_json_test.go
+++ b/cmd/evener-tui/hub_credential_json_test.go
@@ -50,28 +50,29 @@ func TestCredentialJsonAction_OpensAPasteModal(t *testing.T) {
 	}
 }
 
-// TestCredentialJsonResult_SendsThePasteAndReadsAPath: the value is either the
-// JSON itself (a bracketed paste) or a path to a file holding it, which the
-// TUI reads on the machine the user typed it on.
+// TestCredentialJsonResult_SendsThePasteAndReadsAPath: the two prompts are
+// separate — one takes the document, the other a path to the file holding it,
+// which the TUI reads on the machine the user typed it on — so neither has to
+// guess which it was given.
 func TestCredentialJsonResult_SendsThePasteAndReadsAPath(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "application_default_credentials.json")
 	if err := os.WriteFile(path, []byte(testCredentialJSON), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	for _, tt := range []struct {
-		name  string
-		value string
+		name, tag, value string
 	}{
-		{name: "pasted json", value: testCredentialJSON},
-		{name: "path to the file", value: path},
-		{name: "path with surrounding space", value: "  " + path + "  "},
+		{name: "pasted document", tag: "credential-json-set:google-vertex", value: testCredentialJSON},
+		{name: "document with surrounding space", tag: "credential-json-set:google-vertex", value: "  " + testCredentialJSON + "  "},
+		{name: "path to the file", tag: "credential-json-file:google-vertex", value: path},
+		{name: "path with surrounding space", tag: "credential-json-file:google-vertex", value: "  " + path + "  "},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			client, got, cleanup := credentialJSONHub(t)
 			defer cleanup()
 			m := newHubModel(client, "http://hub.test")
 			m.followupModal = &tuipick.TextInputModal{}
-			updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: tt.value})
+			updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: tt.tag, Value: tt.value})
 			if updated.(hubModel).followupModal != nil {
 				t.Fatal("the modal should be dismissed")
 			}
@@ -89,37 +90,68 @@ func TestCredentialJsonResult_SendsThePasteAndReadsAPath(t *testing.T) {
 	}
 }
 
-// TestCredentialJsonResult_UnreadablePathIsReportedAndNotSent: a path that
+// TestCredentialJsonFile_ReadsOffTheUpdateLoop: the file is read inside the
+// command, not while handling the key, so a slow filesystem cannot hold up
+// the interface. The file is created only after the handler returns, so a
+// read that happened there would have failed and the command would carry
+// that failure instead of the document.
+func TestCredentialJsonFile_ReadsOffTheUpdateLoop(t *testing.T) {
+	client, got, cleanup := credentialJSONHub(t)
+	defer cleanup()
+	path := filepath.Join(t.TempDir(), "adc.json")
+	m := newHubModel(client, "http://hub.test")
+	m.followupModal = &tuipick.TextInputModal{}
+	_, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-file:google-vertex", Value: path})
+	if cmd == nil {
+		t.Fatal("want a cmd")
+	}
+	if got.Value != "" {
+		t.Fatalf("nothing should have been stored yet; the hub received %q", got.Value)
+	}
+	if err := os.WriteFile(path, []byte(testCredentialJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if res, ok := cmd().(launchconfig.AuthApiKeySetResultMsg); !ok || res.Err != nil {
+		t.Fatalf("the read belongs in the cmd, which runs after this file exists: %#v", cmd())
+	}
+	if got.Value != testCredentialJSON {
+		t.Fatalf("hub received %q, want the file's contents", got.Value)
+	}
+}
+
+// TestCredentialJsonFile_UnreadablePathIsReportedAndNotSent: a path that
 // cannot be read is the user's mistake to see — by its reason, since the
 // value itself is never repeated — and nothing is stored.
-func TestCredentialJsonResult_UnreadablePathIsReportedAndNotSent(t *testing.T) {
+func TestCredentialJsonFile_UnreadablePathIsReportedAndNotSent(t *testing.T) {
 	client, got, cleanup := credentialJSONHub(t)
 	defer cleanup()
 	missing := filepath.Join(t.TempDir(), "no-such-credentials.json")
 	m := newHubModel(client, "http://hub.test")
 	m.followupModal = &tuipick.TextInputModal{}
-	updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: missing})
-	if cmd != nil {
-		t.Fatalf("nothing should be sent for an unreadable path; got %+v", cmd())
+	updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-file:google-vertex", Value: missing})
+	if updated.(hubModel).followupModal != nil {
+		t.Fatal("the modal should be dismissed")
 	}
-	err := updated.(hubModel).err
-	if err == nil || !strings.Contains(err.Error(), "no such file or directory") {
-		t.Fatalf("err = %v, want one giving the reason the read failed", err)
+	if cmd == nil {
+		t.Fatal("want a cmd carrying the failure")
 	}
-	if strings.Contains(err.Error(), missing) {
-		t.Fatalf("err = %q, must not repeat what was submitted", err)
+	res, ok := cmd().(launchconfig.AuthApiKeySetResultMsg)
+	if !ok || res.Err == nil || !strings.Contains(res.Err.Error(), "no such file or directory") {
+		t.Fatalf("result = %#v, want one giving the reason the read failed", cmd())
+	}
+	if strings.Contains(res.Err.Error(), missing) {
+		t.Fatalf("err = %q, must not repeat what was submitted", res.Err)
 	}
 	if got.Value != "" {
 		t.Fatalf("the hub must not be called; it received %q", got.Value)
 	}
 }
 
-// TestCredentialJsonResult_NeverEchoesWhatWasSubmitted: the error line is
-// rendered and persists after the panel closes, so a value that is neither a
-// document nor a readable path — the wrong secret pasted into this prompt —
-// must not put any of itself there. The reason it failed is what the user
-// needs.
-func TestCredentialJsonResult_NeverEchoesWhatWasSubmitted(t *testing.T) {
+// TestCredentialJsonFile_NeverEchoesWhatWasSubmitted: the error line is
+// rendered and persists after the panel closes, so a value that cannot be
+// read as a path — a secret typed into the file prompt by mistake — must not
+// put any of itself there. The reason it failed is what the user needs.
+func TestCredentialJsonFile_NeverEchoesWhatWasSubmitted(t *testing.T) {
 	const wrongSecret = `sk-ant-api03-SECRET-MATERIAL-that-is-not-a-path-or-a-document`
 	for _, tt := range []struct {
 		name  string
@@ -134,14 +166,15 @@ func TestCredentialJsonResult_NeverEchoesWhatWasSubmitted(t *testing.T) {
 			defer cleanup()
 			m := newHubModel(client, "http://hub.test")
 			m.followupModal = &tuipick.TextInputModal{}
-			updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: tt.value})
-			if cmd != nil {
-				t.Fatalf("nothing should be sent; got %+v", cmd())
+			_, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-file:google-vertex", Value: tt.value})
+			if cmd == nil {
+				t.Fatal("want a cmd carrying the failure")
 			}
-			err := updated.(hubModel).err
-			if err == nil {
-				t.Fatal("the failure must be reported")
+			res, ok := cmd().(launchconfig.AuthApiKeySetResultMsg)
+			if !ok || res.Err == nil {
+				t.Fatalf("the failure must be reported: %#v", cmd())
 			}
+			err := res.Err
 			if strings.Contains(err.Error(), "SECRET") || strings.Contains(err.Error(), tt.value) {
 				t.Fatalf("err = %q, must not repeat what was submitted", err)
 			}
@@ -165,23 +198,25 @@ func assertCredentialPathRefused(t *testing.T, value, want string) {
 	defer cleanup()
 	m := newHubModel(client, "http://hub.test")
 	m.followupModal = &tuipick.TextInputModal{}
-	done := make(chan tea.Model, 1)
+	done := make(chan tea.Msg, 1)
 	go func() {
-		updated, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: value})
-		if cmd != nil {
-			t.Errorf("nothing should be sent; got %+v", cmd())
+		_, cmd := m.handleTextInputResult(tuipick.TextInputResultMsg{Tag: "credential-json-file:google-vertex", Value: value})
+		if cmd == nil {
+			t.Error("want a cmd carrying the failure")
+			done <- nil
+			return
 		}
-		done <- updated
+		done <- cmd()
 	}()
-	var updated tea.Model
+	var msg tea.Msg
 	select {
-	case updated = <-done:
+	case msg = <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("handling blocked: the path was opened instead of being refused")
+		t.Fatal("reading blocked: the path was opened instead of being refused")
 	}
-	err := updated.(hubModel).err
-	if err == nil || !strings.Contains(err.Error(), want) {
-		t.Fatalf("err = %v, want one saying %q", err, want)
+	res, ok := msg.(launchconfig.AuthApiKeySetResultMsg)
+	if !ok || res.Err == nil || !strings.Contains(res.Err.Error(), want) {
+		t.Fatalf("result = %#v, want an error saying %q", msg, want)
 	}
 	if got.Value != "" {
 		t.Fatalf("the hub must not be called; it received %q", got.Value)
@@ -210,8 +245,10 @@ func TestCredentialJsonResult_CancelledOrEmptyStoresNothing(t *testing.T) {
 		name string
 		msg  tuipick.TextInputResultMsg
 	}{
-		{name: "cancelled", msg: tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Cancelled: true}},
-		{name: "empty", msg: tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: "   "}},
+		{name: "cancelled paste", msg: tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Cancelled: true}},
+		{name: "empty paste", msg: tuipick.TextInputResultMsg{Tag: "credential-json-set:google-vertex", Value: "   "}},
+		{name: "cancelled file", msg: tuipick.TextInputResultMsg{Tag: "credential-json-file:google-vertex", Cancelled: true}},
+		{name: "empty file", msg: tuipick.TextInputResultMsg{Tag: "credential-json-file:google-vertex", Value: "   "}},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			client, got, cleanup := credentialJSONHub(t)

--- a/cmd/evener-tui/hub_credential_json_unix_test.go
+++ b/cmd/evener-tui/hub_credential_json_unix_test.go
@@ -3,6 +3,7 @@
 package tui
 
 import (
+	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -19,4 +20,24 @@ func TestCredentialJsonResult_RefusesPipesAndDevices(t *testing.T) {
 	}
 	t.Run("named pipe", func(t *testing.T) { assertCredentialPathRefused(t, fifo, "not a regular file") })
 	t.Run("character device", func(t *testing.T) { assertCredentialPathRefused(t, "/dev/zero", "not a regular file") })
+}
+
+// TestCredentialJsonResult_BoundsAFileThatGrowsAfterItIsOpened: the size is
+// judged on the opened file and the read is bounded, so a file that is
+// replaced or extended between the check and the read cannot get past the
+// limit. Written as a file that reports one size and holds more, which is
+// what such a race produces.
+func TestCredentialJsonResult_BoundsAFileThatGrowsAfterItIsOpened(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "grows.json")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write(make([]byte, maxCredentialFileBytes+4096)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertCredentialPathRefused(t, path, "too large")
 }

--- a/cmd/evener-tui/hub_credential_json_unix_test.go
+++ b/cmd/evener-tui/hub_credential_json_unix_test.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package tui
+
+import (
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestCredentialJsonResult_RefusesPipesAndDevices: the two paths that would
+// not merely fail but hang or grow without bound — a pipe never returns, and
+// a character device never ends — refused before the file is opened. Both
+// are unix-only shapes, so they live apart from the portable cases.
+func TestCredentialJsonResult_RefusesPipesAndDevices(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	t.Run("named pipe", func(t *testing.T) { assertCredentialPathRefused(t, fifo, "not a regular file") })
+	t.Run("character device", func(t *testing.T) { assertCredentialPathRefused(t, "/dev/zero", "not a regular file") })
+}

--- a/cmd/evener-tui/hub_dashboard_view.go
+++ b/cmd/evener-tui/hub_dashboard_view.go
@@ -59,7 +59,7 @@ func (m hubModel) dashboardView() string {
 			TopBar:  topBar,
 			Body:    b.String(),
 			Overlay: m.credentialsPanel.View(),
-			Footer:  "[Enter] set api key  [O] OAuth sign-in  [C] clear  [Esc] close",
+			Footer:  "[Enter] set credential  [O] OAuth sign-in  [C] clear  [Esc] close",
 			Height:  m.height,
 		}.View()
 	}

--- a/cmd/evener-tui/hub_update_config.go
+++ b/cmd/evener-tui/hub_update_config.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -409,21 +410,36 @@ func credentialJSONDocument(value string) (string, error) {
 	if strings.HasPrefix(path, "~/") || path == "~" {
 		path = filepath.Join(envvars.Home.Getenv(), strings.TrimPrefix(path, "~"))
 	}
-	// This runs on the update loop, so what the path names is checked before
-	// it is opened: reading a pipe would never return and the interface would
-	// stop responding, and reading a character device would grow until the
-	// process died. A credential document is a small regular file.
-	switch info, err := os.Stat(path); {
-	case err != nil:
-		return "", credentialPathError(err)
-	case !info.Mode().IsRegular():
-		return "", errors.New("credential JSON: the path it was read as is not a regular file")
-	case info.Size() > maxCredentialFileBytes:
-		return "", fmt.Errorf("credential JSON: the file it was read as is too large (over %d bytes)", maxCredentialFileBytes)
-	}
-	data, err := os.ReadFile(path)
+	return readCredentialFile(path)
+}
+
+// readCredentialFile reads a credential document from a path the user gave.
+// This runs on the update loop, where a read that never returns stops the
+// interface responding and one that never ends exhausts the process, so the
+// file is opened without blocking, judged by what the open descriptor
+// actually is, and read through a bound. Checking the path and then opening
+// it by name again would leave a window for it to become something else.
+func readCredentialFile(path string) (string, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|nonblockingOpen, 0)
 	if err != nil {
 		return "", credentialPathError(err)
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		return "", credentialPathError(err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.New("credential JSON: the path it was read as is not a regular file")
+	}
+	// One byte past the bound, so a file at exactly the bound still reads and
+	// anything longer is refused however it grew.
+	data, err := io.ReadAll(io.LimitReader(f, maxCredentialFileBytes+1))
+	if err != nil {
+		return "", credentialPathError(err)
+	}
+	if len(data) > maxCredentialFileBytes {
+		return "", fmt.Errorf("credential JSON: the file it was read as is too large (over %d bytes)", maxCredentialFileBytes)
 	}
 	return string(data), nil
 }

--- a/cmd/evener-tui/hub_update_config.go
+++ b/cmd/evener-tui/hub_update_config.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -409,7 +411,14 @@ func credentialJSONDocument(value string) (string, error) {
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("read credential JSON: %w", err)
+		// What was submitted is either a mistyped path or a secret pasted
+		// into the wrong prompt, and this error is rendered and outlives the
+		// panel — so report why it failed and none of the value itself. A
+		// PathError's message repeats the path, so only its reason is kept.
+		if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
+			err = pathErr.Err
+		}
+		return "", fmt.Errorf("credential JSON: it does not start with %q, and the path it was read as could not be opened: %w", "{", err)
 	}
 	return string(data), nil
 }

--- a/cmd/evener-tui/hub_update_config.go
+++ b/cmd/evener-tui/hub_update_config.go
@@ -409,18 +409,38 @@ func credentialJSONDocument(value string) (string, error) {
 	if strings.HasPrefix(path, "~/") || path == "~" {
 		path = filepath.Join(envvars.Home.Getenv(), strings.TrimPrefix(path, "~"))
 	}
+	// This runs on the update loop, so what the path names is checked before
+	// it is opened: reading a pipe would never return and the interface would
+	// stop responding, and reading a character device would grow until the
+	// process died. A credential document is a small regular file.
+	switch info, err := os.Stat(path); {
+	case err != nil:
+		return "", credentialPathError(err)
+	case !info.Mode().IsRegular():
+		return "", errors.New("credential JSON: the path it was read as is not a regular file")
+	case info.Size() > maxCredentialFileBytes:
+		return "", fmt.Errorf("credential JSON: the file it was read as is too large (over %d bytes)", maxCredentialFileBytes)
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
-		// What was submitted is either a mistyped path or a secret pasted
-		// into the wrong prompt, and this error is rendered and outlives the
-		// panel — so report why it failed and none of the value itself. A
-		// PathError's message repeats the path, so only its reason is kept.
-		if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
-			err = pathErr.Err
-		}
-		return "", fmt.Errorf("credential JSON: it does not start with %q, and the path it was read as could not be opened: %w", "{", err)
+		return "", credentialPathError(err)
 	}
 	return string(data), nil
+}
+
+// maxCredentialFileBytes bounds the file the prompt will read. The largest
+// real credential document is a service-account key of a few kilobytes.
+const maxCredentialFileBytes = 1 << 20
+
+// credentialPathError reports why a submitted value could not be read as a
+// path without repeating the value: it is either a mistyped path or a secret
+// pasted into the wrong prompt, and this error is rendered and outlives the
+// panel. A PathError's own message names the path, so only its reason is kept.
+func credentialPathError(err error) error {
+	if pathErr, ok := errors.AsType[*fs.PathError](err); ok {
+		err = pathErr.Err
+	}
+	return fmt.Errorf("credential JSON: it does not start with %q, and the path it was read as could not be opened: %w", "{", err)
 }
 
 func (m hubModel) handleAuthApiKeySetResult(msg launchconfig.AuthApiKeySetResultMsg) (tea.Model, tea.Cmd) {

--- a/cmd/evener-tui/hub_update_config.go
+++ b/cmd/evener-tui/hub_update_config.go
@@ -152,8 +152,14 @@ func (m hubModel) handleCredentialsAction(msg launchconfig.CredentialsActionMsg)
 	case "setCredentialJson":
 		modal := tuipick.NewCredentialPasteModal(
 			"Credential JSON for "+msg.Instance,
-			"Paste a service-account key or application_default_credentials.json,\nor type the path to the file holding it:",
+			"Paste a service-account key or application_default_credentials.json.\nTo read it from a file instead, cancel and press f.",
 			"credential-json-set:"+msg.Instance)
+		m.followupModal = &modal
+		return m, nil
+	case "loadCredentialJson":
+		modal := tuipick.NewPathTextInputModal(
+			"Path to the credential JSON for "+msg.Instance+":",
+			"credential-json-file:"+msg.Instance, "")
 		m.followupModal = &modal
 		return m, nil
 	case "logout":
@@ -331,19 +337,30 @@ func (m hubModel) handleTextInputResult(msg tuipick.TextInputResultMsg) (tea.Mod
 	if provider, ok := strings.CutPrefix(msg.Tag, "credential-json-set:"); ok {
 		m.followupModal = nil
 		value := strings.TrimSpace(msg.Value)
-		if msg.Cancelled || value == "" {
-			return m, nil
-		}
-		document, err := credentialJSONDocument(value)
-		if err != nil {
-			m.err = err
+		if msg.Cancelled || value == "" || m.client == nil {
 			return m, nil
 		}
 		m.err = nil
-		if m.client != nil {
-			return m, launchconfig.CmdAuthCredentialJsonSet(m.client, provider, document)
+		return m, launchconfig.CmdAuthCredentialJsonSet(m.client, provider, value)
+	}
+	if provider, ok := strings.CutPrefix(msg.Tag, "credential-json-file:"); ok {
+		m.followupModal = nil
+		path := strings.TrimSpace(msg.Value)
+		if msg.Cancelled || path == "" || m.client == nil {
+			return m, nil
 		}
-		return m, nil
+		m.err = nil
+		client := m.client
+		// The read happens inside the command, off the update loop, so a slow
+		// or unreadable path cannot hold up the interface. Its failure takes
+		// the same route as the hub's own, so both reach the error line.
+		return m, func() tea.Msg {
+			document, err := readCredentialFile(path)
+			if err != nil {
+				return launchconfig.AuthApiKeySetResultMsg{Err: err}
+			}
+			return launchconfig.CmdAuthCredentialJsonSet(client, provider, document)()
+		}
 	}
 	if rest, ok := strings.CutPrefix(msg.Tag, "oauth-redirect:"); ok {
 		parts := strings.SplitN(rest, ":", 2)
@@ -395,31 +412,19 @@ func (m hubModel) handleTextInputResult(msg tuipick.TextInputResultMsg) (tea.Mod
 	return m, nil
 }
 
-// credentialJSONDocument resolves what the credential-JSON prompt collected
-// into the document to store: the paste itself, or the contents of the file
-// the user named instead. A terminal that brackets its pastes delivers the
-// whole document in one key message; naming the file is the way in from one
-// that does not, and the file is read here because the path is on the
-// machine the user typed it on, not the hub's. The hub validates whatever
-// this returns, so no parsing happens here.
-func credentialJSONDocument(value string) (string, error) {
-	if strings.HasPrefix(value, "{") {
-		return value, nil
-	}
-	path := value
+// readCredentialFile reads a credential document from a path the user gave,
+// on the machine they typed it on rather than the hub's. Its caller runs it
+// inside a command, off the update loop, so a slow filesystem cannot hold up
+// the interface; the file is still opened without blocking, so a path that
+// names a pipe cannot leave that command waiting forever either. What the
+// open descriptor actually is decides whether it is read, and the read is
+// bounded — checking the path and then opening it by name again would leave
+// a window for it to become something else. The hub validates the document,
+// so no parsing happens here.
+func readCredentialFile(path string) (string, error) {
 	if strings.HasPrefix(path, "~/") || path == "~" {
 		path = filepath.Join(envvars.Home.Getenv(), strings.TrimPrefix(path, "~"))
 	}
-	return readCredentialFile(path)
-}
-
-// readCredentialFile reads a credential document from a path the user gave.
-// This runs on the update loop, where a read that never returns stops the
-// interface responding and one that never ends exhausts the process, so the
-// file is opened without blocking, judged by what the open descriptor
-// actually is, and read through a bound. Checking the path and then opening
-// it by name again would leave a window for it to become something else.
-func readCredentialFile(path string) (string, error) {
 	f, err := os.OpenFile(path, os.O_RDONLY|nonblockingOpen, 0)
 	if err != nil {
 		return "", credentialPathError(err)

--- a/cmd/evener-tui/hub_update_config.go
+++ b/cmd/evener-tui/hub_update_config.go
@@ -2,12 +2,15 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-tui/internal/launchconfig"
 	"primeradiant.com/evener/cmd/evener-tui/internal/tuipick"
+	"primeradiant.com/evener/envvars"
 )
 
 // Handlers for the auth / credentials / instance / launch-config domain of
@@ -141,6 +144,13 @@ func (m hubModel) handleCredentialsAction(msg launchconfig.CredentialsActionMsg)
 	switch msg.Action {
 	case "set":
 		modal := tuipick.NewTextInputModalMasked(fmt.Sprintf("API key for %s:", msg.Instance), "credential-set:"+msg.Instance)
+		m.followupModal = &modal
+		return m, nil
+	case "setCredentialJson":
+		modal := tuipick.NewCredentialPasteModal(
+			"Credential JSON for "+msg.Instance,
+			"Paste a service-account key or application_default_credentials.json,\nor type the path to the file holding it:",
+			"credential-json-set:"+msg.Instance)
 		m.followupModal = &modal
 		return m, nil
 	case "logout":
@@ -315,6 +325,23 @@ func (m hubModel) handleTextInputResult(msg tuipick.TextInputResultMsg) (tea.Mod
 		}
 		return m, nil
 	}
+	if provider, ok := strings.CutPrefix(msg.Tag, "credential-json-set:"); ok {
+		m.followupModal = nil
+		value := strings.TrimSpace(msg.Value)
+		if msg.Cancelled || value == "" {
+			return m, nil
+		}
+		document, err := credentialJSONDocument(value)
+		if err != nil {
+			m.err = err
+			return m, nil
+		}
+		m.err = nil
+		if m.client != nil {
+			return m, launchconfig.CmdAuthCredentialJsonSet(m.client, provider, document)
+		}
+		return m, nil
+	}
 	if rest, ok := strings.CutPrefix(msg.Tag, "oauth-redirect:"); ok {
 		parts := strings.SplitN(rest, ":", 2)
 		m.followupModal = nil
@@ -363,6 +390,28 @@ func (m hubModel) handleTextInputResult(msg tuipick.TextInputResultMsg) (tea.Mod
 		return m, launchconfig.CmdSetLayer(m.client, panel.CWD(), layer, updatedLayer)
 	}
 	return m, nil
+}
+
+// credentialJSONDocument resolves what the credential-JSON prompt collected
+// into the document to store: the paste itself, or the contents of the file
+// the user named instead. A terminal that brackets its pastes delivers the
+// whole document in one key message; naming the file is the way in from one
+// that does not, and the file is read here because the path is on the
+// machine the user typed it on, not the hub's. The hub validates whatever
+// this returns, so no parsing happens here.
+func credentialJSONDocument(value string) (string, error) {
+	if strings.HasPrefix(value, "{") {
+		return value, nil
+	}
+	path := value
+	if strings.HasPrefix(path, "~/") || path == "~" {
+		path = filepath.Join(envvars.Home.Getenv(), strings.TrimPrefix(path, "~"))
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read credential JSON: %w", err)
+	}
+	return string(data), nil
 }
 
 func (m hubModel) handleAuthApiKeySetResult(msg launchconfig.AuthApiKeySetResultMsg) (tea.Model, tea.Cmd) {

--- a/cmd/evener-tui/internal/launchconfig/credentials_panel.go
+++ b/cmd/evener-tui/internal/launchconfig/credentials_panel.go
@@ -56,12 +56,6 @@ type CredentialsPanel struct {
 	testPending    map[string]bool
 	testResults    map[string]appwire.AuthTestResponse
 	testGeneration uint64
-
-	// notice is an explanation shown under noticeFor's row when Enter has
-	// no action to run for that instance; any other key, or a list refresh,
-	// clears it.
-	notice    string
-	noticeFor string
 }
 
 func NewCredentialsPanel() CredentialsPanel {
@@ -143,7 +137,6 @@ func (p CredentialsPanel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		p.testGeneration++
 		p.testPending = nil
 		p.testResults = nil
-		p.notice, p.noticeFor = "", ""
 		p.loading = false
 		p.err = m.Err
 		if m.Err == nil {
@@ -192,10 +185,6 @@ func (p CredentialsPanel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (p CredentialsPanel) updateList(m tea.KeyMsg) (tea.Model, tea.Cmd) {
-	// The notice answers one Enter; any other key moves on from it.
-	if m.Type != tea.KeyEnter {
-		p.notice, p.noticeFor = "", ""
-	}
 	switch m.Type {
 	case tea.KeyEsc, tea.KeyCtrlC:
 		p.cancelled = true
@@ -221,15 +210,11 @@ func (p CredentialsPanel) updateList(m tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if strings.Contains(modes, "oauth") {
 			return p, func() tea.Msg { return CredentialsActionMsg{Action: "oauth", Instance: cur.Name} }
 		}
-		// A gcp-adc instance is configured by application-default
-		// credentials or a pasted credential JSON; the TUI has no multiline
-		// paste, so say where the paste lives instead of doing nothing.
+		// A gcp-adc instance takes a pasted service-account key or
+		// application-default JSON, into the same store the web hub's
+		// Providers & credentials writes.
 		if strings.Contains(modes, "credentialJson") {
-			// Pre-broken into lines that fit the overlay under the row's
-			// indent, so the wrap never splits "credential JSON" or the
-			// section name.
-			p.notice = "Uses application-default credentials. To store a\ncredential JSON, paste it in the web hub under\nProviders & credentials."
-			p.noticeFor = cur.Name
+			return p, func() tea.Msg { return CredentialsActionMsg{Action: "setCredentialJson", Instance: cur.Name} }
 		}
 	case tea.KeyRunes:
 		s := string(m.Runes)
@@ -510,11 +495,6 @@ func (p CredentialsPanel) View() string {
 			} else if result, ok := p.testResults[inst.Name]; ok {
 				rows = append(rows, "    "+result.Status+": "+result.Message)
 			}
-			if p.notice != "" && p.noticeFor == inst.Name {
-				for line := range strings.SplitSeq(p.notice, "\n") {
-					rows = append(rows, "    "+lipgloss.NewStyle().Foreground(th.TextDim).Render(line))
-				}
-			}
 		}
 		body = strings.Join(rows, "\n")
 	}
@@ -524,7 +504,7 @@ func (p CredentialsPanel) View() string {
 		footer = tuiprim.ActionBarForWidth(width, tuiprim.KbdHint("enter", "next/submit"), tuiprim.KbdHint("esc", "cancel"))
 	} else {
 		footer = tuiprim.ActionBarForWidth(width,
-			tuiprim.KbdHint("enter", "set key"),
+			tuiprim.KbdHint("enter", "set credential"),
 			tuiprim.KbdHint("t", "test credentials"),
 			tuiprim.KbdHint("o", "OAuth"),
 			tuiprim.KbdHint("c", "clear"),

--- a/cmd/evener-tui/internal/launchconfig/credentials_panel.go
+++ b/cmd/evener-tui/internal/launchconfig/credentials_panel.go
@@ -244,6 +244,15 @@ func (p CredentialsPanel) updateList(m tea.KeyMsg) (tea.Model, tea.Cmd) {
 				return p, nil
 			}
 			return p, func() tea.Msg { return CredentialsActionMsg{Action: "oauth", Instance: cur.Name} }
+		case "f":
+			// Reading the document from a file is its own action, so neither
+			// prompt has to guess whether what it was handed is a path or the
+			// credential itself.
+			cur := p.selectedInstance()
+			if cur == nil || !strings.Contains(strings.Join(cur.AuthModes, ","), "credentialJson") {
+				return p, nil
+			}
+			return p, func() tea.Msg { return CredentialsActionMsg{Action: "loadCredentialJson", Instance: cur.Name} }
 		case "*":
 			cur := p.selectedInstance()
 			if cur == nil {
@@ -505,6 +514,7 @@ func (p CredentialsPanel) View() string {
 	} else {
 		footer = tuiprim.ActionBarForWidth(width,
 			tuiprim.KbdHint("enter", "set credential"),
+			tuiprim.KbdHint("f", "credential from file"),
 			tuiprim.KbdHint("t", "test credentials"),
 			tuiprim.KbdHint("o", "OAuth"),
 			tuiprim.KbdHint("c", "clear"),

--- a/cmd/evener-tui/internal/launchconfig/credentials_panel_test.go
+++ b/cmd/evener-tui/internal/launchconfig/credentials_panel_test.go
@@ -71,7 +71,10 @@ func TestCredentialsPanel_EnterTriggersSet(t *testing.T) {
 	}
 }
 
-func TestCredentialsPanel_EnterOnACredentialJsonInstanceExplainsWhereToPaste(t *testing.T) {
+// TestCredentialsPanel_EnterOnACredentialJsonInstanceSetsTheCredentialJson:
+// a gcp-adc instance takes a pasted credential JSON here, the same store the
+// web hub's Providers & credentials writes; it no longer points at the hub.
+func TestCredentialsPanel_EnterOnACredentialJsonInstanceSetsTheCredentialJson(t *testing.T) {
 	m := NewCredentialsPanel()
 	updated, _ := m.Update(InstanceListResultMsg{List: appwire.InstanceListResponse{Instances: []appwire.InstanceEntry{
 		{Name: "anthropic", ProviderID: "anthropic", ActiveSource: "none", AuthModes: []string{"apiKey"}},
@@ -80,27 +83,25 @@ func TestCredentialsPanel_EnterOnACredentialJsonInstanceExplainsWhereToPaste(t *
 	// The list opens on anthropic; Down lands on google-vertex.
 	onVertex, _ := updated.Update(tea.KeyMsg{Type: tea.KeyDown})
 	next, cmd := onVertex.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	if cmd != nil {
-		t.Fatalf("Enter emitted %+v; the TUI has no credential-JSON action to run", cmd())
+	if cmd == nil {
+		t.Fatal("Enter on a credential-JSON instance should produce a cmd")
 	}
-	const label = "Providers & credentials" // the web hub's settings row (sections.ts)
-	view := next.View()
-	if !strings.Contains(view, "credential JSON") || !strings.Contains(view, "web hub") || !strings.Contains(view, label) {
-		t.Fatalf("view after Enter = %q, want a notice naming the credential JSON, the web hub, and %q", view, label)
+	got, ok := cmd().(CredentialsActionMsg)
+	if !ok {
+		t.Fatalf("cmd msg = %T, want CredentialsActionMsg", cmd())
 	}
-	moved, _ := next.Update(tea.KeyMsg{Type: tea.KeyUp})
-	if strings.Contains(moved.View(), label) {
-		t.Fatal("the notice must clear when the cursor moves to another instance")
+	if got.Action != "setCredentialJson" || got.Instance != "google-vertex" {
+		t.Fatalf("msg = %+v, want the credential-JSON action for google-vertex", got)
 	}
-	back, _ := moved.Update(tea.KeyMsg{Type: tea.KeyDown})
-	again, _ := back.Update(tea.KeyMsg{Type: tea.KeyEnter})
-	if !strings.Contains(again.View(), label) {
-		t.Fatal("Enter on the instance again must show the notice again")
+	if view := next.View(); strings.Contains(view, "web hub") {
+		t.Fatalf("the panel must no longer send the user to the web hub: %q", view)
 	}
-	formOpen, _ := again.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
-	formClosed, _ := formOpen.Update(tea.KeyMsg{Type: tea.KeyEsc})
-	if strings.Contains(formClosed.View(), label) {
-		t.Fatal("the notice must not survive opening and closing the form")
+	// An adc-only instance has nothing to set here and stays silent.
+	adcOnly, _ := NewCredentialsPanel().Update(InstanceListResultMsg{List: appwire.InstanceListResponse{Instances: []appwire.InstanceEntry{
+		{Name: "vertex-adc", ProviderID: "google-vertex", ActiveSource: "adc", CredentialRequired: true, AuthModes: []string{"adc"}},
+	}}})
+	if _, cmd := adcOnly.Update(tea.KeyMsg{Type: tea.KeyEnter}); cmd != nil {
+		t.Fatalf("an adc-only instance has no credential to set; got %+v", cmd())
 	}
 }
 

--- a/cmd/evener-tui/internal/launchconfig/credentials_panel_test.go
+++ b/cmd/evener-tui/internal/launchconfig/credentials_panel_test.go
@@ -105,6 +105,30 @@ func TestCredentialsPanel_EnterOnACredentialJsonInstanceSetsTheCredentialJson(t 
 	}
 }
 
+// TestCredentialsPanel_LoadsACredentialJsonFromAFile: reading the document
+// from a file is its own action, so neither prompt has to guess whether what
+// it was given is a path or a secret.
+func TestCredentialsPanel_LoadsACredentialJsonFromAFile(t *testing.T) {
+	m := NewCredentialsPanel()
+	updated, _ := m.Update(InstanceListResultMsg{List: appwire.InstanceListResponse{Instances: []appwire.InstanceEntry{
+		{Name: "anthropic", ProviderID: "anthropic", ActiveSource: "none", AuthModes: []string{"apiKey"}},
+		{Name: "google-vertex", ProviderID: "google-vertex", ActiveSource: "none", CredentialRequired: true, AuthModes: []string{"adc", "credentialJson"}},
+	}}})
+	onVertex, _ := updated.Update(tea.KeyMsg{Type: tea.KeyDown})
+	_, cmd := onVertex.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	if cmd == nil {
+		t.Fatal("f on a credential-JSON instance should produce a cmd")
+	}
+	got, ok := cmd().(CredentialsActionMsg)
+	if !ok || got.Action != "loadCredentialJson" || got.Instance != "google-vertex" {
+		t.Fatalf("msg = %#v, want the load-from-file action for google-vertex", cmd())
+	}
+	// The key means nothing for an instance that takes no credential JSON.
+	if _, cmd := updated.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")}); cmd != nil {
+		t.Fatalf("an API-key instance has no credential JSON to load; got %+v", cmd())
+	}
+}
+
 // --- new instance-based tests ---
 
 func TestCredentialsPanel_GroupsByType(t *testing.T) {

--- a/cmd/evener-tui/internal/launchconfig/launchconfig_client.go
+++ b/cmd/evener-tui/internal/launchconfig/launchconfig_client.go
@@ -115,6 +115,20 @@ func CmdAuthApiKeySet(client *appwire.Client, provider, value string) tea.Cmd {
 	}
 }
 
+// CmdAuthCredentialJsonSet stores a Google credential JSON for a gcp-adc
+// instance. The hub validates the document before storing it, so its error is
+// the parse failure, and the result is the same status the API-key set
+// returns — the credential store changed either way.
+func CmdAuthCredentialJsonSet(client *appwire.Client, provider, value string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		var resp appwire.AuthStatusResponse
+		err := client.Request(ctx, appwire.MethodEvenerAuthCredentialJsonSet, appwire.AuthCredentialJsonSetParams{Provider: provider, Value: value}, &resp)
+		return AuthApiKeySetResultMsg{Status: resp, Err: err}
+	}
+}
+
 func CmdAuthLogout(client *appwire.Client, provider string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmd/evener-tui/internal/tuipick/text_input_modal.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal.go
@@ -23,12 +23,11 @@ type TextInputModal struct {
 	prompt string
 	input  string
 	mask   bool
-	// summarize renders pasted material as a character count instead of the
-	// value itself, so a credential is never echoed while a typed path stays
-	// visible. sawPaste records that the terminal reported a paste, which is
-	// what distinguishes the two.
+	// summarize renders the value as a character count instead of the value
+	// itself. A prompt that asks for a credential sets it and echoes nothing:
+	// a terminal that marks no pastes makes typed and pasted material
+	// indistinguishable, and guessing from shape cannot be made reliable.
 	summarize bool
-	sawPaste  bool
 	paths     bool
 	done      bool
 	width     int
@@ -54,15 +53,15 @@ func NewTextInputModalMasked(prompt, tag string) TextInputModal {
 	return TextInputModal{prompt: prompt, tag: tag, mask: true}
 }
 
-// NewCredentialPasteModal takes a credential the user pastes whole — a
-// terminal delivers a bracketed paste as one KeyRunes message carrying every
-// rune, newlines included, so a pretty-printed JSON document arrives intact
-// and its newlines never reach the Enter branch. The alternative input is a
-// path to the file holding it, for a terminal that does not bracket its
-// pastes; the field keeps path completion for that, and shows a pasted
-// credential as a character count rather than echoing it.
+// NewCredentialPasteModal takes a credential document the user pastes whole:
+// a terminal delivers a bracketed paste as one KeyRunes message carrying
+// every rune, newlines included, so a pretty-printed JSON document arrives
+// intact and its newlines never reach the Enter branch. It echoes nothing —
+// the field shows a character count — because the prompt asks for exactly one
+// thing and that thing is secret. Reading the document from a file is a
+// separate prompt, which takes a path and has nothing to hide.
 func NewCredentialPasteModal(title, prompt, tag string) TextInputModal {
-	return TextInputModal{title: title, prompt: prompt, tag: tag, summarize: true, paths: true, width: 60}
+	return TextInputModal{title: title, prompt: prompt, tag: tag, summarize: true, width: 60}
 }
 
 func (m TextInputModal) Init() tea.Cmd { return nil }
@@ -97,35 +96,10 @@ func (m TextInputModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.input += "\n"
 			}
 		case tea.KeyRunes:
-			// The terminal marks its pastes, and that is the one signal that
-			// tells material the user brought in from elsewhere — a
-			// credential of any shape — from a path they typed here.
-			m.sawPaste = m.sawPaste || v.Paste
 			m.input += string(v.Runes)
 		}
 	}
 	return m, nil
-}
-
-// pastedMaterial reports whether the value is credential material rather than
-// a path the user typed. Every credential document evener accepts is a JSON
-// object (registry.CheckCredentialJSON unmarshals into a struct, so the text
-// must start with "{"), and a line break can only arrive by paste — so those
-// two tests cover the material that must never be echoed, whatever its
-// length. A path stays visible however long it is.
-func (m TextInputModal) pastedMaterial() bool {
-	value := strings.TrimSpace(m.input)
-	if value == "" {
-		return false
-	}
-	if m.sawPaste || strings.HasPrefix(value, "{") || strings.ContainsAny(value, "\n\r") {
-		return true
-	}
-	// A terminal without bracketed paste marks nothing as pasted, so nothing
-	// here can tell a pasted secret from a typed one. What the prompt asks to
-	// be typed is a path, so that is what it shows; anything else is treated
-	// as material to keep off the screen.
-	return !strings.HasPrefix(value, "/") && !strings.HasPrefix(value, "~") && !strings.HasPrefix(value, ".")
 }
 
 // printable drops the control bytes a paste can carry, so clipboard content
@@ -141,8 +115,8 @@ func printable(s string) string {
 
 func (m TextInputModal) inputView() string {
 	display := printable(m.input)
-	if m.summarize && m.pastedMaterial() {
-		return fmt.Sprintf("> [%d characters pasted]", len([]rune(m.input)))
+	if m.summarize && m.input != "" {
+		return fmt.Sprintf("> [%d characters]", len([]rune(m.input)))
 	}
 	if m.mask {
 		display = ""

--- a/cmd/evener-tui/internal/tuipick/text_input_modal.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal.go
@@ -102,14 +102,16 @@ func (m TextInputModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// printable drops the control bytes a paste can carry, so clipboard content
-// cannot drive the terminal from a rendered field.
+// printable drops the control characters a paste can carry, so clipboard
+// content cannot drive the terminal from a rendered field. C1 goes with C0
+// and DEL: U+009B is CSI and U+009D is OSC, each a control introducer on its
+// own rather than part of an escape sequence.
 func printable(s string) string {
 	return strings.Map(func(r rune) rune {
-		if r == '\t' || (r >= 0x20 && r != 0x7f) {
-			return r
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return -1
 		}
-		return -1
+		return r
 	}, s)
 }
 

--- a/cmd/evener-tui/internal/tuipick/text_input_modal.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal.go
@@ -23,10 +23,12 @@ type TextInputModal struct {
 	prompt string
 	input  string
 	mask   bool
-	// summarize renders a value that is plainly pasted material — multi-line
-	// or long — as a character count instead of the value itself, so a
-	// credential is never echoed while a typed path stays visible.
+	// summarize renders pasted material as a character count instead of the
+	// value itself, so a credential is never echoed while a typed path stays
+	// visible. sawPaste records that the terminal reported a paste, which is
+	// what distinguishes the two.
 	summarize bool
+	sawPaste  bool
 	paths     bool
 	done      bool
 	width     int
@@ -82,27 +84,52 @@ func (m TextInputModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.paths {
 				m.input = CompleteLastPathSegment(m.input, nil)
 			}
+		case tea.KeySpace:
+			// A space is its own key type, not a rune; a field that drops it
+			// cannot hold a path — or any value — with a space in it.
+			m.input += " "
+		case tea.KeyCtrlJ:
+			// A terminal that does not bracket its pastes sends the document
+			// as ordinary keys, and bubbletea maps LF to this (only CR is
+			// KeyEnter). Keeping it is what lets such a paste accumulate
+			// whole in the field built to receive one.
+			if m.summarize {
+				m.input += "\n"
+			}
 		case tea.KeyRunes:
+			// The terminal marks its pastes, and that is the one signal that
+			// tells material the user brought in from elsewhere — a
+			// credential of any shape — from a path they typed here.
+			m.sawPaste = m.sawPaste || v.Paste
 			m.input += string(v.Runes)
 		}
 	}
 	return m, nil
 }
 
-// pastedMaterial reports whether the value is plainly a pasted document
-// rather than something typed into the field: a line break can only arrive by
-// paste, and no path a user types reaches this length.
+// pastedMaterial reports whether the value is credential material rather than
+// a path the user typed. Every credential document evener accepts is a JSON
+// object (registry.CheckCredentialJSON unmarshals into a struct, so the text
+// must start with "{"), and a line break can only arrive by paste — so those
+// two tests cover the material that must never be echoed, whatever its
+// length. A path stays visible however long it is.
 func (m TextInputModal) pastedMaterial() bool {
-	return strings.ContainsAny(m.input, "\n\r") || len([]rune(m.input)) > pastedValueRunes
+	return m.sawPaste || strings.HasPrefix(strings.TrimSpace(m.input), "{") || strings.ContainsAny(m.input, "\n\r")
 }
 
-// pastedValueRunes is the length past which a value is treated as pasted
-// material. The longest realistic credential path (a home-relative gcloud
-// application-default file) is about 55 runes.
-const pastedValueRunes = 80
+// printable drops the control bytes a paste can carry, so clipboard content
+// cannot drive the terminal from a rendered field.
+func printable(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || (r >= 0x20 && r != 0x7f) {
+			return r
+		}
+		return -1
+	}, s)
+}
 
 func (m TextInputModal) inputView() string {
-	display := m.input
+	display := printable(m.input)
 	if m.summarize && m.pastedMaterial() {
 		return fmt.Sprintf("> [%d characters pasted]", len([]rune(m.input)))
 	}

--- a/cmd/evener-tui/internal/tuipick/text_input_modal.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal.go
@@ -1,6 +1,7 @@
 package tuipick
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,9 +23,13 @@ type TextInputModal struct {
 	prompt string
 	input  string
 	mask   bool
-	paths  bool
-	done   bool
-	width  int
+	// summarize renders a value that is plainly pasted material — multi-line
+	// or long — as a character count instead of the value itself, so a
+	// credential is never echoed while a typed path stays visible.
+	summarize bool
+	paths     bool
+	done      bool
+	width     int
 }
 
 func NewTextInputModal(prompt, tag string) TextInputModal {
@@ -45,6 +50,17 @@ func NewPathTextInputModal(prompt, tag, input string) TextInputModal {
 
 func NewTextInputModalMasked(prompt, tag string) TextInputModal {
 	return TextInputModal{prompt: prompt, tag: tag, mask: true}
+}
+
+// NewCredentialPasteModal takes a credential the user pastes whole — a
+// terminal delivers a bracketed paste as one KeyRunes message carrying every
+// rune, newlines included, so a pretty-printed JSON document arrives intact
+// and its newlines never reach the Enter branch. The alternative input is a
+// path to the file holding it, for a terminal that does not bracket its
+// pastes; the field keeps path completion for that, and shows a pasted
+// credential as a character count rather than echoing it.
+func NewCredentialPasteModal(title, prompt, tag string) TextInputModal {
+	return TextInputModal{title: title, prompt: prompt, tag: tag, summarize: true, paths: true, width: 60}
 }
 
 func (m TextInputModal) Init() tea.Cmd { return nil }
@@ -73,8 +89,23 @@ func (m TextInputModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// pastedMaterial reports whether the value is plainly a pasted document
+// rather than something typed into the field: a line break can only arrive by
+// paste, and no path a user types reaches this length.
+func (m TextInputModal) pastedMaterial() bool {
+	return strings.ContainsAny(m.input, "\n\r") || len([]rune(m.input)) > pastedValueRunes
+}
+
+// pastedValueRunes is the length past which a value is treated as pasted
+// material. The longest realistic credential path (a home-relative gcloud
+// application-default file) is about 55 runes.
+const pastedValueRunes = 80
+
 func (m TextInputModal) inputView() string {
 	display := m.input
+	if m.summarize && m.pastedMaterial() {
+		return fmt.Sprintf("> [%d characters pasted]", len([]rune(m.input)))
+	}
 	if m.mask {
 		display = ""
 		var displaySb80 strings.Builder

--- a/cmd/evener-tui/internal/tuipick/text_input_modal.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal.go
@@ -114,7 +114,18 @@ func (m TextInputModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // two tests cover the material that must never be echoed, whatever its
 // length. A path stays visible however long it is.
 func (m TextInputModal) pastedMaterial() bool {
-	return m.sawPaste || strings.HasPrefix(strings.TrimSpace(m.input), "{") || strings.ContainsAny(m.input, "\n\r")
+	value := strings.TrimSpace(m.input)
+	if value == "" {
+		return false
+	}
+	if m.sawPaste || strings.HasPrefix(value, "{") || strings.ContainsAny(value, "\n\r") {
+		return true
+	}
+	// A terminal without bracketed paste marks nothing as pasted, so nothing
+	// here can tell a pasted secret from a typed one. What the prompt asks to
+	// be typed is a path, so that is what it shows; anything else is treated
+	// as material to keep off the screen.
+	return !strings.HasPrefix(value, "/") && !strings.HasPrefix(value, "~") && !strings.HasPrefix(value, ".")
 }
 
 // printable drops the control bytes a paste can carry, so clipboard content

--- a/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
@@ -186,6 +186,37 @@ func TestCredentialPasteModal_SummarizesAnythingPasted(t *testing.T) {
 	}
 }
 
+// TestCredentialPasteModal_ShowsOnlyWhatLooksLikeAPath: a terminal without
+// bracketed paste marks nothing as pasted, so the field cannot tell a pasted
+// secret from a typed one. It shows what looks like a path and summarizes
+// everything else, which is the side to err on in a credential prompt.
+func TestCredentialPasteModal_ShowsOnlyWhatLooksLikeAPath(t *testing.T) {
+	withTestColorProfile(t)
+	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "t")
+	for _, tt := range []struct {
+		name, typed string
+		shown       bool
+	}{
+		{name: "absolute path", typed: "/home/somebody/adc.json", shown: true},
+		{name: "home path", typed: "~/.config/gcloud/adc.json", shown: true},
+		{name: "relative path", typed: "./adc.json", shown: true},
+		{name: "unmarked secret", typed: "sk-ant-api03-SECRET-MATERIAL-typed-without-a-paste-mark", shown: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			typed, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tt.typed)})
+			view := ansiPattern.ReplaceAllString(typed.(TextInputModal).View(), "")
+			// The summary marker is the reliable signal: a long value is
+			// wrapped by the overlay, so searching for it whole can miss it.
+			if summarized := strings.Contains(view, "characters pasted"); summarized == tt.shown {
+				t.Fatalf("summarized = %t, want shown = %t for %q: %q", summarized, tt.shown, tt.typed, view)
+			}
+			if tt.shown && !strings.Contains(view, tt.typed) {
+				t.Fatalf("a path short enough to fit must render whole: %q", view)
+			}
+		})
+	}
+}
+
 // TestTextInputModal_DoesNotRenderControlBytes: clipboard content reaches the
 // view, so an escape sequence in it must not reach the terminal.
 func TestTextInputModal_DoesNotRenderControlBytes(t *testing.T) {

--- a/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
@@ -41,6 +41,56 @@ func TestTextInputModal_CapturesAndSubmits(t *testing.T) {
 	}
 }
 
+// TestCredentialPasteModal_TakesAWholeBracketedPaste: a terminal sends a
+// bracketed paste as ONE KeyRunes message carrying every rune, newlines
+// included (bubbletea's detectBracketedPaste), so a pretty-printed credential
+// JSON arrives whole and its newlines never reach the Enter branch.
+func TestCredentialPasteModal_TakesAWholeBracketedPaste(t *testing.T) {
+	const json = "{\n  \"type\": \"authorized_user\",\n  \"client_id\": \"a\"\n}"
+	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "credential-json-set:vertex")
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(json), Paste: true})
+	if cmd != nil {
+		t.Fatalf("a paste must not submit or cancel; got %+v", cmd())
+	}
+	_, cmd = updated.(TextInputModal).Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("Enter after the paste should submit")
+	}
+	res, ok := cmd().(TextInputResultMsg)
+	if !ok {
+		t.Fatalf("cmd msg = %T, want TextInputResultMsg", cmd())
+	}
+	if res.Value != json || res.Cancelled {
+		t.Fatalf("Value = %q cancelled=%t, want the paste verbatim", res.Value, res.Cancelled)
+	}
+}
+
+// TestCredentialPasteModal_SummarizesASecretAndShowsAPath: the field never
+// echoes a pasted credential, but a typed path stays visible so it can be
+// read and Tab-completed.
+func TestCredentialPasteModal_SummarizesASecretAndShowsAPath(t *testing.T) {
+	withTestColorProfile(t)
+	const json = "{\n  \"type\": \"service_account\",\n  \"private_key\": \"SECRET-MATERIAL\"\n}"
+	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "credential-json-set:vertex")
+	pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(json), Paste: true})
+	view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), "")
+	if strings.Contains(view, "SECRET-MATERIAL") || strings.Contains(view, "service_account") {
+		t.Fatalf("the pasted credential must never be echoed: %q", view)
+	}
+	if !strings.Contains(view, "characters") {
+		t.Fatalf("a pasted credential should render as a character count: %q", view)
+	}
+	if strings.Count(view, "\n") > strings.Count(ansiPattern.ReplaceAllString(m.View(), ""), "\n") {
+		t.Fatalf("a multi-line paste must not grow the overlay: %q", view)
+	}
+
+	const path = "~/.config/gcloud/application_default_credentials.json"
+	typed, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(path)})
+	if got := ansiPattern.ReplaceAllString(typed.(TextInputModal).View(), ""); !strings.Contains(got, path) {
+		t.Fatalf("a typed path must stay visible for editing and completion: %q", got)
+	}
+}
+
 func TestTextInputModal_EscapeCancels(t *testing.T) {
 	m := NewTextInputModal("x", "")
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})

--- a/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
@@ -65,32 +65,6 @@ func TestCredentialPasteModal_TakesAWholeBracketedPaste(t *testing.T) {
 	}
 }
 
-// TestCredentialPasteModal_SummarizesASecretAndShowsAPath: the field never
-// echoes a pasted credential, but a typed path stays visible so it can be
-// read and Tab-completed.
-func TestCredentialPasteModal_SummarizesASecretAndShowsAPath(t *testing.T) {
-	withTestColorProfile(t)
-	const json = "{\n  \"type\": \"service_account\",\n  \"private_key\": \"SECRET-MATERIAL\"\n}"
-	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "credential-json-set:vertex")
-	pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(json), Paste: true})
-	view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), "")
-	if strings.Contains(view, "SECRET-MATERIAL") || strings.Contains(view, "service_account") {
-		t.Fatalf("the pasted credential must never be echoed: %q", view)
-	}
-	if !strings.Contains(view, "characters") {
-		t.Fatalf("a pasted credential should render as a character count: %q", view)
-	}
-	if strings.Count(view, "\n") > strings.Count(ansiPattern.ReplaceAllString(m.View(), ""), "\n") {
-		t.Fatalf("a multi-line paste must not grow the overlay: %q", view)
-	}
-
-	const path = "~/.config/gcloud/application_default_credentials.json"
-	typed, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(path)})
-	if got := ansiPattern.ReplaceAllString(typed.(TextInputModal).View(), ""); !strings.Contains(got, path) {
-		t.Fatalf("a typed path must stay visible for editing and completion: %q", got)
-	}
-}
-
 // TestTextInputModal_CapturesSpaces: bubbletea delivers a space as KeySpace,
 // not KeyRunes, so a field that ignores it cannot hold a path like
 // "~/Google Drive/adc.json" — or any typed value with a space in it.
@@ -141,79 +115,40 @@ func TestCredentialPasteModal_AccumulatesAnUnbracketedLineFeedPaste(t *testing.T
 	}
 }
 
-// TestCredentialPasteModal_SummarizesEveryCredentialAndShowsLongPaths: what
-// must never be echoed is a credential document, and every document the hub
-// accepts is a JSON object — so the rule keys on that, not on a length whose
-// margin over the shortest acceptable document was two runes. A path stays
-// visible however long it is.
-func TestCredentialPasteModal_SummarizesEveryCredentialAndShowsLongPaths(t *testing.T) {
-	withTestColorProfile(t)
-	// The shortest document CheckCredentialJSON accepts: an allowed type plus
-	// its three required fields at one character each.
-	const shortest = `{"type":"authorized_user","client_id":"a","client_secret":"b","refresh_token":"c"}`
-	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "t")
-	pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(shortest), Paste: true})
-	if view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), ""); strings.Contains(view, "authorized_user") {
-		t.Fatalf("the shortest acceptable credential must still be summarized: %q", view)
-	}
-	// Longer than any threshold a length rule would use, and still a path.
-	// The overlay wraps it, so the tail is what proves it was not summarized.
-	const longPath = "/Users/somebody/Library/Application Support/gcloud/application_default_credentials.json"
-	typed, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(longPath)})
-	view := ansiPattern.ReplaceAllString(typed.(TextInputModal).View(), "")
-	if strings.Contains(view, "characters pasted") || !strings.Contains(view, "application_default_credentials.json") {
-		t.Fatalf("a long path must stay visible: %q", view)
-	}
-}
-
-// TestCredentialPasteModal_SummarizesAnythingPasted: the shape rule keeps a
-// typed path visible, and the terminal already says which input was a paste —
-// so a secret pasted into this prompt by mistake, whatever its shape or
-// length, is summarized too.
-func TestCredentialPasteModal_SummarizesAnythingPasted(t *testing.T) {
-	withTestColorProfile(t)
-	const wrongSecret = "sk-ant-api03-SECRET-MATERIAL-pasted-into-the-credential-json-prompt-by-mistake"
-	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "t")
-	pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(wrongSecret), Paste: true})
-	view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), "")
-	if strings.Contains(view, "SECRET-MATERIAL") {
-		t.Fatalf("anything pasted must be summarized, whatever its shape: %q", view)
-	}
-	// A paste stays summarized as the user edits around it.
-	trimmed, _ := pasted.(TextInputModal).Update(tea.KeyMsg{Type: tea.KeyBackspace})
-	if view := ansiPattern.ReplaceAllString(trimmed.(TextInputModal).View(), ""); strings.Contains(view, "SECRET-MATERIAL") {
-		t.Fatalf("editing a pasted value must not reveal it: %q", view)
-	}
-}
-
-// TestCredentialPasteModal_ShowsOnlyWhatLooksLikeAPath: a terminal without
-// bracketed paste marks nothing as pasted, so the field cannot tell a pasted
-// secret from a typed one. It shows what looks like a path and summarizes
-// everything else, which is the side to err on in a credential prompt.
-func TestCredentialPasteModal_ShowsOnlyWhatLooksLikeAPath(t *testing.T) {
+// TestCredentialPasteModal_NeverEchoesWhateverItIsGiven: the prompt asks for
+// one thing, a credential document, so it echoes nothing at all. Whether a
+// value was pasted or typed cannot be told apart on a terminal that marks no
+// pastes, and guessing from its shape is what this replaces; a path goes to
+// the separate file prompt, which has nothing secret to hide.
+func TestCredentialPasteModal_NeverEchoesWhateverItIsGiven(t *testing.T) {
 	withTestColorProfile(t)
 	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "t")
-	for _, tt := range []struct {
-		name, typed string
-		shown       bool
-	}{
-		{name: "absolute path", typed: "/home/somebody/adc.json", shown: true},
-		{name: "home path", typed: "~/.config/gcloud/adc.json", shown: true},
-		{name: "relative path", typed: "./adc.json", shown: true},
-		{name: "unmarked secret", typed: "sk-ant-api03-SECRET-MATERIAL-typed-without-a-paste-mark", shown: false},
+	for _, tt := range []struct{ name, typed string }{
+		{name: "document", typed: `{"type":"authorized_user","client_id":"a"}`},
+		{name: "unmarked secret", typed: "sk-ant-api03-SECRET-MATERIAL"},
+		{name: "secret shaped like a path", typed: "/9j/4AAQSkZJRgABAQAA-SECRET-MATERIAL"},
+		{name: "windows-shaped secret", typed: `C:\SECRET-MATERIAL`},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			typed, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tt.typed)})
 			view := ansiPattern.ReplaceAllString(typed.(TextInputModal).View(), "")
-			// The summary marker is the reliable signal: a long value is
-			// wrapped by the overlay, so searching for it whole can miss it.
-			if summarized := strings.Contains(view, "characters pasted"); summarized == tt.shown {
-				t.Fatalf("summarized = %t, want shown = %t for %q: %q", summarized, tt.shown, tt.typed, view)
-			}
-			if tt.shown && !strings.Contains(view, tt.typed) {
-				t.Fatalf("a path short enough to fit must render whole: %q", view)
+			if !strings.Contains(view, "characters") || strings.Contains(view, "SECRET-MATERIAL") || strings.Contains(view, "authorized_user") {
+				t.Fatalf("the credential prompt must echo nothing: %q", view)
 			}
 		})
+	}
+}
+
+// TestPathTextInputModal_ShowsThePath: the file prompt takes a path, which is
+// not secret, so it stays visible for editing and completion on any platform.
+func TestPathTextInputModal_ShowsThePath(t *testing.T) {
+	withTestColorProfile(t)
+	for _, path := range []string{"~/.config/gcloud/adc.json", `C:\Users\somebody\adc.json`, `\\server\share\adc.json`} {
+		m := NewPathTextInputModal("path:", "t", "")
+		typed, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(path)})
+		if view := ansiPattern.ReplaceAllString(typed.(TextInputModal).View(), ""); !strings.Contains(view, path) {
+			t.Fatalf("a typed path must stay visible: %q", view)
+		}
 	}
 }
 

--- a/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
@@ -153,14 +153,29 @@ func TestPathTextInputModal_ShowsThePath(t *testing.T) {
 }
 
 // TestTextInputModal_DoesNotRenderControlBytes: clipboard content reaches the
-// view, so an escape sequence in it must not reach the terminal.
+// view, so nothing a terminal would obey may reach it — the C1 block included,
+// where U+009B is CSI and U+009D is OSC, each a control introducer in its own
+// right rather than part of an escape sequence. The file prompt is the one
+// that renders what it is given, so it is the one tested.
 func TestTextInputModal_DoesNotRenderControlBytes(t *testing.T) {
 	withTestColorProfile(t)
-	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "t")
-	pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("adc\x1b[2J\x00.json"), Paste: true})
-	view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), "")
-	if strings.ContainsAny(view, "\x1b\x00") {
-		t.Fatalf("control bytes must not be rendered: %q", view)
+	for _, tt := range []struct{ name, pasted string }{
+		{name: "C0 and DEL", pasted: "adc\x1b[2J\x00\x7f.json"},
+		{name: "C1 introducers", pasted: "adc\u009b2J\u009d0;x\a.json"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewPathTextInputModal("path:", "t", "")
+			pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tt.pasted), Paste: true})
+			view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), "")
+			for _, r := range view {
+				if r < 0x20 && r != '\n' || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+					t.Fatalf("view carries control character %U: %q", r, view)
+				}
+			}
+			if !strings.Contains(view, "adc") || !strings.Contains(view, ".json") {
+				t.Fatalf("the printable part of the value must survive: %q", view)
+			}
+		})
 	}
 }
 

--- a/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
+++ b/cmd/evener-tui/internal/tuipick/text_input_modal_test.go
@@ -91,6 +91,113 @@ func TestCredentialPasteModal_SummarizesASecretAndShowsAPath(t *testing.T) {
 	}
 }
 
+// TestTextInputModal_CapturesSpaces: bubbletea delivers a space as KeySpace,
+// not KeyRunes, so a field that ignores it cannot hold a path like
+// "~/Google Drive/adc.json" — or any typed value with a space in it.
+func TestTextInputModal_CapturesSpaces(t *testing.T) {
+	m := NewTextInputModal("path:", "")
+	var updated tea.Model = m
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("~/Google")},
+		{Type: tea.KeySpace},
+		{Type: tea.KeyRunes, Runes: []rune("Drive/adc.json")},
+	} {
+		updated, _ = updated.(TextInputModal).Update(key)
+	}
+	_, cmd := updated.(TextInputModal).Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := cmd().(TextInputResultMsg).Value; got != "~/Google Drive/adc.json" {
+		t.Fatalf("Value = %q, want the space kept", got)
+	}
+}
+
+// TestCredentialPasteModal_AccumulatesAnUnbracketedLineFeedPaste: a terminal
+// that does not bracket its pastes sends the document as ordinary keys, and
+// bubbletea maps LF to KeyCtrlJ (only CR is KeyEnter). The credential field
+// keeps those newlines and their spaces, so such a paste still arrives whole
+// and only the user's own Enter submits it.
+func TestCredentialPasteModal_AccumulatesAnUnbracketedLineFeedPaste(t *testing.T) {
+	const document = "{\n  \"type\": \"authorized_user\",\n  \"client_id\": \"a\"\n}"
+	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "credential-json-set:vertex")
+	var updated tea.Model = m
+	for _, r := range document {
+		var key tea.KeyMsg
+		switch r {
+		case '\n':
+			key = tea.KeyMsg{Type: tea.KeyCtrlJ}
+		case ' ':
+			key = tea.KeyMsg{Type: tea.KeySpace}
+		default:
+			key = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}
+		}
+		var cmd tea.Cmd
+		updated, cmd = updated.(TextInputModal).Update(key)
+		if cmd != nil {
+			t.Fatalf("no key of an unbracketed paste may submit; %q did", string(r))
+		}
+	}
+	_, cmd := updated.(TextInputModal).Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if got := cmd().(TextInputResultMsg).Value; got != document {
+		t.Fatalf("Value = %q, want the document intact", got)
+	}
+}
+
+// TestCredentialPasteModal_SummarizesEveryCredentialAndShowsLongPaths: what
+// must never be echoed is a credential document, and every document the hub
+// accepts is a JSON object — so the rule keys on that, not on a length whose
+// margin over the shortest acceptable document was two runes. A path stays
+// visible however long it is.
+func TestCredentialPasteModal_SummarizesEveryCredentialAndShowsLongPaths(t *testing.T) {
+	withTestColorProfile(t)
+	// The shortest document CheckCredentialJSON accepts: an allowed type plus
+	// its three required fields at one character each.
+	const shortest = `{"type":"authorized_user","client_id":"a","client_secret":"b","refresh_token":"c"}`
+	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "t")
+	pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(shortest), Paste: true})
+	if view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), ""); strings.Contains(view, "authorized_user") {
+		t.Fatalf("the shortest acceptable credential must still be summarized: %q", view)
+	}
+	// Longer than any threshold a length rule would use, and still a path.
+	// The overlay wraps it, so the tail is what proves it was not summarized.
+	const longPath = "/Users/somebody/Library/Application Support/gcloud/application_default_credentials.json"
+	typed, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(longPath)})
+	view := ansiPattern.ReplaceAllString(typed.(TextInputModal).View(), "")
+	if strings.Contains(view, "characters pasted") || !strings.Contains(view, "application_default_credentials.json") {
+		t.Fatalf("a long path must stay visible: %q", view)
+	}
+}
+
+// TestCredentialPasteModal_SummarizesAnythingPasted: the shape rule keeps a
+// typed path visible, and the terminal already says which input was a paste —
+// so a secret pasted into this prompt by mistake, whatever its shape or
+// length, is summarized too.
+func TestCredentialPasteModal_SummarizesAnythingPasted(t *testing.T) {
+	withTestColorProfile(t)
+	const wrongSecret = "sk-ant-api03-SECRET-MATERIAL-pasted-into-the-credential-json-prompt-by-mistake"
+	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "t")
+	pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(wrongSecret), Paste: true})
+	view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), "")
+	if strings.Contains(view, "SECRET-MATERIAL") {
+		t.Fatalf("anything pasted must be summarized, whatever its shape: %q", view)
+	}
+	// A paste stays summarized as the user edits around it.
+	trimmed, _ := pasted.(TextInputModal).Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	if view := ansiPattern.ReplaceAllString(trimmed.(TextInputModal).View(), ""); strings.Contains(view, "SECRET-MATERIAL") {
+		t.Fatalf("editing a pasted value must not reveal it: %q", view)
+	}
+}
+
+// TestTextInputModal_DoesNotRenderControlBytes: clipboard content reaches the
+// view, so an escape sequence in it must not reach the terminal.
+func TestTextInputModal_DoesNotRenderControlBytes(t *testing.T) {
+	withTestColorProfile(t)
+	m := NewCredentialPasteModal("Credential JSON", "Paste it:", "t")
+	pasted, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("adc\x1b[2J\x00.json"), Paste: true})
+	view := ansiPattern.ReplaceAllString(pasted.(TextInputModal).View(), "")
+	if strings.ContainsAny(view, "\x1b\x00") {
+		t.Fatalf("control bytes must not be rendered: %q", view)
+	}
+}
+
 func TestTextInputModal_EscapeCancels(t *testing.T) {
 	m := NewTextInputModal("x", "")
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -518,8 +518,7 @@ else → `{loc}-aiplatform.googleapis.com`. `auth = gcp-adc`: application-defaul
 credentials on the host, or a **credential JSON stored under the instance
 name** (a service-account key or an `application_default_credentials.json`,
 pasted in the hub's instance sheet, pasted into the TUI's credentials panel
-with Enter on the instance — which also takes the path to the file, for a
-terminal whose unbracketed pastes would submit at each line — or written
+with Enter on the instance or read from a file with `f` there, or written
 into `credentials.toml`; other credential types, such as `external_account`,
 are refused), which outranks the ADC file. Requests authenticated with user credentials — an
 `authorized_user` ADC file or a stored `authorized_user` JSON — carry

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -517,9 +517,11 @@ tracked as
 else → `{loc}-aiplatform.googleapis.com`. `auth = gcp-adc`: application-default
 credentials on the host, or a **credential JSON stored under the instance
 name** (a service-account key or an `application_default_credentials.json`,
-pasted in the hub's instance sheet or written into `credentials.toml`;
-other credential types, such as `external_account`, are refused), which
-outranks the ADC file. Requests authenticated with user credentials — an
+pasted in the hub's instance sheet, pasted into the TUI's credentials panel
+with Enter on the instance — which also takes the path to the file, for a
+terminal that does not bracket its pastes — or written into
+`credentials.toml`; other credential types, such as `external_account`, are
+refused), which outranks the ADC file. Requests authenticated with user credentials — an
 `authorized_user` ADC file or a stored `authorized_user` JSON — carry
 `x-goog-user-project` = `GOOGLE_VERTEX_PROJECT`, which such credentials need
 for calls that have no project in their path (the model listing).

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -519,9 +519,9 @@ credentials on the host, or a **credential JSON stored under the instance
 name** (a service-account key or an `application_default_credentials.json`,
 pasted in the hub's instance sheet, pasted into the TUI's credentials panel
 with Enter on the instance — which also takes the path to the file, for a
-terminal that does not bracket its pastes — or written into
-`credentials.toml`; other credential types, such as `external_account`, are
-refused), which outranks the ADC file. Requests authenticated with user credentials — an
+terminal whose unbracketed pastes would submit at each line — or written
+into `credentials.toml`; other credential types, such as `external_account`,
+are refused), which outranks the ADC file. Requests authenticated with user credentials — an
 `authorized_user` ADC file or a stored `authorized_user` JSON — carry
 `x-goog-user-project` = `GOOGLE_VERTEX_PROJECT`, which such credentials need
 for calls that have no project in their path (the model listing).

--- a/docs/superpowers/specs/2026-05-29-provider-instances-phase-2-ui.md
+++ b/docs/superpowers/specs/2026-05-29-provider-instances-phase-2-ui.md
@@ -23,7 +23,10 @@ the credential source-layers (reusing today's oauth>file>env shadowing), and act
 A per-type `[+ add instance]` opens an inline form: name, apiStyle (openai only),
 base_url, credential (later / API key / OAuth). **TUI** (`credentials_panel.go`): the
 same data as a grouped key-driven list — `↑↓` move, `enter` set key, `o` oauth, `c`
-clear, `n` new, `e` edit, `x` remove, `*` default, `esc` close.
+clear, `n` new, `e` edit, `x` remove, `*` default, `esc` close. (Amended
+2026-09-06: Enter sets whichever credential the instance's auth modes offer —
+an API key, or a pasted Google credential JSON for a `gcp-adc` instance — so
+its hint reads "set credential".)
 
 ## 3. Data contract (`internal/appwire/types.go`)
 

--- a/docs/superpowers/specs/2026-05-29-provider-instances-phase-2-ui.md
+++ b/docs/superpowers/specs/2026-05-29-provider-instances-phase-2-ui.md
@@ -26,7 +26,8 @@ same data as a grouped key-driven list — `↑↓` move, `enter` set key, `o` o
 clear, `n` new, `e` edit, `x` remove, `*` default, `esc` close. (Amended
 2026-09-06: Enter sets whichever credential the instance's auth modes offer —
 an API key, or a pasted Google credential JSON for a `gcp-adc` instance — so
-its hint reads "set credential".)
+its hint reads "set credential"; `f` reads that credential JSON from a file
+instead.)
 
 ## 3. Data contract (`internal/appwire/types.go`)
 

--- a/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
+++ b/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
@@ -372,16 +372,17 @@ Without bracketing, the document arrives as ordinary keys, and the outcome
 turns on which byte the terminal sends for a line break: LF maps to
 `KeyCtrlJ`, CR to `KeyEnter`. The field keeps both LF and space (it dropped
 them before), so an LF paste still accumulates whole. A CR paste submits at
-each line and cannot work; the prompt therefore also accepts the path to the
-file holding the document, read on the machine the user typed it on, not the
-hub's, with the field's path completion.
+each line and cannot work, which is one of two reasons for the second way in:
+`f` on the instance asks for the path to the file holding the document, read
+on the machine the user typed it on, not the hub's, with path completion.
 
-The field shows what looks like a path — a value beginning `/`, `~`, or `.`
-that the terminal did not report as a paste — and renders everything else as
-a character count. That way no credential material is echoed: a document is
-a JSON object, a paste is marked as one where the terminal supports it, and
-where it does not, a value that is not path-shaped is treated as material to
-keep off the screen. A path stays visible however long it is.
+The other reason is that the two inputs cannot be told apart. Reading them
+through one prompt meant guessing whether a value was a path or the
+credential — by shape, or by whether the terminal marked it as a paste — and
+a terminal that marks no pastes leaves no signal to guess from. So the paste
+prompt echoes nothing at all: it renders a character count, whatever it is
+given. The file prompt shows its path, which is not secret, on any platform's
+path syntax.
 Control bytes are stripped from what is rendered, since clipboard content
 reaches the view. A value that is neither a document nor a readable path is
 reported by its reason alone: the error line is rendered and outlives the
@@ -389,11 +390,12 @@ panel, so it repeats none of what was submitted. For the same reason
 `CheckCredentialJSON` bounds the two values its refusals quote back (an
 unsupported `type`, a foreign `token_uri`) to a short prefix.
 
-The path is read on the update loop, where a read that never returns stops
-the interface responding and one that never ends exhausts the process. So it
-is opened without blocking, judged by what the open descriptor actually is —
-a regular file, nothing else — and read through a bound. Checking the path
-and then opening it by name again would leave a window for it to become
+The file is read inside the command rather than while the key is handled, so
+a slow filesystem cannot hold up the interface. It is still opened without
+blocking, so a path naming a pipe cannot leave that command waiting forever
+either; what the open descriptor actually is decides whether it is read — a
+regular file, nothing else — and the read is bounded. Checking the path and
+then opening it by name again would leave a window for it to become
 something else in between.
 
 ## 5. End-to-end flows the hub must support after this change

--- a/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
+++ b/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
@@ -385,7 +385,14 @@ any shape pasted here by mistake.
 Control bytes are stripped from what is rendered, since clipboard content
 reaches the view. A value that is neither a document nor a readable path is
 reported by its reason alone: the error line is rendered and outlives the
-panel, so it repeats none of what was submitted.
+panel, so it repeats none of what was submitted. For the same reason
+`CheckCredentialJSON` bounds the two values its refusals quote back (an
+unsupported `type`, a foreign `token_uri`) to a short prefix.
+
+The path is read on the update loop, so what it names is checked before it is
+opened: only a regular file under a bounded size is read. Reading a pipe
+would never return and the interface would stop responding; reading a
+character device would grow until the process died.
 
 ## 5. End-to-end flows the hub must support after this change
 

--- a/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
+++ b/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
@@ -355,6 +355,23 @@ naming the instance and "stored credential".
 None. The `evener providers` commands are untouched; the docs note that the
 same value can be placed in `credentials.toml` by hand.
 
+### 4.6 TUI (amended 2026-09-06)
+
+Originally out of scope: the credentials panel had no multi-line input, so
+Enter on a `credentialJson` instance showed a notice naming the web hub as
+the place to paste (roborev round 9 of PR #879). That notice is gone. Enter
+now opens a paste prompt and stores the document through the same
+`evener/auth/credentialJson/set` the hub calls.
+
+A terminal delivers a bracketed paste as one key message carrying every
+rune, newlines included, so a pretty-printed JSON document arrives whole and
+its newlines never reach the submit branch. The prompt also accepts the path
+to the file holding the document, which is how a terminal that does not
+bracket its pastes gets one in; the path is read on the machine the user
+typed it on, not the hub's, and the field keeps path completion for it. The
+field never echoes pasted material — it renders as a character count — while
+a typed path stays visible.
+
 ## 5. End-to-end flows the hub must support after this change
 
 1. **Express key.** Settings → Credentials → Add provider instance → base

--- a/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
+++ b/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
@@ -376,12 +376,12 @@ each line and cannot work; the prompt therefore also accepts the path to the
 file holding the document, read on the machine the user typed it on, not the
 hub's, with the field's path completion.
 
-The field never echoes credential material — anything the terminal reports as
-a paste, anything starting with `{`, and anything containing a line break,
-renders as a character count — while a typed path stays visible however long
-it is. Every document the hub accepts is a JSON object, so those tests cover
-them all without a length threshold, and the paste mark covers a secret of
-any shape pasted here by mistake.
+The field shows what looks like a path — a value beginning `/`, `~`, or `.`
+that the terminal did not report as a paste — and renders everything else as
+a character count. That way no credential material is echoed: a document is
+a JSON object, a paste is marked as one where the terminal supports it, and
+where it does not, a value that is not path-shaped is treated as material to
+keep off the screen. A path stays visible however long it is.
 Control bytes are stripped from what is rendered, since clipboard content
 reaches the view. A value that is neither a document nor a readable path is
 reported by its reason alone: the error line is rendered and outlives the
@@ -389,10 +389,12 @@ panel, so it repeats none of what was submitted. For the same reason
 `CheckCredentialJSON` bounds the two values its refusals quote back (an
 unsupported `type`, a foreign `token_uri`) to a short prefix.
 
-The path is read on the update loop, so what it names is checked before it is
-opened: only a regular file under a bounded size is read. Reading a pipe
-would never return and the interface would stop responding; reading a
-character device would grow until the process died.
+The path is read on the update loop, where a read that never returns stops
+the interface responding and one that never ends exhausts the process. So it
+is opened without blocking, judged by what the open descriptor actually is —
+a regular file, nothing else — and read through a bound. Checking the path
+and then opening it by name again would leave a window for it to become
+something else in between.
 
 ## 5. End-to-end flows the hub must support after this change
 

--- a/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
+++ b/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
@@ -365,12 +365,27 @@ now opens a paste prompt and stores the document through the same
 
 A terminal delivers a bracketed paste as one key message carrying every
 rune, newlines included, so a pretty-printed JSON document arrives whole and
-its newlines never reach the submit branch. The prompt also accepts the path
-to the file holding the document, which is how a terminal that does not
-bracket its pastes gets one in; the path is read on the machine the user
-typed it on, not the hub's, and the field keeps path completion for it. The
-field never echoes pasted material — it renders as a character count — while
-a typed path stays visible.
+its newlines never reach the submit branch. Measured against bubbletea's own
+reader, that holds at every size tried, up to 100k runes.
+
+Without bracketing, the document arrives as ordinary keys, and the outcome
+turns on which byte the terminal sends for a line break: LF maps to
+`KeyCtrlJ`, CR to `KeyEnter`. The field keeps both LF and space (it dropped
+them before), so an LF paste still accumulates whole. A CR paste submits at
+each line and cannot work; the prompt therefore also accepts the path to the
+file holding the document, read on the machine the user typed it on, not the
+hub's, with the field's path completion.
+
+The field never echoes credential material — anything the terminal reports as
+a paste, anything starting with `{`, and anything containing a line break,
+renders as a character count — while a typed path stays visible however long
+it is. Every document the hub accepts is a JSON object, so those tests cover
+them all without a length threshold, and the paste mark covers a secret of
+any shape pasted here by mistake.
+Control bytes are stripped from what is rendered, since clipboard content
+reaches the view. A value that is neither a document nor a readable path is
+reported by its reason alone: the error line is rendered and outlives the
+panel, so it repeats none of what was submitted.
 
 ## 5. End-to-end flows the hub must support after this change
 

--- a/llm/registry/credential_json.go
+++ b/llm/registry/credential_json.go
@@ -56,6 +56,23 @@ func CredentialJSONType(raw []byte) string {
 // resolves; the tokenauth authenticator and the hub's
 // evener/auth/credentialJson/set run the identical check, so a value the
 // registry resolves is one the authenticator will accept.
+//
+// A refusal that quotes the value it refused bounds what it quotes
+// (clipEcho): the document may be anything a user pasted, and callers render
+// the message.
+//
+// clipEcho shows enough of a refused value to identify it and no more. The
+// TUI's credential prompt keeps such a message on screen after the prompt
+// closes, so an unbounded echo would put a mistakenly pasted secret there.
+func clipEcho(s string) string {
+	const limit = 40
+	r := []rune(s)
+	if len(r) <= limit {
+		return s
+	}
+	return string(r[:limit]) + "…"
+}
+
 func CheckCredentialJSON(raw []byte) error {
 	if !json.Valid(raw) {
 		return errors.New("not valid JSON")
@@ -65,7 +82,7 @@ func CheckCredentialJSON(raw []byte) error {
 		return errors.New(`credential JSON has no "type" field`)
 	}
 	if !AllowedCredentialJSONTypes[t] {
-		return fmt.Errorf("credential type %q is not supported: paste a service-account key or an authorized_user file", t)
+		return fmt.Errorf("credential type %q is not supported: paste a service-account key or an authorized_user file", clipEcho(t))
 	}
 	// Every field the gate reads is decoded through a tagged field, the way
 	// Google's library reads it: key names match case-insensitively and the
@@ -113,7 +130,7 @@ func CheckCredentialJSON(raw []byte) error {
 	if isJSONValue(cred.TokenURL) {
 		var s string
 		if json.Unmarshal(cred.TokenURL, &s) != nil || !googleTokenEndpoints[s] {
-			return fmt.Errorf("token_uri %s is not Google's OAuth token endpoint", string(cred.TokenURL))
+			return fmt.Errorf("token_uri %s is not Google's OAuth token endpoint", clipEcho(string(cred.TokenURL)))
 		}
 	}
 	// Google's parser decodes its whole credential file, every type's fields

--- a/llm/registry/credential_json.go
+++ b/llm/registry/credential_json.go
@@ -61,14 +61,23 @@ func CredentialJSONType(raw []byte) string {
 // (clipEcho): the document may be anything a user pasted, and callers render
 // the message.
 //
-// clipEcho shows enough of a refused value to identify it and no more. The
-// TUI's credential prompt keeps such a message on screen after the prompt
-// closes, so an unbounded echo would put a mistakenly pasted secret there.
+// clipEcho shows enough of a refused value to identify it and no more, with
+// nothing in it a terminal would obey. The TUI's credential prompt keeps such
+// a message on screen after the prompt closes, so an unbounded echo would put
+// a mistakenly pasted secret there; and JSON carries control characters raw
+// above U+001F, C1 among them (U+009B is CSI), which a terminal reads as the
+// start of a command rather than as text.
 func clipEcho(s string) string {
 	const limit = 40
-	r := []rune(s)
+	safe := strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			return -1
+		}
+		return r
+	}, s)
+	r := []rune(safe)
 	if len(r) <= limit {
-		return s
+		return safe
 	}
 	return string(r[:limit]) + "…"
 }

--- a/llm/registry/credential_json_test.go
+++ b/llm/registry/credential_json_test.go
@@ -216,6 +216,45 @@ func TestCredentialJSONType(t *testing.T) {
 	}
 }
 
+// TestCheckCredentialJSONBoundsWhatItEchoes: two refusals name the value
+// they refused, and callers render those messages — the TUI keeps one on
+// screen after its prompt closes. A document pasted by mistake can carry
+// anything in those fields, so the message shows enough of the value to
+// identify it and no more.
+func TestCheckCredentialJSONBoundsWhatItEchoes(t *testing.T) {
+	long := strings.Repeat("S", 400)
+	for _, tt := range []struct {
+		name, raw, want string
+	}{
+		{
+			name: "unsupported type",
+			raw:  `{"type":"` + long + `"}`,
+			want: "is not supported",
+		},
+		{
+			name: "foreign token_uri",
+			raw:  `{"type":"authorized_user","client_id":"a","client_secret":"b","refresh_token":"c","token_uri":"https://attacker.example/` + long + `"}`,
+			want: "is not Google's OAuth token endpoint",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckCredentialJSON([]byte(tt.raw))
+			if err == nil {
+				t.Fatal("want a refusal")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("err = %q, want it to say %q", err, tt.want)
+			}
+			if strings.Contains(err.Error(), long) {
+				t.Fatalf("err repeats the whole value: %q", err)
+			}
+			if len(err.Error()) > 200 {
+				t.Fatalf("err is %d bytes, want a bounded message: %q", len(err.Error()), err)
+			}
+		})
+	}
+}
+
 // testServiceAccountJSON returns a service_account credential JSON whose
 // private_key is a freshly generated PKCS#8 RSA key, so no key material
 // lives in the repository. llm/registry and llm/providers/tokenauth share no

--- a/llm/registry/credential_json_test.go
+++ b/llm/registry/credential_json_test.go
@@ -255,6 +255,32 @@ func TestCheckCredentialJSONBoundsWhatItEchoes(t *testing.T) {
 	}
 }
 
+// TestCheckCredentialJSONEchoesNothingATerminalWouldObey: the values these
+// refusals quote are rendered — the TUI puts one on its error line — and JSON
+// may carry control characters raw, C1 among them, which a terminal reads as
+// commands. None survives into the message.
+func TestCheckCredentialJSONEchoesNothingATerminalWouldObey(t *testing.T) {
+	// U+009B is CSI: a terminal treats it as the start of a control sequence.
+	// Raw in a JSON string it is legal, since JSON only requires escaping
+	// below U+0020.
+	for _, tt := range []struct{ name, raw string }{
+		{name: "type", raw: "{\"type\":\"bad\u009b2Jstill-bad\"}"},
+		{name: "token_uri", raw: "{\"type\":\"authorized_user\",\"client_id\":\"a\",\"client_secret\":\"b\",\"refresh_token\":\"c\",\"token_uri\":\"https://x.example/\u009b2J\u0085\"}"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckCredentialJSON([]byte(tt.raw))
+			if err == nil {
+				t.Fatal("want a refusal")
+			}
+			for _, r := range err.Error() {
+				if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+					t.Fatalf("err carries control character %U: %q", r, err)
+				}
+			}
+		})
+	}
+}
+
 // testServiceAccountJSON returns a service_account credential JSON whose
 // private_key is a freshly generated PKCS#8 RSA key, so no key material
 // lives in the repository. llm/registry and llm/providers/tokenauth share no


### PR DESCRIPTION
The TUI's credentials panel could not store a Google credential JSON. Enter on a `gcp-adc` instance showed a notice telling the user to go paste it in the web hub, because the panel had no multi-line input. It has one now.

## How a single-line field takes a multi-line document

A terminal delivers a bracketed paste as **one** key message carrying every rune, newlines included (bubbletea's `detectBracketedPaste`, v1.3.10), and the TUI does not disable bracketed paste. So a pretty-printed `application_default_credentials.json` arrives whole and its newlines never reach the branch that submits the prompt. Enter on a `credentialJson` instance opens that prompt and stores what it collects through `evener/auth/credentialJson/set`, the same RPC the web hub calls, so both surfaces write the same store and the hub validates the document before it lands.

Without bracketing, the document arrives as ordinary keys, and the outcome turns on which byte the terminal sends for a line break: LF maps to `ctrl+j`, CR to `enter`. The field now keeps both LF and space, which it dropped before, so an LF paste still accumulates whole and only the user's own Enter submits it. A CR paste submits at each line and cannot work, which is one reason for the second way in.

The other reason is that the two inputs cannot be told apart. `f` on the instance asks for the path to the file holding the document, read on the machine the user typed it on, not the hub's, with path completion. Serving both through one prompt would mean guessing whether a value was a path or the credential, and a terminal that marks no pastes leaves no signal to guess from. So the paste prompt echoes nothing at all, rendering a character count whatever it is handed, and the file prompt shows its path, which is not secret, in any platform's path syntax. The file is read inside the command rather than while the key is handled, so a slow filesystem cannot stall the interface, and it is opened without blocking so a path naming a pipe cannot leave that command waiting forever. What the open descriptor actually is decides whether it is read, and the read is bounded. Control bytes are stripped from the rendered value, since clipboard content reaches the view. A value that is neither a document nor a readable path is reported by its reason alone: the error line is rendered and outlives the panel, so it repeats none of what was submitted.

## Changes

- `credentials_panel.go`: Enter on a `credentialJson` instance emits the credential-JSON action; the notice fields, their clearing and their rendering are deleted. The footer hint reads "set credential", since Enter now sets whichever credential the instance offers.
- `text_input_modal.go`: `NewCredentialPasteModal`, which summarizes pasted material and keeps path completion.
- `hub_update_config.go`: opens the prompt for the new action; `credentialJSONDocument` resolves paste-or-path; the result routes to the credential-JSON store.
- `launchconfig_client.go`: `CmdAuthCredentialJsonSet`.

## Tests

`text_input_modal_test.go` covers a whole bracketed paste accumulating without submitting, an unbracketed line-feed paste accumulating the same way with its spaces and newlines intact, spaces being typable, the shortest document the hub accepts still being summarized, a long path staying visible, and control bytes not reaching the view. `credentials_panel_test.go` covers the action for a `credentialJson` instance and silence for an `adc`-only one. `hub_credential_json_test.go` covers the prompt, a pasted document reaching the hub verbatim, a path being read (with surrounding whitespace), a failure repeating none of what was submitted, and cancel/empty storing nothing. The paste branch, the file-read branch and the error's redaction were each mutated away to confirm the tests bite.

The second commit is the fix round for a review of the first: it found that the failure path printed the submitted value into a rendered error line that outlives the panel, that the field silently dropped spaces and line feeds, that the no-echo rule's length threshold had a two-rune margin over the shortest acceptable credential, and that control bytes reached the view. The review also confirmed the single-message paste behaviour empirically at 101, 401, 5,101 and 100,101 runes.

Docs: the Vertex paragraph in `docs/llm-providers.md`, a new §4.6 amendment in the Vertex spec recording that the notice is superseded, and a keybinding amendment in the phase-2 UI spec.

https://claude.ai/code/session_01KqwE2HUhZDJvbqhmKPv5xz
