### PR TITLE
fix(agent): settle a child's abandoned environments by disposition

### DIFF
--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -521,7 +521,7 @@ func (s *Session) close(ctx context.Context, cleanupEnv bool) {
 			// does not cover: worktreeRestoreEnv holds only the launch
 			// environment, so a switch leaves the clone it came from reachable
 			// from nothing.
-			s.retainAbandonedEnvironmentScratch()
+			s.settleAbandonedEnvironmentScratch(retainChildScratch)
 		}
 
 		// SessionEnd hooks (best-effort, bounded timeout)
@@ -606,28 +606,33 @@ func (s *Session) recordAbandonedEnvironmentLocked(prior, next *execenv.LocalExe
 	s.abandonedEnvs = append(s.abandonedEnvs, prior)
 }
 
-// retainAbandonedEnvironmentScratch releases the leases of every scratch the
-// environments this session swapped away from still own, keeping the
-// directories for the handoff, and retires their file-tool layers through the
-// drain — RetainSessionScratch does both.
+// settleAbandonedEnvironmentScratch settles the scratch every environment this
+// session swapped away from still owns, under the same disposition as the
+// environment the session holds now: a handoff releases the leases and keeps
+// the directories, a discard drops both. Neither settlement runs Cleanup, so
+// no process table is touched.
 //
-// close calls it after the current environment's Cleanup, for the same reason
-// the parked environment's retain runs there: an abandoned environment shares
-// the current clone's process table, so its processes are already reaped and
-// running Cleanup on it would reap that table a second time. What is left on
-// it is what a shared child minted after the session moved on, which nothing
-// else will ever release. teardownChildSession also calls it, unconditionally
-// and without a Cleanup of its own: a session whose environment is its live
-// parent's own never runs cleanupEnv at all, so this is the only place that
-// ever drains a worktree clone such a child built for itself and then swapped
-// away from.
-func (s *Session) retainAbandonedEnvironmentScratch() {
+// close calls it (always a handoff) after the current environment's Cleanup,
+// for the same reason the parked environment's retain runs there: an abandoned
+// environment shares the current clone's process table, so its processes are
+// already reaped and running Cleanup on it would reap that table a second
+// time. What is left on it is what a shared child minted after the session
+// moved on, which nothing else will ever release. teardownChildSession also
+// calls it: a session whose environment is its live parent's own never runs
+// cleanupEnv at all, so this is the only place that ever drains a worktree
+// clone such a child built for itself and then swapped away from. It passes
+// its own disposition for symmetry with the current environment — the scratch
+// of a child being dropped is dropped wherever it sits. No production caller
+// reaches the discard side with a swapped child today: only a manage_worktree
+// op records an abandoned environment, which takes a turn, and every teardown
+// that discards fires before the child's run loop starts.
+func (s *Session) settleAbandonedEnvironmentScratch(scratch childScratchDisposition) {
 	s.mu.Lock()
 	abandoned := s.abandonedEnvs
 	s.abandonedEnvs = nil
 	s.mu.Unlock()
 	for _, env := range abandoned {
-		env.RetainSessionScratch()
+		releaseOwnedChildEnvironment(env, scratch)
 	}
 }
 

--- a/agent/subagent_teardown_unix_test.go
+++ b/agent/subagent_teardown_unix_test.go
@@ -820,3 +820,72 @@ func TestSharedEnvChildInsideTheParentBoxKeepsTheParentScratchLease(t *testing.T
 		t.Errorf("the child's teardown released the box's scratch %s lease while the parent is still working in it", boxTmp)
 	}
 }
+
+// A child's teardown settles the environments it swapped away from under the
+// same disposition as the environment it still holds: a handoff keeps the
+// directories with their leases released, a discard drops both. The scratch of
+// a child being dropped is dropped wherever it sits.
+//
+// No production caller reaches the discard side with a swapped child — an
+// abandoned environment is recorded only by a manage_worktree op, which takes a
+// turn, and every teardown that discards fires before the child's run loop
+// starts — so this drives teardownChildSession directly rather than faking a
+// production path into it.
+func TestChildTeardownSettlesAbandonedEnvironmentsByDisposition(t *testing.T) {
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	parent := newSession(t, withClient(client), withDir(t.TempDir()), withoutGitSnapshot())
+	parentLocal, ok := parent.currentEnv().(*execenv.LocalExecutionEnvironment)
+	if !ok {
+		t.Fatalf("parent env = %T, want a local environment", parent.currentEnv())
+	}
+
+	// A child holding one environment it swapped away from, with the scratch a
+	// command minted there while it was still the child's own.
+	childWithAbandonedScratch := func(t *testing.T) (*Session, string) {
+		t.Helper()
+		child, err := NewSession(client, parent.currentProfile(), parentLocal.WithWorkingDirectory(t.TempDir()), SessionConfig{
+			MaxSubagentDepth: 1,
+			testOnly:         testConfig{skipGitSnapshot: true},
+		})
+		if err != nil {
+			t.Fatalf("NewSession on the child's clone: %v", err)
+		}
+		child.ownsEnv = true
+		abandoned := parentLocal.WithWorkingDirectory(t.TempDir())
+		if _, err := abandoned.ExecCommand(context.Background(), "true", 5000, "", nil); err != nil {
+			t.Fatalf("ExecCommand on the abandoned environment: %v", err)
+		}
+		scratch := abandoned.SessionScratchDir()
+		if scratch == "" {
+			t.Fatal("the abandoned environment minted no session scratch, so there is nothing to settle")
+		}
+		if !scratchLeaseHeld(t, scratch) {
+			t.Fatal("the abandoned environment's scratch lease is not held before the teardown")
+		}
+		child.mu.Lock()
+		child.abandonedEnvs = append(child.abandonedEnvs, abandoned)
+		child.mu.Unlock()
+		return child, scratch
+	}
+
+	discarded, discardedScratch := childWithAbandonedScratch(t)
+	t.Cleanup(func() { _ = os.RemoveAll(discardedScratch) })
+
+	teardownChildSession(context.Background(), discarded, disposeChildScratch)
+
+	if _, err := os.Stat(discardedScratch); !os.IsNotExist(err) {
+		t.Errorf("a discarded child's abandoned scratch %s survived its teardown (stat: %v), want it dropped with its lease", discardedScratch, err)
+	}
+
+	handed, handedScratch := childWithAbandonedScratch(t)
+	t.Cleanup(func() { _ = os.RemoveAll(handedScratch) })
+
+	teardownChildSession(context.Background(), handed, retainChildScratch)
+
+	if _, err := os.Stat(handedScratch); err != nil {
+		t.Errorf("a handed-off child's abandoned scratch %s was removed, want it kept for the handoff: %v", handedScratch, err)
+	} else if scratchLeaseHeld(t, handedScratch) {
+		t.Errorf("the handed-off child's abandoned scratch %s lease is still held after its teardown", handedScratch)
+	}
+}

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -219,10 +219,11 @@ func teardownChildSession(ctx context.Context, sess *Session, scratch childScrat
 	// Every entry is a clone the child built for itself by entering or switching
 	// worktrees and then swapped away from: no child close runs the cleanupEnv
 	// block that drains sess.abandonedEnvs, so this is the only teardown that
-	// reaches them. Retaining releases their leases without touching any process
-	// table — the parent's own object can never be in this list
-	// (recordAbandonedEnvironmentLocked excludes it by construction).
-	sess.retainAbandonedEnvironmentScratch()
+	// reaches them. They take the same disposition as the environment the child
+	// still holds, and neither settlement touches a process table. The parent's
+	// own object can never be in this list (recordAbandonedEnvironmentLocked
+	// excludes it by construction).
+	sess.settleAbandonedEnvironmentScratch(scratch)
 	releaseOwnedChildEnvironment(sess.environmentOwnedAtTeardown(), scratch)
 }
 


### PR DESCRIPTION
The review round for #928, which merged before the round landed. Nothing else
is in it: the branch is current main plus that one commit.

## What it closes

roborev's Low on `subagents.go:225` — `teardownChildSession` settled the
environments a child had swapped away from with a retain regardless of the
teardown's disposition, so a child being discarded left its abandoned scratch
directories behind.

## What changed

`retainAbandonedEnvironmentScratch` becomes
`settleAbandonedEnvironmentScratch(scratch childScratchDisposition)`: it drains
`abandonedEnvs` under `s.mu` as before and routes each entry through
`releaseOwnedChildEnvironment`, the same call that already settles the
environment the child still holds. A handoff releases the leases and keeps the
directories; a discard drops both. `teardownChildSession` passes its own
disposition, and `close`'s `cleanupEnv` block passes `retainChildScratch`
explicitly.

Neither settlement runs `Cleanup`, so no process table is touched — the
invariant on `teardownChildSession` still holds — and the parent's own
environment is excluded from the list exactly as before, by
`recordAbandonedEnvironmentLocked`.

## Reachability

The discard side has no production caller today, and the drain's doc comment
says so. An abandoned environment is recorded only by `recordAbandonedEnvironmentLocked`
← `swapEnvAndRefresh` ← `enterWorktree`/`exitWorktree` ← the five
`manage_worktree` op handlers, so the child must have run a turn. Every teardown
that passes `disposeChildScratch` comes through `disposeUnadoptedSubagentSession`,
whose callers all fire before the child's run loop starts: the failure paths
inside `prepareSubagentRunFromSelection`, a failed
`trackAndLaunchPreparedSubagent` (which errors only on its closed-session branch,
before `launchSubagentRun`), and the stable-delegate start failures
(`failCommittedStart`, `retainFailedStartCandidate`, `discardAdopted` via
`failAdoptedStart`, all before `preseedInput` and launch).

Because of that the test drives `teardownChildSession` directly rather than
faking a production path into it: it builds a child with a recorded abandoned
environment whose scratch a real command minted, tears it down once under each
disposition, and asserts the directory is gone under discard and kept with its
lease released under handoff. Pinning the drain back to an unconditional retain
fails it on `a discarded child's abandoned scratch /…/evener-sandbox-3375112118
survived its teardown (stat: <nil>), want it dropped with its lease`.

## Gates

Run on this branch with a private `GOCACHE`, all 0 FAIL:

- `gofmt -l agent/*.go`: clean.
- `go vet ./...` and `go vet -tags evenerfuzz ./...`: exit 0.
- `make lint-golangci`, `make lint-evenerfuzz lint-eval`: PASS.
- `GOMAXPROCS=4 go test -race ./agent/ -count=1`: `ok … 694.525s`.
- `GOMAXPROCS=4 go test -tags evenerfuzz -run Fuzz ./agent/ -count=1`: `ok … 99.857s`.
- `GOMAXPROCS=4 go test ./agent/ -count=1 -timeout 40m`: `ok … 278.012s`.

Follow-up to #913, which #928 already closed.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT