### PR TITLE
feat(webui): type ramp, reading measure, rhythm, headings, folded tool runs

### DIFF
--- a/cmd/evener-hub/frontend/index.html
+++ b/cmd/evener-hub/frontend/index.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <!-- Zoom is never locked (WCAG 1.4.4): every editable field is 16px on
-         phones (tokens.css's phone block sets --font-size-body to 16px), so
-         iOS Safari has nothing to auto-zoom into; viewport-fit=cover makes
+    <!-- Zoom is never locked (WCAG 1.4.4): every editable control is 16px on
+         phones (tokens.css's phone block sets --font-size-control and
+         --font-size-body to 16px; display-gates.test.ts scans every control
+         rule), so iOS Safari has nothing to auto-zoom into; viewport-fit=cover makes
          the env(safe-area-inset-*) paddings in the mobile shell nonzero.
          interactive-widget=resizes-content
          makes Chromium/Android shrink the layout viewport when the on-screen

--- a/cmd/evener-hub/frontend/index.html
+++ b/cmd/evener-hub/frontend/index.html
@@ -2,16 +2,17 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <!-- Pinned like an installed app: maximum-scale=1/user-scalable=no stop
-         iOS Safari's auto-zoom when a sub-16px field (the composer textarea)
-         gains focus; viewport-fit=cover makes the env(safe-area-inset-*)
-         paddings in the mobile shell nonzero. interactive-widget=resizes-content
+    <!-- Zoom is never locked (WCAG 1.4.4): every editable field is 16px on
+         phones (tokens.css's phone block sets --font-size-body to 16px), so
+         iOS Safari has nothing to auto-zoom into; viewport-fit=cover makes
+         the env(safe-area-inset-*) paddings in the mobile shell nonzero.
+         interactive-widget=resizes-content
          makes Chromium/Android shrink the layout viewport when the on-screen
          keyboard opens, so the fixed mobile shell (and the composer docked in
          its footer) rides up instead of sliding under the keyboard; browsers
          that don't know the key (Safari) ignore it — Safari gets the same
          result from useKeyboardInset's visualViewport-driven --keyboard-inset. -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
     <!-- Mirrors tokens.css's dark --surface-0 and the PWA manifest's
          background_color/theme_color; src/styles/pwa-manifest-colors.test.ts
          locks all three together. -->

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure-phone/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure-phone/assert.mjs
@@ -1,0 +1,28 @@
+// The phone half of the reading-measure contract (typography-spacing-
+// critique-2026-09-06 finding 2): below 700px the agent opener is a grid whose
+// prose drops to a full-width second row, so it gets the whole pane rather
+// than the column beside the 24px avatar. Measured before the fix: 260px of
+// 375 (28 characters a line); measured with the phone block mis-ordered in
+// the stylesheet: 187px (19 a line).
+const MIN_SPAN = 0.85;
+const MIN_CHARS_PER_LINE = 30;
+
+export default function assert(m) {
+  const span = m.proseWidth / m.paneInner;
+  if (m.viewport > 699) {
+    return { pass: false, reason: `harness viewport is ${m.viewport}px; the phone rules need <700px (case.json viewport)` };
+  }
+  if (span < MIN_SPAN) {
+    return {
+      pass: false,
+      reason: `opener prose spans ${(span * 100).toFixed(0)}% of the pane (${m.proseWidth.toFixed(0)}px of ${m.paneInner}px, starting ${m.proseLeft.toFixed(0)}px in) - the agent opener's phone grid is not applying (block order in agentmessageitem.module.css?)`,
+    };
+  }
+  if (m.charsPerLine < MIN_CHARS_PER_LINE) {
+    return { pass: false, reason: `only ${m.charsPerLine.toFixed(0)} characters per line at ${m.fontSize}` };
+  }
+  return {
+    pass: true,
+    reason: `opener prose spans ${(span * 100).toFixed(0)}% of the pane, ${m.charsPerLine.toFixed(0)} chars/line over ${m.lines} lines at ${m.fontSize}`,
+  };
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure-phone/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure-phone/case.json
@@ -1,0 +1,24 @@
+{
+  "name": "transcript-measure-phone",
+  "description": "transcript on a 375px phone: the opener's prose spans the pane under the avatar + header row instead of the column beside the avatar, and gets at least 30 characters per line (typography-spacing-critique-2026-09-06 finding 2)",
+  "cssFiles": [
+    "styles/global.css",
+    "styles/tokens.css",
+    "panes/session/transcript/turnblock.module.css",
+    "panes/session/transcript/messages/agentmessageitem.module.css",
+    "widgets/speakeravatar/speakeravatar.module.css",
+    "widgets/markdown/markdown.module.css"
+  ],
+  "viewport": {
+    "width": 375,
+    "height": 812,
+    "deviceScaleFactor": 2,
+    "mobile": true
+  },
+  "mutation": {
+    "declaration": "agentmessageitem.module.css: the @media (max-width: 699px) block moved above the base .opener rule (the cascade-order bug this case was written for, 2026-09-06)",
+    "verified": "2026-09-06",
+    "expect": "fail",
+    "note": "With the phone block above the base rule the prose spans 55% of the pane (187px of 343) at 19 characters per line."
+  }
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure-phone/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure-phone/harness.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>transcript-measure-phone layoutguard harness</title>
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="resolved.css">
+<style>
+  body { margin: 0; background: var(--surface-0); font-family: var(--font-sans); }
+  /* PaneScaffold's phone body: 16px of padding a side on a 375px screen. */
+  .pane { box-sizing: border-box; width: 375px; padding: 0 16px; background: var(--surface-1); }
+</style>
+</head>
+<body data-font-size="m" data-transcript-measure="reading">
+<!-- The same opener DOM as cases/transcript-measure (AgentMessageItem.tsx's
+     wrap(): .message.opener > .tile + .column > .header + .bubble > .root > p),
+     measured in a real 375px viewport so the <700px media rules apply. -->
+<div class="pane" data-pane>
+  <div class="turn" data-turn>
+    <div class="message opener">
+      <span class="tile" aria-hidden="true"></span>
+      <div class="column">
+        <div class="header"><span class="name">Agent</span><span class="meta">preview · 2m ago</span></div>
+        <div class="bubble">
+          <div class="root">
+            <p data-prose>The transcript display flow is ready. I inspected the projection layer and its test coverage, then traced how each turn is reduced into display items before the virtual list renders them. The reducer keys subagent modules on turn id alone, which two sessions can share, so I added the session ref to the key and updated the three call sites that read it.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+<script>
+function lineCount(el) {
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  const tops = new Set();
+  for (const rect of range.getClientRects()) tops.add(Math.round(rect.top));
+  return tops.size;
+}
+window.measure = () => {
+  const pane = document.querySelector("[data-pane]");
+  const paneInner = pane.clientWidth - 32;
+  const prose = document.querySelector("[data-prose]");
+  const lines = lineCount(prose);
+  const chars = prose.textContent.length;
+  const proseRect = prose.getBoundingClientRect();
+  return {
+    viewport: window.innerWidth,
+    paneInner,
+    proseWidth: proseRect.width,
+    proseLeft: proseRect.left - pane.getBoundingClientRect().left,
+    lines,
+    chars,
+    charsPerLine: chars / Math.max(1, lines),
+    fontSize: getComputedStyle(prose).fontSize,
+  };
+};
+</script>
+</body>
+</html>

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure/assert.mjs
@@ -1,0 +1,31 @@
+// The reading-measure contract (docs/web-ui/typography-spacing-critique-
+// 2026-09-06.md R2): the conversation column is bounded by
+// --session-measure (44rem on body, tokens.css), so a plain agent paragraph
+// never runs past ~100 characters per line however wide the window is, and
+// the column sits centred in the pane rather than pinned to its left edge.
+// Measured before the token existed: 149 characters per line at 1440.
+const MAX_CHARS_PER_LINE = 100;
+
+export default function assert(measurements) {
+  const failures = [];
+  const reasons = [];
+  for (const m of measurements) {
+    const label = `${m.window}px window`;
+    if (m.charsPerLine > MAX_CHARS_PER_LINE) {
+      failures.push(
+        `${label}: paragraph runs ${m.charsPerLine.toFixed(0)} characters per line (${m.lines} lines, turn ${m.turnWidth.toFixed(0)}px wide at ${m.fontSize}) - --session-measure is missing or too wide`,
+      );
+    }
+    // 1px, not 0, to stay clear of sub-pixel centring noise.
+    if (Math.abs(m.leftGap - m.rightGap) > 1) {
+      failures.push(
+        `${label}: column is not centred (left gap ${m.leftGap.toFixed(1)}px, right gap ${m.rightGap.toFixed(1)}px) - .turn lost its margin-inline: auto or its max-width`,
+      );
+    }
+    reasons.push(
+      `${label}: ${m.charsPerLine.toFixed(0)} chars/line over ${m.lines} lines, column ${m.turnWidth.toFixed(0)}px centred (${m.leftGap.toFixed(0)}/${m.rightGap.toFixed(0)}px gaps)`,
+    );
+  }
+  if (failures.length > 0) return { pass: false, reason: failures.join("; ") };
+  return { pass: true, reason: reasons.join("; ") };
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure/case.json
@@ -1,0 +1,28 @@
+{
+  "name": "transcript-measure",
+  "description": "transcript: a plain agent paragraph never runs past 100 characters per line in a 1440- or 1920-wide window, and the conversation column is centred in the pane at both widths (typography-spacing-critique-2026-09-06 R2)",
+  "cssFiles": [
+    "styles/global.css",
+    "styles/tokens.css",
+    "panes/session/transcript/turnblock.module.css",
+    "panes/session/transcript/messages/agentmessageitem.module.css",
+    "widgets/speakeravatar/speakeravatar.module.css",
+    "widgets/markdown/markdown.module.css"
+  ],
+  "viewport": {
+    "width": 1920,
+    "height": 900,
+    "deviceScaleFactor": 1,
+    "mobile": false
+  },
+  "widthMatrix": [
+    { "width": 1112, "window": 1440 },
+    { "width": 1592, "window": 1920 }
+  ],
+  "mutation": {
+    "declaration": "tokens.css: body { --session-measure: 44rem } set to 76rem (the pre-2026-09-06 literal)",
+    "verified": "2026-09-06",
+    "expect": "fail",
+    "note": "Measured 2026-09-06: at 76rem the paragraph runs 126 characters per line in the 1440 window (the 1216px column exceeds the 1112px pane) and 157 in the 1920 window."
+  }
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-measure/harness.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<title>transcript-measure layoutguard harness</title>
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="resolved.css">
+<style>
+  body { margin: 0; background: var(--surface-0); font-family: var(--font-sans); }
+  .fixtures { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; padding: 8px; }
+  .fixture { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
+  .fixtureLabel { color: var(--ink-low); font: var(--font-size-caption) var(--font-mono); }
+  /* The pane's content box: PaneScaffold's body minus its padding. Each
+     fixture sets its own width from case.json's widthMatrix - the two
+     entries are 1440 and 1920 windows minus the 280px rail and the pane's
+     own 2 x 24px padding. */
+  .pane { box-sizing: border-box; background: var(--surface-1); }
+</style>
+</head>
+<body data-font-size="m" data-transcript-measure="reading">
+<!-- Reproduces AgentMessageItem's exchange-opener DOM (AgentMessageItem.tsx's
+     wrap(): .message.opener > SpeakerAvatar .tile + .column > .header + .bubble
+     > Markdown .root > p) inside TurnBlock's .turn, against the REAL class
+     names from turnblock/agentmessageitem/speakeravatar/markdown. The geometry
+     under test: how many characters a plain paragraph gets per line, and
+     whether .turn is centred in the pane. -->
+<main class="fixtures"></main>
+
+<template id="fixture-template">
+  <section class="fixture">
+    <div class="fixtureLabel"></div>
+    <div class="pane" data-pane>
+      <div class="turn" data-turn>
+        <div class="message opener">
+          <span class="tile" aria-hidden="true"></span>
+          <div class="column">
+            <div class="header"><span class="name">Agent</span><span class="meta">preview/preview-model · 2m ago</span></div>
+            <div class="bubble">
+              <div class="root">
+                <p data-prose>The transcript display flow is ready. I inspected the projection layer and its test coverage, then traced how each turn is reduced into display items before the virtual list renders them. The reducer keys subagent modules on turn id alone, which two sessions can share, so I added the session ref to the key and updated the three call sites that read it. The focused view and the read-only pane both render the same item components, so the change lands in both places without a second edit. Tests cover the cross-session case now, and the guard that measures overflow at four widths still passes without a change to its fixtures.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+const fixtures = __LAYOUTGUARD_WIDTH_MATRIX__;
+const template = document.querySelector("#fixture-template");
+const fixtureRoot = document.querySelector(".fixtures");
+for (const spec of fixtures) {
+  const fragment = template.content.cloneNode(true);
+  const fixture = fragment.querySelector(".fixture");
+  fixture.dataset.width = String(spec.width);
+  fixture.dataset.window = String(spec.window);
+  fixture.querySelector(".fixtureLabel").textContent = `${spec.window}px window / ${spec.width}px pane`;
+  fixture.querySelector("[data-pane]").style.width = `${spec.width}px`;
+  fixtureRoot.append(fragment);
+}
+
+// Distinct line-box tops of the paragraph's inline content = rendered line
+// count; the same Range technique the critique measured the live app with.
+function lineCount(el) {
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  const tops = new Set();
+  for (const rect of range.getClientRects()) tops.add(Math.round(rect.top));
+  return tops.size;
+}
+
+window.measure = () =>
+  [...document.querySelectorAll(".fixture")].map((fixture) => {
+    const pane = fixture.querySelector("[data-pane]").getBoundingClientRect();
+    const turn = fixture.querySelector("[data-turn]").getBoundingClientRect();
+    const prose = fixture.querySelector("[data-prose]");
+    const lines = lineCount(prose);
+    const chars = prose.textContent.length;
+    return {
+      window: Number(fixture.dataset.window),
+      width: Number(fixture.dataset.width),
+      lines,
+      chars,
+      charsPerLine: chars / Math.max(1, lines),
+      turnWidth: turn.width,
+      leftGap: turn.left - pane.left,
+      rightGap: pane.right - turn.right,
+      fontSize: getComputedStyle(prose).fontSize,
+    };
+  });
+</script>
+</body>
+</html>

--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -121,9 +121,10 @@ function assertResult(result, expectedWidth) {
     failures.push(`mobile title is not the span the ${expectedWidth}px breakpoint selects`);
   if (displayed(result.desktopTitle) === mobile)
     failures.push(`desktop title is not the span the ${expectedWidth}px breakpoint selects`);
-  if (visible(result.mobileIntro) !== mobile)
-    failures.push(`prompt orientation visibility is wrong at ${expectedWidth}px`);
-
+  // The prompt heading and subtitle show at EVERY width now (the desktop
+  // pane used to hide them behind a 12px uppercase title - critique R7), so
+  // the intro must be visible whether or not the layout is the phone's.
+  if (!visible(result.promptIntro)) failures.push(`prompt intro is not visible at ${expectedWidth}px`);
   // Issue #198: the prompt card is the composer, so its control row holds the
   // composer's controls in the composer's place - at EVERY width, which is why
   // this block is outside the mobile branch. The pane used to pass PromptCard a
@@ -226,19 +227,6 @@ function assertResult(result, expectedWidth) {
       if (row.minHeight !== "48px" || row.height < 48)
         failures.push(`row ${row.label} is below 48px: ${JSON.stringify(row)}`);
     }
-    const prompt = result.accessiblePrompt;
-    if (
-      prompt.headingTag !== "h3" ||
-      prompt.headingText !== "What should the agent do?" ||
-      !prompt.headingVisible ||
-      prompt.subtitleTag !== "p" ||
-      prompt.subtitleText !== "Leave blank to start a dormant session." ||
-      !prompt.subtitleVisible ||
-      prompt.headingHiddenFromAT ||
-      prompt.subtitleHiddenFromAT
-    ) {
-      failures.push(`prompt orientation is not persistently accessible: ${JSON.stringify(prompt)}`);
-    }
   }
 
   // Staged attachments (kata 289v). The harness stages them through the
@@ -247,6 +235,21 @@ function assertResult(result, expectedWidth) {
   const staged = result.attachments;
   if (staged.tiles.length !== STAGED_ATTACHMENTS) {
     failures.push(`expected ${STAGED_ATTACHMENTS} staged attachment tiles in the tree, found ${staged.tiles.length}`);
+  }
+  // Persistently accessible at every width, not only the phone's: the heading
+  // is the page's own (an h2 under the pane title), never aria-hidden.
+  const prompt = result.accessiblePrompt;
+  if (
+    prompt.headingTag !== "h2" ||
+    prompt.headingText !== "What should the agent do?" ||
+    !prompt.headingVisible ||
+    prompt.subtitleTag !== "p" ||
+    prompt.subtitleText !== "Leave blank to start a dormant session." ||
+    !prompt.subtitleVisible ||
+    prompt.headingHiddenFromAT ||
+    prompt.subtitleHiddenFromAT
+  ) {
+    failures.push(`prompt orientation is not persistently accessible: ${JSON.stringify(prompt)}`);
   }
   if (staged.row === null) {
     failures.push("staged-attachment row is not in the measured tree");

--- a/cmd/evener-hub/frontend/src/App.tsx
+++ b/cmd/evener-hub/frontend/src/App.tsx
@@ -1,7 +1,8 @@
 import { lazy, Suspense } from "react";
 import { AppShell } from "./shell/AppShell";
 
-// Dev-only routes, at /dev/widgets and /dev/harness. import.meta.env.DEV
+// Dev-only routes, at /dev/widgets, /dev/surfaces, /dev/type and
+// /dev/harness. import.meta.env.DEV
 // keeps each lazy() import (and everything it pulls in) out of the graph
 // entirely for a production build: `npm run build` emits no gallery/harness
 // chunk (see this task's report for the dist/ listing that confirms it).
@@ -11,6 +12,11 @@ const WidgetGallery = import.meta.env.DEV ? lazy(() => import("./dev/WidgetGalle
 // with fixture/seeded-store data instead of live network data - see
 // dev/SurfaceGallery.tsx's own header.
 const SurfaceGallery = import.meta.env.DEV ? lazy(() => import("./dev/SurfaceGallery")) : null;
+// TypeSpecimen is the same shape again, at /dev/type: the type ramp, the
+// leading, the eyebrow recipe, the rhythm steps and the two measures, all
+// rendered from the real tokens so a ramp change is reviewed as a picture
+// rather than a diff - see dev/TypeSpecimen.tsx's own header.
+const TypeSpecimen = import.meta.env.DEV ? lazy(() => import("./dev/TypeSpecimen")) : null;
 // DevHarness is a named export (dev/DevHarness.tsx), not a default one -
 // React.lazy needs a Promise<{default}>, so this adapts the import rather
 // than changing DevHarness's own export shape (which dev/DevHarness.test.tsx
@@ -31,6 +37,13 @@ export function App() {
     return (
       <Suspense fallback={null}>
         <SurfaceGallery />
+      </Suspense>
+    );
+  }
+  if (TypeSpecimen !== null && window.location.pathname === "/dev/type") {
+    return (
+      <Suspense fallback={null}>
+        <TypeSpecimen />
       </Suspense>
     );
   }

--- a/cmd/evener-hub/frontend/src/dev/TypeSpecimen.test.tsx
+++ b/cmd/evener-hub/frontend/src/dev/TypeSpecimen.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, expect, test } from "vitest";
+import TypeSpecimen from "./TypeSpecimen";
+
+afterEach(cleanup);
+
+// The whole specimen is wrapped in ThemeFlip, which renders its children
+// once per theme, so every label on the page appears exactly twice.
+// Asserting the count (rather than getByText, which throws on the second
+// match) is what pins "both themes render" - the point of the route.
+const THEMES = 2;
+
+const RAMP_LABELS = ["caption 12", "ui 13", "body 15", "pane-title 18", "page-title 22", "display 28"];
+const RHYTHM_LABELS = ["rhythm-line 4", "rhythm-item 8", "rhythm-group 16", "rhythm-exchange 24"];
+const LEADING_LABELS = ["line-height-ui", "line-height-body", "line-height-title"];
+const MEASURE_LABELS = ["44rem", "64rem"];
+
+test("renders without throwing, with the intro note", () => {
+  render(<TypeSpecimen />);
+  expect(screen.getByText(/type specimen/i)).toBeTruthy();
+});
+
+test.each(RAMP_LABELS)("shows the ramp step %s in both themes", (label) => {
+  render(<TypeSpecimen />);
+  expect(screen.getAllByText(label)).toHaveLength(THEMES);
+});
+
+test.each(LEADING_LABELS)("shows the line-height sample %s in both themes", (label) => {
+  render(<TypeSpecimen />);
+  expect(screen.getAllByText(label)).toHaveLength(THEMES);
+});
+
+test.each(RHYTHM_LABELS)("shows the rhythm step %s in both themes", (label) => {
+  render(<TypeSpecimen />);
+  expect(screen.getAllByText(label)).toHaveLength(THEMES);
+});
+
+test.each(MEASURE_LABELS)("shows a paragraph at the %s measure in both themes", (label) => {
+  render(<TypeSpecimen />);
+  expect(screen.getAllByText(label)).toHaveLength(THEMES);
+});
+
+test("shows the eyebrow recipe rendered in itself", () => {
+  render(<TypeSpecimen />);
+  expect(screen.getAllByText("Recommended")).toHaveLength(THEMES);
+});
+
+test("the measure paragraph is the same 600-character text in both columns", () => {
+  render(<TypeSpecimen />);
+  const paragraphs = screen.getAllByText(/A session is a conversation with an agent/);
+  // one per measure, per theme
+  expect(paragraphs).toHaveLength(2 * THEMES);
+  for (const paragraph of paragraphs) {
+    expect(paragraph.textContent?.length).toBe(600);
+  }
+});

--- a/cmd/evener-hub/frontend/src/dev/TypeSpecimen.tsx
+++ b/cmd/evener-hub/frontend/src/dev/TypeSpecimen.tsx
@@ -1,0 +1,178 @@
+import { requireClass } from "../widgets/internal/requireClass";
+import { ThemeFlip } from "./ThemeFlip";
+import styles from "./typespecimen.module.css";
+
+const MODULE = "typespecimen.module.css";
+const CLASS = {
+  page: requireClass(styles.page, MODULE, "page"),
+  intro: requireClass(styles.intro, MODULE, "intro"),
+  section: requireClass(styles.section, MODULE, "section"),
+  sectionTitle: requireClass(styles.sectionTitle, MODULE, "sectionTitle"),
+  note: requireClass(styles.note, MODULE, "note"),
+  rowLabel: requireClass(styles.rowLabel, MODULE, "rowLabel"),
+  rampRow: requireClass(styles.rampRow, MODULE, "rampRow"),
+  rampSample: requireClass(styles.rampSample, MODULE, "rampSample"),
+  sizeCaption: requireClass(styles.sizeCaption, MODULE, "sizeCaption"),
+  sizeUi: requireClass(styles.sizeUi, MODULE, "sizeUi"),
+  sizeBody: requireClass(styles.sizeBody, MODULE, "sizeBody"),
+  sizePaneTitle: requireClass(styles.sizePaneTitle, MODULE, "sizePaneTitle"),
+  sizePageTitle: requireClass(styles.sizePageTitle, MODULE, "sizePageTitle"),
+  sizeDisplay: requireClass(styles.sizeDisplay, MODULE, "sizeDisplay"),
+  leadingRow: requireClass(styles.leadingRow, MODULE, "leadingRow"),
+  leadingSample: requireClass(styles.leadingSample, MODULE, "leadingSample"),
+  leadingUi: requireClass(styles.leadingUi, MODULE, "leadingUi"),
+  leadingBody: requireClass(styles.leadingBody, MODULE, "leadingBody"),
+  leadingTitle: requireClass(styles.leadingTitle, MODULE, "leadingTitle"),
+  eyebrow: requireClass(styles.eyebrow, MODULE, "eyebrow"),
+  rhythmRow: requireClass(styles.rhythmRow, MODULE, "rhythmRow"),
+  rhythmBar: requireClass(styles.rhythmBar, MODULE, "rhythmBar"),
+  barLine: requireClass(styles.barLine, MODULE, "barLine"),
+  barItem: requireClass(styles.barItem, MODULE, "barItem"),
+  barGroup: requireClass(styles.barGroup, MODULE, "barGroup"),
+  barExchange: requireClass(styles.barExchange, MODULE, "barExchange"),
+  measures: requireClass(styles.measures, MODULE, "measures"),
+  measureColumn: requireClass(styles.measureColumn, MODULE, "measureColumn"),
+  measureLabel: requireClass(styles.measureLabel, MODULE, "measureLabel"),
+  measureValue: requireClass(styles.measureValue, MODULE, "measureValue"),
+  prose: requireClass(styles.prose, MODULE, "prose"),
+  measureReading: requireClass(styles.measureReading, MODULE, "measureReading"),
+  measureWide: requireClass(styles.measureWide, MODULE, "measureWide"),
+};
+
+const RAMP_SAMPLE = "Sphinx of black quartz, judge my vow — 0123456789";
+
+// The label is <token suffix> <base px>: the size a step renders at with
+// the font-size preference on M. S/L/XL scale the whole ramp through
+// --font-scale, so the ratios between these rows never change.
+const RAMP: { label: string; sizeClass: string }[] = [
+  { label: "caption 12", sizeClass: CLASS.sizeCaption },
+  { label: "ui 13", sizeClass: CLASS.sizeUi },
+  { label: "body 15", sizeClass: CLASS.sizeBody },
+  { label: "pane-title 18", sizeClass: CLASS.sizePaneTitle },
+  { label: "page-title 22", sizeClass: CLASS.sizePageTitle },
+  { label: "display 28", sizeClass: CLASS.sizeDisplay },
+];
+
+const LEADING_SAMPLE =
+  "Three lines of one sentence, set at one size, so the only thing that changes between these samples is the leading itself.";
+
+const LEADING: { label: string; leadingClass: string }[] = [
+  { label: "line-height-ui", leadingClass: CLASS.leadingUi },
+  { label: "line-height-body", leadingClass: CLASS.leadingBody },
+  { label: "line-height-title", leadingClass: CLASS.leadingTitle },
+];
+
+// The label is <token suffix> <resolved px>: each --rhythm-* step aliases
+// a --space-* value, and the bar beside it is exactly that tall.
+const RHYTHM: { label: string; barClass: string }[] = [
+  { label: "rhythm-line 4", barClass: CLASS.barLine },
+  { label: "rhythm-item 8", barClass: CLASS.barItem },
+  { label: "rhythm-group 16", barClass: CLASS.barGroup },
+  { label: "rhythm-exchange 24", barClass: CLASS.barExchange },
+];
+
+// 600 characters of ordinary prose - long enough that the two measures
+// differ by more than one line, short enough to read both before deciding.
+const MEASURE_PROSE =
+  "A session is a conversation with an agent that can read your files, run commands, and delegate work to other agents. The transcript is the record of that conversation: what you asked, what the agent decided, which tools it reached for, and what came back. Most of it is prose, and prose is what a measure is for. A column this wide holds roughly ninety characters to the line, close to the range typographers argued for long before screens, and it still leaves room for a hundred-column code block without a horizontal scrollbar. Read a few lines of each column and pick whichever one tires you less.";
+
+const MEASURES: { name: string; value: string; widthClass: string }[] = [
+  { name: "Reading measure", value: "44rem", widthClass: CLASS.measureReading },
+  { name: "Wide measure", value: "64rem", widthClass: CLASS.measureWide },
+];
+
+/**
+ * The specimen body, rendered once per theme by ThemeFlip. Everything here
+ * is set from a token and nothing else - the page's whole job is to show
+ * what the ramp, the leading, the eyebrow recipe, the rhythm steps and the
+ * two measures actually look like, so a change to any of them is reviewed
+ * as a picture instead of a diff (critique R1-R3, R10).
+ */
+function Specimen() {
+  return (
+    <>
+      <section className={CLASS.section}>
+        <h2 className={CLASS.sectionTitle}>Ramp</h2>
+        <p className={CLASS.note}>
+          Each row is set in its own --font-size-* token. The number is the base px at font-size M.
+        </p>
+        {RAMP.map(({ label, sizeClass }) => (
+          <div className={CLASS.rampRow} key={label}>
+            <p className={CLASS.rowLabel}>{label}</p>
+            <p className={`${CLASS.rampSample} ${sizeClass}`}>{RAMP_SAMPLE}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className={CLASS.section}>
+        <h2 className={CLASS.sectionTitle}>Leading</h2>
+        <p className={CLASS.note}>Same size, same column width; only line-height differs.</p>
+        {LEADING.map(({ label, leadingClass }) => (
+          <div className={CLASS.leadingRow} key={label}>
+            <p className={CLASS.rowLabel}>{label}</p>
+            <p className={`${CLASS.leadingSample} ${leadingClass}`}>{LEADING_SAMPLE}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className={CLASS.section}>
+        <h2 className={CLASS.sectionTitle}>Eyebrow</h2>
+        <p className={CLASS.eyebrow}>Recommended</p>
+        <p className={CLASS.note}>
+          The one uppercase recipe: --font-size-caption, --font-weight-medium, --ink-mid, uppercase, letter-spacing
+          --tracking-eyebrow. Two words at most; never a sentence.
+        </p>
+      </section>
+
+      <section className={CLASS.section}>
+        <h2 className={CLASS.sectionTitle}>Rhythm</h2>
+        <p className={CLASS.note}>
+          Each bar is as tall as the step it names — the four gaps a surface may put between things.
+        </p>
+        {RHYTHM.map(({ label, barClass }) => (
+          <div className={CLASS.rhythmRow} key={label}>
+            <p className={CLASS.rowLabel}>{label}</p>
+            <div className={`${CLASS.rhythmBar} ${barClass}`} />
+          </div>
+        ))}
+      </section>
+
+      <section className={CLASS.section}>
+        <h2 className={CLASS.sectionTitle}>Measure</h2>
+        <p className={CLASS.note}>
+          The same 600-character paragraph at body size and --line-height-body, at both measures.
+        </p>
+        <div className={CLASS.measures}>
+          {MEASURES.map(({ name, value, widthClass }) => (
+            <div className={CLASS.measureColumn} key={value}>
+              <p className={CLASS.measureLabel}>
+                {name} <span className={CLASS.measureValue}>{value}</span>
+              </p>
+              <p className={`${CLASS.prose} ${widthClass}`}>{MEASURE_PROSE}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}
+
+/**
+ * `/dev/type`: the type specimen. Dev build only — see src/App.tsx, which
+ * gates the route (and this module's import) behind import.meta.env.DEV so
+ * it never reaches a production bundle, exactly as it does for
+ * /dev/widgets and /dev/surfaces.
+ */
+export default function TypeSpecimen() {
+  return (
+    <div className={CLASS.page}>
+      <p className={CLASS.intro}>
+        Type specimen — the ramp, the leading, the eyebrow recipe, the rhythm steps and the two measures, rendered from
+        the real tokens in both themes.
+      </p>
+      <ThemeFlip>
+        <Specimen />
+      </ThemeFlip>
+    </div>
+  );
+}

--- a/cmd/evener-hub/frontend/src/dev/gallery-sections/emptystate.tsx
+++ b/cmd/evener-hub/frontend/src/dev/gallery-sections/emptystate.tsx
@@ -22,6 +22,9 @@ export default function EmptyStateGallerySection() {
               action={<Button size="sm">New session</Button>}
             />
           </div>
+          <div className={styles.sample}>
+            <EmptyState title="No session open" hint="size=display: the welcome hero" size="display" />
+          </div>
         </div>
       </ThemeFlip>
     </section>

--- a/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
@@ -308,8 +308,8 @@ function measureSpawn() {
     };
   });
 
-  const heading = document.querySelector<HTMLElement>("[data-testid='spawn-mobile-prompt-intro'] h3");
-  const subtitle = document.querySelector<HTMLElement>("[data-testid='spawn-mobile-prompt-intro'] p");
+  const heading = document.querySelector<HTMLElement>("[data-testid='spawn-prompt-intro'] h2");
+  const subtitle = document.querySelector<HTMLElement>("[data-testid='spawn-prompt-intro'] p");
   const pluginSummary = document.querySelector<HTMLElement>('[data-testid="spawn-plugin-summary"]');
   const pluginRow = document.querySelector<HTMLElement>('[data-label="Plugins"]');
   const pluginSheet = document.querySelector<HTMLElement>('[role="dialog"][aria-labelledby] h2')?.parentElement
@@ -325,7 +325,7 @@ function measureSpawn() {
     viewport: { width: window.innerWidth, height: window.innerHeight },
     mobileConfig: readVisibility(mobileConfigElement, "mobile config"),
     desktopConfig: readVisibility(desktopConfigElement, "desktop config"),
-    mobileIntro: visibility('[data-testid="spawn-mobile-prompt-intro"]'),
+    promptIntro: visibility('[data-testid="spawn-prompt-intro"]'),
     desktopTitle: visibility('[data-testid="pane-title-desktop"]'),
     mobileTitle: visibility('[data-testid="pane-title-mobile"]'),
     promptCard: measurePromptCard(),
@@ -334,10 +334,10 @@ function measureSpawn() {
     accessiblePrompt: {
       headingTag: heading?.tagName.toLowerCase() ?? "missing",
       headingText: heading?.textContent?.trim() ?? "",
-      headingVisible: heading ? isVisible(visibility("[data-testid='spawn-mobile-prompt-intro'] h3")) : false,
+      headingVisible: heading ? isVisible(visibility("[data-testid='spawn-prompt-intro'] h2")) : false,
       subtitleTag: subtitle?.tagName.toLowerCase() ?? "missing",
       subtitleText: subtitle?.textContent?.trim() ?? "",
-      subtitleVisible: subtitle ? isVisible(visibility("[data-testid='spawn-mobile-prompt-intro'] p")) : false,
+      subtitleVisible: subtitle ? isVisible(visibility("[data-testid='spawn-prompt-intro'] p")) : false,
       headingHiddenFromAT: heading?.getAttribute("aria-hidden") === "true",
       subtitleHiddenFromAT: subtitle?.getAttribute("aria-hidden") === "true",
     },

--- a/cmd/evener-hub/frontend/src/dev/typespecimen.module.css
+++ b/cmd/evener-hub/frontend/src/dev/typespecimen.module.css
@@ -1,0 +1,206 @@
+/*
+ * /dev/type — the type specimen (critique R10). Every rule here reads a
+ * token and nothing else: the page IS the ramp, so a literal size or a
+ * hand-tuned spacing anywhere in this file would make the specimen lie
+ * about what the app renders.
+ */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  padding: var(--space-6);
+}
+
+.intro {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sectionTitle {
+  margin: 0;
+  font-size: var(--font-size-pane-title);
+  line-height: var(--line-height-title);
+}
+
+.note {
+  margin: 0;
+  color: var(--ink-mid);
+  font-family: var(--font-sans); /* a chrome label, never mono - see Direction */
+  font-size: var(--font-size-caption);
+}
+
+/* Every specimen row shares one label column so the samples line up down
+ * the page regardless of which section they belong to. */
+.rowLabel {
+  width: 140px;
+  flex: none;
+  margin: 0;
+  color: var(--ink-mid);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-caption);
+}
+
+/* --- the ramp ---------------------------------------------------------
+ * One row per --font-size-* token, its sample set in the token it names. */
+
+.rampRow {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-4);
+}
+
+.rampSample {
+  margin: 0;
+  color: var(--ink-hi);
+  line-height: var(--line-height-title);
+}
+
+.sizeCaption {
+  font-size: var(--font-size-caption);
+}
+
+.sizeUi {
+  font-size: var(--font-size-ui);
+}
+
+.sizeBody {
+  font-size: var(--font-size-body);
+}
+
+.sizePaneTitle {
+  font-size: var(--font-size-pane-title);
+}
+
+.sizePageTitle {
+  font-size: var(--font-size-page-title);
+}
+
+.sizeDisplay {
+  font-size: var(--font-size-display);
+  letter-spacing: var(--tracking-display);
+}
+
+/* --- line-heights -----------------------------------------------------
+ * Each sample is narrow enough that its paragraph wraps to three lines, so
+ * the leading is visible as the gap between them rather than as a number. */
+
+.leadingRow {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+}
+
+.leadingSample {
+  max-width: 22rem;
+  margin: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-body);
+}
+
+.leadingUi {
+  line-height: var(--line-height-ui);
+}
+
+.leadingBody {
+  line-height: var(--line-height-body);
+}
+
+.leadingTitle {
+  line-height: var(--line-height-title);
+}
+
+/* --- the eyebrow recipe ----------------------------------------------- */
+
+.eyebrow {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+}
+
+/* --- the rhythm steps -------------------------------------------------
+ * A bar as tall as the step it names: the four gaps the transcript is
+ * allowed to put between things, at a glance and to scale. */
+
+.rhythmRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.rhythmBar {
+  width: 240px;
+  border-radius: var(--radius-chip);
+  background: var(--edge-strong);
+}
+
+.barLine {
+  height: var(--rhythm-line);
+}
+
+.barItem {
+  height: var(--rhythm-item);
+}
+
+.barGroup {
+  height: var(--rhythm-group);
+}
+
+.barExchange {
+  height: var(--rhythm-exchange);
+}
+
+/* --- the measure ------------------------------------------------------
+ * The same paragraph twice, at the reading measure and the wide one, so
+ * the choice is made by reading rather than by arguing about numbers. The
+ * two widths are literal here on purpose: this page is where they are
+ * being compared, not consumed. */
+
+.measures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-6);
+}
+
+.measureColumn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.measureLabel {
+  margin: 0;
+  color: var(--ink-mid);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-caption);
+}
+
+.measureValue {
+  color: var(--ink-hi);
+  font-family: var(--font-mono);
+}
+
+.prose {
+  margin: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-body);
+}
+
+.measureReading {
+  max-width: 44rem;
+}
+
+.measureWide {
+  max-width: 64rem;
+}

--- a/cmd/evener-hub/frontend/src/panes/session/Session.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.tsx
@@ -18,7 +18,7 @@
 // text - is exactly what that slot cannot promise. The footer's layout can.
 // PendingChips travels with the composer (it's contextually
 // "chips beside the composer", per its own doc comment) and shares its
-// 76rem measure so the input aligns with the transcript's own content
+// --session-measure so the input aligns with the transcript's own content
 // column; SessionChrome now lives in the composer's own PromptCard control row.
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useStore } from "zustand";

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/StatusRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/StatusRow.tsx
@@ -34,7 +34,7 @@ const CLASS = {
   row: requireClass(styles.row, "statusrow.module.css", "row"),
   identity: requireClass(styles.identity, "statusrow.module.css", "identity"),
   item: requireClass(styles.item, "statusrow.module.css", "item"),
-  mono: requireClass(styles.mono, "statusrow.module.css", "mono"),
+  figure: requireClass(styles.figure, "statusrow.module.css", "figure"),
   context: requireClass(styles.context, "statusrow.module.css", "context"),
   contextMeter: requireClass(styles.contextMeter, "statusrow.module.css", "contextMeter"),
   contextPercent: requireClass(styles.contextPercent, "statusrow.module.css", "contextPercent"),
@@ -176,7 +176,7 @@ export function StatusRow({ sessionRef, model, now }: StatusRowProps) {
                 tone={contextTone(model.contextPressure)}
               />
             </span>
-            <span className={`${CLASS.contextPercent} ${CLASS.mono}`} data-testid="status-row-context-percent">
+            <span className={`${CLASS.contextPercent} ${CLASS.figure}`} data-testid="status-row-context-percent">
               {`${contextPercent}%`}
             </span>
           </span>
@@ -187,7 +187,7 @@ export function StatusRow({ sessionRef, model, now }: StatusRowProps) {
           feeding it an absence fabricates a measurement. Same gate
           DetailsPanel's own work-time row uses. */}
       {running && workMs > 0 && (
-        <span className={`${CLASS.item} ${CLASS.mono} ${CLASS.workTime}`} data-testid="status-row-work-time">
+        <span className={`${CLASS.item} ${CLASS.figure} ${CLASS.workTime}`} data-testid="status-row-work-time">
           {formatWorkDuration(workMs)}
         </span>
       )}
@@ -197,7 +197,7 @@ export function StatusRow({ sessionRef, model, now }: StatusRowProps) {
           session. */}
       {queueDepth > 0 && (
         <span
-          className={`${CLASS.item} ${CLASS.mono} ${CLASS.queue}`}
+          className={`${CLASS.item} ${CLASS.figure} ${CLASS.queue}`}
           data-testid="status-row-queue"
           role="status"
           aria-label={`${queueDepth} queued`}

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/activitypanel.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/activitypanel.module.css
@@ -124,7 +124,7 @@
   flex: none;
   text-align: center;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--ink-low);
 }
 /* The kind glyph carries the row's status hue (it replaced the status dot):
@@ -187,7 +187,7 @@
 .detailCommand {
   display: block;
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--ink-hi);
   /* The expanded strip shows the WHOLE command, wrapped - the dense row's
    * ellipsis is the collapsed form, this is its unabridged counterpart. */
@@ -198,7 +198,7 @@
   display: block;
   margin-top: var(--space-1);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--ink-low);
 }
 /* The output tail preview inside the detail strip. No max-height/scroll:
@@ -211,7 +211,7 @@
   border-radius: var(--radius-control);
   background: var(--surface-1);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--ink-mid);
   white-space: pre-wrap;
   overflow-wrap: anywhere;

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/detailspanel.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/detailspanel.module.css
@@ -23,7 +23,8 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  color: var(--ink-low);
+  letter-spacing: var(--tracking-eyebrow);
+  color: var(--ink-mid);
 }
 
 /* One label/value row per fact, label above value so the exact figures get a

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/modelswitch.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/modelswitch.module.css
@@ -21,16 +21,19 @@
   transition: background-color var(--motion-duration-hover) var(--motion-easing-standard);
 }
 
-/* The model id, in this row's caption size. Mono because a model id is an
- * identifier - the same face the strip gives its figures and timings
- * (statusrow.module.css's .mono). */
+/* The model id, in this row's caption size. Sans, not mono: an id is an
+ * identifier, but this is the row's most-read label and chrome takes the UI
+ * face (principle 7, docs/web-ui/decisions.md); the qualified id keeps its
+ * mono treatment in the Details sheet. Tabular figures hold the version
+ * digits steady across switches. */
 .value {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--ink-mid);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
   font-size: var(--font-size-caption);
 }
 

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/statusrow.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/statusrow.module.css
@@ -200,6 +200,9 @@
   opacity: 0;
   cursor: pointer;
   font: inherit;
+  /* A real native select: it must not inherit the trigger's caption size,
+   * or iOS zooms into it on focus (--font-size-control is 16px on phones). */
+  font-size: var(--font-size-control);
 }
 
 /* Standard visually-hidden recipe: keeps a real, focus-order-preserving

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/statusrow.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/statusrow.module.css
@@ -44,10 +44,12 @@
   flex: none;
 }
 
-/* Figures, identifiers and timings - the faces mono is for. Chrome labels never
- * take it. */
-.mono {
-  font-family: var(--font-mono);
+/* Figures and timings: the sans face with tabular digits, so a changing
+ * count never reflows its neighbours. Mono is reserved for machine text
+ * (code, paths, commands) - a percentage or a clock is a figure, not code. */
+.figure {
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
 }
 
 .contextMeter {

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/taskspanel.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/taskspanel.module.css
@@ -42,7 +42,7 @@
   font-weight: var(--font-weight-medium);
   color: var(--ink-mid);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .groupCount {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/CurrentWork.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/CurrentWork.test.tsx
@@ -125,5 +125,5 @@ test("uses the approved semantic green ring and uppercase micro-label treatment"
 
   const label = currentWorkCssRule("label");
   expect(label).toContain("text-transform: uppercase");
-  expect(label).toContain("letter-spacing: var(--tracking-micro)");
+  expect(label).toContain("letter-spacing: var(--tracking-eyebrow)");
 });

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
@@ -196,14 +196,14 @@ test("the tab strip buttons reach the tap floor on a coarse pointer", () => {
 // list's measureElement can measure it - a max-height or overflow of its own
 // would clip the batch behind an internal scrollbar and lie to the
 // measurement, and any flex-basis sizing belongs to a footer slot it no
-// longer occupies. It centers on the transcript's 76rem reading measure
+// longer occupies. It centers on the transcript's --session-measure reading measure
 // (turnblock.module.css's --session-measure).
 test("the dock sizes to its content as a transcript row, with no internal scroll boundary", () => {
   const css = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "askdock.module.css"), "utf8");
   const rule = css.match(/\.dock\s*\{([^}]*)\}/);
   expect(rule, "askdock.module.css must declare a .dock rule").not.toBeNull();
   const body = rule![1]!;
-  expect(body).toContain("max-width: 76rem");
+  expect(body).toContain("max-width: var(--session-measure)");
   expect(body).toContain("margin-inline: auto");
   expect(body).not.toContain("max-height");
   expect(body).not.toContain("overflow");

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askdock.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askdock.module.css
@@ -7,12 +7,12 @@
    * passes it as TranscriptBody's trailingRow): it sizes to its content so
    * the list's measureElement can measure it, and it scrolls away with the
    * transcript instead of owning a footer slot with its own internal
-   * scroll. Centered on the same 76rem reading measure as .turn
-   * (turnblock.module.css's --session-measure, a sibling stream's file -
-   * keep the two literals in sync until both consolidate onto a shared
-   * tokens.css property). */
+   * scroll. Centered on the same reading measure as .turn: --session-measure
+   * is declared on <body> in tokens.css (44rem, or 64rem under the
+   * Transcript width preference), and this row sits outside the .turn
+   * column, so it reads the token itself. */
   width: 100%;
-  max-width: 76rem;
+  max-width: var(--session-measure);
   margin-inline: auto;
   min-width: 0;
 }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askquestioncard.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askquestioncard.module.css
@@ -100,7 +100,7 @@
 
 .textInput {
   flex: 1;
-  font-size: var(--font-size-ui);
+  font-size: var(--font-size-control);
   color: var(--ink-hi);
   background: var(--surface-0);
   border: 1px solid var(--edge);

--- a/cmd/evener-hub/frontend/src/panes/session/composer/composer.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/composer.module.css
@@ -62,7 +62,7 @@
   width: 80px;
   height: 80px;
   border: 1px solid var(--edge);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-chip);
   overflow: hidden;
   background: var(--surface-2);
   transition: border-color var(--motion-duration-overlay);
@@ -125,7 +125,7 @@
   right: 0;
   background: color-mix(in oklab, var(--surface-0) 90%, transparent);
   color: var(--ink-hi);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   padding: 2px 4px;
   text-align: center;
   font-family: var(--font-mono);

--- a/cmd/evener-hub/frontend/src/panes/session/composer/currentwork.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/currentwork.module.css
@@ -49,7 +49,7 @@
   color: var(--ink-mid);
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: var(--tracking-micro);
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .value {
@@ -69,7 +69,7 @@
   font: inherit;
   text-align: left;
   text-decoration: underline;
-  text-decoration-color: var(--edge-hi);
+  text-decoration-color: var(--edge-strong);
   text-underline-offset: 2px;
 }
 
@@ -78,7 +78,7 @@
 }
 
 .link:focus-visible {
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-chip);
   outline: var(--focus-ring);
   outline-offset: 2px;
 }

--- a/cmd/evener-hub/frontend/src/panes/session/composer/currentwork.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/currentwork.module.css
@@ -47,7 +47,8 @@
 .label {
   flex: none;
   color: var(--ink-mid);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-caption);
   text-transform: uppercase;
   letter-spacing: var(--tracking-eyebrow);
 }

--- a/cmd/evener-hub/frontend/src/panes/session/session.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/session.module.css
@@ -70,7 +70,7 @@
 
 .coldStart {
   width: 100%;
-  max-width: 76rem;
+  max-width: var(--session-measure);
   margin-inline: auto;
   padding: var(--space-6) var(--space-4);
 }
@@ -89,9 +89,8 @@
 }
 
 .measure {
-  /* matches transcript measure — consolidate to a token after the UX settles */
   width: 100%;
-  max-width: 76rem;
+  max-width: var(--session-measure);
   margin-inline: auto;
   flex: 1 1 auto;
   min-height: 0;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRunGroup.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRunGroup.tsx
@@ -8,7 +8,7 @@
 // exists to spare the reader (and the render) the rows it stands for, and a
 // closed run that still mounted every tool body would spare neither. That is
 // also why the folded entries carry no view anchors of their own - TurnBlock
-// gives the whole run ONE anchor, so a run is one position in the scroll
+// gives the whole run ONE anchor that lists its members, so a run is one position in the scroll
 // coordinator's list whether it is open or closed rather than a set of
 // anchors that appear and vanish with a click.
 import type { ThreadModel, TurnModel } from "../../../protocol/model";
@@ -72,7 +72,7 @@ export function ToolRunGroup({ run, turn, sessionRef, renderContext, thread }: T
         <span className={CLASS.chevron} aria-hidden="true" data-open={open ? "true" : "false"}>
           <Chevron />
         </span>
-        <span className={CLASS.label}>{runLabel(run, toolRendererFor)}</span>
+        <span className={CLASS.label}>{runLabel(run, toolRendererFor, { cwd: thread?.cwd })}</span>
       </summary>
       {open && (
         <div className={CLASS.body}>

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRunGroup.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRunGroup.tsx
@@ -1,0 +1,101 @@
+// One row standing in for a run of settled, uneventful tool calls (critique
+// R9; toolRuns.ts decides what a run is). Structurally it is the same
+// disclosure ProjectedIntentGroup uses - a <details> whose open state lives
+// in the shared disclosureStore, so a reader's choice survives re-projection
+// and the transcript's expand/collapse-all baselines reach it.
+//
+// Unlike the intent group, the body is MOUNTED ONLY WHILE OPEN: a folded run
+// exists to spare the reader (and the render) the rows it stands for, and a
+// closed run that still mounted every tool body would spare neither. That is
+// also why the folded entries carry no view anchors of their own - TurnBlock
+// gives the whole run ONE anchor, so a run is one position in the scroll
+// coordinator's list whether it is open or closed rather than a set of
+// anchors that appear and vanish with a click.
+import type { ThreadModel, TurnModel } from "../../../protocol/model";
+import {
+  disclosureScopeForSession,
+  expandDetailsByDefault,
+  type TranscriptRenderContextValue,
+  useTranscriptRenderContext,
+} from "../../../transcriptDisplay/renderContext";
+import { Chevron } from "../../../widgets";
+import {
+  disclosureDefault,
+  isDisclosureOpen,
+  scopedDisclosureId,
+  toggleDisclosure,
+} from "../../../widgets/disclosure/disclosureStore";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import { ToolCallItem } from "./ToolCallItem";
+import { toolRendererFor } from "./toolRenderers";
+import { runLabel, type ToolRun } from "./toolRuns";
+import styles from "./toolrungroup.module.css";
+import { threadFingerprintForItem } from "./types";
+
+const CLASS = {
+  group: requireClass(styles.group, "toolrungroup.module.css", "group"),
+  summary: requireClass(styles.summary, "toolrungroup.module.css", "summary"),
+  chevron: requireClass(styles.chevron, "toolrungroup.module.css", "chevron"),
+  label: requireClass(styles.label, "toolrungroup.module.css", "label"),
+  body: requireClass(styles.body, "toolrungroup.module.css", "body"),
+};
+
+export interface ToolRunGroupProps {
+  run: ToolRun;
+  /** The turn the folded calls belong to, threaded so an expanded row sees
+   * exactly what it would have seen unfolded. */
+  turn: TurnModel;
+  sessionRef?: string;
+  renderContext?: TranscriptRenderContextValue;
+  thread?: ThreadModel;
+}
+
+export function ToolRunGroup({ run, turn, sessionRef, renderContext, thread }: ToolRunGroupProps) {
+  const context = useTranscriptRenderContext();
+  const { config } = context;
+  const scope = disclosureScopeForSession(context, sessionRef);
+  const disclosureKey = scopedDisclosureId(scope, run.id);
+  // A reader who has asked for expanded details has asked to see the calls,
+  // so the run opens with everything else at that level.
+  const fallback = expandDetailsByDefault(config) || disclosureDefault(scope, run.id, false);
+  const open = isDisclosureOpen(disclosureKey, fallback);
+  return (
+    <details className={CLASS.group} data-testid="tool-run" open={open}>
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: summary is natively keyboard-operable */}
+      <summary
+        className={CLASS.summary}
+        onClick={(event) => {
+          event.preventDefault();
+          toggleDisclosure(disclosureKey, fallback);
+        }}
+      >
+        <span className={CLASS.chevron} aria-hidden="true" data-open={open ? "true" : "false"}>
+          <Chevron />
+        </span>
+        <span className={CLASS.label}>{runLabel(run, toolRendererFor)}</span>
+      </summary>
+      {open && (
+        <div className={CLASS.body}>
+          {run.entries.map((entry) => (
+            <ToolCallItem
+              key={entry.id}
+              item={entry.item}
+              turn={turn}
+              // Every folded entry is a settled call by construction
+              // (toolRuns.ts's foldable), so none of them is live.
+              live={false}
+              sessionRef={sessionRef}
+              renderContext={renderContext ?? context}
+              thread={thread}
+              threadFingerprint={threadFingerprintForItem(
+                entry.item,
+                thread,
+                toolRendererFor(entry.item.toolName ?? "").summarySuffix?.(entry.item, thread),
+              )}
+            />
+          ))}
+        </div>
+      )}
+    </details>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
@@ -17,6 +17,7 @@ import { exchangeOpenersFor } from "./exchangeOpeners";
 import { FlowOverlay } from "./flow/FlowOverlay";
 import { useTranscriptViewRegistration } from "./flow/useTranscriptScroll";
 import { ProjectedIntentGroup, TurnBlock } from "./TurnBlock";
+import { foldTurnEntries } from "./toolRuns";
 import { asTurnError } from "./turnFailure";
 import "./messages";
 import "./tools";
@@ -208,15 +209,35 @@ export function transcriptRowsForProjection(projection: TranscriptProjection): r
   return rows;
 }
 
+// Anchors are registered from the SAME fold TurnBlock renders (toolRuns.ts's
+// foldTurnEntries): a folded run is one anchor under the run's id, carrying
+// its first entry's source index, because while the run is closed no element
+// carries the individual entry ids and a restore that looked for one would
+// find nothing (roborev on PR #947).
 export function transcriptAnchorEntriesForRows(rows: readonly TranscriptBodyRow[]): readonly TranscriptAnchorEntry[] {
   return rows.flatMap((row, index) => {
-    const entries = row.kind === "intentGroup" ? row.entries : row.turn.entries;
-    return entries.map((entry) => ({
-      id: entry.id,
-      sourceIndex: entry.sourceIndex,
-      index,
-      isMessage: entry.kind === "item" && entry.isMessage,
-    }));
+    if (row.kind === "intentGroup") {
+      return row.entries.map((entry) => ({
+        id: entry.id,
+        sourceIndex: entry.sourceIndex,
+        index,
+        isMessage: false,
+      }));
+    }
+    return foldTurnEntries(row.turn).flatMap((entry) => {
+      if (entry.kind === "run") {
+        const first = entry.entries[0];
+        return first ? [{ id: entry.id, sourceIndex: first.sourceIndex, index, isMessage: false }] : [];
+      }
+      return [
+        {
+          id: entry.id,
+          sourceIndex: entry.sourceIndex,
+          index,
+          isMessage: entry.kind === "item" && entry.isMessage,
+        },
+      ];
+    });
   });
 }
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
@@ -50,6 +50,8 @@ export interface TranscriptAnchorEntry {
   readonly sourceIndex: number;
   readonly index: number;
   readonly isMessage: boolean;
+  /** For a folded tool run: the entry ids it stands in for (toolRuns.ts). */
+  members?: readonly string[];
 }
 
 interface FlatEntry {
@@ -227,7 +229,17 @@ export function transcriptAnchorEntriesForRows(rows: readonly TranscriptBodyRow[
     return foldTurnEntries(row.turn).flatMap((entry) => {
       if (entry.kind === "run") {
         const first = entry.entries[0];
-        return first ? [{ id: entry.id, sourceIndex: first.sourceIndex, index, isMessage: false }] : [];
+        return first
+          ? [
+              {
+                id: entry.id,
+                sourceIndex: first.sourceIndex,
+                index,
+                isMessage: false,
+                members: entry.entries.map((member) => member.id),
+              },
+            ]
+          : [];
       }
       return [
         {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TranscriptBody.tsx
@@ -253,6 +253,18 @@ export function transcriptAnchorEntriesForRows(rows: readonly TranscriptBodyRow[
   });
 }
 
+// The disclosure ids ToolRunGroup mints (run:<first entry>) for the runs
+// TurnBlock will fold. The projector's eligibleDisclosureIds inventory only
+// knows source item ids, so without these the Full-view baseline could not
+// clear a run the reader closed before leaving Full and coming back
+// (roborev on PR #947): a stale explicit close would keep the run shut in a
+// view whose contract is "everything open".
+export function transcriptRunDisclosureIdsForRows(rows: readonly TranscriptBodyRow[]): readonly string[] {
+  return rows.flatMap((row) =>
+    row.kind === "turn" ? foldTurnEntries(row.turn).flatMap((entry) => (entry.kind === "run" ? [entry.id] : [])) : [],
+  );
+}
+
 export function transcriptSourceTurnRowIndexesForRows(rows: readonly TranscriptBodyRow[]): ReadonlyMap<string, number> {
   const indexes = new Map<string, number>();
   for (const [index, row] of rows.entries()) {
@@ -316,12 +328,18 @@ export function TranscriptBody({
   const focusFallbackRef = useRef<HTMLElement>(null);
   const projection = useMemo(() => projectThread(model, config), [model, config]);
   const rows = useMemo(() => transcriptRowsForProjection(projection), [projection]);
+  // Source item ids from the projector plus the folded-run ids the rows will
+  // render, so the Full baseline reaches every disclosure on screen.
+  const eligibleDisclosureIds = useMemo(
+    () => [...projection.eligibleDisclosureIds, ...transcriptRunDisclosureIdsForRows(rows)],
+    [projection, rows],
+  );
   const openers = useMemo(() => exchangeOpenersFor(model.turns), [model.turns]);
   const agentLabel = modelLabel(model.modelProvider, model.model);
   const itemRenderFingerprint = [
     configFingerprint(config),
     JSON.stringify(projection.metadata),
-    projection.eligibleDisclosureIds.join("\0"),
+    eligibleDisclosureIds.join("\0"),
     surface,
     sessionRef,
     disclosureScope,
@@ -332,6 +350,7 @@ export function TranscriptBody({
       createTranscriptRenderContext({
         config,
         projection,
+        eligibleDisclosureIds,
         surface,
         sessionRef,
         disclosureScope,
@@ -483,6 +502,7 @@ export function TranscriptBody({
     <TranscriptRenderProvider
       config={config}
       projection={projection}
+      eligibleDisclosureIds={eligibleDisclosureIds}
       surface={surface}
       sessionRef={sessionRef}
       disclosureScope={disclosureScope}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -718,6 +718,26 @@ test("the folded row counts the steps and names the consequential one", () => {
   expect(screen.getByTestId("tool-run").textContent).toContain("3 steps · Wrote foo.py");
 });
 
+test("a folded run's anchor lists the entries it stands in for", () => {
+  // roborev on PR #947: scroll/focus restoration for the second or third call
+  // needs a way from that call's id to the one anchor the run renders.
+  render(
+    withConfig(
+      TOOLS_CONFIG,
+      <TurnBlock
+        turn={turn(
+          [toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "read_file")],
+          { status: "completed" },
+          TOOLS_CONFIG,
+        )}
+        viewAnchorIndex={0}
+      />,
+    ),
+  );
+  const anchor = document.querySelector('[data-view-anchor-id="run:a"]');
+  expect(anchor?.getAttribute("data-view-anchor-members")).toBe("a,b,c");
+});
+
 test("two calls are not a run: they keep their own rows", () => {
   renderTools([toolItem("a", "read_file"), toolItem("b", "read_file")]);
   expect(screen.queryByTestId("tool-run")).toBeNull();

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -671,3 +671,110 @@ test("the turn column can shrink below its content's natural width", () => {
   expect(turn).not.toBeNull();
   expect(turn![1]).toContain("min-width: 0");
 });
+
+// --- Folding a settled run of tool calls (critique R9) --------------------
+//
+// These render at the "tools" level - the shipped desktop default, whose
+// expandedDetails is off, so a fold actually folds. At "activity"/"full" the
+// reader has asked for everything expanded and a run opens with the rest.
+
+const TOOLS_CONFIG = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+
+function toolItem(id: string, toolName: string, overrides: Partial<ItemModel> = {}): ItemModel {
+  return item({
+    id,
+    type: "commandExecution",
+    toolName,
+    status: "completed",
+    argumentsJSON: JSON.stringify({ file_path: `${id}.ts` }),
+    ...overrides,
+  });
+}
+
+function renderTools(items: ItemModel[], turnOverrides: Partial<TurnModel> = { status: "completed" }) {
+  render(withConfig(TOOLS_CONFIG, <TurnBlock turn={turn(items, turnOverrides, TOOLS_CONFIG)} />));
+}
+
+function openRun() {
+  const summary = screen.getByTestId("tool-run").querySelector("summary");
+  if (summary === null) throw new Error("the folded run rendered no summary to click");
+  fireEvent.click(summary);
+}
+
+test("a settled turn folds three quiet tool calls into one row that opens to them", () => {
+  renderTools([toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "read_file")]);
+  expect(screen.getAllByTestId("tool-run")).toHaveLength(1);
+  expect(screen.queryAllByTestId("tool-row")).toHaveLength(0);
+  openRun();
+  expect(screen.getAllByTestId("tool-row")).toHaveLength(3);
+});
+
+test("the folded row counts the steps and names the consequential one", () => {
+  renderTools([
+    toolItem("a", "read_file"),
+    toolItem("b", "write_file", { argumentsJSON: JSON.stringify({ file_path: "foo.py" }) }),
+    toolItem("c", "read_file"),
+  ]);
+  expect(screen.getByTestId("tool-run").textContent).toContain("3 steps · Wrote foo.py");
+});
+
+test("two calls are not a run: they keep their own rows", () => {
+  renderTools([toolItem("a", "read_file"), toolItem("b", "read_file")]);
+  expect(screen.queryByTestId("tool-run")).toBeNull();
+  expect(screen.getAllByTestId("tool-row")).toHaveLength(2);
+});
+
+test("a failed call breaks the run: every row stays visible", () => {
+  renderTools([
+    toolItem("a", "read_file"),
+    toolItem("b", "read_file", { status: "failed", error: "no such file" }),
+    toolItem("c", "read_file"),
+    toolItem("d", "read_file"),
+  ]);
+  expect(screen.queryByTestId("tool-run")).toBeNull();
+  expect(screen.getAllByTestId("tool-row")).toHaveLength(4);
+});
+
+test("a live turn never folds: each call keeps its own row while the agent works", () => {
+  renderTools([toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "read_file")], {
+    status: "inProgress",
+  });
+  expect(screen.queryByTestId("tool-run")).toBeNull();
+  expect(screen.getAllByTestId("tool-row")).toHaveLength(3);
+});
+
+test("a never-fold tool splits the run around itself", () => {
+  renderTools([
+    toolItem("a", "read_file"),
+    toolItem("b", "use_skill"),
+    toolItem("c", "read_file"),
+    toolItem("d", "read_file"),
+    toolItem("e", "read_file"),
+  ]);
+  expect(screen.getAllByTestId("tool-run")).toHaveLength(1);
+  expect(screen.getAllByTestId("tool-row")).toHaveLength(2);
+});
+
+test("a folded run takes the run-content indent, like the rows it stands in for", () => {
+  renderTools([toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "read_file")]);
+  expectInsideRunContent(screen.getByTestId("tool-run"));
+});
+
+test("a folded run keeps a view anchor so scroll coordination still has a position for it", () => {
+  render(
+    withConfig(
+      TOOLS_CONFIG,
+      <TurnBlock
+        turn={turn(
+          [toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "read_file")],
+          { status: "completed" },
+          TOOLS_CONFIG,
+        )}
+        viewAnchorIndex={7}
+      />,
+    ),
+  );
+  const anchor = document.querySelector('[data-view-anchor-id="run:a"]');
+  expect(anchor).not.toBeNull();
+  expect(anchor?.getAttribute("data-view-anchor-index")).toBe("7");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
@@ -101,7 +101,12 @@ export function projectedEntryAnchor(entry: ProjectedEntry, viewAnchorIndex: num
 function runAnchorFor(run: ToolRun, viewAnchorIndex: number | undefined) {
   const first = run.entries[0];
   if (!first) return undefined;
-  return projectedEntryAnchor({ ...first, id: run.id }, viewAnchorIndex);
+  const anchor = projectedEntryAnchor({ ...first, id: run.id }, viewAnchorIndex);
+  if (!anchor) return undefined;
+  // The ids this anchor stands in for, so a scroll position or focus
+  // captured on the second or third call (useTranscriptScroll) still finds
+  // its way back to the run once the calls have folded.
+  return { ...anchor, "data-view-anchor-members": run.entries.map((entry) => entry.id).join(",") };
 }
 
 export interface ProjectedIntentGroupProps {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
@@ -28,8 +28,10 @@ import { SeenDivider } from "./flow/SeenDivider";
 import { rowRoleFor } from "./layoutRoles";
 import { TurnSeparator } from "./messages";
 import { ToolCallItem } from "./ToolCallItem";
+import { ToolRunGroup } from "./ToolRunGroup";
 import { TurnFailureEndCap } from "./TurnFailureEndCap";
 import { toolRendererFor } from "./toolRenderers";
+import { foldToolRuns, type ToolRun } from "./toolRuns";
 import styles from "./turnblock.module.css";
 import { asTurnError } from "./turnFailure";
 import { itemRendererFor, threadFingerprintForItem } from "./types";
@@ -91,6 +93,15 @@ export function projectedEntryAnchor(entry: ProjectedEntry, viewAnchorIndex: num
     "data-view-anchor-turn-id": entry.turnId,
     "data-view-anchor-message": entry.kind === "item" && entry.isMessage,
   } as const;
+}
+
+// A folded run stands in for its entries in the anchor list too: it borrows
+// the first folded entry's turn and source index, under the run's own id, so
+// no two anchors can ever claim the same id when the run is open.
+function runAnchorFor(run: ToolRun, viewAnchorIndex: number | undefined) {
+  const first = run.entries[0];
+  if (!first) return undefined;
+  return projectedEntryAnchor({ ...first, id: run.id }, viewAnchorIndex);
 }
 
 export interface ProjectedIntentGroupProps {
@@ -212,15 +223,44 @@ export function TurnBlock({
     visibleItems.every((item, index) => item === sourceTurn.items[index]);
   const shownTurn: TurnModel = allItemsVisible ? sourceTurn : { ...sourceTurn, items: [...visibleItems] };
   const viewAnchorFor = (entry: ProjectedEntry) => projectedEntryAnchor(entry, viewAnchorIndex);
+  // Once a turn has settled, a run of uneventful tool calls collapses to one
+  // row (critique R9, toolRuns.ts). "inProgress" is the wire's own live turn
+  // status (the projector reads the same literal), so a turn still working
+  // keeps every call visible as it arrives.
+  const laidOut = foldToolRuns(projectedTurn.entries, {
+    turnSettled: sourceTurn.status !== "inProgress",
+    descriptorFor: toolRendererFor,
+  });
   const renderedEntries: ReactNode[] = [];
-  for (let index = 0; index < projectedTurn.entries.length; index += 1) {
-    const entry = projectedTurn.entries[index];
+  for (let index = 0; index < laidOut.length; index += 1) {
+    const entry = laidOut[index];
     if (!entry) continue;
+    if (entry.kind === "run") {
+      renderedEntries.push(
+        <div
+          key={entry.id}
+          className={CLASS.runContent}
+          data-testid="run-content"
+          // The whole run is one position for scroll coordination, open or
+          // closed - see ToolRunGroup's header.
+          {...runAnchorFor(entry, viewAnchorIndex)}
+        >
+          <ToolRunGroup
+            run={entry}
+            turn={shownTurn}
+            sessionRef={sessionRef}
+            renderContext={itemRenderContext}
+            thread={thread}
+          />
+        </div>,
+      );
+      continue;
+    }
     if (entry.kind === "intent") {
       const group: Extract<ProjectedEntry, { kind: "intent" }>[] = [entry];
-      while (projectedTurn.entries[index + 1]?.kind === "intent") {
+      while (laidOut[index + 1]?.kind === "intent") {
         index += 1;
-        const next = projectedTurn.entries[index];
+        const next = laidOut[index];
         if (next?.kind === "intent") group.push(next);
       }
       renderedEntries.push(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
@@ -31,7 +31,7 @@ import { ToolCallItem } from "./ToolCallItem";
 import { ToolRunGroup } from "./ToolRunGroup";
 import { TurnFailureEndCap } from "./TurnFailureEndCap";
 import { toolRendererFor } from "./toolRenderers";
-import { foldToolRuns, type ToolRun } from "./toolRuns";
+import { foldTurnEntries, type ToolRun } from "./toolRuns";
 import styles from "./turnblock.module.css";
 import { asTurnError } from "./turnFailure";
 import { itemRendererFor, threadFingerprintForItem } from "./types";
@@ -227,10 +227,7 @@ export function TurnBlock({
   // row (critique R9, toolRuns.ts). "inProgress" is the wire's own live turn
   // status (the projector reads the same literal), so a turn still working
   // keeps every call visible as it arrives.
-  const laidOut = foldToolRuns(projectedTurn.entries, {
-    turnSettled: sourceTurn.status !== "inProgress",
-    descriptorFor: toolRendererFor,
-  });
+  const laidOut = foldTurnEntries(projectedTurn);
   const renderedEntries: ReactNode[] = [];
   for (let index = 0; index < laidOut.length; index += 1) {
     const entry = laidOut[index];

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/livenessline.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/livenessline.module.css
@@ -5,7 +5,7 @@
  * pane's edge padding and .measure's own gap spaces siblings apart. */
 .line {
   font-size: var(--font-size-caption);
-  color: var(--ink-low);
+  color: var(--ink-mid);
 }
 
 /* stalled reads with more weight/contrast than the merely-quiet line, but

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
@@ -1601,6 +1601,21 @@ describe("view-mode anchor preservation", () => {
     expect(transformedAnchors.every((anchor) => anchor.index >= 0 && anchor.index < 2)).toBe(true);
   });
 
+  test("an anchor captured on a call that has since folded restores to its run row", () => {
+    // roborev on PR #947: only the first folded entry's id used to map to the
+    // run; the second and third had no anchor to restore to.
+    const positions: ViewAnchorPosition[] = [
+      { id: "run:a", sourceIndex: 0, index: 0, offset: 0, isMessage: false, members: ["a", "b", "c"] },
+      { id: "agent-4", sourceIndex: 4, index: 1, offset: 0, isMessage: true },
+    ];
+    expect(
+      restoreTopAnchor(
+        captureTopAnchor({ id: "b", sourceIndex: 1, index: 0, offset: 12, isMessage: false }),
+        positions,
+      ),
+    ).toEqual({ id: "run:a", index: 0, offset: 12 });
+  });
+
   test("captures and restores the same stable entry and viewport offset", () => {
     const anchor = captureTopAnchor({ id: "turn-4", sourceIndex: 4, index: 4, offset: 18, isMessage: true });
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.test.ts
@@ -1616,6 +1616,57 @@ describe("view-mode anchor preservation", () => {
     ).toEqual({ id: "run:a", index: 0, offset: 12 });
   });
 
+  // roborev on PR #947 (round seven): one source item wears a different id
+  // per view - intent:<id> in Intent, <id> in Tools/Full, run:<id> once it
+  // folds - so a restore across a view change has to match by source
+  // identity (with the source index agreeing), not by the literal id.
+  test("a position captured on an intent proxy restores to the same source item in a tool-call view", () => {
+    const positions: ViewAnchorPosition[] = [
+      { id: "a", sourceIndex: 0, index: 0, offset: 0, isMessage: false },
+      { id: "b", sourceIndex: 1, index: 1, offset: 0, isMessage: false },
+      { id: "agent-4", sourceIndex: 4, index: 2, offset: 0, isMessage: true },
+    ];
+    expect(
+      restoreTopAnchor(
+        captureTopAnchor({ id: "intent:b", sourceIndex: 1, index: 0, offset: 7, isMessage: false }),
+        positions,
+      ),
+    ).toEqual({ id: "b", index: 1, offset: 7 });
+  });
+
+  test("a position captured on an intent proxy restores to the folded run that now holds its source item", () => {
+    const positions: ViewAnchorPosition[] = [
+      { id: "run:a", sourceIndex: 0, index: 0, offset: 0, isMessage: false, members: ["a", "b", "c"] },
+      { id: "agent-4", sourceIndex: 4, index: 1, offset: 0, isMessage: true },
+    ];
+    expect(
+      restoreTopAnchor(
+        captureTopAnchor({ id: "intent:b", sourceIndex: 1, index: 0, offset: 7, isMessage: false }),
+        positions,
+      ),
+    ).toEqual({ id: "run:a", index: 0, offset: 7 });
+  });
+
+  test("a tool-call view position restores to its intent proxy in Intent view", () => {
+    const positions: ViewAnchorPosition[] = [
+      { id: "intent:b", sourceIndex: 1, index: 3, offset: 0, isMessage: false },
+      { id: "agent-4", sourceIndex: 4, index: 4, offset: 0, isMessage: true },
+    ];
+    expect(
+      restoreTopAnchor(captureTopAnchor({ id: "b", sourceIndex: 1, index: 0, offset: 7, isMessage: false }), positions),
+    ).toEqual({ id: "intent:b", index: 3, offset: 7 });
+  });
+
+  test("the same identity at a different source index is another item: the nearest message wins instead", () => {
+    const positions: ViewAnchorPosition[] = [
+      { id: "agent-0", sourceIndex: 0, index: 0, offset: 0, isMessage: true },
+      { id: "intent:b", sourceIndex: 5, index: 1, offset: 0, isMessage: false },
+    ];
+    expect(
+      restoreTopAnchor(captureTopAnchor({ id: "b", sourceIndex: 1, index: 0, offset: 7, isMessage: false }), positions),
+    ).toEqual({ id: "agent-0", index: 0, offset: 7 });
+  });
+
   test("captures and restores the same stable entry and viewport offset", () => {
     const anchor = captureTopAnchor({ id: "turn-4", sourceIndex: 4, index: 4, offset: 18, isMessage: true });
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
@@ -177,6 +177,10 @@ const capturedFocusMetadata = new WeakMap<CapturedTranscriptView, CapturedFocusM
 
 function sourceIdentity(id: string): string {
   if (id.startsWith("intent:")) return id.slice("intent:".length);
+  // A folded tool run's anchor is its first entry's id under the run prefix
+  // (toolRuns.ts): a focus captured on that entry before the turn settled
+  // still resolves to the run it folded into.
+  if (id.startsWith("run:")) return id.slice("run:".length);
   if (id.startsWith("tools:")) return id.slice("tools:".length).split(":")[0] ?? id;
   return id;
 }
@@ -278,15 +282,24 @@ function focusNodeMatches(candidate: HTMLElement, metadata: CapturedFocusMetadat
   return metadata.sourceIndex === undefined || sourceIndex === undefined || sourceIndex === metadata.sourceIndex;
 }
 
-function closedIntentSummary(anchor: HTMLElement): HTMLElement | undefined {
-  if (!anchor.dataset.viewAnchorId?.startsWith("intent:")) return undefined;
-  const details = anchor.closest<HTMLDetailsElement>('details[data-testid="intent-group"]:not([open])');
-  const summary = details?.querySelector(":scope > summary");
+// A closed disclosure that owns the anchor: an intent-group entry's anchor
+// sits INSIDE its <details>, a folded tool run's anchor wraps its own
+// <details> (TurnBlock's runAnchorFor), so the two are looked up from
+// opposite directions. Either way the summary is the thing to focus.
+function closedGroupSummary(anchor: HTMLElement): HTMLElement | undefined {
+  const id = anchor.dataset.viewAnchorId ?? "";
+  let summary: Element | null | undefined;
+  if (id.startsWith("intent:")) {
+    const details = anchor.closest<HTMLDetailsElement>('details[data-testid="intent-group"]:not([open])');
+    summary = details?.querySelector(":scope > summary");
+  } else if (id.startsWith("run:")) {
+    summary = anchor.querySelector(':scope > details[data-testid="tool-run"]:not([open]) > summary');
+  }
   return summary instanceof HTMLElement ? summary : undefined;
 }
 
 function focusAnchor(anchor: HTMLElement, metadata: CapturedFocusMetadata): boolean {
-  const summary = closedIntentSummary(anchor);
+  const summary = closedGroupSummary(anchor);
   if (summary) {
     summary.focus();
     if (summary.ownerDocument.activeElement === summary) return true;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
@@ -95,6 +95,9 @@ export interface ViewAnchorPosition {
   height?: number;
   /** User/agent content survives every focused representation. */
   isMessage: boolean;
+  /** For a folded tool run (toolRuns.ts): the entry ids it stands in for. A
+   * capture on any of them resolves to this anchor. */
+  members?: readonly string[];
 }
 
 export interface ViewAnchor {
@@ -125,6 +128,10 @@ export function restoreTopAnchor(
 ): RestoredViewAnchor | undefined {
   const exact = positions.find((position) => position.id === anchor.id);
   if (exact) return { id: exact.id, index: exact.index, offset: anchor.offset };
+  // The entry has folded into a tool run since it was captured: the run's
+  // anchor is the row that now stands where the entry stood.
+  const owner = positions.find((position) => position.members?.includes(anchor.id));
+  if (owner) return { id: owner.id, index: owner.index, offset: anchor.offset };
 
   const nearest = positions
     .filter((position) => position.isMessage)
@@ -142,6 +149,7 @@ function readAnchorPositions(el: HTMLElement): ViewAnchorPosition[] {
   return Array.from(el.querySelectorAll<HTMLElement>("[data-view-anchor-id]")).map((row, renderedIndex) => {
     const rect = row.getBoundingClientRect();
     const sourceIndex = Number(row.dataset.viewAnchorSourceIndex ?? renderedIndex);
+    const members = row.dataset.viewAnchorMembers;
     return {
       id: row.dataset.viewAnchorId ?? "",
       sourceIndex,
@@ -149,6 +157,7 @@ function readAnchorPositions(el: HTMLElement): ViewAnchorPosition[] {
       offset: rect.top - viewportTop,
       height: rect.height,
       isMessage: row.dataset.viewAnchorMessage === "true",
+      ...(members ? { members: members.split(",") } : {}),
     };
   });
 }
@@ -269,14 +278,26 @@ function anchorFromCapture(
   return captureTopAnchor({ ...source, offset: captured.anchorOffset });
 }
 
+// A folded run's anchor answers for every entry it folded (its members): a
+// focus captured on the third call of a run that has since folded restores to
+// the run - its summary when closed, the row itself when open.
+function membersMatch(members: readonly string[] | undefined, metadata: CapturedFocusMetadata): boolean {
+  return (
+    members?.some((member) => member === metadata.anchorId || sourceIdentity(member) === metadata.sourceIdentity) ??
+    false
+  );
+}
+
 function focusCandidateMatches(candidate: ViewAnchorPosition, metadata: CapturedFocusMetadata): boolean {
   if (candidate.id === metadata.anchorId) return true;
+  if (membersMatch(candidate.members, metadata)) return true;
   if (sourceIdentity(candidate.id) !== metadata.sourceIdentity) return false;
   return metadata.sourceIndex === undefined || candidate.sourceIndex === metadata.sourceIndex;
 }
 
 function focusNodeMatches(candidate: HTMLElement, metadata: CapturedFocusMetadata): boolean {
   if (candidate.dataset.viewAnchorId === metadata.anchorId) return true;
+  if (membersMatch(candidate.dataset.viewAnchorMembers?.split(","), metadata)) return true;
   if (sourceIdentity(candidate.dataset.viewAnchorId ?? "") !== metadata.sourceIdentity) return false;
   const sourceIndex = sourceIndexFromDataset(candidate);
   return metadata.sourceIndex === undefined || sourceIndex === undefined || sourceIndex === metadata.sourceIndex;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/useTranscriptScroll.ts
@@ -122,16 +122,36 @@ export function captureTopAnchor(position: ViewAnchorPosition): ViewAnchor {
   };
 }
 
+// The rendered position that stands for a captured anchor's source item. One
+// source item wears a different id per view - intent:<id> in Intent, <id> in
+// Tools/Full, tools:<id>:… for a summary, run:<id> once it folds - so after
+// the literal id, match the source identity (sourceIdentity strips the view
+// prefixes) with the source index agreeing where the capture carries one,
+// then a folded run whose members carry the item (roborev on PR #947).
+function positionForAnchor(
+  anchor: { id: string; sourceIndex?: number },
+  positions: readonly ViewAnchorPosition[],
+): ViewAnchorPosition | undefined {
+  const exact = positions.find((position) => position.id === anchor.id);
+  if (exact) return exact;
+  const identity = sourceIdentity(anchor.id);
+  const sameSource = positions.find(
+    (position) =>
+      sourceIdentity(position.id) === identity &&
+      (anchor.sourceIndex === undefined || position.sourceIndex === anchor.sourceIndex),
+  );
+  if (sameSource) return sameSource;
+  return positions.find((position) =>
+    position.members?.some((member) => member === anchor.id || sourceIdentity(member) === identity),
+  );
+}
+
 export function restoreTopAnchor(
   anchor: ViewAnchor,
   positions: readonly ViewAnchorPosition[],
 ): RestoredViewAnchor | undefined {
-  const exact = positions.find((position) => position.id === anchor.id);
-  if (exact) return { id: exact.id, index: exact.index, offset: anchor.offset };
-  // The entry has folded into a tool run since it was captured: the run's
-  // anchor is the row that now stands where the entry stood.
-  const owner = positions.find((position) => position.members?.includes(anchor.id));
-  if (owner) return { id: owner.id, index: owner.index, offset: anchor.offset };
+  const same = positionForAnchor(anchor, positions);
+  if (same) return { id: same.id, index: same.index, offset: anchor.offset };
 
   const nearest = positions
     .filter((position) => position.isMessage)
@@ -273,7 +293,8 @@ function anchorFromCapture(
 ): ViewAnchor | undefined {
   const metadata = capturedAnchorMetadata.get(captured);
   if (metadata) return metadata;
-  const source = candidates.find((candidate) => candidate.id === captured.anchorId);
+  if (captured.anchorId === undefined) return undefined;
+  const source = positionForAnchor({ id: captured.anchorId }, candidates);
   if (!source) return undefined;
   return captureTopAnchor({ ...source, offset: captured.anchorOffset });
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
@@ -345,14 +345,19 @@ test("a continuation fragment's bubble carries the uniform-radius continuation c
   expect(screen.queryByTestId("agent-speaker-header")).toBeNull();
 });
 
-test("the bubble fills are token color-mixes and the continuation radius is uniform", () => {
+test("agent prose is a document: the bubble wrapper has no fill, no radius, and spans the column", () => {
+  // typography-spacing-critique-2026-09-06 R9: with the column bounded, the
+  // neutral wash behind every agent paragraph stopped doing any work. The
+  // user's words keep their accent wash (usermessageitem.module.css).
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "agentmessageitem.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
   const bubble = /\.bubble\s*\{([^}]*)\}/.exec(css);
   expect(bubble).not.toBeNull();
-  expect(bubble![1]).toMatch(/background:\s*color-mix\(in oklab, var\(--ink-mid\)/);
+  expect(bubble![1]).not.toMatch(/background\s*:/);
+  expect(bubble![1]).not.toMatch(/border-radius\s*:/);
+  expect(bubble![1]).toMatch(/width:\s*100%/);
   expect(bubble![1]).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
-  expect(css).toMatch(/\.continuation\s*\{[^}]*border-radius:\s*var\(--radius-pane\);/);
+  expect(css).toMatch(/\.continuation\s*\{[^}]*margin-top:\s*var\(--rhythm-item\);/);
 });
 
 // The live path renders through the SAME Markdown widget as the settled

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
@@ -288,7 +288,7 @@ test("sets --prose-font-size once, on the .message ancestor the live and settled
 test("the agent message keeps .message a bare layout row - the bubble treatment lives on .bubble, not the row", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "agentmessageitem.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
-  expect(css).toMatch(/\.message\s*\{[\s\S]*padding:\s*var\(--space-1\)\s+0;/);
+  expect(css).toMatch(/\.message\s*\{[\s\S]*padding:\s*var\(--rhythm-line\)\s+0;/);
   expect(css).not.toMatch(/\.message\s*\{[\s\S]*--prose-font-size:/);
   expect(css).not.toMatch(/\.message\s*\{[^}]*background\s*:/);
   expect(css).not.toMatch(/\.message\s*\{[^}]*border\s*:/);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
@@ -21,7 +21,7 @@
 // ImagePlaceholder) - so, unlike UserMessageView, there is no images branch.
 import { memo } from "react";
 import type { SteeringKind } from "../../../../protocol/types.gen";
-import { SteeringGlyph } from "../../../../widgets";
+import { Chevron, SteeringGlyph } from "../../../../widgets";
 import { isDisclosureOpen, toggleDisclosure } from "../../../../widgets/disclosure/disclosureStore";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { itemScopeKey } from "../tools/subagentModuleStore";
@@ -132,7 +132,7 @@ function SteeringDivider({
           data-open={open ? "true" : "false"}
           data-testid="steering-chevron"
         >
-          ▸
+          <Chevron />
         </span>
       </summary>
       <pre className={CLASS.body}>{text}</pre>

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/UserMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/UserMessageItem.test.tsx
@@ -165,12 +165,13 @@ test("the slack-lean layout is token-backed and has no prose card treatment", ()
   // 651px row).
   expect(css).toMatch(/\.content\s*\{[\s\S]*flex:\s*1 1 auto;[\s\S]*min-width:\s*0;/);
   expect(css).toMatch(/\.header\s*\{[\s\S]*display:\s*flex;[\s\S]*align-items:\s*baseline;/);
-  // Speaker name at body size / medium weight / --ink-hi (spec decision 1);
-  // clock time at caption / --ink-low.
+  // Speaker name at body size / semibold / --ink-hi (spec decision 1, weight
+  // raised by typography-spacing-critique-2026-09-06 R3 so the header is a
+  // landmark); clock time at ui size / --ink-mid (readable, not sub-AA).
   expect(css).toMatch(
-    /\.name\s*\{[\s\S]*font-size:\s*var\(--font-size-body\);[\s\S]*font-weight:\s*var\(--font-weight-medium\);[\s\S]*color:\s*var\(--ink-hi\);/,
+    /\.name\s*\{[\s\S]*font-size:\s*var\(--font-size-body\);[\s\S]*font-weight:\s*var\(--font-weight-semibold\);[\s\S]*color:\s*var\(--ink-hi\);/,
   );
-  expect(css).toMatch(/\.time\s*\{[\s\S]*font-size:\s*var\(--font-size-caption\);[\s\S]*color:\s*var\(--ink-low\);/);
+  expect(css).toMatch(/\.time\s*\{[\s\S]*font-size:\s*var\(--font-size-ui\);[\s\S]*color:\s*var\(--ink-mid\);/);
   // Text at --ink-hi (spec decision 5 - the header now carries the
   // boundary-scannability the old --ink-mid demotion was buying).
   expect(css).toMatch(/\.text\s*\{[\s\S]*color:\s*var\(--ink-hi\);/);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/UserMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/UserMessageItem.test.tsx
@@ -157,12 +157,12 @@ test("the slack-lean layout is token-backed and has no prose card treatment", ()
   expect(css).toMatch(/\.message\s*\{[\s\S]*display:\s*flex;[\s\S]*gap:\s*var\(--speaker-gap\);/);
   expect(css).toMatch(/\.avatar\s*\{[\s\S]*flex:\s*none;/);
   // The content column must SPAN the row (flex: 1 1 auto), matching the agent
-  // side's .column: left shrink-to-fit, the bubble's max-width: 92% becomes a
+  // side's .column: left shrink-to-fit, the bubble's max-width becomes a
   // cyclic percentage against a containing block sized by the bubble itself,
-  // which resolves to roughly 92% of the text's own width and wraps the tail
-  // words of every message wider than the header (2026-07-30 live-DOM
-  // measurement: "commit and merge" clamped to 133px and wrapped in a 651px
-  // row).
+  // which resolves against the text's own width and wraps the tail words of
+  // every message wider than the header (2026-07-30 live-DOM measurement at
+  // the old 92% cap: "commit and merge" clamped to 133px and wrapped in a
+  // 651px row).
   expect(css).toMatch(/\.content\s*\{[\s\S]*flex:\s*1 1 auto;[\s\S]*min-width:\s*0;/);
   expect(css).toMatch(/\.header\s*\{[\s\S]*display:\s*flex;[\s\S]*align-items:\s*baseline;/);
   // Speaker name at body size / medium weight / --ink-hi (spec decision 1);
@@ -178,8 +178,18 @@ test("the slack-lean layout is token-backed and has no prose card treatment", ()
   expect(css).toMatch(/\.actions\s*\{[\s\S]*margin-left:\s*auto;/);
   expect(css).toMatch(/\.message:hover\s+\.actions/);
   expect(css).toMatch(/\.message:focus-within\s+\.actions/);
-  // No breakpoint in this component - TurnBlock owns the gutter media query.
-  expect(css).not.toMatch(/@media/);
+  // One breakpoint, and it is not the gutter's (TurnBlock owns that): below
+  // 700px the row becomes a grid so the bubble spans the pane under the
+  // avatar + header row (typography-spacing-critique-2026-09-06 finding 2:
+  // prose got 260px of a 375px screen). The avatar never leaves the header
+  // line; the content column dissolves (display: contents) so its header and
+  // body are the grid's own items.
+  const phone = /@media \(max-width: 699px\)\s*\{([\s\S]*)\}\s*$/.exec(css);
+  expect(phone).not.toBeNull();
+  expect(phone![1]).toMatch(/\.message\s*\{[^}]*display:\s*grid;[^}]*grid-template-columns:\s*auto minmax\(0, 1fr\);/);
+  expect(phone![1]).toMatch(/\.message > \.content\s*\{[^}]*display:\s*contents;/);
+  expect(phone![1]).toMatch(/\.message \.body\s*\{[^}]*grid-column:\s*1 \/ -1;/);
+  expect(css.split("@media").length).toBe(2);
   expect(css).not.toMatch(/\.message\s*\{[^}]*background\s*:/);
   expect(css).not.toMatch(/\.message\s*\{[^}]*border\s*:/);
 });
@@ -206,7 +216,7 @@ test("the user bubble is an accent-wash token fill, hugging its content, tailed 
   expect(body).not.toBeNull();
   expect(body![1]).toMatch(/background:\s*var\(--accent-bg\)/);
   expect(body![1]).toMatch(/width:\s*fit-content/);
-  expect(body![1]).toMatch(/max-width:\s*92%/);
+  expect(body![1]).toMatch(/max-width:\s*100%/);
   expect(body![1]).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
   // The 4px (control-radius) corner is the top-left one - toward the avatar.
   expect(body![1]).toMatch(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentMessageSize.contract.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentMessageSize.contract.test.ts
@@ -26,7 +26,9 @@ test("prose typography stays with Markdown/StreamingText: the .message wrapper d
   expect(uncommented).not.toMatch(/\.message\s*\{[^}]*font-size\s*:/);
 });
 
-test("the speaker header's name is body-size like the prose it introduces; only the meta drops to caption", () => {
+test("the speaker header's name is body-size like the prose it introduces; only the meta drops to the ui size", () => {
   expect(uncommented).toMatch(/\.name\s*\{[^}]*font-size:\s*var\(--font-size-body\);/);
-  expect(uncommented).toMatch(/\.meta\s*\{[^}]*font-size:\s*var\(--font-size-caption\);/);
+  // ui, not caption: the model label and clock are read, not glanced past
+  // (typography-spacing-critique-2026-09-06 finding 7).
+  expect(uncommented).toMatch(/\.meta\s*\{[^}]*font-size:\s*var\(--font-size-ui\);/);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
@@ -12,9 +12,10 @@
  * size bump fired on every mid-turn narrative fragment, dozens per
  * session, and cancelled itself. */
 .message {
-  /* --space-1, not --space-2: with prose now in a per-fragment bubble (see
-   * .bubble), consecutive agent messages stack like chat rows - tight. */
-  padding: var(--space-1) 0;
+  /* One rhythm step inside an exchange: consecutive agent fragments stack
+   * like chat rows - tight. The larger steps live on the user message
+   * (exchange) and the turn separator (group). */
+  padding: var(--rhythm-line) 0;
 }
 
 /* The chat bubble (2026-07-30-transcript-chat-bubbles-design.md, decisions
@@ -103,12 +104,16 @@
   display: flex;
   align-items: baseline;
   gap: var(--space-2);
+  margin-bottom: var(--rhythm-line);
 }
 
+/* Semibold: the speaker header is the transcript's one structural landmark
+ * per exchange, and at body size a medium weight next to regular prose was
+ * not a landmark (typography-spacing-critique-2026-09-06 finding 1). */
 .name {
   font-family: var(--font-sans);
   font-size: var(--font-size-body);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-semibold);
   color: var(--ink-hi);
 }
 
@@ -116,8 +121,8 @@
  * element itself only renders when at least one part exists. */
 .meta {
   font-family: var(--font-sans);
-  font-size: var(--font-size-caption);
-  color: var(--ink-low);
+  font-size: var(--font-size-ui);
+  color: var(--ink-mid);
 }
 
 /* The live stream wrapper. Its only job is the streaming caret - the design

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
@@ -43,29 +43,6 @@
   margin-top: var(--rhythm-item);
 }
 
-/* Below the gutter breakpoint (turnblock.module.css's 700px) the opener
- * becomes a grid: the avatar and the speaker header share the first row and
- * the prose drops to a full-width second row. Measured before this: prose
- * got 260px of a 375px screen (28 characters a line) because the avatar
- * column indented the whole bubble. display: contents dissolves the column
- * so its header and bubble become the grid's own items. */
-@media (max-width: 699px) {
-  .opener {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr);
-    column-gap: var(--speaker-gap);
-    row-gap: var(--space-1);
-    align-items: center;
-  }
-
-  .opener > .column {
-    display: contents;
-  }
-
-  .opener .bubble {
-    grid-column: 1 / -1;
-  }
-}
 
 /* Exchange openers only: the item becomes a flex row [avatar][column]. The
  * gap with the 24px avatar makes the 34px content column TurnBlock's gutter
@@ -155,5 +132,32 @@
     /* Disables the blink but keeps the static caret - the glyph itself
      * still honestly reflects "still live", only the motion is removed. */
     animation: none;
+  }
+}
+
+/* Last in the file on purpose: the base .opener rule sets display: flex at
+ * the same specificity, and the later declaration wins, so this block must
+ * follow it (measured on a 375px phone before the move: prose in a 187px
+ * column, 19 characters a line). Below the gutter breakpoint (turnblock.module.css's 700px) the opener
+ * becomes a grid: the avatar and the speaker header share the first row and
+ * the prose drops to a full-width second row. Measured before this: prose
+ * got 260px of a 375px screen (28 characters a line) because the avatar
+ * column indented the whole bubble. display: contents dissolves the column
+ * so its header and bubble become the grid's own items. */
+@media (max-width: 699px) {
+  .opener {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: var(--speaker-gap);
+    row-gap: var(--space-1);
+    align-items: center;
+  }
+
+  .opener > .column {
+    display: contents;
+  }
+
+  .opener .bubble {
+    grid-column: 1 / -1;
   }
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
@@ -13,37 +13,34 @@
  * session, and cancelled itself. */
 .message {
   /* One rhythm step inside an exchange: consecutive agent fragments stack
-   * like chat rows - tight. The larger steps live on the user message
-   * (exchange) and the turn separator (group). */
+   * tight. The larger steps live on the user message (exchange) and the
+   * turn separator (group). */
   padding: var(--rhythm-line) 0;
 }
 
-/* The chat bubble (2026-07-30-transcript-chat-bubbles-design.md, decisions
- * 1-3): every agent fragment - opener and continuation alike - sits in a
- * neutral ink wash, hugging its content (width: fit-content + max-width).
- * The fill is a color-mix over --ink-mid, NOT --surface-2: in the light
- * theme --surface-1 and --surface-2 measure identical to the pane, so a
- * surface token would be invisible exactly where the transcript is densest
- * (the same trap toolcallitem.module.css's hover note records). The 4px
- * corner faces the avatar (top-left, the chat "tail") on openers; .column
- * is a flex column and this is a flex item, so align-self keeps it hugged
- * there too. */
+/* The agent's answer is the document, not a bubble (typography-spacing-
+ * critique-2026-09-06 R9, revising the 2026-07-30 chat-bubbles decision for
+ * the agent side only): with the column bounded to --session-measure the
+ * neutral wash stopped doing any work and read as a slab behind every
+ * paragraph. The user's own words keep their accent wash
+ * (usermessageitem.module.css) - short, and helped by a shape. The wrapper
+ * survives as the prose's layout box: full column width, one rhythm step of
+ * vertical padding, no fill, no radius. */
 .bubble {
-  align-self: flex-start;
-  width: fit-content;
+  align-self: stretch;
+  width: 100%;
   /* Bounded by the column (--session-measure on body), never by a
    * percentage of the pane: 92% of a full-bleed pane measured 149
    * characters per line at 1440 (typography-spacing-critique-2026-09-06). */
   max-width: 100%;
-  padding: var(--space-2) var(--space-3);
-  background: color-mix(in oklab, var(--ink-mid) 6%, transparent);
-  border-radius: var(--radius-control) var(--radius-pane) var(--radius-pane) var(--radius-pane);
+  padding: var(--rhythm-line) 0;
 }
 
-/* Continuation fragments (no avatar, no header): fully rounded - with no
- * tile beside them there is nothing for a tail to point at. */
+/* Continuation fragments (no avatar, no header) follow a tool run or a
+ * thought: one item step above them separates the prose from the row it
+ * continues from. */
 .continuation {
-  border-radius: var(--radius-pane);
+  margin-top: var(--rhythm-item);
 }
 
 /* Below the gutter breakpoint (turnblock.module.css's 700px) the opener

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
@@ -30,7 +30,10 @@
 .bubble {
   align-self: flex-start;
   width: fit-content;
-  max-width: 92%;
+  /* Bounded by the column (--session-measure on body), never by a
+   * percentage of the pane: 92% of a full-bleed pane measured 149
+   * characters per line at 1440 (typography-spacing-critique-2026-09-06). */
+  max-width: 100%;
   padding: var(--space-2) var(--space-3);
   background: color-mix(in oklab, var(--ink-mid) 6%, transparent);
   border-radius: var(--radius-control) var(--radius-pane) var(--radius-pane) var(--radius-pane);
@@ -40,6 +43,30 @@
  * tile beside them there is nothing for a tail to point at. */
 .continuation {
   border-radius: var(--radius-pane);
+}
+
+/* Below the gutter breakpoint (turnblock.module.css's 700px) the opener
+ * becomes a grid: the avatar and the speaker header share the first row and
+ * the prose drops to a full-width second row. Measured before this: prose
+ * got 260px of a 375px screen (28 characters a line) because the avatar
+ * column indented the whole bubble. display: contents dissolves the column
+ * so its header and bubble become the grid's own items. */
+@media (max-width: 699px) {
+  .opener {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: var(--speaker-gap);
+    row-gap: var(--space-1);
+    align-items: center;
+  }
+
+  .opener > .column {
+    display: contents;
+  }
+
+  .opener .bubble {
+    grid-column: 1 / -1;
+  }
 }
 
 /* Exchange openers only: the item becomes a flex row [avatar][column]. The

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringitem.module.css
@@ -10,9 +10,9 @@
 }
 
 /* One 12px gutter column, one ink for the whole row (design-system.md §7).
- * --ink-mid, not --ink-low: --ink-low measures 2.97:1 dark / 3.64:1 light
- * against --surface-1, under the 4.5:1 AA floor, and the kind is the payload a
- * reader auditing steering came for. */
+ * --ink-mid, not --ink-low: the kind is the payload a reader auditing
+ * steering came for, and --ink-low is placeholder ink (4.72:1 dark / 4.76:1
+ * light on --surface-1 since the 2026-09-06 raise; --ink-mid 6.51 / 5.84). */
 .summary {
   display: flex;
   flex-wrap: wrap;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringitem.module.css
@@ -69,17 +69,23 @@
 .chevron {
   display: inline-flex;
   flex: none;
-  font-size: 9px;
+  align-self: center;
 }
 
-.chevron[data-open="true"] {
-  transform: rotate(90deg);
-}
-
+/* The shared widgets/chevron svg turns, never the span: a square icon box
+ * cannot overhang its layout box at any rotation (toolcallitem.module.css's
+ * own chevron note records the horizontal-scrollbar escape a rotated text
+ * glyph caused). */
 @media (prefers-reduced-motion: no-preference) {
-  .chevron {
+  .chevron > svg {
     transition: transform var(--motion-duration-overlay) var(--motion-easing-standard);
   }
+}
+
+/* After the transition rule: this selector outranks it, and Biome's
+ * noDescendingSpecificity wants the lower-specificity rule first. */
+.chevron[data-open="true"] > svg {
+  transform: rotate(90deg);
 }
 
 .body {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/thinkblock.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/thinkblock.module.css
@@ -27,13 +27,14 @@
    * only a flex row centres the glyph against the label text. Body-sized like
    * the settled summary (the draft restyle, mockup #4): a caption-sized
    * eyebrow was quiet through SIZE, and the design law demotes through ink
-   * only - --ink-low already carries the whole recession. */
+   * only - --ink-mid carries the recession (--ink-low is sub-AA for a line a
+   * reader actually reads). */
   display: flex;
   align-items: center;
   margin-bottom: var(--space-1);
   font-family: var(--font-sans);
   font-size: var(--font-size-body);
-  color: var(--ink-low);
+  color: var(--ink-mid);
 }
 
 /* The kind glyph leading the thought row - in the RAIL beside the line, at
@@ -118,7 +119,7 @@
   border-radius: var(--radius-control);
   font-family: var(--font-sans);
   font-size: var(--font-size-body);
-  color: var(--ink-low);
+  color: var(--ink-mid);
 }
 
 /* The label text as its own flex item so it - not the chevron after it - is

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/turnseparator.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/turnseparator.module.css
@@ -3,6 +3,7 @@
 .row {
   padding: var(--space-1) 0;
   font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
   font-size: var(--font-size-caption);
   color: var(--ink-mid);
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/turnseparator.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/turnseparator.module.css
@@ -1,7 +1,9 @@
 /* Compact, chrome-only row - never machine-mono (this is UI furniture
  * summarizing a turn, not authored/machine content itself). */
 .row {
-  padding: var(--space-1) 0;
+  /* A turn footer closes a group: one group step above it, one line step
+   * below before whatever the next turn opens with. */
+  padding: var(--rhythm-group) 0 var(--rhythm-line);
   font-family: var(--font-sans);
   font-variant-numeric: tabular-nums;
   font-size: var(--font-size-caption);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/usermessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/usermessageitem.module.css
@@ -49,13 +49,14 @@
 }
 
 /* flex: 1 1 auto - the column SPANS the row, it does not shrink-to-fit. It
- * must: the bubble below caps itself at max-width: 92% OF THIS COLUMN, and a
+ * must: the bubble below caps itself at 100% OF THIS COLUMN, and a
  * shrink-to-fit column is sized by the bubble in turn - a cyclic percentage
- * the browser resolves to roughly 92% of the bubble's own max-content, so
- * every message wider than the header got its tail words wrapped even in a
- * wide window (live-DOM measurement 2026-07-30: "commit and merge" clamped
- * to 133px in a 651px row). With the column spanning the row, 92% resolves
- * against the row width and fit-content hugs short messages instead. Same
+ * the browser resolves against the bubble's own max-content, so every
+ * message wider than the header got its tail words wrapped even in a wide
+ * window (live-DOM measurement 2026-07-30, at the old 92% cap: "commit and
+ * merge" clamped to 133px in a 651px row). With the column spanning the row,
+ * the cap resolves against the row width and fit-content hugs short messages
+ * instead. Same
  * contract as the agent side's .column (agentmessageitem.module.css).
  * min-width: 0 - a flex item's automatic minimum size would otherwise pin the
  * column to its longest unbreakable word and defeat the text's break-word
@@ -115,7 +116,9 @@
   flex-direction: column;
   gap: var(--space-1);
   width: fit-content;
-  max-width: 92%;
+  /* Bounded by the column (--session-measure on body), not a percentage of
+   * the pane - see agentmessageitem.module.css's .bubble. */
+  max-width: 100%;
   padding: var(--space-2) var(--space-3);
   background: var(--accent-bg);
   border-radius: var(--radius-control) var(--radius-pane) var(--radius-pane) var(--radius-pane);
@@ -129,4 +132,26 @@
   line-height: var(--line-height-body);
   /* --ink-hi: spec decision 5 - see this file's header comment. */
   color: var(--ink-hi);
+}
+
+/* Below the gutter breakpoint the row becomes a grid so the bubble spans the
+ * pane under the avatar + header row (the agent side does the same - see
+ * agentmessageitem.module.css). The content column dissolves so its header
+ * and body are the grid's own items. */
+@media (max-width: 699px) {
+  .message {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: var(--speaker-gap);
+    row-gap: var(--space-1);
+    align-items: center;
+  }
+
+  .message > .content {
+    display: contents;
+  }
+
+  .message .body {
+    grid-column: 1 / -1;
+  }
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/usermessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/usermessageitem.module.css
@@ -38,6 +38,13 @@
    * property from (kata T9). */
   gap: var(--speaker-gap);
   padding: var(--rhythm-line) 0;
+}
+
+/* The exchange step belongs to the message that OPENS an exchange (the
+ * default). Mid-turn user steering renders through this same view with
+ * opensExchange={false} (SteeringItem.tsx): it joins work already under
+ * way, so it takes no boundary spacing. */
+.message[data-opens-exchange="true"] {
   margin-top: var(--rhythm-exchange);
 }
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/usermessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/usermessageitem.module.css
@@ -14,12 +14,13 @@
  * exchange boundary scannable - that the new speaker header now does better;
  * the boundary no longer needs the words themselves muted.
  *
- * The exchange boundary is marked by the speaker header alone (avatar +
- * "You" + time) - deliberately NOT by extra vertical space above the
- * message: a turn is one LLM round-trip and a real session runs dozens of
- * them per accepted input, but even at true exchange boundaries added
- * margin read as dead air (Jesse's call, 2026-07-30). The boundary fires a
- * handful of times per session, and the header is signal enough. */
+ * The exchange boundary is marked by the speaker header AND one
+ * --rhythm-exchange step above the message. The 2026-07-30 ruling against
+ * added margin ("dead air") was made when lines ran 150 characters and
+ * every row sat 4px apart; with the column bounded to --session-measure
+ * (typography-spacing-critique-2026-09-06 R2/R3) the step reads as a
+ * paragraph break, not air, and it is what lets the eye find the next
+ * exchange in a long session without hunting for a 24px avatar. */
 .message {
   display: flex;
   align-items: flex-start;
@@ -36,10 +37,8 @@
    * (Session.tsx), so there is no ancestor there to inherit the custom
    * property from (kata T9). */
   gap: var(--speaker-gap);
-  /* --space-1, not --space-2: with the body now a bubble (see .body), the
-   * message is a chat row, and chat rows sit tight - the bubble's own fill
-   * carries the separation the old document rhythm bought with air. */
-  padding: var(--space-1) 0;
+  padding: var(--rhythm-line) 0;
+  margin-top: var(--rhythm-exchange);
 }
 
 /* flex: none - the tile keeps its 24px edge when the row is squeezed; the
@@ -80,7 +79,7 @@
 .name {
   font-family: var(--font-sans);
   font-size: var(--font-size-body);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-semibold);
   color: var(--ink-hi);
 }
 
@@ -88,8 +87,8 @@
  * the item carries a startedAt - never a placeholder. */
 .time {
   font-family: var(--font-sans);
-  font-size: var(--font-size-caption);
-  color: var(--ink-low);
+  font-size: var(--font-size-ui);
+  color: var(--ink-mid);
 }
 
 .actions {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/rawitemview.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/rawitemview.module.css
@@ -8,9 +8,9 @@
 .type {
   font-family: var(--font-mono);
   font-size: var(--font-size-caption);
-  color: var(--ink-low);
+  color: var(--ink-mid);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-display);
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .text {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolFoldPolicy.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolFoldPolicy.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "vitest";
+// Registers every tool descriptor the same way the session pane does.
+import "./TurnBlock";
+import { toolRendererFor } from "./toolRenderers";
+
+// The fold policy table (toolRenderers.ts's `fold`): folding is opt-in, so a
+// read-only tool that forgets to opt in silently stops folding (roborev on
+// PR #947 caught find_session_transcripts) and a mutating tool that opts
+// into "quiet" would hide its effect inside a run. Pin every registered
+// tool's value here; a new tool has to take a position.
+const QUIET = [
+  "read_file",
+  "grep",
+  "grep_files",
+  "grep_search",
+  "list_dir",
+  "list_directory",
+  "glob",
+  "web_fetch",
+  "web_search",
+  "read_transcript",
+  "read_session_transcript",
+  "find_session_transcripts",
+];
+const CONSEQUENTIAL = [
+  "edit_file",
+  "write_file",
+  "apply_patch",
+  "shell",
+  "exec_command",
+  "run_shell_command",
+  "manage_worktree",
+];
+const NEVER = [
+  "delegate",
+  "ask_user",
+  "task_list",
+  "use_skill",
+  "job_status",
+  "job_read_output",
+  "job_list",
+  "job_stop",
+  "delegate_send",
+  "job_send_message",
+  "job_anything_else",
+];
+
+test.each(QUIET)("%s is a read-only step: fold quiet", (name) => {
+  expect(toolRendererFor(name).fold).toBe("quiet");
+});
+
+test.each(CONSEQUENTIAL)("%s mutates: fold consequential", (name) => {
+  expect(toolRendererFor(name).fold).toBe("consequential");
+});
+
+test.each(NEVER)("%s is a card the reader must see: fold never", (name) => {
+  expect(toolRendererFor(name).fold).toBe("never");
+});
+
+test("an unregistered (MCP) tool has no fold policy, which toolRuns treats as never", () => {
+  expect(toolRendererFor("mcp__some_server__deploy").fold).toBeUndefined();
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRenderers.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRenderers.ts
@@ -49,6 +49,17 @@ export interface ToolRendererDescriptor {
   // review call: fixed-width everywhere made every tool read like a
   // terminal); shell opts in because its summary IS a command.
   monoSummary?: boolean;
+  // How this tool behaves when a settled turn's tool calls are folded into a
+  // single run row (toolRuns.ts):
+  //   "never"         - a card the reader must always see on its own: a
+  //                     delegate, an ask, a task list, a skill, a job. It
+  //                     breaks the run around it rather than joining one;
+  //   "consequential" - a mutating step (an edit, a shell command, a
+  //                     worktree change). It folds, and it is what a folded
+  //                     run's summary names;
+  //   unset           - a quiet step (a read, a search, a web fetch). It
+  //                     folds and only ever contributes to the count.
+  fold?: "never" | "consequential";
   body?: ComponentType<ToolRenderProps>; // expanded content; default raw output
   // outputImageSize sizes the generic output-images gallery ToolCallItem
   // renders after the body: undefined keeps the default 96px thumbnails,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRenderers.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRenderers.ts
@@ -57,9 +57,13 @@ export interface ToolRendererDescriptor {
   //   "consequential" - a mutating step (an edit, a shell command, a
   //                     worktree change). It folds, and it is what a folded
   //                     run's summary names;
-  //   unset           - a quiet step (a read, a search, a web fetch). It
-  //                     folds and only ever contributes to the count.
-  fold?: "never" | "consequential";
+  //   "quiet"         - a read-only step (a read, a search, a web fetch). It
+  //                     folds and only ever contributes to the count;
+  //   unset           - does not fold. Folding is opt-in per descriptor: an
+  //                     unregistered tool (every MCP tool inherits
+  //                     DEFAULT_DESCRIPTOR) may have side effects the reader
+  //                     must see, so it breaks a run exactly like "never".
+  fold?: "never" | "quiet" | "consequential";
   body?: ComponentType<ToolRenderProps>; // expanded content; default raw output
   // outputImageSize sizes the generic output-images gallery ToolCallItem
   // renders after the body: undefined keeps the default 96px thumbnails,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
@@ -966,11 +966,10 @@ test("the stated intent renders in italics", () => {
 });
 
 // kata rdry: the demoted line is a tool-RESULT ("Wrote fizzbuzz.py"), not a
-// placeholder/disabled/timestamp - --ink-low's documented job (design-system.md)
-// - and measures 2.97:1 dark / 3.64:1 light, under the 4.5:1 AA floor for body
-// text. Same precedent as usermessageitem's .tag (moved off --ink-low for the
-// same reason). --ink-mid clears AA at 6.86/6.56 in both themes.
-test("the demoted summary line is readable text (--ink-mid), not the sub-AA --ink-low", () => {
+// placeholder/disabled/timestamp - --ink-low's documented job (design-system.md).
+// --ink-low clears AA since the 2026-09-06 raise (4.72:1 dark / 4.76:1 light
+// on --surface-1), but text a reader reads takes --ink-mid (6.51 / 5.84).
+test("the demoted summary line is readable text (--ink-mid), not the placeholder --ink-low", () => {
   const demoted = /\.demoted\s*\{([^}]*)\}/.exec(rowCss());
   expect(demoted).not.toBeNull();
   expect(demoted![1]).toMatch(/var\(--ink-mid\)/);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
@@ -955,7 +955,7 @@ test("the rationale-to-call gap is tightened to line-leading only, still tighter
   expect(css).toMatch(/\.demoted\s*\{[^}]*line-height:\s*var\(--line-height-title\)/);
   const call = /\.call\s*\{([^}]*)\}/.exec(css);
   expect(call).not.toBeNull();
-  expect(call![1]).toContain("padding: var(--space-2) 0");
+  expect(call![1]).toContain("padding: var(--rhythm-item) 0");
 });
 
 // The intent is the agent's stated rationale for the call - commentary on

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.test.ts
@@ -23,9 +23,16 @@ const message = (id: string): Extract<ProjectedEntry, { kind: "item" }> => ({
 
 const descriptorFor = (name: string) => ({
   match: name,
-  summary: () => (name === "write_file" ? "Wrote foo.py" : `Read ${name}`),
-  fold:
+  summary: (_item: ItemModel, ctx?: { cwd?: string }) =>
     name === "write_file"
+      ? "Wrote foo.py"
+      : name === "shell"
+        ? ctx?.cwd
+          ? "Ran ls"
+          : "Ran cd /repo && ls"
+        : `Read ${name}`,
+  fold:
+    name === "write_file" || name === "shell"
       ? ("consequential" as const)
       : name === "delegate"
         ? ("never" as const)
@@ -137,4 +144,13 @@ test("with no consequential step the label names the last call", () => {
     descriptorFor,
   });
   expect(runLabel(run as ToolRun, descriptorFor)).toBe("3 steps · Read grep");
+});
+
+test("the label hands the working-directory context to the summary, as an expanded row does", () => {
+  const [run] = foldToolRuns([tool("a", "read_file"), tool("b", "shell"), tool("c", "read_file")], {
+    turnSettled: true,
+    descriptorFor,
+  });
+  expect(runLabel(run as never, descriptorFor, { cwd: "/repo" })).toBe("3 steps · Ran ls");
+  expect(runLabel(run as never, descriptorFor)).toBe("3 steps · Ran cd /repo && ls");
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "vitest";
+import type { ItemModel } from "../../../protocol/model";
+import type { ProjectedEntry } from "../../../transcriptDisplay/projector";
+import { foldToolRuns, runLabel, type ToolRun } from "./toolRuns";
+
+const tool = (id: string, toolName: string, status = "completed"): Extract<ProjectedEntry, { kind: "item" }> => ({
+  kind: "item",
+  id,
+  turnId: "t1",
+  sourceIndex: 0,
+  isMessage: false,
+  item: { id, turnId: "t1", type: "commandExecution", text: "", toolName, status } as ItemModel,
+});
+
+const message = (id: string): Extract<ProjectedEntry, { kind: "item" }> => ({
+  kind: "item",
+  id,
+  turnId: "t1",
+  sourceIndex: 0,
+  isMessage: true,
+  item: { id, turnId: "t1", type: "agentMessage", text: "hello", status: "completed" } as ItemModel,
+});
+
+const descriptorFor = (name: string) => ({
+  match: name,
+  summary: () => (name === "write_file" ? "Wrote foo.py" : `Read ${name}`),
+  fold: name === "write_file" ? ("consequential" as const) : name === "delegate" ? ("never" as const) : undefined,
+});
+
+test("three settled quiet calls fold into one run", () => {
+  const out = foldToolRuns([tool("a", "read_file"), tool("b", "read_file"), tool("c", "grep")], {
+    turnSettled: true,
+    descriptorFor,
+  });
+  expect(out).toHaveLength(1);
+  expect(out[0]).toMatchObject({ kind: "run", entries: [{ id: "a" }, { id: "b" }, { id: "c" }] });
+});
+
+test("two calls do not fold", () => {
+  const out = foldToolRuns([tool("a", "read_file"), tool("b", "read_file")], { turnSettled: true, descriptorFor });
+  expect(out.map((e) => e.kind)).toEqual(["item", "item"]);
+});
+
+test("a failed call breaks the run and stays visible", () => {
+  const out = foldToolRuns(
+    [tool("a", "read_file"), tool("b", "read_file", "failed"), tool("c", "read_file"), tool("d", "read_file")],
+    { turnSettled: true, descriptorFor },
+  );
+  expect(out.map((e) => e.kind)).toEqual(["item", "item", "item", "item"]);
+});
+
+test("a live turn never folds", () => {
+  const out = foldToolRuns([tool("a", "read_file"), tool("b", "read_file"), tool("c", "read_file")], {
+    turnSettled: false,
+    descriptorFor,
+  });
+  expect(out.map((e) => e.kind)).toEqual(["item", "item", "item"]);
+});
+
+test("a never-fold tool splits the run", () => {
+  const out = foldToolRuns(
+    [
+      tool("a", "read_file"),
+      tool("b", "delegate"),
+      tool("c", "read_file"),
+      tool("d", "read_file"),
+      tool("e", "read_file"),
+    ],
+    { turnSettled: true, descriptorFor },
+  );
+  expect(out.map((e) => e.kind)).toEqual(["item", "item", "run"]);
+});
+
+test("prose between calls splits the run", () => {
+  const out = foldToolRuns(
+    [
+      tool("a", "read_file"),
+      tool("b", "read_file"),
+      tool("c", "read_file"),
+      message("m"),
+      tool("d", "read_file"),
+      tool("e", "read_file"),
+    ],
+    { turnSettled: true, descriptorFor },
+  );
+  expect(out.map((e) => e.kind)).toEqual(["run", "item", "item", "item"]);
+});
+
+test("a still-running call breaks the run even in a settled turn", () => {
+  const out = foldToolRuns(
+    [tool("a", "read_file"), tool("b", "read_file", "inProgress"), tool("c", "read_file"), tool("d", "read_file")],
+    { turnSettled: true, descriptorFor },
+  );
+  expect(out.map((e) => e.kind)).toEqual(["item", "item", "item", "item"]);
+});
+
+test("a run keeps the folded entries in wire order", () => {
+  const [run] = foldToolRuns([tool("a", "read_file"), tool("b", "read_file"), tool("c", "read_file")], {
+    turnSettled: true,
+    descriptorFor,
+  });
+  expect((run as ToolRun).entries.map((e) => e.id)).toEqual(["a", "b", "c"]);
+  expect((run as ToolRun).id).toBe("run:a");
+});
+
+test("the label names the consequential step", () => {
+  const [run] = foldToolRuns([tool("a", "read_file"), tool("b", "write_file"), tool("c", "read_file")], {
+    turnSettled: true,
+    descriptorFor,
+  });
+  expect(runLabel(run as ToolRun, descriptorFor)).toBe("3 steps · Wrote foo.py");
+});
+
+test("with no consequential step the label names the last call", () => {
+  const [run] = foldToolRuns([tool("a", "read_file"), tool("b", "read_file"), tool("c", "grep")], {
+    turnSettled: true,
+    descriptorFor,
+  });
+  expect(runLabel(run as ToolRun, descriptorFor)).toBe("3 steps · Read grep");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.test.ts
@@ -24,7 +24,27 @@ const message = (id: string): Extract<ProjectedEntry, { kind: "item" }> => ({
 const descriptorFor = (name: string) => ({
   match: name,
   summary: () => (name === "write_file" ? "Wrote foo.py" : `Read ${name}`),
-  fold: name === "write_file" ? ("consequential" as const) : name === "delegate" ? ("never" as const) : undefined,
+  fold:
+    name === "write_file"
+      ? ("consequential" as const)
+      : name === "delegate"
+        ? ("never" as const)
+        : name === "mcp_send_email"
+          ? undefined
+          : ("quiet" as const),
+});
+
+test("a tool with no fold policy (an unregistered or MCP tool) never folds and breaks the run", () => {
+  const out = foldToolRuns(
+    [tool("a", "read_file"), tool("b", "mcp_send_email"), tool("c", "read_file"), tool("d", "read_file")],
+    { turnSettled: true, descriptorFor },
+  );
+  expect(out.map((e) => e.kind)).toEqual(["item", "item", "item", "item"]);
+  const alone = foldToolRuns([tool("x", "mcp_send_email"), tool("y", "mcp_send_email"), tool("z", "mcp_send_email")], {
+    turnSettled: true,
+    descriptorFor,
+  });
+  expect(alone.map((e) => e.kind)).toEqual(["item", "item", "item"]);
 });
 
 test("three settled quiet calls fold into one run", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.ts
@@ -12,12 +12,15 @@
 //   - anything that is not a plain, completed, unremarkable call BREAKS the
 //     run and stays visible on its own: a failure, a call still in flight, a
 //     descriptor that auto-expands, a `fold: "never"` card (a delegate, an
-//     ask, a task list), and any non-tool entry (prose, reasoning, a system
-//     notice). A break flushes the run rather than spanning it, so a folded
-//     row can never gather calls the reader saw separated by an answer;
+//     ask, a task list), any descriptor that has not opted in at all (an
+//     unregistered or MCP tool may have side effects the reader must see,
+//     so only `fold: "quiet"` and `fold: "consequential"` join a run), and
+//     any non-tool entry (prose, reasoning, a system notice). A break
+//     flushes the run rather than spanning it, so a folded row can never
+//     gather calls the reader saw separated by an answer;
 //   - a run has to be worth folding. Two rows are not clutter; three are.
-import type { ProjectedEntry } from "../../../transcriptDisplay/projector";
-import type { ToolRendererDescriptor } from "./toolRenderers";
+import type { ProjectedEntry, ProjectedTurn } from "../../../transcriptDisplay/projector";
+import { type ToolRendererDescriptor, toolRendererFor } from "./toolRenderers";
 
 export type ToolItemEntry = Extract<ProjectedEntry, { kind: "item" }>;
 
@@ -45,7 +48,7 @@ function foldable(entry: ProjectedEntry, opts: FoldOptions): entry is ToolItemEn
   if (item.status !== "completed") return false;
   if (item.error !== undefined && item.error !== "") return false;
   const descriptor = opts.descriptorFor(item.toolName ?? "");
-  if (descriptor.fold === "never") return false;
+  if (descriptor.fold !== "quiet" && descriptor.fold !== "consequential") return false;
   if (descriptor.failed?.(item) || descriptor.autoExpand?.(item)) return false;
   return true;
 }
@@ -86,4 +89,19 @@ export function runLabel(run: ToolRun, descriptorFor: FoldOptions["descriptorFor
   // future caller ever hands one over empty.
   if (!named) return steps;
   return `${steps} · ${descriptorFor(named.item.toolName ?? "").summary(named.item)}`;
+}
+
+/**
+ * The one fold every consumer of a turn's entries must agree on. TurnBlock
+ * renders from it and TranscriptBody registers scroll/focus anchors from it,
+ * so a folded run is ONE anchor in both places (its id, the first entry's
+ * source index) and never a set of entry ids that no rendered element carries
+ * while the run is closed. "inProgress" is TurnModel.status's live literal
+ * (the projector reads the same one).
+ */
+export function foldTurnEntries(turn: ProjectedTurn): (ProjectedEntry | ToolRun)[] {
+  return foldToolRuns(turn.entries, {
+    turnSettled: turn.source.status !== "inProgress",
+    descriptorFor: toolRendererFor,
+  });
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.ts
@@ -1,0 +1,89 @@
+// Folding a run of finished, uneventful tool calls into one row (critique
+// R9, principle 2 / decisions.md topic 06 Alt A): once a turn has settled,
+// the reader does not need four separate rows saying a file was read - they
+// need one row naming what the run amounted to, which opens to the rows when
+// they do.
+//
+// Three rules keep the fold honest, and every one of them is about not
+// hiding something the reader would want:
+//
+//   - a LIVE turn never folds. While the agent is still working, each call
+//     appearing is the progress signal;
+//   - anything that is not a plain, completed, unremarkable call BREAKS the
+//     run and stays visible on its own: a failure, a call still in flight, a
+//     descriptor that auto-expands, a `fold: "never"` card (a delegate, an
+//     ask, a task list), and any non-tool entry (prose, reasoning, a system
+//     notice). A break flushes the run rather than spanning it, so a folded
+//     row can never gather calls the reader saw separated by an answer;
+//   - a run has to be worth folding. Two rows are not clutter; three are.
+import type { ProjectedEntry } from "../../../transcriptDisplay/projector";
+import type { ToolRendererDescriptor } from "./toolRenderers";
+
+export type ToolItemEntry = Extract<ProjectedEntry, { kind: "item" }>;
+
+export interface ToolRun {
+  kind: "run";
+  /** Derived from the first folded entry, so the run's disclosure state is
+   * stable across re-renders of the same turn. */
+  id: string;
+  entries: ToolItemEntry[];
+}
+
+export interface FoldOptions {
+  /** False while the turn is still running - see the header. */
+  turnSettled: boolean;
+  descriptorFor: (toolName: string) => Pick<ToolRendererDescriptor, "summary" | "fold" | "failed" | "autoExpand">;
+}
+
+// Two folded rows save one row and cost a click; three start to read as
+// clutter. The threshold is the whole reason a pair stays expanded.
+const MIN_RUN = 3;
+
+function foldable(entry: ProjectedEntry, opts: FoldOptions): entry is ToolItemEntry {
+  if (entry.kind !== "item" || entry.item.type !== "commandExecution") return false;
+  const { item } = entry;
+  if (item.status !== "completed") return false;
+  if (item.error !== undefined && item.error !== "") return false;
+  const descriptor = opts.descriptorFor(item.toolName ?? "");
+  if (descriptor.fold === "never") return false;
+  if (descriptor.failed?.(item) || descriptor.autoExpand?.(item)) return false;
+  return true;
+}
+
+export function foldToolRuns(entries: readonly ProjectedEntry[], opts: FoldOptions): (ProjectedEntry | ToolRun)[] {
+  if (!opts.turnSettled) return [...entries];
+  const out: (ProjectedEntry | ToolRun)[] = [];
+  let run: ToolItemEntry[] = [];
+  const flush = () => {
+    const first = run[0];
+    if (first && run.length >= MIN_RUN) out.push({ kind: "run", id: `run:${first.id}`, entries: run });
+    else out.push(...run);
+    run = [];
+  };
+  for (const entry of entries) {
+    if (foldable(entry, opts)) {
+      run.push(entry);
+      continue;
+    }
+    flush();
+    out.push(entry);
+  }
+  flush();
+  return out;
+}
+
+// The summary a folded run wears: how many steps, and what the run amounted
+// to. The named step is the LAST consequential one (a mutation - an edit, a
+// shell command, a worktree change), because that is what the run did; with
+// none, the last call, because that is where the run ended up.
+export function runLabel(run: ToolRun, descriptorFor: FoldOptions["descriptorFor"]): string {
+  const newestFirst = [...run.entries].reverse();
+  const named =
+    newestFirst.find((entry) => descriptorFor(entry.item.toolName ?? "").fold === "consequential") ?? newestFirst[0];
+  const steps = `${run.entries.length} steps`;
+  // foldToolRuns never mints a run below MIN_RUN, so there is always a step
+  // to name; the bare count keeps the row honest rather than throwing if a
+  // future caller ever hands one over empty.
+  if (!named) return steps;
+  return `${steps} · ${descriptorFor(named.item.toolName ?? "").summary(named.item)}`;
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRuns.ts
@@ -20,7 +20,7 @@
 //     gather calls the reader saw separated by an answer;
 //   - a run has to be worth folding. Two rows are not clutter; three are.
 import type { ProjectedEntry, ProjectedTurn } from "../../../transcriptDisplay/projector";
-import { type ToolRendererDescriptor, toolRendererFor } from "./toolRenderers";
+import { type ToolRendererDescriptor, type ToolSummaryContext, toolRendererFor } from "./toolRenderers";
 
 export type ToolItemEntry = Extract<ProjectedEntry, { kind: "item" }>;
 
@@ -79,7 +79,10 @@ export function foldToolRuns(entries: readonly ProjectedEntry[], opts: FoldOptio
 // to. The named step is the LAST consequential one (a mutation - an edit, a
 // shell command, a worktree change), because that is what the run did; with
 // none, the last call, because that is where the run ended up.
-export function runLabel(run: ToolRun, descriptorFor: FoldOptions["descriptorFor"]): string {
+// ctx is the same ToolSummaryContext an expanded row hands its descriptor
+// (ToolCallItem passes the thread's cwd), so a shell step's label drops the
+// redundant "cd <cwd> && " prefix exactly as the row beneath it does.
+export function runLabel(run: ToolRun, descriptorFor: FoldOptions["descriptorFor"], ctx?: ToolSummaryContext): string {
   const newestFirst = [...run.entries].reverse();
   const named =
     newestFirst.find((entry) => descriptorFor(entry.item.toolName ?? "").fold === "consequential") ?? newestFirst[0];
@@ -88,7 +91,7 @@ export function runLabel(run: ToolRun, descriptorFor: FoldOptions["descriptorFor
   // to name; the bare count keeps the row honest rather than throwing if a
   // future caller ever hands one over empty.
   if (!named) return steps;
-  return `${steps} · ${descriptorFor(named.item.toolName ?? "").summary(named.item)}`;
+  return `${steps} · ${descriptorFor(named.item.toolName ?? "").summary(named.item, ctx)}`;
 }
 
 /**

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
@@ -6,7 +6,7 @@
 .call {
   display: flex;
   flex-direction: column;
-  padding: var(--space-2) 0;
+  padding: var(--rhythm-item) 0;
 }
 
 /* The shared row (ToolRow.tsx) - see that file for the row grammar it

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
@@ -296,11 +296,11 @@
  * needed to keep the row at two lines. */
 /* kata rdry: this line is a tool RESULT ("Wrote fizzbuzz.py"), shown on every
  * intent-bearing row in every transcript - not a placeholder/disabled/
- * timestamp, --ink-low's documented job (design-system.md). --ink-low measured
- * 2.97:1 dark / 3.64:1 light against --surface-1, under the 4.5:1 AA floor for
- * body text; --ink-mid clears it at 6.86/6.56. Same fix as usermessageitem's
- * .tag. There is no longer a hover override to --ink-mid - resting state
- * already reads it. */
+ * timestamp, --ink-low's documented job (design-system.md). When this was
+ * moved --ink-low sat under the 4.5:1 AA floor; it clears it since the
+ * 2026-09-06 raise (4.72:1 dark / 4.76:1 light on --surface-1), but a result
+ * a reader actually reads still takes --ink-mid (6.51 / 5.84). There is no
+ * longer a hover override to --ink-mid - resting state already reads it. */
 .demoted {
   flex: 0 0 100%;
   color: var(--ink-mid);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolrungroup.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolrungroup.module.css
@@ -1,0 +1,67 @@
+/* A folded run of settled tool calls (critique R9, toolRuns.ts). The
+ * collapsed row is deliberately quieter than the tool rows it stands in for:
+ * it is a count and one name, at the same UI step and the same --rhythm-item
+ * padding a single tool call takes, so a turn's vertical rhythm does not
+ * change when a run folds. */
+.group {
+  min-width: 0;
+}
+
+.summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--rhythm-item) 0;
+  color: var(--ink-mid);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-ui);
+  cursor: pointer;
+  /* Suppress the UA's own disclosure triangle: this summary draws the app's
+   * shared Chevron instead (widgets/chevron). */
+  list-style: none;
+}
+
+.summary::-webkit-details-marker {
+  display: none;
+}
+
+.summary:hover {
+  background: color-mix(in oklab, var(--ink-mid) 8%, transparent);
+  border-radius: var(--radius-control);
+}
+
+.summary:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+/* The chevron turns to point down when the run opens - the same rotation
+ * toolcallitem.module.css gives a tool row's own chevron, so one disclosure
+ * gesture reads the same everywhere in the transcript. */
+.chevron {
+  display: inline-flex;
+  flex: none;
+  color: var(--ink-mid);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .chevron > svg {
+    transition: transform var(--motion-duration-overlay) var(--motion-easing-standard);
+  }
+}
+
+.chevron[data-open="true"] > svg {
+  transform: rotate(90deg);
+}
+
+.label {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolrungroup.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolrungroup.module.css
@@ -35,6 +35,16 @@
   outline-offset: 2px;
 }
 
+/* Phone tap floor (2026-07-30-mobile-session-layout-design.md, decision 4):
+ * the summary is the one control that opens a folded run, so it takes the
+ * same --tap-min widgets/disclosure's summary does. min-height, not height,
+ * so the desktop row keeps its own rhythm. */
+@media (max-width: 899px) {
+  .summary {
+    min-height: var(--tap-min);
+  }
+}
+
 /* The chevron turns to point down when the run opens - the same rotation
  * toolcallitem.module.css gives a tool row's own chevron, so one disclosure
  * gesture reads the same everywhere in the transcript. */

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.tsx
@@ -109,6 +109,7 @@ function AskUserBody({ item }: ToolRenderProps) {
 
 registerToolRenderer({
   match: "ask_user",
+  fold: "never", // a question put to the reader is never folded away
   icon: "ask",
   summary(item: ItemModel) {
     const questions = parseAskUserQuestions(item);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askuser.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askuser.module.css
@@ -43,7 +43,7 @@
   font-size: var(--font-size-caption);
   color: var(--ink-mid);
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .note {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.module.css
@@ -72,7 +72,7 @@
 /* --- Section eyebrow (micro-label pattern, design system §6) --- */
 .eyebrow {
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   color: var(--ink-mid);
   text-transform: uppercase;
   letter-spacing: var(--tracking-eyebrow);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.module.css
@@ -2,8 +2,8 @@
    Follows the design system (docs/web-ui/design-system.md): all colors,
    spacing, radii, and fonts use var(--token) from tokens.css. The 4px
    space grid (--space-1..4) sizes all gaps and padding. Section eyebrows
-   use the micro-label pattern (caption size, --font-weight-medium,
-   --ink-low, uppercase, --tracking-micro). Mono (--font-mono) is reserved
+   use the eyebrow pattern (caption size, --font-weight-medium,
+   --ink-mid, uppercase, --tracking-eyebrow). Mono (--font-mono) is reserved
    for machine text (delegate ID, paths, model, sandbox mode, tool chips,
    transcript ref). The four attention hues carry their designated meanings:
    --alive for running, --attention for needs-human, --danger for failure. */
@@ -25,7 +25,7 @@
 
 .headId {
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--font-size-caption);
   color: var(--ink-hi);
   font-weight: 500;
 }
@@ -40,14 +40,14 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   color: var(--ink-mid);
 }
 
 .metaSeg {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: var(--space-1);
   padding: 0 var(--space-2);
 }
 
@@ -58,7 +58,6 @@
 .metaSep {
   color: var(--edge-strong);
   user-select: none;
-  margin-right: 2px;
 }
 
 .metaK {
@@ -72,11 +71,11 @@
 
 /* --- Section eyebrow (micro-label pattern, design system §6) --- */
 .eyebrow {
-  font-size: 11px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
-  color: var(--ink-low);
+  color: var(--ink-mid);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-micro);
+  letter-spacing: var(--tracking-eyebrow);
   margin-bottom: var(--space-1);
 }
 
@@ -87,8 +86,8 @@
 }
 
 .mandateBody {
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: var(--font-size-ui);
+  line-height: var(--line-height-body);
   color: var(--ink-hi);
 }
 
@@ -101,8 +100,8 @@
 }
 
 .diagnosticBody {
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: var(--font-size-ui);
+  line-height: var(--line-height-body);
   color: var(--ink-hi);
 }
 
@@ -126,8 +125,8 @@
   display: flex;
   align-items: baseline;
   gap: var(--space-3);
-  font-size: 12px;
-  line-height: 1.5;
+  font-size: var(--font-size-caption);
+  line-height: var(--line-height-body);
 }
 
 .envK {
@@ -135,12 +134,12 @@
   flex-shrink: 0;
   color: var(--ink-low);
   font-family: var(--font-sans);
-  font-size: 11px;
+  font-size: var(--font-size-caption);
 }
 
 .envV {
   color: var(--ink-hi);
-  font-size: 12px;
+  font-size: var(--font-size-caption);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -149,7 +148,7 @@
 
 .envVmono {
   font-family: var(--font-mono);
-  font-size: 11.5px;
+  font-size: var(--font-size-caption);
 }
 
 .envVmuted {
@@ -170,12 +169,12 @@
 
 .toolChip {
   font-family: var(--font-mono);
-  font-size: 10.5px;
+  font-size: var(--font-size-caption);
   color: var(--ink-mid);
   background: var(--surface-inset);
   border: 1px solid var(--edge);
   border-radius: var(--radius-chip);
-  padding: 1px 6px;
+  padding: 0 var(--space-2);
 }
 
 /* --- Footer --- */

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/editTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/editTools.tsx
@@ -67,6 +67,7 @@ function filePathArg(item: ItemModel): string | undefined {
 registerToolRenderer({
   match: "edit_file",
   icon: "edit",
+  fold: "consequential", // a mutation: it names the run it folds into
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const path = str(args, "file_path") ?? str(args, "path") ?? "";
@@ -87,6 +88,7 @@ function WriteFileBody({ item }: ToolRenderProps) {
 registerToolRenderer({
   match: "write_file",
   icon: "edit",
+  fold: "consequential",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const path = str(args, "file_path") ?? str(args, "path") ?? "";
@@ -128,6 +130,7 @@ function ApplyPatchBody({ item }: ToolRenderProps) {
 registerToolRenderer({
   match: "apply_patch",
   icon: "edit",
+  fold: "consequential",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const patch = str(args, "patch") ?? "";

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.tsx
@@ -70,6 +70,7 @@ function readFileTarget(item: ItemModel): string {
 registerToolRenderer({
   match: "read_file",
   icon: "file",
+  fold: "quiet",
   // An image read displays the picture itself at up to 600px square, not a
   // 96px thumbnail - the picture IS this call's output.
   outputImageSize: "large",
@@ -109,6 +110,7 @@ function grepTarget(args: Record<string, unknown>): string {
 
 const grepDescriptor: ToolRendererDescriptor = {
   match: (name: string) => name === "grep" || name === "grep_files" || name === "grep_search",
+  fold: "quiet",
   icon: "search",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
@@ -120,6 +122,7 @@ registerToolRenderer(grepDescriptor);
 
 const lsDescriptor: ToolRendererDescriptor = {
   match: (name: string) => name === "list_dir" || name === "list_directory",
+  fold: "quiet",
   icon: "folder",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
@@ -134,6 +137,7 @@ registerToolRenderer(lsDescriptor);
 registerToolRenderer({
   match: "glob",
   icon: "search",
+  fold: "quiet",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const pattern = str(args, "pattern") ?? str(args, "glob") ?? "";

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.tsx
@@ -97,6 +97,9 @@ function jobControlTarget(item: ItemModel): string {
 registerToolRenderer({
   match: (name) => name === "job_status" || name === "job_read_output",
   icon: "job",
+  // Background work is state a reader tracks across a turn, so every job
+  // row stays on its own line rather than folding into a run.
+  fold: "never",
   summary(item: ItemModel) {
     const parsedOutput = parseJSONObject(item.output);
     const jobId = jobControlTarget(item);
@@ -109,6 +112,7 @@ registerToolRenderer({
 registerToolRenderer({
   match: "job_list",
   icon: "job",
+  fold: "never",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const status = args.status;
@@ -121,6 +125,7 @@ registerToolRenderer({
 registerToolRenderer({
   match: "job_stop",
   icon: "job",
+  fold: "never",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const jobId = str(args, "target") ?? str(args, "job_id") ?? "";
@@ -339,6 +344,7 @@ function DelegateSendBody(props: ToolRenderProps) {
 registerToolRenderer({
   match: (name) => name === "delegate_send" || name === "job_send_message",
   icon: "send",
+  fold: "never",
   summary: delegateSendSummary,
   openTranscriptRef: delegateSendTranscriptRef,
   // The summary quotes the delegate target verbatim before the status meta
@@ -362,6 +368,7 @@ registerToolRenderer({
 registerToolRenderer({
   match: (name) => name.startsWith("job_"),
   icon: "job",
+  fold: "never",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const operation = str(args, "operation");

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/readTranscript.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/readTranscript.tsx
@@ -163,6 +163,7 @@ function ReadTranscriptBody(props: ToolRenderProps) {
 registerToolRenderer({
   match: (name) => name === "read_transcript" || name === "read_session_transcript",
   icon: "transcript",
+  fold: "quiet",
   // Says what was read and how much, never a dump of the call.
   summary(item: ItemModel) {
     const how = extent(item);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/shellTool.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/shellTool.tsx
@@ -140,6 +140,7 @@ registerToolRenderer({
   match: (name) => name === "shell" || name === "exec_command" || name === "run_shell_command",
   icon: "terminal",
   monoSummary: true,
+  fold: "consequential",
   // The exit code is NOT in the summary: a nonzero exit is announced by the
   // row's failure glyph instead (A2 - "exit 1" as the headline made every
   // failure look like a footnote). The number itself stays reachable via

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.tsx
@@ -385,6 +385,7 @@ function DelegateBody({ item, sessionRef }: ToolRenderProps) {
 
 registerToolRenderer({
   match: "delegate",
+  fold: "never", // a delegate card is never folded away into a run
   icon: "delegate",
   summary(item: ItemModel) {
     return item.description ?? "";

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentmodule.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentmodule.module.css
@@ -132,8 +132,8 @@
 .sectionLabel {
   font-size: var(--font-size-caption);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--ink-low);
+  letter-spacing: var(--tracking-eyebrow);
+  color: var(--ink-mid);
 }
 .mandate {
   font-family: var(--font-sans);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/taskCard.tsx
@@ -282,6 +282,7 @@ function TaskCardBody({ item }: ToolRenderProps) {
 
 registerToolRenderer({
   match: "task_list",
+  fold: "never", // the plan card stays visible
   icon: "tasks",
   summary: taskMutationSummary,
   body: TaskCardBody,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/useSkillTool.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/useSkillTool.tsx
@@ -22,6 +22,7 @@ function UseSkillBody({ item }: ToolRenderProps) {
 
 registerToolRenderer({
   match: "use_skill",
+  fold: "never", // which skill is running is never a footnote
   icon: "skill",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/webTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/webTools.tsx
@@ -131,6 +131,7 @@ function WebFetchBody({ item }: ToolRenderProps) {
 registerToolRenderer({
   match: "web_fetch",
   icon: "globe",
+  fold: "quiet",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const url = str(args, "url") ?? "";
@@ -168,6 +169,7 @@ function WebSearchBody({ item }: ToolRenderProps) {
 registerToolRenderer({
   match: "web_search",
   icon: "search",
+  fold: "quiet",
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
     const query = clip(str(args, "query") ?? str(args, "q") ?? "", QUERY_CLIP);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/worktreeTool.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/worktreeTool.tsx
@@ -175,6 +175,9 @@ function FindSessionTranscriptsBody(props: ToolRenderProps) {
 
 registerToolRenderer({
   match: "find_session_transcripts",
+  // A read-only search: folds and only counts (toolFoldPolicy.test.ts pins
+  // every registered tool's policy).
+  fold: "quiet",
   summary: findSessionsSummary,
   body: FindSessionTranscriptsBody,
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/worktreeTool.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/worktreeTool.tsx
@@ -109,6 +109,7 @@ function worktreeSummary(item: { argumentsJSON?: string; output?: string }): str
 registerToolRenderer({
   match: "manage_worktree",
   summary: worktreeSummary,
+  fold: "consequential", // creates/switches/removes a tree: a mutation
   // The output really is parseable JSON here (see this file's header), but
   // whether each operation deserves its own structured body is a bigger
   // question than the row this fix is about - a head-clipped dump is honest

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/transcriptAnchors.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/transcriptAnchors.test.tsx
@@ -32,7 +32,9 @@ function turnRow(items: ItemModel[], status: string): TranscriptTurnRow {
 test("a settled run of quiet tool calls registers one anchor under the run id", () => {
   const items = [toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "glob")];
   const anchors = transcriptAnchorEntriesForRows([turnRow(items, "completed")]);
-  expect(anchors).toEqual([{ id: "run:a", sourceIndex: 0, index: 0, isMessage: false }]);
+  // members: the ids the run stands in for, so a focus or scroll position
+  // captured on the second or third call still resolves to the run.
+  expect(anchors).toEqual([{ id: "run:a", sourceIndex: 0, index: 0, isMessage: false, members: ["a", "b", "c"] }]);
 });
 
 test("a live turn registers every entry, matching the rows TurnBlock renders while the agent works", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/transcriptAnchors.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/transcriptAnchors.test.tsx
@@ -1,14 +1,37 @@
-import { expect, test } from "vitest";
-import type { ItemModel, TurnModel } from "../../../protocol/model";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import type { ItemModel, ThreadModel, TurnModel } from "../../../protocol/model";
+import { makeTranscriptDisplayConfig } from "../../../transcriptDisplay/config";
 import type { ProjectedEntry, ProjectedTurn } from "../../../transcriptDisplay/projector";
+import { resetDisclosureStoreForTests } from "../../../widgets/disclosure/disclosureStore";
 // Registers the tool descriptors (fsTools' read_file is fold: "quiet") the
 // same way the real session pane does - through TurnBlock's side-effect
 // import of ./tools.
 import "./TurnBlock";
-import { type TranscriptTurnRow, transcriptAnchorEntriesForRows } from "./TranscriptBody";
+import {
+  TranscriptBody,
+  type TranscriptTurnRow,
+  transcriptAnchorEntriesForRows,
+  transcriptRunDisclosureIdsForRows,
+} from "./TranscriptBody";
 
+beforeEach(resetDisclosureStoreForTests);
+afterEach(cleanup);
+
+// description: a call with a stated intent projects as an ordinary item
+// entry at the tool-call levels; an intent-less call projects as a
+// "critical" entry (projector.ts's decisionFor), which never folds.
 function toolItem(id: string, toolName: string, status = "completed"): ItemModel {
-  return { id, turnId: "t1", type: "commandExecution", text: "", toolName, status } as ItemModel;
+  return {
+    id,
+    turnId: "t1",
+    type: "commandExecution",
+    text: "",
+    toolName,
+    status,
+    description: `Look at ${id}`,
+    output: "ok",
+  } as ItemModel;
 }
 
 function turnRow(items: ItemModel[], status: string): TranscriptTurnRow {
@@ -52,4 +75,49 @@ test("a tool with no fold policy keeps its own anchor and breaks the run", () =>
   ];
   const anchors = transcriptAnchorEntriesForRows([turnRow(items, "completed")]);
   expect(anchors.map((anchor) => anchor.id)).toEqual(["a", "b", "c", "d"]);
+});
+
+// roborev on PR #947 (round five): the Full-view baseline clears stale closed
+// choices only for ids in the eligible inventory, and the projector's inventory
+// knows source item ids, not the run:<first> ids ToolRunGroup mints.
+test("a settled run's disclosure id joins the Full-baseline inventory; a live turn adds none", () => {
+  const items = [toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "glob")];
+  expect(transcriptRunDisclosureIdsForRows([turnRow(items, "completed")])).toEqual(["run:a"]);
+  expect(transcriptRunDisclosureIdsForRows([turnRow(items, "inProgress")])).toEqual([]);
+});
+
+// The behaviour that inventory buys: close a folded run in Full, leave Full,
+// come back - Full's "everything open" baseline reopens it.
+test("re-entering Full view reopens a run the reader closed there", () => {
+  const items = [
+    { id: "u", turnId: "t1", type: "userMessage", text: "look around", status: "completed" },
+    toolItem("a", "read_file"),
+    toolItem("b", "read_file"),
+    toolItem("c", "glob"),
+  ] as ItemModel[];
+  const model = {
+    ref: "preview:runs",
+    threadId: "thread_runs",
+    name: "Runs",
+    status: { type: "idle" },
+    modelProvider: "preview",
+    model: "preview-model",
+    askPending: false,
+    pendingEscalations: [],
+    turns: [{ id: "t1", status: "completed", items }],
+  } as unknown as ThreadModel;
+  const preset = (level: "tools" | "full") => makeTranscriptDisplayConfig({ kind: "preset", level });
+  const view = (level: "tools" | "full") => (
+    <TranscriptBody model={model} config={preset(level)} surface="preview" disclosureScope="preview:runs" />
+  );
+  const { rerender } = render(view("full"));
+  const run = () => screen.getByTestId("tool-run") as HTMLDetailsElement;
+  expect(run().open).toBe(true);
+  const summary = run().querySelector("summary");
+  if (summary === null) throw new Error("the run rendered no summary");
+  fireEvent.click(summary);
+  expect(run().open).toBe(false);
+  rerender(view("tools"));
+  rerender(view("full"));
+  expect(run().open).toBe(true);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/transcriptAnchors.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/transcriptAnchors.test.tsx
@@ -1,0 +1,53 @@
+import { expect, test } from "vitest";
+import type { ItemModel, TurnModel } from "../../../protocol/model";
+import type { ProjectedEntry, ProjectedTurn } from "../../../transcriptDisplay/projector";
+// Registers the tool descriptors (fsTools' read_file is fold: "quiet") the
+// same way the real session pane does - through TurnBlock's side-effect
+// import of ./tools.
+import "./TurnBlock";
+import { type TranscriptTurnRow, transcriptAnchorEntriesForRows } from "./TranscriptBody";
+
+function toolItem(id: string, toolName: string, status = "completed"): ItemModel {
+  return { id, turnId: "t1", type: "commandExecution", text: "", toolName, status } as ItemModel;
+}
+
+function turnRow(items: ItemModel[], status: string): TranscriptTurnRow {
+  const source: TurnModel = { id: "t1", status, items } as TurnModel;
+  const entries: ProjectedEntry[] = items.map((item, sourceIndex) => ({
+    kind: "item",
+    id: item.id,
+    turnId: "t1",
+    sourceIndex,
+    item,
+    isMessage: false,
+  }));
+  const turn: ProjectedTurn = { id: "t1", source, entries, visibleItems: items };
+  return { kind: "turn", id: "t1", turn, sourceTurnIndex: 0, showTurnSeparator: true };
+}
+
+// roborev on PR #947: TurnBlock renders a folded run under ONE anchor
+// (run:<first entry>), so the anchor registry must advertise that anchor -
+// not the three entry ids no element carries while the run is closed - or a
+// restore after a remount looks for an id that is not in the DOM.
+test("a settled run of quiet tool calls registers one anchor under the run id", () => {
+  const items = [toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "glob")];
+  const anchors = transcriptAnchorEntriesForRows([turnRow(items, "completed")]);
+  expect(anchors).toEqual([{ id: "run:a", sourceIndex: 0, index: 0, isMessage: false }]);
+});
+
+test("a live turn registers every entry, matching the rows TurnBlock renders while the agent works", () => {
+  const items = [toolItem("a", "read_file"), toolItem("b", "read_file"), toolItem("c", "glob")];
+  const anchors = transcriptAnchorEntriesForRows([turnRow(items, "inProgress")]);
+  expect(anchors.map((anchor) => anchor.id)).toEqual(["a", "b", "c"]);
+});
+
+test("a tool with no fold policy keeps its own anchor and breaks the run", () => {
+  const items = [
+    toolItem("a", "read_file"),
+    toolItem("b", "mcp_deploy"),
+    toolItem("c", "read_file"),
+    toolItem("d", "glob"),
+  ];
+  const anchors = transcriptAnchorEntriesForRows([turnRow(items, "completed")]);
+  expect(anchors.map((anchor) => anchor.id)).toEqual(["a", "b", "c", "d"]);
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/turnblock.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/turnblock.module.css
@@ -1,16 +1,8 @@
 .turn {
-  /* Centered reading measure (webui-ux-transcript C2): the composer pins
-   * its own max-width to this SAME 76rem literal (composer.module.css, a
-   * sibling stream's file - out of this manifest's reach) so the input
-   * aligns with the conversation column above it; keep the two literals in
-   * sync until both consolidate onto a shared tokens.css custom property
-   * once the UX has settled. Declared and used on this one rule (not
-   * inherited from an ancestor) because .turn is also reused by the
-   * read-only "open beside" transcript pane (panes/transcript/
-   * Transcript.tsx), which doesn't sit under this stream's own FlowOverlay
-   * wrap - a single ancestor declaration wouldn't reach it there.
-   */
-  --session-measure: 76rem;
+  /* Centered reading measure: --session-measure is declared on <body> in
+   * tokens.css (44rem, or 64rem under the Transcript width preference), so
+   * this column, the composer's .measure and the cold-start block all read
+   * one value and stay aligned. */
   /* Speaker geometry (--speaker-avatar-size/-gap/-gutter) comes from
    * tokens.css: .turn and the focused view are sibling render trees, so no
    * component class could be the single source for both. */

--- a/cmd/evener-hub/frontend/src/panes/settings/SettingsNav.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/SettingsNav.test.tsx
@@ -68,7 +68,7 @@ test("renders all 15 legacy section links with their visible labels", () => {
 
 test("renders the 3 cluster headers", () => {
   render(<SettingsNav activeId="general" onNavigate={vi.fn()} />);
-  expect(screen.getByText("Agents & models")).toBeTruthy();
+  expect(screen.getByText("Agent setup")).toBeTruthy();
   expect(screen.getByText("Extensions")).toBeTruthy();
   expect(screen.getByText("Daemon")).toBeTruthy();
 });
@@ -114,7 +114,7 @@ test("a cluster header hides once every one of its links is filtered out", async
   await user.type(screen.getByRole("searchbox", { name: "Filter settings" }), "storage");
 
   expect(screen.getByText("Daemon")).toBeTruthy(); // Storage matches, stays
-  expect(screen.queryByText("Agents & models")).toBeNull(); // nothing in it matches
+  expect(screen.queryByText("Agent setup")).toBeNull(); // nothing in it matches
   expect(screen.queryByText("Extensions")).toBeNull();
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections.test.ts
@@ -36,13 +36,13 @@ test("the 6 ungrouped sections are General/Theme/Transcript display/Display/Noti
   expect(SETTINGS_SECTIONS.slice(0, 6)).toEqual(ungrouped);
 });
 
-test('the "Agents & models" cluster has exactly these 4 sections, in order, right after the ungrouped ones', () => {
+test('the "Agent setup" cluster has exactly these 4 sections, in order, right after the ungrouped ones', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "agents-models");
   expect(cluster.map((s) => s.label)).toEqual(["Providers & credentials", "Agents", "Evener launch", "In-repo config"]);
   expect(SETTINGS_SECTIONS.slice(6, 10)).toEqual(cluster);
 });
 
-test('the "Extensions" cluster has exactly these 4 sections, in order, right after "Agents & models"', () => {
+test('the "Extensions" cluster has exactly these 4 sections, in order, right after "Agent setup"', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "extensions");
   expect(cluster.map((s) => s.label)).toEqual(["Marketplaces & Plugins", "Plugins", "Skills", "MCP servers"]);
   expect(SETTINGS_SECTIONS.slice(10, 14)).toEqual(cluster);
@@ -63,7 +63,7 @@ test("the credentials section's id is exactly credentials (the /credentials alia
 });
 
 test("SETTINGS_CLUSTERS lists the 3 labeled clusters in nav order", () => {
-  expect(SETTINGS_CLUSTERS.map((c) => c.label)).toEqual(["Agents & models", "Extensions", "Daemon"]);
+  expect(SETTINGS_CLUSTERS.map((c) => c.label)).toEqual(["Agent setup", "Extensions", "Daemon"]);
 });
 
 test("every section's cluster field (when set) references a real cluster id", () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections.ts
@@ -27,7 +27,7 @@ export interface SettingsCluster {
 }
 
 export const SETTINGS_CLUSTERS: SettingsCluster[] = [
-  { id: "agents-models", label: "Agents & models" },
+  { id: "agents-models", label: "Agent setup" },
   { id: "extensions", label: "Extensions" },
   { id: "daemon", label: "Daemon" },
 ];

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.module.css
@@ -34,7 +34,7 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .list {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/instanceDialogs.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/instanceDialogs.module.css
@@ -18,6 +18,8 @@
 .textarea {
   width: 100%;
   font-family: var(--font-mono);
-  font-size: 0.85em;
+  /* An editable control: the control size, never a fraction of the line
+   * (0.85em was 13px, under iOS Safari's 16px zoom threshold on phones). */
+  font-size: var(--font-size-control);
   resize: vertical;
 }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/oauthDialogs.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/oauthDialogs.module.css
@@ -21,6 +21,10 @@
   font-size: var(--font-size-caption);
 }
 
+/* The device code the user has to read off this screen and type into a
+ * browser, so its characters are held apart. --tracking-eyebrow is the one
+ * opening-up tracking the ramp has; the code is not an eyebrow, but the
+ * alternative is a third tracking value for a single rule. */
 .code {
   padding: var(--space-3);
   border-radius: var(--radius-control);
@@ -30,7 +34,7 @@
   font-size: var(--font-size-page-title);
   font-weight: var(--font-weight-semibold);
   text-align: center;
-  letter-spacing: 0.05em;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .status {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/launchShared/LaunchConfigForm.module.css
@@ -17,7 +17,7 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .field {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/theme.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/theme.test.tsx
@@ -36,6 +36,7 @@ beforeEach(() => {
   document.documentElement.removeAttribute("data-theme");
   delete document.body.dataset.phoneDensity;
   delete document.body.dataset.fontSize;
+  delete document.body.dataset.transcriptMeasure;
   resetPrefsStoreForTests();
   resetToastStoreForTests();
 });
@@ -114,5 +115,18 @@ describe("Font size", () => {
 
     expect(prefsStore.getState().fontSize).toBe("xl");
     expect(document.body.dataset.fontSize).toBe("xl");
+  });
+});
+
+describe("Transcript width", () => {
+  test("defaults to Reading and updates the pref plus document.body.dataset.transcriptMeasure", async () => {
+    const user = userEvent.setup();
+    renderWithToasts();
+    expect(screen.getByRole("radio", { name: "Reading" }).getAttribute("aria-checked")).toBe("true");
+
+    await user.click(screen.getByRole("radio", { name: "Wide" }));
+
+    expect(prefsStore.getState().transcriptMeasure).toBe("wide");
+    expect(document.body.dataset.transcriptMeasure).toBe("wide");
   });
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/theme.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/theme.test.tsx
@@ -97,11 +97,11 @@ describe("Phone density", () => {
   });
 
   // The help copy must name the gate that's actually shipped in tokens.css
-  // (@media (max-width: 900px), matching useIsMobile's own breakpoint) -
+  // (@media (max-width: 899px), matching useIsMobile's own breakpoint) -
   // not a stale number that names a different, unimplemented gate.
-  test("the help copy states the shipped 900px density gate", () => {
+  test("the help copy states the shipped 899px density gate", () => {
     renderWithToasts();
-    expect(screen.getByText(/phones \(≤900px\)/)).toBeTruthy();
+    expect(screen.getByText(/phones \(≤899px\)/)).toBeTruthy();
   });
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/theme.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/theme.tsx
@@ -28,6 +28,11 @@ const FONT_SIZE_OPTIONS: RadioGroupOption[] = [
   { value: "xl", label: "XL" },
 ];
 
+const TRANSCRIPT_MEASURE_OPTIONS: RadioGroupOption[] = [
+  { value: "reading", label: "Reading" },
+  { value: "wide", label: "Wide" },
+];
+
 /**
  * Settings -> Theme (parity-m7-settings.md §3): 3 localStorage-only
  * preferences, no wire access - every control here reads/writes prefs.ts
@@ -52,11 +57,12 @@ export function ThemeSection() {
   const theme = usePrefsStore((s) => s.theme);
   const phoneDensity = usePrefsStore((s) => s.phoneDensity);
   const fontSize = usePrefsStore((s) => s.fontSize);
+  const transcriptMeasure = usePrefsStore((s) => s.transcriptMeasure);
   const { push } = useToasts();
 
   return (
     <div className={CLASS.root}>
-      <p className={CLASS.intro}>Theme, density, and font size are saved per-browser.</p>
+      <p className={CLASS.intro}>Theme, density, font size and transcript width are saved per-browser.</p>
 
       <div className={CLASS.row}>
         <RadioGroup
@@ -89,6 +95,16 @@ export function ThemeSection() {
           onChange={(value) => prefsStore.getState().setFontSize(value as "s" | "m" | "l" | "xl")}
         />
         <p className={CLASS.help}>Scales all UI text. M is the default.</p>
+      </div>
+
+      <div className={CLASS.row}>
+        <RadioGroup
+          label="Transcript width"
+          value={transcriptMeasure}
+          options={TRANSCRIPT_MEASURE_OPTIONS}
+          onChange={(value) => prefsStore.getState().setTranscriptMeasure(value as "reading" | "wide")}
+        />
+        <p className={CLASS.help}>Reading keeps lines near 90 characters. Wide uses more of the window.</p>
       </div>
     </div>
   );

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/theme.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/theme.tsx
@@ -84,7 +84,7 @@ export function ThemeSection() {
           options={PHONE_DENSITY_OPTIONS}
           onChange={(value) => prefsStore.getState().setPhoneDensity(value as "compact" | "comfortable")}
         />
-        <p className={CLASS.help}>Scales line spacing on phones (≤900px). Compact is the default.</p>
+        <p className={CLASS.help}>Scales line spacing on phones (≤899px). Compact is the default.</p>
       </div>
 
       <div className={CLASS.row}>

--- a/cmd/evener-hub/frontend/src/panes/settings/settings.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/settings.module.css
@@ -24,7 +24,7 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.02em;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .link {

--- a/cmd/evener-hub/frontend/src/panes/settings/settings.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/settings.module.css
@@ -72,6 +72,9 @@
   flex-direction: column;
   gap: var(--space-3);
   min-width: 0;
+  /* One reading measure, shared with the transcript: label/value hairlines
+   * that spanned 900px+ read as a spreadsheet (critique finding 8). */
+  max-width: var(--session-measure);
   overflow-y: auto;
 }
 

--- a/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/MobileSettingRows.module.css
@@ -54,7 +54,7 @@
 .caret {
   flex: 0 0 auto;
   color: var(--ink-mid);
-  font-size: var(--font-size-title);
+  font-size: var(--font-size-pane-title);
   line-height: 1;
 }
 

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -500,10 +500,23 @@ test("mobile Spawn keeps the approved prompt hierarchy visible while the prompt 
 
   await user.type(screen.getByRole("textbox", { name: "Prompt" }), "typed mobile work");
 
-  expect(screen.getByTestId("pane-title-mobile").textContent).toBe("new");
+  expect(screen.getByTestId("pane-title-mobile").textContent).toBe("New session");
   expect(screen.getByRole("heading", { name: "What should the agent do?" })).toBeTruthy();
   expect(screen.getByText("Leave blank to start a dormant session.")).toBeTruthy();
   expect((screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement).value).toBe("typed mobile work");
+});
+
+// The placeholder repeated the heading and subtitle standing right above it
+// almost word for word, so the field spent its one line saying what the page
+// had already said. The dormant-start rule it also carried stays on the page,
+// in that intro.
+test("the prompt placeholder does not repeat the heading", async () => {
+  renderSpawn(readyClient());
+  await settled();
+
+  const prompt = screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
+  expect(prompt.placeholder).toBe("Describe the task…");
+  expect(screen.getByText("Leave blank to start a dormant session.")).toBeTruthy();
 });
 
 // The card's control-row compression and touch floors are pinned by the
@@ -553,7 +566,7 @@ test("the primary verb is Start, in the card's own corner, and the page is title
 
   const start = screen.getByTestId("spawn-submit");
   expect(start.textContent).toBe("Start");
-  expect(screen.getByTestId("pane-title-desktop").textContent).toBe("Start an agent");
+  expect(screen.getByTestId("pane-title-desktop").textContent).toBe("New session");
   // Inside the card, not in a detached actions strip below it.
   expect(screen.getByTestId("spawn-prompt-card").contains(start)).toBe(true);
   expect(screen.getByRole("button", { name: "Start" })).toBeTruthy();
@@ -570,17 +583,6 @@ test("the Start button's word collapses to the glyph below the compact pane thre
   const css = readFileSync(join(here, "spawn.module.css"), "utf8");
   expect(css).toMatch(/\.form\s*\{[^}]*container-type:\s*inline-size/);
   expect(css).toMatch(/@container \(max-width: 559px\)[\s\S]*?\.submitLabel\s*\{[^}]*display:\s*none/);
-});
-
-// The dormant-start rule rides in the placeholder rather than a separate
-// instruction line above the form: it is a fact about THIS field.
-test("the dormant hint lives in the placeholder, not a standalone instruction line", async () => {
-  renderSpawn(readyClient());
-  await settled();
-
-  const prompt = screen.getByRole("textbox", { name: "Prompt" });
-  expect(prompt.getAttribute("placeholder")).toBe("What should the agent work on? Leave blank to start it dormant.");
-  expect(screen.queryByText(/leave the prompt blank/i)).toBeNull();
 });
 
 // Writing the prompt is what starting an agent IS, so the caret starts there

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -533,7 +533,11 @@ test("mobile-only spawn hierarchy and row scale stay gated from desktop", () => 
     "",
   );
 
-  expect(spawnCss).toContain(".mobilePromptIntro");
+  // The prompt heading shows at every width now (critique R7); only the
+  // settings-style rows stay phone-only.
+  expect(spawnCss).toContain(".promptIntro");
+  expect(spawnCss).not.toContain(".mobilePromptIntro");
+  expect(spawnCss).toContain(".mobileConfig");
   expect(spawnCss).toContain("@media (max-width: 899px)");
   expect(rowsCss).toContain("min-height: 48px");
   expect(rowsCss).toContain("font-size: var(--font-size-body)");

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -857,7 +857,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       ? harnesses.map((h) => ({ value: h.id, label: h.label }))
       : [{ value: "evener", label: "evener" }];
   return (
-    <PaneScaffold title="Start an agent" mobileTitle="new">
+    <PaneScaffold title="New session" mobileTitle="New session">
       <div className={CLASS.form}>
         {staleNotice !== null && (
           <div className={CLASS.notice} role="status">
@@ -930,11 +930,10 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
                 onChange={(e) => updatePrompt(e.target.value)}
                 onKeyDown={handlePromptKeyDown}
                 onPaste={handlePaste}
-                // The dormant-start rule rides in the placeholder rather than a
-                // separate instruction line above the form: it is a fact about
-                // THIS field, and a sentence of chrome explaining a field is
-                // worse than the field explaining itself.
-                placeholder="What should the agent work on? Leave blank to start it dormant."
+                // Short, because the intro above the card already asks the
+                // question and states the dormant-start rule; a placeholder
+                // that repeats them spends the field's one line on nothing.
+                placeholder="Describe the task…"
                 aria-label="Prompt"
                 autoGrow
                 // The PromptCard around it draws the one border this field

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -129,9 +129,9 @@ const CLASS = {
   effortSelect: requireClass(styles.effortSelect, "spawn.module.css", "effortSelect"),
   srOnly: requireClass(styles.srOnly, "spawn.module.css", "srOnly"),
   mobileConfig: requireClass(styles.mobileConfig, "spawn.module.css", "mobileConfig"),
-  mobilePromptIntro: requireClass(styles.mobilePromptIntro, "spawn.module.css", "mobilePromptIntro"),
-  mobilePromptHeading: requireClass(styles.mobilePromptHeading, "spawn.module.css", "mobilePromptHeading"),
-  mobilePromptSubtitle: requireClass(styles.mobilePromptSubtitle, "spawn.module.css", "mobilePromptSubtitle"),
+  promptIntro: requireClass(styles.promptIntro, "spawn.module.css", "promptIntro"),
+  promptHeading: requireClass(styles.promptHeading, "spawn.module.css", "promptHeading"),
+  promptSubtitle: requireClass(styles.promptSubtitle, "spawn.module.css", "promptSubtitle"),
   modelNote: requireClass(styles.modelNote, "spawn.module.css", "modelNote"),
   submitLabel: requireClass(styles.submitLabel, "spawn.module.css", "submitLabel"),
   pluginDesktop: requireClass(pluginSelectionStyles.desktopSurface, "pluginSelection.module.css", "desktopSurface"),
@@ -913,9 +913,9 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
           />
         )}
 
-        <div className={CLASS.mobilePromptIntro} data-testid="spawn-mobile-prompt-intro">
-          <h3 className={CLASS.mobilePromptHeading}>What should the agent do?</h3>
-          <p className={CLASS.mobilePromptSubtitle}>Leave blank to start a dormant session.</p>
+        <div className={CLASS.promptIntro} data-testid="spawn-prompt-intro">
+          <h2 className={CLASS.promptHeading}>What should the agent do?</h2>
+          <p className={CLASS.promptSubtitle}>Leave blank to start a dormant session.</p>
         </div>
 
         {/* The prompt shares its card and attachment controls with the session composer. */}

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
@@ -335,12 +335,11 @@
     max-width: none;
   }
 
-  /* 16px is the floor iOS Safari zooms the page to reach; a smaller field font
-   * makes focusing the prompt scale the whole layout. The min-height keeps the
-   * field a usable writing surface on a short viewport where the card's
-   * line-count floor would otherwise be all it gets. */
+  /* The field's size comes from widgets/textarea (the 16px phone floor lives
+   * there); the min-height keeps the field a usable writing surface on a
+   * short viewport where the card's line-count floor would otherwise be all
+   * it gets. */
   .form textarea {
-    font-size: var(--font-size-body);
     min-height: 96px;
   }
 

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
@@ -1,9 +1,14 @@
-/* Session creation: project directory, prompt, then secondary settings. */
+/* Session creation: heading, project directory, prompt, then secondary
+ * settings - one centred column on the same measure the transcript reads
+ * at, so the form sits in the pane instead of pinned to its left edge
+ * (typography-spacing-critique-2026-09-06 R7). */
 .form {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
-  max-width: 720px;
+  gap: var(--space-5);
+  width: 100%;
+  max-width: var(--session-measure);
+  margin-inline: auto;
   /* The query container for the Start button's word collapse below: a docked
    * pane squeezed narrow inside a desktop viewport must compact exactly like
    * the phone does. inline-size containment is safe here - this box's width
@@ -207,19 +212,22 @@
   display: none;
 }
 
-.mobilePromptIntro {
-  display: none;
+/* The page's heading, at every width: the phone always had it, desktop hid
+ * it behind a 12px uppercase pane title (critique finding 8). */
+.promptIntro {
+  display: block;
 }
 
-.mobilePromptHeading {
+.promptHeading {
   margin: 0;
   color: var(--ink-hi);
-  font-size: var(--font-size-pane-title);
+  font-size: var(--font-size-page-title);
   font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-display);
   line-height: var(--line-height-title);
 }
 
-.mobilePromptSubtitle {
+.promptSubtitle {
   margin: var(--space-1) 0 0;
   color: var(--ink-mid);
   font-size: var(--font-size-body);
@@ -338,10 +346,6 @@
   }
 
   .mobileConfig {
-    display: block;
-  }
-
-  .mobilePromptIntro {
     display: block;
   }
 }

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
@@ -329,7 +329,7 @@
    * field a usable writing surface on a short viewport where the card's
    * line-count floor would otherwise be all it gets. */
   .form textarea {
-    font-size: 16px;
+    font-size: var(--font-size-body);
     min-height: 96px;
   }
 

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
@@ -185,6 +185,9 @@
    * disabled control and promise an interaction the select refuses. */
   cursor: inherit;
   font: inherit;
+  /* A real native select: it must not inherit the trigger's caption size,
+   * or iOS zooms into it on focus (--font-size-control is 16px on phones). */
+  font-size: var(--font-size-control);
 }
 
 .effortTrigger:not([data-disabled="true"]) .effortSelect {

--- a/cmd/evener-hub/frontend/src/panes/welcome/Welcome.tsx
+++ b/cmd/evener-hub/frontend/src/panes/welcome/Welcome.tsx
@@ -26,7 +26,12 @@ export default function Welcome({ params, focused }: PaneProps<WelcomePaneParams
   // welcome panel); passing it here too would render the note twice.
   return (
     <PaneScaffold title="Welcome">
-      <EmptyState title="No session open" hint={params.note} action={<WelcomeContent showNewSession showHints />} />
+      <EmptyState
+        title="No session open"
+        hint={params.note}
+        size="display"
+        action={<WelcomeContent showNewSession showHints />}
+      />
     </PaneScaffold>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/welcome/WelcomeContent.tsx
+++ b/cmd/evener-hub/frontend/src/panes/welcome/WelcomeContent.tsx
@@ -8,6 +8,7 @@ import styles from "./welcome.module.css";
 const CLASS = {
   actions: requireClass(styles.actions, "welcome.module.css", "actions"),
   hints: requireClass(styles.hints, "welcome.module.css", "hints"),
+  hintList: requireClass(styles.hintList, "welcome.module.css", "hintList"),
   hintRow: requireClass(styles.hintRow, "welcome.module.css", "hintRow"),
   hintFooter: requireClass(styles.hintFooter, "welcome.module.css", "hintFooter"),
 };
@@ -84,12 +85,16 @@ export function WelcomeContent({ note, showNewSession, showResume = true, showHi
       </p>
       {showHints && (
         <div className={CLASS.hints}>
-          {CHORD_HINTS.map((hint) => (
-            <div className={CLASS.hintRow} key={hint.desc}>
-              <KeyHint keys={hint.keys} />
-              <span>{hint.desc}</span>
-            </div>
-          ))}
+          <dl className={CLASS.hintList}>
+            {CHORD_HINTS.map((hint) => (
+              <div className={CLASS.hintRow} key={hint.desc}>
+                <dt>
+                  <KeyHint keys={hint.keys} />
+                </dt>
+                <dd>{hint.desc}</dd>
+              </div>
+            ))}
+          </dl>
           <p className={CLASS.hintFooter}>
             <KeyHint keys={["?"]} /> inside the command palette shows all shortcuts.
           </p>

--- a/cmd/evener-hub/frontend/src/panes/welcome/welcome.module.css
+++ b/cmd/evener-hub/frontend/src/panes/welcome/welcome.module.css
@@ -47,7 +47,7 @@
 
 .orientation {
   max-width: 36rem;
-  margin: var(--space-3) 0 0;
+  margin: var(--space-4) 0 0;
   color: var(--ink-mid);
   font-family: var(--font-sans);
   font-size: var(--font-size-body);
@@ -65,21 +65,40 @@
   margin-top: var(--space-4);
 }
 
-.hintRow {
-  display: flex;
+/* The chords as a two-column list: keys right-aligned in one column, what
+ * they do in the next, so the three rows line up instead of centring each
+ * on its own width. `display: contents` on each row hands its dt/dd to the
+ * grid. */
+.hintList {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: var(--space-3);
+  row-gap: var(--space-2);
   align-items: center;
-  gap: var(--space-2);
+  margin: 0;
+}
+
+.hintRow {
+  display: contents;
   color: var(--ink-mid);
   font-family: var(--font-sans);
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-ui);
+}
+
+.hintRow > dt {
+  justify-self: end;
+}
+
+.hintRow > dd {
+  margin: 0;
 }
 
 .hintFooter {
   display: flex;
   align-items: center;
   gap: var(--space-1);
-  margin: var(--space-1) 0 0;
-  color: var(--ink-low);
+  margin: var(--space-2) 0 0;
+  color: var(--ink-mid);
   font-family: var(--font-sans);
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-ui);
 }

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheet.module.css
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/cheatsheet.module.css
@@ -10,7 +10,7 @@
   color: var(--ink-mid);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  letter-spacing: var(--tracking-display);
+  letter-spacing: var(--tracking-eyebrow);
   text-transform: uppercase;
 }
 

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.module.css
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.module.css
@@ -1,3 +1,16 @@
 .singleScrollPanel {
   overflow: hidden;
 }
+
+/* The rail fills the drawer flush: the sheet body's own inset made the rail
+ * read as a panel nested inside a panel (Rail.module.css's own mobile rule
+ * already drops the rail's width and border for the same reason). */
+.flushBody {
+  padding: 0;
+}
+
+/* The welcome copy that shows when nothing is focused keeps the inset the
+ * body gave up. */
+.drawerWelcome {
+  padding: var(--space-4);
+}

--- a/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/MobilePanel.tsx
@@ -33,8 +33,13 @@ export function MobilePanel({ rail, open, onClose }: MobilePanelProps) {
       title="Sessions"
       size="wide"
       panelClassName={styles.singleScrollPanel}
+      bodyClassName={styles.flushBody}
     >
-      {nothingFocused && <WelcomeContent showResume={false} showHints={false} />}
+      {nothingFocused && (
+        <div className={styles.drawerWelcome}>
+          <WelcomeContent showResume={false} showHints={false} />
+        </div>
+      )}
       {rail}
     </Sheet>
   );

--- a/cmd/evener-hub/frontend/src/shell/palette/commandpalette.module.css
+++ b/cmd/evener-hub/frontend/src/shell/palette/commandpalette.module.css
@@ -53,7 +53,9 @@
   box-shadow: var(--shadow-inset-field);
   color: var(--ink-hi);
   font-family: var(--font-sans);
-  font-size: var(--font-size-body);
+  /* The body size, floored at the phone's 16px control size: body alone is
+   * 14.4px under the S preference on a phone (display-gates.test.ts). */
+  font-size: max(var(--font-size-control), var(--font-size-body));
   transition: border-color var(--motion-duration-hover) var(--motion-easing-standard);
 }
 

--- a/cmd/evener-hub/frontend/src/shell/palette/commandpalette.module.css
+++ b/cmd/evener-hub/frontend/src/shell/palette/commandpalette.module.css
@@ -87,12 +87,12 @@
 
 .sectionHeader {
   padding: var(--space-2) var(--space-2) var(--space-1);
-  color: var(--ink-low);
+  color: var(--ink-mid);
   font-family: var(--font-sans);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-display);
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .row {

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.module.css
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.module.css
@@ -65,15 +65,6 @@
   gap: var(--space-2);
 }
 
-/* The header icon buttons' GLYPHS: they're text glyphs (⌕ ☰ ⚙), so
- * they size to the button's font-size - the IconButton's icon span is 1em x
- * 1em of it - never to the box. md made the boxes 32px but left the glyphs
- * at --font-size-ui (13px); --font-size-pane-title (16px) reads at the md
- * box's scale. */
-.brand button {
-  font-size: var(--font-size-pane-title);
-}
-
 /* Stretches the primary Button to the rail's full width without touching the
  * widget's own computed className (Button owns its class list). */
 .newSession {

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.module.css
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.module.css
@@ -54,8 +54,8 @@
   flex: none;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
+  gap: var(--space-3);
+  padding: var(--space-4);
   border-bottom: 1px solid var(--edge);
 }
 
@@ -120,18 +120,18 @@
 }
 
 .section {
-  padding: var(--space-2) 0;
+  padding: var(--space-3) 0;
 }
 
 .sectionTitle {
   margin: 0;
   padding: var(--space-1) var(--space-4);
-  color: var(--ink-low);
+  color: var(--ink-mid);
   font-family: var(--font-sans);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .sectionHeadingRow {
@@ -159,12 +159,12 @@
   padding: var(--space-1) var(--space-4);
   border: none;
   background: transparent;
-  color: var(--ink-low);
+  color: var(--ink-mid);
   font-family: var(--font-sans);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-eyebrow);
   cursor: default;
   transition: background-color var(--motion-duration-hover) var(--motion-easing-standard);
 }

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
@@ -252,6 +252,24 @@ describe("resource-backed Rail", () => {
     }
   });
 
+  // The header's three icons are drawn, not typed: global.css subsets Inter to
+  // Latin, so the text glyphs these buttons carried (the gear, the magnifier,
+  // the burger) came from whatever system fallback happened to have those code
+  // points, at whatever weight it drew them - right beside the app's own SVG
+  // chevrons and open-box icon.
+  test("the header icon buttons draw SVG icons, not text glyphs outside the subsetted font", () => {
+    installState();
+
+    render(<Rail onHide={vi.fn()} />);
+
+    const brand = within(screen.getByTestId("rail-brand"));
+    for (const label of ["Settings", "Search", "Hide sidebar"]) {
+      const button = brand.getByRole("button", { name: label });
+      expect(button.querySelector("svg")).toBeTruthy();
+      expect(button.textContent?.trim()).toBe("");
+    }
+  });
+
   test("renders loaded global and project resources without a transport read", () => {
     installState([
       sectionResource("live", [summary({ title: "Live resource" })]),
@@ -280,6 +298,16 @@ describe("resource-backed Rail", () => {
 
     expect(screen.queryByRole("status", { name: "Loading" })).toBeNull();
     expect(screen.getByText(/no sessions yet/i)).toBeTruthy();
+  });
+  // The empty state sits directly under the rail's own "+ New session" button,
+  // so it cannot answer "how do I start one?" with the command line.
+  test("the rail's empty state does not send people to the command line", () => {
+    installState([], emptyManifest());
+
+    render(<Rail />);
+
+    expect(screen.queryByText(/command line/i)).toBeNull();
+    expect(screen.getByText("No sessions yet")).toBeTruthy();
   });
   test.each(["v2"] as const)("shows a visible skeleton for a pending %s manifest until it settles", (mode) => {
     const empty = emptyManifest();

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -74,6 +74,7 @@ import { RAIL_WIDTH_PROPERTY, RailResizeHandle } from "./RailResizeHandle";
 import { RailRow, type RailRowActions } from "./RailRow";
 import dialogStyles from "./railDialog.module.css";
 import { loadExpansion, projectNodeExpansionKey, saveExpansion } from "./railExpansion";
+import { GearIcon, SearchIcon, SidebarIcon } from "./railIcons";
 import {
   archivedCount,
   archivedProjectNodes,
@@ -1405,7 +1406,7 @@ function NavigationRail({
           <IconButton
             data-testid="rail-settings"
             label="Settings"
-            icon={<span aria-hidden="true">⚙</span>}
+            icon={<GearIcon />}
             variant="quiet"
             size="md"
             onClick={() => navigate("/settings")}
@@ -1415,7 +1416,7 @@ function NavigationRail({
               data-testid="rail-search"
               data-search-trigger="true"
               label="Search"
-              icon={<span aria-hidden="true">⌕</span>}
+              icon={<SearchIcon />}
               variant="quiet"
               size="md"
             />
@@ -1424,7 +1425,7 @@ function NavigationRail({
             <IconButton
               data-rail-toggle=""
               label="Hide sidebar"
-              icon={<span aria-hidden="true">☰</span>}
+              icon={<SidebarIcon />}
               variant="quiet"
               size="md"
               onClick={onHide}
@@ -1451,7 +1452,7 @@ function NavigationRail({
           />
         )}
         {!loading && !displayed && !loadError && manifest && (
-          <EmptyState title="No sessions yet" hint="Start a session from the command line to see it here." />
+          <EmptyState title="No sessions yet" hint="Start one with the button above." />
         )}
         {displayed && (
           <>

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.module.css
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.module.css
@@ -299,7 +299,7 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  color: var(--ink-low);
+  color: var(--ink-mid);
   font-size: var(--font-size-caption);
 }
 
@@ -337,7 +337,7 @@
  * .actions menu borrows the same cell). The slot owns the right alignment
  * and the occupant/menu visibility swap; this class is only the text. */
 .time {
-  color: var(--ink-low);
+  color: var(--ink-mid);
   font-family: var(--font-sans);
   font-variant-numeric: tabular-nums;
   font-size: var(--font-size-caption);

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.module.css
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.module.css
@@ -338,13 +338,14 @@
  * and the occupant/menu visibility swap; this class is only the text. */
 .time {
   color: var(--ink-low);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
   font-size: var(--font-size-caption);
 }
 
 /* Third occupant of the shared .rightSlot cell (RailRow.tsx renders exactly
  * one of the three): the words a session that has never run shows INSTEAD
- * of an age. Set in the UI sans face rather than .time's mono,
+ * of an age. Proportional figures rather than .time's tabular ones,
  * because this is a sentence, not a measurement - and in --ink-mid rather than
  * .time's --ink-low, because a glanceable age can sit below the AA text floor
  * and a phrase the reader has to actually read cannot. Deliberately NOT a

--- a/cmd/evener-hub/frontend/src/shell/rail/railIcons.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/railIcons.tsx
@@ -1,0 +1,53 @@
+// The rail header's three icons, drawn on the app's 16x16 icon grid (the same
+// grammar as widgets/chevron, openbutton's OpenIcon and TreeDrawer's
+// SessionsIcon).
+//
+// They replace the text glyphs the header used to render. global.css subsets
+// Inter to Latin, so those code points came from whatever system fallback
+// happened to have them, at whatever stroke weight it drew them - sitting
+// beside the app's own SVG chevrons and open-box icon. Drawing them makes the
+// weight and the size design decisions rather than a fallback font's.
+//
+// `aria-hidden` is spelled out on each <svg> rather than carried in the shared
+// props below: every one of these is an IconButton's icon, whose `label` is the
+// button's only accessible name, and the a11y lint reads the attribute off the
+// element rather than through a spread.
+
+const ICON = { viewBox: "0 0 16 16", width: 16, height: 16 } as const;
+const STROKE = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.5,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+} as const;
+
+export function GearIcon() {
+  return (
+    <svg {...ICON} aria-hidden="true">
+      <circle cx="8" cy="8" r="2.25" {...STROKE} />
+      <path
+        d="M8 1.75v2M8 12.25v2M1.75 8h2M12.25 8h2M3.6 3.6l1.4 1.4M11 11l1.4 1.4M3.6 12.4 5 11M11 5l1.4-1.4"
+        {...STROKE}
+      />
+    </svg>
+  );
+}
+
+export function SearchIcon() {
+  return (
+    <svg {...ICON} aria-hidden="true">
+      <circle cx="7" cy="7" r="4.25" {...STROKE} />
+      <path d="M10.2 10.2 14 14" {...STROKE} />
+    </svg>
+  );
+}
+
+export function SidebarIcon() {
+  return (
+    <svg {...ICON} aria-hidden="true">
+      <rect x="2" y="3" width="12" height="10" rx="1.5" {...STROKE} />
+      <path d="M6 3v10" {...STROKE} />
+    </svg>
+  );
+}

--- a/cmd/evener-hub/frontend/src/stores/prefs.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.test.ts
@@ -222,6 +222,12 @@ describe("corrupted/unrecognized localStorage values fall back to the documented
     expect(prefsStore.getState().fontSize).toBe("m");
   });
 
+  test("an unrecognized transcriptMeasure falls back to reading", () => {
+    localStorage.setItem(KEY("transcriptMeasure"), "huge");
+    resetPrefsStoreForTests();
+    expect(prefsStore.getState().transcriptMeasure).toBe("reading");
+  });
+
   test("a non-'1'/'0' boolean pref falls back to its default rather than reading as true", () => {
     // Every boolean pref this store holds now defaults off, so the fallback
     // is only observable in this direction: a garbage value must not read as
@@ -243,6 +249,20 @@ describe("corrupted/unrecognized localStorage values fall back to the documented
     localStorage.setItem(KEY("enterToSend"), "true");
     resetPrefsStoreForTests();
     expect(prefsStore.getState().enterToSend).toBe(false); // default, not true
+  });
+});
+
+describe("transcriptMeasure (Settings -> Theme -> Transcript width)", () => {
+  // Mirrors fontSize/phoneDensity: an enum pref persisted under its own flat
+  // evener.prefs.<name> key and mirrored onto <body data-transcript-measure>,
+  // which tokens.css keys --session-measure off (44rem reading / 64rem wide).
+  test("defaults to reading, persists under evener.prefs.transcriptMeasure, and mirrors onto body", () => {
+    expect(prefsStore.getState().transcriptMeasure).toBe("reading");
+    expect(document.body.dataset.transcriptMeasure).toBe("reading");
+    prefsStore.getState().setTranscriptMeasure("wide");
+    expect(localStorage.getItem("evener.prefs.transcriptMeasure")).toBe("wide");
+    expect(document.body.dataset.transcriptMeasure).toBe("wide");
+    expect(prefsStore.getState().transcriptMeasure).toBe("wide");
   });
 });
 

--- a/cmd/evener-hub/frontend/src/stores/prefs.ts
+++ b/cmd/evener-hub/frontend/src/stores/prefs.ts
@@ -47,7 +47,7 @@
 // instead of unconditionally clearing the attribute the way it used to.
 // The section's own help copy ("default follows your OS preference") is
 // what this makes true; before this, "system" always rendered dark
-// regardless of the OS. phoneDensity/fontSize
+// regardless of the OS. phoneDensity/fontSize/transcriptMeasure
 // get the same document-mirroring treatment the legacy's settings-
 // appearance.js gave them (onto document.body.dataset), and tokens.css now
 // keys off both: the type ramp scales off <body data-font-size> and the
@@ -86,6 +86,10 @@ import {
 export type ThemePref = "system" | "light" | "dark";
 export type PhoneDensityPref = "compact" | "comfortable";
 export type FontSizePref = "s" | "m" | "l" | "xl";
+// Settings -> Theme -> Transcript width: the conversation column's measure.
+// tokens.css keys --session-measure off <body data-transcript-measure>
+// (44rem reading, 64rem wide).
+export type TranscriptMeasurePref = "reading" | "wide";
 export type TranscriptStatusKey = "roundTimings" | "tokenCounts" | "hookExitsAll" | "hookExitsNormal" | "promptLoaded";
 export type NotificationKey = "title" | "favicon" | "os" | "sound";
 export type NotificationsLoudScopePref = "asks" | "all";
@@ -96,6 +100,7 @@ export interface PrefsStoreState {
   sidebarHidden: boolean;
   sidebarWidth: number;
   fontSize: FontSizePref;
+  transcriptMeasure: TranscriptMeasurePref;
   transcript: Record<TranscriptStatusKey, boolean>;
   // Composer prefs (Display section, parity-m7-settings.md §5). Field names
   // match the PINNED evener.prefs.enterToSend / evener.prefs.showCost keys.
@@ -123,6 +128,7 @@ export interface PrefsStoreState {
   setSidebarHidden(value: boolean): void;
   setSidebarWidth(value: number): void;
   setFontSize(value: FontSizePref): void;
+  setTranscriptMeasure(value: TranscriptMeasurePref): void;
   setTranscriptStatus(key: TranscriptStatusKey, value: boolean): void;
   setEnterToSend(value: boolean): void;
   setShowCost(value: boolean): void;
@@ -314,6 +320,7 @@ function readEnum<T extends string>(name: string, allowed: readonly T[], fallbac
 const THEME_VALUES: readonly ThemePref[] = ["system", "light", "dark"];
 const PHONE_DENSITY_VALUES: readonly PhoneDensityPref[] = ["compact", "comfortable"];
 const FONT_SIZE_VALUES: readonly FontSizePref[] = ["s", "m", "l", "xl"];
+const TRANSCRIPT_MEASURE_VALUES: readonly TranscriptMeasurePref[] = ["reading", "wide"];
 const LOUD_SCOPE_VALUES: readonly NotificationsLoudScopePref[] = ["asks", "all"];
 
 // Per-field localStorage key names for the two grouped record fields -
@@ -455,6 +462,10 @@ function applyFontSize(value: FontSizePref): void {
   document.body.dataset.fontSize = value;
 }
 
+function applyTranscriptMeasure(value: TranscriptMeasurePref): void {
+  document.body.dataset.transcriptMeasure = value;
+}
+
 // loadInitialState re-derives every field from localStorage (plus the
 // document side effects above) - shared by the store's own creator function
 // and resetPrefsStoreForTests(), so a test that seeds localStorage and then
@@ -466,6 +477,7 @@ function loadInitialState(): Omit<
   | "setSidebarHidden"
   | "setSidebarWidth"
   | "setFontSize"
+  | "setTranscriptMeasure"
   | "setTranscriptStatus"
   | "setEnterToSend"
   | "setShowCost"
@@ -477,15 +489,18 @@ function loadInitialState(): Omit<
   const theme = readEnum("theme", THEME_VALUES, "system");
   const phoneDensity = readEnum("phoneDensity", PHONE_DENSITY_VALUES, "compact");
   const fontSize = readEnum("fontSize", FONT_SIZE_VALUES, "m");
+  const transcriptMeasure = readEnum("transcriptMeasure", TRANSCRIPT_MEASURE_VALUES, "reading");
   applyTheme(theme);
   applyPhoneDensity(phoneDensity);
   applyFontSize(fontSize);
+  applyTranscriptMeasure(transcriptMeasure);
   return {
     theme,
     phoneDensity,
     sidebarHidden: readBool("sidebarHidden", false),
     sidebarWidth: readNumber("sidebarWidth", SIDEBAR_WIDTH_DEFAULT, clampSidebarWidth),
     fontSize,
+    transcriptMeasure,
     transcript: loadTranscript(),
     enterToSend: readBool("enterToSend", false),
     showCost: readBool("showCost", false),
@@ -534,6 +549,12 @@ export const prefsStore = createStore<PrefsStoreState>((set) => ({
     writeRaw("fontSize", value);
     applyFontSize(value);
     set({ fontSize: value });
+  },
+
+  setTranscriptMeasure(value) {
+    writeRaw("transcriptMeasure", value);
+    applyTranscriptMeasure(value);
+    set({ transcriptMeasure: value });
   },
 
   setTranscriptStatus(key, value) {

--- a/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
@@ -132,7 +132,10 @@ test("--font-size-control is the ui step on desktop and the body (16px) step on 
   expect(CSS).toMatch(/\n\s*--font-size-control: var\(--font-size-ui\);/);
   const media = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
   expect(media).not.toBeNull();
-  expect(media![1]).toMatch(/--font-size-control: var\(--font-size-body\);/);
+  // max(16px, …), not the body size alone: the S font-size preference scales
+  // the phone body to 14.4px, and iOS zooms into a 14.4px field just the same
+  // (roborev on PR #947).
+  expect(media![1]).toMatch(/--font-size-control: max\(16px, var\(--font-size-body\)\);/);
   expect(media![1]).toMatch(/--font-size-body: calc\(16px \* var\(--font-scale\)\);/);
 });
 

--- a/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
@@ -103,4 +103,49 @@ test("the 44px touch-target floor is declared inside the phone media query (2026
   const media = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
   expect(media, "tokens.css must have a max-width:899px media block").not.toBeNull();
   expect(media![1]).toMatch(/--tap-min:\s*44px/);
+});
+
+// --- editable controls are 16px on phones -------------------------------
+//
+// index.html no longer locks zoom (viewport-pin.test.ts), so the guarantee
+// that iOS Safari has nothing to auto-zoom into moves here: every rule that
+// styles an editable control - an input/select/textarea element selector, or
+// one of the classes the widgets and panes put on their own controls - sizes
+// its text from --font-size-control (the ui step on desktop, the body step on
+// phones) or --font-size-body. roborev on PR #947 caught the inputs and
+// selects that still took --font-size-ui after the lock was removed.
+const CONTROL_SELECTOR_RE =
+  /(^|[\s,>+~(])(input|select|textarea)(\b|[:.[])|\.(input|select|textarea|textInput|effortSelect)(\b|[:.[])/;
+const CONTROL_SIZE_RE = /font-size:\s*var\(--font-size-(control|body)\)/;
+
+function walkCss(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...walkCss(full));
+    else if (entry.isFile() && entry.name.endsWith(".css")) found.push(full);
+  }
+  return found;
+}
+
+test("--font-size-control is the ui step on desktop and the body (16px) step on phones", () => {
+  expect(CSS).toMatch(/\n\s*--font-size-control: var\(--font-size-ui\);/);
+  const media = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
+  expect(media).not.toBeNull();
+  expect(media![1]).toMatch(/--font-size-control: var\(--font-size-body\);/);
+  expect(media![1]).toMatch(/--font-size-body: calc\(16px \* var\(--font-scale\)\);/);
+});
+
+test("every rule that sizes an editable control uses --font-size-control or --font-size-body", () => {
+  const srcRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+  for (const file of walkCss(srcRoot)) {
+    const css = readFileSync(file, "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+    for (const block of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      const selector = block[1]!.trim().split("\n").pop() ?? "";
+      const body = block[2]!;
+      if (!CONTROL_SELECTOR_RE.test(selector)) continue;
+      if (!/font-size:/.test(body)) continue;
+      expect(body, `${file.slice(srcRoot.length + 1)}: ${selector}`).toMatch(CONTROL_SIZE_RE);
+    }
+  }
 });

--- a/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
@@ -71,22 +71,22 @@ test("the type ramp no longer sits as raw px in :root (single source of truth is
   expect(rootBlock![1]).not.toMatch(/--font-size-body:/);
 });
 
-test("phone density is gated behind the <=900px phone media query", () => {
+test("phone density is gated behind the <=899px phone media query", () => {
   // Desktop must never inherit a density override: the whole gate lives inside
   // the phone media query. Assert the comfortable multiplier is inside a
-  // max-width:900px block, not at top level.
-  const media = /@media\s*\(max-width:\s*900px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
-  expect(media, "tokens.css must have a max-width:900px media block").not.toBeNull();
+  // max-width:899px block, not at top level.
+  const media = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
+  expect(media, "tokens.css must have a max-width:899px media block").not.toBeNull();
   expect(media![1]).toMatch(/body\[data-phone-density="comfortable"\]\s*\{[^}]*--density-scale:\s*1\.25/);
 });
 
 test("phone density opens vertical rhythm by scaling line-height through --density-scale", () => {
-  const media = /@media\s*\(max-width:\s*900px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
+  const media = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
   expect(media![1]).toMatch(/--line-height-body:\s*calc\([^;]*var\(--density-scale\)/);
 });
 
 test("the compact density default leaves the base grid unscaled (multiplier 1)", () => {
-  const media = /@media\s*\(max-width:\s*900px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
+  const media = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
   // The base body rule inside the media query seeds --density-scale: 1 so
   // "compact" (and any unset value) holds the base line-height. Reads the
   // bare body rule's own value (baseDensityScale above) rather than
@@ -100,7 +100,7 @@ test("the compact density default leaves the base grid unscaled (multiplier 1)",
 });
 
 test("the 44px touch-target floor is declared inside the phone media query (2026-07-30-mobile-session-layout-design.md, decision 4)", () => {
-  const media = /@media\s*\(max-width:\s*900px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
-  expect(media, "tokens.css must have a max-width:900px media block").not.toBeNull();
+  const media = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/.exec(CSS);
+  expect(media, "tokens.css must have a max-width:899px media block").not.toBeNull();
   expect(media![1]).toMatch(/--tap-min:\s*44px/);
 });

--- a/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
@@ -116,7 +116,10 @@ test("the 44px touch-target floor is declared inside the phone media query (2026
 // selects that still took --font-size-ui after the lock was removed.
 const CONTROL_SELECTOR_RE =
   /(^|[\s,>+~(])(input|select|textarea)(\b|[:.[])|\.(input|select|textarea|textInput|effortSelect)(\b|[:.[])/;
-const CONTROL_SIZE_RE = /font-size:\s*var\(--font-size-(control|body)\)/;
+// var(--font-size-control), or the textarea's max(control, body) - never the
+// body size alone, which the S preference scales under 16px on phones.
+const CONTROL_SIZE_RE =
+  /font-size:\s*(var\(--font-size-control\)|max\(var\(--font-size-control\), var\(--font-size-body\)\))/;
 
 function walkCss(dir: string): string[] {
   const found: string[] = [];

--- a/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/display-gates.test.ts
@@ -155,3 +155,14 @@ test("every rule that sizes an editable control uses --font-size-control or --fo
     }
   }
 });
+
+// The folded tool-run row is an interactive control (a <summary> the reader
+// taps to open the calls), so it takes the same phone tap floor
+// widgets/disclosure's own summary does (roborev on PR #947).
+test("the folded-run summary meets the phone tap floor", () => {
+  const srcRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+  const css = readFileSync(join(srcRoot, "panes/session/transcript/toolrungroup.module.css"), "utf8");
+  const phone = /@media\s*\(max-width:\s*899px\)\s*\{([\s\S]*?)\n\}/.exec(css);
+  expect(phone, "toolrungroup.module.css must have a max-width:899px block").not.toBeNull();
+  expect(phone![1]).toMatch(/\.summary\s*\{[^}]*min-height:\s*var\(--tap-min\)/);
+});

--- a/cmd/evener-hub/frontend/src/styles/faces.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/faces.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+
+// Principle 7 (docs/web-ui/decisions.md): mono is for machine text only.
+// These rules style chrome a person reads constantly - the model chip, the
+// status row's figures, rail ages, turn footers - and must stay on the sans
+// face with tabular figures, never JetBrains Mono (docs/web-ui/typography-
+// spacing-critique-2026-09-06.md finding 5 / R5). Read off disk like
+// token-contract.test.ts: jsdom evaluates no cascade.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const SRC = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function rule(path: string, selector: string): string {
+  const css = readFileSync(join(SRC, path), "utf8");
+  const escaped = selector.replace(/[.[\]]/g, (c) => `\\${c}`);
+  const match = new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+  if (!match) throw new Error(`${path}: no rule ${selector}`);
+  return match[1]!;
+}
+
+test.each([
+  ["panes/session/chrome/modelswitch.module.css", ".value"],
+  ["panes/session/chrome/statusrow.module.css", ".figure"],
+  ["shell/rail/RailRow.module.css", ".time"],
+  ["panes/session/transcript/messages/turnseparator.module.css", ".row"],
+])("%s %s is sans with tabular figures", (path, selector) => {
+  const body = rule(path, selector);
+  expect(body).not.toMatch(/--font-mono/);
+  expect(body).toMatch(/font-variant-numeric:\s*tabular-nums/);
+});
+
+test("the status row no longer offers a mono class for figures", () => {
+  const css = readFileSync(join(SRC, "panes/session/chrome/statusrow.module.css"), "utf8");
+  expect(css).not.toMatch(/(?:^|\n)\.mono\s*\{/);
+});

--- a/cmd/evener-hub/frontend/src/styles/measure.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/measure.test.ts
@@ -39,6 +39,10 @@ test("the reading measure is one body-level token with a wide override", () => {
   // The literal used to live on .turn and be hand-copied into session.module.css.
   expect(read("panes/session/transcript/turnblock.module.css")).not.toMatch(/--session-measure:\s*\d/);
   expect(read("panes/session/session.module.css")).not.toMatch(/76rem/);
+  // The ask dock is the transcript's trailing virtual row and sits outside
+  // the .turn column, so it has to take the token itself (roborev, PR #947).
+  expect(read("panes/session/composer/askDock/askdock.module.css")).toMatch(/max-width: var\(--session-measure\)/);
+  expect(read("panes/session/composer/askDock/askdock.module.css")).not.toMatch(/76rem/);
 });
 
 test("prose is bounded by the column, not a percentage of the pane", () => {

--- a/cmd/evener-hub/frontend/src/styles/measure.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/measure.test.ts
@@ -46,8 +46,15 @@ test("prose is bounded by the column, not a percentage of the pane", () => {
   expect(read("panes/session/transcript/messages/usermessageitem.module.css")).not.toMatch(/max-width:\s*92%/);
 });
 
-test("the composer field takes the body size", () => {
+test("the composer field takes the body size, floored at the control size on phones", () => {
+  // max(control, body): body on desktop (15px, where control is the 13px ui
+  // step), and never under the 16px control floor on phones - --font-size-body
+  // alone drops to 14.4px under the S preference (roborev on PR #947).
   expect(read("widgets/textarea/textarea.module.css")).toMatch(
-    /\.textarea\s*\{[^}]*font-size: var\(--font-size-body\)/,
+    /\.textarea\s*\{[^}]*font-size: max\(var\(--font-size-control\), var\(--font-size-body\)\)/,
   );
+  // The spawn pane's phone override used to re-set the body size; it now
+  // inherits the widget's floor and only keeps the writing-surface height.
+  const spawn = read("panes/spawn/spawn.module.css");
+  expect(spawn).not.toMatch(/\.form textarea\s*\{[^}]*font-size/);
 });

--- a/cmd/evener-hub/frontend/src/styles/measure.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/measure.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+
+// The type ramp and the reading measure (docs/web-ui/typography-spacing-
+// critique-2026-09-06.md R1, R2), pinned off disk the way token-contract
+// does: jsdom evaluates no cascade, so the contract is on the declarations.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const SRC = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (path: string): string => readFileSync(join(SRC, path), "utf8");
+
+test("the ramp is 12/13/15/18/22/28 with a 16px body on phones", () => {
+  const tokens = read("styles/tokens.css");
+  const steps = [
+    ["caption", 12],
+    ["ui", 13],
+    ["body", 15],
+    ["pane-title", 18],
+    ["page-title", 22],
+    ["display", 28],
+  ] as const;
+  for (const [name, px] of steps) {
+    expect(tokens, `--font-size-${name}`).toMatch(
+      new RegExp(`--font-size-${name}: calc\\(${px}px \\* var\\(--font-scale\\)\\);`),
+    );
+  }
+  const phoneStart = tokens.indexOf("@media (max-width: 899px)");
+  expect(phoneStart, "tokens.css phone block uses the 899px boundary").toBeGreaterThan(0);
+  const phone = tokens.slice(phoneStart);
+  expect(phone).toMatch(/--font-size-body: calc\(16px \* var\(--font-scale\)\);/);
+});
+
+test("the reading measure is one body-level token with a wide override", () => {
+  const tokens = read("styles/tokens.css");
+  expect(tokens).toMatch(/--session-measure: 44rem;/);
+  expect(tokens).toMatch(/body\[data-transcript-measure="wide"\]\s*\{\s*--session-measure: 64rem;/);
+  // The literal used to live on .turn and be hand-copied into session.module.css.
+  expect(read("panes/session/transcript/turnblock.module.css")).not.toMatch(/--session-measure:\s*\d/);
+  expect(read("panes/session/session.module.css")).not.toMatch(/76rem/);
+});
+
+test("prose is bounded by the column, not a percentage of the pane", () => {
+  expect(read("panes/session/transcript/messages/agentmessageitem.module.css")).not.toMatch(/max-width:\s*92%/);
+  expect(read("panes/session/transcript/messages/usermessageitem.module.css")).not.toMatch(/max-width:\s*92%/);
+});
+
+test("the composer field takes the body size", () => {
+  expect(read("widgets/textarea/textarea.module.css")).toMatch(
+    /\.textarea\s*\{[^}]*font-size: var\(--font-size-body\)/,
+  );
+});

--- a/cmd/evener-hub/frontend/src/styles/rhythm.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/rhythm.test.ts
@@ -3,23 +3,13 @@
 // The vertical-rhythm and heading contract (docs/web-ui/typography-spacing-
 // critique-2026-09-06.md R3, R4), pinned off disk the way token-contract
 // does: jsdom evaluates no cascade, so the contract is on the declarations.
-import { readdirSync, readFileSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, test } from "vitest";
 
 const SRC = dirname(dirname(fileURLToPath(import.meta.url)));
 const read = (path: string): string => readFileSync(join(SRC, path), "utf8");
-
-function walkCss(dir: string): string[] {
-  const found: string[] = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) found.push(...walkCss(full));
-    else if (entry.isFile() && entry.name.endsWith(".css")) found.push(relative(SRC, full));
-  }
-  return found;
-}
 
 const rule = (css: string, selector: string): string => {
   const escaped = selector.replace(/[.[\]>]/g, (c) => `\\${c}`);
@@ -34,21 +24,6 @@ test("pane titles are sentence-case headings, not micro-labels", () => {
   expect(title).toMatch(/font-size: var\(--font-size-pane-title\)/);
   expect(title).toMatch(/font-weight: var\(--font-weight-semibold\)/);
   expect(title).toMatch(/color: var\(--ink-hi\)/);
-});
-
-test("every uppercase rule is a complete caption-size eyebrow in --ink-mid or darker", () => {
-  for (const path of walkCss(SRC)) {
-    const css = read(path).replace(/\/\*[\s\S]*?\*\//g, "");
-    for (const block of css.matchAll(/\{([^{}]*)\}/g)) {
-      const body = block[1]!;
-      if (!/text-transform:\s*uppercase/.test(body)) continue;
-      expect(body, `${path}: uppercase rule lacks caption size`).toMatch(/font-size: var\(--font-size-caption\)/);
-      expect(body, `${path}: uppercase rule lacks eyebrow tracking`).toMatch(
-        /letter-spacing: var\(--tracking-eyebrow\)/,
-      );
-      expect(body, `${path}: uppercase rule sits in --ink-low`).not.toMatch(/color: var\(--ink-low\)/);
-    }
-  }
 });
 
 test("exchange boundaries, runs and pane bodies use the rhythm and space tokens", () => {

--- a/cmd/evener-hub/frontend/src/styles/rhythm.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/rhythm.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+
+// The vertical-rhythm and heading contract (docs/web-ui/typography-spacing-
+// critique-2026-09-06.md R3, R4), pinned off disk the way token-contract
+// does: jsdom evaluates no cascade, so the contract is on the declarations.
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const SRC = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (path: string): string => readFileSync(join(SRC, path), "utf8");
+
+function walkCss(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...walkCss(full));
+    else if (entry.isFile() && entry.name.endsWith(".css")) found.push(relative(SRC, full));
+  }
+  return found;
+}
+
+const rule = (css: string, selector: string): string => {
+  const escaped = selector.replace(/[.[\]>]/g, (c) => `\\${c}`);
+  const match = new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+  if (!match) throw new Error(`no rule ${selector}`);
+  return match[1]!;
+};
+
+test("pane titles are sentence-case headings, not micro-labels", () => {
+  const title = rule(read("widgets/panescaffold/panescaffold.module.css"), ".title");
+  expect(title).not.toMatch(/text-transform/);
+  expect(title).toMatch(/font-size: var\(--font-size-pane-title\)/);
+  expect(title).toMatch(/font-weight: var\(--font-weight-semibold\)/);
+  expect(title).toMatch(/color: var\(--ink-hi\)/);
+});
+
+test("every uppercase rule is a complete caption-size eyebrow in --ink-mid or darker", () => {
+  for (const path of walkCss(SRC)) {
+    const css = read(path).replace(/\/\*[\s\S]*?\*\//g, "");
+    for (const block of css.matchAll(/\{([^{}]*)\}/g)) {
+      const body = block[1]!;
+      if (!/text-transform:\s*uppercase/.test(body)) continue;
+      expect(body, `${path}: uppercase rule lacks caption size`).toMatch(/font-size: var\(--font-size-caption\)/);
+      expect(body, `${path}: uppercase rule lacks eyebrow tracking`).toMatch(
+        /letter-spacing: var\(--tracking-eyebrow\)/,
+      );
+      expect(body, `${path}: uppercase rule sits in --ink-low`).not.toMatch(/color: var\(--ink-low\)/);
+    }
+  }
+});
+
+test("exchange boundaries, runs and pane bodies use the rhythm and space tokens", () => {
+  const user = read("panes/session/transcript/messages/usermessageitem.module.css");
+  expect(rule(user, ".message")).toMatch(/margin-top: var\(--rhythm-exchange\)/);
+  const tool = read("panes/session/transcript/toolcallitem.module.css");
+  expect(rule(tool, ".call")).toMatch(/padding: var\(--rhythm-item\) 0/);
+  const scaffold = read("widgets/panescaffold/panescaffold.module.css");
+  expect(rule(scaffold, ".body")).toMatch(/padding: var\(--space-5\)/);
+  const separator = read("panes/session/transcript/messages/turnseparator.module.css");
+  expect(rule(separator, ".row")).toMatch(/padding: var\(--rhythm-group\) 0 var\(--rhythm-line\)/);
+});
+
+test("the most-read quiet text sits in --ink-mid, not --ink-low", () => {
+  const think = read("panes/session/transcript/messages/thinkblock.module.css");
+  expect(rule(think, ".summary")).toMatch(/color: var\(--ink-mid\)/);
+  expect(rule(think, ".label")).toMatch(/color: var\(--ink-mid\)/);
+  const liveness = read("panes/session/transcript/flow/livenessline.module.css");
+  expect(rule(liveness, ".line")).toMatch(/color: var\(--ink-mid\)/);
+  const agent = read("panes/session/transcript/messages/agentmessageitem.module.css");
+  expect(rule(agent, ".meta")).toMatch(/color: var\(--ink-mid\)/);
+});

--- a/cmd/evener-hub/frontend/src/styles/rhythm.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/rhythm.test.ts
@@ -28,7 +28,11 @@ test("pane titles are sentence-case headings, not micro-labels", () => {
 
 test("exchange boundaries, runs and pane bodies use the rhythm and space tokens", () => {
   const user = read("panes/session/transcript/messages/usermessageitem.module.css");
-  expect(rule(user, ".message")).toMatch(/margin-top: var\(--rhythm-exchange\)/);
+  // Only a message that OPENS an exchange takes the exchange step: mid-turn
+  // user steering renders through the same view with opensExchange={false}
+  // and must not claim the boundary (roborev, PR #947).
+  expect(rule(user, ".message")).not.toMatch(/margin-top/);
+  expect(rule(user, '.message[data-opens-exchange="true"]')).toMatch(/margin-top: var\(--rhythm-exchange\)/);
   const tool = read("panes/session/transcript/toolcallitem.module.css");
   expect(rule(tool, ".call")).toMatch(/padding: var\(--rhythm-item\) 0/);
   const scaffold = read("widgets/panescaffold/panescaffold.module.css");

--- a/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
@@ -850,6 +850,28 @@ test("the four -ink companions clear 4.5:1 on their theme's lightest text ground
   }
 });
 
+// --ink-low is documented as placeholder/disabled/timestamp ink, but 96
+// text rules set it as `color` (docs/web-ui/typography-spacing-critique-
+// 2026-09-06.md finding 7). It therefore has to clear AA on the two grounds
+// text actually sits on in each theme, the same bar the -ink companions meet.
+test("--ink-low clears 4.5:1 on the page and pane surfaces in both themes", () => {
+  const themes = [
+    { name: "dark", block: extractBlock(TOKENS_CSS, /(?:^|\n):root(?:\s*,\s*\[data-theme="dark"\])?\s*\{/) },
+    { name: "light", block: extractBlock(TOKENS_CSS, /\[data-theme="light"\][^{]*\{/) },
+  ];
+  for (const theme of themes) {
+    const inkLow = declaredToken(theme.block, "--ink-low");
+    expect(inkLow, `${theme.name} declares --ink-low`).toBeDefined();
+    for (const groundName of ["--surface-0", "--surface-1"]) {
+      const ground = declaredToken(theme.block, groundName);
+      expect(ground, `${theme.name} declares ${groundName}`).toBeDefined();
+      if (!inkLow || !ground) continue;
+      const ratio = contrastRatio(parseHexColor(inkLow), parseHexColor(ground));
+      expect(ratio, `${theme.name} --ink-low on ${groundName}`).toBeGreaterThanOrEqual(4.5);
+    }
+  }
+});
+
 // --- (d) z-index values must use the token ladder ----------------------
 //
 // Every z-index in the app comes from the token ladder (--z-raised, --z-sticky-bar,

--- a/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/token-contract.test.ts
@@ -1064,3 +1064,302 @@ test("does not flag outline or box-shadow mentioned only in comments", () => {
   expect(focusRingViolations("/* outline: 2px solid red; */ .a { position: relative; }")).toEqual([]);
   expect(focusRingViolations("/* box-shadow: inset 0 0 0 2px var(--accent); */ .a { color: red; }")).toEqual([]);
 });
+
+// --- (g) every bare var(--token) resolves to a declared property --------
+//
+// `var(--radius-sm)` shipped in two rules - composer.module.css:65 and
+// currentwork.module.css:81 (docs/web-ui/typography-spacing-critique-
+// 2026-09-06.md, "Bugs found on the way"): --radius-sm was never a token,
+// so the attachment tile rendered square and nothing said a word. CSS
+// resolves an undeclared var() to the property's initial value and moves
+// on - no error, no warning, and nothing in a screenshot that looks
+// obviously wrong.
+//
+// Only the FALLBACK-LESS form is a violation: `var(--x, 4px)` is a
+// deliberate, self-documenting default (streamingtext.module.css uses it
+// for the prose hooks), so the scan only matches a var() whose token name
+// is followed straight by `)`.
+//
+// The declared set is the union over EVERY stylesheet, not tokens.css
+// alone - modules legitimately declare their own local custom properties
+// (--textarea-min-lines in textarea, --sheet-inline-size in sheet) and set
+// them on a nested selector or inside a media query. For the same reason
+// this is the one mechanism here that also scans tokens.css, which both
+// declares and references (--focus-ring composes var(--accent)): a
+// dangling reference there breaks a rule exactly the same way.
+const CUSTOM_PROPERTY_DECLARATION_RE = /(--[a-zA-Z0-9-]+)\s*:/g;
+const BARE_VAR_RE = /var\(\s*(--[a-zA-Z0-9-]+)\s*\)/g;
+
+// Names no stylesheet is required to declare. Three groups, all listed
+// because the check cannot tell "nothing declares this" from "nothing
+// declares this yet":
+//   - JS writes it, as an inline style or a setProperty call, so no
+//     stylesheet ever declares it: --keyboard-inset (shell/
+//     useKeyboardInset.ts), --rail-width (shell/rail/RailResizeHandle.tsx),
+//     --fill (Meter and RecommendationCard paint their fill width).
+//   - A theming hook a container sets to retint the content it owns:
+//     --markdown-ink, --prose-ink, --prose-font-size.
+//   - Declared today only under a media query or an attribute selector
+//     (--tap-min, --density-scale, --font-scale). The declaration scan
+//     picks those up anyway; they are named here so this check never
+//     silently depends on where that one declaration happens to live.
+const UNDECLARED_BY_DESIGN = new Set([
+  "--keyboard-inset",
+  "--rail-width",
+  "--fill",
+  "--markdown-ink",
+  "--prose-ink",
+  "--prose-font-size",
+  "--tap-min",
+  "--density-scale",
+  "--font-scale",
+]);
+
+const DECLARED_CUSTOM_PROPERTIES = new Set<string>();
+for (const text of Object.values(STYLESHEETS)) {
+  for (const match of text.replace(COMMENT_RE, " ").matchAll(CUSTOM_PROPERTY_DECLARATION_RE)) {
+    DECLARED_CUSTOM_PROPERTIES.add(match[1]!);
+  }
+}
+
+function undefinedTokenViolations(
+  cssText: string,
+  declared: ReadonlySet<string> = DECLARED_CUSTOM_PROPERTIES,
+): string[] {
+  const violations: string[] = [];
+  const withoutComments = cssText.replace(COMMENT_RE, " ");
+  for (const match of withoutComments.matchAll(BARE_VAR_RE)) {
+    const name = match[1]!;
+    // dockview declares its own --dv-* theme properties inside the library;
+    // shell/dockview-theme.css only ever overrides and composes them.
+    if (name.startsWith("--dv-")) continue;
+    if (UNDECLARED_BY_DESIGN.has(name)) continue;
+    if (!declared.has(name)) violations.push(name);
+  }
+  return violations;
+}
+
+for (const [path, text] of Object.entries(STYLESHEETS)) {
+  test(`${path} references only declared custom properties`, () => {
+    expect(undefinedTokenViolations(text)).toEqual([]);
+  });
+}
+
+test("the declared set spans module-local custom properties, not just tokens.css", () => {
+  expect(DECLARED_CUSTOM_PROPERTIES.has("--space-4")).toBe(true);
+  expect(DECLARED_CUSTOM_PROPERTIES.has("--textarea-min-lines")).toBe(true);
+  expect(DECLARED_CUSTOM_PROPERTIES.has("--sheet-inline-size")).toBe(true);
+  // The shipped bug's name: referenced twice, declared nowhere, ever.
+  expect(DECLARED_CUSTOM_PROPERTIES.has("--radius-sm")).toBe(false);
+});
+
+test("catches a fallback-less var() naming an undeclared token", () => {
+  const declared = new Set(["--radius-chip"]);
+  expect(undefinedTokenViolations(".tile { border-radius: var(--radius-sm); }", declared)).toEqual(["--radius-sm"]);
+  expect(undefinedTokenViolations(".a { color: var(--edge-hi); }", declared)).toEqual(["--edge-hi"]);
+});
+
+test("allows a var() that carries its own fallback", () => {
+  expect(undefinedTokenViolations(".tile { border-radius: var(--radius-sm, 4px); }", new Set())).toEqual([]);
+  // A token used as another var()'s fallback is itself fallback-less, so it
+  // still has to resolve - that nested reference is the one that renders
+  // when the outer name is unset.
+  const declared = new Set(["--font-size-body"]);
+  expect(undefinedTokenViolations(".a { font-size: var(--prose-size, var(--font-size-body)); }", declared)).toEqual([]);
+  expect(undefinedTokenViolations(".a { font-size: var(--prose-size, var(--font-size-gone)); }", declared)).toEqual([
+    "--font-size-gone",
+  ]);
+});
+
+test("allows dockview's own --dv-* properties and the runtime-set names", () => {
+  expect(undefinedTokenViolations(".dockview-theme-evener { --dv-tab-bg: var(--dv-foo); }", new Set())).toEqual([]);
+  expect(undefinedTokenViolations(".fill { width: var(--fill); }", new Set())).toEqual([]);
+  expect(undefinedTokenViolations(".shell { padding-bottom: var(--keyboard-inset); }", new Set())).toEqual([]);
+});
+
+test("does not flag a var() named only in a comment", () => {
+  const declared = new Set(["--radius-chip"]);
+  expect(
+    undefinedTokenViolations("/* was var(--radius-sm) */ .tile { border-radius: var(--radius-chip); }", declared),
+  ).toEqual([]);
+});
+
+// --- (h) type sizes come from the ramp, never from a px literal ---------
+//
+// The critique counted 18 literal px font-sizes outside tokens.css - 9px,
+// 10.5px, 11px x8, 11.5px x2, 12px x2, 13px x2, 16px x2 (docs/web-ui/
+// typography-spacing-critique-2026-09-06.md, "Literal (off-ramp) sizes").
+// An off-ramp size ignores --font-scale, so the Settings text-size control
+// silently does not move that text, and it puts a size on screen the ramp
+// never agreed to.
+//
+// Relative units are not literals in this sense and stay legal: `0.86em`
+// on inline code sizes it against whatever line it sits in and rides the
+// ramp with that line, as do `%` and `inherit`. Only a px number in the
+// value fails - including one hidden inside a calc(), which is how a
+// literal would otherwise slip past while still looking tokenized.
+const FONT_SIZE_RE = /font-size\s*:\s*([^;}]+)/gi;
+const PX_LITERAL_RE = /\b[\d.]+px\b/i;
+
+function literalFontSizeViolations(cssText: string): string[] {
+  const violations: string[] = [];
+  const withoutComments = cssText.replace(COMMENT_RE, " ");
+  for (const match of withoutComments.matchAll(FONT_SIZE_RE)) {
+    const value = match[1]!.trim();
+    if (PX_LITERAL_RE.test(value)) violations.push(value);
+  }
+  return violations;
+}
+
+for (const [path, text] of OTHER_STYLESHEETS) {
+  test(`${path} sizes type from the ramp, not a px literal`, () => {
+    expect(literalFontSizeViolations(text)).toEqual([]);
+  });
+}
+
+test("catches a literal px font-size", () => {
+  expect(literalFontSizeViolations(".a { font-size: 11px; }")).toEqual(["11px"]);
+  expect(literalFontSizeViolations(".a { font-size: 10.5px; }")).toEqual(["10.5px"]);
+});
+
+test("catches a px literal hidden inside a calc()", () => {
+  expect(literalFontSizeViolations(".a { font-size: calc(12px * var(--font-scale)); }")).toEqual([
+    "calc(12px * var(--font-scale))",
+  ]);
+});
+
+test("allows ramp tokens, inherit, and relative units", () => {
+  expect(literalFontSizeViolations(".a { font-size: var(--font-size-ui); }")).toEqual([]);
+  expect(literalFontSizeViolations(".a { font-size: var(--font-size-caption); }")).toEqual([]);
+  expect(literalFontSizeViolations(".a { font-size: 0.86em; }")).toEqual([]);
+  expect(literalFontSizeViolations(".a { font-size: 1em; }")).toEqual([]);
+  expect(literalFontSizeViolations(".a { font-size: 90%; }")).toEqual([]);
+  expect(literalFontSizeViolations(".a { font-size: inherit; }")).toEqual([]);
+});
+
+test("does not flag a px font-size mentioned only in a comment", () => {
+  expect(literalFontSizeViolations("/* was font-size: 11px */ .a { font-size: var(--font-size-caption); }")).toEqual(
+    [],
+  );
+});
+
+// --- (i) tracking comes from one of the two tracking tokens -------------
+//
+// The critique found five hand-written tracking values in use at once
+// (-0.02em, 0.02em x4, 0.04em x5, 0.05em x2, 0.08em x7) doing two jobs
+// between them. The ramp settles it at two tokens, one per job:
+// --tracking-display (-0.02em) tightens semibold titles, --tracking-eyebrow
+// (0.06em) opens THE uppercase eyebrow. `inherit` and `normal` are the two
+// ways to say "no tracking of my own", and stay legal.
+const LETTER_SPACING_RE = /letter-spacing\s*:\s*([^;}]+)/gi;
+const TRACKING_VALUE_RE = /^(var\(--tracking-(?:display|eyebrow)\)|inherit|normal)$/;
+
+function trackingViolations(cssText: string): string[] {
+  const violations: string[] = [];
+  const withoutComments = cssText.replace(COMMENT_RE, " ");
+  for (const match of withoutComments.matchAll(LETTER_SPACING_RE)) {
+    const value = match[1]!.trim();
+    if (!TRACKING_VALUE_RE.test(value)) violations.push(value);
+  }
+  return violations;
+}
+
+for (const [path, text] of OTHER_STYLESHEETS) {
+  test(`${path} tracks type with a tracking token`, () => {
+    expect(trackingViolations(text)).toEqual([]);
+  });
+}
+
+test("catches a hand-written tracking value", () => {
+  expect(trackingViolations(".a { letter-spacing: 0.04em; }")).toEqual(["0.04em"]);
+  expect(trackingViolations(".a { letter-spacing: 0.05em; }")).toEqual(["0.05em"]);
+  expect(trackingViolations(".a { letter-spacing: -0.02em; }")).toEqual(["-0.02em"]);
+});
+
+test("allows the two tracking tokens and the two opt-outs", () => {
+  expect(trackingViolations(".a { letter-spacing: var(--tracking-display); }")).toEqual([]);
+  expect(trackingViolations(".a { letter-spacing: var(--tracking-eyebrow); }")).toEqual([]);
+  expect(trackingViolations(".a { letter-spacing: inherit; }")).toEqual([]);
+  expect(trackingViolations(".a { letter-spacing: normal; }")).toEqual([]);
+});
+
+test("does not flag letter-spacing mentioned only in a comment", () => {
+  expect(trackingViolations("/* letter-spacing: 0.04em; */ .a { color: var(--ink-mid); }")).toEqual([]);
+});
+
+// --- (j) uppercase means the whole eyebrow recipe -----------------------
+//
+// Uppercase is the app's ONE eyebrow: caption size, --tracking-eyebrow, at
+// most two words, never a sentence. The critique found 21 uppercase rules
+// disagreeing about all three of size, tracking and ink (docs/web-ui/
+// typography-spacing-critique-2026-09-06.md finding 4). Uppercase at body
+// size with default tracking is just shouting; uppercase in --ink-low is
+// shouting quietly, which is the worst of both.
+//
+// This supersedes the interim copy of the check that lived in
+// rhythm.test.ts while the uppercase sites were being fixed.
+//
+// The block regex matches innermost brace pairs, so a rule nested inside a
+// media query is checked as itself and the wrapper is skipped - the recipe
+// is a property of the rule, not of what surrounds it.
+const RULE_BLOCK_RE = /\{([^{}]*)\}/g;
+const UPPERCASE_RE = /text-transform\s*:\s*uppercase/;
+const CAPTION_SIZE_RE = /font-size\s*:\s*var\(--font-size-caption\)/;
+const EYEBROW_TRACKING_RE = /letter-spacing\s*:\s*var\(--tracking-eyebrow\)/;
+const INK_LOW_TEXT_RE = /color\s*:\s*var\(--ink-low\)/;
+
+function eyebrowRecipeViolations(cssText: string): string[] {
+  const violations: string[] = [];
+  const withoutComments = cssText.replace(COMMENT_RE, " ");
+  for (const block of withoutComments.matchAll(RULE_BLOCK_RE)) {
+    const body = block[1]!;
+    if (!UPPERCASE_RE.test(body)) continue;
+    if (!CAPTION_SIZE_RE.test(body)) violations.push("uppercase without caption size");
+    if (!EYEBROW_TRACKING_RE.test(body)) violations.push("uppercase without eyebrow tracking");
+    if (INK_LOW_TEXT_RE.test(body)) violations.push("uppercase in --ink-low");
+  }
+  return violations;
+}
+
+for (const [path, text] of OTHER_STYLESHEETS) {
+  test(`${path} writes every uppercase rule as a complete eyebrow`, () => {
+    expect(eyebrowRecipeViolations(text)).toEqual([]);
+  });
+}
+
+test("catches an uppercase rule missing a piece of the recipe", () => {
+  expect(eyebrowRecipeViolations(".a { text-transform: uppercase; letter-spacing: var(--tracking-eyebrow); }")).toEqual(
+    ["uppercase without caption size"],
+  );
+  expect(eyebrowRecipeViolations(".a { font-size: var(--font-size-caption); text-transform: uppercase; }")).toEqual([
+    "uppercase without eyebrow tracking",
+  ]);
+});
+
+test("catches an uppercase rule set in --ink-low", () => {
+  expect(
+    eyebrowRecipeViolations(
+      ".a { font-size: var(--font-size-caption); text-transform: uppercase; letter-spacing: var(--tracking-eyebrow); color: var(--ink-low); }",
+    ),
+  ).toEqual(["uppercase in --ink-low"]);
+});
+
+test("allows a complete eyebrow", () => {
+  expect(
+    eyebrowRecipeViolations(
+      ".a { font-size: var(--font-size-caption); text-transform: uppercase; letter-spacing: var(--tracking-eyebrow); color: var(--ink-mid); }",
+    ),
+  ).toEqual([]);
+});
+
+test("ignores a rule that is not uppercase at all", () => {
+  expect(eyebrowRecipeViolations(".a { text-transform: none; }")).toEqual([]);
+  expect(eyebrowRecipeViolations(".a { text-transform: capitalize; font-size: var(--font-size-body); }")).toEqual([]);
+  expect(eyebrowRecipeViolations(".a { color: var(--ink-low); font-size: var(--font-size-body); }")).toEqual([]);
+});
+
+test("does not flag an uppercase rule quoted only in a comment", () => {
+  expect(eyebrowRecipeViolations("/* .old { text-transform: uppercase; } */ .a { color: var(--ink-mid); }")).toEqual(
+    [],
+  );
+});

--- a/cmd/evener-hub/frontend/src/styles/tokens.css
+++ b/cmd/evener-hub/frontend/src/styles/tokens.css
@@ -41,7 +41,7 @@
   --edge-strong: #3A3C40; /* control borders, overlay rings */
   --ink-hi: #F2F3F4; /* primary text */
   --ink-mid: #A5A8AD; /* secondary text */
-  --ink-low: #6C6F75; /* placeholders, disabled, timestamps */
+  --ink-low: #8A8E95; /* placeholders, disabled, timestamps - 4.7:1 on --surface-1, 5.4:1 on --surface-0 (AA, token-contract) */
 
   /* --- the four attention-family hues (dark) --------------------------
    * Exactly one meaning per hue, everywhere in the app. Reaching for one
@@ -129,13 +129,14 @@
   --font-weight-medium: 500;
   --font-weight-semibold: 600;
   --tracking-display: -0.02em; /* display weight (600) titles only */
-  --tracking-micro: 0.08em; /* uppercase micro-labels (card/pane section headers) */
+  --tracking-eyebrow: 0.06em; /* THE uppercase eyebrow tracking: caption size, <=2 words, never sentences */
 
   /* The type ramp itself is declared on <body> (see the font-size preference
    * gate below), not here, so the Settings → Theme font-size choice can scale
    * the whole ramp. Only the theme-invariant line-heights stay at the root. */
   --line-height-body: 1.5;
   --line-height-title: 1.3;
+  --line-height-ui: 1.4; /* dense chrome rows: rail, status row, tables */
 
   /* --- space + shape ------------------------------------------------- */
   /* 4px grid. */
@@ -148,6 +149,13 @@
   --space-7: 40px;
   --space-8: 48px;
   --space-9: 64px;
+
+  /* Vertical rhythm, named by what sits on either side (docs/web-ui/
+   * typography-spacing-critique-2026-09-06.md R3). */
+  --rhythm-line: var(--space-1); /* 4: inside one item (intent -> call) */
+  --rhythm-item: var(--space-2); /* 8: between items in a run */
+  --rhythm-group: var(--space-4); /* 16: run -> next speaker header; above a turn footer */
+  --rhythm-exchange: var(--space-5); /* 24: above a user message */
 
   /* Transcript speaker geometry, declared once for every surface that
    * renders speaker rows (session pane's turn blocks AND focused view, the
@@ -249,10 +257,10 @@
   --edge-strong: #E0E2E5;
   --ink-hi: #1F2124;
   --ink-mid: #62656B;
-  /* Beautiful UI's #9A9DA3 is too light to serve as the diff marker ink
-   * (the contract needs >=3:1 on the diff washes); darkened to the nearest
-   * neutral that clears it. */
-  --ink-low: #86898F;
+  /* Beautiful UI's #9A9DA3 is too light to serve as text at all: --ink-low
+   * carries 96 text rules, so it clears AA on white (4.8:1) and --surface-0
+   * (4.6:1), which also covers the diff marker's own >=3:1 floor. */
+  --ink-low: #6F737A;
 
   /* Deviation from Beautiful UI's #EF720C: its 15%/24% -bg tints on white
    * render salmon/peach (#FFEBE0/#FFDFCD, oklch hue ~51deg), while the design
@@ -340,6 +348,7 @@ body {
   --font-size-body: calc(14px * var(--font-scale));
   --font-size-pane-title: calc(16px * var(--font-scale));
   --font-size-page-title: calc(20px * var(--font-scale));
+  --font-size-display: calc(28px * var(--font-scale)); /* welcome hero only */
 }
 
 body[data-font-size="s"] { --font-scale: 0.9; }

--- a/cmd/evener-hub/frontend/src/styles/tokens.css
+++ b/cmd/evener-hub/frontend/src/styles/tokens.css
@@ -349,6 +349,11 @@ body {
   --font-size-pane-title: calc(18px * var(--font-scale)); /* pane/sheet/dialog titles: sentence case, semibold */
   --font-size-page-title: calc(22px * var(--font-scale)); /* section headings, the spawn heading */
   --font-size-display: calc(28px * var(--font-scale)); /* welcome hero only */
+  /* Every editable control (input, select, textarea, and the raw ones a pane
+   * renders itself) sizes its text from this: the ui step on desktop, the
+   * 16px body step on phones, because iOS Safari zooms into any focused
+   * field under 16px and index.html no longer locks zoom to hide that. */
+  --font-size-control: var(--font-size-ui);
   /* The conversation column and everything aligned to it (composer, cold
    * start, the spawn form, settings content). 44rem = 704px: ~90 characters
    * at 15px, room for a 100-column code block. Declared on body so the
@@ -381,6 +386,7 @@ body[data-font-size="xl"] { --font-scale: 1.25; }
      * IS the field size (widgets/textarea takes it), so the phone body is
      * 16px and index.html no longer locks the viewport's zoom. */
     --font-size-body: calc(16px * var(--font-scale));
+    --font-size-control: var(--font-size-body);
     /* The touch-target floor (2026-07-30-mobile-session-layout-design.md,
      * decision 4): 44px per the platform HIG. Declared here, consumed by
      * button.module.css / iconbutton.module.css's own phone blocks as

--- a/cmd/evener-hub/frontend/src/styles/tokens.css
+++ b/cmd/evener-hub/frontend/src/styles/tokens.css
@@ -134,8 +134,8 @@
   /* The type ramp itself is declared on <body> (see the font-size preference
    * gate below), not here, so the Settings → Theme font-size choice can scale
    * the whole ramp. Only the theme-invariant line-heights stay at the root. */
-  --line-height-body: 1.5;
-  --line-height-title: 1.3;
+  --line-height-body: 1.6; /* 15px -> 24px, on the 4px grid */
+  --line-height-title: 1.25;
   --line-height-ui: 1.4; /* dense chrome rows: rail, status row, tables */
 
   /* --- space + shape ------------------------------------------------- */
@@ -343,12 +343,21 @@
  */
 body {
   --font-scale: 1;
-  --font-size-caption: calc(12px * var(--font-scale));
-  --font-size-ui: calc(13px * var(--font-scale));
-  --font-size-body: calc(14px * var(--font-scale));
-  --font-size-pane-title: calc(16px * var(--font-scale));
-  --font-size-page-title: calc(20px * var(--font-scale));
+  --font-size-caption: calc(12px * var(--font-scale)); /* timestamps, meta */
+  --font-size-ui: calc(13px * var(--font-scale)); /* dense chrome: rail rows, status row, tables, chips, controls */
+  --font-size-body: calc(15px * var(--font-scale)); /* prose, composer, forms, settings values */
+  --font-size-pane-title: calc(18px * var(--font-scale)); /* pane/sheet/dialog titles: sentence case, semibold */
+  --font-size-page-title: calc(22px * var(--font-scale)); /* section headings, the spawn heading */
   --font-size-display: calc(28px * var(--font-scale)); /* welcome hero only */
+  /* The conversation column and everything aligned to it (composer, cold
+   * start, the spawn form, settings content). 44rem = 704px: ~90 characters
+   * at 15px, room for a 100-column code block. Declared on body so the
+   * Settings -> Theme -> Transcript width preference below can widen it. */
+  --session-measure: 44rem;
+}
+
+body[data-transcript-measure="wide"] {
+  --session-measure: 64rem;
 }
 
 body[data-font-size="s"] { --font-scale: 0.9; }
@@ -356,17 +365,22 @@ body[data-font-size="m"] { --font-scale: 1; }
 body[data-font-size="l"] { --font-scale: 1.1; }
 body[data-font-size="xl"] { --font-scale: 1.25; }
 
-/* Phone density (≤900px only — the "phone" in phone-density). "comfortable"
+/* Phone density (≤899px, the same boundary as useIsMobile and every other
+ * phone rule — the "phone" in phone-density). "comfortable"
  * opens up vertical rhythm; "compact" (the default) holds the base grid. The
  * multiplier scales the body line-height — the app's global row-rhythm lever;
  * desktop never sees any of this, the whole gate lives inside the media query.
- * The 1.5 mirrors the :root --line-height-body base (a custom property can't
+ * The 1.6 mirrors the :root --line-height-body base (a custom property can't
  * reference its own inherited value without a cycle, so the base is repeated
  * here rather than aliased). */
-@media (max-width: 900px) {
+@media (max-width: 899px) {
   body {
     --density-scale: 1;
-    --line-height-body: calc(1.5 * var(--density-scale));
+    --line-height-body: calc(1.6 * var(--density-scale));
+    /* iOS Safari zooms into any focused field under 16px, and the body size
+     * IS the field size (widgets/textarea takes it), so the phone body is
+     * 16px and index.html no longer locks the viewport's zoom. */
+    --font-size-body: calc(16px * var(--font-scale));
     /* The touch-target floor (2026-07-30-mobile-session-layout-design.md,
      * decision 4): 44px per the platform HIG. Declared here, consumed by
      * button.module.css / iconbutton.module.css's own phone blocks as

--- a/cmd/evener-hub/frontend/src/styles/tokens.css
+++ b/cmd/evener-hub/frontend/src/styles/tokens.css
@@ -386,7 +386,9 @@ body[data-font-size="xl"] { --font-scale: 1.25; }
      * IS the field size (widgets/textarea takes it), so the phone body is
      * 16px and index.html no longer locks the viewport's zoom. */
     --font-size-body: calc(16px * var(--font-scale));
-    --font-size-control: var(--font-size-body);
+    /* A floor, not an alias: the S preference scales the phone body to
+     * 14.4px, and iOS zooms into a 14.4px field just the same. */
+    --font-size-control: max(16px, var(--font-size-body));
     /* The touch-target floor (2026-07-30-mobile-session-layout-design.md,
      * decision 4): 44px per the platform HIG. Declared here, consumed by
      * button.module.css / iconbutton.module.css's own phone blocks as

--- a/cmd/evener-hub/frontend/src/styles/viewport-pin.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/viewport-pin.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
 
-// Regression net for the mobile "focus zooms the page" defect: iOS Safari
-// auto-zooms when an editable field under 16px (the composer textarea is
-// 13px via --font-size-ui) gains focus, because the viewport meta permitted
-// scaling. The fix pins the viewport instead of restyling the composer, so
-// the web UI behaves like an installed app. Reads index.html straight off
+// The viewport meta used to pin zoom (maximum-scale=1, user-scalable=no) to
+// stop iOS Safari auto-zooming into the 13px composer field. That disabled
+// pinch-zoom for the whole app (WCAG 1.4.4 resize text). Every editable
+// field is now 16px on phones - tokens.css's phone block sets
+// --font-size-body to 16px and widgets/textarea takes the body size - so
+// the lock is gone and must not come back. Reads index.html straight off
 // disk with node:fs, the same approach pwa-manifest-colors.test.ts uses.
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -22,12 +23,12 @@ function viewportContent(): string {
   return match[1]!;
 }
 
-test("the viewport meta pins zoom so focusing a field cannot scale the page", () => {
+test("the viewport meta never disables zoom", () => {
   const content = viewportContent();
   expect(content).toContain("width=device-width");
   expect(content).toContain("initial-scale=1");
-  expect(content).toContain("maximum-scale=1");
-  expect(content).toContain("user-scalable=no");
+  expect(content).not.toContain("maximum-scale");
+  expect(content).not.toContain("user-scalable");
 });
 
 test("the viewport meta uses viewport-fit=cover so safe-area insets are nonzero", () => {

--- a/cmd/evener-hub/frontend/src/styles/viewport-pin.test.ts
+++ b/cmd/evener-hub/frontend/src/styles/viewport-pin.test.ts
@@ -3,9 +3,10 @@
 // The viewport meta used to pin zoom (maximum-scale=1, user-scalable=no) to
 // stop iOS Safari auto-zooming into the 13px composer field. That disabled
 // pinch-zoom for the whole app (WCAG 1.4.4 resize text). Every editable
-// field is now 16px on phones - tokens.css's phone block sets
-// --font-size-body to 16px and widgets/textarea takes the body size - so
-// the lock is gone and must not come back. Reads index.html straight off
+// control is now 16px on phones - tokens.css's phone block sets
+// --font-size-control (and --font-size-body) to 16px, and every input,
+// select and textarea rule takes one of those (display-gates.test.ts scans
+// for it) - so the lock is gone and must not come back. Reads index.html straight off
 // disk with node:fs, the same approach pwa-manifest-colors.test.ts uses.
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";

--- a/cmd/evener-hub/frontend/src/widgets/difftable/difftable.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/difftable/difftable.module.css
@@ -22,9 +22,9 @@
   padding: var(--space-2) var(--space-3);
   background: var(--surface-inset);
   border-bottom: 1px solid var(--edge);
-  color: var(--ink-low);
+  color: var(--ink-mid);
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: var(--tracking-eyebrow);
   white-space: nowrap;

--- a/cmd/evener-hub/frontend/src/widgets/difftable/difftable.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/difftable/difftable.module.css
@@ -26,7 +26,7 @@
   font-size: var(--font-size-caption);
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: var(--tracking-micro);
+  letter-spacing: var(--tracking-eyebrow);
   white-space: nowrap;
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/directorypicker/directorypicker.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/directorypicker/directorypicker.module.css
@@ -73,6 +73,7 @@
   min-width: 0;
   flex: 1;
   font-family: var(--font-mono);
+  font-size: var(--font-size-control);
 }
 .listHeading {
   display: flex;
@@ -197,9 +198,6 @@
   }
   .browse {
     padding: var(--space-3);
-  }
-  .input {
-    font-size: var(--font-size-body);
   }
   .row {
     min-height: var(--tap-min);

--- a/cmd/evener-hub/frontend/src/widgets/directorypicker/directorypicker.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/directorypicker/directorypicker.module.css
@@ -199,7 +199,7 @@
     padding: var(--space-3);
   }
   .input {
-    font-size: 16px;
+    font-size: var(--font-size-body);
   }
   .row {
     min-height: var(--tap-min);

--- a/cmd/evener-hub/frontend/src/widgets/emptystate/emptystate.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/emptystate/emptystate.module.css
@@ -16,6 +16,12 @@
   letter-spacing: var(--tracking-display);
 }
 
+/* size="display": the welcome pane's hero, the one place the display step
+ * is used (tokens.css). */
+.titleDisplay {
+  font-size: var(--font-size-display);
+}
+
 .hint {
   margin: 0;
   max-width: 40ch;

--- a/cmd/evener-hub/frontend/src/widgets/emptystate/emptystate.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/emptystate/emptystate.test.tsx
@@ -43,3 +43,11 @@ test("renders title, hint, and action together", () => {
   expect(screen.getByText("Start one from the command palette.")).toBeTruthy();
   expect(screen.getByRole("button", { name: "New session" })).toBeTruthy();
 });
+
+test("size=display adds the display-size title class; the default does not", () => {
+  const { container, rerender } = render(<EmptyState title="No session open" size="display" />);
+  const title = () => container.querySelector('[data-testid="empty-state"] > p');
+  expect(title()?.className).toMatch(/titleDisplay/);
+  rerender(<EmptyState title="No session open" />);
+  expect(title()?.className).not.toMatch(/titleDisplay/);
+});

--- a/cmd/evener-hub/frontend/src/widgets/emptystate/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/emptystate/index.tsx
@@ -15,11 +15,15 @@ export interface EmptyStateProps {
    * rather than a deliberate requirement, and kept optional.
    */
   action?: ReactNode;
+  /** "display" sets the title at --font-size-display: for the one pane
+   * whose empty state IS the page (Welcome). Default keeps pane-title. */
+  size?: "default" | "display";
 }
 
 const BASE_CLASS = {
   emptyState: requireClass(styles.emptyState, "emptystate.module.css", "emptyState"),
   title: requireClass(styles.title, "emptystate.module.css", "title"),
+  titleDisplay: requireClass(styles.titleDisplay, "emptystate.module.css", "titleDisplay"),
   hint: requireClass(styles.hint, "emptystate.module.css", "hint"),
   action: requireClass(styles.action, "emptystate.module.css", "action"),
 };
@@ -34,10 +38,12 @@ const BASE_CLASS = {
  * remounted). Those assertions previously matched the session pane's own
  * empty-state copy, which coupled a shared shell test to wording that panes
  * are free to change; the testid says what they actually mean. */
-export function EmptyState({ title, hint, action }: EmptyStateProps) {
+export function EmptyState({ title, hint, action, size = "default" }: EmptyStateProps) {
   return (
     <div className={BASE_CLASS.emptyState} data-testid="empty-state">
-      <p className={BASE_CLASS.title}>{title}</p>
+      <p className={size === "display" ? `${BASE_CLASS.title} ${BASE_CLASS.titleDisplay}` : BASE_CLASS.title}>
+        {title}
+      </p>
       {hint !== undefined && <p className={BASE_CLASS.hint}>{hint}</p>}
       {action !== undefined && <div className={BASE_CLASS.action}>{action}</div>}
     </div>

--- a/cmd/evener-hub/frontend/src/widgets/input/input.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/input/input.module.css
@@ -7,7 +7,7 @@
   box-shadow: var(--shadow-inset-field);
   color: var(--ink-hi);
   font-family: var(--font-sans);
-  font-size: var(--font-size-ui);
+  font-size: var(--font-size-control);
   transition:
     background-color var(--motion-duration-hover) var(--motion-easing-standard),
     border-color var(--motion-duration-hover) var(--motion-easing-standard),

--- a/cmd/evener-hub/frontend/src/widgets/inspectorcard/inspectorcard.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/inspectorcard/inspectorcard.module.css
@@ -20,7 +20,7 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-micro);
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .body {

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.module.css
@@ -63,7 +63,7 @@
   background: var(--surface-1);
   color: var(--ink-hi);
   font-family: var(--font-sans);
-  font-size: var(--font-size-ui);
+  font-size: var(--font-size-control);
 }
 
 .input:focus-visible {

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.module.css
@@ -95,7 +95,7 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .row {

--- a/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.module.css
@@ -14,14 +14,17 @@
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-3) var(--space-5);
   background: var(--surface-inset);
   border-bottom: 1px solid var(--edge);
 }
 
-/* Micro-label pattern (Beautiful UI chrome pass, §2): a pane title is chrome,
- * not prose, so it reads as a small uppercase label on the header band
- * rather than a heading-sized title. */
+/* A pane's title is its page heading (typography-spacing-critique-2026-09-06
+ * R4): sentence case, the pane-title step, semibold, full ink. The uppercase
+ * micro-label stays for containers INSIDE a page (InspectorCard,
+ * RecommendationCard, Table headers); as a page title it made the page's
+ * heading its smallest text, and a session's prompt rendered as an
+ * uppercase sentence. */
 .title {
   flex: 1 1 auto;
   /* min-width: 0 is required for ellipsis truncation inside a flex row -
@@ -31,12 +34,11 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  color: var(--ink-mid);
+  color: var(--ink-hi);
   font-family: var(--font-sans);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-medium);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-eyebrow);
+  font-size: var(--font-size-pane-title);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-display);
   line-height: var(--line-height-title);
 }
 
@@ -79,7 +81,7 @@
    * 5), so anything still too wide clips instead of giving the whole page
    * a horizontal scrollbar. */
   overflow-x: clip;
-  padding: var(--space-4);
+  padding: var(--space-5);
   /* End-of-scroll content stays clear of a phone's home-indicator band now
    * that StackHost's blanket host padding is gone (see that rule's comment):
    * footer-less panes (welcome, settings, spawn, doc) dock nothing of their
@@ -87,13 +89,13 @@
    * where this resolves to plain --space-4. The inset yields when the on-screen
    * keyboard covers the home-indicator band (useKeyboardInset's
    * --keyboard-inset, 0px everywhere else): max(0, inset - keyboard) keeps
-   * full inset when the keyboard is closed and plain --space-4 when open. */
-  padding-bottom: calc(var(--space-4) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)));
+   * full inset when the keyboard is closed and plain --space-5 when open. */
+  padding-bottom: calc(var(--space-5) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)));
 }
 
 .footer {
   flex: none;
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-3) var(--space-5);
   /* The composer docks here (Session.tsx): its safe-area accommodation
    * belongs on this bar, not on a container (the old StackHost host padding
    * lifted the whole pane off the screen's bottom edge, leaving a dead band
@@ -129,6 +131,18 @@
    * (decision 3), so the whole row goes away on mobile. */
   .header {
     display: none;
+  }
+
+  /* The phone keeps the tighter edge inset: 24px a side would spend 48px of
+   * a 375px screen on margins. */
+  .body {
+    padding: var(--space-4);
+    padding-bottom: calc(var(--space-4) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)));
+  }
+
+  .footer {
+    padding: var(--space-3) var(--space-4);
+    padding-bottom: calc(var(--space-3) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)));
   }
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.module.css
@@ -36,7 +36,7 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-micro);
+  letter-spacing: var(--tracking-eyebrow);
   line-height: var(--line-height-title);
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.test.tsx
@@ -289,6 +289,6 @@ test("the title renders as an uppercase micro-label, not a pane-title-sized head
   expect(rule).toContain("font-size: var(--font-size-caption)");
   expect(rule).toContain("font-weight: var(--font-weight-medium)");
   expect(rule).toContain("text-transform: uppercase");
-  expect(rule).toContain("letter-spacing: var(--tracking-micro)");
+  expect(rule).toContain("letter-spacing: var(--tracking-eyebrow)");
   expect(rule).toContain("color: var(--ink-mid)");
 });

--- a/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/panescaffold/panescaffold.test.tsx
@@ -200,7 +200,7 @@ test("the body keeps end-of-scroll content clear of the home indicator", () => {
   const css = readFileSync(join(here, "panescaffold.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
   const bodyRule = css.match(/\.body \{([^}]*)\}/)?.[1] ?? "";
   expect(bodyRule).toContain(
-    "padding-bottom: calc(var(--space-4) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)))",
+    "padding-bottom: calc(var(--space-5) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px)))",
   );
 });
 
@@ -282,13 +282,16 @@ test("the header sits on the inset surface", () => {
   expect(rule).toContain("border-bottom: 1px solid var(--edge)");
 });
 
-test("the title renders as an uppercase micro-label, not a pane-title-sized heading", () => {
+test("the title renders as a sentence-case pane-title heading, not an uppercase micro-label", () => {
+  // typography-spacing-critique-2026-09-06 R4: the pane IS the page, so its
+  // title is the page heading. The micro-label recipe stays for containers
+  // inside a page (InspectorCard, RecommendationCard, Table headers).
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "panescaffold.module.css"), "utf8");
   const rule = css.match(/\.title \{([^}]*)\}/)?.[1] ?? "";
-  expect(rule).toContain("font-size: var(--font-size-caption)");
-  expect(rule).toContain("font-weight: var(--font-weight-medium)");
-  expect(rule).toContain("text-transform: uppercase");
-  expect(rule).toContain("letter-spacing: var(--tracking-eyebrow)");
-  expect(rule).toContain("color: var(--ink-mid)");
+  expect(rule).toContain("font-size: var(--font-size-pane-title)");
+  expect(rule).toContain("font-weight: var(--font-weight-semibold)");
+  expect(rule).not.toContain("text-transform");
+  expect(rule).toContain("letter-spacing: var(--tracking-display)");
+  expect(rule).toContain("color: var(--ink-hi)");
 });

--- a/cmd/evener-hub/frontend/src/widgets/pathfield/pathfield.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/pathfield/pathfield.module.css
@@ -100,7 +100,9 @@
 
 /* Section eyebrow: "Recent projects", and the directory being listed (the
  * "you are here" affordance). Small, quiet, not an option. The directory can
- * be long, so it ellipsizes rather than widening the panel. */
+ * be long, so it ellipsizes rather than widening the panel. Tracking belongs
+ * to the two rows this shape carries, not to the shape: .groupLabel is an
+ * uppercase eyebrow and opens up, .groupPath is a path and does not. */
 .groupRow {
   padding: var(--space-2) var(--space-2) var(--space-1);
   overflow: hidden;
@@ -109,7 +111,6 @@
   font-weight: var(--font-weight-medium);
   text-overflow: ellipsis;
   white-space: nowrap;
-  letter-spacing: 0.04em;
 }
 
 /* The current directory reads as a path, not as a section title, so it keeps

--- a/cmd/evener-hub/frontend/src/widgets/pathfield/pathfield.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/pathfield/pathfield.module.css
@@ -70,7 +70,7 @@
   box-shadow: var(--shadow-inset-field);
   color: var(--ink-hi);
   font-family: var(--font-mono);
-  font-size: var(--font-size-ui);
+  font-size: var(--font-size-control);
   transition:
     background-color var(--motion-duration-hover) var(--motion-easing-standard),
     border-color var(--motion-duration-hover) var(--motion-easing-standard),

--- a/cmd/evener-hub/frontend/src/widgets/pathfield/pathfield.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/pathfield/pathfield.module.css
@@ -120,7 +120,10 @@
 }
 
 .groupLabel {
+  font-size: var(--font-size-caption);
+  color: var(--ink-mid);
   text-transform: uppercase;
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 /* 94yg: a directory click both picks the value and descends into it (spec

--- a/cmd/evener-hub/frontend/src/widgets/recommendationcard/recommendationcard.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/recommendationcard/recommendationcard.module.css
@@ -16,7 +16,7 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-micro);
+  letter-spacing: var(--tracking-eyebrow);
 }
 
 .title {

--- a/cmd/evener-hub/frontend/src/widgets/recommendationcard/recommendationcard.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/recommendationcard/recommendationcard.module.css
@@ -11,7 +11,7 @@
 
 .eyebrow {
   margin: 0;
-  color: var(--ink-low);
+  color: var(--ink-mid);
   font-family: var(--font-sans);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-medium);

--- a/cmd/evener-hub/frontend/src/widgets/select/select.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/select/select.module.css
@@ -13,7 +13,7 @@
   box-shadow: var(--shadow-inset-field);
   color: var(--ink-hi);
   font-family: var(--font-sans);
-  font-size: var(--font-size-ui);
+  font-size: var(--font-size-control);
   transition:
     background-color var(--motion-duration-hover) var(--motion-easing-standard),
     border-color var(--motion-duration-hover) var(--motion-easing-standard),

--- a/cmd/evener-hub/frontend/src/widgets/sheet/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/index.tsx
@@ -36,6 +36,11 @@ export interface SheetProps {
   /** Optional extra class appended to the panel element after the side and
    * size classes. */
   panelClassName?: string;
+  /** Optional extra class appended to the body element (after the shared
+   * dialog body class). The mobile sessions drawer uses it to drop the body
+   * padding so the rail fills the sheet flush instead of sitting in an inset
+   * box (typography-spacing-critique-2026-09-06 finding 9). */
+  bodyClassName?: string;
 }
 
 const BASE_PANEL_CLASS = requireClass(dialogStyles.panel, "dialog.module.css", "panel");
@@ -92,6 +97,7 @@ export function Sheet({
   footer,
   expandable,
   panelClassName,
+  bodyClassName,
 }: SheetProps) {
   const [geometry, setGeometry] = useState<"peek" | "full">(expandable?.fullScreenFirst ? "full" : "peek");
   const dragStartYRef = useRef<number | null>(null);
@@ -164,7 +170,14 @@ export function Sheet({
 
   if (!expandable) {
     return (
-      <OverlayPanel open={open} onClose={onClose} title={title} footer={footer} panelClassName={composedPanelClassName}>
+      <OverlayPanel
+        open={open}
+        onClose={onClose}
+        title={title}
+        footer={footer}
+        panelClassName={composedPanelClassName}
+        bodyClassName={bodyClassName}
+      >
         {children}
       </OverlayPanel>
     );
@@ -181,7 +194,7 @@ export function Sheet({
       footer={footer}
       handle={<DragHandle onPointerDown={startDrag} />}
       headerClassName={EXPANDABLE_HEADER_CLASS}
-      bodyClassName={EXPANDABLE_BODY_CLASS}
+      bodyClassName={bodyClassName ? `${EXPANDABLE_BODY_CLASS} ${bodyClassName}` : EXPANDABLE_BODY_CLASS}
       panelClassName={`${composedExpandablePanelClassName} ${EXPANDABLE_BOTTOM_CLASS}`}
       style={heightStyle}
     >

--- a/cmd/evener-hub/frontend/src/widgets/sheet/sheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/sheet/sheet.test.tsx
@@ -304,3 +304,12 @@ test("tap on handle toggles peek to full", () => {
   fireEvent.pointerUp(window, { clientY: 100 });
   expect(panel.querySelector("[data-geometry]")?.getAttribute("data-geometry")).toBe("full");
 });
+
+test("bodyClassName is appended to the body element", () => {
+  render(
+    <Sheet side="left" open onClose={() => {}} title="Sessions" bodyClassName="flush">
+      drawer body
+    </Sheet>,
+  );
+  expect(screen.getByText("drawer body").className).toMatch(/flush/);
+});

--- a/cmd/evener-hub/frontend/src/widgets/table/table.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/table/table.module.css
@@ -53,7 +53,7 @@
   font-size: var(--font-size-caption);
   font-weight: 500;
   text-transform: uppercase;
-  letter-spacing: var(--tracking-micro);
+  letter-spacing: var(--tracking-eyebrow);
   white-space: nowrap;
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/table/table.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/table/table.module.css
@@ -49,9 +49,9 @@
   padding: var(--space-2) var(--space-3);
   background: var(--surface-inset);
   border-bottom: 1px solid var(--edge);
-  color: var(--ink-low);
+  color: var(--ink-mid);
   font-size: var(--font-size-caption);
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   letter-spacing: var(--tracking-eyebrow);
   white-space: nowrap;

--- a/cmd/evener-hub/frontend/src/widgets/textarea/textarea.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/textarea/textarea.module.css
@@ -14,7 +14,7 @@
   box-shadow: var(--shadow-inset-field);
   color: var(--ink-hi);
   font-family: var(--font-sans);
-  font-size: var(--font-size-ui);
+  font-size: var(--font-size-body);
   line-height: var(--line-height-body);
   /* box-sizing is border-box app-wide (styles/global.css), so the floor has to
    * carry this variant's own vertical padding on top of the text lines. */

--- a/cmd/evener-hub/frontend/src/widgets/textarea/textarea.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/textarea/textarea.module.css
@@ -14,7 +14,11 @@
   box-shadow: var(--shadow-inset-field);
   color: var(--ink-hi);
   font-family: var(--font-sans);
-  font-size: var(--font-size-body);
+  /* Prose input reads at the body size on desktop (the control step is the
+   * 13px ui size there), and never under the phone's 16px control floor:
+   * --font-size-body alone is 14.4px under the S preference on a phone, which
+   * iOS Safari zooms into. */
+  font-size: max(var(--font-size-control), var(--font-size-body));
   line-height: var(--line-height-body);
   /* box-sizing is border-box app-wide (styles/global.css), so the floor has to
    * carry this variant's own vertical padding on top of the text lines. */

--- a/cmd/evener-hub/frontend/src/widgets/tree/tree.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/tree/tree.module.css
@@ -6,7 +6,7 @@
 .row {
   display: flex;
   align-items: center;
-  min-height: 28px;
+  min-height: 32px;
   padding: 0 var(--space-2);
   border-radius: var(--radius-control);
   cursor: default;

--- a/docs/superpowers/plans/2026-09-06-webui-typography-spacing.md
+++ b/docs/superpowers/plans/2026-09-06-webui-typography-spacing.md
@@ -1,0 +1,924 @@
+# Web UI typography, spacing and balance — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the web hub read well: a real type ramp, a bounded reading measure, a four-step vertical rhythm, sentence-case pane headings, disciplined faces and figures, an AA `--ink-low`, mobile fixes, folded tool-call runs, and contract tests so none of it fragments again.
+
+**Architecture:** Every value change lands in `styles/tokens.css` and is consumed through `var(--name)`, so the existing token contract carries it; component stylesheets change only where they consumed a literal, an undefined token, or a decision this plan revises. New behaviour (tool-run folding, the transcript-width preference, the type specimen route) follows the repo's existing patterns exactly: zustand prefs mirrored onto `<body data-*>`, `disclosureStore` for persisted open state, `/dev/*` routes gated by `import.meta.env.DEV`, layoutguard cases for geometry.
+
+**Tech Stack:** React 19, CSS Modules, vitest + Testing Library (jsdom), Biome, layoutguard (headless Chrome via `scripts/layoutguard`).
+
+**Spec:** `docs/web-ui/typography-spacing-critique-2026-09-06.md` (findings + R1–R10). `docs/web-ui/design-system.md` is the standing design law and gets updated in Task 10.
+
+## Global Constraints
+
+- All paths below are relative to `cmd/evener-hub/frontend/` unless they start with `docs/`. Run frontend commands from that directory.
+- No colour literal outside `src/styles/tokens.css`; no raw `z-index`; focus rings only via `var(--focus-ring)` (`src/styles/token-contract.test.ts` enforces all three).
+- After this plan: no `font-size: <n>px` outside `tokens.css`; `letter-spacing` only via `--tracking-display` / `--tracking-eyebrow`; every `text-transform: uppercase` rule also declares `font-size: var(--font-size-caption)` and `letter-spacing: var(--tracking-eyebrow)` (Task 9 enforces).
+- Spacing only via `--space-*` / `--rhythm-*` tokens (existing convention; do not add raw px).
+- Sentence case for all UI copy. Eyebrows are at most two words.
+- Before every commit: `npx biome check --write <touched files under src/>`; then `npx vitest run <touched test files>`. Before the PR: `make test-web` and `make test-web-browser` (Chrome is installed on this host) from the repo root.
+- Never `git add -A` (the frontend's `node_modules` is an untracked symlink here). Add files by path.
+- Tests: no test may assert mocked behaviour; jsdom cannot evaluate CSS, so geometry assertions go in layoutguard cases and token/value assertions read the stylesheets off disk (the `token-contract.test.ts` pattern).
+- Commit after each task with a conventional subject (`fix(webui): …`, `feat(webui): …`, `docs(web-ui): …`), no attribution lines.
+
+---
+
+### Task 1: Token hygiene — undefined tokens, literal sizes, the eyebrow tracking token, an AA `--ink-low`
+
+**Files:**
+- Modify: `src/styles/tokens.css`
+- Modify: `src/panes/session/composer/composer.module.css:65,128`
+- Modify: `src/panes/session/composer/currentwork.module.css:47-55,72,81`
+- Modify: `src/panes/spawn/MobileSettingRows.module.css:57`
+- Modify: `src/panes/session/transcript/messages/steeringitem.module.css:69-74` and `src/panes/session/transcript/messages/SteeringItem.tsx` (chevron)
+- Modify: `src/panes/session/transcript/tools/delegateStatus.module.css`
+- Modify: `src/panes/session/chrome/activitypanel.module.css:127,190,201,214`
+- Modify: `src/panes/spawn/spawn.module.css:332` and `src/widgets/directorypicker/directorypicker.module.css:202`
+- Test: `src/styles/token-contract.test.ts` (add the `--ink-low` AA check)
+
+**Interfaces:**
+- Produces tokens later tasks consume: `--tracking-eyebrow: 0.06em` (replaces `--tracking-micro`, which is deleted), `--line-height-ui: 1.4`, `--font-size-display`, `--rhythm-line/-item/-group/-exchange`, `--session-measure`. Task 4 sets the ramp values; this task only adds the new names with today's values so nothing moves yet.
+
+- [ ] **Step 1: Write the failing `--ink-low` contrast test**
+
+Append to `src/styles/token-contract.test.ts`, right after the existing test `"the four -ink companions clear 4.5:1 on their theme's lightest text grounds"`:
+
+```ts
+// --ink-low is documented as placeholder/disabled/timestamp ink, but 96
+// text rules set it as `color` (docs/web-ui/typography-spacing-critique-
+// 2026-09-06.md finding 7). It therefore has to clear AA on the two grounds
+// text actually sits on in each theme, the same bar the -ink companions meet.
+test("--ink-low clears 4.5:1 on the page and pane surfaces in both themes", () => {
+  const themes = [
+    { name: "dark", block: extractBlock(TOKENS_CSS, /(?:^|\n):root(?:\s*,\s*\[data-theme="dark"\])?\s*\{/) },
+    { name: "light", block: extractBlock(TOKENS_CSS, /\[data-theme="light"\][^{]*\{/) },
+  ];
+  for (const theme of themes) {
+    const inkLow = declaredToken(theme.block, "--ink-low");
+    expect(inkLow, `${theme.name} declares --ink-low`).toBeDefined();
+    for (const groundName of ["--surface-0", "--surface-1"]) {
+      const ground = declaredToken(theme.block, groundName);
+      expect(ground, `${theme.name} declares ${groundName}`).toBeDefined();
+      if (!inkLow || !ground) continue;
+      const ratio = contrastRatio(parseHexColor(inkLow), parseHexColor(ground));
+      expect(ratio, `${theme.name} --ink-low on ${groundName}`).toBeGreaterThanOrEqual(4.5);
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run src/styles/token-contract.test.ts -t "ink-low"`
+Expected: FAIL, dark ratio ≈3.08 on `--surface-1`.
+
+- [ ] **Step 3: Change the two `--ink-low` values and add the new token names**
+
+In `src/styles/tokens.css`:
+
+- Dark block: `--ink-low: #8A8E95; /* placeholders, disabled, timestamps — 4.7:1 on --surface-1, 5.4:1 on --surface-0 */`
+- Light block: `--ink-low: #6F737A; /* 4.8:1 on white, 4.6:1 on --surface-0; also clears the diff-marker 3:1 floor */`
+- Replace `--tracking-micro: 0.08em;` with `--tracking-eyebrow: 0.06em; /* the ONE uppercase eyebrow tracking: caption size, ≤2 words */`
+- After `--line-height-title: 1.3;` add `--line-height-ui: 1.4; /* dense chrome rows: rail, status row, tables */`
+- In the `body` ramp block add `--font-size-display: calc(28px * var(--font-scale)); /* welcome hero only */` (Task 4 sets the rest of the ramp).
+- After the `--space-9` line add:
+
+```css
+  /* Vertical rhythm, named by what sits on either side (critique R3). */
+  --rhythm-line: var(--space-1); /* 4: inside one item (intent → call) */
+  --rhythm-item: var(--space-2); /* 8: between items in a run */
+  --rhythm-group: var(--space-4); /* 16: run → next speaker header; above a turn footer */
+  --rhythm-exchange: var(--space-5); /* 24: above a user message */
+```
+
+- [ ] **Step 4: Fix the four undefined-token sites**
+
+- `composer.module.css:65` `border-radius: var(--radius-sm);` → `border-radius: var(--radius-chip);`
+- `currentwork.module.css:81` same replacement.
+- `currentwork.module.css:72` `text-decoration-color: var(--edge-hi);` → `text-decoration-color: var(--edge-strong);`
+- `MobileSettingRows.module.css:57` `font-size: var(--font-size-title);` → `font-size: var(--font-size-pane-title);`
+
+- [ ] **Step 5: Replace every literal font-size with a token**
+
+- `composer.module.css:128` `font-size: 11px;` → `font-size: var(--font-size-caption);`
+- `activitypanel.module.css` lines 127, 190, 201, 214: `11px` → `var(--font-size-caption)`.
+- `delegateStatus.module.css`: `.headId` 11.5px → `var(--font-size-caption)`; `.meta` 11px → caption; `.eyebrow` 11px → caption and `letter-spacing: var(--tracking-micro)` → `var(--tracking-eyebrow)`, `color: var(--ink-low)` → `var(--ink-mid)`; `.mandateBody` / `.diagnosticBody` 13px → `var(--font-size-ui)` and `line-height: 1.5` → `var(--line-height-body)`; `.envRow` 12px → caption, `line-height: 1.5` → `var(--line-height-body)`; `.envK` 11px → caption; `.envV` 12px → caption; `.envVmono` 11.5px → caption; `.toolChip` 10.5px → caption; `.metaSeg { gap: 5px }` → `gap: var(--space-1)`; `.metaSep { margin-right: 2px }` → delete the margin; `.toolChip { padding: 1px 6px }` → `padding: 0 var(--space-2)`.
+- `spawn.module.css:332` and `directorypicker.module.css:202`: the phone `font-size: 16px` rules become `font-size: var(--font-size-body);` (Task 4 makes body 16px on phones, which is what these literals were for).
+- `steeringitem.module.css` `.chevron { font-size: 9px }`: delete the rule's `font-size`; in `SteeringItem.tsx` render the shared `Chevron` widget (`import { Chevron } from "../../../../widgets"`, `<span className={CLASS.chevron} data-open={open}><Chevron direction="right" /></span>`) exactly the way `ToolRow.tsx` does, and rotate the `svg` (`.chevron[data-open="true"] > svg { transform: rotate(90deg) }`). Read `ToolRow.tsx`'s chevron block first and mirror it.
+- Replace the remaining `--tracking-micro` consumers with `--tracking-eyebrow`: `currentwork.module.css:.label`, `widgets/inspectorcard/inspectorcard.module.css`, `widgets/difftable/difftable.module.css`, `widgets/recommendationcard/recommendationcard.module.css`, `widgets/panescaffold/panescaffold.module.css` (Task 5 restyles this rule; for now just rename the token), `widgets/table/table.module.css`. `grep -rn 'tracking-micro' src` must return nothing.
+
+- [ ] **Step 6: Run the contract, the touched component tests, and Biome**
+
+Run: `npx biome check --write src/styles src/panes/session/composer src/panes/session/transcript src/panes/spawn src/widgets && npx vitest run src/styles src/panes/session/transcript/messages src/panes/session/composer src/widgets/inspectorcard src/widgets/table src/widgets/difftable src/widgets/recommendationcard`
+Expected: PASS, including the new `--ink-low` test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/styles/tokens.css src/styles/token-contract.test.ts src/panes/session/composer/composer.module.css src/panes/session/composer/currentwork.module.css src/panes/spawn/MobileSettingRows.module.css src/panes/session/transcript/messages/steeringitem.module.css src/panes/session/transcript/messages/SteeringItem.tsx src/panes/session/transcript/tools/delegateStatus.module.css src/panes/session/chrome/activitypanel.module.css src/panes/spawn/spawn.module.css src/widgets/directorypicker/directorypicker.module.css src/widgets/inspectorcard/inspectorcard.module.css src/widgets/difftable/difftable.module.css src/widgets/recommendationcard/recommendationcard.module.css src/widgets/panescaffold/panescaffold.module.css src/widgets/table/table.module.css
+git commit -m "fix(webui): token hygiene - undefined tokens, literal sizes, AA ink-low, eyebrow tracking"
+```
+
+---
+
+### Task 2: Rail icons as SVG, and the four copy fixes
+
+**Files:**
+- Create: `src/shell/rail/railIcons.tsx`
+- Modify: `src/shell/rail/Rail.tsx:1405-1432` (icons), `:1454` (empty-state copy)
+- Modify: `src/panes/spawn/Spawn.tsx:860` (`mobileTitle`), `:916-919` (intro), the `PromptCard`/`Textarea` placeholder near `:924`
+- Test: `src/shell/rail/Rail.test.tsx` (or the nearest existing rail test file — `ls src/shell/rail/*.test.tsx`), `src/panes/spawn/Spawn.test.tsx:503,556`
+
+**Interfaces:**
+- Produces `GearIcon`, `SearchIcon`, `SidebarIcon`: `() => JSX.Element`, 16×16 `viewBox`, `stroke="currentColor"`, `strokeWidth="1.5"`, `aria-hidden="true"` — the same grammar as `TreeDrawer.tsx`'s `SessionsIcon` and `widgets/chevron`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In the rail test file add:
+
+```tsx
+test("the header icon buttons draw SVG icons, not text glyphs outside the subsetted font", () => {
+  renderRail(); // use the file's existing render helper
+  for (const label of ["Settings", "Search"]) {
+    const button = screen.getByRole("button", { name: label });
+    expect(button.querySelector("svg")).toBeTruthy();
+    expect(button.textContent?.trim()).toBe("");
+  }
+});
+
+test("the rail's empty state does not send people to the command line", () => {
+  renderRailWithNoSessions();
+  expect(screen.queryByText(/command line/i)).toBeNull();
+  expect(screen.getByText("No sessions yet")).toBeTruthy();
+});
+```
+
+In `Spawn.test.tsx` change line 503 to `expect(screen.getByTestId("pane-title-mobile").textContent).toBe("New session");` and line 556 to `.toBe("New session")`. Add:
+
+```tsx
+test("the prompt placeholder does not repeat the heading", async () => {
+  // reuse the mobile render setup of the test at ~line 490
+  const prompt = screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
+  expect(prompt.placeholder).toBe("Describe the task…");
+});
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+Run: `npx vitest run src/shell/rail src/panes/spawn/Spawn.test.tsx`
+Expected: FAIL on the four new/changed assertions.
+
+- [ ] **Step 3: Implement**
+
+`src/shell/rail/railIcons.tsx`:
+
+```tsx
+// The rail header's three icons, drawn on the app's 16x16 icon grid
+// (widgets/chevron, openbutton's OpenIcon, TreeDrawer's SessionsIcon).
+// They replace the text glyphs ⚙ ⌕ ☰: global.css subsets Inter to Latin,
+// so those code points came from whatever system fallback had them.
+const ICON = { viewBox: "0 0 16 16", width: 16, height: 16, "aria-hidden": true } as const;
+const STROKE = { fill: "none", stroke: "currentColor", strokeWidth: 1.5, strokeLinecap: "round", strokeLinejoin: "round" } as const;
+
+export function GearIcon() {
+  return (
+    <svg {...ICON}>
+      <circle cx="8" cy="8" r="2.25" {...STROKE} />
+      <path d="M8 1.75v2M8 12.25v2M1.75 8h2M12.25 8h2M3.6 3.6l1.4 1.4M11 11l1.4 1.4M3.6 12.4 5 11M11 5l1.4-1.4" {...STROKE} />
+    </svg>
+  );
+}
+
+export function SearchIcon() {
+  return (
+    <svg {...ICON}>
+      <circle cx="7" cy="7" r="4.25" {...STROKE} />
+      <path d="M10.2 10.2 14 14" {...STROKE} />
+    </svg>
+  );
+}
+
+export function SidebarIcon() {
+  return (
+    <svg {...ICON}>
+      <rect x="2" y="3" width="12" height="10" rx="1.5" {...STROKE} />
+      <path d="M6 3v10" {...STROKE} />
+    </svg>
+  );
+}
+```
+
+In `Rail.tsx`: import the three, replace `icon={<span aria-hidden="true">⚙</span>}` → `icon={<GearIcon />}`, `⌕` → `<SearchIcon />`, `☰` → `<SidebarIcon />`. Change line 1454's hint to `hint="Start one with the button above."`. The `.brand button { font-size: var(--font-size-pane-title) }` rule in `Rail.module.css` sized the text glyphs; delete it (SVG icons size themselves).
+
+In `Spawn.tsx`: `mobileTitle="New session"` and `title="New session"`; textarea `placeholder="Describe the task…"` (find the `placeholder=` prop inside the spawn `PromptCard`'s `Textarea`).
+
+- [ ] **Step 4: Run tests + Biome**
+
+Run: `npx biome check --write src/shell/rail src/panes/spawn && npx vitest run src/shell/rail src/panes/spawn`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shell/rail/railIcons.tsx src/shell/rail/Rail.tsx src/shell/rail/Rail.module.css src/shell/rail/*.test.tsx src/panes/spawn/Spawn.tsx src/panes/spawn/Spawn.test.tsx
+git commit -m "fix(webui): SVG rail icons; sentence-case spawn titles; empty-state and placeholder copy"
+```
+
+---
+
+### Task 3: Faces and figures — sans for chrome, tabular figures, mono only for machine text
+
+**Files:**
+- Modify: `src/panes/session/chrome/modelswitch.module.css:.value`
+- Modify: `src/panes/session/chrome/statusrow.module.css:.mono`
+- Modify: `src/shell/rail/RailRow.module.css:.time`
+- Modify: `src/panes/session/transcript/messages/turnseparator.module.css:.row`
+- Modify: `src/panes/spawn/spawn.module.css:.branch`
+- Test: `src/styles/faces.test.ts` (new, reads CSS off disk like `token-contract.test.ts`)
+
+- [ ] **Step 1: Write the failing test**
+
+`src/styles/faces.test.ts`:
+
+```ts
+// Principle 7 (docs/web-ui/decisions.md): mono is for machine text only.
+// These five rules style chrome a person reads constantly (the model chip,
+// status figures, rail ages, turn footers, the branch line) and must stay
+// on the sans face with tabular figures, never JetBrains Mono.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const SRC = dirname(dirname(fileURLToPath(import.meta.url)));
+const rule = (path: string, selector: string): string => {
+  const css = readFileSync(join(SRC, path), "utf8");
+  const match = new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`).exec(css);
+  if (!match) throw new Error(`${path}: no rule ${selector}`);
+  return match[1]!;
+};
+
+test.each([
+  ["panes/session/chrome/modelswitch.module.css", ".value"],
+  ["panes/session/chrome/statusrow.module.css", ".figure"],
+  ["shell/rail/RailRow.module.css", ".time"],
+  ["panes/session/transcript/messages/turnseparator.module.css", ".row"],
+])("%s %s is sans with tabular figures", (path, selector) => {
+  const body = rule(path, selector);
+  expect(body).not.toMatch(/--font-mono/);
+  expect(body).toMatch(/font-variant-numeric:\s*tabular-nums/);
+});
+```
+
+- [ ] **Step 2: Run it, watch it fail**
+
+Run: `npx vitest run src/styles/faces.test.ts`
+Expected: FAIL (`.figure` missing; mono present).
+
+- [ ] **Step 3: Implement**
+
+- `modelswitch.module.css .value`: `font-family: var(--font-mono)` → `font-family: var(--font-sans); font-variant-numeric: tabular-nums;`. Update the rule's comment: the id is an identifier but it is the row's most-read label, so it takes the UI face; the qualified id stays in the Details sheet in mono.
+- `statusrow.module.css`: rename `.mono` to `.figure` with `font-family: var(--font-sans); font-variant-numeric: tabular-nums;` and update `StatusRow.tsx` (`grep -n 'styles.mono\|CLASS.mono' src/panes/session/chrome/StatusRow.tsx`) and any test that references the class name.
+- `RailRow.module.css .time`: drop `font-family: var(--font-mono)`, add `font-variant-numeric: tabular-nums;`.
+- `turnseparator.module.css .row`: add `font-variant-numeric: tabular-nums;`.
+- `spawn.module.css .branch`: keep mono (a branch name is machine text) — no change; listed only so the implementer does not "fix" it.
+
+- [ ] **Step 4: Run tests + Biome, commit**
+
+Run: `npx biome check --write src/panes/session/chrome src/shell/rail src/panes/session/transcript/messages src/styles && npx vitest run src/styles/faces.test.ts src/panes/session/chrome src/shell/rail`
+Expected: PASS.
+
+```bash
+git add src/styles/faces.test.ts src/panes/session/chrome/modelswitch.module.css src/panes/session/chrome/statusrow.module.css src/panes/session/chrome/StatusRow.tsx src/shell/rail/RailRow.module.css src/panes/session/transcript/messages/turnseparator.module.css
+git commit -m "fix(webui): sans + tabular figures for model, status, rail ages and turn footers"
+```
+
+---
+
+### Task 4: The ramp, the measure, the transcript-width preference, and the viewport
+
+**Files:**
+- Modify: `src/styles/tokens.css` (body ramp block, phone block)
+- Modify: `src/widgets/textarea/textarea.module.css:17`
+- Modify: `src/panes/session/transcript/turnblock.module.css:15-28`
+- Modify: `src/panes/session/session.module.css:.coldStart,.measure`
+- Modify: `src/panes/session/transcript/messages/agentmessageitem.module.css:.bubble,.opener,.column`
+- Modify: `src/panes/session/transcript/messages/usermessageitem.module.css:.message,.content,.body`
+- Modify: `src/stores/prefs.ts`, `src/panes/settings/sections/theme.tsx`
+- Modify: `index.html` (viewport meta + comment)
+- Test: `src/styles/viewport-pin.test.ts` (rewrite), `src/stores/prefs.test.ts`, `src/panes/settings/sections/theme.test.tsx`, `src/styles/measure.test.ts` (new), layoutguard case `scripts/layoutguard/cases/transcript-measure/`
+
+**Interfaces:**
+- Produces pref `transcriptMeasure: "reading" | "wide"` (`TranscriptMeasurePref`), setter `setTranscriptMeasure`, localStorage key `evener.prefs.transcriptMeasure`, document mirror `<body data-transcript-measure>`; CSS `--session-measure` declared on `body` (44rem) and overridden to 64rem by `body[data-transcript-measure="wide"]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Rewrite `src/styles/viewport-pin.test.ts` (keep the file name so the guard's history stays findable):
+
+```ts
+// @vitest-environment node
+
+// The viewport meta used to pin zoom (maximum-scale=1, user-scalable=no) to
+// stop iOS Safari auto-zooming into the 13px composer. That disabled
+// pinch-zoom for the whole app (WCAG 1.4.4). Every editable field is now
+// 16px on phones (tokens.css's phone block sets --font-size-body: 16px and
+// widgets/textarea takes it), so the lock is gone and must not come back.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const STYLES_DIR = dirname(fileURLToPath(import.meta.url));
+const FRONTEND_ROOT = dirname(dirname(STYLES_DIR));
+const INDEX_HTML = readFileSync(join(FRONTEND_ROOT, "index.html"), "utf8");
+
+function viewportContent(): string {
+  const match = /<meta name="viewport" content="([^"]*)"/.exec(INDEX_HTML);
+  if (!match) throw new Error("viewport-pin test: could not locate the viewport meta in index.html");
+  return match[1]!;
+}
+
+test("the viewport meta never disables zoom", () => {
+  const content = viewportContent();
+  expect(content).toContain("width=device-width");
+  expect(content).toContain("initial-scale=1");
+  expect(content).not.toContain("maximum-scale");
+  expect(content).not.toContain("user-scalable");
+});
+
+test("the viewport meta uses viewport-fit=cover so safe-area insets are nonzero", () => {
+  expect(viewportContent()).toContain("viewport-fit=cover");
+});
+
+test("the viewport meta resizes content around the on-screen keyboard", () => {
+  expect(viewportContent()).toContain("interactive-widget=resizes-content");
+});
+```
+
+`src/styles/measure.test.ts` (new, node environment, same off-disk reading):
+
+```ts
+// @vitest-environment node
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const SRC = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (p: string) => readFileSync(join(SRC, p), "utf8");
+
+test("the ramp is 12/13/15/18/22/28 with 16px body on phones", () => {
+  const tokens = read("styles/tokens.css");
+  for (const [name, px] of [["caption", 12], ["ui", 13], ["body", 15], ["pane-title", 18], ["page-title", 22], ["display", 28]] as const) {
+    expect(tokens).toMatch(new RegExp(`--font-size-${name}: calc\\(${px}px \\* var\\(--font-scale\\)\\);`));
+  }
+  const phone = tokens.slice(tokens.indexOf("@media (max-width: 899px)"));
+  expect(phone).toMatch(/--font-size-body: calc\(16px \* var\(--font-scale\)\);/);
+});
+
+test("the reading measure is one body-level token with a wide override", () => {
+  const tokens = read("styles/tokens.css");
+  expect(tokens).toMatch(/--session-measure: 44rem;/);
+  expect(tokens).toMatch(/body\[data-transcript-measure="wide"\]\s*\{\s*--session-measure: 64rem;/);
+  expect(read("panes/session/transcript/turnblock.module.css")).not.toMatch(/--session-measure:\s*\d/);
+  expect(read("panes/session/session.module.css")).not.toMatch(/76rem/);
+});
+
+test("prose is bounded by the column, not a percentage of the pane", () => {
+  expect(read("panes/session/transcript/messages/agentmessageitem.module.css")).not.toMatch(/max-width:\s*92%/);
+  expect(read("panes/session/transcript/messages/usermessageitem.module.css")).not.toMatch(/max-width:\s*92%/);
+});
+
+test("the composer field takes the body size", () => {
+  expect(read("widgets/textarea/textarea.module.css")).toMatch(/\.textarea\s*\{[^}]*font-size: var\(--font-size-body\)/);
+});
+```
+
+In `src/stores/prefs.test.ts`, inside the `describe("corrupted/unrecognized localStorage values …")` block add:
+
+```ts
+  test("an unrecognized transcriptMeasure falls back to reading", () => {
+    localStorage.setItem(KEY("transcriptMeasure"), "huge");
+    resetPrefsStoreForTests();
+    expect(prefsStore.getState().transcriptMeasure).toBe("reading");
+  });
+```
+
+and a new describe:
+
+```ts
+describe("transcriptMeasure", () => {
+  test("defaults to reading, persists under evener.prefs.transcriptMeasure, and mirrors onto body", () => {
+    expect(prefsStore.getState().transcriptMeasure).toBe("reading");
+    expect(document.body.dataset.transcriptMeasure).toBe("reading");
+    prefsStore.getState().setTranscriptMeasure("wide");
+    expect(localStorage.getItem("evener.prefs.transcriptMeasure")).toBe("wide");
+    expect(document.body.dataset.transcriptMeasure).toBe("wide");
+  });
+});
+```
+
+In `theme.test.tsx` add a describe mirroring the "Font size" one:
+
+```tsx
+describe("Transcript width", () => {
+  test("defaults to Reading and updates the pref plus document.body.dataset.transcriptMeasure", async () => {
+    const user = userEvent.setup();
+    renderWithToasts();
+    expect(screen.getByRole("radio", { name: "Reading" }).getAttribute("aria-checked")).toBe("true");
+    await user.click(screen.getByRole("radio", { name: "Wide" }));
+    expect(prefsStore.getState().transcriptMeasure).toBe("wide");
+    expect(document.body.dataset.transcriptMeasure).toBe("wide");
+  });
+});
+```
+
+(Also add `delete document.body.dataset.transcriptMeasure;` beside the existing `delete document.body.dataset.fontSize;` in that file's reset hook.)
+
+- [ ] **Step 2: Run them, watch them fail**
+
+Run: `npx vitest run src/styles/viewport-pin.test.ts src/styles/measure.test.ts src/stores/prefs.test.ts src/panes/settings/sections/theme.test.tsx`
+Expected: FAIL on every new assertion.
+
+- [ ] **Step 3: tokens.css**
+
+Replace the `body { --font-scale … }` block with:
+
+```css
+body {
+  --font-scale: 1;
+  --font-size-caption: calc(12px * var(--font-scale)); /* timestamps, meta */
+  --font-size-ui: calc(13px * var(--font-scale)); /* dense chrome: rail rows, status row, tables, chips, controls */
+  --font-size-body: calc(15px * var(--font-scale)); /* prose, composer, forms, settings values */
+  --font-size-pane-title: calc(18px * var(--font-scale)); /* pane/sheet/dialog titles: sentence case, semibold */
+  --font-size-page-title: calc(22px * var(--font-scale)); /* section headings, the spawn heading */
+  --font-size-display: calc(28px * var(--font-scale)); /* welcome hero only */
+  /* The conversation column and everything aligned to it (composer, cold
+   * start). 44rem = 704px: ~90 characters at 15px, room for a 100-column
+   * code block. Declared on body so the Theme preference below can widen it. */
+  --session-measure: 44rem;
+}
+
+body[data-transcript-measure="wide"] {
+  --session-measure: 64rem;
+}
+```
+
+Root block line-heights: `--line-height-body: 1.6; /* 15px → 24px, on the 4px grid */`, `--line-height-title: 1.25;`, keep `--line-height-ui: 1.4` from Task 1. In the phone block change `--line-height-body: calc(1.5 * var(--density-scale));` to `calc(1.6 * var(--density-scale))` and add `--font-size-body: calc(16px * var(--font-scale)); /* iOS zooms into any field under 16px; body is the field size */`.
+
+- [ ] **Step 4: Consumers**
+
+- `widgets/textarea/textarea.module.css` `.textarea`: `font-size: var(--font-size-ui)` → `var(--font-size-body)`.
+- `turnblock.module.css`: delete the `--session-measure: 76rem;` declaration and its comment paragraph; `.turn` keeps `max-width: var(--session-measure); margin-inline: auto;`.
+- `session.module.css`: `.coldStart` and `.measure` `max-width: 76rem` → `max-width: var(--session-measure)`; delete the "consolidate to a token" comment.
+- `agentmessageitem.module.css` `.bubble`: `max-width: 92%` → `max-width: 100%`. Below 700px make the opener a grid so prose spans the pane:
+
+```css
+@media (max-width: 699px) {
+  .opener {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    column-gap: var(--speaker-gap);
+    row-gap: var(--rhythm-line);
+  }
+  /* The column dissolves so its header sits beside the avatar and its
+   * bubble drops to a full-width second row. */
+  .column {
+    display: contents;
+  }
+  .opener .bubble {
+    grid-column: 1 / -1;
+  }
+}
+```
+
+- `usermessageitem.module.css`: `.body` `max-width: 92%` → `100%`; the same phone grid on `.message` with `.content { display: contents }` and `.message .body { grid-column: 1 / -1 }` (the `.actions` inside `.header` keep working; `.header` is a grid item now).
+- `index.html`: viewport content becomes `width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content`; rewrite the comment: fields are 16px on phones so zoom is not locked.
+
+- [ ] **Step 5: The preference**
+
+`prefs.ts`: add `export type TranscriptMeasurePref = "reading" | "wide";`, state field `transcriptMeasure: TranscriptMeasurePref;`, setter `setTranscriptMeasure(value: TranscriptMeasurePref): void;`, `const TRANSCRIPT_MEASURE_VALUES: readonly TranscriptMeasurePref[] = ["reading", "wide"];`, `function applyTranscriptMeasure(value) { document.body.dataset.transcriptMeasure = value; }`, read in `loadInitialState` via `readEnum("transcriptMeasure", TRANSCRIPT_MEASURE_VALUES, "reading")` + `applyTranscriptMeasure(...)`, add `"setTranscriptMeasure"` to the `Omit` list, and the setter body `writeRaw("transcriptMeasure", value); applyTranscriptMeasure(value); set({ transcriptMeasure: value });`. Update the file's top comment sentence that lists document-mirrored prefs.
+
+`theme.tsx`: add
+
+```tsx
+const TRANSCRIPT_MEASURE_OPTIONS: RadioGroupOption[] = [
+  { value: "reading", label: "Reading" },
+  { value: "wide", label: "Wide" },
+];
+```
+
+and a fourth row after Font size:
+
+```tsx
+      <div className={CLASS.row}>
+        <RadioGroup
+          label="Transcript width"
+          value={transcriptMeasure}
+          options={TRANSCRIPT_MEASURE_OPTIONS}
+          onChange={(value) => prefsStore.getState().setTranscriptMeasure(value as "reading" | "wide")}
+        />
+        <p className={CLASS.help}>Reading keeps lines near 90 characters. Wide uses more of the window.</p>
+      </div>
+```
+
+with `const transcriptMeasure = usePrefsStore((s) => s.transcriptMeasure);`. Update the intro copy to "Theme, density, font size and transcript width are saved per-browser."
+
+- [ ] **Step 6: The layoutguard case**
+
+Create `scripts/layoutguard/cases/transcript-measure/` with:
+
+`case.json`
+```json
+{
+  "name": "transcript-measure",
+  "description": "transcript: a plain agent paragraph never runs past 100 characters per line at 1440 and 1920, and the conversation column is centred at both widths",
+  "cssFiles": [
+    "styles/global.css",
+    "styles/tokens.css",
+    "panes/session/transcript/turnblock.module.css",
+    "panes/session/transcript/messages/agentmessageitem.module.css",
+    "widgets/markdown/markdown.module.css"
+  ],
+  "widthMatrix": [{ "width": 1440 }, { "width": 1920 }],
+  "mutation": {
+    "declaration": "tokens.css: body { --session-measure: 44rem } (set to 76rem - the paragraph runs ~150 chars/line at 1440)",
+    "verified": "2026-09-06",
+    "expect": "fail"
+  }
+}
+```
+
+`harness.html`: body sets `data-font-size="m" data-transcript-measure="reading"`; a `.turn` div containing the opener markup (`div.message.opener > span.avatar + div.column > div.header + div.bubble > div.root > p#prose`) with a 600-character plain paragraph; `window.measure()` returns `{ lines, chars, columnLeft, columnRight, bodyWidth }` where lines = distinct `Range.getClientRects()` tops of `#prose` (the same technique used in the critique), and uses the `__LAYOUTGUARD_WIDTH_MATRIX__` hook the way `cases/compact-session-footer/harness.html` does (read that harness first and copy its matrix wiring verbatim).
+
+`assert.mjs`: for each width, `charsPerLine = chars / lines`; fail if `> 100`; fail if `Math.abs(columnLeft - (bodyWidth - columnRight)) > 1` (not centred). Pass reason reports both numbers per width.
+
+Run: `npm run layoutguard -- transcript-measure` (Chrome required). Then verify the mutation once by hand (set 76rem, expect fail, revert).
+
+- [ ] **Step 7: Run everything touched**
+
+Run: `npx biome check --write src index.html scripts/layoutguard/cases/transcript-measure && npx vitest run src/styles src/stores src/panes/settings src/panes/session src/widgets/textarea && npm run layoutguard -- transcript-measure`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add index.html src/styles/tokens.css src/styles/viewport-pin.test.ts src/styles/measure.test.ts src/widgets/textarea/textarea.module.css src/panes/session/transcript/turnblock.module.css src/panes/session/session.module.css src/panes/session/transcript/messages/agentmessageitem.module.css src/panes/session/transcript/messages/usermessageitem.module.css src/stores/prefs.ts src/stores/prefs.test.ts src/panes/settings/sections/theme.tsx src/panes/settings/sections/theme.test.tsx scripts/layoutguard/cases/transcript-measure
+git commit -m "feat(webui): 15/16px body ramp, 44rem reading measure with wide preference, zoom no longer locked"
+```
+
+---
+
+### Task 5: Rhythm, pane headings, and one eyebrow
+
+**Files:**
+- Modify: `src/widgets/panescaffold/panescaffold.module.css:.header,.title,.body,.footer`
+- Modify: `src/panes/session/transcript/messages/agentmessageitem.module.css:.message,.header,.name,.meta`
+- Modify: `src/panes/session/transcript/messages/usermessageitem.module.css:.message,.name,.time`
+- Modify: `src/panes/session/transcript/toolcallitem.module.css:.call`
+- Modify: `src/panes/session/transcript/messages/turnseparator.module.css:.row`
+- Modify: `src/panes/session/transcript/messages/thinkblock.module.css:.label,.summary`
+- Modify: `src/panes/session/transcript/flow/livenessline.module.css:.line`
+- Modify: `src/widgets/tree/tree.module.css:.row`, `src/shell/rail/Rail.module.css:.header,.section,.sectionTitle,.sectionDisclosure`, `src/shell/rail/RailRow.module.css:.activity,.time`
+- Modify every uppercase site so its rule declares `font-size: var(--font-size-caption); letter-spacing: var(--tracking-eyebrow); color: var(--ink-mid)` (the 21 rules listed in the critique's finding 4: `Rail.module.css` ×2, `commandpalette.module.css .sectionHeader`, `cheatsheet.module.css .groupTitle`, `settings.module.css .clusterHeader`, `LaunchConfigForm.module.css .groupHeader`, `currentwork.module.css .label`, `CredentialsSection.module.css .groupHeader`, `rawitemview.module.css .type`, `askuser.module.css .detail,.recommended`, `subagentmodule.module.css .section,.sectionLabel`, `delegateStatus.module.css .eyebrow`, `taskspanel.module.css .groupHead`, `detailspanel.module.css .sectionTitle`, `difftable.module.css .headerCell`, `recommendationcard.module.css .eyebrow`, `modelCatalog.module.css .groupRow`, `pathfield.module.css .groupPath,.groupLabel`, `table.module.css .headerCell`)
+- Modify: `src/panes/settings/sections.ts:30` ("Agents & models" → "Models") and its tests `sections.test.ts:39,45,66`, `SettingsNav.test.tsx:71`
+- Modify: `src/panes/session/transcript/tools/askuser.module.css .detail` (three-word uppercase label: drop the transform, keep caption + ink-mid)
+- Test: `src/styles/rhythm.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+`src/styles/rhythm.test.ts` (node env, off-disk reads as in Task 4):
+
+```ts
+test("pane titles are sentence-case headings, not micro-labels", () => {
+  const css = read("widgets/panescaffold/panescaffold.module.css");
+  const title = /\.title\s*\{([^}]*)\}/.exec(css)![1]!;
+  expect(title).not.toMatch(/text-transform/);
+  expect(title).toMatch(/font-size: var\(--font-size-pane-title\)/);
+  expect(title).toMatch(/color: var\(--ink-hi\)/);
+});
+
+test("every uppercase rule is a complete caption-size eyebrow", () => {
+  for (const path of walkCss()) {
+    const css = read(path).replace(/\/\*[\s\S]*?\*\//g, "");
+    for (const block of css.matchAll(/\{([^}]*)\}/g)) {
+      const body = block[1]!;
+      if (!/text-transform:\s*uppercase/.test(body)) continue;
+      expect(body, `${path}: uppercase rule lacks caption size`).toMatch(/font-size: var\(--font-size-caption\)/);
+      expect(body, `${path}: uppercase rule lacks eyebrow tracking`).toMatch(/letter-spacing: var\(--tracking-eyebrow\)/);
+    }
+  }
+});
+
+test("exchange boundaries and runs use the rhythm tokens", () => {
+  expect(read("panes/session/transcript/messages/usermessageitem.module.css")).toMatch(/\.message\s*\{[^}]*margin-top: var\(--rhythm-exchange\)/);
+  expect(read("panes/session/transcript/toolcallitem.module.css")).toMatch(/\.call\s*\{[^}]*padding: var\(--rhythm-item\) 0/);
+  expect(read("widgets/panescaffold/panescaffold.module.css")).toMatch(/\.body\s*\{[^}]*padding: var\(--space-5\)/);
+});
+```
+
+(`walkCss()` = the same recursive reader `token-contract.test.ts` uses; copy the eight lines rather than exporting from a test file.)
+
+- [ ] **Step 2: Run it, watch it fail**
+
+Run: `npx vitest run src/styles/rhythm.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: PaneScaffold**
+
+```css
+.header {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  background: var(--surface-inset);
+  border-bottom: 1px solid var(--edge);
+}
+
+/* A pane's title is its page heading (critique R4): sentence case, the
+ * pane-title step, semibold, full ink. The uppercase micro-label stays for
+ * containers INSIDE a page (InspectorCard, RecommendationCard, Table). */
+.title {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--ink-hi);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-pane-title);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-display);
+  line-height: var(--line-height-title);
+}
+```
+
+`.body { padding: var(--space-5); padding-bottom: calc(var(--space-5) + max(0px, env(safe-area-inset-bottom) - var(--keyboard-inset, 0px))); }` and in the 899px block `.body { padding: var(--space-4); padding-bottom: calc(var(--space-4) + …same…); }`. `.footer` padding `var(--space-3) var(--space-5)` on desktop, `var(--space-3) var(--space-4)` in the phone block.
+
+- [ ] **Step 4: Transcript rhythm**
+
+- `agentmessageitem.module.css .message { padding: var(--rhythm-line) 0; }`; `.name { font-size: var(--font-size-body); font-weight: var(--font-weight-semibold); }`; `.meta { font-size: var(--font-size-ui); color: var(--ink-mid); }`; `.header { margin-bottom: var(--rhythm-line); }`.
+- `usermessageitem.module.css .message { padding: var(--rhythm-line) 0; margin-top: var(--rhythm-exchange); }` and add `.message:first-child { margin-top: 0; }`; `.name` semibold; `.time { font-size: var(--font-size-ui); color: var(--ink-mid); }`. Update the header comment: the 2026-07-30 "no dead air" ruling is revised by the critique (R3): with a bounded measure, the exchange step is a paragraph break.
+- `toolcallitem.module.css .call { padding: var(--rhythm-item) 0; }`; `.intent` and `.summary` `font-size: var(--font-size-ui)` stay; `.demoted` stays `--ink-mid`.
+- `turnseparator.module.css .row { padding: var(--rhythm-group) 0 var(--rhythm-line); }`.
+- `thinkblock.module.css .label, .summary { color: var(--ink-mid); }` (they were `--ink-low`).
+- `livenessline.module.css .line { color: var(--ink-mid); }`.
+
+- [ ] **Step 5: Rail rhythm**
+
+- `tree.module.css .row { min-height: 32px; }`.
+- `Rail.module.css .header { padding: var(--space-4) var(--space-4); gap: var(--space-3); }`; `.section { padding: var(--space-3) 0; }`; `.sectionTitle` and `.sectionDisclosure`: `color: var(--ink-mid); font-size: var(--font-size-caption); letter-spacing: var(--tracking-eyebrow);` (replacing `0.04em` and `--ink-low`).
+- `RailRow.module.css .activity { color: var(--ink-mid); }` for the neutral case (the three hue classes still override); `.time { color: var(--ink-mid); }`.
+
+- [ ] **Step 6: The eyebrow sweep**
+
+For each of the 21 uppercase rules: replace any `letter-spacing: 0.02em|0.04em|0.05em|var(--tracking-micro)` with `var(--tracking-eyebrow)`; ensure `font-size: var(--font-size-caption)`; replace `color: var(--ink-low)` with `var(--ink-mid)`. `askuser.module.css .detail` labels a sentence — delete its `text-transform` and `letter-spacing` and keep caption + `--ink-mid`. Rename the settings cluster: `sections.ts:30` label `"Models"`, and update the three test expectations that spell "Agents & models".
+
+- [ ] **Step 7: Run, Biome, commit**
+
+Run: `npx biome check --write src && npx vitest run src/styles src/widgets/panescaffold src/panes/settings src/panes/session/transcript src/shell/rail src/widgets/table src/widgets/difftable src/widgets/recommendationcard src/widgets/inspectorcard src/widgets/pathfield src/widgets/modelCatalog src/shell/palette src/shell/cheatsheet`
+Expected: PASS.
+
+```bash
+git add src/styles/rhythm.test.ts src/widgets/panescaffold/panescaffold.module.css src/panes/session/transcript src/shell/rail src/widgets/tree/tree.module.css src/panes/settings src/shell/palette/commandpalette.module.css src/shell/cheatsheet/cheatsheet.module.css src/widgets/table/table.module.css src/widgets/difftable/difftable.module.css src/widgets/recommendationcard/recommendationcard.module.css src/widgets/inspectorcard/inspectorcard.module.css src/widgets/pathfield/pathfield.module.css src/widgets/modelCatalog/modelCatalog.module.css src/panes/session/composer/currentwork.module.css src/panes/session/chrome
+git commit -m "feat(webui): four-step rhythm, sentence-case pane headings, one eyebrow recipe"
+```
+
+---
+
+### Task 6: Desktop balance and the phone drawer
+
+**Files:**
+- Modify: `src/panes/spawn/spawn.module.css:.form,.mobilePromptIntro,.mobilePromptHeading,.mobilePromptSubtitle` and `src/panes/spawn/Spawn.tsx:916-919`
+- Modify: `src/panes/settings/settings.module.css:.content`
+- Modify: `src/panes/welcome/welcome.module.css`, `src/panes/welcome/WelcomeContent.tsx`, `src/widgets/emptystate/emptystate.module.css:.title`
+- Modify: the drawer host — `grep -rn 'TreeDrawer\|"Sessions"' src/shell/mobile/StackHost.tsx` finds the `Sheet` that mounts `<Rail scrollOwner="parent" …/>`; the Sheet body's padding plus the rail's `--surface-canvas` fill is the inset box. Add a `flush` prop to `Sheet`? No — keep the widget; instead give the drawer's rail wrapper a class that zeroes the sheet body padding for this one consumer (`src/shell/mobile/treedrawer.module.css .drawerBody { margin: calc(-1 * var(--space-4)); }` is the smallest change; confirm against `dialog.module.css .body { padding: var(--space-4) }`).
+- Test: `src/panes/spawn/Spawn.test.tsx`, `src/panes/welcome/Welcome.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+`Spawn.test.tsx`: in the desktop render test (~line 550) add `expect(screen.getByRole("heading", { name: "What should the agent do?" })).toBeTruthy();` (today the heading exists in the DOM but is display:none on desktop; the assertion is about the rename below, so make it `getByRole("heading", { name: "What should the agent do?", level: 2 })`).
+
+`Welcome.test.tsx`: add `expect(screen.getByRole("heading", { name: "No session open" }).className).toMatch(/display/);` — the empty-state title on the welcome pane takes the display size via a new `EmptyState` prop `size="display"`.
+
+- [ ] **Step 2: Run, watch fail**
+
+Run: `npx vitest run src/panes/spawn/Spawn.test.tsx src/panes/welcome`
+
+- [ ] **Step 3: Spawn on desktop**
+
+`spawn.module.css`: `.form { margin-inline: auto; max-width: var(--session-measure); gap: var(--space-5); }`; rename `.mobilePromptIntro` → `.promptIntro` (shown at every width: delete the `display: none` and the phone `display: block`), `.mobilePromptHeading` → `.promptHeading { font-size: var(--font-size-page-title); letter-spacing: var(--tracking-display); }`, `.mobilePromptSubtitle` → `.promptSubtitle`. Update the `CLASS` map and JSX in `Spawn.tsx` (`h3` → `h2`). Delete the `PaneScaffold` `title`'s duplicate by keeping `title="New session"` (the heading is the page's; the pane title stays for the top bar / tab).
+
+- [ ] **Step 4: Settings and welcome**
+
+`settings.module.css .content { max-width: var(--session-measure); }`.
+
+`emptystate/index.tsx`: add `size?: "default" | "display"`; `.titleDisplay { font-size: var(--font-size-display); }` in `emptystate.module.css`; gallery section `src/dev/gallery-sections/emptystate.tsx` shows both. `Welcome.tsx` passes `size="display"`. In `WelcomeContent.tsx` render the chord hints as a two-column definition list (`<dl className={CLASS.hints}><div><dt><KeyHint …/></dt><dd>{desc}</dd></div>…</dl>`) with `.hints { display: grid; grid-template-columns: auto 1fr; column-gap: var(--space-3); row-gap: var(--space-2); }` — keep the `hints`/`hintRow`/`hintFooter` class names so `welcome.overflow.test.tsx` still resolves them.
+
+- [ ] **Step 5: The drawer**
+
+Apply the flush wrapper from the Files list; verify with `npm run shellguard` (Chrome) that the drawer's tap targets still pass.
+
+- [ ] **Step 6: Run, Biome, commit**
+
+Run: `npx biome check --write src/panes/spawn src/panes/settings src/panes/welcome src/widgets/emptystate src/shell/mobile src/dev && npx vitest run src/panes/spawn src/panes/settings src/panes/welcome src/widgets/emptystate src/shell/mobile src/dev`
+
+```bash
+git add src/panes/spawn src/panes/settings/settings.module.css src/panes/welcome src/widgets/emptystate src/dev/gallery-sections/emptystate.tsx src/shell/mobile
+git commit -m "feat(webui): centred spawn form with its heading on desktop, bounded settings, display-size welcome, flush drawer"
+```
+
+---
+
+### Task 7: Fold tool-call runs; agent prose as a document
+
+**Files:**
+- Modify: `src/panes/session/transcript/toolRenderers.ts` (`fold?: "never" | "consequential"` on `ToolRendererDescriptor`)
+- Modify: `src/panes/session/transcript/tools/editTools.tsx`, `shellTool.tsx`, `worktreeTool.tsx` (`fold: "consequential"`); `subagentModule.tsx`, `askUser.tsx`, `taskCard.tsx`, `jobTools.tsx`, `useSkillTool.tsx` (`fold: "never"`)
+- Create: `src/panes/session/transcript/toolRuns.ts`, `src/panes/session/transcript/ToolRunGroup.tsx`, `src/panes/session/transcript/toolrungroup.module.css`
+- Modify: `src/panes/session/transcript/TurnBlock.tsx:216-268`
+- Modify: `src/panes/session/transcript/messages/agentmessageitem.module.css:.bubble,.continuation`
+- Test: `src/panes/session/transcript/toolRuns.test.ts`, `src/panes/session/transcript/TurnBlock.test.tsx`
+
+**Interfaces:**
+- `foldToolRuns(entries: readonly ProjectedEntry[], opts: { turnSettled: boolean; descriptorFor: (toolName: string) => ToolRendererDescriptor }): (ProjectedEntry | ToolRun)[]` where `ToolRun = { kind: "run"; id: string; entries: Extract<ProjectedEntry, { kind: "item" }>[] }`.
+- `runLabel(run: ToolRun, descriptorFor): string` → `"{n} steps · {summary}"` where summary is the last entry whose descriptor has `fold === "consequential"`, else the last entry.
+
+- [ ] **Step 1: Failing unit tests for the fold**
+
+`toolRuns.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest";
+import type { ItemModel } from "../../../protocol/model";
+import type { ProjectedEntry } from "../../../transcriptDisplay/projector";
+import { foldToolRuns, runLabel } from "./toolRuns";
+
+const tool = (id: string, toolName: string, status = "completed"): Extract<ProjectedEntry, { kind: "item" }> => ({
+  kind: "item", id, turnId: "t1", sourceIndex: 0, isMessage: false,
+  item: { id, turnId: "t1", type: "commandExecution", text: "", toolName, status } as ItemModel,
+});
+const descriptorFor = (name: string) => ({
+  match: name,
+  summary: () => (name === "write_file" ? "Wrote foo.py" : `Read ${name}`),
+  fold: name === "write_file" ? ("consequential" as const) : name === "delegate" ? ("never" as const) : undefined,
+});
+
+test("three settled quiet calls fold into one run", () => {
+  const out = foldToolRuns([tool("a", "read_file"), tool("b", "read_file"), tool("c", "grep")], { turnSettled: true, descriptorFor });
+  expect(out).toHaveLength(1);
+  expect(out[0]).toMatchObject({ kind: "run", entries: [{ id: "a" }, { id: "b" }, { id: "c" }] });
+});
+
+test("two calls do not fold", () => {
+  const out = foldToolRuns([tool("a", "read_file"), tool("b", "read_file")], { turnSettled: true, descriptorFor });
+  expect(out.map((e) => e.kind)).toEqual(["item", "item"]);
+});
+
+test("a failed call breaks the run and stays visible", () => {
+  const out = foldToolRuns([tool("a", "read_file"), tool("b", "read_file", "failed"), tool("c", "read_file"), tool("d", "read_file")], { turnSettled: true, descriptorFor });
+  expect(out.map((e) => e.kind)).toEqual(["item", "item", "item", "item"]);
+});
+
+test("a live turn never folds", () => {
+  const out = foldToolRuns([tool("a", "read_file"), tool("b", "read_file"), tool("c", "read_file")], { turnSettled: false, descriptorFor });
+  expect(out.map((e) => e.kind)).toEqual(["item", "item", "item"]);
+});
+
+test("a never-fold tool splits the run", () => {
+  const out = foldToolRuns([tool("a", "read_file"), tool("b", "delegate"), tool("c", "read_file"), tool("d", "read_file"), tool("e", "read_file")], { turnSettled: true, descriptorFor });
+  expect(out.map((e) => e.kind)).toEqual(["item", "item", "run"]);
+});
+
+test("the label names the consequential step", () => {
+  const [run] = foldToolRuns([tool("a", "read_file"), tool("b", "write_file"), tool("c", "read_file")], { turnSettled: true, descriptorFor });
+  expect(runLabel(run as never, descriptorFor)).toBe("3 steps · Wrote foo.py");
+});
+```
+
+- [ ] **Step 2: Run, watch fail** — `npx vitest run src/panes/session/transcript/toolRuns.test.ts` (module missing).
+
+- [ ] **Step 3: `toolRuns.ts`**
+
+```ts
+import type { ProjectedEntry } from "../../../transcriptDisplay/projector";
+import type { ToolRendererDescriptor } from "./toolRenderers";
+
+export type ToolItemEntry = Extract<ProjectedEntry, { kind: "item" }>;
+export interface ToolRun { kind: "run"; id: string; entries: ToolItemEntry[] }
+export interface FoldOptions { turnSettled: boolean; descriptorFor: (toolName: string) => Pick<ToolRendererDescriptor, "summary" | "fold" | "failed" | "autoExpand">; }
+
+const MIN_RUN = 3;
+
+function foldable(entry: ProjectedEntry, opts: FoldOptions): entry is ToolItemEntry {
+  if (entry.kind !== "item" || entry.item.type !== "commandExecution") return false;
+  const { item } = entry;
+  if (item.status !== "completed") return false;
+  const d = opts.descriptorFor(item.toolName ?? "");
+  if (d.fold === "never") return false;
+  if (d.failed?.(item) || d.autoExpand?.(item)) return false;
+  return true;
+}
+
+export function foldToolRuns(entries: readonly ProjectedEntry[], opts: FoldOptions): (ProjectedEntry | ToolRun)[] {
+  if (!opts.turnSettled) return [...entries];
+  const out: (ProjectedEntry | ToolRun)[] = [];
+  let run: ToolItemEntry[] = [];
+  const flush = () => {
+    if (run.length >= MIN_RUN) out.push({ kind: "run", id: `run:${run[0]!.id}`, entries: run });
+    else out.push(...run);
+    run = [];
+  };
+  for (const entry of entries) {
+    if (foldable(entry, opts)) run.push(entry);
+    else { flush(); out.push(entry); }
+  }
+  flush();
+  return out;
+}
+
+export function runLabel(run: ToolRun, descriptorFor: FoldOptions["descriptorFor"]): string {
+  const named = [...run.entries].reverse().find((e) => descriptorFor(e.item.toolName ?? "").fold === "consequential") ?? run.entries[run.entries.length - 1]!;
+  return `${run.entries.length} steps · ${descriptorFor(named.item.toolName ?? "").summary(named.item)}`;
+}
+```
+
+Add `fold?: "never" | "consequential";` to `ToolRendererDescriptor` with a comment: `never` = a card a reader must always see (delegates, asks, task lists, skills, jobs); `consequential` = a mutating step that names a folded run (edits, shell, worktree); unset = quiet (reads, searches, web).
+
+- [ ] **Step 4: `ToolRunGroup.tsx` and its CSS**
+
+A `<details data-testid="tool-run">` + `<summary className={CLASS.summary}>` with the run label and a `Chevron` (same idiom as `ProjectedIntentGroup` in `TurnBlock.tsx`, including `disclosureScopeForSession`, `scopedDisclosureId(scope, run.id)`, `isDisclosureOpen`, `toggleDisclosure`, and `expandDetailsByDefault(config)` as the fallback). The body renders each entry through `ToolCallItem` exactly as the non-folded path does (copy the `<ItemRenderer …/>` props block from `TurnBlock.tsx:238-253`; the component is `ToolCallItem`). CSS: `.summary { display: inline-flex; align-items: center; gap: var(--space-2); padding: var(--rhythm-line) 0; color: var(--ink-mid); font-family: var(--font-sans); font-size: var(--font-size-ui); cursor: pointer; list-style: none; }`, `.summary::-webkit-details-marker { display: none }`, `.summary:hover { background: color-mix(in oklab, var(--ink-mid) 8%, transparent); border-radius: var(--radius-control); }`, `.summary:focus-visible { outline: var(--focus-ring); outline-offset: 2px; }`, `.body { display: flex; flex-direction: column; }`.
+
+- [ ] **Step 5: Wire into `TurnBlock.tsx`**
+
+Replace the `for` loop's input: `const laidOut = foldToolRuns(projectedTurn.entries, { turnSettled: sourceTurn.status !== "inProgress", descriptorFor: (name) => toolRendererFor(name) });` and iterate `laidOut`; when `entry.kind === "run"`, push `<div key={entry.id} className={CLASS.runContent} data-testid="run-content"><ToolRunGroup run={entry} …same props as items… /></div>`. Check `TurnModel.status`'s literal values in `protocol/model.ts` and use the in-progress one.
+
+`TurnBlock.test.tsx` additions: a settled turn with three `read_file` items renders one `tool-run` and zero `tool-row` until the summary is clicked, then three `tool-row`; a turn with a failed middle item renders three `tool-row` and no `tool-run`.
+
+- [ ] **Step 6: Agent prose as a document**
+
+`agentmessageitem.module.css .bubble`: remove `background`, `border-radius`, and horizontal padding; keep `padding: var(--rhythm-line) 0; max-width: 100%; width: 100%;`. Delete `.continuation`'s radius rule (keep the class for the TSX). Rewrite the header comment: the user's words keep the accent wash; the agent's answer is the document (critique R9). Keep `usermessageitem.module.css .body` as is.
+
+- [ ] **Step 7: Run, Biome, commit**
+
+Run: `npx biome check --write src/panes/session/transcript && npx vitest run src/panes/session/transcript src/dev`
+
+```bash
+git add src/panes/session/transcript
+git commit -m "feat(webui): fold settled tool-call runs into one row; agent prose reads as a document"
+```
+
+---
+
+### Task 8: The type specimen route
+
+**Files:**
+- Create: `src/dev/TypeSpecimen.tsx`, `src/dev/typespecimen.module.css`, `src/dev/TypeSpecimen.test.tsx`
+- Modify: `src/App.tsx` (route `/dev/type`, DEV-gated like the others)
+- Modify: `docs/web-ui/README.md` (mention `/dev/type` beside `/dev/widgets`)
+
+- [ ] **Step 1: Failing test** — `TypeSpecimen.test.tsx`: renders, shows one row per ramp step (`getByText("caption 12")` … `getByText("display 28")`), shows the four rhythm steps and a paragraph at each of the two measures, both themes via `ThemeFlip`.
+- [ ] **Step 2: Run, watch fail.**
+- [ ] **Step 3: Implement** — a page listing: every `--font-size-*` token rendered in itself with its name and px; the three line-heights; the eyebrow recipe; `--rhythm-*` as labelled spacer bars; a 600-character paragraph inside a `.turn`-width column at `reading` and `wide`; wrapped in `ThemeFlip`. `App.tsx`: `const TypeSpecimen = import.meta.env.DEV ? lazy(() => import("./dev/TypeSpecimen")) : null;` and the `/dev/type` branch.
+- [ ] **Step 4: Run, Biome, commit** — `git commit -m "feat(webui): /dev/type specimen route"`.
+
+---
+
+### Task 9: Enforce it — token-contract extensions
+
+**Files:**
+- Modify: `src/styles/token-contract.test.ts`
+
+- [ ] **Step 1: Add four checks with poison tests, in the file's own style (a `violations(cssText)` helper, one `test.each` over `OTHER_STYLESHEETS`, then hand-written snippets proving catch and non-catch):**
+
+1. **Undefined tokens.** Collect every `--name` declared in any stylesheet; for every `var(--name)` with no fallback (`var(--x)` not followed by `,`), fail if not declared. Exempt `--dv-*` (dockview) and the runtime-set names `--keyboard-inset --rail-width --tap-min --fill --markdown-ink --prose-font-size --prose-ink --density-scale --font-scale --textarea-min-lines --sheet-inline-size`. Poison: `var(--radius-sm)` caught; `var(--radius-sm, 4px)` allowed.
+2. **No literal font-size.** `font-size:\s*\d` outside `tokens.css` fails. Poison: `font-size: 11px` caught; `font-size: var(--font-size-ui)`, `font-size: 0.86em`, `font-size: inherit` allowed (em is relative and legal for inline code).
+3. **Tracking via tokens.** `letter-spacing:` must be `var(--tracking-display)`, `var(--tracking-eyebrow)`, `inherit`, or `normal`.
+4. **Uppercase = eyebrow recipe.** Every rule block with `text-transform: uppercase` also declares `font-size: var(--font-size-caption)` and `letter-spacing: var(--tracking-eyebrow)` (this supersedes the interim copy in `rhythm.test.ts`; delete that test there once this one exists).
+
+- [ ] **Step 2: Run** — `npx vitest run src/styles` — expect PASS on the real tree (Tasks 1 and 5 already cleaned it) and the poison snippets.
+- [ ] **Step 3: Commit** — `git commit -m "test(webui): contract-test undefined tokens, literal sizes, tracking and eyebrow recipe"`.
+
+---
+
+### Task 10: Docs and the design law
+
+**Files:**
+- Modify: `docs/web-ui/design-system.md` §1 Type line, §2 Type / Space & shape paragraphs (ramp 12/13/15/18/22/28, line-heights 1.4/1.6/1.25, `--tracking-eyebrow` replaces `--tracking-micro`, `--rhythm-*`, `--session-measure` + the Transcript width preference, pane titles are headings, micro-label stays for cards), §6 copy rules (eyebrow recipe, ≤2 words, enforced), §4 list item 7–10 (the new contract checks)
+- Modify: `docs/web-ui/decisions.md`: a `## 2026-09-06 typography, measure and rhythm` entry recording: the ramp; the 44rem measure and why (149 chars/line measured); the exchange step reversing the 2026-07-30 "no dead air" ruling; agent prose as a document (partially reversing 2026-07-30 bubbles); tool-run folding landing principle 2 / topic 06 Alt A; pane titles as headings (superseding the micro-label port for panes); zoom lock removed.
+- Modify: `docs/web-ui/typography-spacing-critique-2026-09-06.md` status line → "implemented by `docs/superpowers/plans/2026-09-06-webui-typography-spacing.md`".
+
+- [ ] **Step 1: Edit the three docs as above.**
+- [ ] **Step 2: Commit** — `git commit -m "docs(web-ui): record the 2026-09-06 typography, measure and rhythm decisions"`.
+
+---
+
+### Task 11: Gates, visual check, PR
+
+- [ ] **Step 1:** From the repo root: `make test-web` then `make test-web-browser`. Fix anything red (the guards measure real geometry at 390/700/1024/1400; a tap-target or overflow regression from the larger body size shows up here).
+- [ ] **Step 2:** Visual pass with the dev server (see `/Users/jesse/.claude/projects/-Users-jesse-git-prime-radiant-evener/memory/webui-screenshot-recipe.md`): `/new`, a session, `/settings`, `/dev/type` at 1440 and 375, both themes. Measure the agent paragraph again: expect ≤ 100 characters per line at 1440 and ≥ 36 on the phone.
+- [ ] **Step 3:** `git push -u origin claude/evener-webui-typography-spacing-3d4fd4` and `gh pr create` with the critique as the description's source: what was measured, what changed (R1–R10 mapped to commits), the two reversed decisions, and how to review (`/dev/type`, Settings → Theme → Transcript width).

--- a/docs/web-ui/README.md
+++ b/docs/web-ui/README.md
@@ -14,6 +14,9 @@ Design documentation for the web hub (`cmd/evener-hub`). Started 2026-06-16.
 - **[ux-plan-2026-07.md](ux-plan-2026-07.md)** — the five-participant study of
   the SPA against the old server-rendered build, and the plan that came out of
   it. Cited from live source comments.
+- **[typography-spacing-critique-2026-09-06.md](typography-spacing-critique-2026-09-06.md)** —
+  measured critique of type scale, measure, rhythm and balance on desktop and
+  phone, with a proposed ramp and enforcement plan. Proposal, not shipped.
 - **[keybindings.md](keybindings.md)** — the keybindings dispatcher: registry,
   scope stack, precedence layers, per-binding policy flags, and how to
   register an action or a chord, the shipped default binding map (including

--- a/docs/web-ui/README.md
+++ b/docs/web-ui/README.md
@@ -43,6 +43,11 @@ There is no static example gallery to keep in sync. Run the dev server and open
 rendered from the real tokens. `src/dev/WidgetGallery.test.tsx` fails the build
 the day a widget has no section, so it cannot silently go stale.
 
+**`/dev/type`** does the same for the type system itself: the size ramp, the
+three line-heights, the eyebrow recipe, the four rhythm steps and a paragraph
+at each measure, in both themes, so a ramp change is reviewed as a picture
+rather than a diff.
+
 The gallery is dev-only: `App.tsx` gates it behind `import.meta.env.DEV`, so a
 production build does not contain it and there is no link to it from the app.
 

--- a/docs/web-ui/decisions.md
+++ b/docs/web-ui/decisions.md
@@ -848,12 +848,16 @@ models" is now **"Agent setup"**.
 
 **Tool-run folding lands principle 2 and topic 06's Alt A**, the row this
 document has carried as "ABSENT, unexplained". In a settled turn, three or
-more consecutive completed, non-failed tool calls whose renderer does not
-declare `fold: "never"` collapse into one `<details>` row labelled
-`N steps · <last consequential summary>`. `fold: "consequential"` (the edit
-tools, shell, worktree) marks the mutations a label may name, since that is
+more consecutive completed, non-failed tool calls whose renderer has opted
+in collapse into one `<details>` row labelled
+`N steps · <last consequential summary>`. Folding is opt-in per descriptor:
+`fold: "quiet"` (the reads, searches, web fetches and transcript reads)
+folds and only counts; `fold: "consequential"` (the edit tools, shell,
+worktree) folds and marks the mutations a label may name, since that is
 what a run amounted to; `fold: "never"` (delegate, ask_user, task_list,
-use_skill, the `job_*` tools) never folds away. A live turn never folds at
+use_skill, the `job_*` tools) and any descriptor with no policy at all,
+which is every unregistered or MCP tool, never fold away, because a tool the
+UI does not know may have had a side effect the reader must see. A live turn never folds at
 all, because while the agent is working each call appearing IS the progress
 signal, and a failure, a call still in flight, an auto-expanding card or any
 non-tool entry breaks the run rather than being spanned by it, so a folded row

--- a/docs/web-ui/decisions.md
+++ b/docs/web-ui/decisions.md
@@ -150,7 +150,7 @@ decision, since every alternative agreed on it.
 | Part | Verdict | Where it stands |
 | --- | --- | --- |
 | A — four meanings, done recedes, colour is scarce | LIVE | `styles/token-contract.test.ts:SEMANTIC_USE_ALLOWLIST` enforces it in CI; `widgets/statusdot:.neutral` gives idle/ended no hue at all. **By design:** the mockup's single blue covered both "live" and "interactive"; shipped tokens split it into `--alive` (agent working) and `--accent` (focus/selection/links only). One meaning per hue — a refinement, not a break. |
-| C — dimmest tone is hairline-and-chrome, never body text | LIVE | `transcript/toolcallitem.module.css:.demoted` carries the measured numbers: `--ink-low` is 2.97:1 dark / 3.64:1 light, under the 4.5:1 floor; `--ink-mid` clears it at 6.86/6.56. The same reasoning is repeated at `usermessageitem:.tag` and `chrome/taskspanel:.staleHint`. |
+| C — dimmest tone is hairline-and-chrome, never body text | LIVE | `transcript/toolcallitem.module.css:.demoted` carries the measured numbers: `--ink-low` is 2.97:1 dark / 3.64:1 light, under the 4.5:1 floor; `--ink-mid` clears it at 6.86/6.56. The same reasoning is repeated at `usermessageitem:.tag` and `chrome/taskspanel:.staleHint`. The rule is unchanged, but those ratios are pre-2026-09-06: `--ink-low` was raised to clear AA that day (see the 2026-09-06 entry below) and the stylesheet comments quoted here still carry the old numbers. |
 | B — every state glyph-paired, colourblind-safe | **CHANGED, unexplained** | Half-shipped, and the half that shipped is the transcript's. `widgets/failureglyph` is a real distinct-shape marker rendered beside any single failed tool call (`ToolRow.tsx`) and any turn-failure notice (`SystemNoticeItem:FailureLine`), as well as beside the status row's failure count — so *failure* is genuinely glyph-paired wherever it appears in the transcript. The gap is everywhere else: `widgets/cadence` draws one dot shape for every state, varying only hue, with an `aria-label` as the sole non-colour signal, and no `FailureGlyph` appears anywhere under `shell/rail/`. So the navigator — the app's primary triage surface — is colour-only for idle / working / needs-you / ended. |
 
 **02 · Chrome & labels** — chose A (sans, sentence-case, hairline) plus D's
@@ -268,7 +268,7 @@ mutating step) + D (peek / ride / drop). Shipped `7bbe0e91e`.
 
 | Part | Verdict | Where it stands |
 | --- | --- | --- |
-| A — a run of finished calls folds to one summary line naming the consequential step | **ABSENT, unexplained** | There is no cluster concept at all. `TurnBlock` renders items one at a time via `itemRendererFor`, and `toolRowGrammar.test.tsx` pins "exactly one per call." A run of read/grep/edit/test calls is a column of individually-collapsible rows. This is also principle 2 of the brief, so its absence is a gap against the design law, not only against one mockup. |
+| A — a run of finished calls folds to one summary line naming the consequential step | **ABSENT, unexplained**. Landed 2026-09-06: see below. | There is no cluster concept at all. `TurnBlock` renders items one at a time via `itemRendererFor`, and `toolRowGrammar.test.tsx` pins "exactly one per call." A run of read/grep/edit/test calls is a column of individually-collapsible rows. This is also principle 2 of the brief, so its absence is a gap against the design law, not only against one mockup. Landed 2026-09-06 as `transcript/toolRuns.ts` + `ToolRunGroup.tsx`; the fold rule is written up in the 2026-09-06 typography, measure and rhythm entry below. |
 | D — peek / ride / drop tri-state | CHANGED | **By design.** The anti-lying principle survives — `tools/helpers.ts:tailFold` and `widgets/codeblock` never offer an "expand" over bytes that are gone, and say so inline. The explicit three-state vocabulary is gone; the state is prose, not a labelled UI state. |
 
 **07 · System churn & silent success** — chose A (quiet one-liner) + B
@@ -764,3 +764,132 @@ the field; real update detection is a backend feature, not a presentation
 choice, and was not smuggled into this redesign. The implementation
 screenshots beside the mockups in the assets directory record what
 actually shipped, in the app's default theme.
+
+## 2026-09-06 typography, measure and rhythm
+
+The pass came out of a measured critique of the running app at 1440x900 and
+375x812 in both themes,
+`docs/web-ui/typography-spacing-critique-2026-09-06.md`; the implementation is
+`docs/superpowers/plans/2026-09-06-webui-typography-spacing.md`, on branch
+`claude/evener-webui-typography-spacing-3d4fd4`. Each paragraph below is one
+decision, and three of them revise decisions recorded earlier in this file.
+
+**The ramp is 12 / 13 / 15 / 18 / 22 / 28, with three line-heights.** The old
+12/13/14/16/20 at 1.5 body / 1.3 title had a ratio of about 1.08 between
+steps, which is one size with rounding error rather than a scale: 340 of 382
+explicit `font-size` declarations picked caption or ui, so nearly everything
+on screen was 12 or 13px and the eye had no landmarks to find. Body is 15
+because Inter at 14 on a 1440 display is a settings-dialog size, and the
+reading products that also carry code sit at 15 to 16. Body is 16 below 900px
+for a second, harder reason: iOS Safari zooms into any focused field under
+16px, and the body size IS the field size (the shared textarea takes it).
+`--line-height-ui` (1.4) is new, for the dense chrome rows 1.6 was too loose
+for. `src/styles/measure.test.ts` pins the six steps and the phone body off
+disk.
+
+**The reading measure is 44rem, with a wide preference.** `--session-measure`
+was a 76rem literal on `.turn`, hand-copied into `session.module.css`. 76rem
+is 1216px, which at a 1440 window is wider than the pane itself, so the column
+was effectively full bleed and a plain agent paragraph measured **149
+characters per line**. The comfortable range is 45 to 75, and the chat
+products that must also show code settle around 90 to 100. 44rem is 704px:
+about 90 characters at 15px, with room for a 100-column code block. It is now
+one token declared on `<body>` that the transcript column, composer, cold
+start, spawn form and settings content all read, so they can no longer drift
+apart. Settings → Theme → Transcript width raises it to 64rem via
+`<body data-transcript-measure="wide">` for readers who want the window back.
+The new layoutguard case `transcript-measure` pins 100 characters per line and
+a centred column at 1440 and 1920; it is mutation-verified, and putting the
+76rem literal back fails it at 126 and 157 characters per line respectively.
+
+**Vertical rhythm is four named steps, which REVISES the 2026-07-30 "no dead
+air" ruling recorded in topic 03.** `--rhythm-line` (4px, inside one item),
+`--rhythm-item` (8px, between items in a run), `--rhythm-group` (16px, between
+a run and the next speaker header, and above a turn footer),
+`--rhythm-exchange` (24px, above a user message). The transcript previously
+had exactly one deliberate step, 4px message padding against 8px tool-call
+padding, because the 2026-07-30 ruling had removed the larger one at exchange
+boundaries as dead air. That ruling was correct for the layout it was made in:
+lines ran 149 characters and every row sat 4px from its neighbour, so added
+margin was air with nothing to separate. With the column bounded to
+`--session-measure`, 24px above a user message reads as a paragraph break, and
+it is what lets the eye find the next exchange in a long session without
+hunting for a 24px avatar. The full reasoning is in
+`usermessageitem.module.css`'s header, which is where the old ruling lived;
+`src/styles/rhythm.test.ts` pins each step to the site that names it.
+
+**Speaker headers are semibold.** At body size, a medium weight beside regular
+prose is a landmark only for a reader already looking for one, and the speaker
+header is the transcript's one structural landmark per exchange. Its meta line
+moved at the same time, from caption-size `--ink-low` to ui-size `--ink-mid`,
+since a model name and a clock time are things a reader actually reads.
+
+**Pane titles are headings, SUPERSEDING the 2026-08-13 micro-label port for
+panes.** The Beautiful UI adoption brought the micro-label across (11.5 to
+12px, uppercase, 0.08em tracking, `--ink-mid`) and made it the PaneScaffold
+title. On a dashboard card that pattern labels a container sitting inside a
+page that has a real heading; here the pane IS the page, so the page's title
+became its smallest text ("START AN AGENT", "GENERAL", "THEME"), and once a
+session had a title, that title was the user's whole prompt rendered as an
+uppercase sentence, which design-system.md §6 already forbade in as many
+words. A PaneScaffold title is now sentence-case `--font-size-pane-title`,
+semibold, `--ink-hi`; a session title is never transformed at all. The
+micro-label keeps its real job under a single name, next.
+
+**One eyebrow recipe, and the rename it forced.** The app had 21
+`text-transform: uppercase` rules spread across four tracking values. There is
+now one token, `--tracking-eyebrow` (0.06em), and one recipe: caption size,
+medium or semibold weight, `--ink-mid` or darker, uppercase, at most two
+words, only ever titling a container inside a page (InspectorCard's header
+band, RecommendationCard's kicker, Table headers, the rail's section titles,
+the settings cluster headers). The two-word cap is a real constraint rather
+than a guideline, and it forced a rename: the settings cluster "Agents &
+models" is now **"Agent setup"**.
+
+**Tool-run folding lands principle 2 and topic 06's Alt A**, the row this
+document has carried as "ABSENT, unexplained". In a settled turn, three or
+more consecutive completed, non-failed tool calls whose renderer does not
+declare `fold: "never"` collapse into one `<details>` row labelled
+`N steps · <last consequential summary>`. `fold: "consequential"` (the edit
+tools, shell, worktree) marks the mutations a label may name, since that is
+what a run amounted to; `fold: "never"` (delegate, ask_user, task_list,
+use_skill, the `job_*` tools) never folds away. A live turn never folds at
+all, because while the agent is working each call appearing IS the progress
+signal, and a failure, a call still in flight, an auto-expanding card or any
+non-tool entry breaks the run rather than being spanned by it, so a folded row
+can never gather calls the reader saw separated by an answer. Three is the
+threshold because two folded rows save one row and cost a click.
+`transcript/toolRuns.ts` decides what a run is; `ToolRunGroup.tsx` renders it,
+with its disclosure state in the shared store.
+
+**`--ink-low` was raised until it clears AA, and then mostly stopped being
+used for reading.** The token is documented for placeholders, disabled
+controls and timestamps, and it was nonetheless the colour of 96 text rules,
+most of them at 12px too, so the two demotions compounded. Dark went to
+`#8A8E95` (4.72:1 on `--surface-1`, 5.40:1 on `--surface-0`) and light to
+`#6F737A` (4.76:1 on white, 4.57:1 on `--surface-0`), and
+`token-contract.test.ts` now pins both. The most-read of those sites (speaker
+meta, thought summaries, the liveness line, rail section titles) moved up to
+`--ink-mid` anyway, which is what topic 01's "dimmest tone is
+hairline-and-chrome, never body text" rule said all along.
+
+**Mono discipline, principle 7, applied to the chrome people look at most.**
+The model chip, the status row's percent/clock/queue figures, the rail's
+relative ages and the turn footer are sans with
+`font-variant-numeric: tabular-nums`, which buys the column alignment that was
+the reason to reach for mono in the first place. Mono stays for code, paths,
+shell summaries, diffs and the identifiers in Details.
+`src/styles/faces.test.ts` pins those four rules off disk.
+
+**The rail's three text glyphs became SVG icons.** `global.css` subsets Inter
+to Latin, so the gear, magnifier and sidebar toggle set as characters were
+rendering from whatever system fallback happened to carry them, at whatever
+stroke weight it had, beside the app's own SVG chevrons and open-box icon.
+`shell/rail/railIcons.tsx` draws all three now, the same reasoning that made
+`SteeringGlyph` an SVG.
+
+**The viewport meta no longer locks zoom.** `index.html` carried
+`maximum-scale=1, user-scalable=no` to stop iOS Safari zooming into the 13px
+composer field, which disabled pinch-zoom for the entire app (WCAG 1.4.4
+resize text). The 16px phone body removed the reason for the lock, so the lock
+is gone, and `src/styles/viewport-pin.test.ts` fails if it comes back.

--- a/docs/web-ui/decisions.md
+++ b/docs/web-ui/decisions.md
@@ -857,7 +857,13 @@ worktree) folds and marks the mutations a label may name, since that is
 what a run amounted to; `fold: "never"` (delegate, ask_user, task_list,
 use_skill, the `job_*` tools) and any descriptor with no policy at all,
 which is every unregistered or MCP tool, never fold away, because a tool the
-UI does not know may have had a side effect the reader must see. A live turn never folds at
+UI does not know may have had a side effect the reader must see. One more
+row never folds, by projection rather than policy: a settled call with no
+stated intent (`description`) projects as a `critical` entry at the tool-call
+levels (`projector.ts`'s `decisionFor`, so the neutral summary reaches the
+renderer), and only `item` entries fold. Runs of intent-less calls therefore
+stay unfolded; extending the fold to `critical` entries is a small separate
+change if a model that omits intents makes it matter. A live turn never folds at
 all, because while the agent is working each call appearing IS the progress
 signal, and a failure, a call still in flight, an auto-expanding card or any
 non-tool entry breaks the run rather than being spanned by it, so a folded row

--- a/docs/web-ui/decisions.md
+++ b/docs/web-ui/decisions.md
@@ -893,3 +893,16 @@ stroke weight it had, beside the app's own SVG chevrons and open-box icon.
 composer field, which disabled pinch-zoom for the entire app (WCAG 1.4.4
 resize text). The 16px phone body removed the reason for the lock, so the lock
 is gone, and `src/styles/viewport-pin.test.ts` fails if it comes back.
+
+**Agent prose is the document; the user's words keep the bubble.** The
+2026-07-30 chat-bubbles decision put every agent fragment in a neutral ink
+wash hugging its content. With the column bounded to `--session-measure` that
+wash stopped doing any work and read as a slab behind every paragraph, so
+`agentmessageitem.module.css`'s `.bubble` is now only the prose's layout box:
+full column width, one `--rhythm-line` step of padding, no fill, no radius.
+Continuation fragments take one `--rhythm-item` step above them instead of a
+uniform radius. The user's own message keeps its `--accent-bg` wash
+(`usermessageitem.module.css`), which a short line benefits from. This
+reverses the bubble decision for the agent side only, and it is the one
+2026-09-06 change that is taste rather than measurement; it is the shape
+both major chat assistants converged on for long technical answers.

--- a/docs/web-ui/design-system.md
+++ b/docs/web-ui/design-system.md
@@ -274,11 +274,14 @@ during implementation (noted inline); this table is the one to trust.
 `src/widgets/`, because it is transcript grammar rather than a reusable primitive: no barrel
 entry, no gallery section. It is what finally renders principle 2 of the mockup brief
 (`decisions.md`, topic 06 Alt A). The rule, owned by `transcript/toolRuns.ts`: in a SETTLED
-turn, three or more consecutive completed, non-failed tool calls whose renderer does not declare
-`fold: "never"` collapse into one `<details>` row labelled `N steps · <last consequential
-summary>`. A descriptor with `fold: "consequential"` (the edit tools, shell, worktree) is a
-mutation, so it is the step the label names; `fold: "never"` (delegate, ask_user, task_list,
-use_skill, the `job_*` tools) never folds and always stays on its own row. A live turn never
+turn, three or more consecutive completed, non-failed tool calls whose renderer has opted in
+collapse into one `<details>` row labelled `N steps · <last consequential summary>`. Folding is
+opt-in: `fold: "quiet"` (the reads, searches, web fetches, transcript reads) folds and only
+counts; `fold: "consequential"` (the edit tools, shell, worktree) folds and is the step the label
+names, being a mutation; `fold: "never"` (delegate, ask_user, task_list, use_skill, the `job_*`
+tools) and any descriptor with no policy, which is every unregistered or MCP tool, stay on their
+own row, because a tool the UI does not know may have had a side effect the reader must see.
+Scroll and focus anchors follow the same fold (`foldTurnEntries`): a folded run is one anchor. A live turn never
 folds at all, and a failure, a call still in flight, an auto-expanding card or any non-tool entry
 breaks the run rather than being spanned by it. Disclosure state goes through the shared
 disclosure store, so a reader's choice survives re-projection and the transcript's

--- a/docs/web-ui/design-system.md
+++ b/docs/web-ui/design-system.md
@@ -45,10 +45,13 @@ design language. The wave-2 hex table originally reproduced here is dropped rath
 than perpetuated as a third stale table; see §2 below for the palette as shipped,
 and `decisions.md` for both re-themes' provenance and rationale.
 
-**Type:** IBM Plex Sans (UI + prose; display = weight 600, tracking −1%) and IBM Plex Mono
-(code, tool output, paths, timings). Scale (px): 12 caption / 13 ui / 14 body / 16 pane-title /
-20 page-title, line-heights 1.5 body, 1.3 titles. Mono never used for chrome labels (retired
-pattern stays retired).
+**Type:** the plan's IBM Plex Sans / IBM Plex Mono pairing and its 12 caption / 13 ui /
+14 body / 16 pane-title / 20 page-title scale at 1.5/1.3 are both superseded: first by the
+2026-08-13 Beautiful UI adoption (Inter Variable + JetBrains Mono Variable), then by the
+2026-09-06 typography pass. The ramp as shipped is 12 caption / 13 ui / 15 body (16 on phones) /
+18 pane-title / 22 page-title / 28 display, line-heights 1.6 body, 1.4 ui, 1.25 titles; see §2
+and `decisions.md`'s 2026-09-06 entry. Mono never used for chrome labels (retired pattern stays
+retired) is the one rule in this paragraph that survived both re-themes intact.
 
 **Space/shape:** 4px grid (`--space-1..9` = 4..64); radius 4 (controls) / 8 (panes, dialogs) / 999px pill (switch track);
 depth = `--edge` borders + surface steps; shadows only on floating layers (menu, popover, toast: `--shadow-overlay`; dialog/sheet: `--shadow-modal`; the tooltip stays border-only — too small to shadow).
@@ -90,7 +93,13 @@ during the re-theme, call sites that used `--surface-2` purely as a hover wash m
 `--hover-1`, so `--surface-2` now appears only on genuinely raised layers and as the neutral
 fill of small static elements (chip/badge neutral tone). Two border weights
 replace the old single `--edge`: `--edge` (hairline) and `--edge-strong` (control borders,
-overlay rings). `--ink-hi/mid/low` are unchanged in role. The four semantic families
+overlay rings). `--ink-hi`/`--ink-mid` are unchanged in role. `--ink-low` was raised on
+2026-09-06 until it clears 4.5:1 on `--surface-0` and `--surface-1` in both themes (4.7:1 and
+5.4:1 dark, 4.8:1 and 4.6:1 light, contract-tested), because 96 text rules were already setting
+it despite the token being documented for chrome. Its role did not change with the value: it is
+still placeholder, disabled and hairline-adjacent ink, and the quiet text a reader actually
+reads (speaker meta, thought summaries, the liveness line, rail section titles) moved up to
+`--ink-mid`. The four semantic families
 (`--attention`, `--alive`, `--danger`, `--accent`) keep their `-bg` (15% mix into the surface)
 and `-edge` (40% mix into the hairline border) companions, and each now also gets a `-ink`
 companion (`--attention-ink`, `--alive-ink`, `--danger-ink`, `--accent-ink`) for text usage.
@@ -114,15 +123,33 @@ blocks (§4, item 4).
 from the `@fontsource-variable/inter` / `@fontsource-variable/jetbrains-mono` npm packages,
 latin subset, `@font-face`-wired in `global.css` — no binaries committed);
 `--font-weight-regular/medium/semibold` (400/500/600); `--tracking-display` (−0.02em, display
-weight only — widened from −0.01em under IBM Plex); `--font-size-caption/ui/body/pane-title/
-page-title` (12/13/14/16/20px); `--line-height-body/title` (1.5/1.3). NEW: `--tracking-micro`
-(0.08em) backs the **micro-label pattern** — card/pane section headers set at 11.5–12px
-uppercase, `--font-weight-medium`, `--tracking-micro`, `--ink-low`/`--ink-mid`, usually on a
-`--surface-inset` band. It's applied through widget chrome (PaneScaffold titles are its one
-adopter today; Dialog keeps its full-size title on an inset band, and Card has no header slot),
-never per-page. This is a distinct pattern from the
-caption-size "section eyebrow" documented in §6 (0.04em tracking, for group labels like the
-rail's "Projects") — eyebrows label a *group*, micro-labels title a *container*.
+weight only — widened from −0.01em under IBM Plex);
+`--font-size-caption/ui/body/pane-title/page-title/display`
+(12/13/15/18/22/28px), with `--font-size-body` rising to 16px below 900px so no editable field
+sits under iOS Safari's zoom threshold; `--line-height-body/ui/title` (1.6/1.4/1.25). The six
+size steps are declared on `<body>` rather than `:root` because each is a `calc()` over
+`--font-scale`, and a custom property resolves that reference against the element it is declared
+on: the Settings → Theme font-size choice sets `--font-scale` on `<body>`, so the whole ramp
+scales together. `src/styles/measure.test.ts` pins the six steps and the phone body off disk.
+
+**The eyebrow recipe.** `--tracking-eyebrow` (0.06em) replaced `--tracking-micro` and the four
+other tracking values that were in use, and it is now THE uppercase tracking in the app. The
+recipe it backs is one rule with no variants: `--font-size-caption`, `--font-weight-medium` (or
+semibold where a header band wants more), `--ink-mid` or darker, `text-transform: uppercase`,
+`letter-spacing: var(--tracking-eyebrow)`, at most two words. It titles a container INSIDE a
+page (InspectorCard's header band, RecommendationCard's kicker, Table headers, the rail's
+section titles, the settings cluster headers) and it is NEVER a pane title: a PaneScaffold title
+is the page's own heading, set sentence-case at `--font-size-pane-title`, semibold, `--ink-hi`
+(§6). Literal `font-size` values outside `tokens.css`, `letter-spacing` outside the
+`--tracking-*` tokens, and any uppercase rule that is not a complete eyebrow are all enforced by
+`src/styles/token-contract.test.ts`.
+
+**Faces and figures.** Mono is for machine text and nothing else: code, paths, shell command
+summaries, diffs, and the identifiers in the Details panel. The chrome a reader looks at
+constantly stays on the sans face with `font-variant-numeric: tabular-nums`, which buys column
+alignment without switching faces: the model chip (`chrome/modelswitch.module.css:.value`), the
+status row's percent/clock/queue figures, the rail's relative ages, and the turn footer.
+`src/styles/faces.test.ts` pins those four rules off disk.
 
 **Space & shape** — `--space-1` through `--space-9` (4/8/12/16/24/32/40/48/64px — IBM Carbon
 Design System's own spacing progression, adopted because it's the only well-known scale that
@@ -131,6 +158,23 @@ grid; unchanged by the re-theme). Radii softened: `--radius-chip` (6px, NEW — 
 small tags), `--radius-control` (4px → 8px — buttons, inputs), `--radius-pane` (8px → 10px —
 panes, cards, dialogs), `--radius-pill` (999px, unchanged — switch track). Everything already on
 the two pre-existing tokens inherited the softer values for free.
+
+**Vertical rhythm** is four named steps over that same grid, so the transcript has a vocabulary
+for how far apart two things sit: `--rhythm-line` (4px, inside one item, an intent line above
+its call), `--rhythm-item` (8px, between items in a run of tool calls), `--rhythm-group` (16px,
+between a run and the next speaker header, and above a turn footer) and `--rhythm-exchange`
+(24px, above a user message). `src/styles/rhythm.test.ts` pins each step to the site that names
+it.
+
+**`--session-measure` is the app's one reading measure**: 44rem (704px, about 90 characters at
+15px, with room for a 100-column code block), declared on `<body>` and raised to 64rem under
+`<body data-transcript-measure="wide">`. Settings → Theme → Transcript width is what writes that
+attribute, through `stores/prefs.ts`. The transcript column, the composer, the cold start, the
+spawn form and the settings content all read the same token, so they widen together and can
+never drift apart the way a hand-copied literal did. The layoutguard case `transcript-measure`
+fails when a plain agent paragraph runs past 100 characters per line at 1440 or 1920, or when
+the column is not centred in its pane. Pane bodies pad `--space-5` on desktop and `--space-4`
+below 900px (`panescaffold.module.css`).
 
 **Motion** — `--motion-duration-attention` (200ms), `--motion-duration-overlay` (120ms),
 `--motion-duration-hover` (150ms, NEW — color/background/border/shadow transitions on
@@ -195,7 +239,7 @@ during implementation (noted inline); this table is the one to trust.
 | **StatusDot** | `{state: CadenceState}` | Just the dot (imports `CadenceState` from Cadence, doesn't redeclare it) — for tighter contexts than Cadence's full trace; carries its own accessible name since nothing else labels it standalone. |
 | **Meter** | `{label: string; value: number; max: number; tone?: "neutral"\|"attention"\|"alive"\|"danger"}` | `role="meter"`; `label` is required (not optional as an early sketch had it) since role=meter needs an accessible name and a Meter can't ship without one. Fill width via a `--fill` style custom property, not an inline style rule. |
 | **Skeleton** | `{lines?: number}` (default 3) | Static bars, no shimmer (honest-liveness rule) — announces "Loading" once for AT; bars themselves are decorative. |
-| **EmptyState** | `{title: string; hint?: string; action?: ReactNode}` | `action` is optional (an early plan sketch showed it required; a pane with nothing actionable — e.g. a read-only empty log — is an ordinary case, and every sibling slot-style prop this wave is optional, so this was kept optional as the more consistent, more correct shape). |
+| **EmptyState** | `{title: string; hint?: string; action?: ReactNode; size?: "default"\|"display"}` | `size="display"` sets the title at `--font-size-display` for the one pane whose empty state IS the page (Welcome); everything else keeps `--font-size-pane-title`. `action` is optional (an early plan sketch showed it required; a pane with nothing actionable — e.g. a read-only empty log — is an ordinary case, and every sibling slot-style prop this wave is optional, so this was kept optional as the more consistent, more correct shape). |
 | **Table** | `{columns: TableColumn<Row>[]; rows: Row[]; rowKey(row); sortKey?; sortDir?: "ascending"\|"descending"; onSortChange?; filters?: {key,label,active}[]; onFilterToggle?; empty?}` | Controlled sort + filter; semantic `<table>`, `aria-sort` on sortable headers, filter chips compose Chip, horizontal overflow scrolls inside the widget. Ported from Beautiful UI's Records/Filter Table. |
 | **DiffTable** | `{columns: {key,label}[]; rows: {key; cells: Record<string,{value; proposed?}>}[]}` | Tabular proposed edits: struck-through old value beside the new one on the neutral `--diff-add-bg` wash — same hue-gate exemption as DiffBlock. Ported from Beautiful UI's Diff Table. |
 | **Loader** | `{label?; startedAt?; now?}` | Indeterminate-wait indicator (pixel grid + mm:ss elapsed); prop-driven like Cadence, no internal timers. Its animation is the sanctioned exception for user-initiated waits — never agent liveness — and lives entirely inside the reduced-motion gate. Ported from Beautiful UI's Loading State. |
@@ -214,7 +258,7 @@ during implementation (noted inline); this table is the one to trust.
 | **Combobox** | `{options: T[]; onQuery; onPick; renderOption?; "aria-label"?; "aria-labelledby"?}` (generic over `T extends {id; label}`) | ARIA 1.2 combobox-with-listbox-popup; real focus never leaves the input. `aria-label`/`aria-labelledby` forward to BOTH the input and the popup listbox (fix-wave: the listbox had no name of its own — see §4) — they're two roles describing one picker, sharing one label source. Debounces `onQuery` 150ms. Never traps focus. |
 | **Menu** | `{trigger: ReactNode; items: {id; label; onSelect; disabled?}[]}` | Trigger + popup; roving tabindex among items (skipping disabled), no typeahead. Popup `role="menu"` gets `aria-labelledby` pointing at the trigger `<button>`'s own id (fix-wave — see §4). Traps focus (`FocusScope trap`). |
 | **Dialog** | `{open; onClose; title; children; footer?}` | Modal: centered, 120ms fade-scale, Escape/scrim-click close, trapped + restored focus. Shares its whole contract with Sheet via the internal `OverlayPanel`. |
-| **Sheet** | `{side?: "right"\|"bottom"; open; onClose; title; children; footer?}` | Same contract as Dialog (shared `OverlayPanel`); only geometry/slide-in animation differs. |
+| **Sheet** | `{side?: "right"\|"bottom"; open; onClose; title; children; footer?; bodyClassName?}` | Same contract as Dialog (shared `OverlayPanel`); only geometry/slide-in animation differs. `bodyClassName` lands on the sheet's own body element, which is how the sessions drawer renders the Rail flush inside the sheet instead of as a bordered box nested in a bordered box. |
 | **FocusScope** | `{trap?: boolean; children}` | The focus-management primitive Dialog/Sheet/Menu build on: moves focus in on mount, restores on unmount; traps Tab/Shift+Tab when `trap`. Does not (yet) set `inert` on anything outside the scope — see §4. |
 | **Tooltip** | `{label: string; children: ReactNode}` | Hover/focus-triggered, 300ms delay, hidden on touch via CSS. `aria-describedby` wired via `cloneElement` onto a single-element child — works for a native element or any widget that forwards a ref + spreads rest props (Button/IconButton both do, since the fix-wave in §4). |
 | **Toast** + `useToasts()` | `useToasts(): {push: (kind, text) => void}`; `<Toast/>` takes no props | Module-singleton queue (`useSyncExternalStore`), mounted once near the app root. 5s auto-dismiss, true pause/resume on hover (tracks remaining time, doesn't restart the full window — fix-wave, see §4). |
@@ -224,6 +268,21 @@ during implementation (noted inline); this table is the one to trust.
 | **DiffBlock** | `{unified: string}` | Per-line domain notation on already-diffed text (dedicated add/remove tints plus `+`/`−` markers); does not compute a diff itself. |
 | **Tree** | `{nodes: T[]; onActivate; onToggle; renderRow}` (generic over `T extends {id; children?; expanded?}`) | Keyboard-navigable (`role="tree"`), roving tabindex, Up/Down/Right/Left/Enter. Fully controlled — `renderRow(node, {depth, expanded, hasChildren, toggle, activate})` owns each row's visible content; Tree owns structure/ARIA/keyboard path only. |
 | **VirtualList** | `{count; estimateSize; renderRow; ref?: Ref<VirtualListHandle>}` | Wraps `@tanstack/react-virtual`; `ref` exposes `{scrollToIndex}` via the React 19 ref-as-prop pattern (not a `forwardRef` wrapper). Sizes come from `estimateSize` alone, no `measureElement`. |
+
+**ToolRunGroup is deliberately not a widget.** It lives at
+`src/panes/session/transcript/ToolRunGroup.tsx` with its own stylesheet, not under
+`src/widgets/`, because it is transcript grammar rather than a reusable primitive: no barrel
+entry, no gallery section. It is what finally renders principle 2 of the mockup brief
+(`decisions.md`, topic 06 Alt A). The rule, owned by `transcript/toolRuns.ts`: in a SETTLED
+turn, three or more consecutive completed, non-failed tool calls whose renderer does not declare
+`fold: "never"` collapse into one `<details>` row labelled `N steps · <last consequential
+summary>`. A descriptor with `fold: "consequential"` (the edit tools, shell, worktree) is a
+mutation, so it is the step the label names; `fold: "never"` (delegate, ask_user, task_list,
+use_skill, the `job_*` tools) never folds and always stays on its own row. A live turn never
+folds at all, and a failure, a call still in flight, an auto-expanding card or any non-tool entry
+breaks the run rather than being spanned by it. Disclosure state goes through the shared
+disclosure store, so a reader's choice survives re-projection and the transcript's
+expand-all/collapse-all baselines reach it; the body mounts only while open.
 
 ---
 
@@ -376,14 +435,22 @@ once: three caption labels shipped on `--font-mono` in the foundation task and w
 fixed in wave-close review — see git history for `gallery-section.module.css` and
 `theme-flip.module.css`. If it happened once, watch for it.)
 
-**Clarification (polish pass, 2026-07-24): small-caps *section eyebrows* are a sanctioned
-pattern, distinct from ALL-CAPS copy.** A short structural group label set in
-`--font-size-caption` + `--font-weight-medium` + `--ink-low` + `text-transform: uppercase` +
-`letter-spacing: 0.04em` (the rail's "Projects", settings' nav group headers, the palette's
-result-group headers, card kickers like "Mandate") is typographic hierarchy, not shouting —
-authored copy stays sentence-case in the source and the transform is presentation-only. The
-pattern is legitimate ONLY for grouping eyebrows at caption size; never for buttons, titles,
-sentences, or anything longer than ~2 words.
+**The eyebrow recipe (2026-09-06, replacing the 2026-07-24 "section eyebrow" clarification
+and the separate micro-label pattern it was distinguished from).** Small-caps *eyebrows* are a
+sanctioned pattern, distinct from ALL-CAPS copy: the copy stays sentence-case in the source and
+the transform is presentation-only. There is now exactly one recipe, one tracking token and one
+size for it: `--font-size-caption`, `--font-weight-medium` (or semibold where a header band
+wants more), `--ink-mid` or darker, `text-transform: uppercase`,
+`letter-spacing: var(--tracking-eyebrow)` (0.06em, which replaced a spread of
+0.02/0.04/0.05/0.08em), and **at most two words**. An eyebrow titles a container INSIDE a page:
+InspectorCard's header band, RecommendationCard's kicker, Table headers, the rail's section
+titles, the settings cluster headers. Three-word labels were the tell that the rule was being
+broken, so "Agents & models" became **"Agent setup"**.
+
+Never an eyebrow: buttons, sentences, and above all **titles**. A pane title is the page's own
+heading, sentence-case at `--font-size-pane-title`, semibold, `--ink-hi` (§2); a session title is
+the user's own prompt and is never transformed at all. Before this, both rendered as a 12px
+uppercase micro-label, which turned a whole prompt into a shouted sentence.
 
 ---
 
@@ -433,11 +500,12 @@ gap, a renderer's idea of what the daemon says drifting from what it actually
 says, is the failure mode this rule exists to prevent.
 
 **Why `--ink-mid` and not `--ink-low`.** Every other quiet system row uses
-`--ink-low`. Measured against `--surface-1` it is 2.97:1 in dark and 3.64:1 in
-light — under the 4.5:1 AA floor, as `usermessageitem.module.css` and
-`toolcallitem.module.css` both already record. A reader scanning steering is
-auditing which kind fired, so the kind is the payload rather than furniture, and
-it sits one ink step up at 6.86:1 / 6.56:1. That step also separates a steer
+`--ink-low`. Measured against `--surface-1` that token is 4.72:1 in dark and
+4.76:1 in light since the 2026-09-06 raise (§2), so it clears the 4.5:1 AA
+floor it used to sit under, but its role is still placeholder and
+hairline-adjacent chrome rather than text a reader is meant to read. A reader
+scanning steering is auditing which kind fired, so the kind is the payload rather than furniture, and
+it sits one ink step up at 6.51:1 / 5.84:1. That step also separates a steer
 from the lifecycle line beneath it by weight as well as by glyph.
 
 **The glyph is a hollow diamond, drawn as SVG rather than set as a character.**
@@ -580,8 +648,13 @@ as one control; read-only facts do not show a misleading caret. Use existing
 surface, edge, ink, spacing, and tap-size tokens. Do not introduce mobile-only
 colors, type tokens, chip backgrounds, or monospace labels.
 
-Editable text remains at least 16px on mobile so focusing a field does not
-trigger browser zoom. An auto-growing textarea has a real content-driven
+Editable text is 16px on phones, and it gets there through the ramp rather
+than per-field: `tokens.css`'s below-900px block sets `--font-size-body` to
+16px and every field takes the body size, so iOS Safari has nothing to
+auto-zoom into. That is what let the viewport meta stop locking zoom (WCAG
+1.4.4 resize text): `index.html` no longer carries
+`maximum-scale=1, user-scalable=no`, and `src/styles/viewport-pin.test.ts`
+fails if either comes back. An auto-growing textarea has a real content-driven
 minimum and maximum, keeps the resize behavior accessible, and reserves space
 for any pinned actions below it. The field remains the same semantic textarea
 and preserves keyboard submission, attachment, paste, and screen-reader
@@ -606,3 +679,13 @@ authoritative frame, terminal/error/cancel state, session change, or pending
 failure; it must never appear for an untouched empty session. Reuse the static
 `Skeleton` widget, keep its accessible loading status and decorative bars, and
 do not add shimmer, pulse, or other motion that implies live data.
+
+Below 700px both speaker rows become a grid rather than a flex row: the avatar
+and the speaker header share the first row and the prose spans the full pane
+underneath them, instead of being indented into the avatar's column for its
+whole height. Measured before this, agent prose got 260px of a 375px screen,
+28 characters a line.
+
+The sessions drawer renders the Rail flush inside the Sheet body (Sheet's
+`bodyClassName`, §3): no inner surface box, no inner radius, because the sheet
+already frames it.

--- a/docs/web-ui/design-system.md
+++ b/docs/web-ui/design-system.md
@@ -385,6 +385,21 @@ six independent checks:
    `2px var(--accent-edge)` ring for active typing — softer than a full `--focus-ring` but still
    present — and `widgets/dropzone/dropzone.module.css` keeps its dashed accent drag-target
    outline, which is drop-here signage, not a focus ring.
+7. **Every `var(--name)` without a fallback resolves to a declaration** somewhere under
+   `src/` (tokens.css or a module's own local property). Exempt: dockview's `--dv-*` and the
+   runtime-set names JS or an inline style declares (`--keyboard-inset`, `--rail-width`,
+   `--tap-min`, `--fill`, `--markdown-ink`, `--prose-font-size`, `--prose-ink`,
+   `--density-scale`, `--font-scale`). Four undefined tokens had shipped before this check
+   (`--radius-sm` twice, `--edge-hi`, `--font-size-title`), each silently falling back to the
+   property's initial value.
+8. **No literal `font-size` in px outside `tokens.css`.** Only `var(--font-size-*)`, `inherit`,
+   and relative units (`em`, `%`) are legal; inline code is sized relative to its line, which
+   is why `em` stays.
+9. **`letter-spacing` only through the two tracking tokens** (`--tracking-display`,
+   `--tracking-eyebrow`), `inherit`, or `normal`.
+10. **Uppercase means the eyebrow recipe.** Any rule block with `text-transform: uppercase`
+    must also declare `font-size: var(--font-size-caption)` and
+    `letter-spacing: var(--tracking-eyebrow)`, and must not set `color: var(--ink-low)`.
 
 Every mechanism above is poison-tested against hand-written snippets proving both what it
 catches and what it must not flag (see the test file itself) — not just asserted to work.

--- a/docs/web-ui/typography-spacing-critique-2026-09-06.md
+++ b/docs/web-ui/typography-spacing-critique-2026-09-06.md
@@ -1,10 +1,16 @@
 # Web UI typography, spacing and balance: critique and recommendations
 
-Status: **proposal**, 2026-09-06. Nothing here has shipped. It is the result of
-reading `design-system.md`, `decisions.md`, `ux-plan-2026-07.md`, the token
-and widget stylesheets under `cmd/evener-hub/frontend/src`, and measuring the
-running app (Vite dev server against a throwaway hub, a real glm-5.2-vision
-session, plus `/dev/surfaces`) at 1440×900 and 375×812 in both themes.
+Status: **implemented**, 2026-09-06, by
+`docs/superpowers/plans/2026-09-06-webui-typography-spacing.md` on branch
+`claude/evener-webui-typography-spacing-3d4fd4`; the decisions it settled,
+including the two earlier rulings it revises, are recorded in
+`decisions.md`'s 2026-09-06 entry. The measurements below are what the app
+looked like before that work, and are kept as the record of why. This
+document is the result of reading `design-system.md`, `decisions.md`,
+`ux-plan-2026-07.md`, the token and widget stylesheets under
+`cmd/evener-hub/frontend/src`, and measuring the running app (Vite dev
+server against a throwaway hub, a real glm-5.2-vision session, plus
+`/dev/surfaces`) at 1440×900 and 375×812 in both themes.
 
 Paths below are relative to `cmd/evener-hub/frontend/src/` unless they start
 with `docs/`.
@@ -332,6 +338,13 @@ disabled controls and hairline-adjacent chrome, which is what its comment says.
   side only, and it is the one recommendation here that is taste rather than
   measurement; it is the convention both major chat assistants converged on
   for long technical answers.
+
+As shipped: agent prose as a document is being applied in this same PR by
+the stream that owns that stylesheet, so the bubble wash is not yet gone
+at the commit this status line was written against. The run label grammar
+shipped as `N steps · <last consequential summary>` rather than the
+sketched "Read 4 files, edited 2 · 1.8s": the count and the consequential
+step survived, the per-run duration did not.
 
 ### R10. Enforce it the way colour is enforced
 

--- a/docs/web-ui/typography-spacing-critique-2026-09-06.md
+++ b/docs/web-ui/typography-spacing-critique-2026-09-06.md
@@ -339,9 +339,9 @@ disabled controls and hairline-adjacent chrome, which is what its comment says.
   measurement; it is the convention both major chat assistants converged on
   for long technical answers.
 
-As shipped: agent prose as a document is being applied in this same PR by
-the stream that owns that stylesheet, so the bubble wash is not yet gone
-at the commit this status line was written against. The run label grammar
+As shipped: agent prose is a document (`agentmessageitem.module.css`, the
+`.bubble` wrapper keeps only its layout role; recorded in `decisions.md`'s
+2026-09-06 entry). The run label grammar
 shipped as `N steps · <last consequential summary>` rather than the
 sketched "Read 4 files, edited 2 · 1.8s": the count and the consequential
 step survived, the per-run duration did not.

--- a/docs/web-ui/typography-spacing-critique-2026-09-06.md
+++ b/docs/web-ui/typography-spacing-critique-2026-09-06.md
@@ -1,0 +1,376 @@
+# Web UI typography, spacing and balance: critique and recommendations
+
+Status: **proposal**, 2026-09-06. Nothing here has shipped. It is the result of
+reading `design-system.md`, `decisions.md`, `ux-plan-2026-07.md`, the token
+and widget stylesheets under `cmd/evener-hub/frontend/src`, and measuring the
+running app (Vite dev server against a throwaway hub, a real glm-5.2-vision
+session, plus `/dev/surfaces`) at 1440×900 and 375×812 in both themes.
+
+Paths below are relative to `cmd/evener-hub/frontend/src/` unless they start
+with `docs/`.
+
+## Overall impression
+
+The system is disciplined and the reading experience is still poor. Those two
+facts are not in tension: the discipline is about *tokens* (no literals, AA
+contract, one focus ring, a 4px grid), and it is real and worth keeping. The
+poverty is about *hierarchy*, *measure* and *rhythm*, which no token contract
+enforces. Every screen is set in the same three sizes (12, 13, 14px), demoted
+only by ink, in one line-height, at whatever width the pane happens to be.
+The result reads as a flat grey list on desktop, and the phone gets the same
+list with the text made smaller by a wasted gutter.
+
+The biggest single opportunity is the transcript: it is the product's reading
+surface and it is currently set like a dashboard sidebar.
+
+## What was measured
+
+| Fact | Value | Where |
+|---|---|---|
+| Type ramp | 12 / 13 / 14 / 16 / 20 px, body 14 | `styles/tokens.css:336-343` |
+| Line heights | 1.5 body, 1.3 title, nothing else | `styles/tokens.css:137-138` |
+| Explicit `font-size` declarations by token | caption 208, ui 132, body 31, pane-title 9, page-title 2 | grep over `src/**/*.css` |
+| Literal (off-ramp) sizes | 9px ×1, 10.5px ×1, 11px ×8, 11.5px ×2, 12px ×2, 13px ×2, 16px ×2 | see §Bugs |
+| Transcript measure | `--session-measure: 76rem` = 1216px | `panes/session/transcript/turnblock.module.css:15` |
+| Agent prose line length, 1440 viewport, plain paragraph | **149 characters/line** (bubble 1087px, 14px Inter) | measured in `/dev/surfaces` |
+| Agent prose line length, real session, 1440 | bubble 1005px, ~125 chars/line | measured live |
+| Agent prose width, 375 viewport | **260px of 375** (69% of the screen), 28 chars/line | measured live |
+| Composer field | 13px, 1108px wide on desktop, 13px on the phone | `widgets/textarea/textarea.module.css:17` |
+| Pane title | 12px, uppercase, 0.08em tracking, `--ink-mid` | `widgets/panescaffold/panescaffold.module.css:24-37` |
+| Session pane title after turn 1 | the whole prompt, set in that 12px uppercase micro-label | observed: "CREATE A SMALL PYTHON SCRIPT NAMED FIZZBUZZ.PY IN THIS DIRECTORY THAT PRINTS…" |
+| `text-transform: uppercase` sites | 21 | grep |
+| Tracking values in use | −0.02em, 0.02em ×4, 0.04em ×5, 0.05em ×2, 0.08em ×7 | grep |
+| `color: var(--ink-low)` on text | 96 declarations; `--ink-low` computes to 3.08:1 dark / 3.51:1 light on `--surface-1` today (the repo's comments record 2.97 / 3.64 from an earlier palette) | WCAG ratio computed from `tokens.css` values |
+| Spacing discipline | 662 token uses vs 48 raw px | grep |
+| Breakpoints | 899px ×22, 900px ×3, 700px ×5, 559, 520, 479, 399, 34rem | grep |
+| Rail | 280px; quiet row 28px, signal row 38px; label 13px; brand 12px `--ink-mid` | `shell/rail/*.module.css`, `widgets/tree/tree.module.css` |
+| Spawn form | 720px, left-pinned inside a 1160px pane at 1440 (440px dead) | `panes/spawn/spawn.module.css:5` |
+| Undefined tokens referenced | `--radius-sm` ×2, `--edge-hi`, `--font-size-title` | see §Bugs |
+
+## Findings
+
+### 1. The ramp has no hierarchy in it (🔴)
+
+Five steps with a ratio of about 1.08 between them is not a scale, it is one
+size with rounding error. Body 14px is the largest text most people ever see;
+16px appears on nine rules and 20px on two. Then 340 of 382 explicit size
+declarations pick *caption* or *ui*, so almost everything on screen is 12 or
+13px. The design law says "quiet through ink, never size" (`thinkblock.module.css`
+header), and that is a fine rule for demoting a thought below its answer. It
+cannot do the other job, which is giving the eye landmarks: a speaker header
+at 14px/500 next to body at 14px/400 is a landmark only if you are already
+looking for it.
+
+Markdown inside agent prose has the same problem one level down: `h3` is body
+size (`widgets/markdown/markdown.module.css:47-49`), `h2` is 16px against 14px
+body. A heading in an agent's answer is nearly invisible.
+
+### 2. Line length is unbounded on desktop and starved on the phone (🔴)
+
+`--session-measure` is 76rem. The root font-size is 16px, so the column is
+1216px, wider than the pane at 1440 and effectively full-bleed. A plain
+paragraph measures 149 characters per line; the comfortable range is 45–75,
+and chat products that must also show code settle around 90–100 in a ~48rem
+column. Nothing in the app currently bounds prose at all: the bubble's
+`max-width: 92%` is 92% of whatever the pane is.
+
+On the phone the opposite happens. The opener message is a flex row of avatar
++ column (`agentmessageitem.module.css:.opener`), the column gets the bubble at
+92%, and the bubble has 24px of its own padding, so prose gets 260px of a
+375px screen. 28 characters per line is below the mobile floor (35–45), and
+the left third of the screen is empty below the avatar.
+
+### 3. Vertical rhythm has one step (🔴)
+
+Message rows pad 4px, tool calls pad 8px, and the only deliberate rhythm cue in
+the transcript is "8px between calls vs 0 inside a call" (`toolcallitem.module.css`
+header comment). The 2026-07-30 ruling against "dead air" at exchange boundaries
+(`usermessageitem.module.css` header) removed the last larger step. With 149-char
+lines and 4px gaps there is now nothing between a user message and the previous
+turn's footer except a 24px avatar. Principle 2 of the brief, folding a run of
+finished tool calls into one line, is recorded as "ABSENT, unexplained" in
+`decisions.md` topic 06; its absence is most of why a working session reads as
+a column of identical rows.
+
+### 4. Micro-labels are doing a heading's job (🟡)
+
+The Beautiful UI micro-label (11.5–12px, uppercase, 0.08em) was ported as the
+*pane title*. On a dashboard card that pattern labels a container that sits
+inside a page with a real heading. Here the pane is the page, so the page's
+title is its smallest text: "START AN AGENT", "GENERAL", "THEME". Once a
+session has a title, that title is the user's whole prompt, and it renders in
+the same uppercase micro-label, which `design-system.md` §6 explicitly forbids
+("never for … sentences, or anything longer than ~2 words"). Both
+"START AN AGENT" and "AGENTS & MODELS" are three words. The frontend-design
+brief lists tracked-out all-caps eyebrows above every heading as the commonest
+tell of a templated page; this UI has 21 of them and four different tracking
+values.
+
+### 5. Mono leaks into chrome (🟡)
+
+Principle 7 (mono only for machine text) is mostly honoured, but the places it
+leaks are the ones you look at constantly: the model id in the status row and
+composer chip (`chrome/modelswitch.module.css:.value`), the effort/model pair
+in the spawn card ("(default) ˅ · (default)" reads like debug output), and the
+rail's relative timestamps (`RailRow.module.css:.time`). Tabular figures in the
+sans face (`font-variant-numeric: tabular-nums`, used on 3 rules today) give
+alignment without switching faces.
+
+### 6. The three rail icons are not in the font (🟡)
+
+`Rail.tsx:1408-1427` renders ⚙ ⌕ ☰ as text. `global.css` subsets Inter to Latin
+(the same reason `SteeringGlyph` is drawn as SVG, per `design-system.md` §7),
+so these three glyphs come from whatever system fallback has them, at whatever
+stroke weight it has. They sit next to SVG chevrons and the SVG open-box icon.
+
+### 7. `--ink-low` is a text colour in practice (🟡)
+
+The token is documented for "placeholders, disabled, timestamps" and measured
+under AA. It is nonetheless the colour of 96 text rules: rail section titles,
+speaker meta, thought summaries, the liveness line, hints, "Configured plugins:
+none", the welcome chord hints. Most of those are 12px too, so the two
+demotions compound. `decisions.md` topic 01 records the rule "dimmest tone is
+hairline-and-chrome, never body text" as LIVE; the grep says otherwise.
+
+### 8. Desktop balance (🟡)
+
+- Spawn: a 720px form pinned to the left edge of a 1160px pane, under a
+  12px uppercase title. The phone version of this same form has a real
+  heading ("What should the agent do?", 16px/600) and a subtitle; desktop
+  hides both (`spawn.module.css:.mobilePromptIntro { display: none }`). The
+  phone found the right answer and desktop does not use it.
+- Settings: a 200px nav and an unbounded content column, so label/value
+  hairlines span 900px+ at 1440 and read as a spreadsheet.
+- Session: the transcript column is centred at 1216px, which at 1440 with a
+  280px rail is wider than the pane, so it is not centred at all; at 1920 it
+  would suddenly be. The composer aligns to the same literal.
+- The pane body padding is 16px at every width. At 1440 that is tight against
+  a 1px hairline; the panes read as browser default margins.
+
+### 9. Mobile (🟡, with one 🔴)
+
+- 🔴 The session composer is 13px on the phone (only the spawn textarea gets
+  16px, `spawn.module.css:332`), and `index.html` sets
+  `maximum-scale=1, user-scalable=no` to stop iOS zooming into it. That
+  disables pinch-zoom for the whole app (WCAG 1.4.4). The fix is a 16px
+  field, not a viewport lock.
+- The spawn pane's top-bar title is the string "new" (`Spawn.tsx:860`,
+  `mobileTitle="new"`): a route slug as a title.
+- The spawn placeholder repeats the heading and subtitle above it almost
+  word for word.
+- The Sessions drawer renders the rail as an inset box inside the Sheet (a
+  darker rounded panel with the brand row and button in it, then a second
+  box for the tree) even though `Rail.module.css` says the mobile rail should
+  fill the sheet flush.
+- The rail's empty state says "Start a session from the command line to see
+  it here" directly under a "+ New session" button.
+- Agent prose at 260px wide (finding 2).
+
+### 10. What works
+
+- Token discipline: 93% of spacing declarations use the grid, no colour
+  literals outside `tokens.css`, one focus ring, contract-tested AA for the
+  `-ink` hues, a real z ladder. Keep all of it; the recommendations below
+  are token *values* and a few new tokens, so the machinery carries them.
+- The mobile spawn form (`MobileSettingRows.module.css`): 48px rows, 16px
+  labels, sentence case, one chevron. It is the best-set screen in the app
+  and the template for the rest of mobile.
+- The rail's signal rows: amber "home · your move" under the title is exactly
+  the kind of quiet, worded state the brief asked for.
+- Inline code as an underline rather than a chip; italic intent lines on tool
+  rows; the `corner-shape: squircle` progressive enhancement.
+
+## Recommendations
+
+Ordered by what a reader gains. Each is scoped so it can be one PR.
+
+### R1. Cut a real type ramp, and set the body at 15px (desktop) / 16px (phone)
+
+Proposed `tokens.css` body block, ratio ≈ 1.2 with a 4px line grid:
+
+```css
+body {
+  --font-scale: 1;
+  --font-size-caption: calc(12px * var(--font-scale));    /* timestamps, meta */
+  --font-size-ui: calc(13px * var(--font-scale));         /* dense chrome: rail rows, status row, tables, chips */
+  --font-size-body: calc(15px * var(--font-scale));       /* prose, composer, forms, settings values */
+  --font-size-pane-title: calc(18px * var(--font-scale)); /* pane/sheet/dialog titles, sentence case, 600 */
+  --font-size-page-title: calc(22px * var(--font-scale)); /* settings section headings, spawn heading */
+  --font-size-display: calc(28px * var(--font-scale));    /* welcome hero only */
+  --line-height-ui: 1.4;      /* 13px → 18px */
+  --line-height-body: 1.6;    /* 15px → 24px, on the grid */
+  --line-height-title: 1.25;
+}
+@media (max-width: 899px) {
+  body { --font-size-body: calc(16px * var(--font-scale)); }
+}
+```
+
+Buttons and inputs stay at `--font-size-ui` in their 24/28/32px boxes, so no
+control geometry changes. Markdown headings become 22 / 18 / 15-semibold, so an
+`h3` in agent prose is finally distinguishable from a paragraph. The existing
+S/M/L/XL preference keeps scaling the whole ramp.
+
+Why 15 and not 14: Inter at 14px on a 1440 display is a settings-dialog size.
+Reading products that also carry code (GitHub, Slack, Linear's content views,
+both major chat assistants) sit at 15–16. The `ux-plan-2026-07` note that "it
+is not typography" was about *information* the old build showed; it did not
+find the current sizes good, only more consistent.
+
+### R2. Bound the measure
+
+```css
+--session-measure: 44rem;        /* 704px: ~90 chars at 15px, room for a 100-col code block */
+--session-measure-wide: 64rem;   /* opt-in "Wide transcript" preference, same Theme section as density */
+```
+
+Apply it to `.turn`, the composer `.measure` and `.coldStart` (they already
+share the literal), drop the bubble's `max-width: 92%` in favour of 100% of
+the column, and centre the column with `margin-inline: auto` so it is centred
+at every width rather than only above 1500px. Add a layoutguard case that
+fails when a plain paragraph exceeds 100 characters per line at 1440 and 1920.
+
+On the phone, below 700px, let the opener bubble span the pane: keep the
+avatar in the header row but make `.column` start at the pane edge (a
+`grid-template-columns: auto 1fr` with the bubble on the full second row).
+That returns ~70px to prose and lifts it to ~38 characters per line.
+
+### R3. Rebuild the rhythm on four steps
+
+Name them so the transcript has a vocabulary for "how far apart":
+
+```css
+--rhythm-line: var(--space-1);   /* 4: inside one item (intent → call) */
+--rhythm-item: var(--space-2);   /* 8: between items in a run */
+--rhythm-group: var(--space-4);  /* 16: between a run and the next speaker header, above a turn footer */
+--rhythm-exchange: var(--space-5); /* 24: above a user message */
+```
+
+This revisits the 2026-07-30 "no dead air" ruling. That ruling was made when
+messages had no bubbles and a 14px header; the header alone cannot mark a
+boundary when lines are 100+ characters. 24px above a user message, with the
+new column width, is not dead air, it is a paragraph break. Pane body padding
+goes to `--space-5` on desktop, `--space-4` on the phone. Rail rows go to 32px
+quiet / 44px signal with `--space-5` between sections.
+
+### R4. Give panes a heading and demote micro-labels back to cards
+
+`PaneScaffold` title becomes `--font-size-pane-title`, 600, sentence case,
+`--ink-hi`, with the cadence beside it. Session titles (a user sentence) render
+at `--font-size-body`, 500, truncated, never transformed. The micro-label
+stays for `InspectorCard`, `RecommendationCard`, `Table` headers and the
+Dialog header band, where it labels a container inside a page.
+
+Collapse the eyebrow spread to one token and one rule:
+
+```css
+--tracking-eyebrow: 0.06em;   /* replaces 0.02 / 0.04 / 0.05 / 0.08 */
+```
+
+12px, 500, uppercase, `--ink-mid` (not `--ink-low`), two words maximum,
+enforced by the copy rule in §6 and a test that every `text-transform:
+uppercase` rule sits on a class named `eyebrow` or `microLabel`. Rename
+"Agents & models" to "Models", "Start an agent" to "New session", so the
+labels that remain fit the rule.
+
+### R5. Faces and figures
+
+- Model: show the catalog display name in sans ("GLM 5.2 Vision"); the
+  qualified id goes in the tooltip and the Details sheet. Effort in sans.
+- Rail timestamps and turn-footer figures: sans with
+  `font-variant-numeric: tabular-nums`. Mono stays for code, paths, shell
+  summaries, diffs, and identifiers in Details.
+- Replace ⚙ ⌕ ☰ with 16px SVG icons through `IconButton`, matching
+  `widgets/chevron` and `OpenIcon` stroke.
+
+### R6. Raise `--ink-low` until it is readable, then stop using it for reading
+
+Dark `#6C6F75` → `#8A8E95` computes to 4.72:1 on `--surface-1`, 5.40:1 on
+`--surface-0`, and 3.89:1 on the pressed/selected wash `--hover-2`. Light
+`#86898F` → `#6F737A` computes to 4.76:1 on white, 4.57:1 on `--surface-0`,
+3.91:1 on `--hover-2`. So the raised value fixes resting text but not text
+that stays `--ink-low` on a selected row; those sites (rail row timestamps,
+palette result meta) need `--ink-mid` regardless. The contract test in
+`styles/token-contract.test.ts` is the authority; add `--ink-low` to its
+AA-pair checks against `--surface-0/1` when the value changes. Then move the
+most-read sites (speaker meta, thought summary, rail section titles, liveness
+line) to `--ink-mid` anyway, so `--ink-low` is left with placeholders,
+disabled controls and hairline-adjacent chrome, which is what its comment says.
+
+### R7. Desktop layout balance
+
+- Spawn: centre the form (`margin-inline: auto`), show the heading and
+  subtitle on desktop at `--font-size-page-title` / body, stack the directory
+  card, prompt card and options with `--space-5`, and drop the uppercase pane
+  title once the heading exists.
+- Settings: cap the content column at 44rem, or render label/value pairs as a
+  two-column definition list with a 160px label column; section title at
+  `--font-size-page-title`.
+- Welcome: the display size for one line, the two buttons, and the chord hints
+  as a small two-column table instead of three centred rows.
+
+### R8. Mobile specifics
+
+- Session composer at 16px on the phone; then remove `maximum-scale=1,
+  user-scalable=no` from `index.html`.
+- `mobileTitle="New session"`; remove the duplicated placeholder copy.
+- Drawer: render the Rail flush inside the Sheet body (no inner surface box,
+  no inner radius); the sheet already frames it.
+- Rail empty-state copy: "No sessions yet. Start one above." or nothing.
+- Keep 44/48px targets as they are; they are already right.
+
+### R9. Transcript grammar (larger, already in the design law)
+
+- Fold a run of finished, non-failing tool calls into one row that names the
+  consequential step and the count ("Read 4 files, edited 2 · 1.8s"), expanding
+  to the rows. This is principle 2 and `decisions.md` topic 06 Alt A; nothing
+  in the rhythm work above substitutes for it.
+- Agent prose as a document, not a bubble: with the column bounded (R2), the
+  neutral wash behind agent text stops doing any work and mostly adds a slab.
+  Keep the accent wash for the user's own words, which are short and benefit
+  from a shape. This reverses the 2026-07-30 bubble decision for the agent
+  side only, and it is the one recommendation here that is taste rather than
+  measurement; it is the convention both major chat assistants converged on
+  for long technical answers.
+
+### R10. Enforce it the way colour is enforced
+
+Extend `styles/token-contract.test.ts`:
+
+1. Every `var(--name)` without a fallback must resolve to a declaration
+   somewhere under `src/`. This would have caught the four undefined tokens
+   in §Bugs.
+2. No literal `font-size: <n>px` outside `tokens.css`.
+3. `letter-spacing` only through `--tracking-*` tokens.
+4. `text-transform: uppercase` only on a class whose name contains `eyebrow`
+   or `microLabel`.
+
+Add a `/dev/type` specimen route beside `/dev/widgets`: the ramp, the four
+rhythm steps and a 100-character paragraph at each measure, in both themes,
+so a ramp change is reviewed as a picture rather than a diff.
+
+## Bugs found on the way
+
+| Site | Problem |
+|---|---|
+| `panes/session/composer/composer.module.css:65` | `var(--radius-sm)` is not a token; the attachment tile renders square |
+| `panes/session/composer/currentwork.module.css:81` | same `--radius-sm` |
+| `panes/session/composer/currentwork.module.css:72` | `var(--edge-hi)` is not a token; the link underline falls back to full ink |
+| `panes/spawn/MobileSettingRows.module.css:57` | `var(--font-size-title)` is not a token; the caret gets the UA default 16px by accident |
+| `panes/session/transcript/messages/steeringitem.module.css:72` | 9px text |
+| `panes/session/transcript/tools/delegateStatus.module.css` | 10.5, 11, 11.5, 12, 13px literals (nine rules), a private ramp |
+| `panes/session/chrome/activitypanel.module.css:127,190,201,214` | 11px literals |
+| `panes/session/composer/composer.module.css:128` | 11px literal, mono, on the image dimensions overlay |
+| `widgets/panescaffold` + session title | a whole sentence rendered as an uppercase micro-label (§6 violation) |
+| `shell/rail/Rail.tsx:1408-1427` | text-glyph icons outside the subsetted font |
+| `index.html` viewport meta | pinch-zoom disabled app-wide |
+
+## Suggested order
+
+1. Bugs + R5 + R6 + R8 copy fixes: small, token-level, no layout risk.
+2. R1 + R2: the ramp and the measure, one PR, verified by the layoutguard
+   sweep at 390/700/1024/1400 plus a new 1920 leg.
+3. R3 + R4 + R7: rhythm, pane headings, spawn/settings layout.
+4. R9: tool-call clustering and the agent-side bubble, each with its own spec
+   since both touch recorded decisions.
+5. R10 alongside 2, so the ramp cannot fragment again.


### PR DESCRIPTION
## Why

The web hub's type, spacing and balance were measured against the running app (1440 and 375, both themes, a real glm-5.2-vision session and the `/dev/surfaces` fixtures). The findings are in `docs/web-ui/typography-spacing-critique-2026-09-06.md`; the headline numbers:

| Before | Measured |
|---|---|
| Type ramp | 12/13/14/16/20, with 340 of 382 size declarations at 12–13px |
| Agent prose line length at 1440 | **149 characters per line** (76rem column, 92% bubble) |
| Agent prose width on a 375px phone | **260px of 375** (28 characters per line) |
| Pane titles | 12px uppercase micro-labels; a session's prompt rendered as an uppercase sentence |
| `--ink-low` (96 text rules) | 3.1:1 dark / 3.5:1 light |
| Phone composer | 13px, with pinch-zoom disabled app-wide to hide it |
| Undefined tokens / off-ramp literal sizes | 4 / 18 (including 9px text) |

## What changed

Each commit is one task of `docs/superpowers/plans/2026-09-06-webui-typography-spacing.md`; every value lands in `tokens.css` and flows through the existing token contract.

- **Ramp**: 12 caption / 13 ui / **15 body (16 on phones)** / 18 pane-title / 22 page-title / 28 display; line-heights 1.6 body, 1.4 ui, 1.25 title.
- **Measure**: `--session-measure: 44rem` on `body` (704px, ~90 characters), shared by the transcript column, composer, cold start, spawn form and settings content; **Settings → Theme → Transcript width** (Reading / Wide, 64rem). Bubbles are bounded by the column, not 92% of the pane. Below 700px both speaker rows become a grid so prose spans the phone under the avatar row.
- **Rhythm**: `--rhythm-line/-item/-group/-exchange` (4/8/16/24). 24px above each user message (revises the 2026-07-30 "no dead air" ruling, now that the column is bounded), 8px between calls, a group step above turn footers; pane bodies pad 24px on desktop.
- **Headings and eyebrows**: pane titles are 18px semibold sentence case. One uppercase recipe (`--tracking-eyebrow` 0.06em, caption size, `--ink-mid`) replaces four tracking values across 21 rules; "Agents & models" → "Agent setup".
- **Tool-call runs fold**: in a settled turn, 3+ consecutive completed, non-failed quiet tool calls collapse to one row ("3 steps · Read fizzbuzz.py"), named by the last consequential step (edit/shell/worktree); delegate, ask, task, skill and job cards never fold. Principle 2 of the brief, recorded as ABSENT since the rewrite.
- **Agent prose as a document**: no wash behind agent paragraphs (user messages keep their accent bubble). Revises the 2026-07-30 bubble decision for the agent side only.
- **Faces and figures**: model chip, status figures, rail ages and turn footers are sans with tabular figures; mono stays for code, paths, shell and diffs. Rail icons are SVG (the ⚙ ⌕ ☰ glyphs were outside Inter's Latin subset).
- **Contrast**: `--ink-low` is 4.7:1 dark / 4.8:1 light on the pane surfaces; the most-read meta moved to `--ink-mid`.
- **Mobile**: 16px fields, pinch-zoom re-enabled (WCAG 1.4.4), "New session" title, flush sessions drawer, duplicated placeholder copy removed.
- **Desktop balance**: centred spawn form with its "What should the agent do?" heading at every width; settings content capped at the measure; display-size welcome with a two-column chord list.
- **Bugs**: `--radius-sm` ×2, `--edge-hi`, `--font-size-title` resolved; 18 literal sizes moved onto the ramp.
- **Enforcement**: `token-contract.test.ts` now fails on undefined tokens, literal `font-size` px, non-token `letter-spacing`, and uppercase rules missing the eyebrow recipe; `measure/rhythm/faces.test.ts` pin the values; layoutguard cases `transcript-measure` (≤100 characters per line and a centred column at 1440/1920) and `transcript-measure-phone` (opener prose spans ≥85% of a 375px pane), both mutation-verified.
- **Docs**: `design-system.md` §1/§2/§3/§6/§11 updated; `decisions.md` gains a 2026-09-06 entry; `/dev/type` renders the ramp, leading, eyebrow, rhythm and both measures in both themes.

## After

Measured on this branch: agent prose 90 characters per line at 1440 in a 704px centred column; 34–39 on a 375px phone spanning the full pane; composer 15px desktop / 16px phone; every uppercase rule is the one recipe.

## How to review

- `/dev/type` for the ramp and measures side by side in both themes.
- Settings → Theme → Transcript width.
- A session with three read-only tool calls in one turn shows the folded run row; a failed or live call never folds.
- `make test-web` and `make test-web-browser` both pass (the browser guards include the two new layoutguard cases).
