### PR TITLE
fix(execenv): make the glob listing and match budgets real bounds

### DIFF
--- a/agent/cov_s3_shelltools_test.go
+++ b/agent/cov_s3_shelltools_test.go
@@ -3,8 +3,10 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -189,5 +191,58 @@ func TestS3Cov_GlobTool_FullyExcludedResultExplainsRatherThanEmpties(t *testing.
 	}
 	if !strings.Contains(res.Output, "index.js") {
 		t.Fatalf("expected include_ignored=true to find the match, got: %q", res.Output)
+	}
+}
+
+// TestS3Cov_GlobTool_TruncationNoteNamesTheCapWithoutDroppingMatches proves
+// the glob tool boundary surfaces GlobBudgeter's truncation (#497): when a
+// glob call hits the match cap, the tool result must still contain every
+// match collected before the cap tripped *and* say the listing was capped,
+// so a model cannot mistake a partial result for the whole answer. A bare
+// strings.Join(matches, "\n") is indistinguishable from an uncapped result,
+// which is exactly the failure mode this guards against.
+//
+// This drives the real environment rather than a fake: GlobBudget's
+// truncation accounting is only ever mutated from inside package execenv, so
+// a fake outside it has no way to make a caller-supplied budget report
+// truncation without actually tripping the walk. Not parallel: it lowers
+// execenv's package-level match cap for its duration.
+func TestS3Cov_GlobTool_TruncationNoteNamesTheCapWithoutDroppingMatches(t *testing.T) {
+	dir := t.TempDir()
+
+	const capAt = 7
+	const fileCount = capAt + 3
+	names := make([]string, fileCount)
+	for i := range names {
+		// Digit-free names: the cap-number assertion below must be satisfiable
+		// only by the note, never by a filename that happens to contain the
+		// cap's digits.
+		names[i] = fmt.Sprintf("match%c%c.txt", 'a'+i/26, 'a'+i%26)
+		if err := os.WriteFile(filepath.Join(dir, names[i]), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(execenv.SetMaxGlobMatchesForTesting(capAt))
+
+	s := newSession(t, withDir(dir))
+	res := s3cov_exec(t, s, "glob", `{"pattern":"*.txt","path":"."}`)
+	if res.IsError {
+		t.Fatalf("glob error: %v", res.Output)
+	}
+	// The note is a separate section after a blank line, so splitting there is
+	// what tells "matches plus a note" apart from a bare match list. Asserting
+	// on the whole output instead would let a match list with no note at all
+	// satisfy every check below.
+	matchList, note, hasNote := strings.Cut(res.Output, "\n\n")
+	if !hasNote || strings.TrimSpace(note) == "" {
+		t.Fatalf("truncated glob result carries no note, so a model cannot tell truncation happened: %q", res.Output)
+	}
+	for _, name := range names[:capAt] {
+		if !strings.Contains(matchList, name) {
+			t.Fatalf("truncated glob result dropped match %q: %q", name, res.Output)
+		}
+	}
+	if !strings.Contains(note, strconv.Itoa(capAt)) {
+		t.Fatalf("the truncation note does not name the cap (%d): %q", capAt, note)
 	}
 }

--- a/agent/execenv/execenv.go
+++ b/agent/execenv/execenv.go
@@ -178,6 +178,22 @@ type ExecutionEnvironment interface {
 type GlobExcluder interface {
 	// GlobWithExclusions behaves like Glob but also returns the number of
 	// candidate matches dropped by the default dotfile/gitignore exclusion
-	// (always 0 when includeIgnored is true).
+	// (always 0 when includeIgnored is true). A listing that would have been
+	// truncated by the match cap comes back as an error instead of a short
+	// list: this entry point has no budget of its own to report truncation
+	// through, so a caller that wants the partial list and a way to tell it
+	// was cut short uses GlobBudgeter instead.
 	GlobWithExclusions(ctx context.Context, pattern, basePath string, includeIgnored bool) (matches []string, excluded int, err error)
+}
+
+// GlobBudgeter is an optional capability an ExecutionEnvironment's Glob may
+// additionally implement, modelled on GlobExcluder for the same reason: it
+// exists so a caller that wants a truncated listing rather than the refusal
+// GlobExcluder gives does not have to widen Glob's own signature, which every
+// implementation — including test doubles with no budget accounting — would
+// otherwise have to grow a meaningless extra parameter for. The caller
+// supplies the budget and reads what the call had to cut off it once the
+// call returns.
+type GlobBudgeter interface {
+	GlobWithBudget(ctx context.Context, pattern, basePath string, includeIgnored bool, budget *GlobBudget) (matches []string, excluded int, err error)
 }

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -1,0 +1,420 @@
+package execenv
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"primeradiant.com/evener/agent/sandbox"
+)
+
+// stubMaxGlobDirListings lowers the directory-listing budget for a test and
+// restores it when the test ends, so a budget test can use a tree small
+// enough for t.TempDir() rather than one large enough to trip the real bound.
+func stubMaxGlobDirListings(t *testing.T, n int) {
+	t.Helper()
+	orig := maxGlobDirListings
+	maxGlobDirListings = n
+	t.Cleanup(func() { maxGlobDirListings = orig })
+}
+
+// stubMaxGlobMatches lowers the match-count budget for a test and restores it
+// when the test ends.
+func stubMaxGlobMatches(t *testing.T, n int) {
+	t.Helper()
+	orig := maxGlobMatches
+	maxGlobMatches = n
+	t.Cleanup(func() { maxGlobMatches = orig })
+}
+
+// globBudgetFixture builds a t.TempDir() tree of n sibling directories, each
+// holding one leaf.txt and one leaf.md, so tests can glob for one extension,
+// both extensions, or count total directories without rebuilding the tree.
+func globBudgetFixture(t *testing.T, n int) (root string) {
+	t.Helper()
+	root = t.TempDir()
+	for i := range n {
+		dir := filepath.Join(root, fmt.Sprintf("dir%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "leaf.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "leaf.md"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// TestGlobStopsAtTheDirectoryListingBudgetWithFileIdentity is the unit-scale
+// reproduction of #497: maxUnidentifiedGlobDirs only ever counted directories
+// whose FileInfo carries no file identity, but ext4/APFS/HFS+ give every
+// directory (dev, ino) identity, so the bound was unreachable on a real
+// filesystem. A `**` glob rooted at a huge real directory tree (like `/`) had
+// termination (the ancestor/SameFile cycle check) but no bound on the work or
+// memory it could spend getting there. This proves the bound now counts every
+// listing, not only identity-less ones — using a real os-backed tree so the
+// test cannot silently drift onto the identity-less arm the old bound covered.
+func TestGlobStopsAtTheDirectoryListingBudgetWithFileIdentity(t *testing.T) {
+	const dirCount = 40
+	root := globBudgetFixture(t, dirCount)
+
+	info, err := os.Stat(filepath.Join(root, "dir00"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasFileIdentity(info) {
+		t.Fatalf("a real directory must carry file identity, else this test exercises the wrong bound")
+	}
+
+	const budget = 8
+	stubMaxGlobDirListings(t, budget)
+
+	var counter *countingFS
+	stubGlobBaseFS(t, func(dir string) fs.FS {
+		counter = &countingFS{FS: os.DirFS(dir)}
+		return counter
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.txt", root, true)
+	if err == nil {
+		t.Fatalf("Glob over a %d-directory tree with a listing budget of %d returned no error and %d matches; the listing budget was not enforced", dirCount, budget, len(matches))
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the glob visibly instead", err)
+	}
+	if counter.calls > budget+1 {
+		t.Fatalf("walk made %d directory listings against a budget of %d, want at most %d", counter.calls, budget, budget+1)
+	}
+	if counter.calls >= dirCount+1 {
+		t.Fatalf("walk listed all %d directories instead of stopping early (%d listings made)", dirCount+1, counter.calls)
+	}
+}
+
+// TestGlobTruncatesAtTheMatchCap proves globMatches's other missing bound: the
+// GlobWalk callback appended every match to the result slice forever, so a
+// `**` pattern with millions of hits accumulated all of them in memory before
+// GlobWithExclusions ever got a chance to return. The cap must also stop the
+// walk itself once it trips, not merely truncate the slice after a full walk
+// completes — a truncate-after-the-fact fix would satisfy the match count but
+// still pay the full listing cost, which is the resource the bug actually
+// wastes. That is why this compares against an uncapped control run over the
+// identical tree rather than a hand-picked listing count.
+func TestGlobTruncatesAtTheMatchCap(t *testing.T) {
+	const fileCount = 24
+	root := globBudgetFixture(t, fileCount)
+
+	var full *countingFS
+	stubGlobBaseFS(t, func(dir string) fs.FS {
+		full = &countingFS{FS: os.DirFS(dir)}
+		return full
+	})
+	fullBudget := NewGlobBudget()
+	fullMatches, _, err := NewLocalExecutionEnvironment(root).GlobWithBudget(t.Context(), "**/*.txt", root, true, fullBudget)
+	if err != nil {
+		t.Fatalf("uncapped control run: %v", err)
+	}
+	if len(fullMatches) != fileCount || fullBudget.TruncatedAt() != 0 {
+		t.Fatalf("uncapped control run = (%d matches, truncatedAt=%d), want (%d, 0)", len(fullMatches), fullBudget.TruncatedAt(), fileCount)
+	}
+
+	stubMaxGlobMatches(t, 5)
+
+	var capped *countingFS
+	stubGlobBaseFS(t, func(dir string) fs.FS {
+		capped = &countingFS{FS: os.DirFS(dir)}
+		return capped
+	})
+	budget := NewGlobBudget()
+	matches, _, err := NewLocalExecutionEnvironment(root).GlobWithBudget(t.Context(), "**/*.txt", root, true, budget)
+	if err != nil {
+		t.Fatalf("capped run: %v", err)
+	}
+	if len(matches) != 5 {
+		t.Fatalf("capped run returned %d matches, want exactly 5", len(matches))
+	}
+	if budget.TruncatedAt() != 5 {
+		t.Fatalf("capped run reported truncatedAt=%d, want 5", budget.TruncatedAt())
+	}
+	if capped.calls >= full.calls {
+		t.Fatalf("capped run made %d directory listings, want fewer than the uncapped run's %d listings (the walk must stop once the match cap trips, not just truncate the result afterward)", capped.calls, full.calls)
+	}
+}
+
+// TestGlobWithExclusionsRefusesRatherThanTruncatingSilently proves requirement
+// (c): a caller with no budget of its own has no way to learn a result was
+// truncated, so GlobWithExclusions must refuse outright — a non-nil error —
+// rather than hand back a plausible-looking short list with a nil error.
+func TestGlobWithExclusionsRefusesRatherThanTruncatingSilently(t *testing.T) {
+	const fileCount = 24
+	root := globBudgetFixture(t, fileCount)
+
+	stubMaxGlobMatches(t, 5)
+
+	matches, excluded, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.txt", root, true)
+	if err == nil {
+		t.Fatalf("GlobWithExclusions over a %d-match tree with a cap of 5 returned (%v, %d, nil); a budget-less caller has no way to learn the list was truncated, so it must refuse instead", fileCount, matches, excluded)
+	}
+}
+
+// TestGlobBudgetIsSharedAcrossBraceExpandedPatterns proves the budget has to
+// live at the glob call, not at each expanded pattern:
+// globpattern.Expand can turn one brace pattern into up to
+// globpattern.MaxExpansions (256) separately-walked patterns, and globMatches
+// runs a fresh globWalkFS per pattern. A budget scoped to that walk would let
+// a 256-way brace expansion multiply the cap by 256 instead of bounding the
+// call it belongs to. Two extensions stand in for two expansions here.
+func TestGlobBudgetIsSharedAcrossBraceExpandedPatterns(t *testing.T) {
+	const fileCount = 24
+	root := globBudgetFixture(t, fileCount)
+
+	stubMaxGlobMatches(t, 5)
+
+	budget := NewGlobBudget()
+	matches, _, err := NewLocalExecutionEnvironment(root).GlobWithBudget(t.Context(), "**/*.{txt,md}", root, true, budget)
+	if err != nil {
+		t.Fatalf("GlobWithBudget: %v", err)
+	}
+	if len(matches) > 5 {
+		t.Fatalf("brace-expanded glob (two patterns) returned %d matches, want at most 5 shared across the whole call, not 5 per expanded pattern", len(matches))
+	}
+	if budget.TruncatedAt() != 5 {
+		t.Fatalf("brace-expanded glob reported truncatedAt=%d, want 5 (the call-wide cap)", budget.TruncatedAt())
+	}
+}
+
+// retained reports how many directory identities this walk is holding, which
+// is the walk's own memory cost: the cycle check consults only the ancestors
+// of the directory it is admitting, so this must track the depth of the path
+// being walked, not the number of directories the walk has ever listed.
+func (w *globWalkFS) retained() int { return len(w.chain) }
+
+// TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked pins the walk's own
+// memory cost, the third defect behind #497. The ancestor cycle check in
+// admit consults only the ancestors of the directory it is admitting, so what
+// the walk holds has to scale with the depth of the path it is on and not
+// with how many directories it has listed in total. A wide, shallow tree
+// (siblings, not nesting) separates the two: 30 siblings are 30 listings at
+// depth one. It builds a real tree so hasFileIdentity is true throughout, and
+// reads retained() rather than measuring memory, which would be flaky to
+// assert on directly.
+func TestGlobWalkRetainsIdentityOnlyForThePathBeingWalked(t *testing.T) {
+	const siblingCount = 30
+	root := globBudgetFixture(t, siblingCount)
+
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: newGlobBudget("glob")}
+	if _, err := w.ReadDir("."); err != nil {
+		t.Fatalf("listing the root: %v", err)
+	}
+	for i := range siblingCount {
+		dir := fmt.Sprintf("dir%02d", i)
+		if _, err := w.ReadDir(dir); err != nil {
+			t.Fatalf("listing %s: %v", dir, err)
+		}
+	}
+
+	if retained := w.retained(); retained > 2 {
+		t.Fatalf("walk retained %d directory identities after listing %d sibling directories; retained count grew with the number of directories listed, not with the depth of the path being walked (want at most 2: the root plus the sibling being listed)", retained, siblingCount)
+	}
+
+	// The cycle check must still work after whatever pruning made the count
+	// above small — a fix that throws identity away entirely would pass the
+	// retention assertion but silently reopen #369 (the `**` / never
+	// terminating). A directory symlink back at the tree root must still be
+	// refused as a readdir on an already-listed ancestor.
+	if err := os.Symlink(root, filepath.Join(root, "loop")); err != nil {
+		t.Skipf("directory symlinks unavailable on this platform: %v", err)
+	}
+	_, err := w.ReadDir("loop")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("ReadDir(loop) through a symlink back at the tree root = %v, want an fs.ErrNotExist PathError (the walk refusing an already-listed ancestor)", err)
+	}
+}
+
+// TestGlobWalkRefusesACycleThroughAnUnlistedAncestor pins the ancestor check
+// for the exact shape doublestar creates when a pattern's meta-free prefix
+// names a path directly: the very first listing the walk ever makes can be
+// several levels below the root, so neither the root (".") nor the path's own
+// parent has ever been pushed onto the chain. identity's fallback (a fresh
+// fs.Stat on a chain miss) has to find the cycle anyway, by walking up to an
+// ancestor it has never listed and stat'ing it fresh.
+//
+// This is a characterization pin, not a red test: it already passes on the
+// current tree. It would fail if identity's chain-miss fallback were replaced
+// by an always-false lookup, since then nothing would catch the cycle before
+// the walk ever lists "." or "a".
+func TestGlobWalkRefusesACycleThroughAnUnlistedAncestor(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, filepath.Join(root, "a", "loop")); err != nil {
+		t.Skipf("directory symlinks unavailable on this platform: %v", err)
+	}
+
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: newGlobBudget("glob")}
+	_, err := w.ReadDir("a/loop")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("ReadDir(a/loop) as the walk's first-ever listing = %v, want an fs.ErrNotExist PathError (the ancestor cycle back to root, caught via a fresh stat rather than the chain)", err)
+	}
+	if _, ok := errors.AsType[*fs.PathError](err); !ok {
+		t.Fatalf("ReadDir(a/loop) = %v (%T), want an *fs.PathError", err, err)
+	}
+}
+
+// TestGlobBudgetErrorRecordsWhetherTheWalkCouldDetectCycles asserts the
+// budget refusal structurally rather than by matching its prose: a caller
+// (or a test) has to be able to tell "this filesystem could never have
+// detected a symlink cycle" from "this really is an enormous tree" without
+// parsing a sentence. cycleSafe carries that distinction — false for an
+// identity-less fstest.MapFS, which can never rule out a cycle, true for an
+// os.DirFS tree, which can — and budget records the bound that was crossed.
+func TestGlobBudgetErrorRecordsWhetherTheWalkCouldDetectCycles(t *testing.T) {
+	stubMaxGlobDirListings(t, 1)
+
+	mapTree := fstest.MapFS{"dir00/leaf.txt": &fstest.MapFile{Data: []byte("x")}}
+	mw := &globWalkFS{FS: mapTree, ctx: t.Context(), budget: newGlobBudget("glob")}
+	if _, err := mw.ReadDir("."); err != nil {
+		t.Fatalf("listing the MapFS root: %v", err)
+	}
+	_, err := mw.ReadDir("dir00")
+	var mapErr *globBudgetError
+	if !errors.As(err, &mapErr) {
+		t.Fatalf("tripping the budget over an identity-less MapFS = %v (%T), want a *globBudgetError", err, err)
+	}
+	if mapErr.cycleSafe {
+		t.Fatalf("globBudgetError.cycleSafe = true for an identity-less filesystem that can never detect a cycle, want false")
+	}
+	if mapErr.budget != maxGlobDirListings {
+		t.Fatalf("globBudgetError.budget = %d, want %d (the active budget)", mapErr.budget, maxGlobDirListings)
+	}
+
+	root := globBudgetFixture(t, 1)
+	ow := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: newGlobBudget("glob")}
+	if _, err := ow.ReadDir("."); err != nil {
+		t.Fatalf("listing the os.DirFS root: %v", err)
+	}
+	_, err = ow.ReadDir("dir00")
+	var osErr *globBudgetError
+	if !errors.As(err, &osErr) {
+		t.Fatalf("tripping the budget over an os.DirFS tree = %v (%T), want a *globBudgetError", err, err)
+	}
+	if !osErr.cycleSafe {
+		t.Fatalf("globBudgetError.cycleSafe = false for an os-backed filesystem that can detect a cycle, want true")
+	}
+	if osErr.budget != maxGlobDirListings {
+		t.Fatalf("globBudgetError.budget = %d, want %d (the active budget)", osErr.budget, maxGlobDirListings)
+	}
+}
+
+// TestSandboxedGlobTruncatesToAStablePrefix proves the sandboxed walk's match
+// cap truncates to a deterministic prefix rather than to whichever entries
+// the filesystem's raw directory order happened to hand back first.
+// secureDirFS.ReadDir sorts its entries lexically after reading a directory,
+// so which files survive a cap tripping mid-listing is the glob's business,
+// not an accident of the fd-backed listing's own order (which has no
+// ordering guarantee of its own to begin with). Every file is written in
+// reverse-lexical order and given an identical mtime, so neither creation
+// order nor modification time can accidentally line up with the alphabetical
+// order the sort guarantees, and two back-to-back runs over the unchanged
+// tree must agree with each other and with that order. An unsorted ReadDir
+// would let the raw fd order decide which files survive truncation instead,
+// breaking the fixture's guarantee that both runs and the lexically-first
+// "want" prefix agree with each other: that is the only way this test can
+// fail.
+func TestSandboxedGlobTruncatesToAStablePrefix(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const fileCount = 12
+	fixedMod := time.Now()
+	for i := fileCount - 1; i >= 0; i-- {
+		p := filepath.Join(worktree, fmt.Sprintf("file%02d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(p, fixedMod, fixedMod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stubMaxGlobMatches(t, 4)
+
+	want := []string{
+		filepath.Join(worktree, "file00.txt"),
+		filepath.Join(worktree, "file01.txt"),
+		filepath.Join(worktree, "file02.txt"),
+		filepath.Join(worktree, "file03.txt"),
+	}
+
+	firstBudget := NewGlobBudget()
+	first, _, err := env.GlobWithBudget(t.Context(), "*.txt", worktree, true, firstBudget)
+	if err != nil {
+		t.Fatalf("first sandboxed glob: %v", err)
+	}
+	if firstBudget.TruncatedAt() != 4 {
+		t.Fatalf("first run truncatedAt = %d, want 4", firstBudget.TruncatedAt())
+	}
+	second, _, err := env.GlobWithBudget(t.Context(), "*.txt", worktree, true, NewGlobBudget())
+	if err != nil {
+		t.Fatalf("second sandboxed glob: %v", err)
+	}
+
+	if !slices.Equal(first, second) {
+		t.Fatalf("two sandboxed globs over the same unchanged tree returned different truncated prefixes: %v vs %v", first, second)
+	}
+	if !slices.Equal(first, want) {
+		t.Fatalf("sandboxed glob truncated to %v, want the lexically first 4: %v", first, want)
+	}
+}
+
+// TestGlobMatchesReportsCancellationAfterTheCapTripped proves globMatches's
+// cap fast path does not shadow a cancellation that landed at the same
+// moment: budget.full() returning early must still check ctx first, or a
+// call cancelled right after the cap tripped comes back reporting truncated
+// success instead of the cancellation the caller actually asked for.
+func TestGlobMatchesReportsCancellationAfterTheCapTripped(t *testing.T) {
+	budget := newGlobBudget("glob")
+	budget.truncated = true
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	matches, err := globMatches(ctx, fstest.MapFS{}, "*.txt", budget)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("globMatches with a tripped cap and a cancelled context = (%v, %v), want context.Canceled", matches, err)
+	}
+}
+
+// TestGlobChargesThePatternWalkOnTheDefaultIgnoreExclusionPath covers the
+// arm the tool actually calls: include_ignored defaults to false, so a
+// .gitignore scan runs over the base before the pattern walk starts. That
+// scan is a separate traversal with its own bound (see the stacked PR that
+// budgets it); what this pins is that its presence does not stop the pattern
+// walk's own listings from being charged, so the default path is bounded
+// rather than silently exempt.
+func TestGlobChargesThePatternWalkOnTheDefaultIgnoreExclusionPath(t *testing.T) {
+	const dirCount = 40
+	const budget = 8
+	root := globBudgetFixture(t, dirCount)
+	stubMaxGlobDirListings(t, budget)
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.txt", root, false)
+	budgetErr, refused := errors.AsType[*globBudgetError](err)
+	if !refused {
+		t.Fatalf("Glob(include_ignored=false) over a %d-directory tree with a listing budget of %d = (%d matches, %v), want a *globBudgetError; the pattern walk's listings are not being charged on the default path", dirCount, budget, len(matches), err)
+	}
+	if budgetErr.count <= budget {
+		t.Fatalf("globBudgetError.count = %d, want more than the budget of %d", budgetErr.count, budget)
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the glob visibly instead", err)
+	}
+}

--- a/agent/execenv/glob_cancel_test.go
+++ b/agent/execenv/glob_cancel_test.go
@@ -63,7 +63,7 @@ func TestGlobMatchesStopsOnContextCancellation(t *testing.T) {
 	tree := globCancelTree()
 
 	full := &countingFS{FS: cancelFS{ctx: t.Context(), fsys: tree}}
-	if _, err := globMatches(t.Context(), full, "**/needle.txt"); err != nil {
+	if _, err := globMatches(t.Context(), full, "**/needle.txt", newGlobBudget("glob")); err != nil {
 		t.Fatalf("uncancelled globMatches: %v", err)
 	}
 	if full.calls < 20 {
@@ -74,7 +74,7 @@ func TestGlobMatchesStopsOnContextCancellation(t *testing.T) {
 	defer cancel()
 	counter := &countingFS{FS: cancelFS{ctx: ctx, fsys: tree}, cancelOn: 3, cancel: cancel}
 
-	matches, err := globMatches(ctx, counter, "**/needle.txt")
+	matches, err := globMatches(ctx, counter, "**/needle.txt", newGlobBudget("glob"))
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("globMatches after mid-walk cancellation = (%v, %v), want context.Canceled", matches, err)
 	}

--- a/agent/execenv/glob_walk_test.go
+++ b/agent/execenv/glob_walk_test.go
@@ -161,11 +161,11 @@ func TestGlobWalkFSBoundsAFilesystemWithoutFileIdentity(t *testing.T) {
 		t.Fatalf("fstest.MapFS should carry no file identity: (%v, %v)", info, err)
 	}
 
-	w := &globWalkFS{FS: tree, ctx: t.Context(), listed: map[string]fs.FileInfo{}}
+	w := &globWalkFS{FS: tree, ctx: t.Context(), budget: newGlobBudget("glob")}
 	if _, err := w.ReadDir("dir"); err != nil {
 		t.Fatalf("first listing: %v", err)
 	}
-	w.unidentified = maxUnidentifiedGlobDirs
+	w.budget.listings = maxGlobDirListings
 	_, err := w.ReadDir("dir")
 	if err == nil {
 		t.Fatal("listing past the bound succeeded, want a refusal")
@@ -176,19 +176,29 @@ func TestGlobWalkFSBoundsAFilesystemWithoutFileIdentity(t *testing.T) {
 }
 
 // TestGlobWalkFSKnowsWhenIdentityIsAvailable pins the discrimination the
-// backstop turns on: an os-backed filesystem carries file identity and is
-// bounded by the cycle check, so it must never be counted against the bound.
+// backstop turns on: identity decides how running out of budget is EXPLAINED,
+// not whether a listing counts toward it. An os-backed filesystem is bounded
+// by the cycle check too, so its listings are charged to the budget exactly
+// like an identity-less filesystem's — only the message a refusal gives once
+// the bound trips differs.
 func TestGlobWalkFSKnowsWhenIdentityIsAvailable(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), listed: map[string]fs.FileInfo{}}
+	w := &globWalkFS{FS: os.DirFS(root), ctx: t.Context(), budget: newGlobBudget("glob")}
 	if _, err := w.ReadDir("sub"); err != nil {
 		t.Fatalf("listing an os-backed directory: %v", err)
 	}
-	if w.unidentified != 0 {
-		t.Fatalf("os-backed listing counted %d unidentified directories, want 0", w.unidentified)
+	if w.budget.listings != 1 {
+		t.Fatalf("os-backed listing charged %d to the budget, want 1", w.budget.listings)
+	}
+	info, err := fs.Stat(w.FS, "sub")
+	if err != nil {
+		t.Fatalf("stat sub: %v", err)
+	}
+	if !hasFileIdentity(info) {
+		t.Fatalf("an os-backed directory must carry file identity")
 	}
 }
 

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1712,14 +1712,11 @@ func (e *LocalExecutionEnvironment) Glob(ctx context.Context, pattern string, ba
 // point over a filesystem they control.
 var globBaseFS = os.DirFS
 
-// GlobWithExclusions implements GlobExcluder: same matching as Glob, but also
-// reports how many candidate matches the default dotfile/gitignore exclusion
-// dropped, so a fully-filtered result can be told apart from a genuinely
-// empty one (see the "silent-empty is the enemy" global constraint). The
-// count never includes matches dropped by sandbox masking — that's a
-// separate security boundary, not something to describe to the caller as
-// "gitignored".
-func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, pattern string, basePath string, includeIgnored bool) ([]string, int, error) {
+// GlobWithBudget implements GlobBudgeter: same matching as Glob, but the
+// caller supplies budget and reads what the call had to cut off it once the
+// call returns (see GlobBudget.TruncatedAt), rather than being refused a
+// truncated listing outright the way GlobWithExclusions is.
+func (e *LocalExecutionEnvironment) GlobWithBudget(ctx context.Context, pattern string, basePath string, includeIgnored bool, budget *GlobBudget) ([]string, int, error) {
 	patterns, err := expandSearchPattern(pattern)
 	if err != nil {
 		return nil, 0, err
@@ -1735,7 +1732,7 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 		defer sfs.release()
 		// Sandboxed: the base is policy-checked and the walk refuses symlink
 		// traversal (no out-of-root match) and drops masked matches.
-		return sfs.glob(ctx, "glob", base, pattern, includeIgnored)
+		return sfs.glob(ctx, "glob", base, pattern, includeIgnored, budget)
 	}
 	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(base)}
 	var ignores *ignoreSet
@@ -1747,7 +1744,7 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 	var abs []string
 	excluded := 0
 	for _, pattern := range patterns {
-		matches, err := globMatches(ctx, fsys, pattern)
+		matches, err := globMatches(ctx, fsys, pattern, budget)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -1774,6 +1771,31 @@ func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, patt
 		return nil, 0, err
 	}
 	return abs, excluded, nil
+}
+
+// GlobWithExclusions implements GlobExcluder: same matching as Glob, but also
+// reports how many candidate matches the default dotfile/gitignore exclusion
+// dropped, so a fully-filtered result can be told apart from a genuinely
+// empty one (see the "silent-empty is the enemy" global constraint). The
+// count never includes matches dropped by sandbox masking — that's a
+// separate security boundary, not something to describe to the caller as
+// "gitignored".
+//
+// The budget backing this call belongs to GlobWithExclusions alone, so a
+// caller here has no way to learn a listing was cut short: a truncation
+// comes back as an error rather than a plausible-looking short list. A
+// caller that wants the partial list uses GlobBudgeter.GlobWithBudget with
+// its own budget instead.
+func (e *LocalExecutionEnvironment) GlobWithExclusions(ctx context.Context, pattern string, basePath string, includeIgnored bool) ([]string, int, error) {
+	budget := NewGlobBudget()
+	matches, excluded, err := e.GlobWithBudget(ctx, pattern, basePath, includeIgnored, budget)
+	if err != nil {
+		return nil, 0, err
+	}
+	if truncatedAt := budget.TruncatedAt(); truncatedAt > 0 {
+		return nil, 0, fmt.Errorf("glob matched more than %d candidates, the cap for one call, so the result would have been incomplete: narrow the pattern or its base directory, or call GlobWithBudget with a budget to get the partial list", truncatedAt)
+	}
+	return matches, excluded, nil
 }
 
 // Grep searches for pattern under path (defaulting to RootDir), using ripgrep

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -2,6 +2,7 @@ package execenv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -52,16 +53,146 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 	return fs.Stat(c.fsys, name)
 }
 
-// maxUnidentifiedGlobDirs bounds a walk over a filesystem whose directories
-// carry no file identity, where globWalkFS's cycle check cannot work. The
-// bound counts directories listed rather than capping depth because a symlink
-// cycle costs unbounded *work*, not merely unbounded depth: one
-// /proc/<pid>/root hop re-enters the entire tree, so a shallow depth cap would
-// still admit a combinatorial re-walk while a deep one would truncate real
-// results. os-backed filesystems never reach this — the cycle check bounds
-// them — so exceeding it means the walk has lost its footing, and it is
-// reported as an error rather than as a short list.
-const maxUnidentifiedGlobDirs = 100_000
+// maxGlobDirListings bounds how many directory listings one glob call may
+// make, across every brace-expanded pattern in it. It counts directories
+// listed rather than capping depth because a symlink cycle costs unbounded
+// *work*, not merely unbounded depth: one /proc/<pid>/root hop re-enters the
+// entire tree, so a shallow depth cap would still admit a combinatorial
+// re-walk while a deep one would truncate real results. It bounds every
+// listing, not only ones on a filesystem without file identity: even where
+// the cycle check works, an unbounded `**` over a huge tree (`/`) still costs
+// unbounded work.
+//
+// The value is a WORK bound, sized so a large monorepo with a wide brace
+// expansion never trips it while `/` does: a 60,000-directory monorepo
+// globbed with a 5-way brace expansion costs on the order of 300,000
+// listings and must not error; `/` on a developer's machine is 500,000 to
+// several million directories and must. 1,000,000 sits between the two.
+var maxGlobDirListings = 1_000_000
+
+// maxGlobMatches bounds how many matches one glob call may accumulate.
+var maxGlobMatches = 10_000
+
+// SetMaxGlobMatchesForTesting overrides maxGlobMatches for the duration of a
+// test, returning a restore func. maxGlobMatches is unexported, so callers
+// outside this package (which cannot reassign it directly the way this
+// package's own tests do) use this to shrink it enough to exercise real
+// truncation without building a tree large enough to trip the production cap.
+func SetMaxGlobMatchesForTesting(n int) (restore func()) {
+	orig := maxGlobMatches
+	maxGlobMatches = n
+	return func() { maxGlobMatches = orig }
+}
+
+// GlobBudget bounds the total work one glob call may spend, shared by every
+// brace-expanded pattern the call walks and, through GlobBudgeter, by every
+// caller that wants to see a truncated listing rather than being refused one.
+// Its fields stay unexported: a caller reads what the call had to cut off it
+// through TruncatedAt rather than inspecting the accounting directly.
+//
+// A budget belongs to one call and its counters are unsynchronized, so it must
+// not be shared across goroutines or reused for a second concurrent call. The
+// walk it accounts for is single-goroutine, and locking every listing to serve
+// a case that does not arise would cost the hot path for nothing; a caller
+// running globs concurrently gives each one its own budget.
+type GlobBudget struct {
+	listings  int
+	matches   int
+	truncated bool
+	op        string
+}
+
+// newGlobBudget constructs a GlobBudget for op, so every internal call site
+// names the operation its budget belongs to rather than leaving the field
+// unset. NewGlobBudget is the entry point for callers outside this package,
+// which always name the operation "glob".
+func newGlobBudget(op string) *GlobBudget {
+	return &GlobBudget{op: op}
+}
+
+// NewGlobBudget constructs a GlobBudget for a glob call, for a caller that
+// wants to supply its own budget to GlobBudgeter.GlobWithBudget rather than
+// go through GlobExcluder.GlobWithExclusions, which creates one internally
+// and has nowhere to report a truncation it finds.
+func NewGlobBudget() *GlobBudget {
+	return newGlobBudget("glob")
+}
+
+// listing charges one more directory listing to the budget regardless of
+// cycleSafe: an unbounded `**` over a huge tree costs unbounded work even
+// where the cycle check works, so the bound has to apply whether or not this
+// filesystem can tell directories apart. cycleSafe only picks which
+// explanation the refusal gives once the bound trips: true when the walk
+// that hit the bound could have detected a symlink cycle on its own (only
+// where the filesystem reports file identity), false when it could not.
+func (b *GlobBudget) listing(cycleSafe bool) error {
+	b.listings++
+	if b.listings <= maxGlobDirListings {
+		return nil
+	}
+	return &globBudgetError{count: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe, op: b.op}
+}
+
+// globBudgetError reports that one glob call ran past its directory-listing
+// budget. cycleSafe records whether the walk that gave up could have
+// detected a symlink cycle on its own — true only where the filesystem
+// reports file identity — which picks which of Error's two explanations
+// applies. count, budget and op are the values a caller can act on without
+// parsing the message.
+type globBudgetError struct {
+	count     int
+	budget    int
+	cycleSafe bool
+	op        string
+}
+
+// advice names the lever that makes a whole call's listing count smaller.
+// Every budget here belongs to a glob, whose pattern decides how much of the
+// tree gets listed, so tightening it is the first thing to try.
+func (e *globBudgetError) advice() string {
+	return "narrow the pattern or its base directory"
+}
+
+func (e *globBudgetError) Error() string {
+	if !e.cycleSafe {
+		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.count, e.budget, e.advice())
+	}
+	return fmt.Sprintf("%s walk made %d directory listings, past the budget of %d for one call: %s", e.op, e.count, e.budget, e.advice())
+}
+
+// match reports whether the walk may keep the next match, so the caller can
+// end the walk itself rather than letting it run to completion and truncating
+// the result afterward — the cap has to bound the work a glob call spends,
+// not only the length of the answer it hands back.
+func (b *GlobBudget) match() bool {
+	if b.matches >= maxGlobMatches {
+		b.truncated = true
+		return false
+	}
+	b.matches++
+	return true
+}
+
+func (b *GlobBudget) full() bool {
+	return b.truncated
+}
+
+// TruncatedAt reports the match cap that cut a glob call short, or 0 when
+// every match was reported, so a caller can hand the cap value to the model
+// without duplicating the truncated check at every call site that needs it.
+func (b *GlobBudget) TruncatedAt() int {
+	if b.truncated {
+		return maxGlobMatches
+	}
+	return 0
+}
+
+// listedDir is one entry on globWalkFS.chain: the identity of a directory on
+// the path currently being walked.
+type listedDir struct {
+	name string
+	info fs.FileInfo
+}
 
 // globWalkFS is the view of the filesystem a single doublestar walk runs over.
 // It supplies the two properties doublestar itself cannot:
@@ -73,7 +204,13 @@ const maxUnidentifiedGlobDirs = 100_000
 // already reachable at a shorter path, so refusing costs no matches. A
 // directory symlink pointing anywhere other than at its own ancestors
 // (node_modules/lib -> ../packages/lib, or /etc -> /private/etc on macOS) is
-// walked normally and its files match under both names.
+// walked normally and its files match under both names. The check
+// deliberately admits one case: two sibling names for the same directory,
+// neither an ancestor of the other (a bind mount, or two symlinks pointing at
+// one shared target), are both listed and so walked twice. That case has no
+// unbounded recursion to catch — a sibling can't be its own ancestor — so it
+// is left to cost two listings against the budget rather than being detected
+// and refused.
 //
 // Abort. doublestar propagates a filesystem error only under
 // WithFailOnIOErrors; without it a cancelled walk keeps grinding through every
@@ -85,13 +222,14 @@ const maxUnidentifiedGlobDirs = 100_000
 type globWalkFS struct {
 	fs.FS
 	ctx context.Context
-	// listed holds the identity of every directory already listed, keyed by
-	// the path it was listed under, so the ancestor check costs a map lookup
-	// per level instead of a stat per level.
-	listed map[string]fs.FileInfo
-	// unidentified counts listed directories whose FileInfo carries no file
-	// identity — the only case maxUnidentifiedGlobDirs bounds.
-	unidentified int
+	// chain holds the identity of every directory on the path currently being
+	// walked, root first, so the ancestor check in admit can compare against
+	// them without retaining one FileInfo for every directory the walk has
+	// ever listed. See push for how it stays pruned to that path.
+	chain []listedDir
+	// budget bounds the directory listings and matches this walk may spend,
+	// shared with the rest of the glob call's brace-expanded patterns.
+	budget *GlobBudget
 }
 
 func (w *globWalkFS) Stat(name string) (fs.FileInfo, error) {
@@ -120,11 +258,11 @@ func (w *globWalkFS) admit(name string) error {
 	if err != nil {
 		return w.hide("stat", name)
 	}
-	if !hasFileIdentity(info) {
-		w.unidentified++
-		if w.unidentified > maxUnidentifiedGlobDirs {
-			return fmt.Errorf("glob walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking", w.unidentified)
-		}
+	identified := hasFileIdentity(info)
+	if err := w.budget.listing(identified); err != nil {
+		return err
+	}
+	if !identified {
 		return nil
 	}
 	// The walk root is skipped: it has no ancestors to cycle back to, and
@@ -132,7 +270,7 @@ func (w *globWalkFS) admit(name string) error {
 	// entry and refuse the second listing doublestar makes of every directory.
 	if name != "." {
 		for dir := path.Dir(name); ; dir = path.Dir(dir) {
-			if ancestor, ok := w.listed[dir]; ok && os.SameFile(ancestor, info) {
+			if ancestor, ok := w.identity(dir); ok && os.SameFile(ancestor, info) {
 				return w.hide("readdir", name)
 			}
 			if dir == "." {
@@ -140,8 +278,44 @@ func (w *globWalkFS) admit(name string) error {
 			}
 		}
 	}
-	w.listed[name] = info
+	w.push(name, info)
 	return nil
+}
+
+// identity answers dir's FileInfo from the chain of directories currently
+// being walked, falling back to a fresh stat on a miss. The chain is only a
+// cache of the path being walked — push prunes it down to that path on every
+// listing — so a walk that jumps between subtrees still compares admit's
+// candidate against every real ancestor by re-stat'ing it, and pruning the
+// chain can never let a cycle slip past the check that costs nothing extra.
+func (w *globWalkFS) identity(dir string) (fs.FileInfo, bool) {
+	for _, d := range w.chain {
+		if d.name == dir {
+			return d.info, true
+		}
+	}
+	info, err := fs.Stat(w.FS, dir)
+	if err != nil {
+		return nil, false
+	}
+	return info, true
+}
+
+// push records name's identity as the innermost entry on the chain, first
+// dropping every entry that is not a proper ancestor of name. Only name's own
+// ancestors are ever consulted by the cycle check, so pruning everything else
+// loses nothing: the chain stays sized to the depth of the path currently
+// being walked rather than growing with the number of directories the walk
+// has listed in total.
+func (w *globWalkFS) push(name string, info fs.FileInfo) {
+	kept := 0
+	for _, d := range w.chain {
+		if d.name != name && (d.name == "." || strings.HasPrefix(name, d.name+"/")) {
+			w.chain[kept] = d
+			kept++
+		}
+	}
+	w.chain = append(w.chain[:kept], listedDir{name: name, info: info})
 }
 
 // hide answers with the walk's cancellation when there is one — the walk runs
@@ -162,21 +336,45 @@ func hasFileIdentity(info fs.FileInfo) bool {
 	return os.SameFile(info, info)
 }
 
+// errGlobMatchesFull signals the GlobWalk callback's own cap trip back out to
+// globMatches: doublestar has no way to end a walk early other than the
+// callback returning an error, so the cap has to speak in that vocabulary and
+// then be told apart from a real failure once GlobWalk returns.
+var errGlobMatchesFull = errors.New("glob match cap reached")
+
 // globMatches runs one expanded glob pattern against fsys, which must already
 // observe ctx (see cancelFS), through a fresh globWalkFS — fresh per pattern,
 // because the directories one pattern listed say nothing about whether another
-// pattern's walk is re-entering itself.
+// pattern's walk is re-entering itself. budget is shared across every pattern
+// in the call: it is checked before the walk starts, so a pattern that runs
+// after the cap has already tripped does not re-walk the tree just to
+// discover it can keep nothing, and it is checked on every match the walk
+// finds, so a `**` with millions of hits stops there instead of accumulating
+// all of them before the caller gets a chance to see any.
 //
 // GlobWalk rather than Glob: it ends the walk the moment the callback returns
-// an error, so a cancellation that lands between two filesystem calls stops
-// the walk at the next match instead of being noticed only after the tree runs
-// out.
-func globMatches(ctx context.Context, fsys fs.FS, pattern string) ([]string, error) {
-	walk := &globWalkFS{FS: fsys, ctx: ctx, listed: map[string]fs.FileInfo{}}
+// an error, so a cancellation — or the match cap tripping — that lands
+// between two filesystem calls stops the walk at the next match instead of
+// being noticed only after the tree runs out.
+func globMatches(ctx context.Context, fsys fs.FS, pattern string, budget *GlobBudget) ([]string, error) {
+	if budget.full() {
+		// A cancelled walk must not come back as a plausible-looking short
+		// list: a cap that is already tripped when a cancellation lands must
+		// still answer with the cancellation, not with the truncated result
+		// the cap alone would produce.
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		return nil, nil
+	}
+	walk := &globWalkFS{FS: fsys, ctx: ctx, budget: budget}
 	var matches []string
 	err := doublestar.GlobWalk(walk, pattern, func(p string, _ fs.DirEntry) error {
 		if cerr := ctx.Err(); cerr != nil {
 			return cerr
+		}
+		if !budget.match() {
+			return errGlobMatchesFull
 		}
 		matches = append(matches, p)
 		return nil
@@ -185,6 +383,12 @@ func globMatches(ctx context.Context, fsys fs.FS, pattern string) ([]string, err
 	// so answer with the cancellation however the walk happened to unwind.
 	if cerr := ctx.Err(); cerr != nil {
 		return nil, cerr
+	}
+	// The match cap ending the walk is not a failure: it is the mechanism by
+	// which the cap bounds the work rather than only the result, so the
+	// matches collected before it tripped are the answer, not an error.
+	if errors.Is(err, errGlobMatchesFull) {
+		return matches, nil
 	}
 	if err != nil {
 		return nil, err

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -48,6 +49,12 @@ func (f *secureDirFS) Open(name string) (fs.File, error) {
 	return os.NewFile(uintptr(fd), name), nil
 }
 
+// ReadDir lists name and sorts the result by name: os.DirFS's own ReadDir
+// already returns entries sorted, and the match cap downstream truncates to a
+// deterministic, lexically-first prefix of what a listing returns, so this
+// arm has to produce the same order or a capped walk here could stop on a
+// different prefix than the same walk over the plain filesystem. The raw
+// fd-backed listing this builds on has no ordering guarantee of its own.
 func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	fd, err := openBeneathRoot(f.baseFd, name, unix.O_RDONLY|unix.O_DIRECTORY, 0)
 	if err != nil {
@@ -55,7 +62,12 @@ func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	df := os.NewFile(uintptr(fd), name)
 	defer func() { _ = df.Close() }()
-	return df.ReadDir(-1)
+	entries, err := df.ReadDir(-1)
+	if err != nil {
+		return nil, err
+	}
+	slices.SortFunc(entries, func(x, y fs.DirEntry) int { return strings.Compare(x.Name(), y.Name()) })
+	return entries, nil
 }
 
 func (f *secureDirFS) Stat(name string) (fs.FileInfo, error) {
@@ -87,11 +99,12 @@ func toFsErr(err error) error {
 // off path (newest mtime first, ties by path). The returned int is the number of
 // candidate matches dropped by the dotfile/gitignore exclusion (see
 // GlobExcluder) — it never includes matches dropped by masking, which is a
-// separate security boundary.
+// separate security boundary. budget is shared across every brace-expanded
+// pattern the call walks, exactly like the off path's GlobWithBudget.
 //
 // Dotfiles/dirs and gitignored paths are excluded by default (matching the
 // off path's Glob), unless includeIgnored is set.
-func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool) ([]string, int, error) {
+func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool, budget *GlobBudget) ([]string, int, error) {
 	patterns, err := expandSearchPattern(pattern)
 	if err != nil {
 		return nil, 0, err
@@ -116,7 +129,7 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 	var abs []string
 	excluded := 0
 	for _, pattern := range patterns {
-		matches, err := globMatches(ctx, fsys, pattern)
+		matches, err := globMatches(ctx, fsys, pattern, budget)
 		if err != nil {
 			return nil, 0, err
 		}

--- a/agent/execenv/securepath_edge_program_fuzz_test.go
+++ b/agent/execenv/securepath_edge_program_fuzz_test.go
@@ -336,10 +336,10 @@ func runSecurePathEdgeContractProgram(t *testing.T, program []byte) securePathEd
 	// Browsing preserves the same denied-base/error contracts as direct reads.
 	// A masked file, hidden file, and binary file are all absent from native grep,
 	// while a visible text hit remains discoverable.
-	if _, _, err := s.glob(t.Context(), "glob", filepath.Join(worktree, "missing-glob-base"), "*", false); err == nil {
+	if _, _, err := s.glob(t.Context(), "glob", filepath.Join(worktree, "missing-glob-base"), "*", false, NewGlobBudget()); err == nil {
 		t.Fatal("sandbox glob missing base unexpectedly succeeded")
 	}
-	if _, _, err := s.glob(t.Context(), "glob", worktree, "[", false); err == nil {
+	if _, _, err := s.glob(t.Context(), "glob", worktree, "[", false, NewGlobBudget()); err == nil {
 		t.Fatal("sandbox glob malformed pattern unexpectedly succeeded")
 	}
 	if _, err := s.grepNative(context.Background(), "[", worktree, "", false, 10, ""); err == nil {

--- a/agent/execenv/securepath_other.go
+++ b/agent/execenv/securepath_other.go
@@ -79,7 +79,7 @@ func (s *sandboxFS) listDir(tool, abs string, depth int) ([]DirEntry, error) {
 	return nil, errSandboxUnsupported()
 }
 
-func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool) ([]string, int, error) {
+func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includeIgnored bool, budget *GlobBudget) ([]string, int, error) {
 	return nil, 0, errSandboxUnsupported()
 }
 

--- a/agent/session_tools_shell.go
+++ b/agent/session_tools_shell.go
@@ -238,22 +238,44 @@ func registerShellTools(reg *tool.Registry, s *Session, deps *toolDeps) error {
 			}
 			var matches []string
 			var excluded int
+			var truncatedAt int
 			var err error
-			if ge, ok := env.(execenv.GlobExcluder); ok {
-				matches, excluded, err = ge.GlobWithExclusions(ctx, pat, path, includeIgnored)
-			} else {
+			switch g := env.(type) {
+			case execenv.GlobBudgeter:
+				budget := execenv.NewGlobBudget()
+				matches, excluded, err = g.GlobWithBudget(ctx, pat, path, includeIgnored, budget)
+				truncatedAt = budget.TruncatedAt()
+			case execenv.GlobExcluder:
+				matches, excluded, err = g.GlobWithExclusions(ctx, pat, path, includeIgnored)
+			default:
 				matches, err = env.Glob(ctx, pat, path, includeIgnored)
 			}
 			if err != nil {
 				return "", err
 			}
+			result := strings.Join(matches, "\n")
 			// Silent-empty is the enemy: a bare "" here is indistinguishable
 			// from "genuinely no matches" when it's actually "every match was
 			// filtered out by the default dotfile/gitignore exclusion" (D2).
 			if len(matches) == 0 && excluded > 0 {
-				return fmt.Sprintf("0 matches after excluding %d dotfile/gitignored path(s); set include_ignored to include them", excluded), nil
+				result = fmt.Sprintf("0 matches after excluding %d dotfile/gitignored path(s); set include_ignored to include them", excluded)
 			}
-			return strings.Join(matches, "\n"), nil
+			if truncatedAt > 0 {
+				// Silent truncation is the same enemy: the matches collected
+				// before the cap tripped look exactly like the whole answer,
+				// and a fully-excluded or fully-masked capped walk would
+				// otherwise report its emptiness as if the walk had finished.
+				// The cap counts candidate matches, before the dotfile/
+				// gitignore exclusion above drops any of them, so the number
+				// of paths actually shown can be smaller than the cap itself.
+				note := fmt.Sprintf("The glob stopped after considering its cap of %d candidate matches; fewer may be shown above once excluded paths are dropped, and there may be more beyond the cap. Narrow the pattern or point path at a smaller directory to see the rest.", truncatedAt)
+				if result == "" {
+					result = note
+				} else {
+					result += "\n\n" + note
+				}
+			}
+			return result, nil
 		},
 	}); err != nil {
 		return err


### PR DESCRIPTION
First of three stacked PRs for #497. This one fixes the original defects; **B** adds the memory bounds (chunked reads, entry caps, cancellation) and **C** budgets grep.

## What was wrong

A `find_files` call with a `**` pattern rooted at `/` could exhaust memory and OOM-kill the agent process. The walk *terminated* — the ancestor/SameFile cycle check added for #369 catches `/proc/<pid>/root` re-entering the tree — but nothing bounded what it spent getting there.

1. **The pattern walk's directory-listing budget was unreachable.** The only counter incremented inside `if !hasFileIdentity(info)`. Every file on ext4, APFS and HFS+ carries `(device, inode)` identity, so on the filesystems agents actually run on that branch was never taken.
2. **Matches accumulated with no cap.** A `**` over `/` is millions of paths.
3. **The walk retained one `fs.FileInfo` per listed directory**, though the cycle check only consults *ancestors* of the directory being admitted.

## What changed

The listing budget charges every listing **the pattern walk** makes, on both the sandboxed and off-sandbox arms. Identity now decides only how exhaustion is *explained*: a filesystem reporting none has no cycle detection at all, and that is worth saying.

Scope worth being precise about: the `.gitignore` scan that runs before the pattern walk when `include_ignored` is false is a **separate traversal and is not charged here** — the stacked #955 budgets it. On a 40-directory tree with the listings budget at 8, that scan accounts for 41 of the 49 `ReadDir` calls. The pattern walk is bounded on that path (`TestGlobChargesThePatternWalkOnTheDefaultIgnoreExclusionPath` pins it); the scan preceding it is not, until B. The budget is shared across a call's brace-expanded patterns, because `globpattern.Expand` turns one pattern into up to `MaxExpansions` of them and a per-walk bound would really be a 256x bound.

Matches are capped, and tripping the cap **ends the walk** rather than truncating after it, so the cap bounds the work and not just the answer's length.

`listed` became an ancestor chain pruned to the path being walked, so retention is O(depth) rather than O(listings). The chain is only a cache: an ancestor it does not hold is re-stat'ed, so a walk that jumps between subtrees still cannot miss a cycle.

Refusals are a typed `globBudgetError` carrying the operation, the bound, the count and whether the walk could have detected a cycle, so callers read fields rather than parse sentences.

## Caller-visible changes

- **`GlobExcluder.GlobWithExclusions` keeps its three return values.** Truncation rides on a caller-supplied budget instead: the new optional `GlobBudgeter` capability lets a caller hand in a `*GlobBudget` and read `TruncatedAt()` off it afterwards. This is the same move `GlobExcluder` itself was introduced as, and its doc comment says so.
- **Without a budget there is nowhere to report truncation, so that path refuses.** `GlobWithExclusions` returns an error rather than a short list with a nil error. A caller that wants the partial list opts in through `GlobBudgeter`.
- The glob tool prefers `GlobBudgeter`, so it still tells the model when the cap cut a listing short, naming the cap and noting it counts *candidate* matches, before dotfile/gitignore exclusion drops any.
- Sandboxed listings are sorted by name, so the match cap truncates to the same prefix on both arms.

## How it is tested

Each bound was written test-first and confirmed failing for its stated reason before the fix. Tests assert *work done*, not just results — listings actually made, identities actually retained — because a fix that finishes the walk and then reports a refusal would satisfy a result-only assertion while still doing the thing that OOMs. First failures:

- `Glob over a 40-directory tree with a listing budget of 8 returned no error and 40 matches; the listing budget was not enforced`
- `walk retained 31 directory identities after listing 30 sibling directories; retained count grew with the number of directories listed, not with the depth of the path being walked`

`TestGlobWithExclusionsRefusesRatherThanTruncatingSilently` pins the budget-less refusal. Termination stays pinned by the #369 regression tests, and a characterization test proves the ancestor check still catches a cycle reached through a never-listed ancestor (verified by mutation: removing `identity`'s stat fallback breaks it).

Gates, all foreground: `gofmt`; `make vet` and `GOOS=windows make vet`; `go vet -tags evenerfuzz ./...`; `make lint-golangci`; `make lint-evenerfuzz lint-eval lint-gofmt lint-internal`; `go test -race ./agent/execenv/`; `-tags evenerfuzz -run Fuzz ./agent/execenv/`; full `go test ./agent/`. Zero failures in each.

Closes #497

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
