### PR TITLE
Revert spark-1.3-contributor max effort

### DIFF
--- a/llm/registry/data/providers_overlay.toml
+++ b/llm/registry/data/providers_overlay.toml
@@ -352,12 +352,6 @@ web_search = true
 # Amazon Bedrock (§9.3): Anthropic's Messages endpoint on bedrock-mantle
 # ---------------------------------------------------------------------------
 
-[providers.meta.models."muse-spark-1.3-contributor"]
-# Muse Spark 1.3 supports the max effort tier: the sibling 1.3 rows (base,
-# openrouter, kilo, vercel) already list it upstream, but meta's own
-# 1.3-contributor row stops at xhigh. Curated until upstream corrects it.
-effort_values = ["minimal", "low", "medium", "high", "xhigh", "max"]
-
 [providers."amazon-bedrock"]
 implicit = true
 surface = "anthropic"


### PR DESCRIPTION
The `max` tier is genuinely unsupported: the live endpoint rejects it with `reasoning_effort 'max' is not supported for model 'muse-spark-1.3-contributor'. Supported values: [minimal, low, medium, high, xhigh]`. Upstream models.dev was right; this removes only the curated overlay row and keeps the snapshot refresh and moonshotai cheap_model move from #952. Verified: inspect shows `minimal..xhigh` from `snapshot/row`; `go test ./llm/registry/` and vet clean.