### PR TITLE
feat(webui): dedicated job_watch renderer with humanized summaries

### DIFF
--- a/agent/job_notify.go
+++ b/agent/job_notify.go
@@ -250,6 +250,14 @@ func formatJobNotificationBlock(n jobNotification, excerpt notificationExcerpt, 
 	if n.TranscriptRef != "" {
 		attrs = append(attrs, notificationAttr("transcript_ref", n.TranscriptRef))
 	}
+	// A job-targeted fire, teardown notice, or send-rail diagnostic carries
+	// no timer WatchID, but its originating watch rides OriginWatchID — emit
+	// it so a reader can identify which watch to inspect or clear. Timers
+	// keep their existing emit path below; the WatchID guard keeps the two
+	// from ever doubling the attribute.
+	if n.OriginWatchID != "" && n.WatchID == "" {
+		attrs = append(attrs, notificationAttr("watch_id", n.OriginWatchID))
+	}
 	if n.Status == jobNotificationEventWatch && n.JobID == "" {
 		if n.WatchID != "" {
 			attrs = append(attrs, notificationAttr("watch_id", n.WatchID))

--- a/agent/job_notify_test.go
+++ b/agent/job_notify_test.go
@@ -1129,3 +1129,58 @@ func TestFormatWatchSendNotificationBlock(t *testing.T) {
 		}
 	}
 }
+
+// A job-targeted watch fire carries no timer WatchID, but its originating
+// watch rides the display-only OriginWatchID — emitted as the watch_id frame
+// attribute so a reader can identify which watch to inspect or clear
+// (RoboRev PR #954). Empty origins emit nothing (no regression for old or
+// hand-built shapes), and a timer's own WatchID path never doubles the attr.
+func TestFormatJobNotificationEmitsOriginWatchID(t *testing.T) {
+	t.Parallel()
+	fired := formatJobNotificationBlock(jobNotification{
+		JobID: "job_a1b2", JobType: "watch", Status: "watch",
+		Reason:        "output_match: ready",
+		OriginWatchID: "watch_09QmWzRtNvxK",
+	}, notificationExcerpt{}, true)
+	if !strings.Contains(fired, `watch_id="watch_09QmWzRtNvxK"`) {
+		t.Errorf("job-targeted fire must carry its originating watch id:\n%s", fired)
+	}
+	if !strings.Contains(fired, "Job job_a1b2 watch.") {
+		t.Errorf("job-targeted fire keeps the generic producer body:\n%s", fired)
+	}
+
+	bare := formatJobNotificationBlock(jobNotification{
+		JobID: "job_a1b2", JobType: "watch", Status: "watch",
+		Reason: "output_match: ready",
+	}, notificationExcerpt{}, true)
+	if strings.Contains(bare, "watch_id=") {
+		t.Errorf("empty origin must not emit a watch_id attribute:\n%s", bare)
+	}
+
+	timer := formatJobNotificationBlock(jobNotification{
+		JobType: "watch", Status: "watch", Reason: "repeat",
+		WatchID: "w1", IntervalSeconds: 300,
+		OriginWatchID: "w1",
+	}, notificationExcerpt{}, true)
+	if got := strings.Count(timer, "watch_id="); got != 1 {
+		t.Errorf("timer must emit watch_id exactly once, got %d:\n%s", got, timer)
+	}
+}
+
+// watchNotificationFromWatch stamps the producing config's id on the
+// display-only origin field — and never on the timer-identity WatchID, which
+// would subject the notice to the orphan-tick drop once its watch detaches.
+func TestWatchNotificationFromWatchStampsOriginWatchID(t *testing.T) {
+	t.Parallel()
+	jm := newTestJM(t)
+	n := jm.watchNotificationFromWatch(&watchConfig{watchID: "watch_origin1"}, "job_x", "output_match: ready", nil)
+	if n.OriginWatchID != "watch_origin1" {
+		t.Errorf("OriginWatchID = %q, want watch_origin1", n.OriginWatchID)
+	}
+	if n.WatchID != "" {
+		t.Errorf("WatchID = %q, want empty (timer-identity field must stay unset)", n.WatchID)
+	}
+	if n.JobID != "job_x" || n.Reason != "output_match: ready" {
+		t.Errorf("notification identity/reason = %q/%q, want job_x/output_match: ready", n.JobID, n.Reason)
+	}
+}

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -3485,12 +3485,28 @@ func watchNotification(jobID, reason string) jobNotification {
 	}
 }
 
+// watchSendDiagnosticNotification builds a send-rail diagnostic (a drop, a
+// failed persist, an eviction) that names the watch whose delivery failed.
+// The watch id rides the display-only OriginWatchID field — never WatchID,
+// which would subject the diagnostic to the orphan-tick drop once its watch
+// detaches (see OriginWatchID's doc comment in jobs.go).
+func watchSendDiagnosticNotification(watchID, jobID, reason string) jobNotification {
+	n := watchNotification(jobID, reason)
+	n.OriginWatchID = watchID
+	return n
+}
+
 func (jm *jobManager) watchNotificationFromWatch(cfg *watchConfig, jobID, reason string, root *provenance.Causal) jobNotification {
 	n := watchNotification(jobID, reason)
 	if cfg == nil {
 		return n
 	}
 	n.Note = cfg.note
+	// The originating watch rides a display-only field, never WatchID: the
+	// session drops a non-terminal WatchID-bearing entry whose timer key no
+	// longer resolves, and a condition watch's key slot is not its id — so a
+	// stamped fire or teardown would vanish as an orphaned tick.
+	n.OriginWatchID = cfg.watchID
 	visibleSessionID := cfg.receiverSessionID
 	if visibleSessionID == "" {
 		visibleSessionID = jm.sessionID
@@ -3702,7 +3718,7 @@ func (jm *jobManager) deliverPendingWatchSend(cfg *watchConfig, state jobstore.W
 	if ensurePending {
 		if err := jm.appendWatchSendPendingState(cfg, state); err != nil {
 			jm.enqueueWatchNotifications([]jobNotification{
-				watchNotification(state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+				watchSendDiagnosticNotification(state.Key.WatchID, state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
 			})
 			return false, err
 		}
@@ -3725,14 +3741,14 @@ func (jm *jobManager) dropWatchSend(state jobstore.WatchSendState, cfg *watchCon
 		WatchSend: &dropped,
 	}}); err != nil {
 		jm.enqueueWatchNotifications([]jobNotification{
-			watchNotification(state.Key.ResolvedWatchedIdentity, "watch send dropped state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+			watchSendDiagnosticNotification(state.Key.WatchID, state.Key.ResolvedWatchedIdentity, "watch send dropped state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
 		})
 		return err
 	}
 	jm.removePendingWatchSend(cfg, dropped.Key, dropped.UpdateSeq)
 	jm.releaseStableWatchReceipt(dropped.DeliveryID)
 	jm.enqueueWatchNotifications([]jobNotification{
-		watchNotification(state.Key.ResolvedWatchedIdentity, "watch send failed: delivery_id="+state.DeliveryID+": "+dropped.DiagnosticReason),
+		watchSendDiagnosticNotification(state.Key.WatchID, state.Key.ResolvedWatchedIdentity, "watch send failed: delivery_id="+state.DeliveryID+": "+dropped.DiagnosticReason),
 	})
 	return nil
 }
@@ -3922,7 +3938,7 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 	if len(record.evictions) != 0 && jm.appendEvents == nil {
 		if err := jm.appendWatchSendEvents(record.pendingEvents); err != nil {
 			jm.enqueueWatchNotifications([]jobNotification{
-				watchNotification(state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+				watchSendDiagnosticNotification(state.Key.WatchID, state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
 			})
 			return state, false, err
 		}
@@ -3933,7 +3949,7 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 			if err != nil {
 				jm.removeWatchSendTerminalSnapshots(applied)
 				jm.enqueueWatchNotifications([]jobNotification{
-					watchNotification(state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+					watchSendDiagnosticNotification(state.Key.WatchID, state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
 				})
 				return record.persisted, true, err
 			}
@@ -3960,7 +3976,7 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 	}
 	if err := jm.appendWatchSendEvents(group); err != nil {
 		jm.enqueueWatchNotifications([]jobNotification{
-			watchNotification(state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+			watchSendDiagnosticNotification(state.Key.WatchID, state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
 		})
 		return state, false, err
 	}
@@ -4002,7 +4018,7 @@ func (jm *jobManager) verifyStableWatchEnqueue(enqueueReceipt *delegateWatchRece
 	deliveryReceipt, err := enqueueReceipt.controller.CompleteWatchEnqueue(enqueueReceipt)
 	if err != nil {
 		jm.enqueueWatchNotifications([]jobNotification{
-			watchNotification(persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+			watchSendDiagnosticNotification(persisted.Key.WatchID, persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
 		})
 		return false, err
 	}
@@ -4010,7 +4026,7 @@ func (jm *jobManager) verifyStableWatchEnqueue(enqueueReceipt *delegateWatchRece
 	folded, err := jm.store.LoadWatchSends()
 	if err != nil {
 		jm.enqueueWatchNotifications([]jobNotification{
-			watchNotification(persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+			watchSendDiagnosticNotification(persisted.Key.WatchID, persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
 		})
 		return true, err
 	}
@@ -4018,7 +4034,7 @@ func (jm *jobManager) verifyStableWatchEnqueue(enqueueReceipt *delegateWatchRece
 	if pending == nil || pending.DeliveryID != persisted.DeliveryID || pending.UpdateSeq != persisted.UpdateSeq {
 		verr := errors.New("stable watch pending frame did not survive durable refold")
 		jm.enqueueWatchNotifications([]jobNotification{
-			watchNotification(persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(verr.Error(), watchReadErrorMaxChars)),
+			watchSendDiagnosticNotification(persisted.Key.WatchID, persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(verr.Error(), watchReadErrorMaxChars)),
 		})
 		return true, verr
 	}
@@ -4295,7 +4311,7 @@ func (jm *jobManager) planWatchSendPending(state jobstore.WatchSendState, d watc
 				TS:        now,
 				WatchSend: &evictedState,
 			}}},
-			diagnostic: watchNotification(evictedState.Key.ResolvedWatchedIdentity, "watch send evicted: "+evictedState.TriggerIdentity),
+			diagnostic: watchSendDiagnosticNotification(evictedState.Key.WatchID, evictedState.Key.ResolvedWatchedIdentity, "watch send evicted: "+evictedState.TriggerIdentity),
 		})
 		overflow--
 	}
@@ -4926,7 +4942,7 @@ func (s *Session) renderUnreachableChildPendingsWithLoaders(
 			continue
 		}
 		jm.removeRuntimePendingWatchSend(dropped)
-		n := watchNotification(state.Key.ResolvedWatchedIdentity, dropped.DiagnosticReason)
+		n := watchSendDiagnosticNotification(state.Key.WatchID, state.Key.ResolvedWatchedIdentity, dropped.DiagnosticReason)
 		n.Provenance = provenance.Clone(state.Provenance)
 		s.enqueueJobNotification(n)
 	}

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -2148,6 +2148,7 @@ type watchHistoryEntry struct {
 	source             string
 	target             string
 	condition          string
+	note               string
 	sendTo             string
 	receiverSessionID  string
 	receiverDelegateID string
@@ -2172,6 +2173,7 @@ func (jm *jobManager) recordWatchEndedLocked(key watchKey, cfg *watchConfig, rea
 		source:             cfg.sourcePublic,
 		target:             cfg.target,
 		condition:          watchConditionSummary(cfg),
+		note:               cfg.note,
 		sendTo:             sendTo,
 		receiverSessionID:  cfg.receiverSessionID,
 		receiverDelegateID: cfg.receiverDelegateID,
@@ -2346,6 +2348,7 @@ func inspectResultFromWatchConfig(key watchKey, cfg *watchConfig) jobWatchInspec
 		Source:     watchPublicSource(cfg.sourcePublic, cfg.target),
 		Watching:   true,
 		Condition:  watchConditionSummary(cfg),
+		Note:       cfg.note,
 		Deliveries: cfg.deliveries,
 		CreatedAt:  cfg.createdAt.Format(time.RFC3339Nano),
 	}
@@ -2363,6 +2366,7 @@ func inspectResultFromWatchHistory(h watchHistoryEntry) jobWatchInspectToolResul
 		Source:     watchPublicSource(h.source, h.target),
 		Watching:   false,
 		Condition:  h.condition,
+		Note:       h.note,
 		Deliveries: h.deliveries,
 		EndReason:  h.endReason,
 		EndedAt:    h.endedAt.Format(time.RFC3339Nano),
@@ -3501,7 +3505,21 @@ func (jm *jobManager) watchNotificationFromWatch(cfg *watchConfig, jobID, reason
 	if cfg == nil {
 		return n
 	}
-	n.Note = cfg.note
+	// The note rides the notification body through withNotificationNote
+	// (agent/job_notify.go), whose escapeNotificationBody escapes only "<"
+	// (kata 72kp): body text is not inside a quoted attribute, so "&" is not
+	// a structural hazard there and passes through verbatim. The frontend
+	// card (NotificationCard.tsx) decodes the full entity set (& < > " ')
+	// on every prose/excerpt, so a note that literally contains "&lt;",
+	// "&amp;", "&quot;" or "&#39;" would decode and display wrong.
+	// Pre-escaping "&" here composes with the body's "<"-only escaping into
+	// the same "&"-first order escapeNotificationText uses for attribute
+	// values, which the card's single decode inverts exactly — a literal
+	// "&lt;" in the note renders "&lt;", not "<". The pre-escape runs here
+	// (not in escapeNotificationBody, which job output and other body text
+	// also share) so only the watch-note lane changes encoding; cfg.note
+	// itself stays raw for list/inspect/frame readers.
+	n.Note = strings.ReplaceAll(cfg.note, "&", "&amp;")
 	// The originating watch rides a display-only field, never WatchID: the
 	// session drops a non-terminal WatchID-bearing entry whose timer key no
 	// longer resolves, and a condition watch's key slot is not its id — so a

--- a/agent/job_watch_condition_note_test.go
+++ b/agent/job_watch_condition_note_test.go
@@ -58,6 +58,40 @@ func TestConditionWatchNote_RidesTheFiredNotification(t *testing.T) {
 	}
 }
 
+// TestConditionWatchNote_LiteralEntityTextSurvivesTheBodyCodec proves the
+// watch-note lane composes into the "&"-first order the frontend card's
+// single full decode inverts exactly (RoboRev combined review of 5c202de,
+// MEDIUM): watchNotificationFromWatch pre-escapes "&", and
+// withNotificationNote's escapeNotificationBody then escapes "<", so a note
+// literally containing "&lt;" rides the wire as "&amp;lt;" — unambiguous
+// with a literal "<" (which rides as "&lt;"). Decoding "&amp;lt;" once
+// restores the literal "&lt;" text, never "<".
+func TestConditionWatchNote_LiteralEntityTextSurvivesTheBodyCodec(t *testing.T) {
+	t.Parallel()
+	jm := newTestJM(t)
+	var notified []jobNotification
+	jm.enqueue = func(n jobNotification) { notified = append(notified, n) }
+
+	rec, _ := jm.createShell(createShellOpts{Command: "x"})
+	const note = `watch for &lt;tag&gt; &amp; &quot;q&quot;`
+	if _, err := jm.configureWatch(watchArgs{Operation: "create", Target: rec.JobID, OutputMatch: "ready", Note: note}); err != nil {
+		t.Fatalf("configure: %v", err)
+	}
+	jm.feedJobOutput(rec.JobID, []byte("server ready\n"), 13)
+	if len(notified) != 1 {
+		t.Fatalf("match must fire once; got %d: %+v", len(notified), notified)
+	}
+	block := formatJobNotificationBlock(notified[0], notificationExcerpt{}, false)
+	// The literal "&lt;" must ride double-escaped ("&amp;lt;"): a single decode
+	// then restores the literal text instead of collapsing it to "<".
+	if !strings.Contains(block, "Note: watch for &amp;lt;tag&amp;gt; &amp;amp; &amp;quot;q&amp;quot;") {
+		t.Fatalf("note literal entity text must ride &amp;-first escaped:\n%s", block)
+	}
+	if strings.Contains(block, "Note: watch for &lt;tag") {
+		t.Fatalf("literal &lt; must not ride single-escaped (ambiguous with a literal <):\n%s", block)
+	}
+}
+
 // TestSessionConditionWatchNote_RidesTheFiredNotification covers the
 // session-target rail, whose watch block is rendered by its own branch.
 func TestSessionConditionWatchNote_RidesTheFiredNotification(t *testing.T) {

--- a/agent/jobs.go
+++ b/agent/jobs.go
@@ -540,6 +540,16 @@ type jobNotification struct {
 	Note            string
 	IntervalSeconds int
 	Terminal        bool
+	// OriginWatchID is the watch that produced this notification, carried for
+	// display only (rendered as the watch_id frame attribute so a reader can
+	// identify which watch to inspect or clear). It is NEVER consulted by
+	// delivery gating: unlike WatchID above — which the session's orphan-tick
+	// drop reads, and which only the timer path may stamp because only a
+	// timer's key slot reconstructs from its id — stamping a timer-identity
+	// field on a condition fire or teardown would swallow that notice as an
+	// orphaned tick once its watch detaches. Job-targeted fires, teardown
+	// notices, and send-rail diagnostics stamp this; timer fires keep WatchID.
+	OriginWatchID string
 	// receiverSessionID/receiverNotify route no-send watch notifications for
 	// concrete descendant watches back to the ancestor session that installed
 	// them. They are in-memory only; active watches are not restored without a

--- a/agent/session_tools_jobs.go
+++ b/agent/session_tools_jobs.go
@@ -1576,10 +1576,15 @@ type jobWatchListToolResult struct {
 }
 
 type jobWatchInspectToolResult struct {
-	WatchID    string `json:"watch_id"`
-	Source     string `json:"source,omitempty"`
-	Watching   bool   `json:"watching"`
-	Condition  string `json:"condition,omitempty"`
+	WatchID   string `json:"watch_id"`
+	Source    string `json:"source,omitempty"`
+	Watching  bool   `json:"watching"`
+	Condition string `json:"condition,omitempty"`
+	// Note rides beside the Condition string: note text is free prose that
+	// may itself contain delimiter-looking text ("; events: [...]"), which
+	// the flattened Condition grammar cannot carry unambiguously (RoboRev PR
+	// #954). Readers prefer this field and fall back to the note: clause.
+	Note       string `json:"note,omitempty"`
 	Deliveries int    `json:"deliveries,omitempty"`
 	CreatedAt  string `json:"created_at,omitempty"`
 	EndReason  string `json:"end_reason,omitempty"`

--- a/agent/session_tools_jobs_timer_test.go
+++ b/agent/session_tools_jobs_timer_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"primeradiant.com/evener/agent/internal/tool"
 	"primeradiant.com/evener/llm"
@@ -150,5 +151,39 @@ func TestJobWatchTool_NegativeTimerReportsTheBoundsError(t *testing.T) {
 		if !res.IsError || !strings.Contains(res.Output, tc.want) {
 			t.Errorf("%s: result = %+v, want the error %q", tc.name, res, tc.want)
 		}
+	}
+}
+
+// TestWatchInspectResultsCarryNote pins the structured-note contract: note
+// text is free prose that may itself contain delimiter-looking text like
+// "; events: [...]", which the flattened Condition grammar cannot carry
+// unambiguously (RoboRev PR #954) — so list/inspect rows carry the note in
+// its own field, verbatim, alongside the Condition string. Both the live
+// config path and the ended-history path must carry it.
+func TestWatchInspectResultsCarryNote(t *testing.T) {
+	t.Parallel()
+	const note = "check; events: [communicate]"
+	cfg := &watchConfig{
+		watchID:      "watch_a1",
+		sourcePublic: "self",
+		outputMatch:  "ready",
+		events:       []string{"assistant.tool"},
+		note:         note,
+		createdAt:    time.Now(),
+	}
+	fromCfg := inspectResultFromWatchConfig(watchKey{}, cfg)
+	if fromCfg.Note != note {
+		t.Fatalf("config inspect note = %q, want %q", fromCfg.Note, note)
+	}
+	fromHistory := inspectResultFromWatchHistory(watchHistoryEntry{
+		id:        "watch_a1",
+		source:    "self",
+		condition: watchConditionSummary(cfg),
+		note:      note,
+		endReason: "fired",
+		endedAt:   time.Now(),
+	})
+	if fromHistory.Note != note {
+		t.Fatalf("history inspect note = %q, want %q", fromHistory.Note, note)
 	}
 }

--- a/agent/watch_batch_seam_test.go
+++ b/agent/watch_batch_seam_test.go
@@ -474,3 +474,50 @@ func TestRecordWatchSendsWakesOwnerOnDurablePrefix(t *testing.T) {
 		}
 	})
 }
+
+// TestPersistPendingWatchSendPersistsEachEvictionOnce guards the batch path
+// against persisting an eviction's terminal events twice: once in the group
+// write and again in a per-eviction loop. A duplicated EventWatchSendEvicted
+// collapses invisibly in the durable fold (a map keyed by watch), so this
+// counts the raw journal records instead — exactly one eviction event per
+// overflow, on both the batch seam and the nil-seam sequential protocol.
+func TestPersistPendingWatchSendPersistsEachEvictionOnce(t *testing.T) {
+	t.Parallel()
+	for _, seam := range []string{"batch", "sequential"} {
+		t.Run(seam, func(t *testing.T) {
+			t.Parallel()
+			jm := newTestJM(t)
+			installWatchBelowValidation(t, jm, watchArgs{
+				Target: "caller",
+				Events: []string{"assistant.message"},
+				Send:   &watchSendArgs{To: "dlg_obs"},
+			})
+			cfg := onlyWatchConfigForTest(t, jm)
+			build := func(target string) watchSendDelivery {
+				jm.mu.Lock()
+				defer jm.mu.Unlock()
+				return jm.watchSendSnapshot(cfg, target, "test", events.SessionEvent{SessionID: jm.sessionID})
+			}
+			for i := range defaultWatchSendPendingCap {
+				if _, _, ok, err := jm.recordWatchSend(build(fmt.Sprintf("target_%d", i))); err != nil || !ok {
+					t.Fatalf("fill send %d: ok=%v err=%v", i, ok, err)
+				}
+			}
+			if seam == "sequential" {
+				jm.appendEvents = nil
+			}
+			if _, _, ok, err := jm.recordWatchSend(build("target_overflow")); err != nil || !ok {
+				t.Fatalf("overflow send: ok=%v err=%v", ok, err)
+			}
+			evicted := 0
+			for _, event := range loadJobStoreEvents(t, jm) {
+				if event.Kind == jobstore.EventWatchSendEvicted {
+					evicted++
+				}
+			}
+			if evicted != 1 {
+				t.Fatalf("%s seam persisted %d EventWatchSendEvicted records, want exactly 1 (no double-persist)", seam, evicted)
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -17,6 +17,7 @@ import { ignoringTurn, itemRendererFor } from "./types";
 import "./tools/shellTool"; // registers the real "shell" descriptor, incl. its own autoExpand heuristic
 import "./tools/fsTools"; // registers the real "read_file" (openBesidePath) + grep/list_dir/glob (opt-out)
 import "./tools/jobTools"; // registers the real "delegate_send" (openTranscriptRef/openTranscriptInline)
+import "./tools/jobWatch"; // registers the real "job_watch" (hasBody predicate)
 import type { ItemModel, ThreadModel, TurnModel } from "../../../protocol/model";
 import * as paneActions from "../../../shell/paneActions";
 import { resetThreadsStoreForTests, threadsStore } from "../../../stores/threads";
@@ -1364,4 +1365,20 @@ test("delegate rows from transcripts recorded before the prompt rename still sho
     />,
   );
   expect(screen.getByTestId("tool-row-intent").textContent).toContain("Legacy brief");
+});
+
+test("a summary-only job_watch clear renders a non-expandable row (hasBody predicate)", () => {
+  render(
+    <ToolCallItem
+      item={item({
+        toolName: "job_watch",
+        argumentsJSON: JSON.stringify({ operation: "clear", watch_id: "watch_short" }),
+        raw: { watch_id: "watch_short", source: "", watching: false },
+        output: "[watch_id watch_short cleared]",
+      })}
+      turn={turn}
+      live={false}
+    />,
+  );
+  expect(screen.queryByTestId("tool-row-body-trigger")).toBeNull();
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -323,8 +323,10 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
 
   // A failed row is never a bare summary line even with no body/images: the
   // reader must be able to open it and read the error, so it is always an
-  // expandable disclosure.
-  if (!Body && !hasOutputImages && !failed) {
+  // expandable disclosure. A descriptor may also report per-item that its
+  // body renders nothing (hasBody) — a summary-only rendering offers no
+  // disclosure that would open to nothing.
+  if ((!Body || descriptor.hasBody?.(item) === false) && !hasOutputImages && !failed) {
     return (
       <div className={CLASS.call} data-testid="tool-call-item" data-tool-name={item.toolName ?? ""}>
         <ToolRow

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -377,13 +377,13 @@ test("concerns surface as a quiet note", async () => {
   expect(screen.getByTestId("notification-card-root").textContent).toContain("edge case A; edge case B");
 });
 
-test("a timer's prose renders decoded and its watch id shows as a field", () => {
+test("a timer's prose renders decoded with no echo metadata and no tone chip", () => {
   render(
     <NotificationCard
       notification={notif({
         type: "watch",
         title: "Watch triggered",
-        tone: "warning",
+        tone: "neutral",
         prose: "Timer fired (every 300s).\nNote: hello &lt;x&gt;",
         watchId: "w1",
       })}
@@ -391,5 +391,48 @@ test("a timer's prose renders decoded and its watch id shows as a field", () => 
   );
   // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-prose").textContent).toContain("Note: hello <x>");
-  expect(screen.getByTestId("notification-field-watch-id").textContent).toContain("w1");
+  // Mockups 23-job-watch §E: no echo fields on a watch card (the watch id
+  // retreats to the raw disclosure) and no tone chip — a fired watch is the
+  // expected outcome.
+  expect(screen.queryByTestId("notification-field-watch-id")).toBeNull();
+  expect(screen.queryByTestId("notification-field-status")).toBeNull();
+  expect(screen.queryByTestId("notification-field-job-type")).toBeNull();
+  expect(screen.queryByTestId("notification-field-output")).toBeNull();
+  expect(screen.queryByTestId("notification-field-reason")).toBeNull();
+  expect(screen.getByTestId("notification-card").getAttribute("data-tone")).toBe("neutral");
+  expect(screen.queryByText("warning")).toBeNull();
+  expect(screen.queryByText("error")).toBeNull();
+});
+
+test("a watch card keeps the watch id inspectable in the raw disclosure", () => {
+  render(
+    <NotificationCard
+      notification={notif({
+        type: "watch",
+        title: "Watch triggered",
+        tone: "neutral",
+        prose: "Timer fired.",
+        watchId: "w1",
+        rawText:
+          '<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="after" output_bytes="0" watch_id="w1">Timer fired.</job-notification>',
+      })}
+    />,
+  );
+  expect(screen.getByTestId("notification-raw").textContent).toContain("w1");
+});
+
+test("a job card still renders its echo metadata (watch suppression is scoped to watch type)", () => {
+  render(
+    <NotificationCard
+      notification={notif({
+        type: "job",
+        title: "Job completed",
+        tone: "success",
+        jobId: "job_42",
+        status: "completed",
+      })}
+    />,
+  );
+  expect(screen.getByTestId("notification-field-job-id").textContent).toContain("job_42");
+  expect(screen.getByTestId("notification-field-status").textContent).toContain("completed");
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -436,3 +436,93 @@ test("a job card still renders its echo metadata (watch suppression is scoped to
   expect(screen.getByTestId("notification-field-job-id").textContent).toContain("job_42");
   expect(screen.getByTestId("notification-field-status").textContent).toContain("completed");
 });
+
+test("a job-targeted watch card names the watched job id and nothing else (RoboRev PR #954, review 3)", () => {
+  // A job-targeted fire carries no watch_id attr at all
+  // (formatJobNotificationBlock emits watch_id only when JobID == ""), so the
+  // job id is the only recoverable identity — shown as what it is, with no
+  // echo fields beside it.
+  render(
+    <NotificationCard
+      notification={notif({
+        type: "watch",
+        title: "Output matched on job_a1b2",
+        tone: "neutral",
+        secondary: "output_match: ready",
+        jobId: "job_a1b2",
+        jobType: "watch",
+        status: "watch",
+        reason: "output_match: ready",
+        outputBytes: 0,
+        prose: "Matched output_match: ready on job_a1b2.",
+        rawText:
+          '<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0">Matched output_match: ready on job_a1b2.</job-notification>',
+      })}
+    />,
+  );
+  // At activity level the card auto-expands (expandByDefault=true).
+  expect(screen.getByTestId("notification-field-job-id").textContent).toContain("job_a1b2");
+  expect(screen.queryByTestId("notification-field-watch-id")).toBeNull();
+  expect(screen.queryByTestId("notification-field-status")).toBeNull();
+  expect(screen.queryByTestId("notification-field-job-type")).toBeNull();
+  expect(screen.queryByTestId("notification-field-output")).toBeNull();
+  expect(screen.queryByTestId("notification-field-reason")).toBeNull();
+});
+
+test("a job-less watch card still shows no identity fields", () => {
+  render(
+    <NotificationCard
+      notification={notif({
+        type: "watch",
+        title: "Timer fired",
+        tone: "neutral",
+        secondary: "every 5m",
+        jobId: undefined,
+        watchId: "w1",
+        prose: "Timer fired (every 300s).",
+        rawText:
+          '<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="repeat" output_bytes="0" watch_id="w1">Timer fired (every 300s).</job-notification>',
+      })}
+    />,
+  );
+  expect(screen.queryByTestId("notification-field-job-id")).toBeNull();
+  expect(screen.queryByTestId("notification-field-watch-id")).toBeNull();
+});
+
+test("a watch card never labels the session source as a job id (RoboRev PR #954, finding M4)", () => {
+  render(
+    <NotificationCard
+      notification={notif({
+        type: "watch",
+        title: "Watch auto-cleared",
+        tone: "neutral",
+        secondary: "watch cleared: self matched 50 times",
+        jobId: "self",
+        prose: "watch cleared: self matched 50 times",
+        rawText:
+          '<job-notification job_id="self" event="watch" job_type="watch" status="watch" reason="watch cleared: self matched 50 times" output_bytes="0">watch cleared: self matched 50 times</job-notification>',
+      })}
+    />,
+  );
+  expect(screen.queryByTestId("notification-field-job-id")).toBeNull();
+});
+
+test("synthesized watch prose with a literal entity renders single-decoded (combined review M2)", () => {
+  // Parser stores prose escaped-form; the card decodes exactly once. A
+  // pattern literally containing "&lt;" must render as that literal text,
+  // never as "<".
+  render(
+    <NotificationCard
+      notification={notif({
+        type: "watch",
+        title: "Output matched on job_a1b2",
+        tone: "neutral",
+        prose: "Matched output_match: a &amp;lt; b on job_a1b2.",
+        rawText:
+          '<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: a &amp;lt; b" output_bytes="0">Job job_a1b2 watch.</job-notification>',
+      })}
+    />,
+  );
+  expect(screen.getByTestId("notification-prose").textContent).toContain("a &lt; b");
+  expect(screen.getByTestId("notification-prose").textContent).not.toContain("a < b");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -391,10 +391,11 @@ test("a timer's prose renders decoded with no echo metadata and no tone chip", (
   );
   // At activity level the card auto-expands (expandByDefault=true).
   expect(screen.getByTestId("notification-prose").textContent).toContain("Note: hello <x>");
-  // Mockups 23-job-watch §E: no echo fields on a watch card (the watch id
-  // retreats to the raw disclosure) and no tone chip — a fired watch is the
-  // expected outcome.
-  expect(screen.queryByTestId("notification-field-watch-id")).toBeNull();
+  // Mockups 23-job-watch §E: no echo fields on a watch card and no tone chip
+  // — a fired watch is the expected outcome. The originating watch id is
+  // identity, not echo: it names which watch to inspect or clear (combined
+  // RoboRev review).
+  expect(screen.getByTestId("notification-field-watch-id").textContent).toContain("w1");
   expect(screen.queryByTestId("notification-field-status")).toBeNull();
   expect(screen.queryByTestId("notification-field-job-type")).toBeNull();
   expect(screen.queryByTestId("notification-field-output")).toBeNull();
@@ -469,7 +470,7 @@ test("a job-targeted watch card names the watched job id and nothing else (RoboR
   expect(screen.queryByTestId("notification-field-reason")).toBeNull();
 });
 
-test("a job-less watch card still shows no identity fields", () => {
+test("a job-less watch card names the watch but no job", () => {
   render(
     <NotificationCard
       notification={notif({
@@ -485,8 +486,8 @@ test("a job-less watch card still shows no identity fields", () => {
       })}
     />,
   );
+  expect(screen.getByTestId("notification-field-watch-id").textContent).toContain("w1");
   expect(screen.queryByTestId("notification-field-job-id")).toBeNull();
-  expect(screen.queryByTestId("notification-field-watch-id")).toBeNull();
 });
 
 test("a watch card never labels the session source as a job id (RoboRev PR #954, finding M4)", () => {
@@ -525,4 +526,47 @@ test("synthesized watch prose with a literal entity renders single-decoded (comb
   );
   expect(screen.getByTestId("notification-prose").textContent).toContain("a &lt; b");
   expect(screen.getByTestId("notification-prose").textContent).not.toContain("a < b");
+});
+
+test("a job-targeted watch card names both the watch and the watched job", () => {
+  render(
+    <NotificationCard
+      notification={notif({
+        type: "watch",
+        title: "Output matched on job_a1b2",
+        tone: "neutral",
+        secondary: "output_match: ready",
+        jobId: "job_a1b2",
+        watchId: "watch_09QmWzRtNvxK",
+        prose: "Matched output_match: ready on job_a1b2.",
+        rawText:
+          '<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0" watch_id="watch_09QmWzRtNvxK">Matched output_match: ready on job_a1b2.</job-notification>',
+      })}
+    />,
+  );
+  expect(screen.getByTestId("notification-field-watch-id").textContent).toContain("watch_09QmWzRtNvxK");
+  expect(screen.getByTestId("notification-field-job-id").textContent).toContain("job_a1b2");
+  expect(screen.queryByTestId("notification-field-status")).toBeNull();
+  expect(screen.queryByTestId("notification-field-reason")).toBeNull();
+});
+
+test("a delivery-failure card earns a warning chip and failure title", () => {
+  render(
+    <NotificationCard
+      notification={notif({
+        type: "watch",
+        title: "Watch delivery failed",
+        tone: "warning",
+        secondary: "watch send failed: delivery_id=wd_1: child unreachable",
+        jobId: "job_a1b2",
+        watchId: "watch_09QmWzRtNvxK",
+        prose: "watch send failed: delivery_id=wd_1: child unreachable",
+        rawText:
+          '<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="watch send failed: delivery_id=wd_1: child unreachable" output_bytes="0" watch_id="watch_09QmWzRtNvxK">watch send failed</job-notification>',
+      })}
+    />,
+  );
+  expect(screen.getByTestId("notification-card").getAttribute("data-tone")).toBe("warning");
+  expect(screen.getByTestId("notification-card").textContent).toContain("warning");
+  expect(screen.getByTestId("notification-card").textContent).toContain("Watch delivery failed");
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.test.tsx
@@ -570,3 +570,116 @@ test("a delivery-failure card earns a warning chip and failure title", () => {
   expect(screen.getByTestId("notification-card").textContent).toContain("warning");
   expect(screen.getByTestId("notification-card").textContent).toContain("Watch delivery failed");
 });
+
+test("two watch cards on the same job expand independently (combined review: disclosure key)", () => {
+  // The disclosure identity prefers the watch id: two watches on one job
+  // must not share a key, or expanding one expands both.
+  const cardA = notif({
+    type: "watch",
+    title: "Output matched on job_a1b2",
+    tone: "neutral",
+    jobId: "job_a1b2",
+    watchId: "watch_aaa",
+    prose: "Matched output_match: ready on job_a1b2.",
+    rawText: "raw-a",
+  });
+  const cardB = notif({
+    type: "watch",
+    title: "Output matched on job_a1b2",
+    tone: "neutral",
+    jobId: "job_a1b2",
+    watchId: "watch_bbb",
+    prose: "Matched output_match: done on job_a1b2.",
+    rawText: "raw-b",
+  });
+  renderTools(
+    <>
+      <NotificationCard notification={cardA} />
+      <NotificationCard notification={cardB} />
+    </>,
+  );
+  const rows = screen.getAllByTestId("notification-card");
+  expect(rows).toHaveLength(2);
+  expect(screen.queryByTestId("notification-card-root")).toBeNull();
+  fireEvent.click(rows[0]!);
+  const roots = screen.getAllByTestId("notification-card-root");
+  expect(roots).toHaveLength(1);
+  expect(roots[0]!.textContent).toContain("ready");
+});
+
+test("a legacy watch card without a watch id still expands by job id", () => {
+  renderTools(
+    <NotificationCard
+      notification={notif({
+        type: "watch",
+        title: "Output matched on job_a1b2",
+        tone: "neutral",
+        jobId: "job_a1b2",
+        prose: "Matched output_match: ready on job_a1b2.",
+        rawText: "raw-legacy",
+      })}
+    />,
+  );
+  expect(screen.queryByTestId("notification-card-root")).toBeNull();
+  fireEvent.click(screen.getByTestId("notification-card"));
+  expect(screen.getByTestId("notification-card-root").textContent).toContain("ready");
+});
+
+test("repeat firings of one watch expand independently (combined review: disclosure key)", () => {
+  // Same watch id, different bodies: content joins identity so repeats do
+  // not share a disclosure key (timer repeats previously diverged via
+  // rawText; the watchId-first key regressed them into one).
+  const first = notif({
+    type: "watch",
+    title: "Timer fired",
+    tone: "neutral",
+    watchId: "w1",
+    prose: "Timer fired (every 300s).",
+    rawText: "raw-first",
+  });
+  const second = notif({
+    type: "watch",
+    title: "Timer fired",
+    tone: "neutral",
+    watchId: "w1",
+    prose: "Timer fired (every 300s), 3 times since your last turn.",
+    rawText: "raw-second",
+  });
+  renderTools(
+    <>
+      <NotificationCard notification={first} />
+      <NotificationCard notification={second} />
+    </>,
+  );
+  const rows = screen.getAllByTestId("notification-card");
+  expect(rows).toHaveLength(2);
+  fireEvent.click(rows[0]!);
+  expect(screen.getAllByTestId("notification-card-root")).toHaveLength(1);
+});
+
+test("byte-identical repeat frames expand independently via disclosure id (L2)", () => {
+  // Same watch id AND same raw text (a repeated delivery renders the same
+  // frame twice): without a per-delivery discriminator the two cards share
+  // one disclosure key and toggle together.
+  const repeat = (rawText: string) =>
+    notif({
+      type: "watch",
+      title: "Timer fired",
+      tone: "neutral",
+      watchId: "w1",
+      prose: "Timer fired (every 300s).",
+      rawText,
+    });
+  const shared =
+    '<job-notification job_id="" event="watch" status="watch" reason="repeat" output_bytes="0" watch_id="w1">Timer fired (every 300s).</job-notification>';
+  renderTools(
+    <>
+      <NotificationCard notification={repeat(shared)} disclosureId="item_1:0" />
+      <NotificationCard notification={repeat(shared)} disclosureId="item_1:1" />
+    </>,
+  );
+  const rows = screen.getAllByTestId("notification-card");
+  expect(rows).toHaveLength(2);
+  fireEvent.click(rows[0]!);
+  expect(screen.getAllByTestId("notification-card-root")).toHaveLength(1);
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx
@@ -131,6 +131,13 @@ function Field({ label, value, testId }: { label: string; value: string | number
 }
 
 function NotificationMetadata({ notification }: { notification: ParsedNotification }) {
+  // Mockups 23-job-watch §E: a watch notification's title names what happened
+  // and its note is the payload — the producer's echo attrs (watch id,
+  // status, job type, output count, reason) are metadata soup that says
+  // nothing, so the card shows none of them. The watch id stays reachable
+  // in the raw disclosure. Job, delegate, watch-send, and observer-callback
+  // paths are untouched.
+  if (notification.type === "watch") return null;
   const fields = [
     notification.delegateId && (
       <Field

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx
@@ -196,15 +196,35 @@ function NotificationMetadata({ notification }: { notification: ParsedNotificati
 export function NotificationCard({
   notification,
   sessionRef,
+  disclosureId,
 }: {
   notification: ParsedNotification;
   sessionRef?: string;
+  // Stable per-delivery discriminator (transcript item id + fragment index,
+  // threaded from SteeringItem). Byte-identical repeat deliveries share
+  // watch id and raw text; without this they share one disclosure key and
+  // toggle together. Optional for backward compatibility — existing callers
+  // render without it and keep today's keys.
+  disclosureId?: string;
 }) {
   const context = useTranscriptRenderContext();
   const { config } = context;
   const disclosureScope = disclosureScopeForSession(context, sessionRef);
-  const notificationId = notification.delegateId ?? notification.jobId ?? notification.rawText;
-  const scopedNotificationId = `notification:${sessionRef ?? "default"}:${notificationId}`;
+  // The disclosure identity prefers the watch id for watch cards: two
+  // watches on the same job share a jobId, and keying by it couples their
+  // expand/collapse state. Content joins identity — repeat firings of one
+  // watch (timer repeats especially) are distinct deliveries that expand
+  // independently; keying by watch id alone re-collapses them into one.
+  // Legacy frames without a watch id fall back to the job id, then the raw
+  // text, exactly as before. Non-watch cards keep delegate → job → raw
+  // identity untouched.
+  const notificationId =
+    notification.type === "watch"
+      ? notification.watchId
+        ? `${notification.watchId}:${notification.rawText}`
+        : (notification.jobId ?? notification.rawText)
+      : (notification.delegateId ?? notification.jobId ?? notification.rawText);
+  const scopedNotificationId = `notification:${sessionRef ?? "default"}:${notificationId}${disclosureId ? `:${disclosureId}` : ""}`;
   const disclosureKey = scopedDisclosureId(disclosureScope, scopedNotificationId);
   const disclosureFallback =
     expandDetailsByDefault(config) || disclosureDefault(disclosureScope, scopedNotificationId, false);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx
@@ -137,7 +137,23 @@ function NotificationMetadata({ notification }: { notification: ParsedNotificati
   // nothing, so the card shows none of them. The watch id stays reachable
   // in the raw disclosure. Job, delegate, watch-send, and observer-callback
   // paths are untouched.
-  if (notification.type === "watch") return null;
+  // A job-targeted watch fire carries NO watch_id attr at all
+  // (formatJobNotificationBlock emits watch_id only when JobID == ""), so
+  // the watched job id is the only recoverable identity — it renders as the
+  // card's one identity line, labelled as what it is (never a watch id),
+  // with every echo field still suppressed. A job-less watch names nothing.
+  if (notification.type === "watch") {
+    // "self" is the watch SOURCE vocabulary (watchPublicSource), never a job
+    // id — a job-targeted fire carries a concrete job_* id. If a sentinel
+    // ever lands in the job id slot, it names the session, not a job, so it
+    // must not render as "Job id: self" (RoboRev PR #954 combined review).
+    if (!notification.jobId || notification.jobId === "self") return null;
+    return (
+      <div className={CLASS.metadata}>
+        <Field key="job-id" label="Job id" value={notification.jobId} testId="notification-field-job-id" />
+      </div>
+    );
+  }
   const fields = [
     notification.delegateId && (
       <Field

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/NotificationCard.tsx
@@ -132,27 +132,31 @@ function Field({ label, value, testId }: { label: string; value: string | number
 
 function NotificationMetadata({ notification }: { notification: ParsedNotification }) {
   // Mockups 23-job-watch §E: a watch notification's title names what happened
-  // and its note is the payload — the producer's echo attrs (watch id,
-  // status, job type, output count, reason) are metadata soup that says
-  // nothing, so the card shows none of them. The watch id stays reachable
-  // in the raw disclosure. Job, delegate, watch-send, and observer-callback
-  // paths are untouched.
-  // A job-targeted watch fire carries NO watch_id attr at all
-  // (formatJobNotificationBlock emits watch_id only when JobID == ""), so
-  // the watched job id is the only recoverable identity — it renders as the
-  // card's one identity line, labelled as what it is (never a watch id),
-  // with every echo field still suppressed. A job-less watch names nothing.
+  // and its note is the payload — the producer's echo attrs (status, job
+  // type, output count, reason) are metadata soup that says nothing, so the
+  // card shows none of them. Identity is the exception: the originating
+  // watch id (the producer stamps every watch frame — timers, job-targeted
+  // fires, teardown notices, send-rail diagnostics) names which watch to
+  // inspect or clear, and a job-targeted fire additionally names its watched
+  // job. Both render as what they are; the raw disclosure keeps the full
+  // frame. Job, delegate, watch-send, and observer-callback paths are
+  // untouched.
+  // A job-targeted watch fire carries NO watch_id attr on older frames
+  // (formatJobNotificationBlock emitted watch_id only when JobID == ""), so
+  // the watched job id is the only recoverable identity there — it renders
+  // as the card's one identity line, labelled as what it is (never a watch
+  // id). A job-less watch names nothing.
   if (notification.type === "watch") {
-    // "self" is the watch SOURCE vocabulary (watchPublicSource), never a job
-    // id — a job-targeted fire carries a concrete job_* id. If a sentinel
-    // ever lands in the job id slot, it names the session, not a job, so it
-    // must not render as "Job id: self" (RoboRev PR #954 combined review).
-    if (!notification.jobId || notification.jobId === "self") return null;
-    return (
-      <div className={CLASS.metadata}>
+    const fields = [
+      notification.watchId && (
+        <Field key="watch-id" label="Watch id" value={notification.watchId} testId="notification-field-watch-id" />
+      ),
+      notification.jobId && notification.jobId !== "self" && (
         <Field key="job-id" label="Job id" value={notification.jobId} testId="notification-field-job-id" />
-      </div>
-    );
+      ),
+    ].filter(Boolean);
+    if (fields.length === 0) return null;
+    return <div className={CLASS.metadata}>{fields}</div>;
   }
   const fields = [
     notification.delegateId && (

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SteeringItem.tsx
@@ -158,8 +158,12 @@ export const SteeringItem = memo(function SteeringItem({ item, sessionRef }: Ite
   if (hasNotification) {
     return (
       <>
-        {fragments.map((fragment, index) =>
-          fragment.kind === "notification" ? (
+        {fragments.map((fragment, index) => {
+          // Per-fragment identity: transcript item id + order-stable parse
+          // index (see below). A stable string the key rule cannot mistake
+          // for a bare loop index.
+          const fragmentKey = `${item.id}:${index}`;
+          return fragment.kind === "notification" ? (
             // rawText is NOT a safe key: a generic notification the daemon
             // never gave a job_id (e.g. a watch-timeout retry, kata rail-nav
             // React invariant) can appear more than once in the same steer
@@ -170,11 +174,15 @@ export const SteeringItem = memo(function SteeringItem({ item, sessionRef }: Ite
             // streamed delta rebuilds this same item with another duplicate.
             // fragments is a fresh, order-stable parse of this one item's
             // text every render (parseSteeringNotifications above), never a
-            // diffed/reordered list, so the array index is a safe, stable
-            // identity here - same reasoning as ExcerptText's own index key in
-            // NotificationCard.tsx.
-            // biome-ignore lint/suspicious/noArrayIndexKey: index is stable - see comment above
-            <NotificationCard key={index} notification={fragment.notification} sessionRef={sessionRef} />
+            // diffed/reordered list, so the fragment key above is a safe,
+            // stable identity - same reasoning as ExcerptText's own index key
+            // in NotificationCard.tsx.
+            <NotificationCard
+              key={fragmentKey}
+              notification={fragment.notification}
+              sessionRef={sessionRef}
+              disclosureId={fragmentKey}
+            />
           ) : (
             // Each interstitial text span gets its own divider, positioned
             // where it appeared in the original text (issue #48) rather than
@@ -189,8 +197,8 @@ export const SteeringItem = memo(function SteeringItem({ item, sessionRef }: Ite
               text={fragment.text}
               sessionRef={sessionRef}
             />
-          ),
-        )}
+          );
+        })}
       </>
     );
   }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment node
 
 import { expect, test } from "vitest";
-import { type ParsedNotification, parseSteeringNotifications, type SteeringFragment } from "./steeringClassify";
+import {
+  decodeNotificationEntities,
+  type ParsedNotification,
+  parseSteeringNotifications,
+  type SteeringFragment,
+} from "./steeringClassify";
 
 // notificationsOf flattens the ordered fragment list down to just its parsed
 // notifications, in order - most existing tests here only care about the
@@ -254,7 +259,9 @@ Timer fired (every 300s).
   const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.type).toBe("watch");
   expect(n.title).toBe("Timer fired");
-  expect(n.secondary).toBe("repeat");
+  // RoboRev PR #954 review 3 (finding G): a bare timer reason humanizes from
+  // the prose lead's seconds.
+  expect(n.secondary).toBe("every 5m");
 });
 
 test("watch titles derive from the trigger: event fires name the event, timers the timer (RoboRev PR #954)", () => {
@@ -495,4 +502,194 @@ the section that keeps regressing
   expect(n.prose).toContain("excerpt:");
   expect(n.prose).toContain("the section that keeps regressing");
   expect(n.excerpt).toBe("");
+});
+
+// --- RoboRev PR #954 review 3: teardown/budget titles (finding A) ------------
+// watchEndedUnfiredMessage / watchLostAtRestartMessage start with
+// "watch ended:"; watchBudgetClearedMessage starts with "watch cleared:".
+// Those reasons must title as an ending, never as a firing.
+
+test("a watch-ended notice titles Watch ended, not a firing", () => {
+  const block = `<job-notification job_id="job_x" event="watch" job_type="watch" status="watch" reason="watch ended: job_x is terminal (status=completed reason=done output_bytes=10); condition never matched" output_bytes="0">
+watch ended: job_x is terminal (status=completed reason=done output_bytes=10); condition never matched
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Watch ended");
+});
+
+test("a budget auto-clear notice titles Watch auto-cleared, not a trigger", () => {
+  // Backend truth: autoClearWatchOverBudgetNotification passes "" as the
+  // job id (agent/job_watch.go) — the cleared target rides the reason, never
+  // a job_id attr. (An earlier revision of this fixture used job_id="self";
+  // no producer emits that — the NotificationCard "self" guard test pins the
+  // defensive rendering instead.)
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="watch cleared: job_a1b2 matched 50 times; re-arm with a tighter condition (higher every or narrower output_match)" output_bytes="0">
+watch cleared: job_a1b2 matched 50 times; re-arm with a tighter condition (higher every or narrower output_match)
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Watch auto-cleared");
+});
+
+// --- RoboRev PR #954 review 3: entity-decoded reasons (finding B) ------------
+// The producer entity-escapes attribute values (escapeNotificationText), and
+// parseQuotedAttrs does NOT decode, so a reason carrying & < > arrives
+// escaped and must be decoded before title/secondary use.
+
+test("an entity-escaped reason decodes in the watch secondary", () => {
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: a &amp; b" output_bytes="0">
+Matched output_match: a &amp; b on job_a1b2.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.secondary).toBe("output_match: a & b");
+});
+
+test("an entity-escaped reason decodes in the watch title", () => {
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="event: a &amp; b" output_bytes="0">
+Watch event triggered: event: a &amp; b.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.title).toBe("Event on job_a1b2: a & b");
+});
+
+// --- RoboRev PR #954 review 3: humanized timer secondaries (finding G) -------
+// Timer reasons are bare ("after"/"repeat"); the prose lead carries the
+// seconds ("Timer fired after 300s." / "Timer fired (every 300s)."), so the
+// secondary humanizes from the prose and falls back to the raw reason.
+
+test("an after-timer secondary humanizes the prose duration", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="after" output_bytes="0" watch_id="w9">
+Timer fired after 300s.
+Note: check the build
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.secondary).toBe("after 5m");
+});
+
+test("a repeat-timer secondary humanizes the prose cadence", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="repeat" output_bytes="0" watch_id="w9">
+Timer fired (every 300s).
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.secondary).toBe("every 5m");
+});
+
+test("a repeat-timer with a since-last-turn tail still humanizes", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="repeat" output_bytes="0" watch_id="w9">
+Timer fired (every 300s), 3 times since your last turn.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.secondary).toBe("every 5m");
+});
+
+test("a timer secondary falls back to the raw reason when the prose does not match", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="after" output_bytes="0" watch_id="w9">
+Something else entirely.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.secondary).toBe("after");
+});
+
+// --- RoboRev PR #954 combined review (ba9a9d0): job-targeted watch bodies ---
+// The producer's non-empty-job_id watch path (agent/job_notify.go
+// formatJobNotificationBlock) emits the generic body "Job <id> watch." with
+// the real trigger only in the escaped reason attr. The card must synthesize
+// its prose from the reason instead of showing the generic sentence.
+
+test("a job-targeted output_match fire synthesizes prose from the reason (finding M3)", () => {
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Output matched on job_a1b2");
+  expect(n.prose).toContain("ready");
+  expect(n.prose).not.toContain("Job job_a1b2 watch.");
+});
+
+test("a job-targeted event fire synthesizes prose from the reason (finding M3)", () => {
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="event: job.notification" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Event on job_a1b2: job.notification");
+  expect(n.prose).toContain("job.notification");
+  expect(n.prose).not.toContain("Job job_a1b2 watch.");
+});
+
+test("a teardown notice keeps its own prose (finding M3)", () => {
+  const block = `<job-notification job_id="job_x" event="watch" job_type="watch" status="watch" reason="watch ended: job_x is terminal (status=completed reason=done output_bytes=10); condition never matched" output_bytes="0">
+watch ended: job_x is terminal (status=completed reason=done output_bytes=10); condition never matched
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.prose).toContain("condition never matched");
+});
+
+// --- RoboRev PR #954 combined review (ba9a9d0): timer hours (finding L1) ----
+// Valid timers run to 86,400s. The dedicated renderer already formats those
+// as hours — the notification humanizers must too, not "after 1440m".
+
+test("an hour-long after-timer humanizes to hours, not minutes", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="after" output_bytes="0" watch_id="w9">
+Timer fired after 3600s.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.secondary).toBe("after 1h");
+});
+
+test("a day-long repeat-timer humanizes to hours, not minutes", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="repeat" output_bytes="0" watch_id="w9">
+Timer fired (every 86400s).
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.secondary).toBe("every 24h");
+});
+
+// --- RoboRev combined review (43fe73f): teardown generic bodies (M1) --------
+// A job-targeted teardown notice's body is ALSO the generic "Job <id> watch."
+// sentence (formatJobNotificationBlock's non-empty-JobID fallthrough covers
+// teardown reasons too, not just condition fires). The card must surface the
+// reason, not the generic sentence.
+
+test("a job-targeted teardown notice surfaces the reason, not the generic body (M1)", () => {
+  const block = `<job-notification job_id="job_x" event="watch" job_type="watch" status="watch" reason="watch ended: job_x is terminal (status=completed reason=done output_bytes=10); condition never matched" output_bytes="0">
+Job job_x watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Watch ended");
+  expect(n.prose).toContain("condition never matched");
+  expect(n.prose).not.toContain("Job job_x watch.");
+});
+
+// --- RoboRev combined review (43fe73f): single entity decode (L1) -----------
+// The producer escapes once; the card decodes once. A matched pattern that
+// literally contains "&lt;" arrives double-escaped ("&amp;lt;") and must
+// decode to the literal "&lt;" text — never all the way to "<".
+
+test("a literal entity sequence in a job-targeted reason decodes exactly once (L1)", () => {
+  // Prose is stored ESCAPED-form (passthrough bodies arrive escaped, so
+  // synthesized prose is re-escaped to match) and NotificationCard decodes
+  // once at render. A matched pattern literally containing "&lt;" arrives
+  // double-escaped ("&amp;lt;"): stored prose keeps one level, the card
+  // renders the literal text — never "<".
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: a &amp;lt; b" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.prose).toContain("a &amp;lt; b");
+  expect(decodeNotificationEntities(n.prose ?? "")).toContain("a &lt; b");
+});
+
+test("a status-only watch frame earns no tone chip (combined review M2)", () => {
+  // The parser types event OR status "watch"; the tone short-circuit must
+  // mirror it. A frame with only status="watch" is still a watch delivery.
+  const block = `<job-notification job_id="job_a1b2" status="watch" job_type="watch" reason="output_match: ready" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.tone).toBe("neutral");
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -693,3 +693,52 @@ Job job_a1b2 watch. Output is available through read_transcript if needed.
   expect(n.type).toBe("watch");
   expect(n.tone).toBe("neutral");
 });
+
+// --- RoboRev combined review (6e38dea): delivery-failure classification ----
+// Send-rail diagnostics ("watch send failed:", "watch send dropped state
+// failed:", "watch send pending state failed:", "watch send evicted:",
+// "output dropped:" — agent/job_watch.go) are failed deliveries, not
+// successful triggers. They must title as failures with a warning tone, not
+// "Watch fired on <job>" with forced neutral.
+
+for (const reason of [
+  "watch send failed: delivery_id=wd_1: child unreachable: done",
+  "watch send dropped state failed: boom",
+  "watch send pending state failed: boom",
+  "watch send evicted: output_match: ready",
+  "output dropped: feed offset regressed from 10 to 5",
+]) {
+  test(`a delivery failure titles Watch delivery failed with warning tone (${reason.split(":")[0]})`, () => {
+    const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="${reason}" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+    const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+    expect(n.type).toBe("watch");
+    expect(n.title).toBe("Watch delivery failed");
+    expect(n.tone).toBe("warning");
+    expect(n.secondary).toContain(reason.split(":")[0]!);
+  });
+}
+
+test("a job-targeted fire parses its watch_id attr", () => {
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0" watch_id="watch_09QmWzRtNvxK">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.watchId).toBe("watch_09QmWzRtNvxK");
+  expect(n.title).toBe("Output matched on job_a1b2");
+});
+
+test("a runtime fallback drop titles Watch delivery failed with warning tone", () => {
+  // renderUnreachableChildPendingsWithLoaders emits the DiagnosticReason
+  // directly ("child unreachable: ..."), outside the "watch send " family —
+  // still a failed delivery, never a firing.
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="child unreachable: output_match: ready" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Watch delivery failed");
+  expect(n.tone).toBe("warning");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -215,7 +215,66 @@ Watch event triggered: file changed.
   const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
   expect(n.type).toBe("watch");
   expect(n.title).toBe("Watch triggered");
-  expect(n.tone).toBe("warning");
+  // Mockups 23-job-watch §E: a fired watch is the expected outcome, never
+  // something needing a human — no watch notification earns a tone chip.
+  expect(n.tone).toBe("neutral");
+});
+
+test("a watch notification with concerns still reads neutral: words carry it, never a chip", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="repeat" output_bytes="0" watch_id="w9">
+Timer fired (every 300s).
+Note: keep an eye on the flaky edge case
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.tone).toBe("neutral");
+});
+
+test("a job-targeted condition fire classifies as watch with its prose and job kept", () => {
+  // RoboRev PR #954: a job-targeted watch fire carries job_id AND
+  // event/status watch. It is still a watch delivery — prose kept whole,
+  // tone neutral, job named in the title, trigger in the secondary.
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0">
+Matched output_match: ready on job_a1b2.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.tone).toBe("neutral");
+  expect(n.jobId).toBe("job_a1b2");
+  expect(n.title).toBe("Output matched on job_a1b2");
+  expect(n.secondary).toBe("output_match: ready");
+  expect(n.prose).toContain("Matched output_match: ready on job_a1b2.");
+  expect(n.excerpt).toBe("");
+});
+
+test("a job-less watch keeps the generic trigger title and its reason as secondary", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="repeat" output_bytes="0" watch_id="w9">
+Timer fired (every 300s).
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Timer fired");
+  expect(n.secondary).toBe("repeat");
+});
+
+test("watch titles derive from the trigger: event fires name the event, timers the timer (RoboRev PR #954)", () => {
+  const eventBlock = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="event: JOB_FINISHED" output_bytes="0">
+Watch event triggered: event: JOB_FINISHED.
+</job-notification>`;
+  const eventN = notif(notificationsOf(parseSteeringNotifications(eventBlock)), 0);
+  expect(eventN.type).toBe("watch");
+  expect(eventN.title).toBe("Event on job_a1b2: JOB_FINISHED");
+  expect(eventN.tone).toBe("neutral");
+  expect(eventN.prose).toContain("Watch event triggered");
+
+  const timerBlock = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="after" output_bytes="0" watch_id="w9">
+Timer fired after 300s.
+Note: check the build
+</job-notification>`;
+  const timerN = notif(notificationsOf(parseSteeringNotifications(timerBlock)), 0);
+  expect(timerN.type).toBe("watch");
+  expect(timerN.title).toBe("Timer fired");
+  expect(timerN.prose).toContain("Note: check the build");
 });
 
 test("an Observer callback parses as a notification", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -742,3 +742,220 @@ Job job_a1b2 watch. Output is available through read_transcript if needed.
   expect(n.title).toBe("Watch delivery failed");
   expect(n.tone).toBe("warning");
 });
+
+// --- RoboRev combined review (322f7aa): job-targeted notes (M2) -------------
+// The producer appends the watch note to every fire body
+// (withNotificationNote). Synthesized job-targeted prose must preserve the
+// trailing Note: section instead of replacing the whole body.
+
+test("a job-targeted fire preserves the trailing note (M2)", () => {
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+Note: check the build
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.prose).toContain("ready");
+  expect(n.prose).toContain("Note: check the build");
+  // The note arrives with its prefix and the synthesizer adds exactly one —
+  // a doubled "Note: Note:" means the section kept the prefix it must strip
+  // (RoboRev PR #954 combined review of 9e38707).
+  expect(n.prose).not.toContain("Note: Note:");
+  expect(n.prose?.match(/Note:/g)?.length).toBe(1);
+  expect(n.prose).not.toContain("Job job_a1b2 watch.");
+});
+
+test("a teardown notice with a note keeps body and note whole (M2)", () => {
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="watch cleared: job_a1b2 matched 50 times; re-arm" output_bytes="0">
+watch cleared: job_a1b2 matched 50 times; re-arm
+Note: tighten the pattern
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.title).toBe("Watch auto-cleared");
+  expect(n.prose).toContain("watch cleared: job_a1b2 matched 50 times; re-arm");
+  expect(n.prose).toContain("Note: tighten the pattern");
+});
+
+// --- RoboRev combined review (322f7aa): dot-all reasons (L1) ---------------
+// Matched output can contain newlines, and the reason attr carries raw text
+// (only entity-escaped). A multiline pattern must title and synthesize, not
+// fall back to generic.
+
+test("a multiline output_match reason titles and synthesizes (L1)", () => {
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: line1
+line2" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.title).toBe("Output matched on job_a1b2");
+  expect(n.prose).toContain("line1");
+  expect(n.prose).toContain("line2");
+});
+
+test("an attach-scan skip titles Watch delivery failed with warning tone", () => {
+  // completeAttachScan emits this when the retained-output read fails: the
+  // watch installs live but its level-trigger is lost — a monitoring
+  // failure, never a firing.
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match attach scan skipped: read failed" output_bytes="0" watch_id="watch_09QmWzRtNvxK">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Watch delivery failed");
+  expect(n.tone).toBe("warning");
+});
+
+// --- RoboRev combined review of 5c202de (MEDIUM): body entity symmetry -----
+// The producer escapes attribute values fully (&, <, >, " — kata 77sf) but
+// notification bodies only for "<" (kata 72kp) — except the watch-note lane,
+// which pre-escapes "&" (agent/job_watch.go's watchNotificationFromWatch), so
+// a note body carries the same "&"-first order as attribute values. A note
+// literally containing "&lt;" rides the wire as "&amp;lt;" and the card's
+// single full decode must restore the literal "&lt;" text — never "<".
+// escapeNoteLikeProducer mirrors that lane: "&"-first pre-escape composed
+// with the body's "<"-only escaping.
+
+// escapeNoteLikeProducer mirrors the watch-note producer lane:
+// watchNotificationFromWatch's "&" pre-escape composed with
+// escapeNotificationBody's "<"-only escaping.
+function escapeNoteLikeProducer(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+}
+
+test("a note containing literal entity text round-trips to the literal text, not a decode (MEDIUM)", () => {
+  const note = "watch for &lt;tag&gt; &amp; &quot;q&quot; &#39;done&#39;";
+  const block = `<job-notification job_id="" event="watch" job_type="watch" status="watch" reason="repeat" output_bytes="0" watch_id="w1">
+Timer fired (every 300s).
+Note: ${escapeNoteLikeProducer(note)}
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  // Prose stays escaped-form in the parse (passthrough bodies arrive escaped);
+  // the card decodes exactly once at render.
+  expect(n.prose).toContain(`Note: ${escapeNoteLikeProducer(note)}`);
+  expect(decodeNotificationEntities(n.prose ?? "")).toContain(`Note: ${note}`);
+  expect(decodeNotificationEntities(n.prose ?? "")).not.toContain("Note: <tag>");
+});
+
+test("a job-targeted fire preserves a note containing literal entity text (MEDIUM)", () => {
+  const note = "escalate when output has &lt;done&gt;";
+  const block = `<job-notification job_id="job_a1b2" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0">
+Job job_a1b2 watch. Output is available through read_transcript if needed.
+Note: ${escapeNoteLikeProducer(note)}
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.prose).toContain("ready");
+  expect(n.prose).toContain(`Note: ${escapeNoteLikeProducer(note)}`);
+  expect(decodeNotificationEntities(n.prose ?? "")).toContain(`Note: ${note}`);
+  expect(decodeNotificationEntities(n.prose ?? "")).not.toContain("Note: <done>");
+});
+
+// --- RoboRev combined review of 51bb12b (MEDIUM): watch_id reclassification -
+// A self/parent job.notification watch IS a watch notification
+// (watchNotificationFromWatch stamps OriginWatchID), but when the event
+// carries finished-job data, jobFinishedEventIdentity (agent/job_notify.go)
+// overwrites Status+Reason with the completed job's own values. The rendered
+// frame therefore carries event/status "completed" WITH a watch_id attr, and
+// the parser must key the watch type off the attr — not off event/status
+// "watch" alone — or the delivery renders as an ordinary job card. The
+// enriched reason is the COMPLETION reason ("exit_zero"), never a trigger, so
+// the card must read it verbatim and never synthesize trigger prose from it.
+
+test("a completed-status frame with a watch_id classifies as a watch delivery (51bb12b MEDIUM)", () => {
+  // Exact post-enrichment producer shape: formatJobNotificationBlock's
+  // fallthrough branch (completed status, terminal body + real excerpt) with
+  // the OriginWatchID emit (agent/job_notify.go).
+  const block = `<job-notification job_id="job_x" event="completed" job_type="shell" description="Run tests" status="completed" reason="exit_zero" output_bytes="80" exit_code="0" transcript_ref="job:job_x" watch_id="watch_09QmWzRtNvxK">
+Job job_x completed. Output is available through read_transcript(transcript_ref="job:job_x") if needed.
+excerpt:
+all tests passed
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.watchId).toBe("watch_09QmWzRtNvxK");
+  expect(n.jobId).toBe("job_x");
+  // A fired watch is the expected outcome: neutral, never a success/error
+  // chip off the completed job's own disposition.
+  expect(n.tone).toBe("neutral");
+  // The delivery titles as a watch firing on the job — never a trigger the
+  // completion reason does not name.
+  expect(n.title).toBe("Watch fired on job_x");
+  expect(n.title).not.toContain("Output matched");
+  // The completion reason surfaces verbatim as the honest fallback, never
+  // reworded into trigger prose.
+  expect(n.secondary).toBe("exit_zero");
+  // The terminal sentence is genuine producer content, kept — and the real
+  // result excerpt is kept too, not dropped the way trigger-watch frames drop
+  // theirs.
+  expect(n.prose).toContain("Job job_x completed.");
+  expect(n.excerpt).toBe("all tests passed");
+});
+
+test("a failed-status frame with a watch_id is still a watch delivery, not a job failure (51bb12b MEDIUM)", () => {
+  const block = `<job-notification job_id="job_x" event="failed" job_type="shell" description="Run tests" status="failed" reason="nonzero exit" output_bytes="12" exit_code="2" transcript_ref="job:job_x" watch_id="watch_09QmWzRtNvxK">
+Job job_x failed. Output is available through read_transcript(transcript_ref="job:job_x") if needed.
+excerpt:
+boom
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  // The watched job failing is card content (excerpt), not card chrome: the
+  // delivery itself is expected, so no error chip.
+  expect(n.tone).toBe("neutral");
+  expect(n.title).toBe("Watch fired on job_x");
+  expect(n.excerpt).toBe("boom");
+});
+
+test("an empty watch_id does not reclassify a completed frame (51bb12b MEDIUM)", () => {
+  const block = `<job-notification job_id="job_x" event="completed" job_type="shell" status="completed" reason="exit_zero" output_bytes="0" exit_code="0" watch_id="">
+Job job_x completed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("job");
+  expect(n.watchId).toBeUndefined();
+  expect(n.tone).toBe("success");
+});
+
+test("a watch_send frame keeps its own type even with a watch_id attr (51bb12b MEDIUM)", () => {
+  // The producer never emits this combination (watch_send frames carry
+  // delivery_id/trigger, no watch_id); the reclassification runs after the
+  // watch_send check so the send rail can never be absorbed into watch type.
+  const block = `<job-notification job_id="job_x" event="watch_send" delivery_id="wd_1" trigger="event: job.notification" watch_id="watch_09QmWzRtNvxK">
+frame text
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch-send");
+});
+
+// --- combined RoboRev review (6bdc9ed): self job ids in watch titles --------
+// watchNotificationFromWatch always sets JobID, and a self-source watch fires
+// with job_id="self" — internal vocabulary NotificationCard already
+// suppresses in the job-id field. Titles must use the same human label the
+// job_watch renderer uses ("this session"), never the raw "self".
+
+test("a self output_match fire titles this session, not self", () => {
+  const block = `<job-notification job_id="self" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0">
+Job self watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Output matched on this session");
+});
+
+test("a self event fire titles this session, not self", () => {
+  const block = `<job-notification job_id="self" event="watch" job_type="watch" status="watch" reason="event: job.notification" output_bytes="0">
+Job self watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Event on this session: job.notification");
+});
+
+test("a self watch-fired fallthrough titles this session, not self", () => {
+  const block = `<job-notification job_id="self" event="completed" job_type="shell" status="completed" reason="exit_zero" output_bytes="0" watch_id="watch_09QmWzRtNvxK">
+Job self completed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.type).toBe("watch");
+  expect(n.title).toBe("Watch fired on this session");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
@@ -194,15 +194,28 @@ function compactStringArray(value: unknown): string[] {
   return value.map((v) => String(v ?? "").trim()).filter(Boolean);
 }
 
-// decodeNotificationEntities is the paired decoder for agent/job_notify.go's
-// escapeNotificationText: the producer HTML-entity-escapes &, <, >, and "
-// before interpolating job/watch-derived text into a <job-notification>
-// wrapper (kata 77sf), so text extracted from that wrapper - a body excerpt,
-// or (below) a delegate's communicate envelope, whose own JSON quotes are
-// escaped the same way as any other body content - must be decoded back
-// before use. &amp; is decoded LAST so double-escaped content only unwraps
-// one level. Exported so NotificationCard.tsx shares this one decoder rather
+// decodeNotificationEntities is the paired decoder for the producer's
+// HTML-entity escaping. Attribute values use agent/job_notify.go's
+// escapeNotificationText, which escapes &, <, >, and " (kata 77sf), so reason
+// / description attrs extracted from the wrapper must be decoded back before
+// use. Body text (prose, notes, excerpts) uses escapeNotificationBody, which
+// escapes only "<" (kata 72kp) — EXCEPT the watch-note lane: the producer
+// pre-escapes "&" in the note (agent/job_watch.go's
+// watchNotificationFromWatch) before the note rides the body, so a note body
+// carries the same "&"-first order as attribute values. That composition is
+// what makes literal entity text round-trip: a note containing "&lt;" rides
+// the wire as "&amp;lt;" and this single full decode restores "&lt;", never
+// "<". &amp; is decoded LAST so double-escaped content only unwraps one
+// level. Exported so NotificationCard.tsx shares this one decoder rather
 // than keeping a second copy for its own excerpt display.
+//
+// Residual asymmetry, documented not fixed: shell/delegate job OUTPUT
+// excerpts also ride the body through escapeNotificationBody ("<"-only), so
+// literal "&lt;" / "&amp;" / "&quot;" / "&#39;" in job output still
+// over-decodes here (there is no "&"-first pre-escape on that lane, and
+// adding one would change the wire format in agent/job_notify.go, out of
+// scope). Watch notes — the finding's case — are exact; excerpts are the
+// known remainder.
 export function decodeNotificationEntities(text: string): string {
   return text
     .replace(/&lt;/g, "<")
@@ -297,15 +310,22 @@ function notificationTone(attrs: Record<string, string>, communicate: Communicat
 // ("watch send failed:", "watch send dropped/pending/stable-enqueue state
 // failed:", "watch send evicted:" — agent/job_watch.go's
 // watchSendDiagnosticNotification sites), the feed guard
-// ("output dropped:"), and the runtime fallback drop ("child unreachable:"
-// — renderUnreachableChildPendingsWithLoaders emits the DiagnosticReason
-// directly, outside the "watch send " family). The "watch send " prefix
-// with its trailing space covers the send-rail family present and future. A
-// failed delivery is not a firing — it titles and tones as a failure so it
-// cannot present as a successful trigger (combined RoboRev review).
+// ("output dropped:"), the attach-scan skip ("output_match attach scan
+// skipped:" — completeAttachScan: the watch installs live but its
+// level-trigger is lost), and the runtime fallback drop
+// ("child unreachable:" — renderUnreachableChildPendingsWithLoaders emits
+// the DiagnosticReason directly, outside the "watch send " family). The
+// "watch send " prefix with its trailing space covers the send-rail family
+// present and future; the others are stable producer wordings named
+// explicitly. A failed delivery is not a firing — it titles and tones as a
+// failure so it cannot present as a successful trigger (combined RoboRev
+// review).
 function isWatchDeliveryFailure(reason: string): boolean {
   return (
-    reason.startsWith("watch send ") || reason.startsWith("output dropped:") || reason.startsWith("child unreachable:")
+    reason.startsWith("watch send ") ||
+    reason.startsWith("output dropped:") ||
+    reason.startsWith("output_match attach scan skipped:") ||
+    reason.startsWith("child unreachable:")
   );
 }
 
@@ -313,11 +333,13 @@ function jobNotificationTone(
   attrs: Record<string, string>,
   communicate: CommunicateEnvelope | null,
   analysis: JobNotificationAnalysis,
+  notificationType?: string,
 ): NotificationTone {
-  if (analysis.disposition === "failure") return "error";
   // A failed delivery earns attention even though it rides a watch frame:
   // the watcher missed something. Checked before the watch short-circuit
-  // below, which is for expected outcomes (fires, teardowns).
+  // below, which is for expected outcomes (fires, teardowns) — and before
+  // the disposition arms, so a failed DELIVERY never reads as the watched
+  // job's own outcome either.
   if (isWatchDeliveryFailure(decodeNotificationEntities(attrs.reason ?? "").trim())) {
     return "warning";
   }
@@ -327,12 +349,18 @@ function jobNotificationTone(
   // covers it too — its "matched 50 times" words carry the signal. The check
   // mirrors the parser's type detection (event OR status "watch"): a
   // status-only watch frame is still a watch delivery, never a chip
-  // (combined RoboRev review).
+  // (combined RoboRev review) — and neither is a watch_id-reclassified
+  // delivery: a self/parent job.notification watch's enriched frame carries
+  // the completed job's event/status/reason, so the attr check cannot see it
+  // as a watch, but the parser's type can. The completed job's own exit must
+  // not tone the watch card (a firing is expected, never attention-worthy),
+  // so this runs before the disposition arms below.
   const event = (attrs.event ?? "").trim().toLowerCase();
   const status = (attrs.status ?? "").trim().toLowerCase();
-  if (event === "watch" || event === "watch_send" || status === "watch") {
+  if (notificationType === "watch" || event === "watch" || event === "watch_send" || status === "watch") {
     return "neutral";
   }
+  if (analysis.disposition === "failure") return "error";
   if ((communicate?.concerns.length ?? 0) > 0 || analysis.disposition === "stopped") {
     return "warning";
   }
@@ -362,12 +390,23 @@ function titleForJobNotification(attrs: Record<string, string>, type: string, pr
     // trigger fallthroughs below.
     if (isWatchDeliveryFailure(reason)) return "Watch delivery failed";
     const jobId = (attrs.job_id ?? "").trim();
-    const outputMatch = /^output_match:\s*(.+)$/.exec(reason)?.[1]?.trim();
-    if (outputMatch && jobId) return `Output matched on ${jobId}`;
+    // The producer's self job id is internal vocabulary: NotificationCard
+    // suppresses a "self" job-id field, so titles must not interpolate it
+    // verbatim ("Output matched on self"). Readers see "this session" — the
+    // same human label jobWatch.tsx's sourceLabel uses.
+    const jobLabel = jobId === "self" ? "this session" : jobId;
+    // Value patterns are dot-all (see watchProse): matched output and event
+    // names can span lines.
+    const outputMatch = /^output_match:\s*([\s\S]+)$/.exec(reason)?.[1]?.trim();
+    if (outputMatch && jobId) return `Output matched on ${jobLabel}`;
     if (/^timer fired/i.test(prose ?? "")) return "Timer fired";
-    const eventFire = /^event:\s*(.+)$/.exec(reason)?.[1]?.trim();
-    if (eventFire && jobId) return `Event on ${jobId}: ${eventFire}`;
-    if (jobId) return `Watch fired on ${jobId}`;
+    const eventFire = /^event:\s*([\s\S]+)$/.exec(reason)?.[1]?.trim();
+    if (eventFire && jobId) return `Event on ${jobLabel}: ${eventFire}`;
+    // A watch_id-reclassified completion (a self/parent job.notification
+    // watch's enriched frame) lands here with the job's completion reason
+    // ("exit_zero", "done", …), never a trigger pattern: it titles as the
+    // watch delivery it is, naming the job but never inventing a trigger.
+    if (jobId) return `Watch fired on ${jobLabel}`;
     return "Watch triggered";
   }
   const status = (attrs.status || attrs.event || "notification").trim();
@@ -382,11 +421,13 @@ function titleForJobNotification(attrs: Record<string, string>, type: string, pr
 // tiny minutes math is duplicated here instead of cross-imported. The hour
 // branch matches the renderer's grammar (whole hours "1h", else "1h05m") so
 // a day-long timer never reads "after 1440m" (RoboRev PR #954 combined
-// review: valid timers run to 86,400s).
+// review: valid timers run to 86,400s). Rounding runs first, mirroring the
+// renderer: a remainder can never surface as 60 ("after 59m60s").
 function humanizeTimerAfter(totalSeconds: number): string {
-  if (totalSeconds < 60) return `after ${Math.round(totalSeconds)}s`;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const leftoverSeconds = Math.round(totalSeconds % 60);
+  const rounded = Math.round(totalSeconds);
+  if (rounded < 60) return `after ${rounded}s`;
+  const totalMinutes = Math.floor(rounded / 60);
+  const leftoverSeconds = rounded % 60;
   if (totalMinutes < 60) {
     return leftoverSeconds === 0
       ? `after ${totalMinutes}m`
@@ -398,9 +439,10 @@ function humanizeTimerAfter(totalSeconds: number): string {
 }
 
 function humanizeTimerEvery(totalSeconds: number): string {
-  if (totalSeconds < 60) return `every ${Math.round(totalSeconds)}s`;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const leftoverSeconds = Math.round(totalSeconds % 60);
+  const rounded = Math.round(totalSeconds);
+  if (rounded < 60) return `every ${rounded}s`;
+  const totalMinutes = Math.floor(rounded / 60);
+  const leftoverSeconds = rounded % 60;
   if (totalMinutes < 60) {
     return leftoverSeconds === 0
       ? `every ${totalMinutes}m`
@@ -443,6 +485,9 @@ function notificationSecondary(
   // review 3).
   if (notificationType === "watch") {
     const reason = decodeNotificationEntities(attrs.reason ?? "").trim();
+    // A watch_id-reclassified completion carries the job's completion reason,
+    // not a trigger: it surfaces verbatim as the honest fallback (never a
+    // synthesized trigger), with the card prose carrying the full sentence.
     return timerSecondaryFromProse(reason, prose) ?? reason;
   }
   const bits: string[] = [];
@@ -468,10 +513,31 @@ function notificationSecondary(
 // review). The synthesis names the trigger, never invented output context —
 // the reason carries the matched pattern / event name, not surrounding
 // output.
+// watchNoteSection splits a notification body into its lead sentence and its
+// trailing producer note ("Note: …", appended by withNotificationNote to
+// every fire body). Returns the note's DECODED text WITHOUT the "Note:"
+// prefix — the caller re-adds it — so the section is decoded first and the
+// bare note re-escaped by the caller into escaped-form prose (splicing raw
+// would corrupt literal entities). Undefined when the body carries no note.
+function watchNoteSection(bodyText: string): string | undefined {
+  const head = "\nNote: ";
+  const idx = bodyText.indexOf(head);
+  if (idx === -1) return undefined;
+  const note = decodeNotificationEntities(bodyText.slice(idx + head.length).trim()).trim();
+  return note === "" ? undefined : note;
+}
+
 function watchProse(attrs: Record<string, string>, bodyText: string): string {
   const jobId = (attrs.job_id ?? "").trim();
   if (!jobId) return bodyText;
   const reason = decodeNotificationEntities(attrs.reason ?? "").trim();
+  // The producer appends the watch's own note to every fire body
+  // (withNotificationNote). Synthesized prose replaces the generic lead
+  // sentence but preserves the note — re-escaped into escaped-form prose so
+  // the card's single decode restores it exactly once.
+  const note = watchNoteSection(bodyText);
+  const withNote = (synthesized: string): string =>
+    note ? `${synthesized}\n${escapeNotificationEntities(`Note: ${note}`)}` : synthesized;
   // Teardown notices ("watch ended:" / "watch cleared:") keep their own
   // prose when the producer emitted it — but a job-targeted teardown's body
   // is the same generic "Job <id> watch." sentence as a condition fire's
@@ -483,22 +549,24 @@ function watchProse(attrs: Record<string, string>, bodyText: string): string {
   // an entity.
   if (reason.startsWith("watch ended:") || reason.startsWith("watch cleared:")) {
     if (decodeNotificationEntities(bodyText).includes(reason)) return bodyText;
-    return escapeNotificationEntities(reason);
+    return withNote(escapeNotificationEntities(reason));
   }
   // Timer fires with a job_id are not a producer shape (timers emit watch_id
   // with an empty job_id), but if one ever arrives the body is already its
   // content — leave it alone.
   if (/^timer fired/i.test(bodyText)) return bodyText;
-  const outputMatch = /^output_match:\s*(.+)$/.exec(reason)?.[1]?.trim();
-  if (outputMatch) return escapeNotificationEntities(`Matched output_match: ${outputMatch} on ${jobId}.`);
-  const eventFire = /^event:\s*(.+)$/.exec(reason)?.[1]?.trim();
-  if (eventFire) return escapeNotificationEntities(`Watch event triggered: ${eventFire} on ${jobId}.`);
-  if (/^progress_tick$/.test(reason)) return escapeNotificationEntities(`Progress tick on ${jobId}.`);
+  // Value patterns are dot-all: matched output can span lines, and the
+  // reason attr carries raw text (only entity-escaped, never line-folded).
+  const outputMatch = /^output_match:\s*([\s\S]+)$/.exec(reason)?.[1]?.trim();
+  if (outputMatch) return withNote(escapeNotificationEntities(`Matched output_match: ${outputMatch} on ${jobId}.`));
+  const eventFire = /^event:\s*([\s\S]+)$/.exec(reason)?.[1]?.trim();
+  if (eventFire) return withNote(escapeNotificationEntities(`Watch event triggered: ${eventFire} on ${jobId}.`));
+  if (/^progress_tick$/.test(reason)) return withNote(escapeNotificationEntities(`Progress tick on ${jobId}.`));
   // Not a recognized trigger reason — the body is whatever the producer
   // sent; only the exact generic sentence is worth replacing, with the
   // escaped reason as the honest fallback.
   const generic = new RegExp(`^Job ${escapeRegExp(jobId)} \\S+\\.`);
-  if (generic.test(bodyText.trim())) return escapeNotificationEntities(reason) || bodyText;
+  if (generic.test(bodyText.trim())) return withNote(escapeNotificationEntities(reason)) || bodyText;
   return bodyText;
 }
 
@@ -518,6 +586,26 @@ function parseJobNotification(block: string): ParsedNotification | null {
   // delivery, with prose worth keeping and no echo metadata worth showing.
   if (attrs.event === "watch" || attrs.status === "watch") type = "watch";
   if (attrs.event === "watch_send") type = "watch-send";
+  // A self/parent job.notification watch delivers the completed job's own
+  // identity: jobFinishedEventIdentity (agent/job_notify.go) overwrites
+  // Status+Reason with the finished job's values, so the frame carries
+  // event/status "completed" (or whatever the job ended as) WITH the
+  // originating watch's id. The watch_id attr is only ever stamped on watch
+  // frames (OriginWatchID for fires/teardowns/diagnostics, WatchID for timers
+  // — agent/job_notify.go's two emit sites, and timer frames already carry
+  // event/status watch), so a non-empty watch_id on anything but a watch-send
+  // frame reclassifies it as a watch delivery. Checked after watch_send
+  // (whose frames carry no watch_id) so the send rail keeps its own type.
+  if (type !== "watch-send" && (attrs.watch_id ?? "").trim() !== "") type = "watch";
+  // A watch-typed frame that names its watch only by id (event/status are the
+  // completed job's, not "watch") is the enriched identity shape above: its
+  // reason is the completion reason ("exit_zero", "done", …), never a trigger,
+  // and its body is the terminal "Job <id> <event>." sentence plus a genuine
+  // result excerpt. Splitting normally keeps the excerpt and the watch note;
+  // routing it through watchProse would drop both for a synthesized trigger
+  // sentence that was never there (never invent trigger prose). Every other
+  // watch frame keeps the watch prose path below.
+  const watchCompletion = type === "watch" && attrs.event !== "watch" && attrs.status !== "watch";
   // A job-targeted watch fire's body is the producer's generic "Job <id>
   // <event>." sentence (formatJobNotificationBlock's fallthrough: the excerpt
   // is ignored for watch frames, so there is no matched output to carry).
@@ -527,7 +615,9 @@ function parseJobNotification(block: string): ParsedNotification | null {
   // Teardown notices ("watch ended:" / "watch cleared:") and timer/event
   // bodies already carry their own prose and pass through untouched.
   const { prose, excerpt } =
-    type === "watch" ? { prose: watchProse(attrs, bodyText), excerpt: "" } : splitNotificationExcerpt(bodyText);
+    type === "watch" && !watchCompletion
+      ? { prose: watchProse(attrs, bodyText), excerpt: "" }
+      : splitNotificationExcerpt(bodyText);
   // A communicate envelope can only ride a delegate's report (the delegate
   // calls communicate to produce it - agent/session_tools_communicate.go).
   // Gate on the actual job type, not on whether the excerpt happens to parse
@@ -542,7 +632,10 @@ function parseJobNotification(block: string): ParsedNotification | null {
   const transcriptRef = isValidTranscriptRef(attrs.transcript_ref) ? attrs.transcript_ref : undefined;
   const description = decodeNotificationEntities(attrs.description ?? "").trim();
   const analysis = analyzeJobNotification(attrs, communicate);
-  const tone = jobNotificationTone(attrs, communicate, analysis);
+  // The parser's type, not the attr echo: a watch_id-reclassified delivery
+  // carries the completed job's event/status/reason, so the attr check inside
+  // cannot see it as a watch — but it still must tone as one (neutral).
+  const tone = jobNotificationTone(attrs, communicate, analysis, type);
   return {
     type,
     title: titleForJobNotification(attrs, type, type === "watch" ? bodyText : undefined),

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
@@ -256,14 +256,16 @@ function notificationTone(attrs: Record<string, string>, communicate: Communicat
   ) {
     return "error";
   }
+  // Mockups 23-job-watch §E: a fired watch is the expected outcome, never
+  // something needing a human — no watch notification earns a tone chip,
+  // ever (not the timer, not a match, not even the budget auto-clear: the
+  // words carry it). Watch events short-circuit before the concerns/
+  // cancelled/stopped warning arm below, which a watch must never reach.
+  if (outerEvent === "watch" || outerEvent === "watch_send" || outerStatus === "watch") {
+    return "neutral";
+  }
   const status = communicateStatus || outerStatus || outerEvent;
-  if (
-    concerns ||
-    status === "cancelled" ||
-    status === "stopped" ||
-    attrs.event === "watch_send" ||
-    attrs.event === "watch"
-  ) {
+  if (concerns || status === "cancelled" || status === "stopped") {
     return "warning";
   }
   if (status === "completed" || status === "done") return "success";
@@ -276,22 +278,38 @@ function jobNotificationTone(
   analysis: JobNotificationAnalysis,
 ): NotificationTone {
   if (analysis.disposition === "failure") return "error";
+  // Same §E rule as notificationTone above: watch and watch-send deliveries
+  // are expected outcomes. The budget auto-clear notice carries the same
+  // watch event as a fire (agent/job_watch.go's watchNotification), so this
+  // covers it too — its "matched 50 times" words carry the signal.
   const event = (attrs.event ?? "").trim().toLowerCase();
-  if (
-    (communicate?.concerns.length ?? 0) > 0 ||
-    analysis.disposition === "stopped" ||
-    event === "watch_send" ||
-    event === "watch"
-  ) {
+  if (event === "watch" || event === "watch_send") {
+    return "neutral";
+  }
+  if ((communicate?.concerns.length ?? 0) > 0 || analysis.disposition === "stopped") {
     return "warning";
   }
   if (analysis.disposition === "success") return "success";
   return "neutral";
 }
 
-function titleForJobNotification(attrs: Record<string, string>, type: string): string {
+function titleForJobNotification(attrs: Record<string, string>, type: string, prose?: string): string {
   if (type === "watch-send") return "Watch delivered";
-  if (type === "watch") return "Watch triggered";
+  if (type === "watch") {
+    // Derive the title from the trigger, not from job presence (RoboRev PR
+    // #954): only an output_match fire is an "Output matched on …". A timer
+    // prose lead ("Timer fired …") keeps a timer title; an event fire
+    // ("event: …" reason) names the event.
+    const reason = (attrs.reason ?? "").trim();
+    const jobId = (attrs.job_id ?? "").trim();
+    const outputMatch = /^output_match:\s*(.+)$/.exec(reason)?.[1]?.trim();
+    if (outputMatch && jobId) return `Output matched on ${jobId}`;
+    if (/^timer fired/i.test(prose ?? "")) return "Timer fired";
+    const eventFire = /^event:\s*(.+)$/.exec(reason)?.[1]?.trim();
+    if (eventFire && jobId) return `Event on ${jobId}: ${eventFire}`;
+    if (jobId) return `Watch fired on ${jobId}`;
+    return "Watch triggered";
+  }
   const status = (attrs.status || attrs.event || "notification").trim();
   if (!status) return "Job notification";
   return `Job ${status}`;
@@ -302,7 +320,13 @@ function notificationSecondary(
   tone: NotificationTone,
   description: string,
   analysis: JobNotificationAnalysis,
+  notificationType?: string,
 ): string {
+  // A watch card's secondary names the trigger (the output_match / event the
+  // watch fired on) — the one producer field that says what happened. The
+  // job_type/status/output echo attrs stay out (NotificationCard suppresses
+  // them for watch type too).
+  if (notificationType === "watch") return (attrs.reason ?? "").trim();
   const bits: string[] = [];
   const type = (attrs.job_type ?? "").trim();
   if (description) bits.push(description);
@@ -321,7 +345,11 @@ function parseJobNotification(block: string): ParsedNotification | null {
   const attrs = parseQuotedAttrs(m[1] ?? "");
   const bodyText = (m[2] ?? "").trim();
   let type = "job";
-  if ((attrs.event === "watch" || attrs.status === "watch") && !attrs.job_id) type = "watch";
+  // A watch fire names its watched job (watchNotificationFromWatch always
+  // sets JobID — agent/job_watch.go), so event/status "watch" wins over the
+  // job_id presence check: a job-targeted condition fire is still a watch
+  // delivery, with prose worth keeping and no echo metadata worth showing.
+  if (attrs.event === "watch" || attrs.status === "watch") type = "watch";
   if (attrs.event === "watch_send") type = "watch-send";
   // A watch notification's body is all prose (the fired sentence plus the
   // watch's own note); only a job report carries an excerpt of job output. The
@@ -346,9 +374,9 @@ function parseJobNotification(block: string): ParsedNotification | null {
   const tone = jobNotificationTone(attrs, communicate, analysis);
   return {
     type,
-    title: titleForJobNotification(attrs, type),
+    title: titleForJobNotification(attrs, type, type === "watch" ? bodyText : undefined),
     tone,
-    secondary: notificationSecondary(attrs, tone, description, analysis),
+    secondary: notificationSecondary(attrs, tone, description, analysis, type),
     jobId: attrs.job_id?.trim() || undefined,
     jobType: attrs.job_type?.trim() || undefined,
     watchId: attrs.watch_id?.trim() || undefined,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
@@ -212,6 +212,18 @@ export function decodeNotificationEntities(text: string): string {
     .replace(/&amp;/g, "&");
 }
 
+// escapeNotificationEntities is decodeNotificationEntities run backward:
+// the producer-side escaping (agent/job_notify.go's escapeNotificationText)
+// for text interpolated into a <job-notification> wrapper. watchProse builds
+// synthesized card prose from an already-DECODED reason, so it re-escapes
+// the synthesis: prose is stored escaped-form throughout (passthrough bodies
+// arrive escaped), and NotificationCard decodes every prose exactly once.
+// Without the re-escape a literal "&lt;" in a matched pattern would decode
+// twice and display wrong (combined RoboRev review).
+export function escapeNotificationEntities(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
 interface CommunicateEnvelope {
   message: string;
   status: string;
@@ -281,9 +293,13 @@ function jobNotificationTone(
   // Same §E rule as notificationTone above: watch and watch-send deliveries
   // are expected outcomes. The budget auto-clear notice carries the same
   // watch event as a fire (agent/job_watch.go's watchNotification), so this
-  // covers it too — its "matched 50 times" words carry the signal.
+  // covers it too — its "matched 50 times" words carry the signal. The check
+  // mirrors the parser's type detection (event OR status "watch"): a
+  // status-only watch frame is still a watch delivery, never a chip
+  // (combined RoboRev review).
   const event = (attrs.event ?? "").trim().toLowerCase();
-  if (event === "watch" || event === "watch_send") {
+  const status = (attrs.status ?? "").trim().toLowerCase();
+  if (event === "watch" || event === "watch_send" || status === "watch") {
     return "neutral";
   }
   if ((communicate?.concerns.length ?? 0) > 0 || analysis.disposition === "stopped") {
@@ -300,7 +316,16 @@ function titleForJobNotification(attrs: Record<string, string>, type: string, pr
     // #954): only an output_match fire is an "Output matched on …". A timer
     // prose lead ("Timer fired …") keeps a timer title; an event fire
     // ("event: …" reason) names the event.
-    const reason = (attrs.reason ?? "").trim();
+    // The reason is producer-escaped (escapeNotificationText) and
+    // parseQuotedAttrs does not decode, so decode before matching — a
+    // pattern containing & < > must title decoded (RoboRev PR #954 review 3).
+    const reason = decodeNotificationEntities(attrs.reason ?? "").trim();
+    // Teardown notices are endings, never firings (RoboRev PR #954 review 3):
+    // watchEndedUnfiredMessage / watchLostAtRestartMessage start with
+    // "watch ended:", watchBudgetClearedMessage with "watch cleared:". The
+    // prose/reason carries which watch and why, so the title stays short.
+    if (reason.startsWith("watch ended:")) return "Watch ended";
+    if (reason.startsWith("watch cleared:")) return "Watch auto-cleared";
     const jobId = (attrs.job_id ?? "").trim();
     const outputMatch = /^output_match:\s*(.+)$/.exec(reason)?.[1]?.trim();
     if (outputMatch && jobId) return `Output matched on ${jobId}`;
@@ -315,18 +340,76 @@ function titleForJobNotification(attrs: Record<string, string>, type: string, pr
   return `Job ${status}`;
 }
 
+// Local duration humanizer for timer secondaries. jobWatch.tsx owns the
+// canonical humanizeSeconds/humanizeInterval, but this file is a message
+// parser and must not import a tool renderer for one of its descriptors —
+// the parser stays independent of any single tool's rendering layer — so the
+// tiny minutes math is duplicated here instead of cross-imported. The hour
+// branch matches the renderer's grammar (whole hours "1h", else "1h05m") so
+// a day-long timer never reads "after 1440m" (RoboRev PR #954 combined
+// review: valid timers run to 86,400s).
+function humanizeTimerAfter(totalSeconds: number): string {
+  if (totalSeconds < 60) return `after ${Math.round(totalSeconds)}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const leftoverSeconds = Math.round(totalSeconds % 60);
+  if (totalMinutes < 60) {
+    return leftoverSeconds === 0
+      ? `after ${totalMinutes}m`
+      : `after ${totalMinutes}m${String(leftoverSeconds).padStart(2, "0")}s`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `after ${hours}h` : `after ${hours}h${String(minutes).padStart(2, "0")}m`;
+}
+
+function humanizeTimerEvery(totalSeconds: number): string {
+  if (totalSeconds < 60) return `every ${Math.round(totalSeconds)}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const leftoverSeconds = Math.round(totalSeconds % 60);
+  if (totalMinutes < 60) {
+    return leftoverSeconds === 0
+      ? `every ${totalMinutes}m`
+      : `every ${totalMinutes}m${String(leftoverSeconds).padStart(2, "0")}s`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `every ${hours}h` : `every ${hours}h${String(minutes).padStart(2, "0")}m`;
+}
+
+// timerSecondaryFromProse humanizes a bare timer reason ("after"/"repeat")
+// from the prose lead's own seconds ("Timer fired after 300s." /
+// "Timer fired (every 300s).", agent/job_notify.go). Undefined when the prose
+// does not match — the caller falls back to the raw reason.
+function timerSecondaryFromProse(reason: string, prose: string | undefined): string | undefined {
+  if (reason !== "after" && reason !== "repeat") return undefined;
+  const seconds = /^Timer fired (?:after|\(every) (\d+)s/.exec((prose ?? "").trim())?.[1];
+  if (seconds === undefined) return undefined;
+  const totalSeconds = Number(seconds);
+  if (!Number.isFinite(totalSeconds)) return undefined;
+  return reason === "after" ? humanizeTimerAfter(totalSeconds) : humanizeTimerEvery(totalSeconds);
+}
+
 function notificationSecondary(
   attrs: Record<string, string>,
   tone: NotificationTone,
   description: string,
   analysis: JobNotificationAnalysis,
   notificationType?: string,
+  prose?: string,
 ): string {
   // A watch card's secondary names the trigger (the output_match / event the
   // watch fired on) — the one producer field that says what happened. The
   // job_type/status/output echo attrs stay out (NotificationCard suppresses
   // them for watch type too).
-  if (notificationType === "watch") return (attrs.reason ?? "").trim();
+  // The reason is producer-escaped (see titleForJobNotification above), so it
+  // is decoded here too; a bare timer reason ("after"/"repeat") humanizes
+  // from the prose lead's seconds instead ("after 5m" / "every 5m"), falling
+  // back to the raw reason when the prose does not match (RoboRev PR #954
+  // review 3).
+  if (notificationType === "watch") {
+    const reason = decodeNotificationEntities(attrs.reason ?? "").trim();
+    return timerSecondaryFromProse(reason, prose) ?? reason;
+  }
   const bits: string[] = [];
   const type = (attrs.job_type ?? "").trim();
   if (description) bits.push(description);
@@ -337,6 +420,55 @@ function notificationSecondary(
   const reason = (attrs.reason ?? "").trim();
   if (reason && (tone === "error" || tone === "warning")) bits.push(reason);
   return bits.join(" · ");
+}
+
+// watchProse is a watch notification's card prose. Most watch bodies ARE
+// their content (timer sentences, teardown notices, event bodies) and pass
+// through verbatim. The one exception is a job-targeted CONDITION fire: the
+// producer's non-empty-job_id path emits only the generic "Job <id> <event>."
+// sentence (formatJobNotificationBlock's fallthrough — the excerpt is ignored
+// for watch frames), keeping the trigger in the escaped reason attr. For that
+// shape the card synthesizes prose from the reason so the expanded card shows
+// what fired instead of the generic sentence (RoboRev PR #954 combined
+// review). The synthesis names the trigger, never invented output context —
+// the reason carries the matched pattern / event name, not surrounding
+// output.
+function watchProse(attrs: Record<string, string>, bodyText: string): string {
+  const jobId = (attrs.job_id ?? "").trim();
+  if (!jobId) return bodyText;
+  const reason = decodeNotificationEntities(attrs.reason ?? "").trim();
+  // Teardown notices ("watch ended:" / "watch cleared:") keep their own
+  // prose when the producer emitted it — but a job-targeted teardown's body
+  // is the same generic "Job <id> watch." sentence as a condition fire's
+  // (formatJobNotificationBlock's non-empty-JobID fallthrough covers every
+  // reason). Only a body that already carries the reason passes through; a
+  // generic body falls to the reason below (combined RoboRev review). The
+  // comparison decodes the body first: the body is escaped-form and the
+  // reason decoded-form, so a raw includes() misses whenever either carries
+  // an entity.
+  if (reason.startsWith("watch ended:") || reason.startsWith("watch cleared:")) {
+    if (decodeNotificationEntities(bodyText).includes(reason)) return bodyText;
+    return escapeNotificationEntities(reason);
+  }
+  // Timer fires with a job_id are not a producer shape (timers emit watch_id
+  // with an empty job_id), but if one ever arrives the body is already its
+  // content — leave it alone.
+  if (/^timer fired/i.test(bodyText)) return bodyText;
+  const outputMatch = /^output_match:\s*(.+)$/.exec(reason)?.[1]?.trim();
+  if (outputMatch) return escapeNotificationEntities(`Matched output_match: ${outputMatch} on ${jobId}.`);
+  const eventFire = /^event:\s*(.+)$/.exec(reason)?.[1]?.trim();
+  if (eventFire) return escapeNotificationEntities(`Watch event triggered: ${eventFire} on ${jobId}.`);
+  if (/^progress_tick$/.test(reason)) return escapeNotificationEntities(`Progress tick on ${jobId}.`);
+  // Not a recognized trigger reason — the body is whatever the producer
+  // sent; only the exact generic sentence is worth replacing, with the
+  // escaped reason as the honest fallback.
+  const generic = new RegExp(`^Job ${escapeRegExp(jobId)} \\S+\\.`);
+  if (generic.test(bodyText.trim())) return escapeNotificationEntities(reason) || bodyText;
+  return bodyText;
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function parseJobNotification(block: string): ParsedNotification | null {
@@ -351,12 +483,16 @@ function parseJobNotification(block: string): ParsedNotification | null {
   // delivery, with prose worth keeping and no echo metadata worth showing.
   if (attrs.event === "watch" || attrs.status === "watch") type = "watch";
   if (attrs.event === "watch_send") type = "watch-send";
-  // A watch notification's body is all prose (the fired sentence plus the
-  // watch's own note); only a job report carries an excerpt of job output. The
-  // tag attributes already say which this is, so decide before splitting -
-  // otherwise a note line reading "excerpt:" would hand the rest of the note
-  // to the excerpt preview.
-  const { prose, excerpt } = type === "watch" ? { prose: bodyText, excerpt: "" } : splitNotificationExcerpt(bodyText);
+  // A job-targeted watch fire's body is the producer's generic "Job <id>
+  // <event>." sentence (formatJobNotificationBlock's fallthrough: the excerpt
+  // is ignored for watch frames, so there is no matched output to carry).
+  // The reason attr holds the actual trigger ("output_match: …" /
+  // "event: …"), so the card synthesizes its prose from the reason instead
+  // of showing the generic sentence (RoboRev PR #954 combined review).
+  // Teardown notices ("watch ended:" / "watch cleared:") and timer/event
+  // bodies already carry their own prose and pass through untouched.
+  const { prose, excerpt } =
+    type === "watch" ? { prose: watchProse(attrs, bodyText), excerpt: "" } : splitNotificationExcerpt(bodyText);
   // A communicate envelope can only ride a delegate's report (the delegate
   // calls communicate to produce it - agent/session_tools_communicate.go).
   // Gate on the actual job type, not on whether the excerpt happens to parse
@@ -376,7 +512,7 @@ function parseJobNotification(block: string): ParsedNotification | null {
     type,
     title: titleForJobNotification(attrs, type, type === "watch" ? bodyText : undefined),
     tone,
-    secondary: notificationSecondary(attrs, tone, description, analysis, type),
+    secondary: notificationSecondary(attrs, tone, description, analysis, type, type === "watch" ? bodyText : undefined),
     jobId: attrs.job_id?.trim() || undefined,
     jobType: attrs.job_type?.trim() || undefined,
     watchId: attrs.watch_id?.trim() || undefined,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
@@ -268,6 +268,14 @@ function notificationTone(attrs: Record<string, string>, communicate: Communicat
   ) {
     return "error";
   }
+  // A failed delivery earns attention even on paths that short-circuit
+  // watch frames below: the watcher missed something. Defense in depth —
+  // watch diagnostics normally arrive as job notifications (which check
+  // this in jobNotificationTone), but no watch-shaped failure must ever
+  // read as an expected outcome (combined RoboRev review).
+  if (isWatchDeliveryFailure(decodeNotificationEntities(attrs.reason ?? "").trim())) {
+    return "warning";
+  }
   // Mockups 23-job-watch §E: a fired watch is the expected outcome, never
   // something needing a human — no watch notification earns a tone chip,
   // ever (not the timer, not a match, not even the budget auto-clear: the
@@ -284,12 +292,35 @@ function notificationTone(attrs: Record<string, string>, communicate: Communicat
   return "neutral";
 }
 
+// isWatchDeliveryFailure reports whether a (decoded) watch reason names a
+// failed delivery rather than a trigger: the send-rail diagnostics
+// ("watch send failed:", "watch send dropped/pending/stable-enqueue state
+// failed:", "watch send evicted:" — agent/job_watch.go's
+// watchSendDiagnosticNotification sites), the feed guard
+// ("output dropped:"), and the runtime fallback drop ("child unreachable:"
+// — renderUnreachableChildPendingsWithLoaders emits the DiagnosticReason
+// directly, outside the "watch send " family). The "watch send " prefix
+// with its trailing space covers the send-rail family present and future. A
+// failed delivery is not a firing — it titles and tones as a failure so it
+// cannot present as a successful trigger (combined RoboRev review).
+function isWatchDeliveryFailure(reason: string): boolean {
+  return (
+    reason.startsWith("watch send ") || reason.startsWith("output dropped:") || reason.startsWith("child unreachable:")
+  );
+}
+
 function jobNotificationTone(
   attrs: Record<string, string>,
   communicate: CommunicateEnvelope | null,
   analysis: JobNotificationAnalysis,
 ): NotificationTone {
   if (analysis.disposition === "failure") return "error";
+  // A failed delivery earns attention even though it rides a watch frame:
+  // the watcher missed something. Checked before the watch short-circuit
+  // below, which is for expected outcomes (fires, teardowns).
+  if (isWatchDeliveryFailure(decodeNotificationEntities(attrs.reason ?? "").trim())) {
+    return "warning";
+  }
   // Same §E rule as notificationTone above: watch and watch-send deliveries
   // are expected outcomes. The budget auto-clear notice carries the same
   // watch event as a fire (agent/job_watch.go's watchNotification), so this
@@ -326,6 +357,10 @@ function titleForJobNotification(attrs: Record<string, string>, type: string, pr
     // prose/reason carries which watch and why, so the title stays short.
     if (reason.startsWith("watch ended:")) return "Watch ended";
     if (reason.startsWith("watch cleared:")) return "Watch auto-cleared";
+    // A failed delivery is not a firing — it titles as what it is, never
+    // "Watch fired on <job>" (combined RoboRev review). Checked before the
+    // trigger fallthroughs below.
+    if (isWatchDeliveryFailure(reason)) return "Watch delivery failed";
     const jobId = (attrs.job_id ?? "").trim();
     const outputMatch = /^output_match:\s*(.+)$/.exec(reason)?.[1]?.trim();
     if (outputMatch && jobId) return `Output matched on ${jobId}`;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRenderers.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRenderers.ts
@@ -65,6 +65,14 @@ export interface ToolRendererDescriptor {
   //                     must see, so it breaks a run exactly like "never".
   fold?: "never" | "quiet" | "consequential";
   body?: ComponentType<ToolRenderProps>; // expanded content; default raw output
+  // hasBody answers per-item whether the body would render anything.
+  // ToolCallItem keys the row's expandability off body presence today, so a
+  // descriptor whose body returns null for some items (a summary-only
+  // rendering) would offer a disclosure that opens to nothing. Absence keeps
+  // today's behavior: any registered body means expandable. The one case
+  // today is job_watch, whose clear and terminal catch-up summaries ARE the
+  // rendering.
+  hasBody?(item: ItemModel): boolean;
   // outputImageSize sizes the generic output-images gallery ToolCallItem
   // renders after the body: undefined keeps the default 96px thumbnails,
   // "large" displays each image whole at up to 600px square. The one case

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/index.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/index.ts
@@ -22,6 +22,7 @@ import "./editTools";
 import "./webTools";
 import "./useSkillTool";
 import "./jobTools";
+import "./jobWatch";
 import "./subagentModule";
 import "./askUser";
 import "./taskCard";

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, expect, test, vi } from "vitest";
 import { toolRendererFor } from "../toolRenderers";
 import "./jobTools";
+import "./jobWatch";
 import type { ItemModel } from "../../../../protocol/model";
 
 afterEach(() => {
@@ -688,19 +689,29 @@ test("job_send_message aliases to the same descriptor as delegate_send, reading 
   );
 });
 
-// --- generic job_* family predicate (e.g. job_watch) ----------------------
+// --- generic job_* family predicate (job_watch has its own descriptor) ----
+// job_watch's exact-match descriptor lives in jobWatch.tsx (mockups
+// 23-job-watch §A-D); the family predicate below still covers every OTHER
+// unlisted job_* name. These pin the predicate with a name no exact
+// descriptor claims, plus the exact-wins-over-predicate precedence rule.
 
 test("an unlisted job_* tool falls to the generic family descriptor, mentioning its operation arg when present", () => {
-  const d = toolRendererFor("job_watch");
-  const args = JSON.stringify({ operation: "list" });
-  expect(d.summary(item({ id: "jw_1", toolName: "job_watch", argumentsJSON: args }))).toBe("job_watch: list");
+  const d = toolRendererFor("job_zzz_unlisted");
+  const args = JSON.stringify({ operation: "frobnicate" });
+  expect(d.summary(item({ id: "jw_1", toolName: "job_zzz_unlisted", argumentsJSON: args }))).toBe(
+    "job_zzz_unlisted: frobnicate",
+  );
 });
 
 test("the generic job_* descriptor degrades to the bare tool name with no operation arg", () => {
-  const d = toolRendererFor("job_watch");
-  expect(d.summary(item({ id: "jw_2", toolName: "job_watch", argumentsJSON: "{}" }))).toBe("job_watch");
+  const d = toolRendererFor("job_zzz_unlisted");
+  expect(d.summary(item({ id: "jw_2", toolName: "job_zzz_unlisted", argumentsJSON: "{}" }))).toBe("job_zzz_unlisted");
 });
 
 test("the generic job_* descriptor never wins over an exact match", () => {
-  expect(toolRendererFor("job_stop")).not.toBe(toolRendererFor("job_watch"));
+  expect(toolRendererFor("job_stop")).not.toBe(toolRendererFor("job_zzz_unlisted"));
+});
+
+test("job_watch resolves to its own descriptor, not the generic family fallback", () => {
+  expect(toolRendererFor("job_watch")).not.toBe(toolRendererFor("job_zzz_unlisted"));
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.tsx
@@ -360,9 +360,10 @@ registerToolRenderer({
   body: DelegateSendBody,
 });
 
-// Generic fallback for any other job_*-family tool (e.g. job_watch) not
-// explicitly registered above - "match by predicate" per this project's
-// own locked ToolRendererDescriptor doc comment. Exact matches above
+// Generic fallback for any other job_*-family tool not explicitly
+// registered anywhere - "match by predicate" per this project's own locked
+// ToolRendererDescriptor doc comment. job_watch has its own exact-match
+// descriptor (jobWatch.tsx, mockups 23-job-watch §A-D); exact matches
 // always win (toolRenderers.ts's own precedence rule), so this only ever
 // resolves for a job_* name none of the specific descriptors claimed.
 registerToolRenderer({

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.module.css
@@ -1,0 +1,110 @@
+/* JobWatchBody: headerless watch card for the job_watch tool (mockups
+   23-job-watch §A-D). Deliberately headerless: no watch-id bar, no status
+   chip, no footer — the collapsed summary line already says what this is,
+   and the body only adds what the summary cannot hold (the full note, the
+   full pattern). The watch id lives where it disambiguates — list rows,
+   inspect summaries, raw disclosures. Follows the design system
+   (docs/web-ui/design-system.md): all colors, spacing, radii, and fonts use
+   var(--token) from tokens.css. Mono (--font-mono) is reserved for machine
+   text (watch ids, source ids, match patterns). Sentence case throughout;
+   color-is-attention: no tone chip on any watch surface (chips survive only
+   as neutral list-row status pills where watching vs ended varies per row).
+   Single-watch bodies carry no semantic hue at all, so this module reaches
+   for no --attention/--alive/--danger var and needs no token-contract
+   exception. */
+
+.card {
+  background: var(--surface-1);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-pane);
+  overflow: hidden;
+}
+
+.section {
+  padding: var(--space-3) var(--space-4);
+}
+
+/* §A: the timer note is human-authored prose, not machine text. */
+.note {
+  font-size: var(--font-size-body);
+  color: var(--ink-hi);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+/* Notes longer than ~20 lines clamp with an honest disclosure; everything
+   at or under shows in full with no disclosure at all. */
+.noteClamped {
+  display: -webkit-box;
+  -webkit-line-clamp: 20;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* §B/D: one condition sentence in prose, patterns and ids in mono. */
+.trigger {
+  font-size: var(--font-size-body);
+  color: var(--ink-hi);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-caption);
+}
+
+/* §C: list rows — the one place watch ids stay visible, beside the
+   per-row watching/ended chip. */
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 9px var(--space-4);
+  border-top: 1px solid var(--edge);
+  font-size: var(--font-size-ui);
+  min-height: var(--tap-min);
+  width: 100%;
+  text-align: left;
+}
+
+.row:first-child {
+  border-top: none;
+}
+
+.rowId {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-caption);
+  flex: none;
+}
+
+.rowCondition {
+  color: var(--ink-mid);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.disclosureSummary {
+  font-size: var(--font-size-ui);
+  color: var(--ink-mid);
+  cursor: pointer;
+  min-height: var(--tap-min);
+  display: flex;
+  align-items: center;
+  list-style: none;
+}
+
+.disclosureSummary::-webkit-details-marker {
+  display: none;
+}
+
+.disclosureSummary:hover {
+  color: var(--ink-hi);
+}
+
+.disclosureSummary:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.module.css
@@ -56,16 +56,45 @@
 }
 
 /* §C: list rows — the one place watch ids stay visible, beside the
-   per-row watching/ended chip. */
+   per-row watching/ended chip. Rows after the first are separated by a top
+   border: rows are direct children of the list container (no per-row
+   wrappers — a wrapper would make every row a first child and erase all
+   separators), and only row elements take the border, never expanded
+   detail sections. */
+.list > [data-testid="job-watch-row"]:not(:first-child) {
+  border-top: 1px solid var(--edge);
+}
+
 .row {
   display: flex;
   align-items: center;
   gap: var(--space-2);
   padding: 9px var(--space-4);
-  border-top: 1px solid var(--edge);
-  font-size: var(--font-size-ui);
   width: 100%;
   text-align: left;
+  /* Native <button> reset (toolcallitem.module.css idiom): the row draws
+     its own surfaces — hover wash, focus ring — never the platform chrome.
+     The font shorthand runs before font-size (a shorthand after the
+     longhand would reset it — noShorthandPropertyOverrides). */
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: var(--font-size-ui);
+  appearance: none;
+  cursor: pointer;
+}
+
+.row:hover {
+  background: color-mix(in oklab, var(--ink-mid) 8%, transparent);
+  border-radius: var(--radius-control);
+}
+
+.row:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: -2px;
 }
 
 /* The 44px tap floor lives under the coarse-pointer media query in
@@ -76,10 +105,6 @@
   .row {
     min-height: var(--tap-min);
   }
-}
-
-.row:first-child {
-  border-top: none;
 }
 
 /* §C: a row that cannot expand is not a control — same layout as a row, no
@@ -93,13 +118,8 @@
   align-items: center;
   gap: var(--space-2);
   padding: 9px var(--space-4);
-  border-top: 1px solid var(--edge);
   font-size: var(--font-size-ui);
   width: 100%;
-}
-
-.rowStatic:first-child {
-  border-top: none;
 }
 
 .rowId {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.module.css
@@ -64,12 +64,41 @@
   padding: 9px var(--space-4);
   border-top: 1px solid var(--edge);
   font-size: var(--font-size-ui);
-  min-height: var(--tap-min);
   width: 100%;
   text-align: left;
 }
 
+/* The 44px tap floor lives under the coarse-pointer media query in
+   tokens.css, so it is only consumed under the same query here (the
+   RailRow treatment) — on desktop the token is undefined and the rows keep
+   their content height. */
+@media (pointer: coarse) {
+  .row {
+    min-height: var(--tap-min);
+  }
+}
+
 .row:first-child {
+  border-top: none;
+}
+
+/* §C: a row that cannot expand is not a control — same layout as a row, no
+   button affordance (no hover wash, no pointer cursor, no tap height, no
+   left-aligned button reset). Rendering a <div> instead of a <button> keeps
+   it out of the tab order entirely (combined RoboRev review: no focusable
+   no-op controls). Note: no PR-number references in this file — the
+   token-contract gate reads "#NNN" as a hex color literal. */
+.rowStatic {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 9px var(--space-4);
+  border-top: 1px solid var(--edge);
+  font-size: var(--font-size-ui);
+  width: 100%;
+}
+
+.rowStatic:first-child {
   border-top: none;
 }
 
@@ -90,10 +119,15 @@
   font-size: var(--font-size-ui);
   color: var(--ink-mid);
   cursor: pointer;
-  min-height: var(--tap-min);
   display: flex;
   align-items: center;
   list-style: none;
+}
+
+@media (pointer: coarse) {
+  .disclosureSummary {
+    min-height: var(--tap-min);
+  }
 }
 
 .disclosureSummary::-webkit-details-marker {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.test.tsx
@@ -1,0 +1,462 @@
+// @vitest-environment jsdom
+
+// job_watch tool descriptor tests (mockups 23-job-watch §A-D).
+//
+// TDD RED: this file is written first, against the generic job_* fallback
+// still registered in jobTools.tsx. Every summary expectation below names
+// the approved per-operation rendering, so each test fails until jobWatch.tsx
+// registers its exact-match "job_watch" descriptor (exact matches win over
+// the family predicate per toolRenderers.ts).
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test } from "vitest";
+import type { ItemModel } from "../../../../protocol/model";
+import { toolRendererFor } from "../toolRenderers";
+import "../tools";
+import "./jobWatch";
+
+afterEach(() => {
+  cleanup();
+});
+
+function item(overrides: Partial<ItemModel> = {}): ItemModel {
+  return { id: "item_1", turnId: "turn_1", type: "commandExecution", text: "", ...overrides };
+}
+
+function watchItem(args: Record<string, unknown>, raw: unknown, output = ""): ItemModel {
+  return item({ toolName: "job_watch", argumentsJSON: JSON.stringify(args), raw, output });
+}
+
+// The hero timer note from the live session in the mockups.
+const TIMER_NOTE =
+  "Check CI34049074976 current published ec738c514a35b604338c5346f98b661d62910623 PR822 and fresh RoboRev. " +
+  "Lastcomment1f935 boundaryfindingfixedec738. USER says job-shell fuzz failure belongs separate PR; no agent edits; " +
+  "diagnosis retained. Task41 only CI/review monitoring remaining, no full local tests/races.";
+
+const TIMER_RAW = {
+  watch_id: "watch_034KEfjYFbfoUaPeHJcLXY",
+  source: "self",
+  watching: true,
+  after_seconds: 300,
+  note: TIMER_NOTE,
+  replaced_existing: false,
+  fired: false,
+};
+
+// --- §A: create timer -----------------------------------------------------
+
+test("create timer summary humanizes after_seconds and heads the note", () => {
+  const d = toolRendererFor("job_watch");
+  expect(d.summary(watchItem({ operation: "create" }, TIMER_RAW))).toBe(
+    "Remind me in 5m · Check CI34049074976 current published ec738c514a…",
+  );
+});
+
+test("create timer body renders the full note as prose with no disclosure at this length", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "create" }, TIMER_RAW)} live={false} />);
+  expect(screen.getByTestId("job-watch-note").textContent).toContain("Task41 only CI/review monitoring");
+  expect(screen.queryByText("Show full note")).toBeNull();
+});
+
+test("a note over ~20 lines clamps behind an honest disclosure", () => {
+  const longNote = Array.from({ length: 25 }, (_, i) => `note line ${i + 1}`).join("\n");
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem({ operation: "create" }, { ...TIMER_RAW, note: longNote, after_seconds: 60 })}
+      live={false}
+    />,
+  );
+  expect(screen.getByText("Show full note")).toBeTruthy();
+  expect(screen.getByTestId("job-watch-note").textContent).toContain("note line 25");
+});
+
+test("the single-watch body never shows the watch id", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "create" }, TIMER_RAW)} live={false} />);
+  expect(screen.getByTestId("job-watch-body").textContent).not.toContain("watch_034KEfjYFbfoUaPeHJcLXY");
+});
+
+// --- §B: create condition watch -------------------------------------------
+
+const CONDITION_RAW = {
+  watch_id: "watch_09QmWzRtNvxK",
+  source: "job_a1b2",
+  watching: true,
+  output_match: "ready|done",
+  events: ["job.notification"],
+  progress_interval_ms: 120000,
+  replaced_existing: false,
+  fired: false,
+};
+
+test("create condition summary humanizes progress_interval_ms and names the pattern", () => {
+  const d = toolRendererFor("job_watch");
+  expect(d.summary(watchItem({ operation: "create" }, CONDITION_RAW))).toContain("job_a1b2");
+  expect(d.summary(watchItem({ operation: "create" }, CONDITION_RAW))).toContain("ready|done");
+  expect(d.summary(watchItem({ operation: "create" }, CONDITION_RAW))).toContain("every 2m");
+  expect(d.summary(watchItem({ operation: "create" }, CONDITION_RAW))).not.toContain("120000");
+});
+
+test("create condition body is one humanized sentence with no raw field names", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "create" }, CONDITION_RAW)} live={false} />);
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("job_a1b2");
+  expect(body).toContain("ready|done");
+  expect(body).toContain("every 2m");
+  expect(body).not.toContain("progress_interval_ms");
+  expect(body).not.toContain("output_match:");
+});
+
+test("event-filter watches name the failing tool-call shape", () => {
+  const raw = {
+    watch_id: "watch_ev1",
+    source: "dlg_7Hk2",
+    watching: true,
+    events: ["assistant.tool"],
+    event_filter: { status: "error" },
+    replaced_existing: false,
+    fired: false,
+  };
+  const d = toolRendererFor("job_watch");
+  expect(d.summary(watchItem({ operation: "create" }, raw))).toContain("dlg_7Hk2");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "create" }, raw)} live={false} />);
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("dlg_7Hk2");
+  expect(body).toContain("error");
+});
+
+// --- §C: list + inspect ----------------------------------------------------
+
+const LIST_RAW = {
+  watches: [
+    {
+      watch_id: "watch_034KEfjYFbfoUaPeHJcLXY",
+      source: "self",
+      watching: true,
+      condition: "after_seconds: 300",
+    },
+    {
+      watch_id: "watch_09QmWzRtNvxK",
+      source: "job_a1b2",
+      watching: true,
+      condition: "output_match: ready|done; progress_interval_ms: 120000",
+    },
+  ],
+  recent_watches: [{ watch_id: "watch_51BdeNpV2sSr", watching: false, end_reason: "budget_exhausted" }],
+  count: 2,
+};
+
+test("list summary counts active vs ended watches", () => {
+  const d = toolRendererFor("job_watch");
+  expect(d.summary(watchItem({ operation: "list" }, LIST_RAW))).toBe("Listed watches (2 active · 1 ended)");
+});
+
+test("list body renders one row per watch with a status chip and the watch id", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "list" }, LIST_RAW)} live={false} />);
+  const rows = screen.getAllByTestId("job-watch-row");
+  expect(rows).toHaveLength(3);
+  const text = screen.getByTestId("job-watch-body").textContent ?? "";
+  // Long ids clip in the row (mockup §C truncates them) with the full id on
+  // the hover title; the short id renders whole.
+  expect(text).toContain("watch_034KEfj…foUaPeHJcLXY");
+  expect(screen.getByTitle("watch_034KEfjYFbfoUaPeHJcLXY")).toBeTruthy();
+  expect(text).toContain("watch_09QmWzRtNvxK");
+  expect(text).toContain("watching");
+  expect(text).toContain("ended");
+});
+
+test("list rows are buttons that expand the row's detail sentence (RoboRev PR #954)", async () => {
+  const user = userEvent.setup();
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "list" }, LIST_RAW)} live={false} />);
+  const rows = screen.getAllByTestId("job-watch-row");
+  expect(rows).toHaveLength(3);
+  for (const row of rows) expect(row.tagName).toBe("BUTTON");
+  // Detail hidden until tapped.
+  expect(screen.queryByTestId("job-watch-row-detail")).toBeNull();
+  await user.click(rows[1]!);
+  const detail = screen.getByTestId("job-watch-row-detail").textContent ?? "";
+  expect(detail).toContain("job_a1b2");
+  expect(detail).toContain("ready|done");
+  await user.click(rows[1]!);
+  expect(screen.queryByTestId("job-watch-row-detail")).toBeNull();
+});
+
+const INSPECT_RAW = {
+  watch_id: "watch_09QmWzRtNvxK",
+  source: "job_a1b2",
+  watching: true,
+  condition: "output_match: ready|done; progress_interval_ms: 120000",
+  deliveries: 3,
+  created_at: "2026-09-06T09:41:00-07:00",
+};
+
+test("inspect summary names the id, watching state, and deliveries used", () => {
+  const d = toolRendererFor("job_watch");
+  expect(d.summary(watchItem({ operation: "inspect", watch_id: "watch_09QmWzRtNvxK" }, INSPECT_RAW))).toBe(
+    "Inspected watch_09QmWzRtNvxK · watching · 3 of 50 used",
+  );
+});
+
+test("inspect body is one sentence with the source, pattern, and budget use", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "inspect", watch_id: "watch_09QmWzRtNvxK" }, INSPECT_RAW)} live={false} />);
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("job_a1b2");
+  expect(body).toContain("ready|done");
+  expect(body).toContain("3 of 50");
+});
+
+test("inspect body humanizes the embedded heartbeat instead of raw milliseconds (RoboRev PR #954)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "inspect", watch_id: "watch_09QmWzRtNvxK" }, INSPECT_RAW)} live={false} />);
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("every 2m");
+  expect(body).not.toContain("120000");
+});
+
+test("inspect body renders embedded events, every throttle, and filter in words (RoboRev PR #954)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_ev" },
+        {
+          watch_id: "watch_ev",
+          source: "dlg_7Hk2",
+          watching: true,
+          condition: "events: [assistant.tool] every 3 where tool_name=read_file, status=error",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("dlg_7Hk2");
+  expect(body).toContain("assistant.tool");
+  expect(body).not.toContain("events: [assistant.tool]");
+  expect(body).not.toContain("where tool_name=");
+});
+
+test("inspect body humanizes a repeating timer condition (RoboRev PR #954)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_rep" },
+        { watch_id: "watch_rep", source: "self", watching: true, condition: "repeat_seconds: 300" },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("every 5m");
+  expect(body).not.toContain("repeat_seconds");
+});
+
+test("list rows humanize repeating timers and event conditions (RoboRev PR #954)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            { watch_id: "watch_rep", source: "self", watching: true, condition: "repeat_seconds: 90" },
+            {
+              watch_id: "watch_ev",
+              source: "dlg_7Hk2",
+              watching: true,
+              condition: "events: [assistant.tool] every 3 where tool_name=read_file, status=error",
+            },
+          ],
+          count: 2,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("every 1m30s");
+  expect(body).not.toContain("repeat_seconds");
+  expect(body).not.toContain("where tool_name=");
+});
+
+test("the every throttle survives in create summaries and bodies (RoboRev PR #954, review 3)", () => {
+  const d = toolRendererFor("job_watch");
+  const args = { operation: "create", source: "dlg_7Hk2", events: ["communicate"], every: 3 };
+  const raw = {
+    watch_id: "watch_ev3",
+    source: "dlg_7Hk2",
+    watching: true,
+    events: ["communicate"],
+    replaced_existing: false,
+    fired: false,
+  };
+  expect(d.summary(watchItem(args, raw))).toContain("(every 3)");
+  const Body = d.body!;
+  render(<Body item={watchItem(args, raw)} live={false} />);
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("(every 3)");
+});
+
+test("a successful-calls filter reads explicitly, not as a bare tool name (RoboRev PR #954, review 3)", () => {
+  const d = toolRendererFor("job_watch");
+  const args = { operation: "create", source: "dlg_7Hk2" };
+  const raw = {
+    watch_id: "watch_ok",
+    source: "dlg_7Hk2",
+    watching: true,
+    events: ["assistant.tool"],
+    event_filter: { tool_name: "read_file", status: "ok" },
+    replaced_existing: false,
+    fired: false,
+  };
+  expect(d.summary(watchItem(args, raw))).toContain("successful tool calls");
+  const Body = d.body!;
+  render(<Body item={watchItem(args, raw)} live={false} />);
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ok");
+  expect(body).toContain("read_file");
+});
+
+test("every list row form expands a detail sentence; no expandable row is a no-op (RoboRev PR #954, review 3)", async () => {
+  const user = userEvent.setup();
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            { watch_id: "watch_evonly", source: "self", watching: true, condition: "events: [communicate]" },
+            {
+              watch_id: "watch_okf",
+              source: "dlg_7Hk2",
+              watching: true,
+              condition: "events: [assistant.tool] where tool_name=read_file, status=ok",
+            },
+            { watch_id: "watch_hb", source: "job_a1b2", watching: true, condition: "progress_interval_ms: 120000" },
+          ],
+          count: 3,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const rows = screen.getAllByTestId("job-watch-row");
+  expect(rows).toHaveLength(3);
+  for (const [index, row] of rows.entries()) {
+    await user.click(row);
+    const details = screen.getAllByTestId("job-watch-row-detail");
+    expect(details).toHaveLength(index + 1);
+  }
+  const text = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(text).toContain("communicate");
+  expect(text).toContain("successful tool calls");
+  expect(text).toContain("every 2m");
+});
+
+test("absent structured state falls back to the raw footer text (RoboRev PR #954)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  const footer = "[watching self · watch_id watch_legacy · after 300s note: hello]";
+  render(
+    <Body
+      item={item({ toolName: "job_watch", argumentsJSON: JSON.stringify({ operation: "create" }), output: footer })}
+      live={false}
+    />,
+  );
+  expect(screen.getByText(footer)).toBeTruthy();
+  // And the summary still degrades to the operation verb, never a bare name.
+  expect(d.summary(item({ toolName: "job_watch", argumentsJSON: JSON.stringify({ operation: "create" }) }))).toBe(
+    "job_watch: create",
+  );
+});
+
+// --- §D: clear + terminal catch-up -----------------------------------------
+
+test("clear summary names the cleared watch id", () => {
+  const d = toolRendererFor("job_watch");
+  const cleared = { watch_id: "watch_034KEfjYFbfoUaPeHJcLXY", source: "", watching: false };
+  // The long id clips (mockup §D truncates it); a short id renders whole.
+  expect(d.summary(watchItem({ operation: "clear", watch_id: "watch_034KEfjYFbfoUaPeHJcLXY" }, cleared))).toBe(
+    "Cleared watch_034KEfj…foUaPeHJcLXY",
+  );
+  expect(
+    d.summary(watchItem({ operation: "clear", watch_id: "watch_short" }, { ...cleared, watch_id: "watch_short" })),
+  ).toContain("Cleared");
+});
+
+test("clear body is empty: the summary line is the rendering", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  const { container } = render(
+    <Body
+      item={watchItem(
+        { operation: "clear", watch_id: "watch_034KEfjYFbfoUaPeHJcLXY" },
+        { watch_id: "watch_034KEfjYFbfoUaPeHJcLXY", source: "", watching: false },
+      )}
+      live={false}
+    />,
+  );
+  expect(container.textContent?.trim() ?? "").toBe("");
+});
+
+test("terminal catch-up summary names the terminal outcome", () => {
+  const d = toolRendererFor("job_watch");
+  const catchup = { source: "job_a1b2", watching: false, terminal_catchup: true, fired: false, status: "completed" };
+  const summary = d.summary(watchItem({ operation: "create" }, catchup));
+  expect(summary).toContain("job_a1b2");
+  expect(summary).toContain("ended");
+  expect(summary).toContain("completed");
+});
+
+test("terminal catch-up body is empty: the summary line is the rendering", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  const { container } = render(
+    <Body
+      item={watchItem(
+        { operation: "create" },
+        { source: "job_a1b2", watching: false, terminal_catchup: true, fired: false, status: "completed" },
+      )}
+      live={false}
+    />,
+  );
+  expect(container.textContent?.trim() ?? "").toBe("");
+});
+
+// --- humanized durations ----------------------------------------------------
+
+test("after 60s reads as one minute and sub-minute stays in seconds", () => {
+  const d = toolRendererFor("job_watch");
+  const oneMinute = watchItem({ operation: "create" }, { ...TIMER_RAW, after_seconds: 60, note: "ping" });
+  expect(d.summary(oneMinute)).toContain("in 1m");
+  const halfMinute = watchItem({ operation: "create" }, { ...TIMER_RAW, after_seconds: 45, note: "ping" });
+  expect(d.summary(halfMinute)).toContain("in 45s");
+});
+
+test("leftover seconds are kept, never rounded into the minute (RoboRev PR #954)", () => {
+  const d = toolRendererFor("job_watch");
+  const ninety = watchItem({ operation: "create" }, { ...TIMER_RAW, after_seconds: 90, note: "ping" });
+  expect(d.summary(ninety)).toContain("in 1m30s");
+  const repeating = watchItem({ operation: "create" }, { ...TIMER_RAW, after_seconds: undefined, repeat_seconds: 90 });
+  expect(d.summary(repeating)).toContain("every 1m30s");
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.test.tsx
@@ -1,12 +1,14 @@
 // @vitest-environment jsdom
 
 // job_watch tool descriptor tests (mockups 23-job-watch §A-D).
-//
 // TDD RED: this file is written first, against the generic job_* fallback
 // still registered in jobTools.tsx. Every summary expectation below names
 // the approved per-operation rendering, so each test fails until jobWatch.tsx
 // registers its exact-match "job_watch" descriptor (exact matches win over
 // the family predicate per toolRenderers.ts).
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, expect, test } from "vitest";
@@ -755,6 +757,80 @@ test("watching rows with unparsable conditions are not buttons (finding M2)", ()
   expect(row.tagName).not.toBe("BUTTON");
 });
 
+// --- combined RoboRev review (6bdc9ed): note-only watching rows ---------------
+// A watching row whose condition parses to no trigger bits must never echo
+// the raw Condition grammar ("note: just a note · this session"): it names
+// the note prose (structured field verbatim, else the parsed note: clause),
+// and falls back to the bare source when there is no note at all.
+
+test("a note-only watching row renders the note prose, not the raw Condition grammar", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [{ watch_id: "watch_x", source: "self", watching: true, condition: "note: just a note" }],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const row = screen.getByTestId("job-watch-row").textContent ?? "";
+  expect(row).toContain("just a note");
+  expect(row).not.toContain("note: just a note");
+});
+
+test("a note-only watching row prefers the structured note field verbatim", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            {
+              watch_id: "watch_x",
+              source: "self",
+              watching: true,
+              condition: "note: just a note",
+              note: "the full note; events: [x] is prose, not a trigger",
+            },
+          ],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const row = screen.getByTestId("job-watch-row").textContent ?? "";
+  expect(row).toContain("the full note; events: [x] is prose, not a trigger");
+  expect(row).not.toContain("note: just a note");
+});
+
+test("a watching row with no triggers and no note names only the source", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [{ watch_id: "watch_x", source: "self", watching: true, condition: "bogus grammar here" }],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const row = screen.getByTestId("job-watch-row").textContent ?? "";
+  expect(row).toContain("this session");
+  expect(row).not.toContain("bogus grammar here");
+});
+
 // --- RoboRev PR #954 combined review (ba9a9d0): lows ------------------------
 // An unrecognized object raw ({} or a legacy/future shape) must fall back to
 // the raw footer text — never an empty card with a "Watch this session"
@@ -1056,4 +1132,793 @@ test("a composite row detail names events and filter beside the pattern (M1)", a
   expect(detail).toContain("assistant.tool");
   expect(detail).toContain("read_file");
   expect(detail).toContain("(every 3)");
+});
+
+// --- RoboRev combined review (e9113df): sub-second + carry precision ------
+// progress_interval_ms is milliseconds: 1500ms must read "every 1.5s", not
+// "every 2s", and rounding must never produce a 60s carry ("every 1m60s").
+
+test("a 1500ms heartbeat keeps sub-second precision", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watch_id: "watch_ms",
+    source: "job_a1b2",
+    watching: true,
+    progress_interval_ms: 1500,
+    replaced_existing: false,
+    fired: false,
+  };
+  expect(d.summary(watchItem({ operation: "create" }, raw))).toBe("Watch job_a1b2 · every 1.5s");
+});
+
+test("millisecond heartbeats normalize rounded carry-over", () => {
+  const d = toolRendererFor("job_watch");
+  const mk = (ms: number) =>
+    watchItem({ operation: "create" }, { watch_id: "w", source: "job_a1b2", watching: true, progress_interval_ms: ms });
+  expect(d.summary(mk(59500))).toBe("Watch job_a1b2 · every 1m");
+  expect(d.summary(mk(119999))).toBe("Watch job_a1b2 · every 2m");
+});
+
+// --- RoboRev combined review (322f7aa): condition notes (M1) ----------------
+// Any watch can carry a note (backend #995); the structured create card must
+// render it alongside the condition sentence, not drop it.
+
+test("a condition create body renders the note alongside the sentence (M1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "create", source: "job_a1b2" },
+        {
+          watch_id: "watch_n",
+          source: "job_a1b2",
+          watching: true,
+          output_match: "ready",
+          note: "check the build",
+          replaced_existing: false,
+          fired: false,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready");
+  expect(body).toContain("check the build");
+});
+
+test("an inspect body renders the embedded note (M1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_n" },
+        {
+          watch_id: "watch_n",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: ready; note: check the build",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready");
+  expect(body).toContain("check the build");
+});
+
+test("a row detail names the embedded note (M1)", async () => {
+  const user = userEvent.setup();
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            {
+              watch_id: "watch_n",
+              source: "job_a1b2",
+              watching: true,
+              condition: "output_match: ready; note: check the build",
+            },
+          ],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  await user.click(screen.getByTestId("job-watch-row"));
+  const detail = screen.getByTestId("job-watch-row-detail").textContent ?? "";
+  expect(detail).toContain("ready");
+  expect(detail).toContain("check the build");
+});
+
+// --- RoboRev combined review (322f7aa): self source label (M3) --------------
+
+test("the self source reads as this session, never verbatim self (M3)", () => {
+  const d = toolRendererFor("job_watch");
+  // Condition summaries name their source; timers never render one (their
+  // summary is cadence + note head), so assert on a condition shape.
+  expect(
+    d.summary(
+      watchItem({ operation: "create" }, { watch_id: "w", source: "self", watching: true, output_match: "ready" }),
+    ),
+  ).toBe("Watch this session for “ready”");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        { watches: [{ watch_id: "w", source: "self", watching: true, condition: "after_seconds: 300" }], count: 1 },
+      )}
+      live={false}
+    />,
+  );
+  const text = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(text).not.toMatch(/(^|\s)self(\s|$)/);
+});
+
+// --- RoboRev combined review (322f7aa): dot-all patterns (L1) --------------
+
+test("a multiline output pattern survives Condition parsing (L1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_ml" },
+        {
+          watch_id: "watch_ml",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: line1\nline2; progress_interval_ms: 120000",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("line1");
+  expect(body).toContain("line2");
+  expect(body).toContain("every 2m");
+});
+
+// --- RoboRev combined review (98e31d5): catch-up/clear ordering (L1) --------
+// A send-branch terminal catch-up raw carries watch_id + watching:false +
+// terminal_catchup:true. Without operation args it must read as a catch-up
+// (terminal outcome), never as "Cleared …".
+
+test("an arg-less send-branch catch-up reads as a catch-up, not a clear (L1)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watch_id: "watch_cu",
+    source: "job_a1b2",
+    watching: false,
+    terminal_catchup: true,
+    fired: true,
+    status: "completed",
+  };
+  const noArgs = item({ toolName: "job_watch", argumentsJSON: "", raw, output: "" });
+  expect(d.summary(noArgs)).toContain("completed");
+  expect(d.summary(noArgs)).not.toContain("Cleared");
+  const Body = d.body!;
+  const { container } = render(<Body item={noArgs} live={false} />);
+  expect(container.textContent?.trim() ?? "").toBe("");
+});
+
+// --- RoboRev combined review (98e31d5): every:1 normalization (L3) ----------
+// The backend normalizes every==1 to unset; the renderer must too, or the
+// same watch describes itself as throttled in create but unthrottled
+// everywhere else.
+
+test("every:1 in create args renders as unthrottled (L3)", () => {
+  const d = toolRendererFor("job_watch");
+  const args = { operation: "create", source: "dlg_7Hk2", events: ["communicate"], every: 1 };
+  const raw = {
+    watch_id: "watch_ev1",
+    source: "dlg_7Hk2",
+    watching: true,
+    events: ["communicate"],
+    replaced_existing: false,
+    fired: false,
+  };
+  expect(d.summary(watchItem(args, raw))).not.toContain("(every 1)");
+  const Body = d.body!;
+  render(<Body item={watchItem(args, raw)} live={false} />);
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").not.toContain("(every 1)");
+});
+
+test("expanded timer rows name the embedded note (e9ab5ec review)", async () => {
+  const user = userEvent.setup();
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  for (const condition of ["after_seconds: 300; note: check the build", "repeat_seconds: 300; note: check the build"]) {
+    cleanup();
+    render(
+      <Body
+        item={watchItem(
+          { operation: "list" },
+          { watches: [{ watch_id: "watch_t", source: "self", watching: true, condition }], count: 1 },
+        )}
+        live={false}
+      />,
+    );
+    await user.click(screen.getByTestId("job-watch-row"));
+    const detail = screen.getByTestId("job-watch-row-detail").textContent ?? "";
+    expect(detail).toContain("check the build");
+  }
+});
+
+// --- RoboRev combined review (80abf55): button reset + separators (L1,L2) ---
+// .row wraps a native <button>: without a reset, native chrome (border,
+// background, font, color, cursor) leaks through. And rows must be direct
+// children of the list container for separators to render.
+
+test("the row rule resets native button chrome", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const css = readFileSync(join(here, "jobWatch.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+  const rowRule = css.match(/\.row\s*\{([^}]*)\}/)?.[1] ?? "";
+  for (const decl of ["background: transparent", "cursor: pointer", "border: 0", "font: inherit"]) {
+    expect(rowRule).toContain(decl);
+  }
+});
+
+test("list rows are direct children of the list container (L2)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            { watch_id: "watch_a", source: "self", watching: true, condition: "after_seconds: 300" },
+            { watch_id: "watch_b", source: "self", watching: true, condition: "after_seconds: 300" },
+          ],
+          count: 2,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const rows = screen.getAllByTestId("job-watch-row");
+  expect(rows).toHaveLength(2);
+  // No per-row wrapper divs: every row is a direct child of one container,
+  // so sibling separators apply to all but the first.
+  const container = rows[0]!.parentElement!;
+  expect(container.querySelectorAll(":scope > [data-testid='job-watch-row']")).toHaveLength(2);
+});
+
+// --- RoboRev combined review (80abf55): summary-only expandability (L3) -----
+// Clear and terminal catch-up results render nothing in the body — their
+// rows must not offer a disclosure that opens to nothing.
+
+test("clear results are not expandable (L3)", () => {
+  const d = toolRendererFor("job_watch");
+  expect(
+    d.hasBody?.(watchItem({ operation: "clear", watch_id: "w" }, { watch_id: "w", source: "", watching: false })),
+  ).toBe(false);
+});
+
+test("terminal catch-up results are not expandable (L3)", () => {
+  const d = toolRendererFor("job_watch");
+  expect(
+    d.hasBody?.(
+      watchItem(
+        { operation: "create" },
+        { source: "job_a1b2", watching: false, terminal_catchup: true, fired: false, status: "completed" },
+      ),
+    ),
+  ).toBe(false);
+});
+
+test("a timer note create stays expandable (L3)", () => {
+  const d = toolRendererFor("job_watch");
+  expect(d.hasBody?.(watchItem({ operation: "create" }, TIMER_RAW))).toBe(true);
+});
+
+// --- RoboRev combined review (80abf55): wildcard everywhere (L4) ------------
+
+test("wildcard events read as any event in summaries and sentences (L4)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watch_id: "watch_wc",
+    source: "dlg_7Hk2",
+    watching: true,
+    events: ["*"],
+    replaced_existing: false,
+    fired: false,
+  };
+  const summary = d.summary(watchItem({ operation: "create", source: "dlg_7Hk2", events: ["*"] }, raw));
+  expect(summary).toContain("any event");
+  expect(summary).not.toMatch(/wakes on \*/);
+  expect(summary).not.toContain("for *");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "create", source: "dlg_7Hk2", events: ["*"] }, raw)} live={false} />);
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("any event");
+  expect(body).not.toContain("wakes on *");
+});
+
+test("a structured note containing delimiters survives whole", () => {
+  // The raw carries the note in its own field beside the Condition string:
+  // free prose that itself contains "; events: [...]" must render verbatim
+  // instead of truncating at the delimiter (RoboRev PR #954). The trigger
+  // clauses still parse from the Condition string beside it.
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_n" },
+        {
+          watch_id: "watch_n",
+          source: "job_a1b2",
+          watching: true,
+          condition:
+            "output_match: p; note: check the build; events: [assistant.tool] every 3 where tool_name=read_file, status=error",
+          note: "check; events: [other]",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("assistant.tool");
+  expect(body).toContain("read_file");
+  expect(body).toContain("(every 3)");
+  expect(body).toContain("check; events: [other]");
+  expect(body).not.toContain("for other");
+});
+
+test("a legacy note-before-events Condition parses every clause", () => {
+  // Stored frames predate the structured note field and use the legacy
+  // ordering "output_match: …; note: …; events: […]" — the parser must not
+  // discard the trigger clauses after the note (RoboRev PR #954).
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_l" },
+        {
+          watch_id: "watch_l",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: ready; note: check; events: [assistant.tool]",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready");
+  expect(body).toContain("assistant.tool");
+  expect(body).toContain("check");
+});
+
+test("an arg-less legacy inspect-miss reads as not found, not cleared", () => {
+  const d = toolRendererFor("job_watch");
+  const miss = item({
+    toolName: "job_watch",
+    argumentsJSON: "",
+    raw: { watch_id: "watch_m", watching: false },
+    output: "",
+  });
+  expect(d.summary(miss)).toBe("Inspected watch_m · not found");
+  expect(d.hasBody?.(miss)).toBe(true);
+  const Body = d.body!;
+  render(<Body item={miss} live={false} />);
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("not found");
+});
+
+test("an arg-less clear with create markers still reads as cleared", () => {
+  const d = toolRendererFor("job_watch");
+  const cleared = item({
+    toolName: "job_watch",
+    argumentsJSON: "",
+    raw: { watch_id: "watch_c", source: "", watching: false, replaced_existing: false, fired: false },
+    output: "",
+  });
+  expect(d.summary(cleared)).toContain("Cleared");
+  expect(d.hasBody?.(cleared)).toBe(false);
+});
+
+test("an arg-less pending inspect with source reads as pending, not cleared", () => {
+  // A pending inspect carries watching:false + source with no end_reason (a
+  // detached watch on the terminal-flush rail) — and no replaced_existing /
+  // fired markers, which only create/clear results carry. Source alone must
+  // never infer a clear.
+  const d = toolRendererFor("job_watch");
+  const pending = item({
+    toolName: "job_watch",
+    argumentsJSON: "",
+    raw: { watch_id: "watch_p", source: "job_a1b2", watching: false },
+    output: "",
+  });
+  expect(d.summary(pending)).toBe("Inspected watch_p · pending");
+  expect(d.hasBody?.(pending)).toBe(true);
+  const Body = d.body!;
+  render(<Body item={pending} live={false} />);
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("pending");
+  expect(body).not.toContain("Cleared");
+});
+
+// --- RoboRev combined review (8a56741): inspect punctuation (finding 1) ------
+// ConditionSentence owns the sentence's single terminal period: an inspect
+// body with deliveries/created metadata must read "matches — 3 deliveries,
+// created …." with exactly one period, never "matches. — 3 deliveries.".
+
+test("an inspect body with deliveries owns one terminal period (8a56741 finding 1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_09QmWzRtNvxK" },
+        {
+          watch_id: "watch_09QmWzRtNvxK",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: ready|done",
+          deliveries: 3,
+          created_at: "2026-09-06T09:41:00-07:00",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).not.toContain("matches. —");
+  expect(body).not.toContain("matches. ");
+  expect(body).toContain("matches — 3 deliveries");
+  expect(body.endsWith(".")).toBe(true);
+});
+
+// --- RoboRev combined review (8a56741): one-shot timer wording (finding 2) ---
+// humanizeSeconds returns "in …" phrases; the one-shot inspect/row-detail
+// renderer must not prefix them with "Reminds" ("Reminds in 5m"). One-shot
+// timers read "Remind me …" (mirroring the create summary); repeating timers
+// keep "Reminds every …".
+
+test("a one-shot timer inspect reads Remind me, not Reminds in (8a56741 finding 2)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_one" },
+        { watch_id: "watch_one", source: "self", watching: true, condition: "after_seconds: 300" },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("Remind me in 5m");
+  expect(body).not.toContain("Reminds in");
+});
+
+test("a one-shot row detail reads Remind me, not Reminds in (8a56741 finding 2)", async () => {
+  const user = userEvent.setup();
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        { watches: [{ watch_id: "watch_one", source: "self", watching: true, condition: "after_seconds: 300" }] },
+      )}
+      live={false}
+    />,
+  );
+  await user.click(screen.getByTestId("job-watch-row"));
+  const detail = screen.getByTestId("job-watch-row-detail").textContent ?? "";
+  expect(detail).toContain("Remind me in 5m");
+  expect(detail).not.toContain("Reminds in");
+});
+
+test("a repeating timer inspect keeps Reminds every (8a56741 finding 2)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_rep" },
+        { watch_id: "watch_rep", source: "self", watching: true, condition: "repeat_seconds: 300" },
+      )}
+      live={false}
+    />,
+  );
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("Reminds every 5m");
+});
+
+// --- RoboRev combined review (8a56741): pending details (finding 3) ----------
+// A pending inspect raw carries the same detail fields as any other inspect
+// (condition, note, deliveries, created_at). The body must render the pending
+// state together with them, not a bare "is pending.".
+
+test("a pending inspect body renders the trigger and details (8a56741 finding 3)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_p" },
+        {
+          watch_id: "watch_p",
+          source: "job_a1b2",
+          watching: false,
+          condition: "output_match: ready|done",
+          deliveries: 3,
+          created_at: "2026-09-06T09:41:00-07:00",
+          note: "check the build",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("pending");
+  expect(body).toContain("ready|done");
+  expect(body).toContain("3 deliveries");
+  expect(body).toContain("created Sep 6");
+  expect(body).toContain("check the build");
+  expect(body).not.toContain("ended");
+});
+
+// --- RoboRev combined review (8a56741): end-reason wording (finding 4) -------
+// List rows and inspect bodies share one formatter over the backend's real
+// end-reason ids (agent/session_tools_jobs.go recentWatchEntry comment,
+// agent/job_watch.go, agent/jobs.go); unknown ids fall back to the raw id.
+
+test("ended rows and inspect bodies name end reasons in words (8a56741 finding 4)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            { watch_id: "watch_b", source: "job_a1b2", watching: false, end_reason: "budget_exhausted" },
+            { watch_id: "watch_t", source: "job_a1b2", watching: false, end_reason: "auto_removed_terminal" },
+            { watch_id: "watch_r", source: "job_a1b2", watching: false, end_reason: "replaced" },
+            { watch_id: "watch_x", source: "job_a1b2", watching: false, end_reason: "mystery_future_id" },
+          ],
+        },
+      )}
+      live={false}
+    />,
+  );
+  const rows = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(rows).toContain("matched 50 times (budget exhausted)");
+  expect(rows).toContain("watched job finished before it could fire");
+  expect(rows).toContain("replaced by a newer watch");
+  expect(rows).toContain("mystery_future_id");
+  expect(rows).not.toContain("budget_exhausted");
+  expect(rows).not.toContain("auto_removed_terminal");
+  cleanup();
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_b" },
+        { watch_id: "watch_b", source: "job_a1b2", watching: false, end_reason: "budget_exhausted" },
+      )}
+      live={false}
+    />,
+  );
+  const inspect = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(inspect).toContain("matched 50 times (budget exhausted)");
+  expect(inspect).not.toContain("budget_exhausted");
+});
+
+// --- RoboRev combined review of 5c202de (LOW): ended inspect details --------
+// The ended inspect branch returned after rendering only the end reason,
+// hiding the structured condition/details + note the backend now carries
+// (inspectResultFromWatchHistory, agent/job_watch.go:2363 — condition, note,
+// deliveries beside end_reason). The ended body must mirror the
+// pending/active branches: end sentence first, then the trigger clauses and
+// the note section.
+
+test("an ended inspect body renders the condition and note beside the end reason (LOW)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_e" },
+        {
+          watch_id: "watch_e",
+          source: "job_a1b2",
+          watching: false,
+          condition: "output_match: ready|done",
+          note: "check the build",
+          deliveries: 3,
+          end_reason: "cleared",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ended");
+  expect(body).toContain("cleared");
+  expect(body).toContain("ready|done");
+  expect(body).toContain("check the build");
+  expect(screen.getByTestId("job-watch-note").textContent).toContain("check the build");
+});
+
+test("an ended timer inspect renders its cadence beside the end reason (LOW)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_et" },
+        {
+          watch_id: "watch_et",
+          source: "self",
+          watching: false,
+          condition: "repeat_seconds: 300",
+          end_reason: "fired",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ended");
+  expect(body).toContain("fired");
+  expect(body).toContain("Reminds every 5m");
+});
+
+test("an ended inspect with no condition still reads as an ending (LOW)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_b" },
+        { watch_id: "watch_b", source: "job_a1b2", watching: false, end_reason: "budget_exhausted" },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("matched 50 times (budget exhausted)");
+  expect(body).not.toContain("budget_exhausted");
+});
+
+// --- RoboRev combined review of 71a7981 (Finding 1) --------------------------
+// A structured note is verbatim prose that may itself contain delimiter-looking
+// text ("; events: […]"). The Condition string embeds it as a note: clause,
+// so parsing the flattened condition without removing that exact clause
+// invents triggers the watch never armed.
+
+test("a structured note with delimiter text invents no triggers in inspect (Finding 1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_delim" },
+        {
+          watch_id: "watch_delim",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: ready; note: check; events: [communicate]",
+          note: "check; events: [communicate]",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready");
+  expect(body).toContain("check; events: [communicate]");
+  expect(body).not.toContain("wakes on communicate");
+  expect(body).not.toContain("Watches job_a1b2: communicate");
+});
+
+test("a structured note with delimiter text invents no triggers in list rows (Finding 1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            {
+              watch_id: "watch_delim",
+              source: "job_a1b2",
+              watching: true,
+              condition: "output_match: ready; note: check; events: [communicate]",
+              note: "check; events: [communicate]",
+            },
+          ],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready");
+  expect(body).not.toContain("communicate");
+});
+
+test("a legacy string-only note keeps the fallback parse (Finding 1)", () => {
+  // Stored frames predate the structured note field: with no structured value
+  // the parser keeps its current behavior — the events clause beside the note
+  // clause still renders.
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_legacy" },
+        {
+          watch_id: "watch_legacy",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: ready; note: check; events: [communicate]",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready");
+  expect(body).toContain("communicate");
+  expect(body).toContain("check");
+});
+
+// --- RoboRev combined review of 71a7981 (Finding 2) --------------------------
+// A valid watch with only a note and no trigger must still surface the note:
+// the summary heads it and the body renders it, mirroring the timer-note
+// create conventions. A truly conditionless watch without a note stays
+// summary-only.
+
+test("a note-only create heads the note in the summary (Finding 2)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watch_id: "watch_noteonly",
+    source: "job_a1b2",
+    watching: true,
+    note: "keep an eye on the flaky shard",
+    replaced_existing: false,
+    fired: false,
+  };
+  expect(d.summary(watchItem({ operation: "create" }, raw))).toBe("Watch job_a1b2 · keep an eye on the flaky shard");
+});
+
+test("a note-only create body renders the full note section (Finding 2)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watch_id: "watch_noteonly",
+    source: "job_a1b2",
+    watching: true,
+    note: "keep an eye on the flaky shard",
+    replaced_existing: false,
+    fired: false,
+  };
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "create" }, raw)} live={false} />);
+  expect(screen.getByTestId("job-watch-note").textContent).toContain("keep an eye on the flaky shard");
+  expect(d.hasBody?.(watchItem({ operation: "create" }, raw))).toBe(true);
+});
+
+test("a conditionless noteless create stays summary-only (Finding 2)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = { watch_id: "watch_bare", source: "self", watching: true };
+  expect(d.summary(watchItem({ operation: "create" }, raw))).toBe("Watch this session");
+  expect(d.hasBody?.(watchItem({ operation: "create" }, raw))).toBe(false);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.test.tsx
@@ -182,7 +182,11 @@ test("list rows are buttons that expand the row's detail sentence (RoboRev PR #9
   render(<Body item={watchItem({ operation: "list" }, LIST_RAW)} live={false} />);
   const rows = screen.getAllByTestId("job-watch-row");
   expect(rows).toHaveLength(3);
-  for (const row of rows) expect(row.tagName).toBe("BUTTON");
+  // Only rows that CAN expand are buttons; the ended row is plain text
+  // (RoboRev PR #954 combined review: no focusable no-op controls).
+  expect(rows[0]!.tagName).toBe("BUTTON");
+  expect(rows[1]!.tagName).toBe("BUTTON");
+  expect(rows[2]!.tagName).not.toBe("BUTTON");
   // Detail hidden until tapped.
   expect(screen.queryByTestId("job-watch-row-detail")).toBeNull();
   await user.click(rows[1]!);
@@ -205,7 +209,7 @@ const INSPECT_RAW = {
 test("inspect summary names the id, watching state, and deliveries used", () => {
   const d = toolRendererFor("job_watch");
   expect(d.summary(watchItem({ operation: "inspect", watch_id: "watch_09QmWzRtNvxK" }, INSPECT_RAW))).toBe(
-    "Inspected watch_09QmWzRtNvxK · watching · 3 of 50 used",
+    "Inspected watch_09QmWzRtNvxK · watching · 3 deliveries",
   );
 });
 
@@ -216,7 +220,7 @@ test("inspect body is one sentence with the source, pattern, and budget use", ()
   const body = screen.getByTestId("job-watch-body").textContent ?? "";
   expect(body).toContain("job_a1b2");
   expect(body).toContain("ready|done");
-  expect(body).toContain("3 of 50");
+  expect(body).toContain("3 deliveries");
 });
 
 test("inspect body humanizes the embedded heartbeat instead of raw milliseconds (RoboRev PR #954)", () => {
@@ -362,6 +366,9 @@ test("every list row form expands a detail sentence; no expandable row is a no-o
   );
   const rows = screen.getAllByTestId("job-watch-row");
   expect(rows).toHaveLength(3);
+  // Every expandable row opens its detail; static rows (none here — all
+  // three watch with parseable conditions) are never buttons.
+  for (const row of rows) expect(row.tagName).toBe("BUTTON");
   for (const [index, row] of rows.entries()) {
     await user.click(row);
     const details = screen.getAllByTestId("job-watch-row-detail");
@@ -459,4 +466,594 @@ test("leftover seconds are kept, never rounded into the minute (RoboRev PR #954)
   expect(d.summary(ninety)).toContain("in 1m30s");
   const repeating = watchItem({ operation: "create" }, { ...TIMER_RAW, after_seconds: undefined, repeat_seconds: 90 });
   expect(d.summary(repeating)).toContain("every 1m30s");
+});
+
+// --- RoboRev PR #954 review 3 -----------------------------------------------
+
+test("an output pattern containing a semicolon survives Condition parsing (finding C)", () => {
+  // output_match is caller-supplied and unbounded, so it may itself contain
+  // "; " — only semicolons introducing a recognized field may split.
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_semi" },
+        {
+          watch_id: "watch_semi",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: a;b; progress_interval_ms: 120000",
+          deliveries: 0,
+          created_at: "2026-09-06T09:41:00-07:00",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("a;b");
+  expect(body).toContain("every 2m");
+});
+
+test("list rows keep a semicolon-bearing pattern whole (finding C)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            {
+              watch_id: "watch_semi",
+              source: "job_a1b2",
+              watching: true,
+              condition: "output_match: a;b; progress_interval_ms: 120000",
+            },
+          ],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("a;b");
+  expect(body).toContain("every 2m");
+});
+
+test("a filter condition's every throttle renders in the list row (finding D)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            {
+              watch_id: "watch_f",
+              source: "dlg_7Hk2",
+              watching: true,
+              condition: "events: [assistant.tool] every 3 where tool_name=read_file, status=error",
+            },
+          ],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("(every 3)");
+});
+
+test("a filter condition's every throttle renders in the create sentence (finding D)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "create", source: "dlg_7Hk2", events: ["assistant.tool"], every: 3 },
+        {
+          watch_id: "watch_f",
+          source: "dlg_7Hk2",
+          watching: true,
+          events: ["assistant.tool"],
+          event_filter: { tool_name: "read_file", status: "error" },
+          replaced_existing: false,
+          fired: false,
+        },
+      )}
+      live={false}
+    />,
+  );
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("(every 3)");
+});
+
+test("a filter condition's every throttle renders in inspect (finding D)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_f" },
+        {
+          watch_id: "watch_f",
+          source: "dlg_7Hk2",
+          watching: true,
+          condition: "events: [assistant.tool] every 3 where tool_name=read_file, status=error",
+        },
+      )}
+      live={false}
+    />,
+  );
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("(every 3)");
+});
+
+test("list rows name the tool for both filter outcomes (finding E)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            {
+              watch_id: "watch_ok",
+              source: "dlg_7Hk2",
+              watching: true,
+              condition: "events: [assistant.tool] where tool_name=read_file, status=ok",
+            },
+            {
+              watch_id: "watch_err",
+              source: "dlg_7Hk2",
+              watching: true,
+              condition: "events: [assistant.tool] where tool_name=read_file, status=error",
+            },
+          ],
+          count: 2,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("successful tool calls on read_file");
+  expect(body).toContain("failed tool calls on read_file");
+});
+
+test("a progress-only create summarizes the heartbeat (finding F)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watch_id: "watch_hb",
+    source: "job_a1b2",
+    watching: true,
+    progress_interval_ms: 120000,
+    replaced_existing: false,
+    fired: false,
+  };
+  expect(d.summary(watchItem({ operation: "create" }, raw))).toBe("Watch job_a1b2 · every 2m");
+});
+
+// --- RoboRev PR #954 combined review (ba9a9d0): watch-state honesty ---------
+// The producer's inspect grammar (agent/session_tools_jobs.go
+// formatJobWatchInspect) is three-way: watching; end_reason set (ended);
+// source set without end_reason (pending — a detached watch still holding
+// frames); neither (not found). "ended" for all three misreports pending
+// watches and invents an ending for missing ones.
+
+test("inspect summary distinguishes pending from ended (finding M1)", () => {
+  const d = toolRendererFor("job_watch");
+  // Detached pending: source present, no end_reason — the terminal-flush rail
+  // still holds its frames, so it is not ended.
+  expect(
+    d.summary(
+      watchItem(
+        { operation: "inspect", watch_id: "watch_p" },
+        { watch_id: "watch_p", source: "job_a1b2", watching: false },
+      ),
+    ),
+  ).toBe("Inspected watch_p · pending");
+  // Truly ended: end_reason present.
+  expect(
+    d.summary(
+      watchItem(
+        { operation: "inspect", watch_id: "watch_e" },
+        { watch_id: "watch_e", source: "job_a1b2", watching: false, end_reason: "budget_exhausted" },
+      ),
+    ),
+  ).toBe("Inspected watch_e · ended");
+  // Missing: neither source nor end_reason — not an ending at all.
+  expect(
+    d.summary(watchItem({ operation: "inspect", watch_id: "watch_m" }, { watch_id: "watch_m", watching: false })),
+  ).toBe("Inspected watch_m · not found");
+});
+
+test("inspect body of a missing watch names no source (finding M1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem({ operation: "inspect", watch_id: "watch_m" }, { watch_id: "watch_m", watching: false })}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("not found");
+  expect(body).not.toContain("this session");
+});
+
+test("inspect body of a pending watch reads pending, never ended (finding M1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_p" },
+        { watch_id: "watch_p", source: "job_a1b2", watching: false },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("pending");
+  expect(body).not.toContain("ended");
+});
+
+test("a pending list row chips pending and the summary counts it (finding M1)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watches: [{ watch_id: "watch_p", source: "job_a1b2", watching: false }],
+    count: 1,
+  };
+  expect(d.summary(watchItem({ operation: "list" }, raw))).toBe("Listed watches (0 active · 1 pending)");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "list" }, raw)} live={false} />);
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("pending");
+});
+
+// --- RoboRev PR #954 combined review (ba9a9d0): non-interactive rows --------
+// A row that cannot expand must not be a focusable <button> with a no-op
+// onClick: ended rows have no detail sentence, and neither do watching rows
+// whose condition parses to nothing.
+
+test("ended rows are not focusable buttons (finding M2)", async () => {
+  const user = userEvent.setup();
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "list" }, LIST_RAW)} live={false} />);
+  const rows = screen.getAllByTestId("job-watch-row");
+  expect(rows).toHaveLength(3);
+  // The two watching rows stay buttons; the ended row is plain text.
+  expect(rows[0]!.tagName).toBe("BUTTON");
+  expect(rows[1]!.tagName).toBe("BUTTON");
+  expect(rows[2]!.tagName).not.toBe("BUTTON");
+  expect(rows[2]!.textContent ?? "").toContain("ended");
+  // Clicking the ended row opens nothing.
+  await user.click(rows[2]!);
+  expect(screen.queryByTestId("job-watch-row-detail")).toBeNull();
+});
+
+test("watching rows with unparsable conditions are not buttons (finding M2)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [{ watch_id: "watch_x", source: "self", watching: true, condition: "note: just a note" }],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const row = screen.getByTestId("job-watch-row");
+  expect(row.tagName).not.toBe("BUTTON");
+});
+
+// --- RoboRev PR #954 combined review (ba9a9d0): lows ------------------------
+// An unrecognized object raw ({} or a legacy/future shape) must fall back to
+// the raw footer text — never an empty card with a "Watch this session"
+// summary that invents state.
+
+test("an unrecognized object raw falls back to the raw footer (finding L2)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  const footer = "[watching self · something the future invented]";
+  render(<Body item={watchItem({ operation: "create" }, {}, footer)} live={false} />);
+  expect(screen.getByText(footer)).toBeTruthy();
+  expect(screen.queryByTestId("job-watch-body")).toBeNull();
+  expect(d.summary(watchItem({ operation: "create" }, {}))).toBe("job_watch: create");
+});
+
+test("a tool-only filter sentence reads matching with the tool named (finding L3)", () => {
+  // The dead ternary's two "matching" branches are collapsed to one path:
+  // a tool-only filter reads "makes a tool call matching on <tool>". (A bare
+  // filter with neither tool nor status cannot reach this sentence — with no
+  // status/tool the events branch wins first, or the row has no detail at
+  // all — so there is no second case to distinguish.)
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "create", source: "dlg_7Hk2" },
+        {
+          watch_id: "watch_toolonly",
+          source: "dlg_7Hk2",
+          watching: true,
+          events: ["assistant.tool"],
+          event_filter: { tool_name: "read_file" },
+          replaced_existing: false,
+          fired: false,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("matching");
+  expect(body).toContain("read_file");
+});
+
+test("an inspect with no id falls back to the operation verb (finding L4)", () => {
+  const d = toolRendererFor("job_watch");
+  expect(d.summary(watchItem({ operation: "inspect" }, { source: "job_a1b2", watching: true }))).toBe(
+    "job_watch: inspect",
+  );
+});
+
+// --- RoboRev combined review (43fe73f): combined triggers (M3) --------------
+// output_match + progress_interval_ms combine freely on a concrete job
+// (only timer fields are mutually exclusive with conditions). The summary
+// and inspect body must name BOTH the pattern and the heartbeat.
+
+test("a combined pattern + heartbeat watch names both (M3)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watch_id: "watch_combo",
+    source: "job_a1b2",
+    watching: true,
+    output_match: "ready|done",
+    progress_interval_ms: 120000,
+    replaced_existing: false,
+    fired: false,
+  };
+  const summary = d.summary(watchItem({ operation: "create" }, raw));
+  expect(summary).toContain("ready|done");
+  expect(summary).toContain("every 2m");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "create" }, raw)} live={false} />);
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready|done");
+  expect(body).toContain("every 2m");
+});
+
+test("a combined pattern + heartbeat inspect names both (M3)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_combo" },
+        {
+          watch_id: "watch_combo",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: ready|done; progress_interval_ms: 120000",
+          deliveries: 1,
+          created_at: "2026-09-06T09:41:00-07:00",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready|done");
+  expect(body).toContain("every 2m");
+});
+
+// --- RoboRev combined review (43fe73f): empty create card (L2) --------------
+// A recognized create with only a source (no timer, no condition) has no
+// sentence to render — the summary ("Watch this session") IS the rendering,
+// so the body must be null, not an empty bordered card.
+
+test("a sourceless-condition create renders no body card (L2)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  const { container } = render(
+    <Body
+      item={watchItem({ operation: "create" }, { watch_id: "watch_bare", source: "self", watching: true })}
+      live={false}
+    />,
+  );
+  expect(container.textContent?.trim() ?? "").toBe("");
+});
+
+// --- RoboRev combined review (43fe73f): live ended rows count ended (L3) ----
+// A live row carrying an end_reason is ended, not pending — the summary must
+// agree with the row chip.
+
+test("a live row with an end_reason counts as ended (L3)", () => {
+  const d = toolRendererFor("job_watch");
+  const raw = {
+    watches: [{ watch_id: "watch_e", source: "job_a1b2", watching: false, end_reason: "cleared" }],
+    count: 1,
+  };
+  expect(d.summary(watchItem({ operation: "list" }, raw))).toBe("Listed watches (0 active · 1 ended)");
+  const Body = d.body!;
+  render(<Body item={watchItem({ operation: "list" }, raw)} live={false} />);
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("ended");
+});
+
+// --- RoboRev combined review (818e809): sentence punctuation (M1) ------------
+// Clause nodes must carry no separators of their own — joining inserts them.
+// Pattern + heartbeat rendered "outputs ready, , heartbeat every 2m".
+
+test("a combined pattern + heartbeat sentence has no doubled comma (M1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "create", source: "job_a1b2" },
+        {
+          watch_id: "watch_combo",
+          source: "job_a1b2",
+          watching: true,
+          output_match: "ready",
+          progress_interval_ms: 120000,
+          replaced_existing: false,
+          fired: false,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).not.toContain(", ,");
+  expect(body).toContain("heartbeat every 2m");
+});
+
+test("a filter sentence joins its clauses with spaces, not commas (M1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "create", source: "dlg_7Hk2", events: ["assistant.tool"], every: 3 },
+        {
+          watch_id: "watch_f",
+          source: "dlg_7Hk2",
+          watching: true,
+          events: ["assistant.tool"],
+          event_filter: { tool_name: "read_file", status: "error" },
+          replaced_existing: false,
+          fired: false,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("makes a tool call on read_file ending in error (assistant.tool) (every 3)");
+});
+
+// --- RoboRev combined review (818e809): heartbeat-only lifecycle (M2) -------
+// Periodic progress ticks never consume the condition-fire budget, so a
+// heartbeat-only watch can live indefinitely — claiming it "auto-clears
+// after 50 matches" is a false lifecycle guarantee.
+
+test("a heartbeat-only sentence claims no auto-clear (M2)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "create", source: "job_a1b2" },
+        {
+          watch_id: "watch_hb",
+          source: "job_a1b2",
+          watching: true,
+          progress_interval_ms: 120000,
+          replaced_existing: false,
+          fired: false,
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("heartbeat every 2m");
+  expect(body).not.toContain("auto-clears");
+});
+
+test("a budgeted trigger keeps the auto-clear clause (M2)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "create", source: "job_a1b2" },
+        {
+          watch_id: "watch_combo",
+          source: "job_a1b2",
+          watching: true,
+          output_match: "ready",
+          progress_interval_ms: 120000,
+          replaced_existing: false,
+          fired: false,
+        },
+      )}
+      live={false}
+    />,
+  );
+  expect(screen.getByTestId("job-watch-body").textContent ?? "").toContain("auto-clears after 50 matches");
+});
+
+// --- RoboRev combined review (33d5b9a): composite detail views (M1) ---------
+// A watch combining output_match with events/filter/every must name every
+// armed clause in the inspect body and the expanded row detail — not just
+// the pattern and heartbeat.
+
+test("a composite inspect body names events and filter beside the pattern (M1)", () => {
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "inspect", watch_id: "watch_combo" },
+        {
+          watch_id: "watch_combo",
+          source: "job_a1b2",
+          watching: true,
+          condition: "output_match: ready; events: [assistant.tool] every 3 where tool_name=read_file, status=error",
+          deliveries: 1,
+          created_at: "2026-09-06T09:41:00-07:00",
+        },
+      )}
+      live={false}
+    />,
+  );
+  const body = screen.getByTestId("job-watch-body").textContent ?? "";
+  expect(body).toContain("ready");
+  expect(body).toContain("assistant.tool");
+  expect(body).toContain("read_file");
+  expect(body).toContain("(every 3)");
+});
+
+test("a composite row detail names events and filter beside the pattern (M1)", async () => {
+  const user = userEvent.setup();
+  const d = toolRendererFor("job_watch");
+  const Body = d.body!;
+  render(
+    <Body
+      item={watchItem(
+        { operation: "list" },
+        {
+          watches: [
+            {
+              watch_id: "watch_combo",
+              source: "job_a1b2",
+              watching: true,
+              condition:
+                "output_match: ready; events: [assistant.tool] every 3 where tool_name=read_file, status=error",
+            },
+          ],
+          count: 1,
+        },
+      )}
+      live={false}
+    />,
+  );
+  await user.click(screen.getByTestId("job-watch-row"));
+  const detail = screen.getByTestId("job-watch-row-detail").textContent ?? "";
+  expect(detail).toContain("ready");
+  expect(detail).toContain("assistant.tool");
+  expect(detail).toContain("read_file");
+  expect(detail).toContain("(every 3)");
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.tsx
@@ -26,6 +26,7 @@ import styles from "./jobWatch.module.css";
 
 const CLASS = {
   card: requireClass(styles.card, "jobWatch.module.css", "card"),
+  list: requireClass(styles.list, "jobWatch.module.css", "list"),
   section: requireClass(styles.section, "jobWatch.module.css", "section"),
   note: requireClass(styles.note, "jobWatch.module.css", "note"),
   noteClamped: requireClass(styles.noteClamped, "jobWatch.module.css", "noteClamped"),
@@ -83,16 +84,24 @@ function strArrayField(object: JsonObject, key: string): string[] {
 }
 
 // humanizeSeconds renders a caller-supplied duration in the units the model
-// asked in: sub-minute stays in seconds ("in 45s"); whole minutes collapse
-// ("in 5m", "in 1m"); leftover seconds are kept ("in 1m30s", never a lossy
-// "in 1m" — RoboRev PR #954); an hour or more names hours and leftover
-// minutes ("in 1h05m"). Zero/negative never reaches here (numField filters
-// it) — the caller falls back to the raw footer text instead of inventing
-// one.
+// asked in: sub-minute stays in seconds ("in 45s", fractional "in 1.5s" for
+// sub-second producer precision such as progress_interval_ms 1500);
+// whole minutes collapse ("in 5m", "in 1m"); leftover seconds are kept
+// ("in 1m30s", never a lossy "in 1m" — RoboRev PR #954); an hour or more
+// names hours and leftover minutes ("in 1h05m"). Rounding happens FIRST, so
+// a 60s carry can never surface ("in 1m60s" — combined RoboRev review):
+// the seconds path runs iff the rounded value is below 60, and the minute
+// path divides the rounded value, whose remainder is always below 60.
+// Zero/negative never reaches here (numField filters it) — the caller falls
+// back to the raw footer text instead of inventing one.
 export function humanizeSeconds(totalSeconds: number): string {
-  if (totalSeconds < 60) return `in ${Math.round(totalSeconds)}s`;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const leftoverSeconds = Math.round(totalSeconds % 60);
+  const rounded = Math.round(totalSeconds);
+  if (rounded < 60) {
+    if (Number.isInteger(totalSeconds)) return `in ${rounded}s`;
+    return `in ${(Math.round(totalSeconds * 10) / 10).toString()}s`;
+  }
+  const totalMinutes = Math.floor(rounded / 60);
+  const leftoverSeconds = rounded % 60;
   if (totalMinutes < 60) {
     return leftoverSeconds === 0
       ? `in ${totalMinutes}m`
@@ -104,13 +113,17 @@ export function humanizeSeconds(totalSeconds: number): string {
 }
 
 // humanizeInterval renders a caller-supplied cadence: sub-minute stays in
-// seconds ("every 45s"), whole minutes collapse ("every 2m"), leftover
-// seconds are kept ("every 1m30s"); hours name hours ("every 1h"). Same
-// zero/negative contract as humanizeSeconds.
+// seconds ("every 45s", fractional "every 1.5s"), whole minutes collapse
+// ("every 2m"), leftover seconds are kept ("every 1m30s"); hours name hours
+// ("every 1h"). Same round-first carry contract as humanizeSeconds.
 export function humanizeInterval(totalSeconds: number): string {
-  if (totalSeconds < 60) return `every ${Math.round(totalSeconds)}s`;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const leftoverSeconds = Math.round(totalSeconds % 60);
+  const rounded = Math.round(totalSeconds);
+  if (rounded < 60) {
+    if (Number.isInteger(totalSeconds)) return `every ${rounded}s`;
+    return `every ${(Math.round(totalSeconds * 10) / 10).toString()}s`;
+  }
+  const totalMinutes = Math.floor(rounded / 60);
+  const leftoverSeconds = rounded % 60;
   if (totalMinutes < 60) {
     return leftoverSeconds === 0
       ? `every ${totalMinutes}m`
@@ -156,10 +169,24 @@ interface ConditionSpec {
   every?: number;
   filterToolName?: string;
   filterStatus?: string;
+  // Any watch carries a note (backend #995), delivered as raw.note on the
+  // create result — not only timers. The create body renders it as a full
+  // section alongside the condition sentence.
+  note?: string;
 }
 
 function numArg(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+
+// everyArg reads the create-args throttle the way the backend stores it:
+// every==1 is the semantic default (fire on each occurrence), normalized to
+// unset everywhere downstream (normalizeWatchArgs), so the renderer treats
+// every<=1 as absent — otherwise the same watch reads throttled in create
+// but unthrottled in list/inspect. numArg's other callers keep raw numerics.
+function everyArg(value: unknown): number | undefined {
+  const n = numArg(value);
+  return n !== undefined && n > 1 ? n : undefined;
 }
 
 function conditionSpec(raw: JsonObject, args?: JsonObject): ConditionSpec | undefined {
@@ -168,14 +195,29 @@ function conditionSpec(raw: JsonObject, args?: JsonObject): ConditionSpec | unde
   const events = strArrayField(raw, "events");
   // `every` rides the create ARGS (DefJobWatch), not the result state —
   // read args first, falling back to the raw in case a producer echoes it.
-  const every = (args ? numArg(args.every) : undefined) ?? numField(raw, "every");
+  // Both sides normalize every<=1 to unset (see everyArg); the Condition
+  // string itself never carries every:1 (the producer zeroes it before the
+  // summary renders), only model-written args can.
+  const every = (args ? everyArg(args.every) : undefined) ?? everyArg(raw.every);
   const filter = asJsonObject(raw.event_filter);
   const filterToolName = filter ? strField(filter, "tool_name") : undefined;
   const filterStatus = filter ? strField(filter, "status") : undefined;
-  if (outputMatch === undefined && progressIntervalMS === undefined && events.length === 0 && !filter) {
+  // The note rides raw.note on every create result (backend #995) — it is
+  // the watch's own prose, rendered as a full section, never folded into
+  // the condition sentence. A note alone still yields a spec: a valid watch
+  // may carry only a note and no trigger, and the create body renders the
+  // note section even without a trigger clause.
+  const note = strField(raw, "note");
+  if (
+    outputMatch === undefined &&
+    progressIntervalMS === undefined &&
+    events.length === 0 &&
+    !filter &&
+    note === undefined
+  ) {
     return undefined;
   }
-  return { outputMatch, progressIntervalMS, events, every, filterToolName, filterStatus };
+  return { outputMatch, progressIntervalMS, events, every, filterToolName, filterStatus, note };
 }
 
 // The heartbeat phrase a condition sentence ends with, if the watch carries
@@ -194,7 +236,16 @@ function cadenceSuffix(spec: ConditionSpec): string | undefined {
 }
 
 function sourceLabel(source: string | undefined): string {
-  return source ?? "this session";
+  // The producer's self source is internal vocabulary (watchPublicSource):
+  // readers see "this session" (mockups 23-job-watch), never a bare "self".
+  return source === undefined || source === "self" ? "this session" : source;
+}
+
+// eventDisplayName renders one watched event kind in words. The producer's
+// wildcard "*" reads as "any event" everywhere — rows, summaries, sentences,
+// details — never as a bare "*" (combined RoboRev review).
+function eventDisplayName(name: string): string {
+  return name === "*" ? "any event" : name;
 }
 
 function noteHead(note: string): string {
@@ -262,7 +313,27 @@ function jobWatchOperation(item: ItemModel, raw: JsonObject | undefined): string
   if (typeof raw.deliveries === "number" || typeof raw.created_at === "string" || typeof raw.end_reason === "string") {
     return "inspect";
   }
-  if (raw.watching === false && typeof raw.watch_id === "string") return "clear";
+  // A send-branch terminal catch-up carries watch_id + watching:false AND
+  // terminal_catchup:true (runTerminalCatchup builds from the live config),
+  // so the catch-up check runs before the clear fallback below — otherwise
+  // an arg-less catch-up misreads as "Cleared …" and drops the terminal
+  // outcome. Catch-up is a create serving mode; the default branches handle
+  // it from here.
+  if (boolField(raw, "terminal_catchup")) return "create";
+  // The clear inference needs a create/clear marker beyond watching:false +
+  // watch_id: a legacy or current inspect-miss is exactly that shape
+  // ({watch_id, watching:false}, no other markers) and must read as an
+  // inspect rendering "not found", never "Cleared …". Genuine clear/create
+  // results carry replaced_existing/fired explicitly (marshalWatchResult
+  // serializes both with no omitempty, even when false — key presence, not
+  // truthiness, is the test). Source is NOT a marker: a pending inspect
+  // carries watching:false + source with no end_reason (a detached watch on
+  // the terminal-flush rail), and must read as an inspect rendering pending,
+  // never "Cleared …".
+  if (raw.watching === false && typeof raw.watch_id === "string") {
+    if ("replaced_existing" in raw || "fired" in raw) return "clear";
+    return "inspect";
+  }
   if (raw.watching === true || typeof raw.note === "string" || typeof raw.output_match === "string") {
     return "create";
   }
@@ -301,6 +372,18 @@ function summarizeCreate(raw: JsonObject, item: ItemModel): string {
   const source = sourceLabel(strField(raw, "source"));
   const condition = conditionSpec(raw, asJsonObject(parseArgs(item.argumentsJSON)));
   if (!condition) return `Watch ${source}`;
+  // A note-only watch arms no trigger: there are no clauses to name, but the
+  // note heads the summary so the note is never lost. Mirrors the timer-note
+  // shape ("Remind me in 5m · <head>") minus the cadence.
+  if (
+    condition.outputMatch === undefined &&
+    condition.progressIntervalMS === undefined &&
+    condition.events.length === 0 &&
+    condition.filterToolName === undefined &&
+    condition.filterStatus === undefined
+  ) {
+    return condition.note ? `Watch ${source} · ${noteHead(condition.note)}` : `Watch ${source}`;
+  }
   // Trigger clauses compose: output_match, events (+every throttle, filter),
   // and the progress heartbeat combine freely on a live watch (only timer
   // fields are mutually exclusive with conditions — the producer's own
@@ -311,7 +394,7 @@ function summarizeCreate(raw: JsonObject, item: ItemModel): string {
   if (condition.outputMatch) clauses.push(`“${condition.outputMatch}”`);
   if (condition.events.length > 0) {
     const throttle = condition.every !== undefined ? ` (every ${condition.every})` : "";
-    clauses.push(`${condition.events.join(", ")}${throttle}`);
+    clauses.push(`${condition.events.map(eventDisplayName).join(", ")}${throttle}`);
   }
   if (condition.filterStatus || condition.filterToolName) {
     // An event-filter watch names the watched shape in words — both
@@ -351,6 +434,10 @@ interface WatchRow {
   watching: boolean;
   source?: string;
   condition?: string;
+  // The structured note field beside the Condition string (verbatim even
+  // when the note contains delimiter-looking text). Preferred over the
+  // note: clause embedded in the Condition string.
+  note?: string;
   endReason?: string;
   deliveries?: number;
 }
@@ -365,6 +452,7 @@ function normalizeRow(value: unknown): WatchRow | undefined {
     watching: row.watching === true,
     source: strField(row, "source"),
     condition: strField(row, "condition"),
+    note: strField(row, "note"),
     endReason: strField(row, "end_reason"),
     deliveries,
   };
@@ -377,7 +465,10 @@ function normalizeRow(value: unknown): WatchRow | undefined {
 // / `progress_interval_ms: N`; `note: …`; `events: [*]` or
 // `events: [a, b]` with optional `every N` and `where tool_name=X,
 // status=Y`. The reader parses that embedded grammar back — inventing
-// nothing, since inspect's raw carries no separate structured fields.
+// nothing. The note: clause is the fallback source for the note: the raw
+// also carries the note in its own structured field (verbatim, immune to
+// delimiter-looking text), which readers prefer; this parse covers stored
+// frames that predate it.
 interface ParsedCondition {
   outputMatch?: string;
   afterSeconds?: number;
@@ -387,6 +478,10 @@ interface ParsedCondition {
   every?: number;
   filterToolName?: string;
   filterStatus?: string;
+  // The watch's own prose payload (backend #995: any watch carries one). The
+  // value is dot-all — notes are multiline prose, and patterns may also span
+  // lines — so all value patterns below use [\s\S], never dot.
+  note?: string;
 }
 
 function numAfter(value: string | undefined): number | undefined {
@@ -406,11 +501,90 @@ function numAfter(value: string | undefined): number | undefined {
 // takes the field reading, matching what list/inspect show.)
 const CONDITION_PART_SPLIT = /;\s*(?=(?:output_match|after_seconds|repeat_seconds|progress_interval_ms|note|events):)/;
 
-function parseConditionText(condition: string): ParsedCondition {
+// WATCH_MESSAGE_MAX_CHARS and WATCH_TRUNCATED_INDICATOR mirror the
+// producer's bounds (agent/job_watch.go): the Condition string embeds the
+// note via limitWatchText(cfg.note, watchMessageMaxChars), which truncates by
+// rune with a "\n[truncated]" indicator and performs no whitespace or line
+// folding — the embedding is otherwise the verbatim note value.
+const WATCH_MESSAGE_MAX_CHARS = 2048;
+const WATCH_TRUNCATED_INDICATOR = "\n[truncated]";
+
+// embeddedNoteCandidates lists the exact strings the producer may have
+// embedded as the note: clause for a structured note value: the value itself
+// (cfg.note is already bounded at storage, so this is the live case), plus
+// the limitWatchText truncation for oversized values from stored frames.
+function embeddedNoteCandidates(note: string): string[] {
+  const runes = Array.from(note);
+  if (runes.length <= WATCH_MESSAGE_MAX_CHARS) return [note];
+  const keep = WATCH_MESSAGE_MAX_CHARS - Array.from(WATCH_TRUNCATED_INDICATOR).length;
+  const truncated =
+    keep <= 0
+      ? runes.slice(0, WATCH_MESSAGE_MAX_CHARS).join("")
+      : runes.slice(0, keep).join("") + WATCH_TRUNCATED_INDICATOR;
+  return truncated === note ? [note] : [note, truncated];
+}
+
+// stripStructuredNoteClause removes the exact note: clause the producer
+// embedded in the flattened Condition string, keyed by the structured note
+// field's verbatim value. The note is free prose that may itself contain
+// delimiter-looking text ("; events: […]") which the head-based split below
+// would otherwise parse as real armed triggers. Only a clause-boundary match
+// is removed — the note: head at the string start or right after the "; "
+// join — and only one adjacent join separator goes with it, so neighboring
+// trigger clauses rejoin intact. Without a structured note (legacy stored
+// frames) the condition parses unchanged.
+function stripStructuredNoteClause(condition: string, note: string | undefined): string {
+  if (!note) return condition;
+  for (const value of embeddedNoteCandidates(note)) {
+    const needle = `note: ${value}`;
+    let index = condition.indexOf(needle);
+    while (index !== -1) {
+      const before = condition.slice(0, index);
+      if (index === 0 || /;\s*$/.test(before)) {
+        let start = index;
+        const leading = /;\s*$/.exec(before);
+        if (leading) start = leading.index;
+        let end = index + needle.length;
+        if (index === 0) {
+          const trailing = /^;\s*/.exec(condition.slice(end));
+          if (trailing) end += trailing[0].length;
+        }
+        return condition.slice(0, start) + condition.slice(end);
+      }
+      index = condition.indexOf(needle, index + 1);
+    }
+  }
+  return condition;
+}
+
+function parseConditionText(condition: string, note?: string): ParsedCondition {
   const parsed: ParsedCondition = { events: [] };
-  for (const part of condition.split(CONDITION_PART_SPLIT)) {
+  // The note head is one clause among the split parts: the producer's join
+  // order puts note: before the events clause (watchConditionSummary), so a
+  // legacy persisted Condition reads "output_match: …; note: …; events: […]"
+  // and every trigger clause parses beside the note (RoboRev PR #954). The
+  // note value runs to the next head or end-of-string — a note that itself
+  // contains delimiter-looking text ("; events: […]") truncates here, which
+  // is why list/inspect raws also carry the note in its own structured field
+  // (readers prefer that field; this parse is the fallback for stored frames
+  // that predate it). Slice-free: every part parses independently, so the
+  // note's own whitespace survives verbatim.
+  // When the caller passes the structured note, its exact embedded clause is
+  // stripped first (stripStructuredNoteClause) so delimiter-looking prose
+  // inside the note never parses as armed triggers.
+  // (A caller-supplied output_match containing "; note: " stays ambiguous
+  // even to the producer's own join — the split takes the field reading,
+  // matching what list/inspect show.)
+  for (const part of stripStructuredNoteClause(condition, note).split(CONDITION_PART_SPLIT)) {
     const text = part.trim();
-    const outputMatch = /^output_match:\s*(.+)$/.exec(text)?.[1]?.trim();
+    // A leading "note:" head (a bare note-only string, which the producer
+    // never emits but a stored transcript could carry) is the whole note.
+    const note = /^(?:note:\s*)([\s\S]+)$/.exec(text)?.[1]?.trim();
+    if (note) {
+      if (!parsed.note) parsed.note = note;
+      continue;
+    }
+    const outputMatch = /^output_match:\s*([\s\S]+)$/.exec(text)?.[1]?.trim();
     if (outputMatch) {
       parsed.outputMatch = outputMatch;
       continue;
@@ -445,10 +619,9 @@ function parseConditionText(condition: string): ParsedCondition {
         if (status) parsed.filterStatus = status;
       }
     }
-    // `note: …` and anything unrecognized stay out: the note is the watch's
-    // own prose (shown by the create body, never by a row), and unknown
-    // future parts degrade to the fallback below rather than inventing
-    // rendering.
+    // Anything unrecognized degrades to the fallback below rather than
+    // inventing rendering. (The note head is terminal and handled above,
+    // so reaching here means this part is genuinely something else.)
   }
   return parsed;
 }
@@ -461,7 +634,7 @@ function rowConditionPhrase(row: WatchRow): string {
   const state = watchState(row);
   if (state === "watching") {
     if (row.condition) {
-      const parsed = parseConditionText(row.condition);
+      const parsed = parseConditionText(row.condition, row.note);
       const source = sourceLabel(row.source);
       if (parsed.afterSeconds !== undefined) return `${humanizeSeconds(parsed.afterSeconds)} · ${source}`;
       if (parsed.repeatSeconds !== undefined) {
@@ -475,7 +648,7 @@ function rowConditionPhrase(row: WatchRow): string {
       // "(every N)" shape (RoboRev PR #954 review 3).
       const every = parsed.every !== undefined ? ` (every ${parsed.every})` : "";
       if (parsed.events.length > 0) {
-        const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
+        const names = parsed.events.map(eventDisplayName).join(", ");
         bits.push(`${names}${every}`);
       }
       if (parsed.filterToolName || parsed.filterStatus) {
@@ -485,7 +658,14 @@ function rowConditionPhrase(row: WatchRow): string {
         bits.push(humanizeInterval(parsed.progressIntervalMS / 1000));
       }
       if (bits.length > 0) return `${bits.join(" · ")} · ${source}`;
-      return `${row.condition} · ${source}`;
+      // No trigger bits parsed: the condition is either a bare note or
+      // unrecognized grammar. A note-only row still names its note (the
+      // structured field verbatim, else the parsed note: clause) — never the
+      // raw Condition grammar ("note: …"). Anything else names just the
+      // source rather than echoing machine tokens.
+      const fallbackNote = row.note ?? parsed.note;
+      if (fallbackNote) return `${fallbackNote} · ${source}`;
+      return source;
     }
     return sourceLabel(row.source);
   }
@@ -493,7 +673,7 @@ function rowConditionPhrase(row: WatchRow): string {
   // session" for a watch that is not there (RoboRev PR #954 combined review).
   if (state === "missing") return "not found";
   if (state === "pending") return `pending · ${sourceLabel(row.source)}`;
-  return row.endReason ? `ended: ${row.endReason}` : "ended";
+  return row.endReason ? `ended: ${endReasonPhrase(row.endReason)}` : "ended";
 }
 
 // watchState reads a watch row/inspect result's lifecycle state in the
@@ -511,6 +691,37 @@ function watchState(entry: { watching: boolean; source?: string; endReason?: str
   if (entry.endReason) return "ended";
   if (entry.source) return "pending";
   return "missing";
+}
+
+// endReasonPhrase renders a watch end_reason id in words, shared by list rows
+// and inspect bodies so the two never drift (8a56741 finding 4). The ids are
+// the whole set the backend records: cleared (explicit clear,
+// agent/job_watch.go clearWatch, "watch cleared"), replaced (a newer watch
+// took the key, agent/job_watch.go:724 "watch replaced"), fired (a one-shot
+// timer retired by its only fire, agent/job_watch.go:3459
+// clearWatchByIDMatchingWithReason), budget_exhausted (the condition-fire
+// budget tripped — the Go notice's own "matched 50 times", agent/job_watch.go
+// watchBudgetClearedMessage), auto_removed_terminal (the watched job went
+// terminal before the condition could match, agent/job_watch.go:3060), and
+// job_manager_closed (agent/jobs.go:737). Anything else falls back to the raw
+// id — never an invented meaning.
+export function endReasonPhrase(endReason: string | undefined): string {
+  switch (endReason) {
+    case "budget_exhausted":
+      return `matched ${WATCH_DELIVERY_BUDGET} times (budget exhausted)`;
+    case "auto_removed_terminal":
+      return "watched job finished before it could fire";
+    case "replaced":
+      return "replaced by a newer watch";
+    case "fired":
+      return "fired";
+    case "cleared":
+      return "cleared";
+    case "job_manager_closed":
+      return "job manager closed";
+    default:
+      return endReason ?? "ended";
+  }
 }
 
 function listCounts(raw: JsonObject): { active: number; pending: number; ended: number } {
@@ -629,7 +840,13 @@ function NoteSection({ note }: { note: string }) {
 // a pattern AND event/filter triggers AND a heartbeat together (only timer
 // fields exclude conditions), so every populated clause renders instead of
 // returning after the first (combined RoboRev review).
-function ConditionSentence({ source, spec }: { source: string; spec: ConditionSpec }) {
+// ConditionSentence owns the sentence's single terminal period (8a56741
+// finding 1): callers with delivery/creation metadata pass it as meta
+// ("3 deliveries, created Sep 6, 09:41") and it joins with an em dash before
+// that one period — the caller never appends its own ("matches. — 3
+// deliveries.").
+function ConditionSentence({ source, spec, meta }: { source: string; spec: ConditionSpec; meta?: string }) {
+  const tail = meta ? ` — ${meta}` : "";
   const heartbeat = heartbeatPhrase(spec);
   // Top-level clauses join with ", " exactly once, in the final render
   // below. Clause nodes carry NO separators of their own — neither leading
@@ -686,7 +903,7 @@ function ConditionSentence({ source, spec }: { source: string; spec: ConditionSp
     if (spec.events.length === 1) {
       parts.push(
         <span key="filter-event">
-          (<span className={CLASS.mono}>{spec.events[0]}</span>)
+          (<span className={CLASS.mono}>{eventDisplayName(spec.events[0] ?? "")}</span>)
         </span>,
       );
     }
@@ -700,7 +917,7 @@ function ConditionSentence({ source, spec }: { source: string; spec: ConditionSp
     const throttle = spec.every !== undefined ? ` (every ${spec.every})` : "";
     head.push(
       <span key="events">
-        wakes on <span className={CLASS.mono}>{spec.events.join(", ")}</span>
+        wakes on <span className={CLASS.mono}>{spec.events.map(eventDisplayName).join(", ")}</span>
         {throttle}
       </span>,
     );
@@ -709,14 +926,21 @@ function ConditionSentence({ source, spec }: { source: string; spec: ConditionSp
   if (head.length === 0) {
     return (
       <span>
-        Watches <span className={CLASS.mono}>{source}</span>.
+        Watches <span className={CLASS.mono}>{source}</span>
+        {tail}.
       </span>
     );
   }
   return (
     <span>
       Wakes you when <span className={CLASS.mono}>{source}</span> {joinNodes(head, ", ")}
-      {budgeted ? <>, auto-clears after {WATCH_DELIVERY_BUDGET} matches.</> : "."}
+      {budgeted ? (
+        <>
+          , auto-clears after {WATCH_DELIVERY_BUDGET} matches{tail}.
+        </>
+      ) : (
+        <>{tail}.</>
+      )}
     </span>
   );
 }
@@ -735,12 +959,30 @@ function CreateBody({ raw, item }: { raw: JsonObject; item: ItemModel }) {
   const source = sourceLabel(strField(raw, "source"));
   const condition = conditionSpec(raw, asJsonObject(parseArgs(item.argumentsJSON)));
   if (!condition) return null;
+  // A note-only watch arms no trigger: there is no sentence, but the note
+  // still renders as its own clamped section (backend #995) rather than
+  // vanishing behind the summary-only rule for triggerless creates.
+  if (
+    condition.outputMatch === undefined &&
+    condition.progressIntervalMS === undefined &&
+    condition.events.length === 0 &&
+    condition.filterToolName === undefined &&
+    condition.filterStatus === undefined
+  ) {
+    return condition.note ? <NoteSection note={condition.note} /> : null;
+  }
+  // Any watch carries a note (backend #995): the sentence names the trigger
+  // and the note renders as its own clamped section below, reusing the
+  // timer-note disclosure — never folded into the sentence.
   return (
-    <div className={CLASS.section}>
-      <div className={CLASS.trigger} data-testid="job-watch-trigger">
-        <ConditionSentence source={source} spec={condition} />
+    <>
+      <div className={CLASS.section}>
+        <div className={CLASS.trigger} data-testid="job-watch-trigger">
+          <ConditionSentence source={source} spec={condition} />
+        </div>
       </div>
-    </div>
+      {condition.note ? <NoteSection note={condition.note} /> : null}
+    </>
   );
 }
 
@@ -757,21 +999,22 @@ function WatchRow({ row }: { row: WatchRow }) {
   const detail = row.watching ? rowDetailPhrase(row) : undefined;
   const state = watchState(row);
   const chip = state === "watching" ? "watching" : state === "missing" ? "not found" : state;
+  // No per-row wrapper div: rows are direct children of the list container
+  // so the container's :not(:first-child) separator applies (a wrapper
+  // would make every row a first child and erase all separators).
   if (!detail) {
     return (
-      <div key={row.id}>
-        <div className={CLASS.rowStatic} data-testid="job-watch-row">
-          <Chip>{chip}</Chip>
-          <span className={CLASS.rowId} title={row.id}>
-            {clipJobID(row.id)}
-          </span>
-          <span className={CLASS.rowCondition}>{rowConditionPhrase(row)}</span>
-        </div>
+      <div className={CLASS.rowStatic} data-testid="job-watch-row">
+        <Chip>{chip}</Chip>
+        <span className={CLASS.rowId} title={row.id}>
+          {clipJobID(row.id)}
+        </span>
+        <span className={CLASS.rowCondition}>{rowConditionPhrase(row)}</span>
       </div>
     );
   }
   return (
-    <div key={row.id}>
+    <>
       <button
         type="button"
         className={CLASS.row}
@@ -792,7 +1035,7 @@ function WatchRow({ row }: { row: WatchRow }) {
           <div className={CLASS.trigger}>{detail}</div>
         </div>
       ) : null}
-    </div>
+    </>
   );
 }
 
@@ -802,7 +1045,12 @@ function WatchRow({ row }: { row: WatchRow }) {
 // (RoboRev PR #954).
 function rowDetailPhrase(row: WatchRow): string | undefined {
   if (!row.watching || !row.condition) return undefined;
-  const parsed = parseConditionText(row.condition);
+  const parsed = parseConditionText(row.condition, row.note);
+  // The structured note wins over the note: clause: it is verbatim even
+  // when the note contains delimiter-looking text that truncates the
+  // clause parse. The clause is the fallback for stored frames that
+  // predate the structured field.
+  const detailNote = row.note ?? parsed.note;
   const source = sourceLabel(row.source);
   const deliveries = row.deliveries !== undefined ? ` — ${row.deliveries} deliveries` : "";
   if (parsed.outputMatch) {
@@ -813,24 +1061,35 @@ function rowDetailPhrase(row: WatchRow): string | undefined {
     // Clauses compose here exactly as in the row phrase and the create
     // summary: a composite watch arms a pattern AND event/filter triggers
     // together, so the detail names every armed clause, never just the
-    // pattern (combined RoboRev review).
+    // pattern (combined RoboRev review). The embedded note rides along as
+    // trailing prose — the row has no disclosure section to host it.
     const bits: string[] = [`“${parsed.outputMatch}”`];
     const every = parsed.every !== undefined ? ` (every ${parsed.every})` : "";
     if (parsed.events.length > 0) {
-      const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
+      const names = parsed.events.map(eventDisplayName).join(", ");
       bits.push(`${names}${every}`);
     }
     if (parsed.filterToolName || parsed.filterStatus) {
       bits.push(`${filterSummaryPhrase(parsed)}${parsed.events.length === 0 ? every : ""}`);
     }
-    return `Watching ${source} for ${bits.join(" · ")}${heartbeat}${deliveries}.`;
+    const note = detailNote ? ` Note: ${detailNote}.` : "";
+    return `Watching ${source} for ${bits.join(" · ")}${heartbeat}${deliveries}.${note}`;
   }
-  if (parsed.afterSeconds !== undefined) return `Reminds ${humanizeSeconds(parsed.afterSeconds)}${deliveries}.`;
-  if (parsed.repeatSeconds !== undefined) return `Reminds ${humanizeInterval(parsed.repeatSeconds)}${deliveries}.`;
+  if (parsed.afterSeconds !== undefined || parsed.repeatSeconds !== undefined) {
+    const seconds = parsed.afterSeconds ?? parsed.repeatSeconds ?? 0;
+    const when = parsed.afterSeconds !== undefined ? humanizeSeconds(seconds) : humanizeInterval(seconds);
+    // Timer Condition strings carry note: too (backend #995) — the detail
+    // names it like every other branch, not just the cadence.
+    const note = detailNote ? ` Note: ${detailNote}.` : "";
+    // A one-shot timer reminds once ("Remind me in 5m", mirroring the create
+    // summary); a repeating timer keeps reminding ("Reminds every 5m").
+    const verb = parsed.afterSeconds !== undefined ? "Remind me" : "Reminds";
+    return `${verb} ${when}${deliveries}.${note}`;
+  }
   const bits: string[] = [];
   const every = parsed.every !== undefined ? ` (every ${parsed.every})` : "";
   if (parsed.events.length > 0) {
-    const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
+    const names = parsed.events.map(eventDisplayName).join(", ");
     bits.push(`${names}${every}`);
   }
   if (parsed.filterToolName || parsed.filterStatus) {
@@ -841,7 +1100,10 @@ function rowDetailPhrase(row: WatchRow): string | undefined {
   if (parsed.progressIntervalMS !== undefined) {
     bits.push(`heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`);
   }
-  if (bits.length > 0) return `Watches ${source}: ${bits.join(" · ")}${deliveries}.`;
+  if (bits.length > 0) {
+    const note = detailNote ? ` Note: ${detailNote}.` : "";
+    return `Watches ${source}: ${bits.join(" · ")}${deliveries}.${note}`;
+  }
   return undefined;
 }
 
@@ -863,7 +1125,7 @@ function ListBody({ raw }: { raw: JsonObject }) {
     );
   }
   return (
-    <div>
+    <div className={CLASS.list}>
       {rows.map((row) => (
         <WatchRow key={row.id} row={row} />
       ))}
@@ -907,41 +1169,252 @@ function InspectBody({ raw }: { raw: JsonObject }) {
   }
   if (state === "pending") {
     const source = sourceLabel(strField(raw, "source"));
+    // The pending raw carries the same trigger/detail fields as any other
+    // inspect (condition, note, deliveries, created_at —
+    // jobWatchInspectToolResult, agent/session_tools_jobs.go:1578) — a bare
+    // "is pending" drops everything the watch is pending FOR (8a56741 finding
+    // 3). The watching branches below own the full trigger grammar; read them
+    // through the same helpers so pending never drifts.
+    const condition = strField(raw, "condition");
+    const structuredNote = strField(raw, "note");
+    const parsed = condition ? parseConditionText(condition, structuredNote) : undefined;
+    const note = structuredNote ?? parsed?.note;
+    const deliveries = typeof raw.deliveries === "number" ? raw.deliveries : undefined;
+    const created = formatCreatedDate(strField(raw, "created_at"));
+    const meta = [deliveries !== undefined ? `${deliveries} deliveries` : "", created ?? ""]
+      .filter((bit) => bit !== "")
+      .join(", ");
+    const spec =
+      parsed && (parsed.outputMatch || parsed.events.length > 0 || parsed.filterToolName || parsed.filterStatus)
+        ? {
+            outputMatch: parsed.outputMatch,
+            events: parsed.events,
+            every: parsed.every,
+            progressIntervalMS: parsed.progressIntervalMS,
+            filterToolName: parsed.filterToolName,
+            filterStatus: parsed.filterStatus,
+          }
+        : undefined;
+    const metaSuffix = meta ? ` — ${meta}` : "";
+    if (spec) {
+      // ConditionSentence owns the condition trigger's terminal period
+      // (finding 1), so pendingTrigger keeps the pending sentence's own
+      // period too: the sentence names the pending state first, then the
+      // same trigger clauses the watching body would render ("Watch on X is
+      // pending: wakes you when …").
+      const pendingTrigger = (
+        <span>
+          Watch on <span className={CLASS.mono}>{source}</span> is pending:{" "}
+          <ConditionSentence
+            source={source}
+            spec={{
+              outputMatch: spec.outputMatch,
+              events: spec.events,
+              every: spec.every,
+              progressIntervalMS: spec.progressIntervalMS,
+              filterToolName: spec.filterToolName,
+              filterStatus: spec.filterStatus,
+            }}
+            meta={meta === "" ? undefined : meta}
+          />
+        </span>
+      );
+      return (
+        <>
+          <div className={CLASS.section}>
+            <div className={CLASS.trigger} data-testid="job-watch-trigger">
+              {pendingTrigger}
+            </div>
+          </div>
+          {note ? <NoteSection note={note} /> : null}
+        </>
+      );
+    }
+    const timerSeconds =
+      parsed?.afterSeconds !== undefined || parsed?.repeatSeconds !== undefined
+        ? (parsed.afterSeconds ?? parsed.repeatSeconds ?? 0)
+        : undefined;
+    if (timerSeconds !== undefined) {
+      const when = parsed?.afterSeconds !== undefined ? humanizeSeconds(timerSeconds) : humanizeInterval(timerSeconds);
+      const verb = parsed?.afterSeconds !== undefined ? "Remind me" : "Reminds";
+      return (
+        <>
+          <div className={CLASS.section}>
+            <div className={CLASS.trigger} data-testid="job-watch-trigger">
+              <span>
+                Watch on <span className={CLASS.mono}>{source}</span> is pending: {verb} {when}
+                {metaSuffix}.
+              </span>
+            </div>
+          </div>
+          {note ? <NoteSection note={note} /> : null}
+        </>
+      );
+    }
+    const heartbeat =
+      parsed?.progressIntervalMS !== undefined
+        ? `heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`
+        : undefined;
+    if (heartbeat) {
+      return (
+        <>
+          <div className={CLASS.section}>
+            <div className={CLASS.trigger} data-testid="job-watch-trigger">
+              <span>
+                Watch on <span className={CLASS.mono}>{source}</span> is pending: {heartbeat}
+                {metaSuffix}.
+              </span>
+            </div>
+          </div>
+          {note ? <NoteSection note={note} /> : null}
+        </>
+      );
+    }
     return (
-      <div className={CLASS.section}>
-        <div className={CLASS.trigger} data-testid="job-watch-trigger">
-          <span>
-            Watch on <span className={CLASS.mono}>{source}</span> is pending.
-          </span>
+      <>
+        <div className={CLASS.section}>
+          <div className={CLASS.trigger} data-testid="job-watch-trigger">
+            <span>
+              Watch on <span className={CLASS.mono}>{source}</span> is pending{metaSuffix}.
+            </span>
+          </div>
         </div>
-      </div>
+        {note ? <NoteSection note={note} /> : null}
+      </>
     );
   }
   const source = sourceLabel(strField(raw, "source"));
   if (state === "ended") {
     const endReason = strField(raw, "end_reason");
+    // The ended raw carries the same trigger/detail fields as any other
+    // inspect (condition, note, deliveries — inspectResultFromWatchHistory,
+    // agent/job_watch.go:2363; the structured note rides beside the Condition
+    // string verbatim — jobWatchInspectToolResult, agent/session_tools_jobs.go).
+    // The end sentence names the outcome first, then the same trigger clauses
+    // the watching body renders, so an ended watch still says what it was
+    // watching for — mirroring the pending branch above — with the note as
+    // its own section below.
+    const condition = strField(raw, "condition");
+    const structuredNote = strField(raw, "note");
+    const parsed = condition ? parseConditionText(condition, structuredNote) : undefined;
+    const note = structuredNote ?? parsed?.note;
+    const deliveries = typeof raw.deliveries === "number" ? raw.deliveries : undefined;
+    const meta = deliveries !== undefined ? `${deliveries} deliveries` : undefined;
+    const endSentence = endReason ? (
+      <span>
+        Watch on <span className={CLASS.mono}>{source}</span> ended — {endReasonPhrase(endReason)}.
+      </span>
+    ) : (
+      <span>
+        Watch on <span className={CLASS.mono}>{source}</span> ended.
+      </span>
+    );
+    const spec =
+      parsed && (parsed.outputMatch || parsed.events.length > 0 || parsed.filterToolName || parsed.filterStatus)
+        ? {
+            outputMatch: parsed.outputMatch,
+            events: parsed.events,
+            every: parsed.every,
+            progressIntervalMS: parsed.progressIntervalMS,
+            filterToolName: parsed.filterToolName,
+            filterStatus: parsed.filterStatus,
+          }
+        : undefined;
+    if (spec) {
+      return (
+        <>
+          <div className={CLASS.section}>
+            <div className={CLASS.trigger} data-testid="job-watch-trigger">
+              {endSentence} <ConditionSentence source={source} spec={spec} meta={meta} />
+            </div>
+          </div>
+          {note ? <NoteSection note={note} /> : null}
+        </>
+      );
+    }
+    const timerSeconds =
+      parsed?.afterSeconds !== undefined || parsed?.repeatSeconds !== undefined
+        ? (parsed.afterSeconds ?? parsed.repeatSeconds ?? 0)
+        : undefined;
+    if (timerSeconds !== undefined) {
+      const when = parsed?.afterSeconds !== undefined ? humanizeSeconds(timerSeconds) : humanizeInterval(timerSeconds);
+      const verb = parsed?.afterSeconds !== undefined ? "Remind me" : "Reminds";
+      const metaSuffix = meta ? ` — ${meta}` : "";
+      return (
+        <>
+          <div className={CLASS.section}>
+            <div className={CLASS.trigger} data-testid="job-watch-trigger">
+              <span>
+                {endSentence} {verb} {when}
+                {metaSuffix}.
+              </span>
+            </div>
+          </div>
+          {note ? <NoteSection note={note} /> : null}
+        </>
+      );
+    }
+    const heartbeat =
+      parsed?.progressIntervalMS !== undefined
+        ? `heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`
+        : undefined;
+    if (heartbeat) {
+      return (
+        <>
+          <div className={CLASS.section}>
+            <div className={CLASS.trigger} data-testid="job-watch-trigger">
+              <span>
+                {endSentence} {heartbeat}
+                {meta ? ` — ${meta}` : ""}.
+              </span>
+            </div>
+          </div>
+          {note ? <NoteSection note={note} /> : null}
+        </>
+      );
+    }
+    if (note || meta) {
+      return (
+        <>
+          <div className={CLASS.section}>
+            <div className={CLASS.trigger} data-testid="job-watch-trigger">
+              <span>
+                {endSentence}
+                {meta ? ` ${meta}.` : ""}
+              </span>
+            </div>
+          </div>
+          {note ? <NoteSection note={note} /> : null}
+        </>
+      );
+    }
     return (
       <div className={CLASS.section}>
         <div className={CLASS.trigger} data-testid="job-watch-trigger">
-          {endReason ? (
-            <span>
-              Watch on <span className={CLASS.mono}>{source}</span> ended — {endReason}.
-            </span>
-          ) : (
-            <span>
-              Watch on <span className={CLASS.mono}>{source}</span> ended.
-            </span>
-          )}
+          {endSentence}
         </div>
       </div>
     );
   }
   const condition = strField(raw, "condition");
-  const parsed = condition ? parseConditionText(condition) : undefined;
+  const structuredNote = strField(raw, "note");
+  const parsed = condition ? parseConditionText(condition, structuredNote) : undefined;
+  // The structured note wins over the note: clause for the same reason as
+  // list rows: it is verbatim even when the note contains delimiter-looking
+  // text. Its exact embedded clause is stripped before parsing (see
+  // stripStructuredNoteClause) so delimiter-looking prose never invents
+  // triggers. The clause is the fallback for stored frames that predate it.
+  const note = structuredNote ?? parsed?.note;
   const deliveries = typeof raw.deliveries === "number" ? raw.deliveries : undefined;
   const created = formatCreatedDate(strField(raw, "created_at"));
-  const used = deliveries !== undefined ? ` — ${deliveries} deliveries` : "";
-  const since = created ? `, ${created}` : "";
+  // ConditionSentence owns the sentence's single terminal period (8a56741
+  // finding 1): metadata arrives as its `meta` clause ("3 deliveries, created
+  // Sep 6, 09:41"), joined with an em dash before the one period — never
+  // appended beside it ("matches. — 3 deliveries.").
+  const meta =
+    [deliveries !== undefined ? `${deliveries} deliveries` : "", created ?? ""]
+      .filter((bit) => bit !== "")
+      .join(", ") || undefined;
   // Every embedded condition form renders humanized: pattern, timer
   // cadence, heartbeat, events (+every throttle), and filter — the same
   // sentence grammar as the create/inspect one-liners, never raw keys. The
@@ -950,9 +1423,9 @@ function InspectBody({ raw }: { raw: JsonObject }) {
   // (combined RoboRev review).
   if (parsed?.outputMatch) {
     return (
-      <div className={CLASS.section}>
-        <div className={CLASS.trigger} data-testid="job-watch-trigger">
-          <span>
+      <>
+        <div className={CLASS.section}>
+          <div className={CLASS.trigger} data-testid="job-watch-trigger">
             <ConditionSentence
               source={source}
               spec={{
@@ -963,29 +1436,34 @@ function InspectBody({ raw }: { raw: JsonObject }) {
                 filterToolName: parsed.filterToolName,
                 filterStatus: parsed.filterStatus,
               }}
+              meta={meta}
             />
-            <span>
-              {used}
-              {since}.
-            </span>
-          </span>
+          </div>
         </div>
-      </div>
+        {note ? <NoteSection note={note} /> : null}
+      </>
     );
   }
   if (parsed?.afterSeconds !== undefined || parsed?.repeatSeconds !== undefined) {
     const seconds = parsed.afterSeconds ?? parsed.repeatSeconds ?? 0;
     const when = parsed.afterSeconds !== undefined ? humanizeSeconds(seconds) : humanizeInterval(seconds);
+    // A one-shot timer reminds once ("Remind me in 5m", mirroring the create
+    // summary); a repeating timer keeps reminding ("Reminds every 5m" —
+    // 8a56741 finding 2).
+    const verb = parsed.afterSeconds !== undefined ? "Remind me" : "Reminds";
+    const metaSuffix = meta ? ` — ${meta}` : "";
     return (
-      <div className={CLASS.section}>
-        <div className={CLASS.trigger} data-testid="job-watch-trigger">
-          <span>
-            Reminds {when}
-            {used}
-            {since}.
-          </span>
+      <>
+        <div className={CLASS.section}>
+          <div className={CLASS.trigger} data-testid="job-watch-trigger">
+            <span>
+              {verb} {when}
+              {metaSuffix}.
+            </span>
+          </div>
         </div>
-      </div>
+        {note ? <NoteSection note={note} /> : null}
+      </>
     );
   }
   if (
@@ -996,24 +1474,24 @@ function InspectBody({ raw }: { raw: JsonObject }) {
       parsed.progressIntervalMS !== undefined)
   ) {
     return (
-      <div className={CLASS.section}>
-        <div className={CLASS.trigger} data-testid="job-watch-trigger">
-          <ConditionSentence
-            source={source}
-            spec={{
-              events: parsed.events,
-              every: parsed.every,
-              progressIntervalMS: parsed.progressIntervalMS,
-              filterToolName: parsed.filterToolName,
-              filterStatus: parsed.filterStatus,
-            }}
-          />
-          <span>
-            {used}
-            {since}.
-          </span>
+      <>
+        <div className={CLASS.section}>
+          <div className={CLASS.trigger} data-testid="job-watch-trigger">
+            <ConditionSentence
+              source={source}
+              spec={{
+                events: parsed.events,
+                every: parsed.every,
+                progressIntervalMS: parsed.progressIntervalMS,
+                filterToolName: parsed.filterToolName,
+                filterStatus: parsed.filterStatus,
+              }}
+              meta={meta}
+            />
+          </div>
         </div>
-      </div>
+        {note ? <NoteSection note={note} /> : null}
+      </>
     );
   }
   return (
@@ -1021,8 +1499,7 @@ function InspectBody({ raw }: { raw: JsonObject }) {
       <div className={CLASS.trigger} data-testid="job-watch-trigger">
         <span>
           Watching <span className={CLASS.mono}>{source}</span>
-          {used}
-          {since}.
+          {meta ? ` — ${meta}` : ""}.
         </span>
       </div>
     </div>
@@ -1072,6 +1549,24 @@ function JobWatchBody(props: ToolRenderProps) {
   }
 }
 
+// jobWatchHasBody mirrors JobWatchBody's null conditions exactly: clear
+// results and terminal catch-ups are summary-only (the summary line IS the
+// rendering), as are noteless timers and sourceless-condition creates.
+// ToolCallItem consults this to withhold the disclosure control that would
+// otherwise open to nothing.
+function jobWatchHasBody(item: ItemModel): boolean {
+  const raw = asJsonObject(item.raw);
+  if (!raw || !isRecognizedWatchResult(raw)) return true;
+  const operation = jobWatchOperation(item, raw);
+  if (operation === "clear") return false;
+  if (operation === "list" || operation === "inspect") return true;
+  if (isTerminalCatchup(raw)) return false;
+  const timer = timerSpec(raw);
+  if (timer && !timer.note) return false;
+  if (!timer && !conditionSpec(raw, asJsonObject(parseArgs(item.argumentsJSON)))) return false;
+  return true;
+}
+
 registerToolRenderer({
   match: "job_watch",
   icon: "job",
@@ -1081,4 +1576,5 @@ registerToolRenderer({
   fold: "never",
   summary: jobWatchSummary,
   body: JobWatchBody,
+  hasBody: jobWatchHasBody,
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.tsx
@@ -1,0 +1,870 @@
+// job_watch descriptor (mockups 23-job-watch §A-D). Ground truth:
+// agent/session_tools_jobs.go's jobWatchToolResult (create/clear/catch-up),
+// jobWatchListToolResult (list), and jobWatchInspectToolResult (inspect)
+// ride item.raw as the State field of tool.StateResult; item.output is the
+// formatJobWatch/formatJobWatchList/formatJobWatchInspect footer text and
+// item.argumentsJSON carries the operation plus the create args.
+//
+// Decisions locked in the mockup pass: humanize every duration (after 300s
+// → "in 5m", progress_interval_ms 120000 → "every 2m"; absolute clock only
+// for created_at); notes render in full to ~20 lines, disclosure only
+// beyond; no watch id on single-watch surfaces (list rows, inspect
+// summaries, raw disclosures only); status chips only in list rows, where
+// watching vs ended varies per row; clear and terminal catch-up are quiet
+// one-liners — the summary line IS the rendering, expanded body empty.
+import { useState } from "react";
+import type { ItemModel } from "../../../../protocol/model";
+import { Chip } from "../../../../widgets";
+import { requireClass } from "../../../../widgets/internal/requireClass";
+import type { ToolRenderProps } from "../toolRenderers";
+import { registerToolRenderer } from "../toolRenderers";
+import { HeadClippedOutputBody } from "./bodies";
+import { clip, clipJobID, parseArgs, str } from "./helpers";
+import styles from "./jobWatch.module.css";
+
+const CLASS = {
+  card: requireClass(styles.card, "jobWatch.module.css", "card"),
+  section: requireClass(styles.section, "jobWatch.module.css", "section"),
+  note: requireClass(styles.note, "jobWatch.module.css", "note"),
+  noteClamped: requireClass(styles.noteClamped, "jobWatch.module.css", "noteClamped"),
+  trigger: requireClass(styles.trigger, "jobWatch.module.css", "trigger"),
+  mono: requireClass(styles.mono, "jobWatch.module.css", "mono"),
+  row: requireClass(styles.row, "jobWatch.module.css", "row"),
+  rowId: requireClass(styles.rowId, "jobWatch.module.css", "rowId"),
+  rowCondition: requireClass(styles.rowCondition, "jobWatch.module.css", "rowCondition"),
+  disclosureSummary: requireClass(styles.disclosureSummary, "jobWatch.module.css", "disclosureSummary"),
+};
+
+// watchDeliveryBudget in agent/job_watch.go: the condition-fire budget every
+// inspect summary measures deliveries against. Carried as a literal with the
+// same "budget" framing the Go side's own notices use ("matched 50 times"),
+// not derived — item.raw carries only the used count.
+const WATCH_DELIVERY_BUDGET = 50;
+
+// NOTE_CLAMP_LINES is the note policy, not a measurement: notes at or under
+// ~20 lines render in full with no disclosure; longer notes clamp behind
+// "Show full note". The line count is a rough split on "\n" (a prose note's
+// lines are display lines, not data), so the boundary is approximate by
+// design — the mockup's "~20 lines".
+const NOTE_CLAMP_LINES = 20;
+
+const NOTE_HEAD_CHARS = 48;
+
+type JsonObject = Record<string, unknown>;
+
+function asJsonObject(value: unknown): JsonObject | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? (value as JsonObject) : undefined;
+}
+
+function strField(object: JsonObject, key: string): string | undefined {
+  const value = object[key];
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+function numField(object: JsonObject, key: string): number | undefined {
+  const value = object[key];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+function boolField(object: JsonObject, key: string): boolean {
+  return object[key] === true;
+}
+
+function strArrayField(object: JsonObject, key: string): string[] {
+  const value = object[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string" && entry !== "");
+}
+
+// humanizeSeconds renders a caller-supplied duration in the units the model
+// asked in: sub-minute stays in seconds ("in 45s"); whole minutes collapse
+// ("in 5m", "in 1m"); leftover seconds are kept ("in 1m30s", never a lossy
+// "in 1m" — RoboRev PR #954); an hour or more names hours and leftover
+// minutes ("in 1h05m"). Zero/negative never reaches here (numField filters
+// it) — the caller falls back to the raw footer text instead of inventing
+// one.
+export function humanizeSeconds(totalSeconds: number): string {
+  if (totalSeconds < 60) return `in ${Math.round(totalSeconds)}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const leftoverSeconds = Math.round(totalSeconds % 60);
+  if (totalMinutes < 60) {
+    return leftoverSeconds === 0
+      ? `in ${totalMinutes}m`
+      : `in ${totalMinutes}m${String(leftoverSeconds).padStart(2, "0")}s`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `in ${hours}h` : `in ${hours}h${String(minutes).padStart(2, "0")}m`;
+}
+
+// humanizeInterval renders a caller-supplied cadence: sub-minute stays in
+// seconds ("every 45s"), whole minutes collapse ("every 2m"), leftover
+// seconds are kept ("every 1m30s"); hours name hours ("every 1h"). Same
+// zero/negative contract as humanizeSeconds.
+export function humanizeInterval(totalSeconds: number): string {
+  if (totalSeconds < 60) return `every ${Math.round(totalSeconds)}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const leftoverSeconds = Math.round(totalSeconds % 60);
+  if (totalMinutes < 60) {
+    return leftoverSeconds === 0
+      ? `every ${totalMinutes}m`
+      : `every ${totalMinutes}m${String(leftoverSeconds).padStart(2, "0")}s`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `every ${hours}h` : `every ${hours}h${String(minutes).padStart(2, "0")}m`;
+}
+
+// A create result is a timer when it carries the timer's own fields
+// (after/repeat seconds plus the admitted note) and no trigger condition
+// (output_match, events, or event filter). Mirrors the producer:
+// marshalWatchResult reports AfterSeconds for a one-shot timer and
+// RepeatSeconds for a repeating one, leaving ProgressIntervalMS zero for
+// timers ("the result speaks in the units the model asked in").
+interface TimerSpec {
+  afterSeconds?: number;
+  repeatSeconds?: number;
+  note?: string;
+}
+
+function timerSpec(raw: JsonObject): TimerSpec | undefined {
+  const afterSeconds = numField(raw, "after_seconds");
+  const repeatSeconds = numField(raw, "repeat_seconds");
+  if (afterSeconds === undefined && repeatSeconds === undefined) return undefined;
+  if (strField(raw, "output_match") !== undefined) return undefined;
+  if (strArrayField(raw, "events").length > 0) return undefined;
+  if (asJsonObject(raw.event_filter) !== undefined) return undefined;
+  return { afterSeconds, repeatSeconds, note: strField(raw, "note") };
+}
+
+// A condition watch's trigger: the output pattern, the heartbeat cadence
+// (progress_interval_ms from the wire), the event list plus its every-Nth
+// throttle (RoboRev PR #954: `every: 3` fires on every third event, and
+// dropping it claims every event fires), and the event-filter shape
+// (assistant.tool errors on a delegate). Empty when the result names no
+// condition at all — a bare source watch the summary still names.
+interface ConditionSpec {
+  outputMatch?: string;
+  progressIntervalMS?: number;
+  events: string[];
+  every?: number;
+  filterToolName?: string;
+  filterStatus?: string;
+}
+
+function numArg(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+
+function conditionSpec(raw: JsonObject, args?: JsonObject): ConditionSpec | undefined {
+  const outputMatch = strField(raw, "output_match");
+  const progressIntervalMS = numField(raw, "progress_interval_ms");
+  const events = strArrayField(raw, "events");
+  // `every` rides the create ARGS (DefJobWatch), not the result state —
+  // read args first, falling back to the raw in case a producer echoes it.
+  const every = (args ? numArg(args.every) : undefined) ?? numField(raw, "every");
+  const filter = asJsonObject(raw.event_filter);
+  const filterToolName = filter ? strField(filter, "tool_name") : undefined;
+  const filterStatus = filter ? strField(filter, "status") : undefined;
+  if (outputMatch === undefined && progressIntervalMS === undefined && events.length === 0 && !filter) {
+    return undefined;
+  }
+  return { outputMatch, progressIntervalMS, events, every, filterToolName, filterStatus };
+}
+
+// The heartbeat phrase a condition sentence ends with, if the watch carries
+// a progress cadence ("heartbeat every 2m"). Undefined when the watch has
+// no progress_interval_ms — the sentence simply has no cadence clause.
+function heartbeatPhrase(spec: ConditionSpec): string | undefined {
+  if (spec.progressIntervalMS === undefined) return undefined;
+  return `heartbeat ${humanizeInterval(spec.progressIntervalMS / 1000)}`;
+}
+
+// The cadence suffix a condition summary carries ("· every 2m").
+// Undefined when the watch has no progress cadence.
+function cadenceSuffix(spec: ConditionSpec): string | undefined {
+  if (spec.progressIntervalMS === undefined) return undefined;
+  return `· ${humanizeInterval(spec.progressIntervalMS / 1000)}`;
+}
+
+function sourceLabel(source: string | undefined): string {
+  return source ?? "this session";
+}
+
+function noteHead(note: string): string {
+  const firstLine = note.split("\n")[0] ?? "";
+  return clip(firstLine.trim(), NOTE_HEAD_CHARS);
+}
+
+function isTerminalCatchup(raw: JsonObject): boolean {
+  return boolField(raw, "terminal_catchup");
+}
+
+function isWatching(raw: JsonObject): boolean {
+  return boolField(raw, "watching");
+}
+
+// jobWatchOperation prefers the call's own operation arg (the verb the model
+// used: create/list/inspect/clear) and falls back to the result shape when
+// the args are absent — a stored transcript predating the arg, or a state
+// whose shape already says what it is (list carries watches[], inspect
+// carries deliveries/created_at/end_reason, a clear carries watching:false
+// with a watch_id).
+function jobWatchOperation(item: ItemModel, raw: JsonObject | undefined): string {
+  const args = parseArgs(item.argumentsJSON);
+  const operation = str(args, "operation");
+  if (operation) return operation;
+  if (raw === undefined) return "";
+  if (Array.isArray(raw.watches) || Array.isArray(raw.recent_watches)) return "list";
+  if (typeof raw.deliveries === "number" || typeof raw.created_at === "string" || typeof raw.end_reason === "string") {
+    return "inspect";
+  }
+  if (raw.watching === false && typeof raw.watch_id === "string") return "clear";
+  if (raw.watching === true || typeof raw.note === "string" || typeof raw.output_match === "string") {
+    return "create";
+  }
+  return "";
+}
+
+function summarizeCreate(raw: JsonObject, item: ItemModel): string {
+  if (isTerminalCatchup(raw)) {
+    const source = strField(raw, "source") ?? "";
+    const status = strField(raw, "status");
+    // The terminal outcome is the whole reason the condition can never
+    // match, so the one-liner names it ("Watch on job_a1b2 ended — job
+    // completed before it could fire"). A catch-up that FIRED matched on
+    // the terminal scan instead — same shape, opposite outcome.
+    if (boolField(raw, "fired")) {
+      return status ? `Watch on ${source} fired on terminal scan — ${status}` : `Watch on ${source} fired`;
+    }
+    return status
+      ? `Watch on ${source} ended — job ${status} before it could fire`
+      : `Watch on ${source} ended — job ended before it could fire`;
+  }
+  const timer = timerSpec(raw);
+  if (timer) {
+    // A one-shot timer reminds once ("Remind me in 5m"); a repeating timer
+    // keeps reminding on its cadence ("Reminds every 5m"). after_seconds
+    // wins when both are somehow present — marshalWatchResult only ever
+    // sets one.
+    const seconds = timer.afterSeconds ?? timer.repeatSeconds ?? 0;
+    const head = timer.note ? noteHead(timer.note) : "";
+    if (timer.afterSeconds !== undefined) {
+      return head ? `Remind me ${humanizeSeconds(seconds)} · ${head}` : `Remind me ${humanizeSeconds(seconds)}`;
+    }
+    const cadence = humanizeInterval(seconds).replace(/^every /, "");
+    return head ? `Reminds every ${cadence} · ${head}` : `Reminds every ${cadence}`;
+  }
+  const source = sourceLabel(strField(raw, "source"));
+  const condition = conditionSpec(raw, asJsonObject(parseArgs(item.argumentsJSON)));
+  if (!condition) return `Watch ${source}`;
+  if (condition.outputMatch) {
+    const suffix = cadenceSuffix(condition);
+    return suffix
+      ? `Watch ${source} for “${condition.outputMatch}” ${suffix}`
+      : `Watch ${source} for “${condition.outputMatch}”`;
+  }
+  if (condition.filterStatus || condition.filterToolName) {
+    // An event-filter watch names the watched shape in words — both
+    // statuses explicitly (RoboRev PR #954: status "ok" was discarded).
+    // Never the raw filter keys.
+    const what = filterSummaryPhrase(condition);
+    return `Watch ${source} for ${what}`;
+  }
+  if (condition.events.length > 0) {
+    const suffix = cadenceSuffix(condition);
+    const throttle = condition.every !== undefined ? ` (every ${condition.every})` : "";
+    const named = `${condition.events.join(", ")}${throttle}`;
+    return suffix ? `Watch ${source} for ${named} ${suffix}` : `Watch ${source} for ${named}`;
+  }
+  return `Watch ${source}`;
+}
+
+// filterSummaryPhrase names an event-filter watch's shape in words for
+// summaries: error and ok both explicit, tool named when present.
+function filterSummaryPhrase(condition: ConditionSpec): string {
+  const tool = condition.filterToolName ? ` on ${condition.filterToolName}` : "";
+  if (condition.filterStatus === "error") return `failed tool calls${tool}`;
+  if (condition.filterStatus === "ok") return `successful tool calls${tool}`;
+  return condition.filterToolName ?? "matching events";
+}
+
+interface WatchRow {
+  id: string;
+  watching: boolean;
+  source?: string;
+  condition?: string;
+  endReason?: string;
+  deliveries?: number;
+}
+
+function normalizeRow(value: unknown): WatchRow | undefined {
+  const row = asJsonObject(value);
+  const id = row ? strField(row, "watch_id") : undefined;
+  if (!row || !id) return undefined;
+  const deliveries = typeof row.deliveries === "number" ? row.deliveries : undefined;
+  return {
+    id,
+    watching: row.watching === true,
+    source: strField(row, "source"),
+    condition: strField(row, "condition"),
+    endReason: strField(row, "end_reason"),
+    deliveries,
+  };
+}
+
+// A parsed inspect/list Condition string. The producer renders a watch
+// config's trigger as one "; "-joined line (watchConditionSummary,
+// agent/job_watch.go:2460-2494, filter grammar watchEventFilterSummary
+// :2497-2508): `output_match: …`; `after_seconds: N` / `repeat_seconds: N`
+// / `progress_interval_ms: N`; `note: …`; `events: [*]` or
+// `events: [a, b]` with optional `every N` and `where tool_name=X,
+// status=Y`. The reader parses that embedded grammar back — inventing
+// nothing, since inspect's raw carries no separate structured fields.
+interface ParsedCondition {
+  outputMatch?: string;
+  afterSeconds?: number;
+  repeatSeconds?: number;
+  progressIntervalMS?: number;
+  events: string[];
+  every?: number;
+  filterToolName?: string;
+  filterStatus?: string;
+}
+
+function numAfter(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
+function parseConditionText(condition: string): ParsedCondition {
+  const parsed: ParsedCondition = { events: [] };
+  for (const part of condition.split(";")) {
+    const text = part.trim();
+    const outputMatch = /^output_match:\s*(.+)$/.exec(text)?.[1]?.trim();
+    if (outputMatch) {
+      parsed.outputMatch = outputMatch;
+      continue;
+    }
+    const afterSeconds = /^after_seconds:\s*(\d+)/.exec(text)?.[1];
+    if (afterSeconds !== undefined) {
+      parsed.afterSeconds = numAfter(afterSeconds);
+      continue;
+    }
+    const repeatSeconds = /^repeat_seconds:\s*(\d+)/.exec(text)?.[1];
+    if (repeatSeconds !== undefined) {
+      parsed.repeatSeconds = numAfter(repeatSeconds);
+      continue;
+    }
+    const progressMS = /^progress_interval_ms:\s*(\d+)/.exec(text)?.[1];
+    if (progressMS !== undefined) {
+      parsed.progressIntervalMS = numAfter(progressMS);
+      continue;
+    }
+    const eventsClause = /^events:\s*\[(.*)\]\s*(?:every\s+(\d+))?\s*(?:where\s+(.+))?$/.exec(text);
+    if (eventsClause) {
+      parsed.events = (eventsClause[1] ?? "")
+        .split(",")
+        .map((name) => name.trim())
+        .filter((name) => name !== "");
+      parsed.every = numAfter(eventsClause[2]);
+      const whereClause = (eventsClause[3] ?? "").trim();
+      if (whereClause) {
+        const tool = /tool_name=([^,\s]+)/.exec(whereClause)?.[1];
+        const status = /status=([^,\s]+)/.exec(whereClause)?.[1];
+        if (tool) parsed.filterToolName = tool;
+        if (status) parsed.filterStatus = status;
+      }
+    }
+    // `note: …` and anything unrecognized stay out: the note is the watch's
+    // own prose (shown by the create body, never by a row), and unknown
+    // future parts degrade to the fallback below rather than inventing
+    // rendering.
+  }
+  return parsed;
+}
+
+// conditionSentence renders one humanized trigger sentence from a parsed
+// Condition: pattern, timer cadence, heartbeat, events, and filter in
+// prose, machine tokens in mono. Shared by list rows (short form) and
+// inspect bodies (full form) so the two never drift.
+function rowConditionPhrase(row: WatchRow): string {
+  if (!row.watching) {
+    return row.endReason ? `ended: ${row.endReason}` : "ended";
+  }
+  if (row.condition) {
+    const parsed = parseConditionText(row.condition);
+    const source = sourceLabel(row.source);
+    if (parsed.afterSeconds !== undefined) return `${humanizeSeconds(parsed.afterSeconds)} · ${source}`;
+    if (parsed.repeatSeconds !== undefined) {
+      return `every ${humanizeInterval(parsed.repeatSeconds).replace(/^every /, "")} · ${source}`;
+    }
+    const bits: string[] = [];
+    if (parsed.outputMatch) bits.push(`“${parsed.outputMatch}”`);
+    if (parsed.events.length > 0) {
+      const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
+      bits.push(parsed.every !== undefined ? `${names} every ${parsed.every}` : names);
+    }
+    if (parsed.filterToolName || parsed.filterStatus) {
+      bits.push(parsed.filterStatus === "error" ? "failed tool calls" : `calls on ${parsed.filterToolName ?? "?"}`);
+    }
+    if (parsed.progressIntervalMS !== undefined) {
+      bits.push(humanizeInterval(parsed.progressIntervalMS / 1000));
+    }
+    if (bits.length > 0) return `${bits.join(" · ")} · ${source}`;
+    return `${row.condition} · ${source}`;
+  }
+  return sourceLabel(row.source);
+}
+
+function listCounts(raw: JsonObject): { active: number; ended: number } {
+  const live = Array.isArray(raw.watches) ? raw.watches : [];
+  const recent = Array.isArray(raw.recent_watches) ? raw.recent_watches : [];
+  let active = 0;
+  let ended = 0;
+  for (const entry of live) {
+    const row = normalizeRow(entry);
+    if (!row) continue;
+    if (row.watching) active += 1;
+    else ended += 1;
+  }
+  ended += recent.filter((entry) => normalizeRow(entry) !== undefined).length;
+  return { active, ended };
+}
+
+function summarizeList(raw: JsonObject): string {
+  const { active, ended } = listCounts(raw);
+  const activeWord = active === 1 ? "1 active" : `${active} active`;
+  if (ended === 0) return `Listed watches (${activeWord})`;
+  const endedWord = ended === 1 ? "1 ended" : `${ended} ended`;
+  return `Listed watches (${activeWord} · ${endedWord})`;
+}
+
+function summarizeInspect(item: ItemModel, raw: JsonObject): string {
+  const args = parseArgs(item.argumentsJSON);
+  const id = strField(raw, "watch_id") ?? str(args, "watch_id") ?? "";
+  const state = isWatching(raw) ? "watching" : "ended";
+  const deliveries = typeof raw.deliveries === "number" ? raw.deliveries : undefined;
+  // Deliveries used measures against the delivery budget ("3 of 50 used")
+  // — the same budget the Go side's own notices name. Ended or
+  // not-yet-delivered watches carry no count to render.
+  if (deliveries !== undefined && isWatching(raw)) {
+    return `Inspected ${id} · ${state} · ${deliveries} of ${WATCH_DELIVERY_BUDGET} used`;
+  }
+  return `Inspected ${id} · ${state}`;
+}
+
+function jobWatchSummary(item: ItemModel): string {
+  const raw = asJsonObject(item.raw);
+  // Without structured state (a stored transcript predating it, or a shape
+  // the normalizer doesn't recognize) fall back to the call's own verb —
+  // the same "job_watch: <operation>" the family fallback rendered, so the
+  // row never regresses to a bare tool name.
+  if (!raw) {
+    const args = parseArgs(item.argumentsJSON);
+    const operation = str(args, "operation");
+    return operation ? `job_watch: ${operation}` : (item.toolName ?? "job_watch");
+  }
+  const operation = jobWatchOperation(item, raw);
+  switch (operation) {
+    case "list":
+      return summarizeList(raw);
+    case "inspect":
+      return summarizeInspect(item, raw);
+    case "clear": {
+      const args = parseArgs(item.argumentsJSON);
+      const id = strField(raw, "watch_id") ?? str(args, "watch_id") ?? "";
+      return id ? `Cleared ${clipJobID(id)}` : "Cleared watch";
+    }
+    default:
+      return summarizeCreate(raw, item);
+  }
+}
+
+function NoteSection({ note }: { note: string }) {
+  const [open, setOpen] = useState(false);
+  const lineCount = note.split("\n").length;
+  const clamped = !open && lineCount > NOTE_CLAMP_LINES;
+  return (
+    <div className={CLASS.section}>
+      <div className={clamped ? `${CLASS.note} ${CLASS.noteClamped}` : CLASS.note} data-testid="job-watch-note">
+        {note}
+      </div>
+      {clamped || open ? (
+        <details data-testid="job-watch-note-disclosure" open={open}>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: <summary> is natively keyboard-operable; controlled for the same single-source-of-truth reason as ToolRow */}
+          <summary
+            className={CLASS.disclosureSummary}
+            onClick={(event) => {
+              event.preventDefault();
+              setOpen((previous) => !previous);
+            }}
+          >
+            {open ? "Show less" : "Show full note"}
+          </summary>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+// conditionSentence renders the one-sentence body for a condition watch:
+// source + condition + cadence in prose, patterns in mono. Raw field names
+// (progress_interval_ms, output_match:) never surface — the cadence is a
+// heartbeat phrase, the pattern is quoted.
+function ConditionSentence({ source, spec }: { source: string; spec: ConditionSpec }) {
+  const heartbeat = heartbeatPhrase(spec);
+  if (spec.outputMatch) {
+    return (
+      <span>
+        Wakes you when <span className={CLASS.mono}>{source}</span> outputs{" "}
+        <span className={CLASS.mono}>{spec.outputMatch}</span>
+        {heartbeat ? `, ${heartbeat}` : ""}, auto-clears after {WATCH_DELIVERY_BUDGET} matches.
+      </span>
+    );
+  }
+  if (spec.filterStatus || spec.filterToolName) {
+    // Both filter statuses read explicitly (RoboRev PR #954: status "ok"
+    // was discarded into a bare tool name). The tool rides along when
+    // present; the event name disambiguates in list/inspect context.
+    const tool = spec.filterToolName ? (
+      <>
+        {" "}
+        on <span className={CLASS.mono}>{spec.filterToolName}</span>
+      </>
+    ) : null;
+    const outcome =
+      spec.filterStatus === "error" ? (
+        <span>
+          ending in <span className={CLASS.mono}>error</span>
+        </span>
+      ) : spec.filterStatus === "ok" ? (
+        <span>
+          ending in <span className={CLASS.mono}>ok</span>
+        </span>
+      ) : spec.filterToolName ? (
+        "matching"
+      ) : (
+        "matching"
+      );
+    // Name the filtered event: in inspect/list context the events array is
+    // not shown separately, and the filter only ever attaches to
+    // assistant.tool — without the name the sentence loses what fires.
+    const eventName =
+      spec.events.length === 1 ? (
+        <>
+          {" "}
+          (<span className={CLASS.mono}>{spec.events[0]}</span>)
+        </>
+      ) : null;
+    return (
+      <span>
+        Wakes you when <span className={CLASS.mono}>{source}</span> makes a tool call {outcome}
+        {tool}
+        {eventName}.
+      </span>
+    );
+  }
+  if (spec.events.length > 0) {
+    const throttle = spec.every !== undefined ? ` (every ${spec.every})` : "";
+    return (
+      <span>
+        Wakes you on <span className={CLASS.mono}>{spec.events.join(", ")}</span>
+        {throttle}
+        {heartbeat ? `, ${heartbeat}` : ""}.
+      </span>
+    );
+  }
+  if (heartbeat) {
+    return (
+      <span>
+        Watches <span className={CLASS.mono}>{source}</span>, {heartbeat}.
+      </span>
+    );
+  }
+  return (
+    <span>
+      Watches <span className={CLASS.mono}>{source}</span>.
+    </span>
+  );
+}
+
+function CreateBody({ raw, item }: { raw: JsonObject; item: ItemModel }) {
+  if (isTerminalCatchup(raw)) return null;
+  const timer = timerSpec(raw);
+  if (timer?.note) return <NoteSection note={timer.note} />;
+  if (timer) return null;
+  const source = sourceLabel(strField(raw, "source"));
+  const condition = conditionSpec(raw, asJsonObject(parseArgs(item.argumentsJSON)));
+  if (!condition) return null;
+  return (
+    <div className={CLASS.section}>
+      <div className={CLASS.trigger} data-testid="job-watch-trigger">
+        <ConditionSentence source={source} spec={condition} />
+      </div>
+    </div>
+  );
+}
+
+function WatchRow({ row }: { row: WatchRow }) {
+  const [open, setOpen] = useState(false);
+  // Rows are real buttons (mockup §C: tappable rows opening the watch's
+  // details). Expanding shows the row's own detail sentence inline — the
+  // same humanized grammar as the inspect body, minus deliveries/created
+  // which list raw does not carry.
+  const detail = row.watching ? rowDetailPhrase(row) : undefined;
+  return (
+    <div key={row.id}>
+      <button
+        type="button"
+        className={CLASS.row}
+        data-testid="job-watch-row"
+        aria-expanded={detail ? open : undefined}
+        onClick={() => {
+          if (detail) setOpen((previous) => !previous);
+        }}
+      >
+        <Chip>{row.watching ? "watching" : "ended"}</Chip>
+        <span className={CLASS.rowId} title={row.id}>
+          {clipJobID(row.id)}
+        </span>
+        <span className={CLASS.rowCondition}>{rowConditionPhrase(row)}</span>
+      </button>
+      {detail && open ? (
+        <div className={CLASS.section} data-testid="job-watch-row-detail">
+          <div className={CLASS.trigger}>{detail}</div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// rowDetailPhrase renders the expanded sentence behind a tapped list row:
+// the row's condition plus its deliveries context when the raw carries it.
+// Every supported form renders — an expandable row must never be a no-op
+// (RoboRev PR #954).
+function rowDetailPhrase(row: WatchRow): string | undefined {
+  if (!row.watching || !row.condition) return undefined;
+  const parsed = parseConditionText(row.condition);
+  const source = sourceLabel(row.source);
+  const deliveries =
+    row.deliveries !== undefined ? ` — ${row.deliveries} of ${WATCH_DELIVERY_BUDGET} deliveries used` : "";
+  if (parsed.outputMatch) {
+    const heartbeat =
+      parsed.progressIntervalMS !== undefined
+        ? `, heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`
+        : "";
+    return `Watching ${source} for “${parsed.outputMatch}”${heartbeat}${deliveries}.`;
+  }
+  if (parsed.afterSeconds !== undefined) return `Reminds ${humanizeSeconds(parsed.afterSeconds)}${deliveries}.`;
+  if (parsed.repeatSeconds !== undefined) return `Reminds ${humanizeInterval(parsed.repeatSeconds)}${deliveries}.`;
+  const bits: string[] = [];
+  if (parsed.events.length > 0) {
+    const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
+    bits.push(parsed.every !== undefined ? `${names} every ${parsed.every}` : names);
+  }
+  if (parsed.filterToolName || parsed.filterStatus) {
+    if (parsed.filterStatus === "error")
+      bits.push(`failed tool calls${parsed.filterToolName ? ` on ${parsed.filterToolName}` : ""}`);
+    else if (parsed.filterStatus === "ok")
+      bits.push(`successful tool calls${parsed.filterToolName ? ` on ${parsed.filterToolName}` : ""}`);
+    else bits.push(`calls on ${parsed.filterToolName ?? "?"}`);
+  }
+  if (parsed.progressIntervalMS !== undefined) {
+    bits.push(`heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`);
+  }
+  if (bits.length > 0) return `Watches ${source}: ${bits.join(" · ")}${deliveries}.`;
+  return undefined;
+}
+
+function ListBody({ raw }: { raw: JsonObject }) {
+  const live = Array.isArray(raw.watches) ? raw.watches : [];
+  const recent = Array.isArray(raw.recent_watches) ? raw.recent_watches : [];
+  const rows: WatchRow[] = [];
+  for (const entry of [...live, ...recent]) {
+    const row = normalizeRow(entry);
+    if (row) rows.push(row);
+  }
+  if (rows.length === 0) {
+    return (
+      <div className={CLASS.section}>
+        <div className={CLASS.trigger} data-testid="job-watch-empty">
+          No watches.
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div>
+      {rows.map((row) => (
+        <WatchRow key={row.id} row={row} />
+      ))}
+    </div>
+  );
+}
+
+// formatCreatedDate renders the inspect created_at as an absolute clock
+// ("created Sep 6, 09:41") — the one place the mockup keeps a clock: a
+// duration since creation would go stale on every render, while the moment
+// the watch was armed stays true.
+function formatCreatedDate(createdAt: string | undefined): string | undefined {
+  if (!createdAt) return undefined;
+  const parsed = new Date(createdAt);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  const month = parsed.toLocaleString("en-US", { month: "short" });
+  const day = parsed.getDate();
+  const hours = String(parsed.getHours()).padStart(2, "0");
+  const minutes = String(parsed.getMinutes()).padStart(2, "0");
+  return `created ${month} ${day}, ${hours}:${minutes}`;
+}
+
+function InspectBody({ raw }: { raw: JsonObject }) {
+  const source = sourceLabel(strField(raw, "source"));
+  if (!isWatching(raw)) {
+    const endReason = strField(raw, "end_reason");
+    return (
+      <div className={CLASS.section}>
+        <div className={CLASS.trigger} data-testid="job-watch-trigger">
+          {endReason ? (
+            <span>
+              Watch on <span className={CLASS.mono}>{source}</span> ended — {endReason}.
+            </span>
+          ) : (
+            <span>
+              Watch on <span className={CLASS.mono}>{source}</span> ended.
+            </span>
+          )}
+        </div>
+      </div>
+    );
+  }
+  const condition = strField(raw, "condition");
+  const parsed = condition ? parseConditionText(condition) : undefined;
+  const deliveries = typeof raw.deliveries === "number" ? raw.deliveries : undefined;
+  const created = formatCreatedDate(strField(raw, "created_at"));
+  const used = deliveries !== undefined ? ` — ${deliveries} of ${WATCH_DELIVERY_BUDGET} deliveries used` : "";
+  const since = created ? `, ${created}` : "";
+  // Every embedded condition form renders humanized: pattern, timer
+  // cadence, heartbeat, events (+every throttle), and filter — the same
+  // sentence grammar as the create/inspect one-liners, never raw keys.
+  if (parsed?.outputMatch) {
+    return (
+      <div className={CLASS.section}>
+        <div className={CLASS.trigger} data-testid="job-watch-trigger">
+          <span>
+            Watching <span className={CLASS.mono}>{source}</span> for{" "}
+            <span className={CLASS.mono}>{parsed.outputMatch}</span>
+            {parsed.progressIntervalMS !== undefined
+              ? `, heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`
+              : ""}
+            {used}
+            {since}.
+          </span>
+        </div>
+      </div>
+    );
+  }
+  if (parsed?.afterSeconds !== undefined || parsed?.repeatSeconds !== undefined) {
+    const seconds = parsed.afterSeconds ?? parsed.repeatSeconds ?? 0;
+    const when = parsed.afterSeconds !== undefined ? humanizeSeconds(seconds) : humanizeInterval(seconds);
+    return (
+      <div className={CLASS.section}>
+        <div className={CLASS.trigger} data-testid="job-watch-trigger">
+          <span>
+            Reminds {when}
+            {used}
+            {since}.
+          </span>
+        </div>
+      </div>
+    );
+  }
+  if (
+    parsed &&
+    (parsed.events.length > 0 ||
+      parsed.filterToolName ||
+      parsed.filterStatus ||
+      parsed.progressIntervalMS !== undefined)
+  ) {
+    return (
+      <div className={CLASS.section}>
+        <div className={CLASS.trigger} data-testid="job-watch-trigger">
+          <ConditionSentence
+            source={source}
+            spec={{
+              events: parsed.events,
+              every: parsed.every,
+              progressIntervalMS: parsed.progressIntervalMS,
+              filterToolName: parsed.filterToolName,
+              filterStatus: parsed.filterStatus,
+            }}
+          />
+          <span>
+            {used}
+            {since}.
+          </span>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className={CLASS.section}>
+      <div className={CLASS.trigger} data-testid="job-watch-trigger">
+        <span>
+          Watching <span className={CLASS.mono}>{source}</span>
+          {used}
+          {since}.
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function JobWatchBody(props: ToolRenderProps) {
+  const { item, live } = props;
+  const raw = asJsonObject(item.raw);
+  // Without structured state (a stored transcript predating it, or a shape
+  // the normalizer doesn't recognize) fall back to the raw footer text —
+  // the call's only useful output (RoboRev PR #954). The structured bodies
+  // above replace the mono wall only when there is structure to render.
+  if (!raw) return <HeadClippedOutputBody item={item} live={live} />;
+  const operation = jobWatchOperation(item, raw);
+  switch (operation) {
+    case "list":
+      return (
+        <div className={CLASS.card} data-testid="job-watch-body">
+          <ListBody raw={raw} />
+        </div>
+      );
+    case "inspect":
+      return (
+        <div className={CLASS.card} data-testid="job-watch-body">
+          <InspectBody raw={raw} />
+        </div>
+      );
+    case "clear":
+      return null;
+    default: {
+      if (isTerminalCatchup(raw)) return null;
+      const timer = timerSpec(raw);
+      if (timer && !timer.note) return null;
+      return (
+        <div className={CLASS.card} data-testid="job-watch-body">
+          <CreateBody raw={raw} item={item} />
+        </div>
+      );
+    }
+  }
+}
+
+registerToolRenderer({
+  match: "job_watch",
+  icon: "job",
+  // A watch card is state a reader tracks across a turn (armed timer,
+  // standing condition, inventory) — it always stands on its own line,
+  // like every other job descriptor after #947.
+  fold: "never",
+  summary: jobWatchSummary,
+  body: JobWatchBody,
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobWatch.tsx
@@ -12,6 +12,8 @@
 // summaries, raw disclosures only); status chips only in list rows, where
 // watching vs ended varies per row; clear and terminal catch-up are quiet
 // one-liners — the summary line IS the rendering, expanded body empty.
+
+import type { ReactNode } from "react";
 import { useState } from "react";
 import type { ItemModel } from "../../../../protocol/model";
 import { Chip } from "../../../../widgets";
@@ -30,15 +32,19 @@ const CLASS = {
   trigger: requireClass(styles.trigger, "jobWatch.module.css", "trigger"),
   mono: requireClass(styles.mono, "jobWatch.module.css", "mono"),
   row: requireClass(styles.row, "jobWatch.module.css", "row"),
+  rowStatic: requireClass(styles.rowStatic, "jobWatch.module.css", "rowStatic"),
   rowId: requireClass(styles.rowId, "jobWatch.module.css", "rowId"),
   rowCondition: requireClass(styles.rowCondition, "jobWatch.module.css", "rowCondition"),
   disclosureSummary: requireClass(styles.disclosureSummary, "jobWatch.module.css", "disclosureSummary"),
 };
 
-// watchDeliveryBudget in agent/job_watch.go: the condition-fire budget every
-// inspect summary measures deliveries against. Carried as a literal with the
-// same "budget" framing the Go side's own notices use ("matched 50 times"),
-// not derived — item.raw carries only the used count.
+// watchDeliveryBudget in agent/job_watch.go: the condition-fire budget the
+// Go side's own notices name ("matched 50 times"). It is NOT the denominator
+// for the deliveries count below: cfg.deliveries counts every model-facing
+// delivery including periodic progress/timer ticks that never consume the
+// condition-fire budget (countWatchDeliveryLocked), so "N of 50" can read
+// past the budget ("55 of 50"). The count renders bare, labeled as what it
+// is (combined RoboRev review).
 const WATCH_DELIVERY_BUDGET = 50;
 
 // NOTE_CLAMP_LINES is the note policy, not a measurement: notes at or under
@@ -204,6 +210,43 @@ function isWatching(raw: JsonObject): boolean {
   return boolField(raw, "watching");
 }
 
+// isRecognizedWatchResult gates the structured renderer: the raw must carry
+// at least one field from the producer's result shapes (create:
+// watching/timer/condition/note/catch-up/identity; list: watches arrays;
+// inspect: watching/deliveries/created_at/end_reason/watch_id). An
+// unrecognized object — {} or a legacy/future shape — falls back to the raw
+// footer text instead of rendering an empty card with an invented "Watch this
+// session" summary (RoboRev PR #954 combined review). The fallback direction
+// is deliberate: unknown shapes show the producer's own words, never an
+// empty card.
+const WATCH_RESULT_FIELDS = [
+  "watching",
+  "watches",
+  "recent_watches",
+  "watch_id",
+  "source",
+  "after_seconds",
+  "repeat_seconds",
+  "output_match",
+  "events",
+  "event_filter",
+  "every",
+  "progress_interval_ms",
+  "note",
+  "deliveries",
+  "created_at",
+  "end_reason",
+  "ended_at",
+  "terminal_catchup",
+  "fired",
+  "status",
+  "replaced_existing",
+];
+
+function isRecognizedWatchResult(raw: JsonObject): boolean {
+  return WATCH_RESULT_FIELDS.some((field) => raw[field] !== undefined);
+}
+
 // jobWatchOperation prefers the call's own operation arg (the verb the model
 // used: create/list/inspect/clear) and falls back to the result shape when
 // the args are absent — a stored transcript predating the arg, or a state
@@ -258,35 +301,49 @@ function summarizeCreate(raw: JsonObject, item: ItemModel): string {
   const source = sourceLabel(strField(raw, "source"));
   const condition = conditionSpec(raw, asJsonObject(parseArgs(item.argumentsJSON)));
   if (!condition) return `Watch ${source}`;
-  if (condition.outputMatch) {
-    const suffix = cadenceSuffix(condition);
-    return suffix
-      ? `Watch ${source} for “${condition.outputMatch}” ${suffix}`
-      : `Watch ${source} for “${condition.outputMatch}”`;
+  // Trigger clauses compose: output_match, events (+every throttle, filter),
+  // and the progress heartbeat combine freely on a live watch (only timer
+  // fields are mutually exclusive with conditions — the producer's own
+  // watchConditionSummary joins every populated clause with "; "). The
+  // summary names every armed clause so none is silently dropped (combined
+  // RoboRev review).
+  const clauses: string[] = [];
+  if (condition.outputMatch) clauses.push(`“${condition.outputMatch}”`);
+  if (condition.events.length > 0) {
+    const throttle = condition.every !== undefined ? ` (every ${condition.every})` : "";
+    clauses.push(`${condition.events.join(", ")}${throttle}`);
   }
   if (condition.filterStatus || condition.filterToolName) {
     // An event-filter watch names the watched shape in words — both
     // statuses explicitly (RoboRev PR #954: status "ok" was discarded).
     // Never the raw filter keys.
-    const what = filterSummaryPhrase(condition);
-    return `Watch ${source} for ${what}`;
+    clauses.push(filterSummaryPhrase(condition));
   }
-  if (condition.events.length > 0) {
-    const suffix = cadenceSuffix(condition);
-    const throttle = condition.every !== undefined ? ` (every ${condition.every})` : "";
-    const named = `${condition.events.join(", ")}${throttle}`;
-    return suffix ? `Watch ${source} for ${named} ${suffix}` : `Watch ${source} for ${named}`;
-  }
-  return `Watch ${source}`;
+  const cadence = cadenceSuffix(condition);
+  if (cadence) clauses.push(cadence.replace(/^· /, ""));
+  if (clauses.length === 0) return `Watch ${source}`;
+  // A bare heartbeat keeps its established "Watch X · every 2m" shape
+  // (RoboRev PR #954 review 3, finding F) — "for" needs a trigger to read
+  // against.
+  if (clauses.length === 1 && cadence) return `Watch ${source} ${cadence}`;
+  return `Watch ${source} for ${clauses.join(" · ")}`;
 }
 
-// filterSummaryPhrase names an event-filter watch's shape in words for
-// summaries: error and ok both explicit, tool named when present.
-function filterSummaryPhrase(condition: ConditionSpec): string {
+// filterSummaryPhrase names an event-filter watch's shape in words, shared by
+// summaries, list rows, and row details so the three never drift (RoboRev PR
+// #954 review 3): error and ok both explicit with the tool named when
+// present; a status-less filter still names the tool ("calls on …"), and a
+// bare filter with neither reads "matching events".
+interface FilterPhrase {
+  filterToolName?: string;
+  filterStatus?: string;
+}
+
+function filterSummaryPhrase(condition: FilterPhrase): string {
   const tool = condition.filterToolName ? ` on ${condition.filterToolName}` : "";
   if (condition.filterStatus === "error") return `failed tool calls${tool}`;
   if (condition.filterStatus === "ok") return `successful tool calls${tool}`;
-  return condition.filterToolName ?? "matching events";
+  return condition.filterToolName ? `calls on ${condition.filterToolName}` : "matching events";
 }
 
 interface WatchRow {
@@ -338,9 +395,20 @@ function numAfter(value: string | undefined): number | undefined {
   return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
+// Split only on semicolons that introduce a recognized Condition field.
+// output_match is caller-supplied and unbounded, so a pattern may itself
+// contain ";" — splitting on every one truncates the pattern (RoboRev PR
+// #954 review 3). The heads below are the producer's exact grammar
+// (watchConditionSummary, agent/job_watch.go:2460-2494): "output_match: ",
+// "after_seconds: N" / "repeat_seconds: N" / "progress_interval_ms: N",
+// "note: ", "events: ...", joined with "; ". (A pattern literally containing
+// "; events: " stays ambiguous even to the producer's own join — the split
+// takes the field reading, matching what list/inspect show.)
+const CONDITION_PART_SPLIT = /;\s*(?=(?:output_match|after_seconds|repeat_seconds|progress_interval_ms|note|events):)/;
+
 function parseConditionText(condition: string): ParsedCondition {
   const parsed: ParsedCondition = { events: [] };
-  for (const part of condition.split(";")) {
+  for (const part of condition.split(CONDITION_PART_SPLIT)) {
     const text = part.trim();
     const outputMatch = /^output_match:\s*(.+)$/.exec(text)?.[1]?.trim();
     if (outputMatch) {
@@ -390,69 +458,114 @@ function parseConditionText(condition: string): ParsedCondition {
 // prose, machine tokens in mono. Shared by list rows (short form) and
 // inspect bodies (full form) so the two never drift.
 function rowConditionPhrase(row: WatchRow): string {
-  if (!row.watching) {
-    return row.endReason ? `ended: ${row.endReason}` : "ended";
+  const state = watchState(row);
+  if (state === "watching") {
+    if (row.condition) {
+      const parsed = parseConditionText(row.condition);
+      const source = sourceLabel(row.source);
+      if (parsed.afterSeconds !== undefined) return `${humanizeSeconds(parsed.afterSeconds)} · ${source}`;
+      if (parsed.repeatSeconds !== undefined) {
+        return `every ${humanizeInterval(parsed.repeatSeconds).replace(/^every /, "")} · ${source}`;
+      }
+      const bits: string[] = [];
+      if (parsed.outputMatch) bits.push(`“${parsed.outputMatch}”`);
+      // The every throttle rides the events bit when one renders, else the
+      // filter bit — it is one shared throttle ("events: […] every N where …"),
+      // so it must never print twice. Parens match the create summary's
+      // "(every N)" shape (RoboRev PR #954 review 3).
+      const every = parsed.every !== undefined ? ` (every ${parsed.every})` : "";
+      if (parsed.events.length > 0) {
+        const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
+        bits.push(`${names}${every}`);
+      }
+      if (parsed.filterToolName || parsed.filterStatus) {
+        bits.push(`${filterSummaryPhrase(parsed)}${parsed.events.length === 0 ? every : ""}`);
+      }
+      if (parsed.progressIntervalMS !== undefined) {
+        bits.push(humanizeInterval(parsed.progressIntervalMS / 1000));
+      }
+      if (bits.length > 0) return `${bits.join(" · ")} · ${source}`;
+      return `${row.condition} · ${source}`;
+    }
+    return sourceLabel(row.source);
   }
-  if (row.condition) {
-    const parsed = parseConditionText(row.condition);
-    const source = sourceLabel(row.source);
-    if (parsed.afterSeconds !== undefined) return `${humanizeSeconds(parsed.afterSeconds)} · ${source}`;
-    if (parsed.repeatSeconds !== undefined) {
-      return `every ${humanizeInterval(parsed.repeatSeconds).replace(/^every /, "")} · ${source}`;
-    }
-    const bits: string[] = [];
-    if (parsed.outputMatch) bits.push(`“${parsed.outputMatch}”`);
-    if (parsed.events.length > 0) {
-      const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
-      bits.push(parsed.every !== undefined ? `${names} every ${parsed.every}` : names);
-    }
-    if (parsed.filterToolName || parsed.filterStatus) {
-      bits.push(parsed.filterStatus === "error" ? "failed tool calls" : `calls on ${parsed.filterToolName ?? "?"}`);
-    }
-    if (parsed.progressIntervalMS !== undefined) {
-      bits.push(humanizeInterval(parsed.progressIntervalMS / 1000));
-    }
-    if (bits.length > 0) return `${bits.join(" · ")} · ${source}`;
-    return `${row.condition} · ${source}`;
-  }
-  return sourceLabel(row.source);
+  // A missing watch has no source to name — sourceLabel would invent "this
+  // session" for a watch that is not there (RoboRev PR #954 combined review).
+  if (state === "missing") return "not found";
+  if (state === "pending") return `pending · ${sourceLabel(row.source)}`;
+  return row.endReason ? `ended: ${row.endReason}` : "ended";
 }
 
-function listCounts(raw: JsonObject): { active: number; ended: number } {
+// watchState reads a watch row/inspect result's lifecycle state in the
+// producer's own three-way grammar (agent/session_tools_jobs.go
+// formatJobWatchInspect, which is also what watchInspectFound in the same file
+// gates on): watching; end_reason set (ended); source set without end_reason
+// (pending — a detached watch on the terminal-flush rail still holding
+// frames); neither (not found — inspectWatchByID's empty return). Collapsing
+// pending and missing into "ended" misreports both (RoboRev PR #954 combined
+// review).
+type WatchState = "watching" | "pending" | "ended" | "missing";
+
+function watchState(entry: { watching: boolean; source?: string; endReason?: string }): WatchState {
+  if (entry.watching) return "watching";
+  if (entry.endReason) return "ended";
+  if (entry.source) return "pending";
+  return "missing";
+}
+
+function listCounts(raw: JsonObject): { active: number; pending: number; ended: number } {
   const live = Array.isArray(raw.watches) ? raw.watches : [];
   const recent = Array.isArray(raw.recent_watches) ? raw.recent_watches : [];
   let active = 0;
-  let ended = 0;
+  let pending = 0;
+  let liveEnded = 0;
   for (const entry of live) {
     const row = normalizeRow(entry);
     if (!row) continue;
-    if (row.watching) active += 1;
-    else ended += 1;
+    // Count by the same state the row chip renders (watchState): a live row
+    // carrying an end_reason is ended, not pending, so the summary can never
+    // disagree with its rows (combined RoboRev review).
+    const state = watchState(row);
+    if (state === "watching") active += 1;
+    else if (state === "pending") pending += 1;
+    else liveEnded += 1;
   }
-  ended += recent.filter((entry) => normalizeRow(entry) !== undefined).length;
-  return { active, ended };
+  // Recent watches are history entries: they ended (inspectResultFromWatchHistory).
+  const ended = liveEnded + recent.filter((entry) => normalizeRow(entry) !== undefined).length;
+  return { active, pending, ended };
 }
 
 function summarizeList(raw: JsonObject): string {
-  const { active, ended } = listCounts(raw);
+  const { active, pending, ended } = listCounts(raw);
   const activeWord = active === 1 ? "1 active" : `${active} active`;
-  if (ended === 0) return `Listed watches (${activeWord})`;
-  const endedWord = ended === 1 ? "1 ended" : `${ended} ended`;
-  return `Listed watches (${activeWord} · ${endedWord})`;
+  const rest: string[] = [];
+  if (pending > 0) rest.push(pending === 1 ? "1 pending" : `${pending} pending`);
+  if (ended > 0) rest.push(ended === 1 ? "1 ended" : `${ended} ended`);
+  return rest.length > 0 ? `Listed watches (${activeWord} · ${rest.join(" · ")})` : `Listed watches (${activeWord})`;
 }
 
 function summarizeInspect(item: ItemModel, raw: JsonObject): string {
   const args = parseArgs(item.argumentsJSON);
   const id = strField(raw, "watch_id") ?? str(args, "watch_id") ?? "";
-  const state = isWatching(raw) ? "watching" : "ended";
+  // No id anywhere (neither the result nor the call names one): there is
+  // nothing to point at, so degrade to the operation verb rather than
+  // rendering "Inspected  · …" with an empty id (RoboRev PR #954 combined
+  // review).
+  if (!id) return "job_watch: inspect";
+  const state = watchState({
+    watching: isWatching(raw),
+    source: strField(raw, "source"),
+    endReason: strField(raw, "end_reason"),
+  });
   const deliveries = typeof raw.deliveries === "number" ? raw.deliveries : undefined;
-  // Deliveries used measures against the delivery budget ("3 of 50 used")
-  // — the same budget the Go side's own notices name. Ended or
-  // not-yet-delivered watches carry no count to render.
-  if (deliveries !== undefined && isWatching(raw)) {
-    return `Inspected ${id} · ${state} · ${deliveries} of ${WATCH_DELIVERY_BUDGET} used`;
+  // Deliveries counts every model-facing delivery (condition fires plus
+  // periodic progress/timer ticks) — bare, with no budget denominator.
+  if (deliveries !== undefined && state === "watching") {
+    return `Inspected ${id} · watching · ${deliveries} deliveries`;
   }
-  return `Inspected ${id} · ${state}`;
+  // The summary speaks the producer's footer words ("not found"), not the
+  // internal state name (formatJobWatchInspect).
+  return `Inspected ${id} · ${state === "missing" ? "not found" : state}`;
 }
 
 function jobWatchSummary(item: ItemModel): string {
@@ -461,7 +574,7 @@ function jobWatchSummary(item: ItemModel): string {
   // the normalizer doesn't recognize) fall back to the call's own verb —
   // the same "job_watch: <operation>" the family fallback rendered, so the
   // row never regresses to a bare tool name.
-  if (!raw) {
+  if (!raw || !isRecognizedWatchResult(raw)) {
     const args = parseArgs(item.argumentsJSON);
     const operation = str(args, "operation");
     return operation ? `job_watch: ${operation}` : (item.toolName ?? "job_watch");
@@ -512,82 +625,106 @@ function NoteSection({ note }: { note: string }) {
 // conditionSentence renders the one-sentence body for a condition watch:
 // source + condition + cadence in prose, patterns in mono. Raw field names
 // (progress_interval_ms, output_match:) never surface — the cadence is a
-// heartbeat phrase, the pattern is quoted.
+// heartbeat phrase, the pattern is quoted. Clauses compose: a watch may arm
+// a pattern AND event/filter triggers AND a heartbeat together (only timer
+// fields exclude conditions), so every populated clause renders instead of
+// returning after the first (combined RoboRev review).
 function ConditionSentence({ source, spec }: { source: string; spec: ConditionSpec }) {
   const heartbeat = heartbeatPhrase(spec);
+  // Top-level clauses join with ", " exactly once, in the final render
+  // below. Clause nodes carry NO separators of their own — neither leading
+  // spaces nor commas — or the join doubles them ("outputs ready, ,
+  // heartbeat …"). The filter's sub-clauses (tool + outcome + event +
+  // every) are one clause: they join with spaces inside a single node
+  // (combined RoboRev review).
+  const head: ReactNode[] = [];
+  // A budgeted trigger is what the 50-match auto-clear bounds: a pattern, an
+  // event list, or an event filter. A heartbeat alone never consumes the
+  // budget (periodic ticks count deliveries but never trip it), so a
+  // heartbeat-only watch claims no auto-clear (combined RoboRev review).
+  const budgeted =
+    spec.outputMatch !== undefined ||
+    spec.events.length > 0 ||
+    spec.filterStatus !== undefined ||
+    spec.filterToolName !== undefined;
   if (spec.outputMatch) {
-    return (
-      <span>
-        Wakes you when <span className={CLASS.mono}>{source}</span> outputs{" "}
-        <span className={CLASS.mono}>{spec.outputMatch}</span>
-        {heartbeat ? `, ${heartbeat}` : ""}, auto-clears after {WATCH_DELIVERY_BUDGET} matches.
-      </span>
+    head.push(
+      <span key="pattern">
+        outputs <span className={CLASS.mono}>{spec.outputMatch}</span>
+      </span>,
     );
   }
   if (spec.filterStatus || spec.filterToolName) {
     // Both filter statuses read explicitly (RoboRev PR #954: status "ok"
     // was discarded into a bare tool name). The tool rides along when
     // present; the event name disambiguates in list/inspect context.
-    const tool = spec.filterToolName ? (
-      <>
-        {" "}
-        on <span className={CLASS.mono}>{spec.filterToolName}</span>
-      </>
-    ) : null;
-    const outcome =
-      spec.filterStatus === "error" ? (
-        <span>
-          ending in <span className={CLASS.mono}>error</span>
-        </span>
-      ) : spec.filterStatus === "ok" ? (
-        <span>
-          ending in <span className={CLASS.mono}>ok</span>
-        </span>
-      ) : spec.filterToolName ? (
-        "matching"
-      ) : (
-        "matching"
+    const parts: ReactNode[] = [];
+    if (spec.filterToolName) {
+      parts.push(
+        <span key="filter-tool">
+          makes a tool call on <span className={CLASS.mono}>{spec.filterToolName}</span>
+        </span>,
       );
+    } else {
+      parts.push(<span key="filter-tool">makes a tool call</span>);
+    }
+    // Both non-status filters (tool-only, or a bare filter with neither
+    // field) read "matching" — a single path, no dead ternary (RoboRev PR
+    // #954 combined review).
+    if (spec.filterStatus === "error" || spec.filterStatus === "ok") {
+      parts.push(
+        <span key="filter-outcome">
+          ending in <span className={CLASS.mono}>{spec.filterStatus}</span>
+        </span>,
+      );
+    } else {
+      parts.push(<span key="filter-outcome">matching</span>);
+    }
     // Name the filtered event: in inspect/list context the events array is
     // not shown separately, and the filter only ever attaches to
     // assistant.tool — without the name the sentence loses what fires.
-    const eventName =
-      spec.events.length === 1 ? (
-        <>
-          {" "}
+    if (spec.events.length === 1) {
+      parts.push(
+        <span key="filter-event">
           (<span className={CLASS.mono}>{spec.events[0]}</span>)
-        </>
-      ) : null;
-    return (
-      <span>
-        Wakes you when <span className={CLASS.mono}>{source}</span> makes a tool call {outcome}
-        {tool}
-        {eventName}.
-      </span>
-    );
-  }
-  if (spec.events.length > 0) {
+        </span>,
+      );
+    }
+    // The every throttle rides the filter sentence too (RoboRev PR #954
+    // review 3): a filter Condition carries it ("events: […] every N where
+    // …"), and dropping it claims every event fires. Same "(every N)" shape
+    // as the events branch below.
+    if (spec.every !== undefined) parts.push(<span key="filter-every">(every {spec.every})</span>);
+    head.push(<span key="filter">{joinNodes(parts, " ")}</span>);
+  } else if (spec.events.length > 0) {
     const throttle = spec.every !== undefined ? ` (every ${spec.every})` : "";
-    return (
-      <span>
-        Wakes you on <span className={CLASS.mono}>{spec.events.join(", ")}</span>
+    head.push(
+      <span key="events">
+        wakes on <span className={CLASS.mono}>{spec.events.join(", ")}</span>
         {throttle}
-        {heartbeat ? `, ${heartbeat}` : ""}.
-      </span>
+      </span>,
     );
   }
-  if (heartbeat) {
+  if (heartbeat) head.push(<span key="heartbeat">{heartbeat}</span>);
+  if (head.length === 0) {
     return (
       <span>
-        Watches <span className={CLASS.mono}>{source}</span>, {heartbeat}.
+        Watches <span className={CLASS.mono}>{source}</span>.
       </span>
     );
   }
   return (
     <span>
-      Watches <span className={CLASS.mono}>{source}</span>.
+      Wakes you when <span className={CLASS.mono}>{source}</span> {joinNodes(head, ", ")}
+      {budgeted ? <>, auto-clears after {WATCH_DELIVERY_BUDGET} matches.</> : "."}
     </span>
   );
+}
+
+// joinNodes joins rendered clause nodes with a separator string, keyed so
+// React needs no index keys.
+function joinNodes(nodes: ReactNode[], separator: string): ReactNode[] {
+  return nodes.flatMap((node, i) => (i === 0 ? [node] : [separator, node]));
 }
 
 function CreateBody({ raw, item }: { raw: JsonObject; item: ItemModel }) {
@@ -610,28 +747,47 @@ function CreateBody({ raw, item }: { raw: JsonObject; item: ItemModel }) {
 function WatchRow({ row }: { row: WatchRow }) {
   const [open, setOpen] = useState(false);
   // Rows are real buttons (mockup §C: tappable rows opening the watch's
-  // details). Expanding shows the row's own detail sentence inline — the
-  // same humanized grammar as the inspect body, minus deliveries/created
-  // which list raw does not carry.
+  // details) — but only when they CAN expand. Expanding shows the row's own
+  // detail sentence inline — the same humanized grammar as the inspect body,
+  // minus deliveries/created which list raw does not carry. A row with no
+  // detail sentence (an ended/pending/missing row, or a watching row whose
+  // condition parses to nothing) renders as a plain div: a focusable button
+  // with a no-op onClick is a control that does nothing (RoboRev PR #954
+  // combined review).
   const detail = row.watching ? rowDetailPhrase(row) : undefined;
+  const state = watchState(row);
+  const chip = state === "watching" ? "watching" : state === "missing" ? "not found" : state;
+  if (!detail) {
+    return (
+      <div key={row.id}>
+        <div className={CLASS.rowStatic} data-testid="job-watch-row">
+          <Chip>{chip}</Chip>
+          <span className={CLASS.rowId} title={row.id}>
+            {clipJobID(row.id)}
+          </span>
+          <span className={CLASS.rowCondition}>{rowConditionPhrase(row)}</span>
+        </div>
+      </div>
+    );
+  }
   return (
     <div key={row.id}>
       <button
         type="button"
         className={CLASS.row}
         data-testid="job-watch-row"
-        aria-expanded={detail ? open : undefined}
+        aria-expanded={open}
         onClick={() => {
-          if (detail) setOpen((previous) => !previous);
+          setOpen((previous) => !previous);
         }}
       >
-        <Chip>{row.watching ? "watching" : "ended"}</Chip>
+        <Chip>{chip}</Chip>
         <span className={CLASS.rowId} title={row.id}>
           {clipJobID(row.id)}
         </span>
         <span className={CLASS.rowCondition}>{rowConditionPhrase(row)}</span>
       </button>
-      {detail && open ? (
+      {open ? (
         <div className={CLASS.section} data-testid="job-watch-row-detail">
           <div className={CLASS.trigger}>{detail}</div>
         </div>
@@ -648,28 +804,39 @@ function rowDetailPhrase(row: WatchRow): string | undefined {
   if (!row.watching || !row.condition) return undefined;
   const parsed = parseConditionText(row.condition);
   const source = sourceLabel(row.source);
-  const deliveries =
-    row.deliveries !== undefined ? ` — ${row.deliveries} of ${WATCH_DELIVERY_BUDGET} deliveries used` : "";
+  const deliveries = row.deliveries !== undefined ? ` — ${row.deliveries} deliveries` : "";
   if (parsed.outputMatch) {
     const heartbeat =
       parsed.progressIntervalMS !== undefined
         ? `, heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`
         : "";
-    return `Watching ${source} for “${parsed.outputMatch}”${heartbeat}${deliveries}.`;
+    // Clauses compose here exactly as in the row phrase and the create
+    // summary: a composite watch arms a pattern AND event/filter triggers
+    // together, so the detail names every armed clause, never just the
+    // pattern (combined RoboRev review).
+    const bits: string[] = [`“${parsed.outputMatch}”`];
+    const every = parsed.every !== undefined ? ` (every ${parsed.every})` : "";
+    if (parsed.events.length > 0) {
+      const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
+      bits.push(`${names}${every}`);
+    }
+    if (parsed.filterToolName || parsed.filterStatus) {
+      bits.push(`${filterSummaryPhrase(parsed)}${parsed.events.length === 0 ? every : ""}`);
+    }
+    return `Watching ${source} for ${bits.join(" · ")}${heartbeat}${deliveries}.`;
   }
   if (parsed.afterSeconds !== undefined) return `Reminds ${humanizeSeconds(parsed.afterSeconds)}${deliveries}.`;
   if (parsed.repeatSeconds !== undefined) return `Reminds ${humanizeInterval(parsed.repeatSeconds)}${deliveries}.`;
   const bits: string[] = [];
+  const every = parsed.every !== undefined ? ` (every ${parsed.every})` : "";
   if (parsed.events.length > 0) {
     const names = parsed.events.includes("*") ? "any event" : parsed.events.join(", ");
-    bits.push(parsed.every !== undefined ? `${names} every ${parsed.every}` : names);
+    bits.push(`${names}${every}`);
   }
   if (parsed.filterToolName || parsed.filterStatus) {
-    if (parsed.filterStatus === "error")
-      bits.push(`failed tool calls${parsed.filterToolName ? ` on ${parsed.filterToolName}` : ""}`);
-    else if (parsed.filterStatus === "ok")
-      bits.push(`successful tool calls${parsed.filterToolName ? ` on ${parsed.filterToolName}` : ""}`);
-    else bits.push(`calls on ${parsed.filterToolName ?? "?"}`);
+    // The same shared filter phrase as rows and summaries (RoboRev PR #954
+    // review 3); the throttle rides here only when no events bit carries it.
+    bits.push(`${filterSummaryPhrase(parsed)}${parsed.events.length === 0 ? every : ""}`);
   }
   if (parsed.progressIntervalMS !== undefined) {
     bits.push(`heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`);
@@ -720,8 +887,38 @@ function formatCreatedDate(createdAt: string | undefined): string | undefined {
 }
 
 function InspectBody({ raw }: { raw: JsonObject }) {
+  const state = watchState({
+    watching: isWatching(raw),
+    source: strField(raw, "source"),
+    endReason: strField(raw, "end_reason"),
+  });
+  // A missing watch has no source to name — sourceLabel would invent "this
+  // session" for a watch that is not there. Pending is a live detached watch
+  // on the terminal-flush rail, not an ending (RoboRev PR #954 combined
+  // review; grammar mirrors formatJobWatchInspect).
+  if (state === "missing") {
+    return (
+      <div className={CLASS.section}>
+        <div className={CLASS.trigger} data-testid="job-watch-trigger">
+          <span>Watch not found.</span>
+        </div>
+      </div>
+    );
+  }
+  if (state === "pending") {
+    const source = sourceLabel(strField(raw, "source"));
+    return (
+      <div className={CLASS.section}>
+        <div className={CLASS.trigger} data-testid="job-watch-trigger">
+          <span>
+            Watch on <span className={CLASS.mono}>{source}</span> is pending.
+          </span>
+        </div>
+      </div>
+    );
+  }
   const source = sourceLabel(strField(raw, "source"));
-  if (!isWatching(raw)) {
+  if (state === "ended") {
     const endReason = strField(raw, "end_reason");
     return (
       <div className={CLASS.section}>
@@ -743,23 +940,34 @@ function InspectBody({ raw }: { raw: JsonObject }) {
   const parsed = condition ? parseConditionText(condition) : undefined;
   const deliveries = typeof raw.deliveries === "number" ? raw.deliveries : undefined;
   const created = formatCreatedDate(strField(raw, "created_at"));
-  const used = deliveries !== undefined ? ` — ${deliveries} of ${WATCH_DELIVERY_BUDGET} deliveries used` : "";
+  const used = deliveries !== undefined ? ` — ${deliveries} deliveries` : "";
   const since = created ? `, ${created}` : "";
   // Every embedded condition form renders humanized: pattern, timer
   // cadence, heartbeat, events (+every throttle), and filter — the same
-  // sentence grammar as the create/inspect one-liners, never raw keys.
+  // sentence grammar as the create/inspect one-liners, never raw keys. The
+  // output-match branch renders through the shared ConditionSentence so a
+  // composite watch names every armed clause, not just the pattern
+  // (combined RoboRev review).
   if (parsed?.outputMatch) {
     return (
       <div className={CLASS.section}>
         <div className={CLASS.trigger} data-testid="job-watch-trigger">
           <span>
-            Watching <span className={CLASS.mono}>{source}</span> for{" "}
-            <span className={CLASS.mono}>{parsed.outputMatch}</span>
-            {parsed.progressIntervalMS !== undefined
-              ? `, heartbeat ${humanizeInterval(parsed.progressIntervalMS / 1000)}`
-              : ""}
-            {used}
-            {since}.
+            <ConditionSentence
+              source={source}
+              spec={{
+                outputMatch: parsed.outputMatch,
+                events: parsed.events,
+                every: parsed.every,
+                progressIntervalMS: parsed.progressIntervalMS,
+                filterToolName: parsed.filterToolName,
+                filterStatus: parsed.filterStatus,
+              }}
+            />
+            <span>
+              {used}
+              {since}.
+            </span>
           </span>
         </div>
       </div>
@@ -828,7 +1036,7 @@ function JobWatchBody(props: ToolRenderProps) {
   // the normalizer doesn't recognize) fall back to the raw footer text —
   // the call's only useful output (RoboRev PR #954). The structured bodies
   // above replace the mono wall only when there is structure to render.
-  if (!raw) return <HeadClippedOutputBody item={item} live={live} />;
+  if (!raw || !isRecognizedWatchResult(raw)) return <HeadClippedOutputBody item={item} live={live} />;
   const operation = jobWatchOperation(item, raw);
   switch (operation) {
     case "list":
@@ -849,6 +1057,12 @@ function JobWatchBody(props: ToolRenderProps) {
       if (isTerminalCatchup(raw)) return null;
       const timer = timerSpec(raw);
       if (timer && !timer.note) return null;
+      // A recognized create with only a source has no sentence to render —
+      // the summary ("Watch this session") IS the rendering. Returning null
+      // here instead of an empty bordered card (CreateBody also returns null
+      // for this shape, but the wrapper div would still draw the card chrome
+      // around nothing — combined RoboRev review).
+      if (!timer && !conditionSpec(raw, asJsonObject(parseArgs(item.argumentsJSON)))) return null;
       return (
         <div className={CLASS.card} data-testid="job-watch-body">
           <CreateBody raw={raw} item={item} />

--- a/docs/web-ui/history/mockups/23-job-watch.html
+++ b/docs/web-ui/history/mockups/23-job-watch.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Evener — job_watch renderer mockups</title>
+<style>
+/* Live tokens, inlined from cmd/evener-hub/frontend/src/styles/tokens.css (dark default + light).
+   Self-contained: no dependency on docs/web-ui/history/mockups/tokens.css (obsolete, archived). */
+:root, [data-theme="dark"] {
+  color-scheme: dark;
+  --surface-0: #17181A; --surface-canvas: #1C1D1F; --surface-1: #232427; --surface-2: #232427;
+  --surface-inset: #1F2022; --hover-1: #2A2B2E; --hover-2: #313236; --field: #2B2C2F;
+  --edge: #2E3033; --edge-strong: #3A3C40;
+  --ink-hi: #F2F3F4; --ink-mid: #A5A8AD; --ink-low: #6C6F75;
+  --attention: #F68F3C; --alive: #3DBB72; --danger: #EE5C61; --accent: #3D9AFF;
+  --attention-bg: color-mix(in oklab, var(--attention) 15%, var(--surface-1));
+  --attention-edge: color-mix(in oklab, var(--attention) 40%, var(--edge));
+  --alive-bg: color-mix(in oklab, var(--alive) 15%, var(--surface-1));
+  --danger-bg: color-mix(in oklab, var(--danger) 15%, var(--surface-1));
+  --accent-bg: color-mix(in oklab, var(--accent) 15%, var(--surface-1));
+  --attention-ink: #F68F3C; --alive-ink: #3DBB72; --danger-ink: #F17478; --accent-ink: #459EFF;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --space-1: 4px; --space-2: 8px; --space-3: 12px; --space-4: 16px; --space-5: 24px; --space-6: 32px;
+  --radius-chip: 6px; --radius-control: 8px; --radius-pane: 10px; --radius-pill: 999px;
+  --focus-ring: 2px solid var(--accent);
+  --shadow-card: 0 0 0 1px var(--edge), 0 1px 2px #00000033, 0 2px 6px #00000033;
+  --motion-easing-standard: ease-out;
+}
+:root[data-theme="light"], [data-theme="light"] {
+  color-scheme: light;
+  --surface-0: #FAFAFB; --surface-canvas: #F1F2F3; --surface-1: #FFFFFF; --surface-2: #FFFFFF;
+  --surface-inset: #F7F8F9; --hover-1: #F4F5F6; --hover-2: #E7E9EB; --field: #F2F2F3;
+  --edge: #ECEDEF; --edge-strong: #E0E2E5;
+  --ink-hi: #1F2124; --ink-mid: #62656B; --ink-low: #86898F;
+  --attention: #F59E0B; --alive: #189A4D; --danger: #E3474C; --accent: #0285FF;
+  --attention-bg: color-mix(in oklab, var(--attention) 15%, var(--surface-1));
+  --attention-edge: color-mix(in oklab, var(--attention) 40%, var(--edge));
+  --danger-bg: color-mix(in oklab, var(--danger) 15%, var(--surface-1));
+  --accent-bg: color-mix(in oklab, var(--accent) 15%, var(--surface-1));
+  --attention-ink: #AD5209; --alive-ink: #137A3D; --danger-ink: #CE1F25; --accent-ink: #0069CA;
+  --shadow-card: 0 0 0 1px var(--edge), 0 1px 2px #1018280A, 0 2px 6px #10182808;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:var(--surface-0);color:var(--ink-hi);font-family:var(--font-sans);font-size:14px;line-height:1.5;-webkit-font-smoothing:antialiased;overflow:auto}
+button{font:inherit;color:inherit;background:none;border:none;cursor:pointer}
+:focus-visible{outline:var(--focus-ring);outline-offset:2px}
+.page{max-width:1060px;margin:0 auto;padding:var(--space-6) var(--space-5) 120px}
+.page-h h1{font-size:20px;font-weight:600;letter-spacing:-0.02em}
+.page-h .sub{margin-top:var(--space-2);color:var(--ink-mid);line-height:1.6;max-width:76ch}
+.themebar{display:flex;gap:var(--space-2);margin-top:var(--space-4);align-items:center}
+.themebar .lbl{font-size:12px;color:var(--ink-low)}
+.seg{display:flex;background:var(--surface-inset);border:1px solid var(--edge);border-radius:var(--radius-pill);padding:2px}
+.seg button{padding:4px 14px;border-radius:var(--radius-pill);font-size:13px;color:var(--ink-mid);min-height:32px}
+.seg button[aria-pressed="true"]{background:var(--hover-2);color:var(--ink-hi)}
+.case{margin-top:var(--space-6);border-top:1px solid var(--edge);padding-top:var(--space-5)}
+.case-h{display:flex;align-items:baseline;gap:var(--space-3);margin-bottom:var(--space-2);flex-wrap:wrap}
+.case-h .badge{font-size:12px;font-weight:600;background:var(--hover-2);border-radius:var(--radius-pill);padding:1px 10px}
+.case-h .ttl{font-size:16px;font-weight:600;letter-spacing:-0.02em}
+.case-h .verdict{font-size:12px;color:var(--ink-low)}
+.cap{font-size:13px;color:var(--ink-mid);line-height:1.6;max-width:80ch;margin-bottom:var(--space-4)}
+.cap b{color:var(--ink-hi);font-weight:600}
+.cap .bad{color:var(--danger-ink)} .cap .good{color:var(--alive-ink)}
+.stage{background:var(--surface-canvas);border:1px solid var(--edge);border-radius:var(--radius-pane);padding:var(--space-4) var(--space-5);max-width:760px;margin-bottom:var(--space-3)}
+.stage-lbl{font-size:11.5px;font-weight:500;letter-spacing:0.08em;text-transform:uppercase;color:var(--ink-low);margin-bottom:var(--space-3)}
+/* ---- transcript tool-row grammar (simplified) ---- */
+.toolrow{border:1px solid var(--edge);border-radius:var(--radius-pane);background:var(--surface-1);box-shadow:var(--shadow-card);margin-bottom:var(--space-3);overflow:hidden}
+.toolrow:last-child{margin-bottom:0}
+.toolsum{display:flex;align-items:center;gap:var(--space-2);padding:10px var(--space-4);font-size:13px;width:100%;text-align:left;min-height:44px}
+.toolsum:hover{background:var(--hover-1)}
+.toolsum .glyph{color:var(--ink-low);font-size:12px;flex:none}
+.toolicon{flex:none;width:20px;height:20px;border-radius:6px;background:var(--surface-inset);border:1px solid var(--edge);display:inline-flex;align-items:center;justify-content:center;font-size:11px;color:var(--ink-mid)}
+.toolsum .txt{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.toolsum .txt .mono{font-family:var(--font-mono);font-size:12px}
+.toolsum .chev{margin-left:auto;color:var(--ink-low);flex:none;font-size:11px}
+.toolbody{border-top:1px solid var(--edge);padding:var(--space-4)}
+/* ---- current (bad) rendering ---- */
+.rawblock{font-family:var(--font-mono);font-size:12px;line-height:1.6;background:var(--surface-inset);border:1px solid var(--edge);border-radius:var(--radius-control);padding:var(--space-3);white-space:pre-wrap;word-break:break-word;color:var(--ink-mid)}
+/* ---- proposed watch card ----
+   Deliberately headerless: no watch-id bar, no status chip, no footer.
+   The summary line already says what this is; the body only adds what the
+   summary cannot hold (the full note, the full pattern). The watch id lives
+   where it disambiguates — list rows, inspect summaries, raw disclosures. */
+.wcard{border:1px solid var(--edge);border-radius:var(--radius-pane);background:var(--surface-1);box-shadow:var(--shadow-card);overflow:hidden}
+.wsec{padding:var(--space-3) var(--space-4)}
+.wtrig{font-size:14px;color:var(--ink-hi)}
+.wtrig .mono{font-family:var(--font-mono);font-size:12.5px}
+.wnote{font-size:14px;color:var(--ink-hi);line-height:1.6;overflow-wrap:anywhere}
+/* Notes longer than ~20 lines clamp with an honest disclosure; everything at
+   or under shows in full with no disclosure at all. */
+.wnote.clamped{display:-webkit-box;-webkit-line-clamp:20;-webkit-box-orient:vertical;overflow:hidden}
+details.disc{margin-top:var(--space-2)}
+details.disc summary{font-size:12.5px;color:var(--ink-mid);cursor:pointer;min-height:44px;display:flex;align-items:center;list-style:none}
+details.disc summary::-webkit-details-marker{display:none}
+details.disc summary::before{content:"▸ ";color:var(--ink-low);font-size:11px}
+details.disc[open] summary::before{content:"▾ "}
+details.disc summary:hover{color:var(--ink-hi)}
+details.disc summary:focus-visible{outline:var(--focus-ring);outline-offset:-2px}
+/* ---- triggered notification ---- */
+.ncard{border:1px solid var(--edge);border-radius:var(--radius-pane);background:var(--surface-1);box-shadow:var(--shadow-card);overflow:hidden}
+.nhead{display:flex;align-items:center;gap:var(--space-2);padding:10px var(--space-4);width:100%;text-align:left;min-height:44px}
+.nhead:hover{background:var(--hover-1)}
+.nhead .title{font-weight:600;font-size:14px;flex:none}
+.nhead .sec{color:var(--ink-low);font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0}
+@media (max-width:720px){.nhead{flex-wrap:wrap}.nhead .sec{flex-basis:100%;white-space:normal}}
+.nmeta{display:flex;flex-wrap:wrap;gap:4px var(--space-4);padding:0 var(--space-4) var(--space-2);font-size:12.5px;color:var(--ink-low)}
+.nmeta .f .fl{color:var(--ink-low)}
+.nmeta .f .fv{font-family:var(--font-mono);font-size:12px;color:var(--ink-mid)}
+.nprose{padding:0 var(--space-4) var(--space-3);font-size:14px;line-height:1.6;color:var(--ink-hi);overflow-wrap:anywhere}
+.nprose .lead{color:var(--ink-mid)}
+.nprose .notelbl{color:var(--ink-low)}
+/* ---- list rows: the one place watch ids stay visible ----
+   Chips stay too: watching vs ended varies per row, so the chip scans. */
+.wrow{display:flex;align-items:center;gap:var(--space-2);padding:9px var(--space-4);border-top:1px solid var(--edge);font-size:13px;min-height:44px;width:100%;text-align:left}
+.wrow:first-child{border-top:none}
+.wrow:hover{background:var(--hover-1)}
+.wrow .wid{font-family:var(--font-mono);font-size:12px;flex:none}
+.wrow .cond{color:var(--ink-mid);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.wrow .chev{margin-left:auto;color:var(--ink-low);flex:none;font-size:11px}
+.chip{display:inline-flex;align-items:center;padding:2px 10px;border-radius:var(--radius-chip);font-size:12px;font-weight:500;background:var(--hover-1);border:1px solid var(--edge);color:var(--ink-mid);white-space:nowrap;flex:none}
+.chip.attn{background:var(--attention-bg);border-color:var(--attention-edge);color:var(--attention-ink)}
+.chip.danger{background:var(--danger-bg);border-color:var(--danger-edge);color:var(--danger-ink)}
+/* ---- phone frame ---- */
+.phones{display:flex;gap:var(--space-5);flex-wrap:wrap}
+.phone{width:360px;flex:none;background:var(--surface-0);border:1px solid var(--edge-strong);border-radius:28px;overflow:hidden;display:flex;flex-direction:column}
+.phone .phead{height:52px;border-bottom:1px solid var(--edge);display:flex;align-items:center;padding:0 var(--space-4);font-weight:600;font-size:15px;flex:none;background:var(--surface-canvas)}
+.phone .pbody{padding:var(--space-3);display:flex;flex-direction:column;gap:var(--space-3);overflow:hidden}
+.rec{margin-top:var(--space-4);padding:var(--space-4);border-left:2px solid var(--alive);background:var(--surface-inset);border-radius:0 var(--radius-control) var(--radius-control) 0;font-size:13px;color:var(--ink-mid);line-height:1.6;max-width:80ch}
+.rec b{color:var(--ink-hi)}
+@media (max-width:720px){.stage{padding:var(--space-3)}}
+</style>
+</head>
+<body>
+<div class="page">
+  <div class="page-h">
+    <h1>job_watch renderer — mockups</h1>
+    <p class="sub">Two surfaces, one vocabulary: the <b>job_watch tool row</b> (collapsed summary + expanded body for create / list / inspect / clear) and the <b>watch-triggered notification</b> (what the agent wakes up to). Real strings from a live session throughout. Toggle the theme — both must hold.</p>
+    <div class="themebar"><span class="lbl">Theme</span><div class="seg" role="group" aria-label="Theme"><button id="t-dark" aria-pressed="true">Dark</button><button id="t-light" aria-pressed="false">Light</button></div></div>
+  </div>
+
+  <!-- A : create timer — the hero case -->
+  <div class="case" id="a">
+    <div class="case-h"><span class="badge">A</span><span class="ttl">Create timer — the note is the body</span><span class="verdict">current vs proposed · desktop</span></div>
+    <p class="cap"><b>Today:</b> summary is the generic fallback <span class="mono">job_watch: create</span>; the body is a raw mono block of the whole footer, so the human-authored <b>note</b> renders as machine text with no truncation. <b>Proposed:</b> the summary says when + the note's head (<span class="mono">Remind me in 5m · Check CI34049074976 current published…</span>); the expanded body is <b>just the note</b>, in full, as sans prose. No header, no “reminds you” sentence, no watch-id bar, no footer — every one of those restated the summary. This note is 5 lines, so no disclosure; notes over ~20 lines clamp with “Show full note”.</p>
+    <div class="stage"><div class="stage-lbl">Current — collapsed + expanded</div>
+      <div class="toolrow">
+        <button class="toolsum"><span class="toolicon">◷</span><span class="txt">job_watch: create</span><span class="chev">▾</span></button>
+        <div class="toolbody"><div class="rawblock">[watching self · watch_id watch_034KEfjYFbfoUaPeHJcLXY · after 300s note: Check CI34049074976 current published ec738c514a35b604338c5346f98b661d62910623 PR822 and fresh RoboRev. Lastcomment1f935 boundaryfindingfixedec738. USER says job-shell fuzz failure belongs separate PR; no agent edits; diagnosis retained. Task41 only CI/review monitoring remaining, no full local tests/races.]</div></div>
+      </div>
+    </div>
+    <div class="stage"><div class="stage-lbl">Proposed — collapsed + expanded</div>
+      <div class="toolrow">
+        <button class="toolsum"><span class="toolicon">◷</span><span class="txt">Remind me in 5m · Check CI34049074976 current published…</span><span class="chev">▾</span></button>
+        <div class="toolbody">
+          <div class="wcard">
+            <div class="wsec"><div class="wnote">Check CI34049074976 current published ec738c514a35b604338c5346f98b661d62910623 PR822 and fresh RoboRev. Lastcomment1f935 boundaryfindingfixedec738. USER says job-shell fuzz failure belongs separate PR; no agent edits; diagnosis retained. Task41 only CI/review monitoring remaining, no full local tests/races.</div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- B : create event / condition watch -->
+  <div class="case" id="b">
+    <div class="case-h"><span class="badge">B</span><span class="ttl">Create condition watch — one sentence, humanized</span><span class="verdict">proposed · desktop</span></div>
+    <p class="cap">Same headerless card. The body is <b>one sentence</b> — source + condition + cadence in prose, patterns in mono. Raw field names never surface: <span class="mono">progress_interval_ms 120000</span> → “every 2m”, <span class="mono">output_match:</span> → quotes, <span class="mono">after 300s</span> → “in 5m”. Producer footer for reference: <span class="mono">[watching job_a1b2 · watch_id watch_09QmWzRtNvxK · output_match: ready|done events: job.notification progress_interval_ms 120000ms]</span>.</p>
+    <div class="stage"><div class="stage-lbl">Proposed — collapsed + expanded</div>
+      <div class="toolrow">
+        <button class="toolsum"><span class="toolicon">◷</span><span class="txt">Watch <span class="mono">job_a1b2</span> for “ready|done” · every 2m</span><span class="chev">▾</span></button>
+        <div class="toolbody">
+          <div class="wcard">
+            <div class="wsec"><div class="wtrig">Wakes you when <span class="mono">job_a1b2</span> outputs <span class="mono">ready|done</span>, heartbeat every 2m, auto-clears after 50 matches.</div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="stage"><div class="stage-lbl">Proposed — event-filter variant (assistant.tool errors on a delegate)</div>
+      <div class="toolrow">
+        <button class="toolsum"><span class="toolicon">◷</span><span class="txt">Watch <span class="mono">dlg_7Hk2</span> for failed tool calls</span><span class="chev">▾</span></button>
+        <div class="toolbody">
+          <div class="wcard">
+            <div class="wsec"><div class="wtrig">Wakes you when <span class="mono">dlg_7Hk2</span> makes a tool call ending in <span class="mono">error</span>.</div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- C : list / inspect -->
+  <div class="case" id="c">
+    <div class="case-h"><span class="badge">C</span><span class="ttl">List + inspect — the standing inventory</span><span class="verdict">proposed · desktop</span></div>
+    <p class="cap">Today <span class="mono">list</span> renders aligned-plaintext rows (<span class="mono">watch_id&nbsp;&nbsp;watching&nbsp;&nbsp;source&nbsp;&nbsp;condition</span>). Proposed: one tappable row per watch — status chip, truncated id, humanized condition — opening the same sentence card as §B. Chips survive <b>only here</b>: watching vs ended varies per row, so they scan. Ended watches read as <b>ended: reason</b>, never as warnings.</p>
+    <div class="stage"><div class="stage-lbl">Proposed — job_watch: list, expanded</div>
+      <div class="toolrow">
+        <button class="toolsum"><span class="toolicon">◷</span><span class="txt">Listed watches (2 active · 1 ended)</span><span class="chev">▾</span></button>
+        <div class="toolbody"><div class="wcard">
+          <button class="wrow"><span class="chip">watching</span><span class="wid">watch_034KEfjY…JcLXY</span><span class="cond">in 5m · this session</span><span class="chev">›</span></button>
+          <button class="wrow"><span class="chip">watching</span><span class="wid">watch_09QmWzRtNvxK</span><span class="cond">“ready|done” · job_a1b2 · every 2m</span><span class="chev">›</span></button>
+          <button class="wrow"><span class="chip">ended</span><span class="wid">watch_51BdeNpV2sSr</span><span class="cond">auto-cleared · matched 50 times</span><span class="chev">›</span></button>
+        </div></div>
+      </div>
+    </div>
+    <div class="stage"><div class="stage-lbl">Proposed — job_watch: inspect, one watch</div>
+      <div class="toolrow">
+        <button class="toolsum"><span class="toolicon">◷</span><span class="txt">Inspected <span class="mono">watch_09QmWzRtNvxK</span> · watching · 3 of 50 used</span><span class="chev">▾</span></button>
+        <div class="toolbody">
+          <div class="wcard">
+            <div class="wsec"><div class="wtrig">Watching <span class="mono">job_a1b2</span> for <span class="mono">ready|done</span> — 3 of 50 deliveries used, created Sep 6, 09:41.</div></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- D : clear + terminal catch-up -->
+  <div class="case" id="d">
+    <div class="case-h"><span class="badge">D</span><span class="ttl">Clear + terminal catch-up — quiet one-liners</span><span class="verdict">proposed · desktop</span></div>
+    <p class="cap">Both are lifecycle facts, not calls to action: no card, no chip — the summary line <b>is</b> the rendering, expanded body empty. Catch-up names the terminal outcome because that is the whole reason the condition can never match.</p>
+    <div class="stage"><div class="stage-lbl">Proposed</div>
+      <div class="toolrow"><button class="toolsum"><span class="toolicon">◷</span><span class="txt">Cleared <span class="mono">watch_034KEfjY…JcLXY</span></span><span class="chev">▾</span></button></div>
+      <div style="height:8px"></div>
+      <div class="toolrow"><button class="toolsum"><span class="toolicon">◷</span><span class="txt">Watch on <span class="mono">job_a1b2</span> ended — job completed before it could fire</span><span class="chev">▾</span></button></div>
+    </div>
+  </div>
+
+  <!-- E : watch-triggered notification -->
+  <div class="case" id="e">
+    <div class="case-h"><span class="badge">E</span><span class="ttl">“Watch triggered” notification — no chip, the note is the payload</span><span class="verdict">current vs proposed · desktop</span></div>
+    <p class="cap"><b>Why it warns today:</b> <span class="mono">steeringClassify.ts</span> hardcodes <span class="mono">event === "watch"</span> to the <b>warning</b> tone, and <span class="mono">NotificationCard</span> renders the producer's echo attrs 1:1 — <span class="mono">job_type watch</span>, <span class="mono">status watch</span>, <span class="mono">output 0</span>, <span class="mono">reason after</span> — metadata soup that says nothing. A fired watch is the <b>expected</b> outcome, never something needing a human: per the color-is-attention rule <b>no watch notification earns a tone chip, ever</b> — not the timer, not a match, not even the budget auto-clear. The title names what happened; the note (or the match) is the prose payload; the watch id retreats to the raw disclosure.</p>
+    <div class="stage"><div class="stage-lbl">Current (from screenshot) — do not ship</div>
+      <div class="ncard">
+        <button class="nhead"><span class="chip attn">warning</span><span class="title">Watch triggered</span><span class="sec">watch · after</span></button>
+        <div class="nmeta">
+          <span class="f"><span class="fl">Watch id </span><span class="fv">watch_034KEfjYFbfoUaPeHJcLXY</span></span>
+          <span class="f"><span class="fl">Status </span><span class="fv">watch</span></span>
+          <span class="f"><span class="fl">Job type </span><span class="fv">watch</span></span>
+          <span class="f"><span class="fl">Output </span><span class="fv">0</span></span>
+          <span class="f"><span class="fl">Reason </span><span class="fv">after</span></span>
+        </div>
+        <div class="nprose"><span class="lead">Timer fired after 300s.</span><br><span class="notelbl">Note: </span>Check CI34049074976 current published ec738c514a35b604338c5346f98b661d62910623 PR822 and fresh RoboRev. Lastcomment1f935 boundaryfindingfixedec738. USER says job-shell fuzz failure belongs separate PR; no agent edits; diagnosis retained. Task41 only CI/review monitoring remaining, no full local tests/races.<br><details class="disc"><summary>Raw notification</summary></details></div>
+      </div>
+    </div>
+    <div class="stage"><div class="stage-lbl">Proposed — timer fired (no chip; full note, no clamp at this length)</div>
+      <div class="ncard">
+        <button class="nhead"><span class="toolicon">◷</span><span class="title">Timer fired</span><span class="sec">after 5m</span></button>
+        <div class="nprose">Check CI34049074976 current published ec738c514a35b604338c5346f98b661d62910623 PR822 and fresh RoboRev. Lastcomment1f935 boundaryfindingfixedec738. USER says job-shell fuzz failure belongs separate PR; no agent edits; diagnosis retained. Task41 only CI/review monitoring remaining, no full local tests/races.<br><details class="disc"><summary>Raw notification · <span style="font-family:var(--font-mono);font-size:11.5px">watch_034KEfjY…JcLXY</span></summary></details></div>
+      </div>
+    </div>
+    <div class="stage"><div class="stage-lbl">Proposed — condition fired on a job (keeps the match, still no chip)</div>
+      <div class="ncard">
+        <button class="nhead"><span class="toolicon">◷</span><span class="title">Output matched on <span style="font-family:var(--font-mono);font-size:12.5px">job_a1b2</span></span><span class="sec">“ready|done”</span></button>
+        <div class="nprose"><span class="lead">Matched tail:</span> <span style="font-family:var(--font-mono);font-size:12.5px">server ready on :8080 … done in 41.2s</span><br><details class="disc"><summary>Raw notification · <span style="font-family:var(--font-mono);font-size:11.5px">watch_09QmWzRtNvxK</span></summary></details></div>
+      </div>
+    </div>
+    <div class="stage"><div class="stage-lbl">Proposed — budget auto-clear (words carry it, still no chip)</div>
+      <div class="ncard">
+        <button class="nhead"><span class="toolicon">◷</span><span class="title">Watch auto-cleared</span><span class="sec">matched 50 times — re-arm with a tighter condition</span></button>
+      </div>
+    </div>
+  </div>
+
+  <!-- F : mobile -->
+  <div class="case" id="f">
+    <div class="case-h"><span class="badge">F</span><span class="ttl">Mobile — 360px frames</span><span class="verdict">hero cases only</span></div>
+    <p class="cap">Same headerless cards. The full note fits the first phone with room to spare — that is the point of the 20-line policy: this 5-line note never clamps, on either width. List rows keep status chips and truncated ids; conditions get whatever width is left.</p>
+    <div class="phones">
+      <div class="phone"><div class="phead">Session</div><div class="pbody">
+        <div class="stage-lbl">Create timer, expanded</div>
+        <div class="toolrow">
+          <button class="toolsum"><span class="toolicon">◷</span><span class="txt">Remind me in 5m · Check CI34049074976…</span><span class="chev">▾</span></button>
+          <div class="toolbody"><div class="wcard"><div class="wsec"><div class="wnote">Check CI34049074976 current published ec738c514a35b604338c5346f98b661d62910623 PR822 and fresh RoboRev. Lastcomment1f935 boundaryfindingfixedec738. USER says job-shell fuzz failure belongs separate PR; no agent edits; diagnosis retained. Task41 only CI/review monitoring remaining, no full local tests/races.</div></div></div></div>
+        </div>
+      </div></div>
+      <div class="phone"><div class="phead">Session</div><div class="pbody">
+        <div class="stage-lbl">Timer fired, expanded</div>
+        <div class="ncard">
+          <div class="nhead"><span class="toolicon">◷</span><span class="title">Timer fired</span><span class="sec">after 5m</span></div>
+          <div class="nprose">Check CI34049074976 current published ec738c514a35b604338c5346f98b661d62910623 PR822 and fresh RoboRev. Lastcomment1f935 boundaryfindingfixedec738. USER says job-shell fuzz failure belongs separate PR; no agent edits; diagnosis retained. Task41 only CI/review monitoring remaining, no full local tests/races.<br><details class="disc"><summary>Raw notification</summary></details></div>
+        </div>
+      </div></div>
+      <div class="phone"><div class="phead">Session</div><div class="pbody">
+        <div class="stage-lbl">List, expanded</div>
+        <div class="wcard">
+          <button class="wrow"><span class="chip">watching</span><span class="wid">watch_034K…LXY</span><span class="cond">in 5m · this session</span><span class="chev">›</span></button>
+          <button class="wrow"><span class="chip">watching</span><span class="wid">watch_09Qm…vxK</span><span class="cond">“ready|done” · every 2m</span><span class="chev">›</span></button>
+          <button class="wrow"><span class="chip">ended</span><span class="wid">watch_51Bd…sSr</span><span class="cond">auto-cleared · 50 matches</span><span class="chev">›</span></button>
+        </div>
+      </div></div>
+    </div>
+  </div>
+
+  <div class="rec"><b>Recommendation.</b> Ship §A + §E together: the two ends of the same timer flow (arm → fire). Decisions locked in this pass: <b>humanize every duration</b> (<span style="font-family:var(--font-mono)">after 300s</span> → “in 5m”, <span style="font-family:var(--font-mono)">progress_interval_ms 120000</span> → “every 2m”; absolute clock only for <span style="font-family:var(--font-mono)">created_at</span>); <b>notes render in full to ~20 lines</b>, disclosure only beyond; <b>no watch id on single-watch surfaces</b> (it disambiguates nothing there — reachable via list rows, inspect summaries, raw disclosures); <b>no status chip where words already say it</b> (chips survive only in list rows, where status varies); <b>no tone chip on any watch notification</b> (a fired watch is the expected outcome — even the budget auto-clear reads fine in words). One <span style="font-family:var(--font-mono)">jobTools.tsx</span> descriptor reading <span style="font-family:var(--font-mono)">item.raw</span> (<span style="font-family:var(--font-mono)">jobWatchToolResult</span>, already on the wire) covers §A–D.</div>
+</div>
+<script>
+const root = document.documentElement;
+const bd = document.getElementById('t-dark'), bl = document.getElementById('t-light');
+function setTheme(t){ root.setAttribute('data-theme', t); bd.setAttribute('aria-pressed', t==='dark'); bl.setAttribute('aria-pressed', t==='light'); }
+bd.addEventListener('click', ()=>setTheme('dark')); bl.addEventListener('click', ()=>setTheme('light'));
+document.querySelectorAll('details.disc summary').forEach(s=>s.addEventListener('click',e=>{e.preventDefault();const d=s.parentElement;d.open=!d.open;}));
+document.querySelectorAll('.toolsum .chev').forEach(c=>{const b=c.closest('button');if(b)b.addEventListener('click',()=>{const tb=b.parentElement.querySelector('.toolbody');if(tb)tb.style.display=tb.style.display==='none'?'':'none';});});
+</script>
+</body>
+</html>


### PR DESCRIPTION
Replaces the generic job_\* fallback for job_watch with an exact-match descriptor (mockups docs/web-ui/history/mockups/23-job-watch.html sections A-D):

- Intent-first summaries with humanized durations (after 300s to in 5m, progress_interval_ms 120000 to every 2m; absolute clock only for created_at)
- Bodies are note-only / one sentence / list rows / empty; notes render in full to ~20 lines with disclosure only beyond
- No watch id on single-watch surfaces (list rows, inspect summaries, raw disclosures only); status chips only in list rows

Watch-triggered notifications drop the false warning tone and the producer echo fields (mockups section E): a fired watch is the expected outcome, never something needing a human. No watch notification earns a tone chip, ever.

Verification: vitest 135/135 on affected files, full transcript suite 1528/1528, tsc clean, Biome clean.