### PR TITLE
fix(execenv): bound the memory a glob walk can materialize

### DIFF
--- a/agent/execenv/gitignore.go
+++ b/agent/execenv/gitignore.go
@@ -2,6 +2,7 @@ package execenv
 
 import (
 	"context"
+	"errors"
 	"io/fs"
 	"path"
 	"strings"
@@ -51,10 +52,21 @@ type ignoreDir struct {
 // this walk otherwise has no other way to honor, since fsys itself (a
 // symlink-refusing, root-confined secureDirFS) enforces confinement but not
 // masking. The off-path caller (no masking concept) passes a no-op skip.
-func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool) *ignoreSet {
+func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool) (*ignoreSet, error) {
 	set := &ignoreSet{}
+	var budgetErr error
 	_ = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
 		if err != nil {
+			// A budget refusal is not an unreadable entry to skip past. This
+			// walk reads the same filesystem the pattern walk does, under the
+			// same bounds, so one can trip here — and an ignoreSet that gave
+			// up partway reports itself complete, silently under-excluding
+			// every rule it never reached. That is a wrong answer rather than
+			// a missing one, so it has to reach the caller.
+			if _, refused := errors.AsType[*globBudgetError](err); refused {
+				budgetErr = err
+				return err
+			}
 			return nil //nolint:nilerr // best-effort: skip unreadable entries
 		}
 		if p != "." && skip != nil && skip(p) {
@@ -85,7 +97,7 @@ func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool) *ignoreSet {
 		set.dirs = append(set.dirs, ignoreDir{rel: dir, matcher: matcher})
 		return nil
 	})
-	return set
+	return set, budgetErr
 }
 
 // matches reports whether relPath (slash-separated, relative to the search

--- a/agent/execenv/gitignore_covtest_test.go
+++ b/agent/execenv/gitignore_covtest_test.go
@@ -40,7 +40,10 @@ func TestIgnoreSet_Matches_PathEqualsDir(t *testing.T) {
 		"sub":            {Mode: os.ModeDir | 0o755},
 		"sub/.gitignore": {Data: []byte(content)},
 	}
-	set := loadIgnoreSet(fsys, nil)
+	set, err := loadIgnoreSet(fsys, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// "sub" == id.rel, so rel becomes "." — "*.log" won't match "."
 	if set.matches("sub", false) {
 		t.Fatal("expected sub (file) NOT to be ignored")
@@ -112,9 +115,12 @@ func TestLoadIgnoreSet_SkipFile(t *testing.T) {
 		"skipme":          {Data: []byte("data\n")},
 		"skipme/file.txt": {Data: []byte("data\n")},
 	}
-	set := loadIgnoreSet(fsys, func(relPath string) bool {
+	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return relPath == "skipme"
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	// The .gitignore at root should still be loaded.
 	if !set.matches("test.tmp", false) {
 		t.Fatal("expected test.tmp to be ignored by root .gitignore")
@@ -156,5 +162,9 @@ func loadIgnoreSetFromLines(t *testing.T, dir string, lines ...string) *ignoreSe
 	fsys := fstest.MapFS{
 		path: {Data: []byte(content)},
 	}
-	return loadIgnoreSet(fsys, nil)
+	set, err := loadIgnoreSet(fsys, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return set
 }

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -34,6 +34,109 @@ func stubMaxGlobMatches(t *testing.T, n int) {
 	t.Cleanup(func() { maxGlobMatches = orig })
 }
 
+// stubMaxGlobDirEntries lowers the per-directory entry budget for a test and
+// restores it when the test ends, so a budget test can use a directory small
+// enough for t.TempDir() rather than one large enough to trip the real bound.
+func stubMaxGlobDirEntries(t *testing.T, n int) {
+	t.Helper()
+	orig := maxGlobDirEntries
+	maxGlobDirEntries = n
+	t.Cleanup(func() { maxGlobDirEntries = orig })
+}
+
+// stubMaxGlobLiveEntries lowers the call-wide live-entry budget for a test
+// and restores it when the test ends, so a budget test can use a tree small
+// enough for t.TempDir() rather than one large enough to trip the real bound.
+func stubMaxGlobLiveEntries(t *testing.T, n int) {
+	t.Helper()
+	orig := maxGlobLiveEntries
+	maxGlobLiveEntries = n
+	t.Cleanup(func() { maxGlobLiveEntries = orig })
+}
+
+// stubGlobDirChunk shrinks the per-syscall chunk size for a test and restores
+// it when the test ends, so a bounded listing has to make several chunk reads
+// over a fixture small enough for t.TempDir() instead of a directory too
+// large to build here.
+func stubGlobDirChunk(t *testing.T, n int) {
+	t.Helper()
+	orig := globDirChunk
+	globDirChunk = n
+	t.Cleanup(func() { globDirChunk = orig })
+}
+
+// pacedDirEntriesFS wraps a directory so a test can observe how many entries
+// a chunked reader actually pulls from it. Its files hand back at most pace
+// entries per ReadDir(n) call once the caller asks for more than that,
+// mirroring the short reads a real filesystem can hand a chunked reader, so a
+// small fixture can still force several round trips instead of resolving in
+// the one big read a directory too large to build here would need. A caller
+// that asks for everything at once (n <= 0 — what an unbounded listing does)
+// still gets the whole directory back in a single call, which is what makes
+// this double also show that today's listing pulls everything at once.
+//
+// When cancel is set, a file also cancels on its cancelOn'th ReadDir(n) call —
+// the same shape countingFS uses for a whole directory listing, scoped down to
+// the chunk calls inside one — so a test can watch how much of a listing a
+// chunk loop keeps pulling after the context that should have stopped it is
+// cancelled.
+type pacedDirEntriesFS struct {
+	fs.FS
+	read     *int
+	pace     int
+	cancelOn int
+	cancel   context.CancelFunc
+}
+
+func (p pacedDirEntriesFS) Open(name string) (fs.File, error) {
+	f, err := p.FS.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	rdf, ok := f.(fs.ReadDirFile)
+	if !ok {
+		return f, nil
+	}
+	return &pacedDirEntriesFile{ReadDirFile: rdf, read: p.read, pace: p.pace, cancelOn: p.cancelOn, cancel: p.cancel}, nil
+}
+
+type pacedDirEntriesFile struct {
+	fs.ReadDirFile
+	read     *int
+	pace     int
+	cancelOn int
+	cancel   context.CancelFunc
+	calls    int
+}
+
+func (p *pacedDirEntriesFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if n > 0 && n > p.pace {
+		n = p.pace
+	}
+	entries, err := p.ReadDirFile.ReadDir(n)
+	*p.read += len(entries)
+	p.calls++
+	if p.cancel != nil && p.calls == p.cancelOn {
+		p.cancel()
+	}
+	return entries, err
+}
+
+// flatEntriesFixture builds a t.TempDir() holding n files and no
+// subdirectories, so a test can force one directory listing to read past the
+// per-directory entry budget without building a tree.
+func flatEntriesFixture(t *testing.T, n int) string {
+	t.Helper()
+	root := t.TempDir()
+	for i := range n {
+		p := filepath.Join(root, fmt.Sprintf("leaf%03d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
 // globBudgetFixture builds a t.TempDir() tree of n sibling directories, each
 // holding one leaf.txt and one leaf.md, so tests can glob for one extension,
 // both extensions, or count total directories without rebuilding the tree.
@@ -80,8 +183,8 @@ func TestGlobStopsAtTheDirectoryListingBudgetWithFileIdentity(t *testing.T) {
 	stubMaxGlobDirListings(t, budget)
 
 	var counter *countingFS
-	stubGlobBaseFS(t, func(dir string) fs.FS {
-		counter = &countingFS{FS: os.DirFS(dir)}
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *GlobBudget) fs.FS {
+		counter = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}}
 		return counter
 	})
 
@@ -114,8 +217,8 @@ func TestGlobTruncatesAtTheMatchCap(t *testing.T) {
 	root := globBudgetFixture(t, fileCount)
 
 	var full *countingFS
-	stubGlobBaseFS(t, func(dir string) fs.FS {
-		full = &countingFS{FS: os.DirFS(dir)}
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *GlobBudget) fs.FS {
+		full = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}}
 		return full
 	})
 	fullBudget := NewGlobBudget()
@@ -130,8 +233,8 @@ func TestGlobTruncatesAtTheMatchCap(t *testing.T) {
 	stubMaxGlobMatches(t, 5)
 
 	var capped *countingFS
-	stubGlobBaseFS(t, func(dir string) fs.FS {
-		capped = &countingFS{FS: os.DirFS(dir)}
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *GlobBudget) fs.FS {
+		capped = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}}
 		return capped
 	})
 	budget := NewGlobBudget()
@@ -189,6 +292,307 @@ func TestGlobBudgetIsSharedAcrossBraceExpandedPatterns(t *testing.T) {
 	}
 	if budget.TruncatedAt() != 5 {
 		t.Fatalf("brace-expanded glob reported truncatedAt=%d, want 5 (the call-wide cap)", budget.TruncatedAt())
+	}
+}
+
+// TestGlobStopsOnADirectoryWithTooManyEntries is the unit-scale reproduction
+// of #497's other half (roborev High): the listing budget and match cap only
+// ever get a say once a directory's ReadDir call returns, and os.DirFS's
+// ReadDir is os.ReadDir, which reads every entry before handing any of them
+// back — so one directory with millions of entries can exhaust memory before
+// either bound is ever consulted. pacedDirEntriesFS paces what a chunked
+// reader gets per call, the same short-read shape a real filesystem can hand
+// back, so a small fixture can still show a listing stopping after a few
+// chunks instead of needing a directory too large to build here. The read
+// counter and peakDirEntries are what tell a fix that stops early apart from
+// one that reads the whole directory and only then reports the refusal — a
+// result-only assertion cannot tell the two apart, but the OOM only the
+// former avoids.
+func TestGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
+	const fileCount = 30
+	root := flatEntriesFixture(t, fileCount)
+
+	const budget = 10
+	stubMaxGlobDirEntries(t, budget)
+
+	var read int
+	var seenBudget *GlobBudget
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, callBudget *GlobBudget) fs.FS {
+		seenBudget = callBudget
+		return boundedDirFS{FS: pacedDirEntriesFS{FS: os.DirFS(dir), read: &read, pace: 5}, budget: callBudget, ctx: ctx}
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "*.txt", root, true)
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Glob over a %d-entry directory with an entry budget of %d = (%v, %v), want a *globBudgetError; nothing bounds how many entries one listing may materialize", fileCount, budget, matches, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "glob" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "glob")
+	}
+	if read > fileCount {
+		t.Fatalf("paced double reported %d entries read out of %d total in the directory, which is impossible", read, fileCount)
+	}
+	if read == fileCount {
+		t.Fatalf("listing read all %d entries before refusing; it must stop near the entry budget of %d instead of materializing the whole directory", read, budget)
+	}
+	if seenBudget.peakDirEntries < budget || seenBudget.peakDirEntries >= fileCount {
+		t.Fatalf("globBudget.peakDirEntries = %d, want at least the entry budget of %d but strictly less than the directory's %d entries (a listing that materializes everything before refusing must not pass this)", seenBudget.peakDirEntries, budget, fileCount)
+	}
+}
+
+// TestGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree proves the
+// call-wide live-entry bound catches what maxGlobDirEntries cannot: a walk
+// holds every ancestor directory's listing alive while it descends into a
+// child, so a deep tree's peak live total is the per-directory entry count
+// times its depth, not any single listing's size. Every directory in the
+// chain here holds fewer entries than a lowered maxGlobDirEntries, so the
+// per-directory cap never trips on its own, but the sum the walk is holding
+// live grows with every level it descends and crosses a lowered
+// maxGlobLiveEntries partway down. peakLiveEntries has to be checked
+// directly, not just the refusal, because a fix that walked the whole tree
+// and only complained at the end would return the same error this test's
+// errors.As check accepts; comparing what was actually held live against the
+// tree's full entry count is what tells the two apart.
+func TestGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree(t *testing.T) {
+	root := t.TempDir()
+
+	const depth = 10    // d00..d09
+	const perLevel = 5  // every directory in the chain holds this many entries
+	const decoySize = 8 // files in a directory outside the chain
+	const perDirBudget = 20
+	const liveBudget = 30
+
+	cur := root
+	for i := range depth {
+		cur = filepath.Join(cur, fmt.Sprintf("d%02d", i))
+		if err := os.MkdirAll(cur, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Every non-leaf directory holds perLevel-1 padding files plus the
+		// subdirectory that continues the chain; the leaf holds perLevel
+		// padding files and no subdirectory, so every level's own listing is
+		// the same size.
+		padding := perLevel - 1
+		if i == depth-1 {
+			padding = perLevel
+		}
+		for p := range padding {
+			if err := os.WriteFile(filepath.Join(cur, fmt.Sprintf("pad%02d.txt", p)), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	// zzz_decoy sorts after the whole d00..d09 chain, so the walk finishes
+	// descending and backing out of the chain before it ever lists this
+	// directory: it contributes to the tree's total entry count but is never
+	// one of the chain's ancestors, so it can never be live at the same time
+	// as the chain's peak.
+	decoy := filepath.Join(root, "zzz_decoy")
+	if err := os.MkdirAll(decoy, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range decoySize {
+		if err := os.WriteFile(filepath.Join(decoy, fmt.Sprintf("leaf%02d.txt", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Total entries in the tree: root's own listing (d00 + zzz_decoy = 2),
+	// plus the chain (depth*perLevel), plus the decoy's own files.
+	totalEntries := 2 + depth*perLevel + decoySize
+
+	stubMaxGlobDirEntries(t, perDirBudget)
+	stubMaxGlobLiveEntries(t, liveBudget)
+
+	var seenBudget *GlobBudget
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *GlobBudget) fs.FS {
+		seenBudget = budget
+		return boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.txt", root, true)
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("Glob over a %d-level tree (peak live so far: %d) with a live-entry budget of %d = (%d matches, %v), want a *globBudgetError; nothing bounds how many entries a walk may hold live across the listings it still has open", depth, seenBudget.peakLiveEntries, liveBudget, len(matches), err)
+	}
+	if budgetErr.kind != budgetLiveEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetLiveEntries", budgetErr.kind)
+	}
+	if seenBudget.peakLiveEntries < liveBudget {
+		t.Fatalf("globBudget.peakLiveEntries = %d, want at least the live-entry budget of %d", seenBudget.peakLiveEntries, liveBudget)
+	}
+	if seenBudget.peakLiveEntries >= totalEntries {
+		t.Fatalf("globBudget.peakLiveEntries = %d, want strictly less than the tree's %d total entries (a fix that walked the whole tree before complaining must not pass this)", seenBudget.peakLiveEntries, totalEntries)
+	}
+}
+
+// TestGlobSucceedsOnAWideShallowTreeUnderTheLiveEntryCeiling is the control
+// for TestGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree above: it
+// holds the same 60 total entries (10 sibling directories of 5 files each,
+// plus the root's own 10-entry listing), but spread across siblings instead
+// of nested, so the walk only ever holds the root's listing plus whichever
+// one sibling it is currently reading — one directory's worth plus the root —
+// no matter how many siblings it has already finished with. The live-entry
+// budget is lowered to the same value the nested test uses, and the call
+// still has to succeed and report every match: a naive cumulative counter
+// that summed every listing ever made instead of releasing the ones the walk
+// has left would grow with every sibling visited and refuse partway through
+// this tree instead, which would break every large flat repository.
+func TestGlobSucceedsOnAWideShallowTreeUnderTheLiveEntryCeiling(t *testing.T) {
+	root := t.TempDir()
+
+	const siblings = 10
+	const filesPerSibling = 5
+	const perDirBudget = 20
+	const liveBudget = 30
+
+	for i := range siblings {
+		dir := filepath.Join(root, fmt.Sprintf("sib%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for f := range filesPerSibling {
+			if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("leaf%02d.txt", f)), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	stubMaxGlobDirEntries(t, perDirBudget)
+	stubMaxGlobLiveEntries(t, liveBudget)
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.txt", root, true)
+	if err != nil {
+		t.Fatalf("Glob over a %d-directory wide tree (same %d total entries as the nested tree above) under a live-entry budget of %d = %v, want nil error; the bound must charge only what the walk is currently holding live, not a running total across the whole call", siblings, siblings*(filesPerSibling+1), liveBudget, err)
+	}
+	if want := siblings * filesPerSibling; len(matches) != want {
+		t.Fatalf("Glob over the wide tree returned %d matches, want %d", len(matches), want)
+	}
+}
+
+// TestGlobMatchesStartsItsLiveEntryAccountingFresh pins the other half of the
+// scoping rule: that globMatches actually applies it. Each expanded pattern
+// is its own traversal, and the ignore-discovery pass before them is another,
+// so a walk has to begin holding nothing. This hands globMatches a budget
+// that is already holding a root listing, as a finished earlier traversal
+// would leave it, and asks for a pattern whose own listing fits the ceiling
+// comfortably on its own.
+func TestGlobMatchesStartsItsLiveEntryAccountingFresh(t *testing.T) {
+	const ceiling = 10
+	const staleRootEntries = 8
+	stubMaxGlobLiveEntries(t, ceiling)
+
+	root := t.TempDir()
+	nested := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 3 {
+		if err := os.WriteFile(filepath.Join(nested, fmt.Sprintf("leaf%02d.txt", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	budget := newGlobBudget("glob")
+	if err := budget.holdEntries(".", staleRootEntries); err != nil {
+		t.Fatalf("seeding a finished traversal's %d held entries: %v", staleRootEntries, err)
+	}
+
+	ctx := t.Context()
+	fsys := boundedDirFS{FS: os.DirFS(root), budget: budget, ctx: ctx}
+	matches, err := globMatches(ctx, fsys, "a/b/*.txt", budget)
+	if err != nil {
+		t.Fatalf("globMatches(a/b/*.txt) = %v, want no refusal: an earlier traversal's %d held entries are no longer live and must not be counted against the ceiling of %d", err, staleRootEntries, ceiling)
+	}
+	if len(matches) != 3 {
+		t.Fatalf("globMatches(a/b/*.txt) returned %d matches, want 3", len(matches))
+	}
+}
+
+// TestGlobLiveEntryTrackingIsScopedToOneTraversal proves the live-entry
+// ceiling is bookkeeping about ONE traversal rather than about the budget
+// object, which several traversals of a single call share. holdEntries keeps
+// every entry that is an ancestor of the directory being listed, which is
+// right inside a traversal — those listings really are still held — and wrong
+// across two, because a directory the previous traversal was holding when it
+// finished is not held any more. Root is an ancestor of everything, so
+// without a reset it survives forever and is counted against every later
+// traversal that starts beneath it.
+//
+// This drives the budget directly rather than through a glob call, so it
+// pins the rule itself instead of whatever order a particular call happens to
+// visit directories in.
+func TestGlobLiveEntryTrackingIsScopedToOneTraversal(t *testing.T) {
+	const ceiling = 10
+	const rootEntries = 8
+	const nestedEntries = 5
+	stubMaxGlobLiveEntries(t, ceiling)
+
+	// Within one traversal an ancestor's listing is still held, so its
+	// entries count toward the ceiling alongside the directory below it.
+	within := newGlobBudget("glob")
+	if err := within.holdEntries(".", rootEntries); err != nil {
+		t.Fatalf("holding %d entries under the root, within the ceiling of %d: %v", rootEntries, ceiling, err)
+	}
+	if err := within.holdEntries("a/b", nestedEntries); err == nil {
+		t.Fatalf("holding %d entries under a/b while the root's %d are still held stayed within the ceiling of %d, want a refusal: an ancestor's listing is still live and has to be counted", nestedEntries, rootEntries, ceiling)
+	}
+
+	// Once a traversal ends, what it was holding is no longer held, so the
+	// next traversal starts from nothing even where it shares ancestors.
+	across := newGlobBudget("glob")
+	if err := across.holdEntries(".", rootEntries); err != nil {
+		t.Fatalf("first traversal holding %d entries under the root: %v", rootEntries, err)
+	}
+	across.resetLive()
+	if err := across.holdEntries("a/b", nestedEntries); err != nil {
+		t.Fatalf("second traversal holding %d entries under a/b = %v, want no refusal: the first traversal's root listing is no longer held and must not be counted against a ceiling of %d", nestedEntries, err, ceiling)
+	}
+}
+
+// TestGlobStopsReadingAChunkedListingOnCancellation proves the other half of
+// reading a directory in chunks: readDirChunked's loop checks ctx between one
+// chunk and the next, so a cancellation landing mid-listing is noticed within
+// about one more chunk of work rather than after the whole directory has been
+// pulled through. cancelFS only checks ctx once, when a listing starts, and
+// the walk callback that finally sees ctx.Err() only runs after ReadDir
+// returns, so the call reports context.Canceled either way regardless of how
+// much of the directory the loop actually read — a test that checked only
+// the returned error would pass even if the loop read every remaining chunk
+// before giving up. What has to be pinned is the chunk loop itself stopping
+// promptly, which is why this also counts how many entries actually came out
+// of the directory file, the same way pacedDirEntriesFS's read counter does
+// for TestGlobStopsOnADirectoryWithTooManyEntries above. Losing the ctx check
+// between chunks would let the loop keep pulling chunks until the directory
+// is exhausted — up to maxGlobDirEntries/globDirChunk chunks of pointless
+// work after the caller asked to stop — while still reporting the same
+// context.Canceled this test's error check alone cannot tell apart from that.
+func TestGlobStopsReadingAChunkedListingOnCancellation(t *testing.T) {
+	const fileCount = 40
+	const chunkSize = 5
+	root := flatEntriesFixture(t, fileCount)
+	stubGlobDirChunk(t, chunkSize)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var read int
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *GlobBudget) fs.FS {
+		fsys := pacedDirEntriesFS{FS: os.DirFS(dir), read: &read, pace: chunkSize, cancelOn: 2, cancel: cancel}
+		return boundedDirFS{FS: fsys, budget: budget, ctx: ctx}
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(ctx, "*.txt", root, true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Glob over a listing cancelled mid-chunk = (%v, %v), want context.Canceled", matches, err)
+	}
+	if want := chunkSize * 3; read > want {
+		t.Fatalf("listing kept reading after cancellation: read %d of %d entries in the directory, want at most %d (about one chunk past the one that observed the cancellation)", read, fileCount, want)
 	}
 }
 
@@ -416,5 +820,104 @@ func TestGlobChargesThePatternWalkOnTheDefaultIgnoreExclusionPath(t *testing.T) 
 	}
 	if errors.Is(err, fs.ErrNotExist) {
 		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the glob visibly instead", err)
+	}
+}
+
+// TestGlobIgnoreDiscoveryRefusesRatherThanUnderExcluding pins that a budget
+// refusal during .gitignore discovery reaches the caller instead of being
+// skipped like an unreadable entry. Discovery reads the same filesystem the
+// pattern walk does, under the same bounds, so one can trip while it is
+// collecting rules. An ignoreSet that gave up partway still reports itself
+// complete, so every rule it never reached silently stops excluding: the call
+// then returns paths it was asked to leave out. That is a wrong answer rather
+// than a missing one, and it is worse than failing.
+//
+// The oversized directory here carries the .gitignore that would exclude the
+// candidate, so swallowing the refusal is directly observable: the glob comes
+// back with a path the rules cover.
+func TestGlobIgnoreDiscoveryRefusesRatherThanUnderExcluding(t *testing.T) {
+	const fileCount = 30
+	const entryCap = 10
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("secret.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "secret.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := range fileCount {
+		if err := os.WriteFile(filepath.Join(root, fmt.Sprintf("bulk%02d.txt", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stubMaxGlobDirEntries(t, entryCap)
+
+	matches, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "secret.txt", root, false)
+	if err == nil {
+		t.Fatalf("Glob(\"secret.txt\") = (%v, nil), want a refusal: discovery gave up on the entry cap before reading the .gitignore that excludes secret.txt, so the rules were never loaded and the path came back anyway", matches)
+	}
+	if _, refused := errors.AsType[*globBudgetError](err); !refused {
+		t.Fatalf("Glob(\"secret.txt\") = %v (%T), want a *globBudgetError", err, err)
+	}
+}
+
+// TestBoundedReadRefusesMidListingOnTheLiveEntryCeiling pins that the
+// live-entry ceiling is consulted while a directory is being read, not once
+// the read is done. The total it bounds already includes every ancestor
+// listing the walk is holding, so a directory whose own entries sit well
+// under the per-directory cap can still cross the ceiling partway through its
+// own read. Charging only at the end would let the peak reach the ceiling
+// plus a whole directory cap before anything refused, which is a ceiling only
+// in retrospect.
+//
+// The assertion is on entries actually held at the moment of refusal, because
+// the returned error is identical either way: what distinguishes the two is
+// how much memory was committed before it arrived.
+func TestBoundedReadRefusesMidListingOnTheLiveEntryCeiling(t *testing.T) {
+	const ancestorHeld = 15
+	const ceiling = 20
+	const dirEntries = 10
+	const chunk = 2
+
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range dirEntries {
+		if err := os.WriteFile(filepath.Join(sub, fmt.Sprintf("f%02d.txt", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stubMaxGlobLiveEntries(t, ceiling)
+	stubGlobDirChunk(t, chunk)
+	// High enough that the per-directory cap never fires: the only bound in
+	// play here is the aggregate one.
+	stubMaxGlobDirEntries(t, 1000)
+
+	budget := newGlobBudget("glob")
+	if err := budget.holdEntries(".", ancestorHeld); err != nil {
+		t.Fatalf("seeding the ancestor's %d held entries: %v", ancestorHeld, err)
+	}
+
+	fsys := boundedDirFS{FS: os.DirFS(root), budget: budget, ctx: t.Context()}
+	entries, err := fsys.ReadDir("sub")
+	budgetErr, refused := errors.AsType[*globBudgetError](err)
+	if !refused {
+		t.Fatalf("ReadDir(sub) with %d entries already held against a ceiling of %d = (%d entries, %v), want a *globBudgetError", ancestorHeld, ceiling, len(entries), err)
+	}
+	if budgetErr.kind != budgetLiveEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetLiveEntries", budgetErr.kind)
+	}
+	// Refusing mid-read means the peak sits just past the ceiling, within one
+	// chunk of it. Refusing after the read would put it at the ancestor's
+	// holdings plus the directory's whole contents.
+	if budgetErr.count > ceiling+chunk {
+		t.Fatalf("refused holding %d entries, want no more than the ceiling of %d plus one chunk of %d: the read ran to the end before the ceiling was consulted", budgetErr.count, ceiling, chunk)
+	}
+	if budget.peakLiveEntries >= ancestorHeld+dirEntries {
+		t.Fatalf("peakLiveEntries = %d, want less than the %d the whole directory would add to the ancestor's holdings: the ceiling was checked only after the read finished", budget.peakLiveEntries, ancestorHeld+dirEntries)
 	}
 }

--- a/agent/execenv/glob_budget_unix_test.go
+++ b/agent/execenv/glob_budget_unix_test.go
@@ -1,0 +1,140 @@
+//go:build linux || darwin
+
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"primeradiant.com/evener/agent/sandbox"
+)
+
+// TestSandboxedGlobStopsOnADirectoryWithTooManyEntries is
+// TestGlobStopsOnADirectoryWithTooManyEntries's sandboxed counterpart:
+// secureDirFS.ReadDir also collects a directory in one df.ReadDir(-1) call
+// before the budget or match cap get a say, so the same OOM shape exists on
+// the sandboxed arm. sandboxFS.glob builds its secureDirFS internally, with no
+// seam over its directory reads the way stubGlobBaseFS gives the plain path,
+// so this constructs a secureDirFS directly instead, over a budget the test
+// owns, and reads peakDirEntries off it once the call returns. A bare
+// errors.As/result check would also pass a listing that materializes the
+// whole directory and only then reports the refusal, which is exactly the
+// shape the OOM this bound exists for takes; peakDirEntries is what tells the
+// two apart.
+func TestSandboxedGlobStopsOnADirectoryWithTooManyEntries(t *testing.T) {
+	env, home, _ := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	// A fresh subdirectory of its own, rather than home itself, so the
+	// sandboxedEnv-created "project" worktree isn't an extra entry the
+	// listing has to account for.
+	bucket := filepath.Join(home, "bucket")
+	if err := os.MkdirAll(bucket, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const fileCount = 30
+	for i := range fileCount {
+		p := filepath.Join(bucket, fmt.Sprintf("leaf%03d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const budget = 10
+	stubMaxGlobDirEntries(t, budget)
+	stubGlobDirChunk(t, 5)
+
+	sfs := env.sandbox()
+	if sfs == nil {
+		t.Fatal("expected a sandboxed environment")
+	}
+	// sandbox() hands back a held layer; the ReadDir call below runs on it, so
+	// the release goes at the end of the operation, not here.
+	defer sfs.release()
+	baseFd, canonical, err := sfs.openReadBaseFd("glob", bucket)
+	if err != nil {
+		t.Fatalf("openReadBaseFd: %v", err)
+	}
+	defer func() { _ = unix.Close(baseFd) }()
+
+	callBudget := newGlobBudget("glob")
+	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs, budget: callBudget, ctx: t.Context()}
+
+	entries, err := fsys.ReadDir(".")
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("secureDirFS.ReadDir over a %d-entry directory with an entry budget of %d = (%d entries, %v), want a *globBudgetError; nothing bounds how many entries one listing may materialize", fileCount, budget, len(entries), err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != callBudget.op {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, callBudget.op)
+	}
+	if callBudget.peakDirEntries < budget || callBudget.peakDirEntries >= fileCount {
+		t.Fatalf("globBudget.peakDirEntries = %d, want at least the entry budget of %d but strictly less than the directory's %d entries (a listing that materializes everything before refusing must not pass this)", callBudget.peakDirEntries, budget, fileCount)
+	}
+}
+
+// TestSandboxedGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree is the
+// sandboxed counterpart to
+// TestGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree above.
+// sandboxFS.glob has no live-entry accounting of its own — it gets the
+// call-wide ceiling only because secureDirFS.ReadDir, like boundedDirFS on the
+// plain path, lists through readDirChunked and charges holdEntries the same
+// way. That inheritance is structural rather than exercised directly anywhere
+// else on this arm, so a change that broke it — secureDirFS falling back to
+// its whole-directory read, or a live-entry accounting bug that only surfaces
+// through the fd-anchored resolver's own directory handles — would have
+// nothing here to catch it before a real sandboxed session hit the same OOM
+// the plain path's fix closes. This drives the identical nested-tree shape
+// through env.GlobWithBudget, which dispatches to sandboxFS.glob once the
+// environment is sandboxed, exercising the inheritance through the real entry
+// point rather than by constructing secureDirFS directly the way the
+// entries-cap sibling above does.
+func TestSandboxedGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const depth = 10   // d00..d09
+	const perLevel = 5 // every directory in the chain holds this many entries
+	const perDirBudget = 20
+	const liveBudget = 30
+
+	cur := worktree
+	for i := range depth {
+		cur = filepath.Join(cur, fmt.Sprintf("d%02d", i))
+		if err := os.MkdirAll(cur, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Every non-leaf directory holds perLevel-1 padding files plus the
+		// subdirectory that continues the chain; the leaf holds perLevel
+		// padding files and no subdirectory, so every level's own listing is
+		// the same size.
+		padding := perLevel - 1
+		if i == depth-1 {
+			padding = perLevel
+		}
+		for p := range padding {
+			if err := os.WriteFile(filepath.Join(cur, fmt.Sprintf("pad%02d.txt", p)), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	stubMaxGlobDirEntries(t, perDirBudget)
+	stubMaxGlobLiveEntries(t, liveBudget)
+
+	budget := NewGlobBudget()
+	matches, _, err := env.GlobWithBudget(t.Context(), "**/*.txt", worktree, true, budget)
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("sandboxed glob over a %d-level tree with a live-entry budget of %d = (%d matches, %v), want a *globBudgetError; secureDirFS is not charging the call-wide live-entry ceiling the way boundedDirFS does on the plain path", depth, liveBudget, len(matches), err)
+	}
+	if budgetErr.kind != budgetLiveEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetLiveEntries", budgetErr.kind)
+	}
+}

--- a/agent/execenv/glob_cancel_test.go
+++ b/agent/execenv/glob_cancel_test.go
@@ -152,7 +152,7 @@ func TestGlobWithExclusionsStopsMidWalk(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	stubGlobBaseFS(t, func(string) fs.FS {
+	stubGlobBaseFS(t, func(context.Context, string, *GlobBudget) fs.FS {
 		return &countingFS{FS: globCancelTree(), cancelOn: 3, cancel: cancel}
 	})
 
@@ -250,7 +250,7 @@ func TestSortPathsByMtimeDescStopsOnCancellation(t *testing.T) {
 // stubGlobBaseFS interposes on the fs.FS the off-sandbox glob walks, so a test
 // can drive the exported entry point over a filesystem it controls, and
 // restores the seam when the test ends.
-func stubGlobBaseFS(t *testing.T, open func(dir string) fs.FS) {
+func stubGlobBaseFS(t *testing.T, open func(ctx context.Context, dir string, budget *GlobBudget) fs.FS) {
 	t.Helper()
 	orig := globBaseFS
 	globBaseFS = open

--- a/agent/execenv/glob_stat_unix_test.go
+++ b/agent/execenv/glob_stat_unix_test.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package execenv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGlobMatchesAStatableUnreadableFile proves boundedDirFS does not hide the
+// fs.StatFS fast path os.DirFS provides underneath it. boundedDirFS embeds
+// fs.FS as a bare interface value, which exposes only Open, so fs.Stat on a
+// boundedDirFS can never find a Stat method and falls back to Open plus
+// File.Stat instead of reaching os.DirFS's own Stat the way it would if
+// boundedDirFS forwarded it. A file that can be stat'ed but not opened (mode
+// 0000) fails that fallback, so it is missed where it used to be found —
+// globWalkFS.Stat and cancelFS.Stat both reach the walk's underlying
+// filesystem through fs.Stat, so the loss shows up in an ordinary literal-name
+// glob. File permissions are meaningless outside Unix, hence the build tag.
+func TestGlobMatchesAStatableUnreadableFile(t *testing.T) {
+	root := t.TempDir()
+	const name = "secret.txt"
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("os.Stat(%q) = %v, want the file to remain stat-able at mode 0000 (else this test proves nothing)", path, err)
+	}
+	if _, err := os.Open(path); err == nil {
+		t.Skip("this user can open a 0000 file; cannot stage a stat-able-but-unreadable file")
+	}
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), name, root, true)
+	if err != nil {
+		t.Fatalf("Glob(%q): %v", name, err)
+	}
+	want := []string{path}
+	if len(matches) != 1 || matches[0] != want[0] {
+		t.Fatalf("Glob(%q) = %v, want %v; the stat-able file was not matched because boundedDirFS hides fs.StatFS, so fs.Stat falls back to Open, which a mode-0000 file fails", name, matches, want)
+	}
+}

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1709,8 +1709,12 @@ func (e *LocalExecutionEnvironment) Glob(ctx context.Context, pattern string, ba
 
 // globBaseFS opens the filesystem the off-sandbox glob walks, rooted at the
 // resolved base directory; a variable so tests can drive the exported entry
-// point over a filesystem they control.
-var globBaseFS = os.DirFS
+// point over a filesystem they control. budget is threaded through so a
+// bounded implementation can charge what it reads while listing, and ctx down
+// to boundedDirFS so its chunk loop can observe cancellation.
+var globBaseFS = func(ctx context.Context, dir string, budget *GlobBudget) fs.FS {
+	return boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}
+}
 
 // GlobWithBudget implements GlobBudgeter: same matching as Glob, but the
 // caller supplies budget and reads what the call had to cut off it once the
@@ -1734,11 +1738,15 @@ func (e *LocalExecutionEnvironment) GlobWithBudget(ctx context.Context, pattern 
 		// traversal (no out-of-root match) and drops masked matches.
 		return sfs.glob(ctx, "glob", base, pattern, includeIgnored, budget)
 	}
-	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(base)}
+	fsys := cancelFS{ctx: ctx, fsys: globBaseFS(ctx, base, budget)}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// No masking concept off the sandboxed path: no-op skip.
-		ignores = loadIgnoreSet(fsys, nil)
+		var err error
+		ignores, err = loadIgnoreSet(fsys, nil)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 	seen := make(map[string]struct{})
 	var abs []string
@@ -1963,7 +1971,10 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 		// file argument, which cannot contain a .gitignore tree of its own.
 		ignoreFS = cancelFS{ctx: ctx, fsys: os.DirFS(filepath.Join(path, walkRoot))}
 	}
-	ignores := loadIgnoreSet(ignoreFS, nil)
+	ignores, err := loadIgnoreSet(ignoreFS, nil)
+	if err != nil {
+		return "", err
+	}
 	excludedByIgnore := 0
 
 	err = grepWalk(fsys, walkRoot, func(p string, d fs.DirEntry, err error) error {

--- a/agent/execenv/sandbox_tools_ignoreset_unix_test.go
+++ b/agent/execenv/sandbox_tools_ignoreset_unix_test.go
@@ -49,9 +49,12 @@ func TestLoadIgnoreSetSkipsMaskedSubtree(t *testing.T) {
 	defer func() { _ = unix.Close(baseFd) }()
 
 	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs}
-	set := loadIgnoreSet(fsys, func(relPath string) bool {
+	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return sfs.underMasked(filepath.Join(canonical, relPath))
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, d := range set.dirs {
 		if d.rel == "vault" || strings.HasPrefix(d.rel, "vault/") {

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -63,12 +65,47 @@ func (c cancelFS) Stat(name string) (fs.FileInfo, error) {
 // the cycle check works, an unbounded `**` over a huge tree (`/`) still costs
 // unbounded work.
 //
-// The value is a WORK bound, sized so a large monorepo with a wide brace
-// expansion never trips it while `/` does: a 60,000-directory monorepo
-// globbed with a 5-way brace expansion costs on the order of 300,000
+// The value itself is a WORK bound rather than a memory bound. Memory is held
+// down by three other things: the match cap, the O(depth) ancestor chain, and
+// the per-directory entry cap. What those leave is maxGlobDirEntries times the
+// walk's depth, which is bounded but not small (see that constant), and
+// raising this number does not make it larger. So this one only has to be big
+// enough that a legitimate call never pays for it: a 60,000-directory
+// monorepo globbed with a 5-way brace expansion costs on the order of 300,000
 // listings and must not error; `/` on a developer's machine is 500,000 to
 // several million directories and must. 1,000,000 sits between the two.
 var maxGlobDirListings = 1_000_000
+
+// globDirChunk is how many entries one bounded listing pulls per syscall. A
+// variable, not a constant: it is the unit the per-listing entry bound is
+// enforced in, so a test has to be able to shrink it below a fixture's size
+// to see a listing stop after a few chunks instead of needing a directory too
+// large to build in a test.
+var globDirChunk = 4096
+
+// maxGlobDirEntries bounds how many entries a SINGLE directory listing may
+// materialize. It is per listing rather than cumulative because it bounds
+// peak memory — but the peak one listing being small does not mean the
+// walk's peak is: both fs.WalkDir and doublestar hold a directory's entry
+// slice live for as long as they are recursing into one of its children, so a
+// walk currently N levels deep is holding up to N listings at once, one per
+// ancestor on the path, and only frees a sibling's slice once it moves on to
+// the next one. The real peak is this cap times the walk's depth. An
+// os.dirEntry is roughly 105 bytes including its name, so one listing at the
+// cap costs on the order of 21 to 25 MB, which has to stay small enough to
+// multiply by a plausible depth without exhausting memory on its own.
+var maxGlobDirEntries = 200_000
+
+// maxGlobLiveEntries bounds how many directory entries one call may hold live
+// at once, summed over every listing its walk still has open. maxGlobDirEntries
+// bounds a single listing, which does not bound the walk: fs.WalkDir and
+// doublestar both keep an ancestor's entry slice alive while they read a
+// child, so a walk N levels deep holds up to N listings at once. This is the
+// aggregate ceiling that makes that sum finite. At roughly 105 bytes per
+// os.dirEntry, 500,000 entries is about 52 MB — a couple of maximal
+// directories' worth, far above any real tree (a deep repository holds a few
+// thousand live entries) and far below what would threaten the process.
+var maxGlobLiveEntries = 500_000
 
 // maxGlobMatches bounds how many matches one glob call may accumulate.
 var maxGlobMatches = 10_000
@@ -84,11 +121,12 @@ func SetMaxGlobMatchesForTesting(n int) (restore func()) {
 	return func() { maxGlobMatches = orig }
 }
 
-// GlobBudget bounds the total work one glob call may spend, shared by every
-// brace-expanded pattern the call walks and, through GlobBudgeter, by every
-// caller that wants to see a truncated listing rather than being refused one.
-// Its fields stay unexported: a caller reads what the call had to cut off it
-// through TruncatedAt rather than inspecting the accounting directly.
+// GlobBudget bounds the total work and memory one glob call may spend, shared
+// by every brace-expanded pattern the call walks and, through GlobBudgeter, by
+// every caller that wants to see a truncated listing rather than being
+// refused one. Its fields stay unexported: a caller reads what the call had
+// to cut off it through TruncatedAt rather than inspecting the accounting
+// directly.
 //
 // A budget belongs to one call and its counters are unsynchronized, so it must
 // not be shared across goroutines or reused for a second concurrent call. The
@@ -100,6 +138,28 @@ type GlobBudget struct {
 	matches   int
 	truncated bool
 	op        string
+	// peakDirEntries is the largest number of entries tooManyEntries has ever
+	// been asked to charge to a single listing. The per-listing bound exists
+	// to cap peak memory, not merely to end in a refusal eventually, so this
+	// is what lets a test tell a listing that stopped after a few chunks
+	// apart from one that read a whole huge directory and only then reported
+	// the refusal — a result-only assertion cannot see the difference, but the
+	// OOM only the former avoids.
+	peakDirEntries int
+	// live holds one entry per directory listing the walk currently has open,
+	// pruned by holdEntries down to just the ancestors of whichever directory
+	// is being listed now.
+	live []liveDir
+	// peakLiveEntries is the largest live total holdEntries has ever computed
+	// across b.live, recorded on every call rather than only the one that
+	// trips, so a test can see how far a walk actually got.
+	peakLiveEntries int
+}
+
+// liveDir is one directory whose listing the walk is still holding.
+type liveDir struct {
+	name string
+	n    int
 }
 
 // newGlobBudget constructs a GlobBudget for op, so every internal call site
@@ -130,20 +190,105 @@ func (b *GlobBudget) listing(cycleSafe bool) error {
 	if b.listings <= maxGlobDirListings {
 		return nil
 	}
-	return &globBudgetError{count: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe, op: b.op}
+	return &globBudgetError{count: b.listings, budget: maxGlobDirListings, cycleSafe: cycleSafe, op: b.op, kind: budgetListings}
 }
 
-// globBudgetError reports that one glob call ran past its directory-listing
-// budget. cycleSafe records whether the walk that gave up could have
-// detected a symlink cycle on its own — true only where the filesystem
-// reports file identity — which picks which of Error's two explanations
-// applies. count, budget and op are the values a caller can act on without
-// parsing the message.
+// tooManyEntries reports the refusal for a listing that has read more entries
+// than one directory may materialize, or nil while it is still under. dir is
+// the directory being listed, named in the refusal so a caller knows which
+// one to act on. It records read against peakDirEntries on every call, not
+// only the one that finally trips, so peakDirEntries reflects how far a
+// listing actually got even on the chunks that stay under the bound.
+func (b *GlobBudget) tooManyEntries(dir string, read int) error {
+	if read > b.peakDirEntries {
+		b.peakDirEntries = read
+	}
+	if read <= maxGlobDirEntries {
+		return nil
+	}
+	return &globBudgetError{count: read, dir: dir, budget: maxGlobDirEntries, cycleSafe: true, op: b.op, kind: budgetEntries}
+}
+
+// isGlobWalkAncestor reports whether dir is a proper ancestor of name in the
+// slash-separated paths a walk uses.
+func isGlobWalkAncestor(dir, name string) bool {
+	return dir != name && (dir == "." || strings.HasPrefix(name, dir+"/"))
+}
+
+// holdEntries records dir's listing of n entries as live and releases every
+// directory that is not one of dir's ancestors: to be listing dir at all the
+// walk must have left them, the same reasoning globWalkFS.push uses for
+// identity. It refuses once the live total crosses maxGlobLiveEntries.
+//
+// A reader calls this repeatedly as it accumulates, with n growing, so the
+// ceiling is consulted while the directory is being read rather than once it
+// is done. Re-recording dir simply replaces its previous count, because the
+// release rule drops any entry that is not a proper ancestor of dir, and dir
+// is not an ancestor of itself.
+func (b *GlobBudget) holdEntries(dir string, n int) error {
+	kept := 0
+	total := n
+	for _, d := range b.live {
+		if isGlobWalkAncestor(d.name, dir) {
+			b.live[kept] = d
+			kept++
+			total += d.n
+		}
+	}
+	b.live = append(b.live[:kept], liveDir{name: dir, n: n})
+	if total > b.peakLiveEntries {
+		b.peakLiveEntries = total
+	}
+	if total > maxGlobLiveEntries {
+		return &globBudgetError{count: total, budget: maxGlobLiveEntries, cycleSafe: true, op: b.op, kind: budgetLiveEntries}
+	}
+	return nil
+}
+
+// resetLive clears the record of directory listings this budget currently
+// holds live, so a traversal beginning now starts from none held open: the
+// total holdEntries computes is meant to reflect only what THAT walk has open
+// at the time, and this budget is shared across more than one traversal in a
+// call (ignore discovery, then each brace-expanded pattern's own walk) with
+// nothing else marking where one ends and the next begins. The cumulative
+// counters — listings, matches, peakDirEntries, peakLiveEntries — are left
+// alone: those are meant to span the whole call, not any one traversal in it.
+func (b *GlobBudget) resetLive() {
+	b.live = nil
+}
+
+// globBudgetKind tells apart the three things a globBudgetError can report:
+// too many directory listings across a whole call, too many entries
+// materialized by a single one of them, or too many entries held live at once
+// across the listings a walk still has open.
+type globBudgetKind int
+
+const (
+	budgetListings globBudgetKind = iota
+	budgetEntries
+	budgetLiveEntries
+)
+
+// globBudgetError reports that one glob call ran past one of its bounds: its
+// directory-listing budget, the per-directory entry budget for a single
+// listing within it, or the call-wide ceiling on entries held live at once.
+// cycleSafe records whether the walk that gave up could have detected a
+// symlink cycle on its own — true only where the filesystem reports file
+// identity — which picks which of the listings kind's two explanations
+// applies; neither a single oversized directory nor an aggregate live total
+// says anything about cycle detection, so those kinds are always cycleSafe.
+// count is the whole call's directory-listing tally, the entry count of the
+// one oversized directory, or the live total, according to kind; dir names
+// the oversized directory and is empty for the other two kinds, which have no
+// single directory to blame. count, dir and budget are the values a caller
+// can act on without parsing any of the sentences.
 type globBudgetError struct {
 	count     int
+	dir       string
 	budget    int
 	cycleSafe bool
 	op        string
+	kind      globBudgetKind
 }
 
 // advice names the lever that makes a whole call's listing count smaller.
@@ -153,7 +298,31 @@ func (e *globBudgetError) advice() string {
 	return "narrow the pattern or its base directory"
 }
 
+// entryAdvice names the lever that gets a caller past one oversized
+// directory, the entries kind's counterpart to advice. Every budget here
+// belongs to a glob, which can spell a pattern that matches inside such a
+// directory without listing all of it.
+func (e *globBudgetError) entryAdvice() string {
+	return "that directory is too large to list, so match inside it more specifically or point the base elsewhere"
+}
+
+// where names the oversized directory the way a caller can act on it. The
+// walk's own root comes through as ".", which tells a model nothing, so it is
+// reported as the base it passed in instead of echoed back as a bare dot.
+func (e *globBudgetError) where() string {
+	if e.dir == "" || e.dir == "." {
+		return "the base directory"
+	}
+	return "directory " + e.dir
+}
+
 func (e *globBudgetError) Error() string {
+	if e.kind == budgetEntries {
+		return fmt.Sprintf("%s walk read %d entries from %s, past the per-directory budget of %d: %s", e.op, e.count, e.where(), e.budget, e.entryAdvice())
+	}
+	if e.kind == budgetLiveEntries {
+		return fmt.Sprintf("%s walk is holding %d directory entries live across the listings it has open, past the call-wide budget of %d: %s", e.op, e.count, e.budget, e.advice())
+	}
 	if !e.cycleSafe {
 		return fmt.Sprintf("%s walk made %d directory listings on a filesystem that reports no file identity, so a symlink cycle cannot be detected: refusing to keep walking past the budget of %d; %s", e.op, e.count, e.budget, e.advice())
 	}
@@ -185,6 +354,139 @@ func (b *GlobBudget) TruncatedAt() int {
 		return maxGlobMatches
 	}
 	return 0
+}
+
+// boundedDirFS lists a directory in chunks instead of materializing it whole,
+// charging what it reads to budget after every chunk so one pathological
+// directory cannot exhaust memory before the listing budget or match cap ever
+// get a say — os.DirFS's own ReadDir, like the raw secureDirFS one it mirrors
+// on the sandboxed arm, reads a directory's entire contents before handing
+// any of it back, which is exactly the shape that lets a single huge
+// directory OOM the walk regardless of how tightly the other bounds are set.
+// It has to sit at the bottom of the plain path's stack, under any test
+// wrapper such as countingFS, so every listing that reaches the walk is
+// charged no matter what observes it from above.
+type boundedDirFS struct {
+	fs.FS
+	// ctx reaches readDirChunked, which checks it between chunks. A chunk
+	// loop reading from an already-open directory handle is invisible to
+	// cancelFS's Open/ReadDir/Stat checks: those see a listing starting, not
+	// the chunks inside one, so without this a cancelled call keeps reading a
+	// directory nobody is waiting for.
+	ctx    context.Context
+	budget *GlobBudget
+}
+
+// Stat forwards to the wrapped fs.FS's own Stat rather than letting fs.Stat
+// fall back to Open plus File.Stat. boundedDirFS embeds fs.FS as a bare
+// interface value, which exposes only Open, so without this forward
+// os.DirFS's fs.StatFS fast path is invisible here and a file that can be
+// stat'ed but not opened (mode 0000) fails a call that used to succeed.
+// fs.ReadFile and fs.Sub lose the same fast path and are deliberately not
+// forwarded: their fallbacks (Open plus ReadAll, and a path-prefixing
+// wrapper) are functionally identical to the fast path, and ReadFile's
+// fallback fails on exactly the unreadable file its fast path would have
+// failed on too, so only Stat's fallback actually changes behavior.
+func (b boundedDirFS) Stat(name string) (fs.FileInfo, error) {
+	return fs.Stat(b.FS, name)
+}
+
+// ReadDir lists name through readDirChunked once Open hands back an
+// fs.ReadDirFile, falling back to reading it whole only for a filesystem that
+// cannot list itself in pieces (a test fake, say). That fallback charges the
+// per-directory entry budget (tooManyEntries) against what it reads, but not
+// the call-wide live-entry ceiling (holdEntries): only readDirChunked folds a
+// listing into live tracking, and this path is unreachable with os.DirFS, the
+// only fs.FS boundedDirFS wraps in production.
+func (b boundedDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	f, err := b.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	rdf, ok := f.(fs.ReadDirFile)
+	if !ok {
+		entries, err := fs.ReadDir(b.FS, name)
+		if err != nil {
+			return nil, err
+		}
+		if berr := b.budget.tooManyEntries(name, len(entries)); berr != nil {
+			return nil, berr
+		}
+		return entries, nil
+	}
+	return readDirChunked(b.ctx, rdf, name, b.budget)
+}
+
+// readDirChunked lists dir by pulling entries from rdf in globDirChunk-sized
+// pieces, charging the running total to budget after each one and returning
+// its refusal the moment it trips rather than waiting for the rest of the
+// directory to come back. A single unchunked ReadDir(-1) call — the shape
+// both os.DirFS's ReadDir and a raw *os.File's ReadDir take — materializes a
+// directory's entire contents before the entry budget or match cap ever get
+// a say, which is exactly what lets one huge directory OOM the walk no
+// matter how tightly the other bounds are set. The pieces are sorted by name
+// only once the whole read is done, not per chunk: a listing that stays
+// under the bound has to come back byte-for-byte what os.ReadDir would have
+// produced, because the match cap downstream truncates to a deterministic,
+// lexically-first prefix of it — sorting mid-stream would let a chunk
+// boundary that fell in a different place change which entries end up in
+// that prefix, and the raw fd-backed listing secureDirFS builds this on top
+// of has no ordering guarantee of its own to begin with.
+//
+// ctx is checked between chunks because cancelFS cannot help here: it guards
+// Open, ReadDir and Stat at the filesystem level, so it tests the context
+// once as a listing begins and never again while this loop holds the
+// directory handle. See boundedDirFS.ctx and secureDirFS.ctx for how it is
+// threaded this far down.
+func readDirChunked(ctx context.Context, rdf fs.ReadDirFile, dir string, budget *GlobBudget) ([]fs.DirEntry, error) {
+	var entries []fs.DirEntry
+	for {
+		// cancelFS guards Open, ReadDir and Stat, so it checks ctx once as a
+		// listing starts and never again; this loop then holds the directory
+		// handle for as many chunks as the entry cap allows. Checking here is
+		// what keeps a cancelled call from reading the rest of a huge
+		// directory nobody is waiting for any more, and it answers with the
+		// same cancellation the rest of the walk returns.
+		if cerr := ctx.Err(); cerr != nil {
+			return nil, cerr
+		}
+		chunk, err := rdf.ReadDir(globDirChunk)
+		entries = append(entries, chunk...)
+		if berr := budget.tooManyEntries(dir, len(entries)); berr != nil {
+			return nil, berr
+		}
+		// Charged as the read accumulates, not once it finishes: the live
+		// total already includes every ancestor listing the walk is holding,
+		// so a directory can cross the ceiling partway through its own read.
+		// Checking afterwards would let the peak reach the ceiling plus this
+		// directory's whole cap before anything refused, which is a ceiling
+		// only in retrospect.
+		if berr := budget.holdEntries(dir, len(entries)); berr != nil {
+			return nil, berr
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+		if len(chunk) == 0 {
+			// Defensive: a well-behaved ReadDirFile signals the end with
+			// io.EOF, but nothing here should trust that every fs.FS does, and
+			// a chunk that reads nothing without an error would otherwise spin
+			// forever.
+			break
+		}
+	}
+	// A cancellation that landed on the final chunk must not come back as a
+	// complete listing, so the answer is the cancellation however the loop
+	// happened to leave it.
+	if cerr := ctx.Err(); cerr != nil {
+		return nil, cerr
+	}
+	slices.SortFunc(entries, func(x, y fs.DirEntry) int { return strings.Compare(x.Name(), y.Name()) })
+	return entries, nil
 }
 
 // listedDir is one entry on globWalkFS.chain: the identity of a directory on
@@ -246,6 +548,14 @@ func (w *globWalkFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	entries, err := fs.ReadDir(w.FS, name)
 	if err != nil {
+		// A per-directory entry-budget refusal has to reach the caller
+		// looking like itself, the same as the listing-count refusal admit
+		// already returns unhidden: folding it into the generic fs.ErrNotExist
+		// below would make doublestar quietly skip the very directory that
+		// tripped the bound instead of ending the walk with the reason why.
+		if _, refused := errors.AsType[*globBudgetError](err); refused {
+			return nil, err
+		}
 		return nil, w.hide("readdir", name)
 	}
 	return entries, nil
@@ -310,7 +620,7 @@ func (w *globWalkFS) identity(dir string) (fs.FileInfo, bool) {
 func (w *globWalkFS) push(name string, info fs.FileInfo) {
 	kept := 0
 	for _, d := range w.chain {
-		if d.name != name && (d.name == "." || strings.HasPrefix(name, d.name+"/")) {
+		if isGlobWalkAncestor(d.name, name) {
 			w.chain[kept] = d
 			kept++
 		}
@@ -350,7 +660,12 @@ var errGlobMatchesFull = errors.New("glob match cap reached")
 // after the cap has already tripped does not re-walk the tree just to
 // discover it can keep nothing, and it is checked on every match the walk
 // finds, so a `**` with millions of hits stops there instead of accumulating
-// all of them before the caller gets a chance to see any.
+// all of them before the caller gets a chance to see any. It also resets the
+// budget's live-entry tracking right before this walk starts (see
+// GlobBudget.resetLive): this is a fresh traversal over fsys, so it must not
+// inherit directories an earlier traversal sharing this budget — ignore
+// discovery, or an earlier pattern in this same call — recorded as held open
+// before it finished with them.
 //
 // GlobWalk rather than Glob: it ends the walk the moment the callback returns
 // an error, so a cancellation — or the match cap tripping — that lands
@@ -367,6 +682,7 @@ func globMatches(ctx context.Context, fsys fs.FS, pattern string, budget *GlobBu
 		}
 		return nil, nil
 	}
+	budget.resetLive()
 	walk := &globWalkFS{FS: fsys, ctx: ctx, budget: budget}
 	var matches []string
 	err := doublestar.GlobWalk(walk, pattern, func(p string, _ fs.DirEntry) error {

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -36,6 +36,15 @@ type secureDirFS struct {
 	baseFd   int
 	basePath string
 	fs       *sandboxFS
+	// budget bounds the entries a single ReadDir call may materialize, shared
+	// with the rest of the glob call's directory-listing budget. nil for a
+	// caller whose listing does not participate in that bound, in which case
+	// ReadDir falls back to reading the directory whole.
+	budget *GlobBudget
+	// ctx is threaded down to readDirChunked the same way boundedDirFS.ctx is
+	// on the off-sandbox path; see that field for why. Only consulted when
+	// budget is set, since that is the only case that reads in chunks.
+	ctx context.Context
 }
 
 func (f *secureDirFS) Open(name string) (fs.File, error) {
@@ -49,12 +58,15 @@ func (f *secureDirFS) Open(name string) (fs.File, error) {
 	return os.NewFile(uintptr(fd), name), nil
 }
 
-// ReadDir lists name and sorts the result by name: os.DirFS's own ReadDir
-// already returns entries sorted, and the match cap downstream truncates to a
-// deterministic, lexically-first prefix of what a listing returns, so this
-// arm has to produce the same order or a capped walk here could stop on a
-// different prefix than the same walk over the plain filesystem. The raw
-// fd-backed listing this builds on has no ordering guarantee of its own.
+// ReadDir lists name through readDirChunked when budget is set, the same
+// helper boundedDirFS uses on the off-sandbox path, so a huge directory here
+// cannot OOM the walk either. A caller with no budget reads the directory
+// whole and sorts it by name: os.DirFS's own ReadDir already returns entries
+// sorted, and the match cap downstream truncates to a deterministic,
+// lexically-first prefix of what a listing returns, so this arm has to
+// produce the same order or a capped walk here could stop on a different
+// prefix than the same walk over the plain filesystem. The raw fd-backed
+// listing both arms build on has no ordering guarantee of its own.
 func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	fd, err := openBeneathRoot(f.baseFd, name, unix.O_RDONLY|unix.O_DIRECTORY, 0)
 	if err != nil {
@@ -62,12 +74,15 @@ func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	df := os.NewFile(uintptr(fd), name)
 	defer func() { _ = df.Close() }()
-	entries, err := df.ReadDir(-1)
-	if err != nil {
-		return nil, err
+	if f.budget == nil {
+		entries, err := df.ReadDir(-1)
+		if err != nil {
+			return nil, err
+		}
+		slices.SortFunc(entries, func(x, y fs.DirEntry) int { return strings.Compare(x.Name(), y.Name()) })
+		return entries, nil
 	}
-	slices.SortFunc(entries, func(x, y fs.DirEntry) int { return strings.Compare(x.Name(), y.Name()) })
-	return entries, nil
+	return readDirChunked(f.ctx, df, name, f.budget)
 }
 
 func (f *secureDirFS) Stat(name string) (fs.FileInfo, error) {
@@ -115,15 +130,18 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 	}
 	defer func() { _ = unix.Close(baseFd) }()
 
-	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
+	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s, budget: budget, ctx: ctx}}
 	var ignores *ignoreSet
 	if !includeIgnored {
 		// Never list or read into a masked subtree while collecting
 		// .gitignore rules — secureDirFS enforces symlink-refusal and root
 		// confinement but not masking, so the skip must be supplied here.
-		ignores = loadIgnoreSet(fsys, func(relPath string) bool {
+		ignores, err = loadIgnoreSet(fsys, func(relPath string) bool {
 			return s.underMasked(filepath.Join(canonical, relPath))
 		})
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 	seen := make(map[string]struct{})
 	var abs []string
@@ -188,9 +206,12 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
 	// Never list or read into a masked subtree while collecting .gitignore
 	// rules — see the matching comment in glob above.
-	ignores := loadIgnoreSet(fsys, func(relPath string) bool {
+	ignores, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return s.underMasked(filepath.Join(canonical, relPath))
 	})
+	if err != nil {
+		return "", err
+	}
 	excludedByIgnore := 0
 	err = secureBrowseWalkDir(fsys, ".", func(rel string, d fs.DirEntry, walkErr error) error {
 		if cancelErr := ctx.Err(); cancelErr != nil {

--- a/agent/execenv/securepath_edge_program_fuzz_test.go
+++ b/agent/execenv/securepath_edge_program_fuzz_test.go
@@ -302,7 +302,7 @@ func runSecurePathEdgeContractProgram(t *testing.T, program []byte) securePathEd
 
 	// secureDirFS rejects invalid virtual paths and invalid root fds with ordinary
 	// fs.PathError values rather than allowing a browse escape.
-	dirFS := &secureDirFS{baseFd: -1, basePath: worktree, fs: s}
+	dirFS := &secureDirFS{baseFd: -1, basePath: worktree, fs: s, budget: newGlobBudget("glob"), ctx: t.Context()}
 	if _, err := dirFS.Open("../escape"); !errors.Is(err, fs.ErrInvalid) {
 		t.Fatalf("secureDirFS invalid Open = %v", err)
 	}


### PR DESCRIPTION
Second of three stacked PRs for #497, on top of #951. **Base it on `fix/497-glob-budget-a`, not main.** #951 fixed the original defects; this one bounds memory; **C** budgets grep.

## What was wrong

#951's listing and match bounds cap how much a walk *does*, not how much it *holds*. Every listing still materialized its whole directory before any bound was consulted: `os.DirFS`'s `ReadDir` is `os.ReadDir`, and the sandboxed arm ended in a single `df.ReadDir(-1)`. One directory holding millions of entries exhausted memory before the listing budget or match cap ever ran.

A per-directory cap alone would not have been enough either. `fs.WalkDir` and doublestar both keep an ancestor's entry slice alive while they read a child, so a walk N levels deep holds N listings at once and the real peak is the cap times depth.

## What changed

- **Chunked listings.** Directories are pulled 4,096 entries at a time and charged after each chunk, so a pathological directory stops partway rather than after it has already been read whole. Entries are sorted once at the end, so a listing that stays under the bound is byte-for-byte what `os.ReadDir` would have produced and the match cap still truncates to the same prefix.
- **A per-directory entry cap** (200,000, roughly 21 MB at ~105 bytes per `os.dirEntry`). The refusal names the directory and says the count is one directory's entries, because the lever there is that directory, not the call.
- **A call-wide live-entry ceiling** (500,000, roughly 52 MB). Release comes free from the rule the ancestor chain already uses: to be listing a directory at all, the walk must have left every non-ancestor. The tracking is scoped to one traversal, so a listing left over from ignore discovery cannot inflate a later pattern walk's total.
- **Per-chunk cancellation.** `cancelFS` guards `Open`, `ReadDir` and `Stat`, so it sees a listing *start* and never the chunks inside it. The loop checks the context itself and answers with the same `context.Canceled` the rest of the walk returns.
- **`Stat` forwarding.** `boundedDirFS` embeds `fs.FS` as a bare interface, which exposes only `Open` and hid `os.DirFS`'s `fs.StatFS`. A file that can be stat'ed but not opened stopped matching a literal glob.

## Caller-visible changes

- **A single directory over 200,000 entries now fails glob outright**, naming that directory, rather than being read into memory.
- **A walk holding more than 500,000 entries live at once fails.** A deep tree of large directories can reach this even when no single directory is over the per-directory cap. A wide, flat repository is unaffected: the bound is on entries held *simultaneously*, not a cumulative count.
- A cancelled glob stops reading a large directory promptly instead of finishing it first.

## How it is tested

Tests assert *work done*, not just results — entries actually read, `peakDirEntries`, `peakLiveEntries` — because a fix that reads a whole directory and then reports a refusal would satisfy a result-only assertion while still doing exactly the thing that OOMs. First failures:

- `Glob over a 30-entry directory with an entry budget of 10 = (...30 matches..., <nil>), want a *globBudgetError`
- `Glob over a 10-level tree (peak live so far: 52) with a live-entry budget of 30 = (49 matches, <nil>), want a *globBudgetError`
- `listing kept reading after cancellation: read 40 of 40 entries in the directory, want at most 15`
- `Glob("secret.txt") = [], want [.../secret.txt]`

`TestGlobSucceedsOnAWideShallowTreeUnderTheLiveEntryCeiling` is the control that keeps the live bound honest: the same total entries spread across siblings must still succeed, because a cumulative counter would break every large flat repository. `TestGlobLiveEntryTrackingIsScopedToOneTraversal` pins the per-traversal scoping, and the sandboxed arm has its own live-entry witness — both verified by mutation.

Gates, all foreground, zero failures each: `gofmt`; `make vet` and `GOOS=windows make vet`; `go vet -tags evenerfuzz ./...`; `make lint-golangci`; `make lint-evenerfuzz lint-eval lint-gofmt lint-internal`; `go test -race ./agent/execenv/`; `-tags evenerfuzz -run Fuzz ./agent/execenv/`; full `go test ./agent/`.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
