### PR TITLE
fix(execenv): budget grep's ignore discovery and its own walk

### DIFF
--- a/agent/execenv/gitignore.go
+++ b/agent/execenv/gitignore.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	gitignore "github.com/sabhiram/go-gitignore"
 )
 
@@ -28,8 +29,13 @@ import (
 // base (e.g. a repo root .gitignore when base is a subdirectory) are not
 // consulted; this is a known simplification for a directory-scoped search.
 type ignoreSet struct {
-	// dirs is ordered root-first so the "deeper overrides shallower" search
-	// above is a simple linear scan.
+	// dirs is in collection order, which is root-first only for a
+	// single-prefix scope: a call scoped to several prefixes appends each
+	// prefix's ancestors and subtree in turn, so {a,b}/*.txt yields ".", "b",
+	// "b/c", "a". Nothing depends on the order today, because matches ORs
+	// every rule that applies and never resets. Anything that later gives a
+	// deeper rule precedence over a shallower one has to sort first rather
+	// than rely on this slice.
 	dirs []ignoreDir
 }
 
@@ -38,11 +44,144 @@ type ignoreDir struct {
 	matcher *gitignore.GitIgnore
 }
 
-// loadIgnoreSet walks fsys (rooted at the search base) collecting every
-// .gitignore file's rules. It is best-effort: unreadable files are skipped
-// rather than failing the search, and a base with no .gitignore files
-// anywhere (including one that is not inside a git repository at all) yields
-// an ignoreSet that matches nothing.
+// ignoreScope is one region of the base discovery has to inspect: a literal
+// prefix, and how many directory levels below it can hold a .gitignore whose
+// rules reach one of the caller's candidates. depth -1 means unbounded.
+type ignoreScope struct {
+	prefix string
+	depth  int
+}
+
+// wholeBaseIgnoreScope is the scope a caller with no pattern to narrow by
+// needs: the whole base, to any depth. Grep uses it, because its own walk
+// covers the whole base too.
+func wholeBaseIgnoreScope() []ignoreScope {
+	return []ignoreScope{{prefix: ".", depth: -1}}
+}
+
+// ignoreScopeDepth reports how many directory levels below a pattern's
+// literal prefix can hold a rule affecting one of its candidates. Only ** can
+// match a directory separator, so without one every remaining separator in
+// the pattern is exactly one level and the reach is bounded; with one it is
+// unbounded (-1). This is what keeps a non-recursive pattern like "*.go" from
+// inspecting a subtree its own walk never lists.
+func ignoreScopeDepth(rest string) int {
+	if strings.Contains(rest, "**") {
+		return -1
+	}
+	return strings.Count(rest, "/")
+}
+
+// ignoreScopeRelDepth reports how many levels below prefix p sits, prefix
+// itself being 0.
+func ignoreScopeRelDepth(prefix, p string) int {
+	if p == prefix {
+		return 0
+	}
+	rel := p
+	if prefix != "." {
+		rel = strings.TrimPrefix(p, prefix+"/")
+	}
+	return strings.Count(rel, "/") + 1
+}
+
+// narrowIgnoreScopes drops the scopes another already covers, so no directory
+// is walked or read twice: an unbounded scope over the whole base subsumes
+// every other, and an unbounded scope subsumes anything at or beneath its own
+// prefix. Scopes sharing a prefix collapse to the deepest reach among them.
+func narrowIgnoreScopes(scopes []ignoreScope) []ignoreScope {
+	deepest := make(map[string]int, len(scopes))
+	order := make([]string, 0, len(scopes))
+	for _, sc := range scopes {
+		if sc.prefix == "." && sc.depth < 0 {
+			return wholeBaseIgnoreScope()
+		}
+		if d, seen := deepest[sc.prefix]; !seen {
+			deepest[sc.prefix] = sc.depth
+			order = append(order, sc.prefix)
+		} else if d >= 0 && (sc.depth < 0 || sc.depth > d) {
+			deepest[sc.prefix] = sc.depth
+		}
+	}
+	kept := make([]ignoreScope, 0, len(order))
+	for _, prefix := range order {
+		covered := false
+		for _, other := range order {
+			if other == prefix || deepest[other] >= 0 {
+				continue
+			}
+			if other == "." || strings.HasPrefix(prefix, other+"/") {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			kept = append(kept, ignoreScope{prefix: prefix, depth: deepest[prefix]})
+		}
+	}
+	return kept
+}
+
+// ignoreAncestors returns prefix's strict ancestor directories, root first
+// ("." through prefix's parent): the levels a rule affecting a path under
+// prefix could live in that the budgeted subtree walk below never visits,
+// since that walk starts at prefix itself. "." has none: it is the base, so
+// there is nothing above it to read.
+func ignoreAncestors(prefix string) []string {
+	if prefix == "." {
+		return nil
+	}
+	parts := strings.Split(prefix, "/")
+	dirs := make([]string, 0, len(parts))
+	dirs = append(dirs, ".")
+	for i := 1; i < len(parts); i++ {
+		dirs = append(dirs, strings.Join(parts[:i], "/"))
+	}
+	return dirs
+}
+
+// ignoreScopeForPatterns builds a glob call's ignore-discovery scope from its
+// expanded patterns: doublestar.SplitPattern's meta-free leading directory for
+// each one, so discovery is scoped to that prefix's subtree instead of the
+// whole base. That is the subtree, not the pattern's own reach: a directory
+// inside the prefix is still walked, and can still refuse, even where the
+// pattern would never have matched inside it — "sub/*.txt" beside a large
+// "sub/huge/" can fail on sub/huge. Narrowing further would mean deciding
+// which descendants a pattern can match before walking them, which is the
+// walk's own job.
+// A pattern starting with a metacharacter (e.g. "**/*.go") splits to ".",
+// scoping discovery to the whole base — correct, since such a pattern's own
+// walk covers the whole base too, so the budget still applies to both
+// consistently.
+func ignoreScopeForPatterns(patterns []string) []ignoreScope {
+	scopes := make([]ignoreScope, len(patterns))
+	for i, pattern := range patterns {
+		prefix, rest := doublestar.SplitPattern(pattern)
+		scopes[i] = ignoreScope{prefix: prefix, depth: ignoreScopeDepth(rest)}
+	}
+	return scopes
+}
+
+// loadIgnoreSet collects every .gitignore rule that can affect a path under
+// one of scope's prefixes ("." meaning the whole base). It is best-effort for
+// I/O errors: unreadable files are skipped rather than failing the search,
+// and a base with no .gitignore files anywhere (including one that is not
+// inside a git repository at all) yields an ignoreSet that matches nothing.
+// The errors it does return are budget refusals, of every kind: the call's
+// listing-count budget, a single directory's entry cap, and the call-wide
+// live-entries ceiling all have to reach the caller, since a partial
+// ignoreSet built from a walk that gave up partway through would silently
+// under-exclude the rest of a huge tree.
+//
+// A rule collected in directory id.rel only ever affects a path equal to or
+// under id.rel (see ignoreSet.matches), so for each of scope's prefixes this
+// reads two disjoint halves: the prefix's strict ancestors, one fs.ReadFile
+// per level and no directory listing at all, then the prefix's own subtree
+// via fs.WalkDir, budgeted exactly like a walk rooted at the base itself
+// would be. A prefix that names a directory absent from fsys makes its
+// WalkDir a no-op rather than a failure: that prefix simply contributes no
+// rules, the same as a literal glob pattern naming a directory that isn't
+// there matches nothing.
 //
 // skip, when non-nil, is consulted for every path (relative to fsys' root,
 // slash-separated) before it is descended into or read; skip returning true
@@ -52,51 +191,124 @@ type ignoreDir struct {
 // this walk otherwise has no other way to honor, since fsys itself (a
 // symlink-refusing, root-confined secureDirFS) enforces confinement but not
 // masking. The off-path caller (no masking concept) passes a no-op skip.
-func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool) (*ignoreSet, error) {
+//
+// budget is the same one the caller's glob walk spends listings from, so
+// ignore discovery and pattern matching together are bounded as one call's
+// worth of work rather than each getting its own unbounded pass over the
+// tree.
+func loadIgnoreSet(fsys fs.FS, skip func(relPath string) bool, budget *GlobBudget, scope []ignoreScope) (*ignoreSet, error) {
 	set := &ignoreSet{}
+	scopes := narrowIgnoreScopes(scope)
+
+	readAncestor := make(map[string]bool)
+	for _, sc := range scopes {
+		for _, dir := range ignoreAncestors(sc.prefix) {
+			if readAncestor[dir] {
+				continue
+			}
+			readAncestor[dir] = true
+			// No dot-directory check here, unlike the subtree walk below: an
+			// ancestor is named by the pattern's own literal prefix, and
+			// isDotPath drops every candidate under a dot-directory before a
+			// rule from one could apply, so a ".config/.gitignore" loaded here
+			// can never change an answer.
+			if dir != "." && skip != nil && skip(dir) {
+				continue
+			}
+			p := ".gitignore"
+			if dir != "." {
+				p = dir + "/.gitignore"
+			}
+			// Masking is per path, so an unmasked directory can still hold a
+			// masked .gitignore, and the base itself is never masked while a
+			// .gitignore directly inside it can be. secureDirFS enforces
+			// symlink refusal and root confinement but not masking, so the
+			// file has to clear skip on its own before it is read — checking
+			// only the directory would read a file the policy hides. The
+			// subtree walk below gets this for free: fs.WalkDir hands it every
+			// entry, files included, and its skip check runs before the read.
+			if skip != nil && skip(p) {
+				continue
+			}
+			data, rerr := fs.ReadFile(fsys, p)
+			if rerr != nil {
+				continue //nolint:nilerr // best-effort: skip a missing or unreadable ancestor .gitignore
+			}
+			matcher := gitignore.CompileIgnoreLines(strings.Split(string(data), "\n")...)
+			set.dirs = append(set.dirs, ignoreDir{rel: dir, matcher: matcher})
+		}
+	}
+
 	var budgetErr error
-	_ = fs.WalkDir(fsys, ".", func(p string, d fs.DirEntry, err error) error {
-		if err != nil {
-			// A budget refusal is not an unreadable entry to skip past. This
-			// walk reads the same filesystem the pattern walk does, under the
-			// same bounds, so one can trip here — and an ignoreSet that gave
-			// up partway reports itself complete, silently under-excluding
-			// every rule it never reached. That is a wrong answer rather than
-			// a missing one, so it has to reach the caller.
-			if _, refused := errors.AsType[*globBudgetError](err); refused {
-				budgetErr = err
-				return err
+	for _, sc := range scopes {
+		_ = fs.WalkDir(fsys, sc.prefix, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				// A budget refusal is not an unreadable entry: skipping it would
+				// let the directory that tripped the bound be read again by
+				// whatever walks next, and would leave this set reported as
+				// complete when it stopped partway, silently under-excluding the
+				// rest of the tree. That holds for the live-entries ceiling as
+				// much as for the other two: this walk has to start at the root
+				// and visit everything below it, so it holds a deeper chain live
+				// than a pattern walk that can skip to a literal prefix, and
+				// reaching the ceiling here means the process is already carrying
+				// the memory the ceiling exists to prevent. Continuing on and
+				// leaving a later walk to refuse would spend that memory first.
+				if _, refused := errors.AsType[*globBudgetError](err); refused {
+					budgetErr = err
+					return err
+				}
+				return nil //nolint:nilerr // best-effort: skip unreadable entries
 			}
-			return nil //nolint:nilerr // best-effort: skip unreadable entries
-		}
-		if p != "." && skip != nil && skip(p) {
+			if p != "." && skip != nil && skip(p) {
+				if d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
 			if d.IsDir() {
-				return fs.SkipDir
+				// Dot-directories (.git, .worktrees, .claude scratch dirs, ...)
+				// never hold .gitignore files worth loading and can be enormous
+				// (.git) — skip them the same way Glob's own match-filtering
+				// does, so this walk doesn't pay to descend into them either.
+				if p != "." && strings.HasPrefix(d.Name(), ".") {
+					return fs.SkipDir
+				}
+				// Past the scope's reach nothing below can hold a rule that
+				// touches one of its candidates, so descending would inspect a
+				// subtree the caller's own walk never lists. Only ** crosses a
+				// separator, which is why an unbounded scope has no cut here.
+				if sc.depth >= 0 && ignoreScopeRelDepth(sc.prefix, p) > sc.depth {
+					return fs.SkipDir
+				}
+				// cycleSafe is always true here: fs.WalkDir never follows a
+				// symlink into a directory, so this walk can never re-enter
+				// itself the way the pattern walk's /proc/<pid>/root case does.
+				// The flag only picks the refusal's wording, not whether the
+				// bound applies — an unbounded walk over a huge tree costs
+				// unbounded work whether or not it could have looped.
+				if err := budget.listing(true); err != nil {
+					budgetErr = err
+					return err
+				}
+				return nil
 			}
-			return nil
-		}
-		if d.IsDir() {
-			// Dot-directories (.git, .worktrees, .claude scratch dirs, ...)
-			// never hold .gitignore files worth loading and can be enormous
-			// (.git) — skip them the same way Glob's own match-filtering
-			// does, so this walk doesn't pay to descend into them either.
-			if p != "." && strings.HasPrefix(d.Name(), ".") {
-				return fs.SkipDir
+			if d.Name() != ".gitignore" {
+				return nil
 			}
+			data, rerr := fs.ReadFile(fsys, p)
+			if rerr != nil {
+				return nil //nolint:nilerr // best-effort: skip unreadable .gitignore
+			}
+			dir := path.Dir(p)
+			matcher := gitignore.CompileIgnoreLines(strings.Split(string(data), "\n")...)
+			set.dirs = append(set.dirs, ignoreDir{rel: dir, matcher: matcher})
 			return nil
+		})
+		if budgetErr != nil {
+			break
 		}
-		if d.Name() != ".gitignore" {
-			return nil
-		}
-		data, rerr := fs.ReadFile(fsys, p)
-		if rerr != nil {
-			return nil //nolint:nilerr // best-effort: skip unreadable .gitignore
-		}
-		dir := path.Dir(p)
-		matcher := gitignore.CompileIgnoreLines(strings.Split(string(data), "\n")...)
-		set.dirs = append(set.dirs, ignoreDir{rel: dir, matcher: matcher})
-		return nil
-	})
+	}
 	return set, budgetErr
 }
 

--- a/agent/execenv/gitignore_covtest_test.go
+++ b/agent/execenv/gitignore_covtest_test.go
@@ -40,7 +40,7 @@ func TestIgnoreSet_Matches_PathEqualsDir(t *testing.T) {
 		"sub":            {Mode: os.ModeDir | 0o755},
 		"sub/.gitignore": {Data: []byte(content)},
 	}
-	set, err := loadIgnoreSet(fsys, nil)
+	set, err := loadIgnoreSet(fsys, nil, newGlobBudget("glob"), wholeBaseIgnoreScope())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestLoadIgnoreSet_SkipFile(t *testing.T) {
 	}
 	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return relPath == "skipme"
-	})
+	}, newGlobBudget("glob"), wholeBaseIgnoreScope())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func loadIgnoreSetFromLines(t *testing.T, dir string, lines ...string) *ignoreSe
 	fsys := fstest.MapFS{
 		path: {Data: []byte(content)},
 	}
-	set, err := loadIgnoreSet(fsys, nil)
+	set, err := loadIgnoreSet(fsys, nil, newGlobBudget("glob"), wholeBaseIgnoreScope())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/execenv/glob_budget_test.go
+++ b/agent/execenv/glob_budget_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -919,5 +920,628 @@ func TestBoundedReadRefusesMidListingOnTheLiveEntryCeiling(t *testing.T) {
 	}
 	if budget.peakLiveEntries >= ancestorHeld+dirEntries {
 		t.Fatalf("peakLiveEntries = %d, want less than the %d the whole directory would add to the ancestor's holdings: the ceiling was checked only after the read finished", budget.peakLiveEntries, ancestorHeld+dirEntries)
+	}
+}
+
+// TestGlobIgnoreDiscoveryIsChargedToTheBudget proves loadIgnoreSet's own walk
+// spends the same budget the pattern walk does, rather than making a pass over
+// the tree that no bound accounts for.
+//
+// Discovery's reach now matches the pattern's, so a pattern that lists nothing
+// no longer isolates it. What still does is the include_ignored control: with
+// it set, discovery is skipped entirely and only the pattern walk's listings
+// are charged, so a budget that fits one pass but not two separates them. The
+// recursive pattern is what makes discovery descend at all.
+func TestGlobIgnoreDiscoveryIsChargedToTheBudget(t *testing.T) {
+	const dirCount = 40
+	// One pass over this tree is the base plus its directories; two passes
+	// exceed this budget, one is comfortably inside it.
+	const budget = dirCount + 20
+	root := globBudgetFixture(t, dirCount)
+	stubMaxGlobDirListings(t, budget)
+
+	var counter *countingFS
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *GlobBudget) fs.FS {
+		counter = &countingFS{FS: boundedDirFS{FS: os.DirFS(dir), budget: budget, ctx: ctx}}
+		return counter
+	})
+
+	matches, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.txt", root, false)
+	if err == nil {
+		t.Fatalf("GlobWithExclusions(include_ignored=false) over a %d-directory tree with a listing budget of %d returned no error and %d matches; ignore discovery's own pass is not charged to the budget", dirCount, budget, len(matches))
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the glob visibly instead", err)
+	}
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("GlobWithExclusions(include_ignored=false) error = %v (%T), want a *globBudgetError", err, err)
+	}
+	if budgetErr.op != "glob" {
+		t.Fatalf("globBudgetError.op = %q, want %q (this is glob's own call, not grep's)", budgetErr.op, "glob")
+	}
+	if counter.calls > budget+1 {
+		t.Fatalf("the call made %d directory listings against a budget of %d, want at most %d: it kept walking past the bound", counter.calls, budget, budget+1)
+	}
+
+	if _, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "does-not-exist.txt", root, true); err != nil {
+		t.Fatalf("GlobWithExclusions(include_ignored=true) = %v, want nil (ignore discovery is skipped entirely, so it cannot trip the budget)", err)
+	}
+}
+
+// TestGlobIgnoreDiscoveryStopsOnADirectoryWithTooManyEntries covers the arm
+// the pattern-walk entry test cannot reach: loadIgnoreSet walks the base with
+// fs.WalkDir, whose callback treats every error it is handed as an unreadable
+// entry to skip. A per-directory entry refusal handed to that callback is not
+// an unreadable entry — it is the bound doing its job — so swallowing it both
+// lets the oversized directory be read again by whatever walks next and
+// leaves ignore discovery reporting a set it never finished collecting, which
+// silently under-excludes the rest of the tree.
+//
+// The pattern is metacharacter-free and matches nothing, so doublestar
+// resolves it with a stat and lists no directory at all: the only walk that
+// can reach the entry bound here is ignore discovery's.
+func TestGlobIgnoreDiscoveryStopsOnADirectoryWithTooManyEntries(t *testing.T) {
+	const fileCount = 30
+	const budget = 10
+	root := flatEntriesFixture(t, fileCount)
+	stubMaxGlobDirEntries(t, budget)
+	stubGlobDirChunk(t, 5)
+
+	matches, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "does-not-exist.txt", root, false)
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("GlobWithExclusions(include_ignored=false) over a %d-entry directory with an entry budget of %d = (%v, %v), want a *globBudgetError; ignore discovery's walk is swallowing the refusal as if it were an unreadable entry", fileCount, budget, matches, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "glob" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "glob")
+	}
+}
+
+// TestGrepIgnoreDiscoveryIsChargedToTheBudget proves the same ignore-discovery
+// budget applies on grep's native fallback, not only glob's: grepNative loads
+// its own ignore set with a fresh budget before it ever walks the tree it
+// greps, so an over-budget tree must fail the grep call, not silently glob
+// past its bound. grepNative is called directly, rather than through a tool
+// dispatch, because that is the "return \"\", err" path a native grep takes
+// when loadIgnoreSet refuses — existing tests such as
+// TestGrep_FallbackWithoutRipgrep reach the same native arm the same way,
+// without needing to defeat ripgrep detection. The error must name "grep" as
+// the operation that spent the budget: the budget is shared code with glob's,
+// so nothing about the failure itself distinguishes the two callers unless
+// the operation name does.
+func TestGrepIgnoreDiscoveryIsChargedToTheBudget(t *testing.T) {
+	const dirCount = 40
+	const budget = 8
+	root := globBudgetFixture(t, dirCount)
+	stubMaxGlobDirListings(t, budget)
+
+	_, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	if err == nil {
+		t.Fatalf("grepNative over a %d-directory tree with a listing budget of %d returned no error; ignore discovery is not charged to the budget", dirCount, budget)
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("budget refusal reported %v, which the walk skips silently; it must fail the grep visibly instead", err)
+	}
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("grepNative error = %v (%T), want a *globBudgetError", err, err)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q (grepNative's ignore discovery, not glob's)", budgetErr.op, "grep")
+	}
+}
+
+// TestGrepWalkIsChargedToTheBudget proves grepNative's own directory walk
+// charges every directory it visits to the shared budget, on top of whatever
+// ignore discovery already charged for the same tree, so a huge tree
+// grepNative walks after ignore discovery completes still costs unbounded
+// work.
+func TestGrepWalkIsChargedToTheBudget(t *testing.T) {
+	const dirCount = 30
+	const budget = 40
+	root := globBudgetFixture(t, dirCount)
+	stubMaxGlobDirListings(t, budget)
+
+	_, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("grepNative's own walk over a %d-directory tree with a listing budget of %d = (_, %v), want a *globBudgetError; grepWalk charges nothing to the budget", dirCount, budget, err)
+	}
+	if budgetErr.kind != budgetListings {
+		t.Fatalf("globBudgetError.kind = %v, want budgetListings", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}
+
+// TestGrepWalkDoesNotChargeSkippedDirectories proves grepNative's own walk
+// charges the listing budget only for directories it actually descends into.
+// The d.IsDir() block in grepNative's callback charges budget.listing(true)
+// only after the dot-directory and gitignore filepath.SkipDir checks earlier
+// in the same callback run, so a directory the walk immediately skips costs
+// nothing. The tree here mixes both kinds of exclusion the callback applies —
+// dot-prefixed directories and directories a root .gitignore matches — and
+// its excluded directories alone outnumber the lowered listing budget, while
+// only a handful of directories are ever actually listed. loadIgnoreSet runs
+// first over the same tree on the same budget, and it skips only the
+// dot-prefixed directories, not the gitignored ones, so its own pass already
+// charges the base plus every real and gitignored directory (1 + 3 + 10 = 14
+// listings) before grepNative's walk begins. grepWalk's own pass then adds 4
+// more — the base plus the 3 real directories it actually descends into —
+// for a total of 18, comfortably under the budget of 25 and comfortably
+// above ignore discovery's 14-listing cost alone, so headroom cannot hide a
+// regression here. Moving the charge above the skip checks would instead
+// start charging the 20 dot and 10 gitignored directories the walk was about
+// to skip anyway, which on their own are more than enough to cross the
+// budget of 25 partway through (the walk gives up as soon as the running
+// total does, well short of a legitimate 18): that is the only way this test
+// can fail.
+func TestGrepWalkDoesNotChargeSkippedDirectories(t *testing.T) {
+	root := t.TempDir()
+
+	const realCount = 3
+	for i := range realCount {
+		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf("dir%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "dir00", "leaf.txt"), []byte("needle\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const dotCount = 20
+	for i := range dotCount {
+		if err := os.MkdirAll(filepath.Join(root, fmt.Sprintf(".excluded%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const gitignoredCount = 10
+	gitignoreLines := make([]string, 0, gitignoredCount)
+	for i := range gitignoredCount {
+		dir := fmt.Sprintf("ignored%02d", i)
+		if err := os.MkdirAll(filepath.Join(root, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		gitignoreLines = append(gitignoreLines, dir+"/")
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte(strings.Join(gitignoreLines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const budget = 25
+	stubMaxGlobDirListings(t, budget)
+
+	out, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	if budgetErr, refused := errors.AsType[*globBudgetError](err); refused {
+		t.Fatalf("grepNative over a tree with %d dot-excluded and %d gitignored directories against only %d listed directories, with a listing budget of %d well above ignore discovery's own cost, refused: %v; the walk is charging directories it is about to skip toward the budget instead of only the ones it actually descends into", dotCount, gitignoredCount, realCount, budget, budgetErr)
+	}
+	if err != nil {
+		t.Fatalf("grepNative: %v", err)
+	}
+	if !strings.Contains(out, "needle") {
+		t.Fatalf("grepNative(%q) = %q, want a match for the needle in dir00/leaf.txt", "needle", out)
+	}
+}
+
+// TestGrepWalkStopsOnADirectoryWithTooManyEntries pins grep's ignore
+// discovery surfacing the entries refusal, not grepNative's own walk. root
+// itself is the one oversized directory here (30 files, no subdirectories),
+// and loadIgnoreSet's fs.WalkDir walk lists it before grepNative's own walk
+// ever starts, so the refusal always comes from ignore discovery's callback
+// swallowing-guard. It cannot also pin the equivalent guard in grepNative's
+// own walk callback: that guard only matters if a directory grows past the
+// entries bound between ignore discovery's pass and the walk's own, and no
+// static tree can produce that — ignore discovery's skip set is always a
+// subset of the walk's, so ignore discovery always reaches (and refuses) any
+// oversized directory first. Only concurrent growth reaches it, which
+// TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+// forces by growing the directory inside a stubbed walk.
+func TestGrepWalkStopsOnADirectoryWithTooManyEntries(t *testing.T) {
+	const fileCount = 30
+	const budget = 10
+	root := flatEntriesFixture(t, fileCount)
+	stubMaxGlobDirEntries(t, budget)
+	stubGlobDirChunk(t, 5)
+
+	out, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("grepNative over a %d-entry directory with an entry budget of %d = (%q, %v), want a *globBudgetError; grep's walks are swallowing the refusal as if it were an unreadable entry", fileCount, budget, out, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}
+
+// TestGlobIgnoreDiscoveryPropagatesTheLiveEntryRefusal pins that discovery
+// reports the live-entry ceiling rather than absorbing it into its
+// best-effort arm. Its walk starts at the scope's prefix and holds the whole
+// chain below it live, so reaching the ceiling there means the process is
+// already carrying the memory the ceiling exists to prevent; continuing and
+// leaving a later walk to refuse would spend it first, and would hand back an
+// ignoreSet that stopped partway while reporting itself complete.
+//
+// This drives loadIgnoreSet directly. Through a glob call the two passes now
+// have the same reach by design, so a recursive pattern's own walk refuses on
+// the same tree whether or not discovery propagated, and the outcomes are
+// indistinguishable. What is being pinned is which pass reports it.
+func TestGlobIgnoreDiscoveryPropagatesTheLiveEntryRefusal(t *testing.T) {
+	const perDir = 8
+	const depth = 6
+	const ceiling = 20
+
+	root := t.TempDir()
+	dir := root
+	for i := range depth {
+		dir = filepath.Join(dir, fmt.Sprintf("level%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for j := range perDir {
+			if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%02d.txt", j)), []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	stubMaxGlobLiveEntries(t, ceiling)
+
+	budget := newGlobBudget("glob")
+	fsys := boundedDirFS{FS: os.DirFS(root), budget: budget, ctx: t.Context()}
+	_, err := loadIgnoreSet(fsys, nil, budget, wholeBaseIgnoreScope())
+	budgetErr, refused := errors.AsType[*globBudgetError](err)
+	if !refused {
+		t.Fatalf("loadIgnoreSet over a %d-level tree holding %d entries per level against a ceiling of %d = %v, want a *globBudgetError; the refusal is being absorbed by discovery's best-effort arm", depth, perDir, ceiling, err)
+	}
+	if budgetErr.kind != budgetLiveEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetLiveEntries", budgetErr.kind)
+	}
+}
+
+// TestGlobBudgetErrorAdviceDependsOnTheOperationAndTheBound pins that advice
+// and entryAdvice each name the lever that can actually fix the refusal they
+// describe, not one that only sounds plausible. A model acts on this advice
+// directly: a grep's pattern is a regex applied to file contents after the
+// walk has already listed everything, so narrowing it cannot reduce how much
+// the walk lists, while a glob's pattern controls what gets listed in the
+// first place, and one oversized directory is a different lever again from a
+// whole call's listing count. Advice that names the wrong lever sends a model
+// off to change something that cannot help, so this asserts the three
+// distinctions structurally instead of embedding any method's wording:
+// collapsing any one of them to a single return value still passes every
+// other test in this package.
+func TestGlobBudgetErrorAdviceDependsOnTheOperationAndTheBound(t *testing.T) {
+	grepListings := &globBudgetError{op: "grep", kind: budgetListings}
+	globListings := &globBudgetError{op: "glob", kind: budgetListings}
+	if grepAdvice, globAdvice := grepListings.advice(), globListings.advice(); grepAdvice == globAdvice {
+		t.Fatalf("advice() collapsed the grep/glob distinction for a listings refusal: grep = %q, glob = %q; narrowing a grep's pattern cannot reduce how much it lists, so the two operations need different advice", grepAdvice, globAdvice)
+	}
+
+	grepEntries := &globBudgetError{op: "grep", kind: budgetEntries}
+	globEntries := &globBudgetError{op: "glob", kind: budgetEntries}
+	if grepEntryAdvice, globEntryAdvice := grepEntries.entryAdvice(), globEntries.entryAdvice(); grepEntryAdvice == globEntryAdvice {
+		t.Fatalf("entryAdvice() collapsed the grep/glob distinction for an entries refusal: grep = %q, glob = %q; a grep cannot spell a pattern that lists less of one directory, so the two operations need different advice", grepEntryAdvice, globEntryAdvice)
+	}
+
+	if entryAdvice, callAdvice := globEntries.entryAdvice(), globListings.advice(); entryAdvice == callAdvice {
+		t.Fatalf("entryAdvice() collapsed into advice() for the same operation: entryAdvice = %q, advice = %q; one oversized directory and a whole call's listing count are not the same lever, so they need different advice", entryAdvice, callAdvice)
+	}
+}
+
+// patternScopeFixture builds a t.TempDir() holding a small sub/ (one .txt
+// file, matching a "sub/*.txt"-shaped pattern) beside an oversized, unrelated
+// huge/ (hugeCount files, enough to trip a lowered per-directory entry cap on
+// its own), so a test can prove ignore discovery scoped to sub/ never reads
+// huge/'s entries.
+func patternScopeFixture(t *testing.T, hugeCount int) (root string) {
+	t.Helper()
+	root = t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "keep.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	huge := filepath.Join(root, "huge")
+	if err := os.MkdirAll(huge, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range hugeCount {
+		if err := os.WriteFile(filepath.Join(huge, fmt.Sprintf("leaf%03d.dat", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// TestGlobIgnoreDiscoverySkipsDirectoriesThePatternCannotReach proves ignore
+// discovery's scope matches a literal pattern prefix's reach. huge/'s file
+// count trips a lowered per-directory entry cap, but "sub/*.txt"'s own
+// pattern walk never visits huge/ at all, so ignore discovery must not visit
+// it either: a sibling directory the pattern walk would never touch cannot be
+// allowed to fail a glob that has nothing to do with it.
+func TestGlobIgnoreDiscoverySkipsDirectoriesThePatternCannotReach(t *testing.T) {
+	const hugeCount = 20
+	root := patternScopeFixture(t, hugeCount)
+	stubMaxGlobDirEntries(t, 10)
+
+	var read int
+	stubGlobBaseFS(t, func(ctx context.Context, dir string, budget *GlobBudget) fs.FS {
+		return boundedDirFS{FS: pacedDirEntriesFS{FS: os.DirFS(dir), read: &read, pace: 1 << 30}, budget: budget, ctx: ctx}
+	})
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "sub/*.txt", root, false)
+	if err != nil {
+		t.Fatalf(`Glob("sub/*.txt") over a base with a %d-file huge/ sibling and a lowered entry cap = (%v, %v), want sub's file and no error; ignore discovery is reading directories the pattern walk can never reach`, hugeCount, matches, err)
+	}
+	want := []string{filepath.Join(root, "sub", "keep.txt")}
+	if !slices.Equal(matches, want) {
+		t.Fatalf("Glob(%q) matches = %v, want %v", "sub/*.txt", matches, want)
+	}
+	if read >= hugeCount {
+		t.Fatalf("ignore discovery (or the pattern walk) read %d entries, enough to have read all of huge/'s %d files; discovery's scope has widened back out to the whole base", read, hugeCount)
+	}
+}
+
+// TestGlobIgnoreDiscoveryStillCoversEverythingForAWildcardPattern guards
+// against TestGlobIgnoreDiscoverySkipsDirectoriesThePatternCannotReach's fix
+// collapsing into "ignore discovery is never budgeted": doublestar.SplitPattern
+// gives "." for a pattern starting with a metacharacter, so "**/*.txt"'s own
+// pattern walk covers the whole base too, and huge/ tripping the entry cap
+// must still refuse the call.
+func TestGlobIgnoreDiscoveryStillCoversEverythingForAWildcardPattern(t *testing.T) {
+	const hugeCount = 20
+	root := patternScopeFixture(t, hugeCount)
+	stubMaxGlobDirEntries(t, 10)
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "**/*.txt", root, false)
+	budgetErr, refused := errors.AsType[*globBudgetError](err)
+	if !refused {
+		t.Fatalf(`Glob("**/*.txt") over a base with a %d-file huge/ sibling and a lowered entry cap = (%v, %v), want a *globBudgetError`, hugeCount, matches, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+}
+
+// TestGlobIgnoreDiscoveryAppliesAnAncestorGitignoreAboveThePrefix proves the
+// ancestors-plus-prefix split in loadIgnoreSet loses no rules: a .gitignore
+// at the base excluding a path under sub/ must still exclude it from a
+// "sub/*.txt" glob, even though discovery no longer walks the base itself to
+// find that .gitignore.
+func TestGlobIgnoreDiscoveryAppliesAnAncestorGitignoreAboveThePrefix(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "keep.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "skip.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".gitignore"), []byte("sub/skip.txt\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	matches, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), "sub/*.txt", root, false)
+	if err != nil {
+		t.Fatalf(`Glob("sub/*.txt") = (%v, %v), want sub/keep.txt and no error`, matches, err)
+	}
+	want := []string{filepath.Join(root, "sub", "keep.txt")}
+	if !slices.Equal(matches, want) {
+		t.Fatalf("Glob(%q) matches = %v, want %v (sub/skip.txt should be excluded by the base .gitignore)", "sub/*.txt", matches, want)
+	}
+}
+
+// TestGlobIgnoreDiscoveryStillPrunesADotDirectoryNamedAsThePrefix pins that
+// the subtree walk applies its dot-directory prune to the prefix directory
+// itself, not only to directories below it. Discovery starts its walk AT the
+// prefix, so a check written against the prefix rather than against the
+// walk's own root would exempt exactly the one directory the caller named,
+// and discovery would descend into a dot-directory the walk is supposed to
+// prune. Here that would cost the entry cap on ".config/huge", which the
+// pattern's own listing of ".config" never touches.
+func TestGlobIgnoreDiscoveryStillPrunesADotDirectoryNamedAsThePrefix(t *testing.T) {
+	const hugeFiles = 20
+	const entryCap = 10
+
+	root := t.TempDir()
+	dotDir := filepath.Join(root, ".config")
+	huge := filepath.Join(dotDir, "huge")
+	if err := os.MkdirAll(huge, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dotDir, "leaf.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := range hugeFiles {
+		if err := os.WriteFile(filepath.Join(huge, fmt.Sprintf("f%02d.txt", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stubMaxGlobDirEntries(t, entryCap)
+
+	_, err := NewLocalExecutionEnvironment(root).Glob(t.Context(), ".config/*.txt", root, false)
+	if budgetErr, refused := errors.AsType[*globBudgetError](err); refused {
+		t.Fatalf("Glob(\".config/*.txt\") = %v, want no refusal: ignore discovery descended into the dot-directory it names as its prefix and paid for %s, which the pattern's own listing never reads", budgetErr, "huge")
+	}
+	if err != nil {
+		t.Fatalf("Glob(\".config/*.txt\") = %v, want no error", err)
+	}
+}
+
+// TestLoadIgnoreSetConsultsSkipForTheScopePrefixItself pins the masking half
+// of the same rule the dot-directory test above pins: the subtree walk's skip
+// check is written against the walk's own root, so it covers the prefix
+// directory as well as everything below it. Discovery starts its walk AT the
+// prefix, and a check written against the prefix instead would exempt exactly
+// the directory the caller named — letting a pattern whose literal prefix is
+// a masked directory have discovery list it and read the rules inside it.
+// secureDirFS enforces symlink refusal and root confinement but not masking;
+// this skip is the only thing that supplies it.
+//
+// This drives loadIgnoreSet directly because the effect is not visible in a
+// glob's results: the bypass reads a masked directory's .gitignore, whose
+// rules only ever apply to paths under that same masked directory, and those
+// are dropped from the answer anyway. What is wrong is the reading, so that
+// is what this observes.
+func TestLoadIgnoreSetConsultsSkipForTheScopePrefixItself(t *testing.T) {
+	fsys := fstest.MapFS{
+		"vault/.gitignore": &fstest.MapFile{Data: []byte("*.log\n")},
+		"vault/keep.txt":   &fstest.MapFile{Data: []byte("x")},
+	}
+
+	var asked []string
+	skip := func(relPath string) bool {
+		asked = append(asked, relPath)
+		return relPath == "vault"
+	}
+
+	set, err := loadIgnoreSet(fsys, skip, newGlobBudget("glob"), []ignoreScope{{prefix: "vault", depth: -1}})
+	if err != nil {
+		t.Fatalf("loadIgnoreSet scoped to a masked prefix: %v", err)
+	}
+	if !slices.Contains(asked, "vault") {
+		t.Fatalf("skip was never consulted about the prefix itself; it was asked about %v, so a masked directory named as a pattern's literal prefix would be walked and read", asked)
+	}
+	for _, d := range set.dirs {
+		if d.rel == "vault" || strings.HasPrefix(d.rel, "vault/") {
+			t.Fatalf("collected a rule from %q inside the masked prefix; masking is the only thing keeping discovery out of that subtree", d.rel)
+		}
+	}
+}
+
+// TestLoadIgnoreSetSkipsAMaskedAncestorGitignoreFile pins the file-level half
+// of the masking check on the ancestor read. Masking is per path: a directory
+// that is not masked can still hold a masked .gitignore, and the base itself
+// is never masked while a .gitignore directly inside it can be. secureDirFS
+// enforces symlink refusal and root confinement but not masking, so if the
+// ancestor read checks only the directory it reads a file the policy hides —
+// the same class as naming a masked directory as a pattern's prefix, one
+// level finer.
+//
+// Like that test this drives loadIgnoreSet directly, because the effect is in
+// what gets read rather than in the answer: rules from a masked ancestor
+// would apply to paths the caller can see, so reading them is both a leak and
+// a wrong exclusion.
+func TestLoadIgnoreSetSkipsAMaskedAncestorGitignoreFile(t *testing.T) {
+	fsys := fstest.MapFS{
+		"sub/.gitignore":      &fstest.MapFile{Data: []byte("*.log\n")},
+		"sub/deep/keep.txt":   &fstest.MapFile{Data: []byte("x")},
+		"sub/deep/.gitignore": &fstest.MapFile{Data: []byte("*.tmp\n")},
+	}
+
+	var asked []string
+	skip := func(relPath string) bool {
+		asked = append(asked, relPath)
+		// The directory is visible; only the rules file inside it is masked.
+		return relPath == "sub/.gitignore"
+	}
+
+	set, err := loadIgnoreSet(fsys, skip, newGlobBudget("glob"), []ignoreScope{{prefix: "sub/deep", depth: -1}})
+	if err != nil {
+		t.Fatalf("loadIgnoreSet with a masked ancestor .gitignore: %v", err)
+	}
+	if !slices.Contains(asked, "sub/.gitignore") {
+		t.Fatalf("skip was never consulted about the ancestor rules file itself; it was asked about %v, so a masked .gitignore inside an unmasked directory would be read", asked)
+	}
+	for _, d := range set.dirs {
+		if d.rel == "sub" {
+			t.Fatalf("collected rules from the masked ancestor .gitignore at %q; masking is the only thing keeping discovery out of that file", d.rel)
+		}
+	}
+}
+
+// nonRecursiveScopeFixture builds a base holding one small file the caller's
+// pattern can match and one large unrelated subtree beneath it, sized so that
+// walking into the subtree trips the per-directory entry cap while listing
+// the base alone does not.
+func nonRecursiveScopeFixture(t *testing.T, hugeFiles int) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "top.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	huge := filepath.Join(root, "huge")
+	if err := os.MkdirAll(huge, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := range hugeFiles {
+		if err := os.WriteFile(filepath.Join(huge, fmt.Sprintf("f%02d.go", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// TestGlobIgnoreDiscoveryStopsAtANonRecursivePatternsDepth pins that a pattern
+// with no ** confines discovery to its own reach. Only ** matches across a
+// separator, so "*.go" can only ever match files directly in the base: the
+// rules that can touch one of its candidates live in the base and nowhere
+// below it. Walking the whole subtree anyway inspects directories the
+// pattern's own walk never lists, and one oversized directory down there then
+// fails a glob that could never have looked inside it.
+func TestGlobIgnoreDiscoveryStopsAtANonRecursivePatternsDepth(t *testing.T) {
+	const hugeFiles = 20
+	const entryCap = 10
+	root := nonRecursiveScopeFixture(t, hugeFiles)
+	stubMaxGlobDirEntries(t, entryCap)
+
+	matches, _, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "*.go", root, false)
+	if err != nil {
+		t.Fatalf("Glob(\"*.go\") = %v, want top.go and no error: discovery walked into a subtree the pattern can never match inside", err)
+	}
+	if len(matches) != 1 || !strings.HasSuffix(matches[0], "top.go") {
+		t.Fatalf("Glob(\"*.go\") = %v, want just top.go", matches)
+	}
+}
+
+// TestGlobIgnoreDiscoveryStillWalksTheSubtreeForARecursivePattern is the
+// other half of scoping by depth: ** reaches every descendant, so discovery
+// has to descend too or it never loads the nested .gitignore files whose
+// rules cover what the pattern matches down there. Without this, scoping
+// could quietly collapse into "discovery never descends", which would
+// silently under-exclude every nested rule.
+//
+// It asserts on exclusion rather than on a refusal: a budget refusal for a
+// recursive pattern comes from the pattern's own walk over the same subtree,
+// so it holds whatever discovery does and would pin nothing.
+func TestGlobIgnoreDiscoveryStillWalksTheSubtreeForARecursivePattern(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, ".gitignore"), []byte("skipme.go\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"skipme.go", "keep.go"} {
+		if err := os.WriteFile(filepath.Join(sub, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	matches, excluded, err := NewLocalExecutionEnvironment(root).GlobWithExclusions(t.Context(), "**/*.go", root, false)
+	if err != nil {
+		t.Fatalf("Glob(\"**/*.go\"): %v", err)
+	}
+	for _, m := range matches {
+		if strings.HasSuffix(m, "skipme.go") {
+			t.Fatalf("Glob(\"**/*.go\") returned %q, which sub/.gitignore excludes; discovery never descended to read that nested rules file", m)
+		}
+	}
+	if excluded == 0 {
+		t.Fatalf("Glob(\"**/*.go\") = (%v, excluded=0), want the nested .gitignore to have excluded skipme.go", matches)
 	}
 }

--- a/agent/execenv/glob_budget_toctou_test.go
+++ b/agent/execenv/glob_budget_toctou_test.go
@@ -1,0 +1,72 @@
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// growDirWithFiles adds n more files to dir, named apart from any fixture's
+// own files so growth never collides with them. It exists so the TOCTOU
+// probes below can turn a directory that was under the entry budget when
+// ignore discovery listed it into one that is over budget by the time the
+// grep walk under test lists it a second time — the concurrent-growth shape
+// the per-directory guard exists for, which no fixture built up front can
+// produce (ignore discovery's skip set is always a subset of the walk's, so
+// it always reaches an oversized directory first on a static tree).
+func growDirWithFiles(t *testing.T, dir string, n int) {
+	t.Helper()
+	for i := range n {
+		p := filepath.Join(dir, fmt.Sprintf("grown%04d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+// forces the concurrent-growth case that no static fixture can produce.
+// grepNative runs two independent passes over the same tree under the same
+// budget: loadIgnoreSet's fs.WalkDir first, then grepWalk's own. Ignore
+// discovery's skip set (dot-prefixed directories only) is always a subset of
+// grepWalk's (which also skips gitignored ones), so on any fixture built up
+// front ignore discovery always reaches an oversized directory first and
+// grepWalk's own callback guard never gets a turn — that guard exists only
+// for a directory that grows past maxGlobDirEntries in the gap between the
+// two passes. This stubs grepWalk itself to open that exact gap: the stub
+// grows the walk root only once grepWalk is invoked, which is after
+// loadIgnoreSet has already listed the same root at its original, in-budget
+// size, and only then delegates to the real fs.WalkDir. The now-oversized
+// root's ReadDir raises the entries refusal from inside grepWalk's own
+// listing, so a pass here can only mean grepNative's own callback guard — not
+// ignore discovery's — carried it out instead of swallowing it as an
+// unreadable entry.
+func TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery(t *testing.T) {
+	const fileCount = 3
+	root := flatEntriesFixture(t, fileCount)
+
+	const budget = 8
+	stubMaxGlobDirEntries(t, budget)
+
+	walk := grepWalk
+	grepWalk = func(fsys fs.FS, name string, fn fs.WalkDirFunc) error {
+		growDirWithFiles(t, root, 20)
+		return walk(fsys, name, fn)
+	}
+	t.Cleanup(func() { grepWalk = walk })
+
+	_, err := NewLocalExecutionEnvironment(root).grepNative(t.Context(), "needle", root, "", false, 100, "")
+	budgetErr, refused := errors.AsType[*globBudgetError](err)
+	if !refused {
+		t.Fatalf("grepNative over a directory that grows past the entry budget of %d between ignore discovery's pass and grepWalk's own = %v, want a *globBudgetError from grepWalk's own callback guard", budget, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}

--- a/agent/execenv/glob_budget_toctou_unix_test.go
+++ b/agent/execenv/glob_budget_toctou_unix_test.go
@@ -1,0 +1,60 @@
+//go:build linux || darwin
+
+package execenv
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/evener/agent/sandbox"
+)
+
+// TestSandboxedGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+// is the sandboxed counterpart: sandboxFS.grepNative runs the same two-pass
+// shape as the off-sandbox arm — loadIgnoreSet walks the base once, then
+// secureBrowseWalkDir walks it again under the same budget — so the same
+// concurrent-growth gap exists and is just as unreachable from a static
+// fixture. This stubs secureBrowseWalkDir the way the off-sandbox probe above
+// stubs grepWalk: it grows the sandboxed worktree only once
+// secureBrowseWalkDir is invoked, after loadIgnoreSet has already listed it
+// at its original, in-budget size, then delegates to the real fs.WalkDir.
+// Growing the tree through the os.WriteFile calls below reaches the
+// filesystem directly, the same way the test's own fixture setup does; it is
+// not an operation the sandboxed environment under test performs.
+func TestSandboxedGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const fileCount = 3
+	for i := range fileCount {
+		p := filepath.Join(worktree, fmt.Sprintf("leaf%03d.txt", i))
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const budget = 8
+	stubMaxGlobDirEntries(t, budget)
+
+	walk := secureBrowseWalkDir
+	secureBrowseWalkDir = func(fsys fs.FS, name string, fn fs.WalkDirFunc) error {
+		growDirWithFiles(t, worktree, 20)
+		return walk(fsys, name, fn)
+	}
+	t.Cleanup(func() { secureBrowseWalkDir = walk })
+
+	_, err := env.Grep(t.Context(), "needle", worktree, "", false, 100, "")
+	budgetErr, refused := errors.AsType[*globBudgetError](err)
+	if !refused {
+		t.Fatalf("sandboxed Grep over a directory that grows past the entry budget of %d between ignore discovery's pass and the walk's own = %v, want a *globBudgetError from grepNative's own callback guard", budget, err)
+	}
+	if budgetErr.kind != budgetEntries {
+		t.Fatalf("globBudgetError.kind = %v, want budgetEntries", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}

--- a/agent/execenv/glob_budget_unix_test.go
+++ b/agent/execenv/glob_budget_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -136,5 +137,114 @@ func TestSandboxedGlobStopsWhenTooManyEntriesAreHeldLiveAcrossADeepTree(t *testi
 	}
 	if budgetErr.kind != budgetLiveEntries {
 		t.Fatalf("globBudgetError.kind = %v, want budgetLiveEntries", budgetErr.kind)
+	}
+}
+
+// TestSandboxedGrepWalkIsChargedToTheBudget is TestGrepWalkIsChargedToTheBudget's
+// sandboxed counterpart: sfs.grepNative's own directory walk charges every
+// directory it visits to the shared budget, on top of whatever ignore
+// discovery already charged for the same tree, so a huge tree grepNative
+// walks after ignore discovery completes still costs unbounded work. The tree
+// here has no .gitignore and is small enough that ignore discovery alone
+// stays well under the lowered listing budget, so a refusal can only be
+// attributed to grepNative's own walk over the tree it is grepping, not to
+// ignore discovery's separate pass over the same tree. Sandboxed sessions
+// always use native grep — LocalExecutionEnvironment.Grep routes to
+// sfs.grepNative whenever e.sandbox() is non-nil, even with ripgrep present —
+// so env.Grep is enough to reach this arm without defeating ripgrep
+// detection.
+func TestSandboxedGrepWalkIsChargedToTheBudget(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const dirCount = 30
+	const budget = 40
+	for i := range dirCount {
+		dir := filepath.Join(worktree, fmt.Sprintf("dir%02d", i))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "leaf.txt"), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stubMaxGlobDirListings(t, budget)
+
+	_, err := env.Grep(t.Context(), "needle", worktree, "", false, 100, "")
+	var budgetErr *globBudgetError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("sandboxed grep's own walk over a %d-directory tree with a listing budget of %d = (_, %v), want a *globBudgetError; sfs.grepNative's walk charges nothing to the budget", dirCount, budget, err)
+	}
+	if budgetErr.kind != budgetListings {
+		t.Fatalf("globBudgetError.kind = %v, want budgetListings", budgetErr.kind)
+	}
+	if budgetErr.op != "grep" {
+		t.Fatalf("globBudgetError.op = %q, want %q", budgetErr.op, "grep")
+	}
+}
+
+// TestSandboxedGrepWalkDoesNotChargeSkippedDirectories is the sandboxed
+// counterpart to TestGrepWalkDoesNotChargeSkippedDirectories: sandboxFS's own
+// walk charges budget.listing(true) once per directory it actually descends
+// into, after the masked/dot/gitignore fs.SkipDir checks earlier in the same
+// callback, not before them. The fixture and budget here are the same
+// arithmetic as the off-sandbox test, because loadIgnoreSet is the identical
+// shared code on both arms: it does not yet know a directory is gitignored
+// while it is still collecting the .gitignore rules that would exclude it, so
+// it charges the base plus every real and gitignored directory (1 + 3 + 10 =
+// 14 listings) but skips only the dot-prefixed ones for free. The
+// sandboxed walk then adds 4 more of its own — the base plus the 3 real
+// directories it actually descends into — for a total of 18, comfortably
+// under the budget of 25 and comfortably above ignore discovery's 14-listing
+// cost alone, so headroom cannot hide a regression here. Moving the charge
+// above the skip checks would instead start charging the 20 dot and 10
+// gitignored directories the walk was about to skip anyway, which on their
+// own are more than enough to cross the budget of 25 partway through (the
+// walk gives up as soon as the running total does, well short of a
+// legitimate 18): that is the only way this test can fail.
+func TestSandboxedGrepWalkDoesNotChargeSkippedDirectories(t *testing.T) {
+	env, _, worktree := sandboxedEnv(t, sandbox.ModeReadOnly)
+
+	const realCount = 3
+	for i := range realCount {
+		if err := os.MkdirAll(filepath.Join(worktree, fmt.Sprintf("dir%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(worktree, "dir00", "leaf.txt"), []byte("needle\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const dotCount = 20
+	for i := range dotCount {
+		if err := os.MkdirAll(filepath.Join(worktree, fmt.Sprintf(".excluded%02d", i)), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const gitignoredCount = 10
+	gitignoreLines := make([]string, 0, gitignoredCount)
+	for i := range gitignoredCount {
+		dir := fmt.Sprintf("ignored%02d", i)
+		if err := os.MkdirAll(filepath.Join(worktree, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		gitignoreLines = append(gitignoreLines, dir+"/")
+	}
+	if err := os.WriteFile(filepath.Join(worktree, ".gitignore"), []byte(strings.Join(gitignoreLines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const budget = 25
+	stubMaxGlobDirListings(t, budget)
+
+	out, err := env.Grep(t.Context(), "needle", worktree, "", false, 100, "")
+	if budgetErr, refused := errors.AsType[*globBudgetError](err); refused {
+		t.Fatalf("sandboxed grepNative over a tree with %d dot-excluded and %d gitignored directories against only %d listed directories, with a listing budget of %d well above ignore discovery's own cost, refused: %v; the walk is charging directories it is about to skip toward the budget instead of only the ones it actually descends into", dotCount, gitignoredCount, realCount, budget, budgetErr)
+	}
+	if err != nil {
+		t.Fatalf("sandboxed Grep: %v", err)
+	}
+	if !strings.Contains(out, "needle") {
+		t.Fatalf("sandboxed Grep(%q) = %q, want a match for the needle in dir00/leaf.txt", "needle", out)
 	}
 }

--- a/agent/execenv/local.go
+++ b/agent/execenv/local.go
@@ -1743,7 +1743,7 @@ func (e *LocalExecutionEnvironment) GlobWithBudget(ctx context.Context, pattern 
 	if !includeIgnored {
 		// No masking concept off the sandboxed path: no-op skip.
 		var err error
-		ignores, err = loadIgnoreSet(fsys, nil)
+		ignores, err = loadIgnoreSet(fsys, nil, budget, ignoreScopeForPatterns(patterns))
 		if err != nil {
 			return nil, 0, err
 		}
@@ -1963,15 +1963,16 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 	// fs.WalkDir does not descend through directory symlinks, matching the
 	// secureDirFS policy on the sandboxed arm while retaining file-symlink
 	// behavior for the unsandboxed fallback.
-	fsys := cancelFS{ctx: ctx, fsys: os.DirFS(path)}
+	budget := newGlobBudget("grep")
+	fsys := cancelFS{ctx: ctx, fsys: boundedDirFS{FS: os.DirFS(path), budget: budget, ctx: ctx}}
 	// No masking concept off the sandboxed path: no-op skip.
 	ignoreFS := fsys
 	if singleFile {
 		// Preserve the old single-file behavior: ignore rules are rooted at the
 		// file argument, which cannot contain a .gitignore tree of its own.
-		ignoreFS = cancelFS{ctx: ctx, fsys: os.DirFS(filepath.Join(path, walkRoot))}
+		ignoreFS = cancelFS{ctx: ctx, fsys: boundedDirFS{FS: os.DirFS(filepath.Join(path, walkRoot)), budget: budget, ctx: ctx}}
 	}
-	ignores, err := loadIgnoreSet(ignoreFS, nil)
+	ignores, err := loadIgnoreSet(ignoreFS, nil, budget, wholeBaseIgnoreScope())
 	if err != nil {
 		return "", err
 	}
@@ -1982,6 +1983,19 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 			return cancelErr
 		}
 		if err != nil {
+			// loadIgnoreSet's walk above already visits every directory this
+			// one would — its skip set (dot-prefixed directories only) is a
+			// strict subset of this walk's (which also skips gitignored
+			// ones) — so it always reaches an oversized directory first on
+			// any static tree and this guard cannot be reached that way. It
+			// is reachable only when a directory grows past the entry bound
+			// in the gap between the two passes, which
+			// TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+			// forces by stubbing grepWalk itself to grow the tree after
+			// ignore discovery has already listed it.
+			if _, refused := errors.AsType[*globBudgetError](err); refused {
+				return err
+			}
 			return nil //nolint:nilerr // best-effort grep: skip unreadable entries and keep walking
 		}
 		relPath := filepath.FromSlash(p)
@@ -1998,6 +2012,16 @@ func (e *LocalExecutionEnvironment) grepNative(ctx context.Context, pattern, pat
 					excludedByIgnore++
 					return filepath.SkipDir
 				}
+			}
+			// fs.WalkDir never follows a directory symlink, so this walk
+			// cannot cycle back into itself the way the glob pattern walk's
+			// ancestor check has to guard against — the same reason ignore
+			// discovery's own budget charge is always cycleSafe. Charged
+			// only here, once the dot/gitignore skips above have already
+			// passed, so a directory the walk is about to skip anyway costs
+			// nothing.
+			if berr := budget.listing(true); berr != nil {
+				return berr
 			}
 			return nil
 		}

--- a/agent/execenv/sandbox_tools_ignoreset_unix_test.go
+++ b/agent/execenv/sandbox_tools_ignoreset_unix_test.go
@@ -48,10 +48,10 @@ func TestLoadIgnoreSetSkipsMaskedSubtree(t *testing.T) {
 	}
 	defer func() { _ = unix.Close(baseFd) }()
 
-	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs}
+	fsys := &secureDirFS{baseFd: baseFd, basePath: canonical, fs: sfs, budget: newGlobBudget("glob"), ctx: t.Context()}
 	set, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return sfs.underMasked(filepath.Join(canonical, relPath))
-	})
+	}, newGlobBudget("glob"), wholeBaseIgnoreScope())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/agent/execenv/search_patterns.go
+++ b/agent/execenv/search_patterns.go
@@ -291,18 +291,27 @@ type globBudgetError struct {
 	kind      globBudgetKind
 }
 
-// advice names the lever that makes a whole call's listing count smaller.
-// Every budget here belongs to a glob, whose pattern decides how much of the
-// tree gets listed, so tightening it is the first thing to try.
+// advice names the lever that makes a whole call's listing count smaller,
+// which differs by operation. A glob's pattern decides how much of the tree
+// gets listed, so tightening it is the first thing to try. A grep's pattern is
+// a regex matched against file contents after the walk has already listed
+// everything, so narrowing it changes nothing about the listings; only a
+// smaller base directory does.
 func (e *globBudgetError) advice() string {
+	if e.op == "grep" {
+		return "narrow the base directory"
+	}
 	return "narrow the pattern or its base directory"
 }
 
 // entryAdvice names the lever that gets a caller past one oversized
-// directory, the entries kind's counterpart to advice. Every budget here
-// belongs to a glob, which can spell a pattern that matches inside such a
-// directory without listing all of it.
+// directory, the entries kind's counterpart to advice. A glob can spell a
+// pattern that matches inside the directory without listing all of it; a grep
+// cannot, so its only lever is a base that does not contain it.
 func (e *globBudgetError) entryAdvice() string {
+	if e.op == "grep" {
+		return "that directory is too large to list, so point the base at a smaller directory that does not contain it"
+	}
 	return "that directory is too large to list, so match inside it more specifically or point the base elsewhere"
 }
 

--- a/agent/execenv/securepath_browse_fdops_unix.go
+++ b/agent/execenv/securepath_browse_fdops_unix.go
@@ -10,7 +10,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -37,13 +36,10 @@ type secureDirFS struct {
 	basePath string
 	fs       *sandboxFS
 	// budget bounds the entries a single ReadDir call may materialize, shared
-	// with the rest of the glob call's directory-listing budget. nil for a
-	// caller whose listing does not participate in that bound, in which case
-	// ReadDir falls back to reading the directory whole.
+	// with the rest of the glob or grep call's directory-listing budget.
 	budget *GlobBudget
 	// ctx is threaded down to readDirChunked the same way boundedDirFS.ctx is
-	// on the off-sandbox path; see that field for why. Only consulted when
-	// budget is set, since that is the only case that reads in chunks.
+	// on the off-sandbox path; see that field for why.
 	ctx context.Context
 }
 
@@ -58,15 +54,9 @@ func (f *secureDirFS) Open(name string) (fs.File, error) {
 	return os.NewFile(uintptr(fd), name), nil
 }
 
-// ReadDir lists name through readDirChunked when budget is set, the same
-// helper boundedDirFS uses on the off-sandbox path, so a huge directory here
-// cannot OOM the walk either. A caller with no budget reads the directory
-// whole and sorts it by name: os.DirFS's own ReadDir already returns entries
-// sorted, and the match cap downstream truncates to a deterministic,
-// lexically-first prefix of what a listing returns, so this arm has to
-// produce the same order or a capped walk here could stop on a different
-// prefix than the same walk over the plain filesystem. The raw fd-backed
-// listing both arms build on has no ordering guarantee of its own.
+// ReadDir lists name through readDirChunked, the same helper boundedDirFS
+// uses on the off-sandbox path, so a huge directory here cannot OOM the walk
+// either.
 func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	fd, err := openBeneathRoot(f.baseFd, name, unix.O_RDONLY|unix.O_DIRECTORY, 0)
 	if err != nil {
@@ -74,14 +64,6 @@ func (f *secureDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	}
 	df := os.NewFile(uintptr(fd), name)
 	defer func() { _ = df.Close() }()
-	if f.budget == nil {
-		entries, err := df.ReadDir(-1)
-		if err != nil {
-			return nil, err
-		}
-		slices.SortFunc(entries, func(x, y fs.DirEntry) int { return strings.Compare(x.Name(), y.Name()) })
-		return entries, nil
-	}
 	return readDirChunked(f.ctx, df, name, f.budget)
 }
 
@@ -136,9 +118,10 @@ func (s *sandboxFS) glob(ctx context.Context, tool, base, pattern string, includ
 		// Never list or read into a masked subtree while collecting
 		// .gitignore rules — secureDirFS enforces symlink-refusal and root
 		// confinement but not masking, so the skip must be supplied here.
+		var err error
 		ignores, err = loadIgnoreSet(fsys, func(relPath string) bool {
 			return s.underMasked(filepath.Join(canonical, relPath))
-		})
+		}, budget, ignoreScopeForPatterns(patterns))
 		if err != nil {
 			return nil, 0, err
 		}
@@ -203,12 +186,13 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 	if err != nil {
 		return "", err
 	}
-	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s}}
+	budget := newGlobBudget("grep")
+	fsys := cancelFS{ctx: ctx, fsys: &secureDirFS{baseFd: baseFd, basePath: canonical, fs: s, budget: budget, ctx: ctx}}
 	// Never list or read into a masked subtree while collecting .gitignore
 	// rules — see the matching comment in glob above.
 	ignores, err := loadIgnoreSet(fsys, func(relPath string) bool {
 		return s.underMasked(filepath.Join(canonical, relPath))
-	})
+	}, budget, wholeBaseIgnoreScope())
 	if err != nil {
 		return "", err
 	}
@@ -218,6 +202,19 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 			return cancelErr
 		}
 		if walkErr != nil {
+			// loadIgnoreSet's walk above already visits every directory this
+			// one would — its skip set (dot-prefixed and masked directories)
+			// is a strict subset of this walk's (which also skips gitignored
+			// ones) — so it always reaches an oversized directory first on
+			// any static tree and this guard cannot be reached that way. It
+			// is reachable only when a directory grows past the entry bound
+			// in the gap between the two passes, which
+			// TestSandboxedGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery
+			// forces by stubbing secureBrowseWalkDir itself to grow the tree
+			// after ignore discovery has already listed it.
+			if _, refused := errors.AsType[*globBudgetError](walkErr); refused {
+				return walkErr
+			}
 			return nil //nolint:nilerr // skip unreadable / symlink-refused entries and keep walking
 		}
 		abs := filepath.Join(canonical, rel)
@@ -236,6 +233,16 @@ func (s *sandboxFS) grepNative(ctx context.Context, pattern, base, globFilter st
 					excludedByIgnore++
 					return fs.SkipDir
 				}
+			}
+			// fs.WalkDir never follows a directory symlink, so this walk
+			// cannot cycle back into itself the way the glob pattern walk's
+			// ancestor check has to guard against — the same reason ignore
+			// discovery's own budget charge above is always cycleSafe.
+			// Charged only here, once the masked/dot/gitignore skips above
+			// have already passed, so a directory the walk is about to skip
+			// anyway costs nothing.
+			if berr := budget.listing(true); berr != nil {
+				return berr
 			}
 			return nil
 		}


### PR DESCRIPTION
Third of three stacked PRs for #497, on top of #955. **Base it on `fix/497-glob-budget-b`, not main.** #951 fixed the original defects, #955 bounded memory; this one budgets grep.

## What was wrong

- **Ignore discovery ran first and unbounded.** `loadIgnoreSet` walks the entire base collecting `.gitignore` rules *before* the traversal that follows it, so a glob or grep with the default `include_ignored: false` traversed the whole tree before any bound applied. `include_ignored: true` skips it, but that is not the default.
- **Grep's own walk had no bound at all.** `grepWalk` and `secureBrowseWalkDir` are plain `fs.WalkDir` seams; nothing charged them.

## What changed

- Ignore discovery's **scope** is now what the traversal after it can reach, rather than the whole base regardless of pattern. A rule collected in a directory only ever affects a path at or under that directory, so the rules that can touch a candidate live in its own ancestors: for each expanded pattern, discovery reads the `.gitignore` at every level from the base down to the pattern's meta-free prefix (one `fs.ReadFile` per level, no listing) and then walks that prefix's subtree under the budget. A pattern starting with a metacharacter has an empty prefix, so discovery walks everything — correct, because that pattern's own walk does too, and the budget then applies to both consistently.
- Ignore discovery spends the same budget the traversal after it spends, on both arms. Its refusal reaches the caller rather than being swallowed as a best-effort I/O error, because a partial ignoreSet reported as complete would silently under-exclude the rest of a huge tree. Every *other* error stays best-effort.
- Both `grepNative`s hoist one budget shared with their ignore discovery, wrap the filesystem they walk so entries are bounded too, and charge a listing per directory.
- The charge lands **after** the dot-prefix, gitignore and masked `SkipDir` checks in the same callback, so a directory the walk turns away from costs nothing. A tree with many excluded directories and few listed ones no longer fails on a budget it never spends.
- `secureDirFS.ReadDir`'s nil-budget fallback from #955 is removed: every construction site now supplies a budget, so listings always go through the chunked reader.

## Caller-visible changes

- **Grep can now fail where it used to return partial output**, on both the sandboxed and off-sandbox arms.
- **Ignore discovery can fail a call**, which affects glob and grep alike whenever `include_ignored` is false. It propagates every budget refusal, the live-entry ceiling included: its walk starts at the root and visits everything below it, so reaching that ceiling means the process is already carrying the memory the ceiling exists to prevent, and leaving a later walk to refuse would spend it first. `TestGlobIgnoreDiscoveryPropagatesTheLiveEntryRefusal` pins that.

## How it is tested

Fixture arithmetic is stated in each test's doc comment and isolates the walk's own charges from ignore discovery's. For example `TestGrepWalkDoesNotChargeSkippedDirectories`: 3 real, 20 dot-excluded and 10 gitignored directories against a budget of 25, where ignore discovery alone costs 14 and the walk legitimately adds 4 — above discovery's cost, below the budget, so headroom cannot hide a regression. Verified by mutation: moving the charge back above the skips fails it with `grep walk made 26 directory listings, past the budget of 25`.

The two walk-callback guards are **not** reachable by any static tree, for the same subset-and-ordering reason above. `TestGrepWalkCarriesTheEntriesRefusalWhenADirectoryGrowsAfterIgnoreDiscovery` and its sandboxed twin force the concurrent case by growing the directory inside a stubbed walk; both were mutation-verified against deleting the guard. The off-sandbox probe lives in a portable test file, since `grepWalk`'s guard is cross-platform and nothing in that probe needs Unix; only the sandboxed twin carries a build constraint.

Gates, all foreground, zero failures each: `gofmt`; `make vet` and `GOOS=windows make vet`; `go vet -tags evenerfuzz ./...`; `make lint-golangci`; `make lint-evenerfuzz lint-eval lint-gofmt lint-internal`; `go test -race ./agent/execenv/`; `-tags evenerfuzz -run Fuzz ./agent/execenv/`; full `go test ./agent/`.

Closes #938

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT
