### PR TITLE
test(agent): pin named-instance cheap model to the registry

### DIFF
--- a/agent/profile_test.go
+++ b/agent/profile_test.go
@@ -1780,16 +1780,19 @@ func TestNamedInstanceKeepsItsIdentity(t *testing.T) {
 		t.Fatalf("after WithModel = %s/%s/%s", rebuilt.ID(), rebuilt.ProviderID(), rebuilt.Model())
 	}
 	// The base's curated cheap_model rides along with the name.
-	if got := work.CheapModel(); got != "kimi-k2.5" {
-		t.Fatalf("CheapModel() = %q, want moonshotai's kimi-k2.5", got)
-	}
-	gemini := namedInstanceProfile("work-google", "google", "gemini-2.5-pro")
-	if got := gemini.CheapModel(); got != "gemini-2.5-flash-lite" {
-		t.Fatalf("CheapModel() = %q, want gemini-2.5-flash-lite", got)
-	}
-	anthropic := namedInstanceProfile("work-anthropic", "anthropic", "claude-opus-4-6")
-	if got := anthropic.CheapModel(); got != "claude-haiku-4-5" {
-		t.Fatalf("CheapModel() = %q, want claude-haiku-4-5", got)
+	for _, tc := range []struct{ name, base, model string }{
+		{"work-kimi", "moonshotai", "kimi-k2.5"},
+		{"work-google", "google", "gemini-2.5-pro"},
+		{"work-anthropic", "anthropic", "claude-opus-4-6"},
+	} {
+		want := baseProviderProfile(tc.base, tc.model).CheapModel()
+		if want == "" || want == tc.model {
+			t.Fatalf("%s curates no cheap model distinct from %q; the fixture proves nothing",
+				tc.base, tc.model)
+		}
+		if got := namedInstanceProfile(tc.name, tc.base, tc.model).CheapModel(); got != want {
+			t.Fatalf("%s CheapModel() = %q, want %s's curated %q", tc.name, got, tc.base, want)
+		}
 	}
 }
 

--- a/agent/profile_testhelpers_test.go
+++ b/agent/profile_testhelpers_test.go
@@ -188,6 +188,13 @@ func namedInstanceProfile(name, base, model string) *provider.Profile {
 	return resolveTestProfile(name, map[string]registry.Provider{name: {Base: base, APIKey: "test"}}, model)
 }
 
+// baseProviderProfile resolves model on the base provider itself, under its
+// own id. It is the reference a named instance's inherited facts are measured
+// against, so a catalog refresh moves both sides together.
+func baseProviderProfile(base, model string) *provider.Profile {
+	return resolveTestProfile(base, map[string]registry.Provider{base: {APIKey: "test"}}, model)
+}
+
 // namedOpenAIInstanceProfile is the fixture's renamed-openai instance profile:
 // an instance whose name differs from the provider id behind it.
 func namedOpenAIInstanceProfile(name, model string) *provider.Profile {


### PR DESCRIPTION
## What was wrong

`TestNamedInstanceKeepsItsIdentity` (agent/profile_test.go) has failed on main since **be6547e26**, which refreshed the embedded models.dev snapshot and moved moonshotai's curated `cheap_model` from `kimi-k2.5` to `kimi-k2.6` in `llm/registry/data/providers_overlay.toml`. CI's `tests` and `race-modules / agent` lanes have been red since 2026-09-06 22:20Z, and every branch cut from main inherits it.

**Mechanism.** The test's invariant is right: a named instance keeps its user-assigned name and inherits its base provider's curated cheap model. It stated that invariant by hardcoding the catalog's values, so `Profile.CheapModel()` — which reads the resolved record the registry inherits from the base — started returning the refreshed value while the literal stayed put:

```
profile_test.go:1784: CheapModel() = "kimi-k2.6", want moonshotai's kimi-k2.5
```

## What changed

Test-only. No production code, no catalog change.

The three cheap-model assertions now measure the named instance against **the same base provider resolved directly as an instance on the fixture registry the test already builds**, so a catalog refresh moves both sides together. A new `baseProviderProfile` helper in `agent/profile_testhelpers_test.go` is a two-line shim over the existing `resolveTestProfile`; no registry-record reader was needed, because the fixture registry resolves a base provider cleanly under its own id. The google and anthropic cases, fragile the same way but passing today, join the same table.

A fixture guard rejects a base that curates no cheap model distinct from the primary model. Without a curated value `CheapModel()` falls back to the primary (the `CheapModelRefDefaultsToPrimary` rule), which would make the equality vacuous. Nothing is relaxed to `!= ""`.

## Mutation evidence

The assertion still catches a lost inheritance. Clearing the inherited `CheapModel` in `record.inherit` (llm/registry/load.go) for an instance whose name differs from its base — leaving the base resolved under its own id untouched — fails the test:

```
profile_test.go:1794: work-kimi CheapModel() = "kimi-k2.5", want moonshotai's curated "kimi-k2.6"
```

(The mutation was reverted from a pre-mutation copy; `git diff llm/registry/load.go` is empty.)

## Gates

| Gate | Result |
| --- | --- |
| `gofmt -l` on both changed files | clean |
| `go vet ./...` (all 8 workspace modules) | clean |
| `go vet -tags evenerfuzz ./...` (all 8 modules) | clean |
| `make lint-golangci` (the CI invocation) | `PASS lint-golangci (52s)` |
| `GOMAXPROCS=4 go test ./agent/ -count=1 -timeout 40m` | `ok primeradiant.com/evener/agent 340.738s`, 0 FAIL |
| `make test-race RACE_SCOPE=agent` (the CI race lane) | `PASS agent 642.56s`, 0 FAIL, 0 DATA RACE |

Both previously-red lanes are green.

## Noted, not fixed

`TestProviderProfile_CheapModel` (agent/profile_test.go ~389) is catalog-derived the same way and will break on a future refresh, but it is not the same shape: its whole subject is "a profile reports its curated cheap model", so pinning it to the registry would make it tautological. Left alone deliberately.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT