### PR TITLE
Hub self-update from Settings (exec-in-place restart)

### DIFF
--- a/appwire/client.go
+++ b/appwire/client.go
@@ -639,6 +639,18 @@ func (c *Client) Upgrade(ctx context.Context, params UpgradeParams) (UpgradeResp
 	return out, err
 }
 
+func (c *Client) UpdateCheck(ctx context.Context, params UpdateCheckParams) (UpdateCheckResponse, error) {
+	var out UpdateCheckResponse
+	err := c.request(ctx, MethodEvenerUpdateCheck, params, &out)
+	return out, err
+}
+
+func (c *Client) UpdateApply(ctx context.Context, params UpdateApplyParams) (UpdateApplyResponse, error) {
+	var out UpdateApplyResponse
+	err := c.request(ctx, MethodEvenerUpdateApply, params, &out)
+	return out, err
+}
+
 func (c *Client) AuthStatus(ctx context.Context, params AuthStatusParams) (AuthStatusResponse, error) {
 	var out AuthStatusResponse
 	err := c.request(ctx, MethodEvenerAuthStatus, params, &out)

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -159,6 +159,8 @@ var Methods = []MethodSpec{
 	{MethodEvenerSearch, SearchParams{}, SearchResponse{}, ScopeHub, "Searches live and persisted sessions for the hub command palette."},
 	{MethodEvenerHarnessesList, HarnessListParams{}, HarnessListResponse{}, ScopeHub, "Lists available harness descriptors."},
 	{MethodEvenerUpgrade, UpgradeParams{}, UpgradeResponse{}, ScopeHub, "Performs or reports a evener binary upgrade."},
+	{MethodEvenerUpdateCheck, UpdateCheckParams{}, UpdateCheckResponse{}, ScopeHub, "Compares the running hub build against a release channel's current commit; dev builds report applicable=false without a network request."},
+	{MethodEvenerUpdateApply, UpdateApplyParams{}, UpdateApplyResponse{}, ScopeHub, "Downloads and installs a channel's build, then execs it in place of the running hub; refused on dev builds."},
 	{MethodEvenerAuthStatus, AuthStatusParams{}, AuthStatusResponse{}, ScopeHub, "Reports auth/credential status for a provider."},
 	{MethodEvenerAuthTest, AuthTestParams{}, AuthTestResponse{}, ScopeHub, "Tests the effective credentials for one configured provider instance without starting a session."},
 	{MethodEvenerAuthLoginStart, AuthLoginStartParams{}, AuthLoginStartResponse{}, ScopeHub, "Begins an OAuth login flow; returns a flow ID and URL."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -79,6 +79,8 @@ const (
 	MethodEvenerSearch                = "evener/search"
 	MethodEvenerHarnessesList         = "evener/harnesses/list"
 	MethodEvenerUpgrade               = "evener/upgrade"
+	MethodEvenerUpdateCheck           = "evener/update/check"
+	MethodEvenerUpdateApply           = "evener/update/apply"
 	MethodEvenerAuthStatus            = "evener/auth/status"
 	MethodEvenerAuthTest              = "evener/auth/test"
 	MethodEvenerAuthLoginStart        = "evener/auth/login/start"
@@ -2048,6 +2050,41 @@ type UpgradeResponse struct {
 	RestartMessage string   `json:"restartMessage"`
 }
 
+// UpdateCheckParams selects the channel to compare the running build against.
+// Empty means the running binary's own upgrade channel.
+type UpdateCheckParams struct {
+	Channel string `json:"channel,omitempty"`
+}
+
+// UpdateCheckResponse reports the running build and what the channel points
+// at. Applicable is false for dev builds, which are never self-updated; the
+// Latest* fields are empty then and no network request was made.
+type UpdateCheckResponse struct {
+	Channel         string `json:"channel"`
+	BuildChannel    string `json:"buildChannel"`
+	CurrentVersion  string `json:"currentVersion"`
+	CurrentCommit   string `json:"currentCommit"`
+	LatestTag       string `json:"latestTag,omitempty"`
+	LatestCommit    string `json:"latestCommit,omitempty"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	Applicable      bool   `json:"applicable"`
+}
+
+// UpdateApplyParams selects the channel to install. Empty means the running
+// binary's own upgrade channel.
+type UpdateApplyParams struct {
+	Channel string `json:"channel,omitempty"`
+}
+
+// UpdateApplyResponse is returned just before the hub execs the installed
+// binary in place; Restarting is always true on success.
+type UpdateApplyResponse struct {
+	Release    string   `json:"release"`
+	Channel    string   `json:"channel"`
+	Installed  []string `json:"installed"`
+	Restarting bool     `json:"restarting"`
+}
+
 type AuthStatusParams struct {
 	Provider string `json:"provider"`
 }
@@ -3178,6 +3215,8 @@ type SettingsHubOverview struct {
 	// Commit is the git commit the binary was built from; empty in dev builds.
 	// Source: web_settings.go settingsData.HubCommit (buildinfo.GitSHA).
 	Commit string `json:"commit,omitempty"`
+	// BuildChannel is buildinfo.BuildChannel(): release, snapshot, or dev.
+	BuildChannel string `json:"buildChannel,omitempty"`
 	// ListenAddr is the hub HTTP server's bind address.
 	// Source: web_settings.go settingsData.HubAddr (cfg.HubAddr).
 	ListenAddr string `json:"listenAddr,omitempty"`

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -1120,6 +1120,8 @@ const recentProjectDirsLimit = 15
 // focused controller registration.
 func registerMiscHandlers(server *appserver.Server, cfg hubcore.WebConfig, sources *appsource.Registry) {
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerUpgrade, hubUpgrade)
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerUpdateCheck, hubUpdateCheck)
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerUpdateApply, hubUpdateApply)
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSearch, func(_ context.Context, params appwire.SearchParams) (appwire.SearchResponse, error) {
 		return hubSearch(cfg, params), nil
 	})

--- a/cmd/evener-hub/app_rpc_settings_overview.go
+++ b/cmd/evener-hub/app_rpc_settings_overview.go
@@ -50,6 +50,7 @@ func settingsHubOverview(cfg hubcore.WebConfig) *appwire.SettingsHubOverview {
 	return &appwire.SettingsHubOverview{
 		Version:        Version,
 		Commit:         buildinfo.GitSHA,
+		BuildChannel:   buildinfo.BuildChannel(),
 		ListenAddr:     cfg.HubAddr,
 		RunDir:         cfg.RunDir,
 		SpawnTimeout:   settingsSpawnTimeoutDisplay,

--- a/cmd/evener-hub/app_rpc_settings_overview_test.go
+++ b/cmd/evener-hub/app_rpc_settings_overview_test.go
@@ -232,3 +232,14 @@ func TestHubRPCSettingsOverview_MCPDiscoveredEmptyWhenConfigMissing(t *testing.T
 		t.Errorf("McpDiscovered.Servers = %+v, want empty", resp.McpDiscovered.Servers)
 	}
 }
+
+func TestSettingsHubOverviewReportsBuildChannel(t *testing.T) {
+	previous := buildinfo.Channel
+	buildinfo.Channel = "snapshot"
+	t.Cleanup(func() { buildinfo.Channel = previous })
+
+	got := settingsHubOverview(hubcore.WebConfig{})
+	if got.BuildChannel != "snapshot" {
+		t.Fatalf("BuildChannel = %q, want snapshot", got.BuildChannel)
+	}
+}

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11874,6 +11874,8 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodEvenerLaunchSetLayer,
 		appwire.MethodEvenerLaunchTrustRepo,
 		appwire.MethodEvenerUpgrade,
+		appwire.MethodEvenerUpdateCheck,
+		appwire.MethodEvenerUpdateApply,
 		appwire.MethodModelList,
 		appwire.MethodEvenerTasksList,
 		appwire.MethodEvenerJobsList,

--- a/cmd/evener-hub/app_update.go
+++ b/cmd/evener-hub/app_update.go
@@ -24,10 +24,11 @@ import (
 // Test seams: the GitHub check, the exec-in-place restart, and the restart
 // goroutine's log destination.
 var (
-	runHubUpdateCheck            = selfupdate.Check
-	scheduleHubRestart           = scheduleHubRestartAfterResponse
-	execHubBinary                = selfupdate.Restart
-	hubUpdateStderr    io.Writer = os.Stderr
+	runHubUpdateCheck             = selfupdate.Check
+	scheduleHubRestart            = scheduleHubRestartAfterResponse
+	execHubBinary                 = selfupdate.Restart
+	hubRestartSupported           = selfupdate.RestartSupported
+	hubUpdateStderr     io.Writer = os.Stderr
 )
 
 // hubRestartDelay is a short grace period for the kernel to flush the apply
@@ -122,6 +123,13 @@ func hubUpdateApply(ctx context.Context, params appwire.UpdateApplyParams) (appw
 	channel, err := validateUpdateChannel(params.Channel)
 	if err != nil {
 		return appwire.UpdateApplyResponse{}, err
+	}
+	// Fail fast where the in-place restart cannot run: without this the
+	// apply would download and install, report Restarting:true, and only
+	// then fail in the post-response goroutine -- leaving the frontend to
+	// poll a hub that never restarts. hubUpgrade (no exec) stays allowed.
+	if !hubRestartSupported() {
+		return appwire.UpdateApplyResponse{}, errors.New("in-place restart is not supported on this platform; use evener/upgrade and restart manually")
 	}
 	if err := tryLockHubUpdate(); err != nil {
 		return appwire.UpdateApplyResponse{}, err

--- a/cmd/evener-hub/app_update.go
+++ b/cmd/evener-hub/app_update.go
@@ -131,6 +131,26 @@ func hubUpdateApply(ctx context.Context, params appwire.UpdateApplyParams) (appw
 	if !hubRestartSupported() {
 		return appwire.UpdateApplyResponse{}, errors.New("in-place restart is not supported on this platform; use evener/upgrade and restart manually")
 	}
+	// Re-check server-side before installing: the store refuses stale
+	// checks, but a direct RPC (or a check that went stale in flight)
+	// would otherwise download, reinstall, and exec an identical build --
+	// and the frontend poll keys on a version change, so a no-op restart
+	// ends in a misleading restart-timeout. Runs before the lock: there
+	// is nothing to serialize when no install follows.
+	fresh, err := runHubUpdateCheck(ctx, selfupdate.CheckOptions{
+		Channel:    channel,
+		CurrentSHA: buildinfo.GitSHA,
+	})
+	if err != nil {
+		return appwire.UpdateApplyResponse{}, err
+	}
+	if !fresh.UpdateAvailable {
+		return appwire.UpdateApplyResponse{
+			Release:    fresh.LatestTag,
+			Channel:    fresh.Channel,
+			Restarting: false,
+		}, nil
+	}
 	if err := tryLockHubUpdate(); err != nil {
 		return appwire.UpdateApplyResponse{}, err
 	}
@@ -335,8 +355,11 @@ func scheduleHubRestartAfterResponse(ctx context.Context, pin restartPin, binary
 			// O_CLOEXEC so a successful Exec drops the lock exactly as
 			// the new image takes over; on failure release it here.
 			// A short timeout: a stuck holder must abort the restart,
-			// not strand the hub past its health-poll window.
-			relockCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			// not strand the hub past its health-poll window. The bound
+			// stays well under the frontend's 30s restart poll (plus the
+			// post-response delay above) so a contended-but-successful
+			// restart still lands before the UI declares a timeout.
+			relockCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			release, err := selfupdate.AcquireInstallLockForVerify(relockCtx, pin.shareBinDir)
 			cancel()
 			if err != nil {

--- a/cmd/evener-hub/app_update.go
+++ b/cmd/evener-hub/app_update.go
@@ -1,0 +1,359 @@
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/buildinfo"
+	"primeradiant.com/evener/envvars"
+	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+// Test seams: the GitHub check, the exec-in-place restart, and the restart
+// goroutine's log destination.
+var (
+	runHubUpdateCheck            = selfupdate.Check
+	scheduleHubRestart           = scheduleHubRestartAfterResponse
+	execHubBinary                = selfupdate.Restart
+	hubUpdateStderr    io.Writer = os.Stderr
+)
+
+// hubRestartDelay is a short grace period for the kernel to flush the apply
+// response frame the send loop has just written; the restart itself already
+// waits for that write (see scheduleHubRestartAfterResponse). A var, not a
+// const, so tests can set it to 0.
+var hubRestartDelay = 500 * time.Millisecond
+
+// hubUpgradeTimeout is the one overall deadline for a complete upgrade
+// operation: archive download + checksums download + verify + install.
+// The per-request http.Client timeout (selfupdate.defaultUpgradeTimeout)
+// applies to each download separately and the two can add up, so without
+// an operation bound a valid update can outlive the frontend's apply
+// timeout and strand the page. Both hubUpdateApply and hubUpgrade funnel
+// through runHubSelfUpgradeWithTimeout. A var so tests can shrink it.
+var hubUpgradeTimeout = 4 * time.Minute
+
+// hubUpdateMu serializes evener/update/apply: copyExecutable in
+// internal/selfupdate writes a fixed dst+".tmp" path, so a second apply
+// racing the first would corrupt the binary a restart is about to exec.
+// It is deliberately left locked after a successful upgrade schedules a
+// restart -- the process is about to be replaced, so a second apply
+// afterward must also be refused, not merely serialized.
+var hubUpdateMu sync.Mutex
+
+// tryLockHubUpdate acquires hubUpdateMu for the two RPCs that can install a
+// new hub binary (evener/update/apply and evener/upgrade), returning the
+// shared "already in progress" error when the other one already holds it.
+func tryLockHubUpdate() error {
+	if !hubUpdateMu.TryLock() {
+		return errors.New("a hub update is already in progress")
+	}
+	return nil
+}
+
+// isDevBuild reports whether this hub was built without a release channel
+// (a worktree build). Such a hub is never self-updated: replacing it with a
+// release binary would silently discard whatever the developer is running.
+func isDevBuild() bool { return buildinfo.BuildChannel() == "dev" }
+
+// validateUpdateChannel resolves requested (defaulting to the build's own
+// upgrade channel) and rejects anything but "release" or "snapshot" --
+// unlike selfupdate.Upgrade's ResolveTarget, which also accepts "current",
+// "latest", and arbitrary "v*" tags. Applying an arbitrary release tag would
+// let evener/update/apply install and exec whatever the caller names.
+func validateUpdateChannel(requested string) (string, error) {
+	ch := envvars.FirstNonEmpty(requested, buildinfo.UpgradeChannel())
+	switch ch {
+	case "release", "snapshot":
+		return ch, nil
+	default:
+		return "", fmt.Errorf("unknown update channel %q", ch)
+	}
+}
+
+// hubUpdateCheck answers evener/update/check: compare the running build to
+// the channel's current commit. Dev builds answer locally.
+func hubUpdateCheck(ctx context.Context, params appwire.UpdateCheckParams) (appwire.UpdateCheckResponse, error) {
+	channel, err := validateUpdateChannel(params.Channel)
+	if err != nil {
+		return appwire.UpdateCheckResponse{}, err
+	}
+	resp := appwire.UpdateCheckResponse{
+		Channel:        channel,
+		BuildChannel:   buildinfo.BuildChannel(),
+		CurrentVersion: buildinfo.Version(),
+		CurrentCommit:  buildinfo.GitSHA,
+	}
+	if isDevBuild() {
+		return resp, nil
+	}
+	result, err := runHubUpdateCheck(ctx, selfupdate.CheckOptions{
+		Channel:    resp.Channel,
+		CurrentSHA: buildinfo.GitSHA,
+	})
+	if err != nil {
+		return appwire.UpdateCheckResponse{}, err
+	}
+	resp.LatestTag = result.LatestTag
+	resp.LatestCommit = result.LatestCommit
+	resp.UpdateAvailable = result.UpdateAvailable
+	resp.Applicable = true
+	return resp, nil
+}
+
+// hubUpdateApply answers evener/update/apply: install the channel's build,
+// then exec it in place once this response has gone out.
+func hubUpdateApply(ctx context.Context, params appwire.UpdateApplyParams) (appwire.UpdateApplyResponse, error) {
+	if isDevBuild() {
+		return appwire.UpdateApplyResponse{}, errors.New("this hub is a dev build; rebuild with make build-hub instead of self-updating")
+	}
+	channel, err := validateUpdateChannel(params.Channel)
+	if err != nil {
+		return appwire.UpdateApplyResponse{}, err
+	}
+	if err := tryLockHubUpdate(); err != nil {
+		return appwire.UpdateApplyResponse{}, err
+	}
+	unlockOnReturn := true
+	defer func() {
+		if unlockOnReturn {
+			hubUpdateMu.Unlock()
+		}
+	}()
+
+	prefix, binDir, shareBinDir := hubInstallDirs()
+	result, err := runHubSelfUpgradeWithTimeout(ctx, selfupdate.Options{
+		Requested:      channel,
+		CurrentChannel: buildinfo.UpgradeChannel(),
+		Prefix:         prefix,
+		BinDir:         binDir,
+		ShareBinDir:    shareBinDir,
+	})
+	if err != nil {
+		return appwire.UpdateApplyResponse{}, err
+	}
+	binary, err := evenerBinaryFrom(channel, result.Installed)
+	if err != nil {
+		return appwire.UpdateApplyResponse{}, err
+	}
+	// Pin the installed binary to the digest Upgrade computed while the
+	// install lock was held: the lock releases at Upgrade return but the
+	// exec runs ~500ms later after the response flush, and a concurrent
+	// installer could swap the binary in between. The restart goroutine
+	// re-verifies and aborts rather than exec'ing a different release
+	// than reported. A missing digest (or unreadable binary) aborts the
+	// apply: silently skipping verification would exec an unverified
+	// binary, and fictional stub paths must not reach a real restart.
+	entry := restartBinary(binary)
+	digest, ok := result.InstalledSHA256[binary]
+	if !ok || digest == "" {
+		return appwire.UpdateApplyResponse{}, fmt.Errorf("upgrade to %s reported no digest for %s; refusing to restart unverified", channel, binary)
+	}
+	pin := restartPin{path: entry, sha256Hex: digest, shareBinDir: result.ShareBinDir}
+	if _, err := os.Stat(entry); err != nil {
+		return appwire.UpdateApplyResponse{}, err
+	}
+	// The process is about to be replaced: leave hubUpdateMu held so a
+	// second apply after this one is also refused.
+	unlockOnReturn = false
+	scheduleHubRestart(ctx, pin, entry, hubRestartArgs(hubProcessArgs()))
+	return appwire.UpdateApplyResponse{
+		Release:    result.Release,
+		Channel:    result.Channel,
+		Installed:  result.Installed,
+		Restarting: true,
+	}, nil
+}
+
+// runHubSelfUpgradeWithTimeout runs one upgrade operation under the
+// overall hubUpgradeTimeout deadline, so stacked per-request timeouts can
+// never push a valid update past what the frontend waits for.
+func runHubSelfUpgradeWithTimeout(ctx context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+	ctx, cancel := context.WithTimeout(ctx, hubUpgradeTimeout)
+	defer cancel()
+	return runHubSelfUpgrade(ctx, opts)
+}
+
+// hubInstallDirs derives the install layout for a self-update from the
+// running hub binary, so a hub installed under /usr/local (or any other
+// prefix) upgrades that installation instead of the ~/.local default.
+// It prefers the INVOCATION path (argv[0]): on Linux os.Executable
+// pre-resolves /proc/self/exe to the share target, making a custom-BINDIR
+// symlink invisible, while argv[0] still names the launched entrypoint.
+// Falls back to os.Executable when argv is empty. Unknown layouts
+// (worktree builds, ad-hoc paths) return empty strings and
+// selfupdate.Upgrade falls back to its own defaults.
+func hubInstallDirs() (prefix, binDir, shareBinDir string) {
+	if args := hubProcessArgs(); len(args) > 0 && args[0] != "" {
+		if prefix, binDir, shareBinDir := selfupdate.InstallDirsFromExecutable(canonicalInvocationPath(args[0])); prefix != "" || binDir != "" {
+			return prefix, binDir, shareBinDir
+		}
+	}
+	exe, err := hubExecutable()
+	if err != nil || exe == "" {
+		return "", "", ""
+	}
+	return selfupdate.InstallDirsFromExecutable(exe)
+}
+
+// canonicalInvocationPath normalizes argv[0] for layout derivation: a bare
+// name (`evener`, as launched via PATH) resolves through exec.LookPath, and
+// a relative path absolutizes against the working directory -- so symlink
+// resolution and layout comparisons below always run on a canonical path
+// instead of comparing relative against absolute inconsistently.
+func canonicalInvocationPath(argv0 string) string {
+	if !strings.Contains(argv0, string(filepath.Separator)) {
+		if resolved, err := exec.LookPath(argv0); err == nil {
+			argv0 = resolved
+		}
+	}
+	if abs, err := filepath.Abs(argv0); err == nil {
+		argv0 = abs
+	}
+	return argv0
+}
+
+// hubRestartArgs returns argv[1:] for the exec-in-place restart, guarding
+// the empty-argv case the same way currentExecutable does: slicing an
+// empty slice panics, and a hub launched with no args restarts bare.
+func hubRestartArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	return args[1:]
+}
+
+// restartBinary picks the path to exec for the in-place restart: the
+// canonical original argv[0] entrypoint when it resolves to the newly
+// installed binary, else the installed path itself. Exec'ing the
+// entrypoint preserves a custom BINDIR across restarts -- after the first
+// update the process image is the new binary either way, but argv[0] as
+// the user launched it keeps the NEXT update's derivation anchored to
+// the configured symlink dir instead of the standard <prefix>/bin.
+func restartBinary(installed string) string {
+	if args := hubProcessArgs(); len(args) > 0 && args[0] != "" {
+		entry := canonicalInvocationPath(args[0])
+		if resolved, err := filepath.EvalSymlinks(entry); err == nil && resolved == installed {
+			return entry
+		}
+	}
+	return installed
+}
+
+// restartPin identifies one installed binary across the lock-release to
+// exec window: the exec path plus the SHA-256 of its bytes as committed
+// under the install lock. (Not an fd: Go opens O_CLOEXEC, so a held lock
+// drops at exec.) The restart goroutine re-verifies immediately before
+// Exec and aborts loudly instead of exec'ing a concurrent installer's
+// release.
+type restartPin struct {
+	path        string
+	sha256Hex   string
+	shareBinDir string
+}
+
+// pinInstalledBinary records the identity of the just-installed binary.
+func pinInstalledBinary(path string) (restartPin, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return restartPin{}, err
+	}
+	sum := sha256.Sum256(data)
+	return restartPin{path: path, sha256Hex: hex.EncodeToString(sum[:])}, nil
+}
+
+// verifyPinnedBinary reports whether path still holds the pinned bytes.
+// Always verifies: there is no skip path, so a pinning failure aborts
+// the restart instead of silently disabling the check.
+func verifyPinnedBinary(path string, pin restartPin) error {
+	got, err := pinInstalledBinary(path)
+	if err != nil {
+		return err
+	}
+	if got.sha256Hex != pin.sha256Hex {
+		return errors.New("installed binary changed since upgrade; refusing to exec a different release")
+	}
+	return nil
+}
+
+// result. installExtractedBinaries also installs "evener-dev" alongside it,
+// so the entry to exec into can't be assumed to be Installed[0].
+func evenerBinaryFrom(channel string, installed []string) (string, error) {
+	for _, path := range installed {
+		if filepath.Base(path) == "evener" {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("upgrade to %s installed no evener binary", channel)
+}
+
+// scheduleHubRestartAfterResponse execs binary with the hub's own arguments
+// once the apply response has been written to the websocket -- the frontend
+// needs that success result to start its health poll, so replacing the
+// process image before the frame goes out would strand the page. When there
+// is no frame to wait for -- ctx carries no appserver connection (a direct
+// call in a test, a non-websocket caller), or the socket died during the
+// install and the send loop has already stopped -- the restart runs
+// immediately, because a hub that never restarts also never releases
+// hubUpdateMu.
+// hubUpdateMu is held across the exec attempt (see its doc comment); on
+// failure the old hub keeps running, so the lock is released here too, or
+// every later apply/upgrade would be refused forever.
+func scheduleHubRestartAfterResponse(ctx context.Context, pin restartPin, binary string, args []string) {
+	restart := func() {
+		go func() {
+			time.Sleep(hubRestartDelay)
+			_, _ = fmt.Fprintf(hubUpdateStderr, "[hub] self-update: restarting as %s\n", binary)
+			abort := func(format string, args ...any) {
+				hubUpdateMu.Unlock()
+				_, _ = fmt.Fprintf(hubUpdateStderr, "[hub] self-update: "+format+"\n", args...)
+			}
+			// Re-acquire the cross-process install lock for the
+			// verify+exec critical section: the install lock released
+			// at Upgrade return, and a concurrent installer could swap
+			// the binary between a bare re-verify and Exec. The fd is
+			// O_CLOEXEC so a successful Exec drops the lock exactly as
+			// the new image takes over; on failure release it here.
+			// A short timeout: a stuck holder must abort the restart,
+			// not strand the hub past its health-poll window.
+			relockCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			release, err := selfupdate.AcquireInstallLockForVerify(relockCtx, pin.shareBinDir)
+			cancel()
+			if err != nil {
+				abort("restart aborted: install lock unavailable: %v", err)
+				return
+			}
+			// The install lock released at Upgrade return; re-verify the
+			// binary is still the one just installed before exec'ing --
+			// a concurrent installer may have swapped it meanwhile.
+			// Abort loudly (old hub keeps running, lock released) rather
+			// than exec a different release than the response reported.
+			if err := verifyPinnedBinary(binary, pin); err != nil {
+				release()
+				abort("restart aborted: %v", err)
+				return
+			}
+			if err := execHubBinary(binary, args); err != nil {
+				release()
+				abort("restart failed, still running the previous binary: %v", err)
+			}
+			// On success Exec replaces the image (dropping the O_CLOEXEC
+			// lock fd); release() is intentionally not called.
+		}()
+	}
+	if !appserver.AfterResponseWritten(ctx, restart) {
+		restart()
+	}
+}

--- a/cmd/evener-hub/app_update.go
+++ b/cmd/evener-hub/app_update.go
@@ -135,12 +135,11 @@ func hubUpdateApply(ctx context.Context, params appwire.UpdateApplyParams) (appw
 	// checks, but a direct RPC (or a check that went stale in flight)
 	// would otherwise download, reinstall, and exec an identical build --
 	// and the frontend poll keys on a version change, so a no-op restart
-	// ends in a misleading restart-timeout. Runs before the lock: there
-	// is nothing to serialize when no install follows.
-	fresh, err := runHubUpdateCheck(ctx, selfupdate.CheckOptions{
-		Channel:    channel,
-		CurrentSHA: buildinfo.GitSHA,
-	})
+	// ends in a misleading restart-timeout. Compose through hubUpdateCheck
+	// (the typed handler) so the option-build and result interpretation
+	// stay in one place. Runs before the lock: there is nothing to
+	// serialize when no install follows.
+	fresh, err := hubUpdateCheck(ctx, appwire.UpdateCheckParams{Channel: channel})
 	if err != nil {
 		return appwire.UpdateApplyResponse{}, err
 	}

--- a/cmd/evener-hub/app_update_deadline_test.go
+++ b/cmd/evener-hub/app_update_deadline_test.go
@@ -1,0 +1,77 @@
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+// TestHubUpdateApplyBoundsTheWholeUpgrade proves the apply path enforces
+// one overall deadline for the complete operation (archive download +
+// checksums download + verify + install), not per-request timeouts that
+// add up: the stub blocks until the passed context expires, and the apply
+// must fail within the overall bound. Fails today because hubUpdateApply
+// passes the caller's unbounded context straight through.
+func TestHubUpdateApplyBoundsTheWholeUpgrade(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previous := hubUpgradeTimeout
+	hubUpgradeTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { hubUpgradeTimeout = previous })
+
+	stubHubSelfUpgrade(t, func(ctx context.Context, _ selfupdate.Options) (selfupdate.Result, error) {
+		<-ctx.Done()
+		return selfupdate.Result{}, ctx.Err()
+	})
+	stubScheduleRestart(t)
+
+	start := time.Now()
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected a deadline error from a stuck upgrade")
+	}
+	if elapsed > 30*time.Second {
+		t.Fatalf("apply took %v with a 200ms overall bound; the operation has no overall deadline", elapsed)
+	}
+}
+
+// TestHubUpgradeBoundsTheWholeUpgrade proves evener/upgrade (the TUI path)
+// shares the same overall deadline: it funnels through the same helper.
+func TestHubUpgradeBoundsTheWholeUpgrade(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previous := hubUpgradeTimeout
+	hubUpgradeTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { hubUpgradeTimeout = previous })
+
+	stubHubSelfUpgrade(t, func(ctx context.Context, _ selfupdate.Options) (selfupdate.Result, error) {
+		<-ctx.Done()
+		return selfupdate.Result{}, ctx.Err()
+	})
+
+	start := time.Now()
+	_, err := hubUpgrade(context.Background(), appwire.UpgradeParams{})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected a deadline error from a stuck upgrade")
+	}
+	if elapsed > 30*time.Second {
+		t.Fatalf("upgrade took %v with a 200ms overall bound; the operation has no overall deadline", elapsed)
+	}
+}
+
+// TestHubUpgradeTimeoutDefaultClearsServerBound pins the shipped default:
+// two back-to-back 5-minute per-request timeouts plus verify/install must
+// fit inside it, and the frontend's APPLY_TIMEOUT_MS (6min, asserted in
+// hubUpdate.test.ts) must clear it in turn -- otherwise a valid update
+// outlives the page's wait and strands the UI after the hub restarts.
+func TestHubUpgradeTimeoutDefaultClearsServerBound(t *testing.T) {
+	if hubUpgradeTimeout <= 0 {
+		t.Fatalf("hubUpgradeTimeout = %v, want a positive overall deadline", hubUpgradeTimeout)
+	}
+	if hubUpgradeTimeout >= 6*time.Minute {
+		t.Fatalf("hubUpgradeTimeout = %v, want it under the frontend APPLY_TIMEOUT_MS (6min)", hubUpgradeTimeout)
+	}
+}

--- a/cmd/evener-hub/app_update_deadline_test.go
+++ b/cmd/evener-hub/app_update_deadline_test.go
@@ -17,6 +17,7 @@ import (
 // passes the caller's unbounded context straight through.
 func TestHubUpdateApplyBoundsTheWholeUpgrade(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	previous := hubUpgradeTimeout
 	hubUpgradeTimeout = 200 * time.Millisecond
 	t.Cleanup(func() { hubUpgradeTimeout = previous })

--- a/cmd/evener-hub/app_update_invocation_test.go
+++ b/cmd/evener-hub/app_update_invocation_test.go
@@ -1,0 +1,203 @@
+package hub
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+// TestHubUpdateApplyPrefersInvocationPath proves the derivation uses the
+// INVOCATION path (argv[0]) first: on Linux os.Executable pre-resolves
+// /proc/self/exe to the share target, making a custom-BINDIR symlink
+// invisible, while argv[0] still names the symlink the user launched.
+// Fails today: hubInstallDirs reads only hubExecutable().
+func TestHubUpdateApplyPrefersInvocationPath(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	root := t.TempDir()
+	shareBin := filepath.Join(root, "share", "evener", "bin")
+	if err := os.MkdirAll(shareBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(shareBin, "evener")
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	customBin := filepath.Join(t.TempDir(), "custom-bin")
+	if err := os.MkdirAll(customBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(customBin, "evener")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	previousExe, previousArgs := hubExecutable, hubProcessArgs
+	// Simulate Linux: Executable pre-resolved, argv[0] still the symlink.
+	hubExecutable = func() (string, error) { return target, nil }
+	hubProcessArgs = func() []string { return []string{link, "hub"} }
+	t.Cleanup(func() { hubExecutable, hubProcessArgs = previousExe, previousArgs })
+
+	var gotOpts selfupdate.Options
+	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return stubInstalledResult(t, filepath.Join(shareBin, "evener")), nil
+	})
+	stubScheduleRestart(t)
+
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.Prefix != root {
+		t.Fatalf("Prefix = %q, want %q", gotOpts.Prefix, root)
+	}
+	if gotOpts.BinDir != customBin {
+		t.Fatalf("BinDir = %q, want the invocation dir %q", gotOpts.BinDir, customBin)
+	}
+	if gotOpts.ShareBinDir != shareBin {
+		t.Fatalf("ShareBinDir = %q, want %q", gotOpts.ShareBinDir, shareBin)
+	}
+}
+
+// TestHubUpdateApplyResolvesBarePathInvocation proves a hub launched as
+// a bare name via PATH (`evener hub`, argv[0]=="evener") still derives the
+// real entrypoint: hubInstallDirs resolves through exec.LookPath before
+// derivation. Fails today: the bare name goes to EvalSymlinks
+// cwd-relative, misses, and falls back to Executable (pre-resolved share
+// target on Linux), losing the custom BINDIR.
+func TestHubUpdateApplyResolvesBarePathInvocation(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	root := t.TempDir()
+	shareBin := filepath.Join(root, "share", "evener", "bin")
+	if err := os.MkdirAll(shareBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(shareBin, "evener")
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	customBin := filepath.Join(t.TempDir(), "custom-bin")
+	if err := os.MkdirAll(customBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(customBin, "evener")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	previousExe, previousArgs := hubExecutable, hubProcessArgs
+	hubExecutable = func() (string, error) { return target, nil }
+	hubProcessArgs = func() []string { return []string{"evener", "hub"} }
+	t.Cleanup(func() { hubExecutable, hubProcessArgs = previousExe, previousArgs })
+	t.Setenv("PATH", customBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var gotOpts selfupdate.Options
+	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return stubInstalledResult(t, filepath.Join(shareBin, "evener")), nil
+	})
+	stubScheduleRestart(t)
+
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.BinDir != customBin {
+		t.Fatalf("BinDir = %q, want PATH-resolved entrypoint %q", gotOpts.BinDir, customBin)
+	}
+}
+
+// TestHubRestartArgsEmptyWhenNoArgs proves the restart never panics when
+// the process was launched with no argv beyond (or an empty) argv[0]:
+// hubProcessArgs()[1:] on an empty slice panics. Fails today at
+// app_update.go's scheduleHubRestart call site.
+func TestHubRestartArgsEmptyWhenNoArgs(t *testing.T) {
+	for _, args := range [][]string{nil, {}, {"/x/evener"}} {
+		if got := hubRestartArgs(args); len(got) != 0 {
+			t.Fatalf("hubRestartArgs(%v) = %v, want empty", args, got)
+		}
+	}
+	if got := hubRestartArgs([]string{"/x/evener", "hub", "-addr", "x"}); len(got) != 3 || got[0] != "hub" {
+		t.Fatalf("hubRestartArgs = %v, want [hub -addr x]", got)
+	}
+}
+
+// TestHubRestartPreservesEntrypoint proves the restart execs the original
+// argv[0] entrypoint when it resolves to the newly installed binary: a
+// custom-BINDIR hub keeps launching through its configured symlink, so
+// the NEXT update still derives the custom dir. Falls back to the
+// installed path when argv is empty or points elsewhere.
+func TestHubRestartPreservesEntrypoint(t *testing.T) {
+	root := t.TempDir()
+	shareBin := filepath.Join(root, "share", "evener", "bin")
+	if err := os.MkdirAll(shareBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	installed := filepath.Join(shareBin, "evener")
+	if err := os.WriteFile(installed, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	customBin := filepath.Join(t.TempDir(), "custom-bin")
+	if err := os.MkdirAll(customBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(customBin, "evener")
+	if err := os.Symlink(installed, link); err != nil {
+		t.Fatal(err)
+	}
+
+	previousArgs := hubProcessArgs
+	t.Cleanup(func() { hubProcessArgs = previousArgs })
+
+	hubProcessArgs = func() []string { return []string{link, "hub"} }
+	if got := restartBinary(installed); got != link {
+		t.Fatalf("restartBinary = %q, want the entrypoint %q", got, link)
+	}
+	hubProcessArgs = func() []string { return []string{"/elsewhere/evener", "hub"} }
+	if got := restartBinary(installed); got != installed {
+		t.Fatalf("restartBinary = %q, want installed fallback %q", got, installed)
+	}
+	hubProcessArgs = func() []string { return nil }
+	if got := restartBinary(installed); got != installed {
+		t.Fatalf("restartBinary = %q, want installed fallback %q", got, installed)
+	}
+}
+
+// TestHubRestartAbortsWhenBinarySwapped proves the restart verifies the
+// installed binary is still the one Upgrade wrote: a concurrent installer
+// swapping the path in the lock-release-to-exec window must abort the
+// restart (loud log, lock released, old hub keeps running) rather than
+// exec a different release than the response reported. Fails today: the
+// exec path carries no identity to check.
+func TestHubRestartAbortsWhenBinarySwapped(t *testing.T) {
+	dir := t.TempDir()
+	installed := filepath.Join(dir, "evener")
+	if err := os.WriteFile(installed, []byte("our release"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pinned, err := pinInstalledBinary(installed)
+	if err != nil {
+		t.Fatalf("pin: %v", err)
+	}
+	// Concurrent installer swaps the path.
+	if err := os.WriteFile(installed, []byte("stranger release"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyPinnedBinary(installed, pinned); err == nil {
+		t.Fatal("expected a mismatch error after the binary was swapped")
+	}
+	if err := os.WriteFile(installed, []byte("our release"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Same bytes, but rewrite... content hash matches again only if the
+	// swap wrote identical bytes; use a fresh pin for the positive case.
+	pinned2, err := pinInstalledBinary(installed)
+	if err != nil {
+		t.Fatalf("pin2: %v", err)
+	}
+	if err := verifyPinnedBinary(installed, pinned2); err != nil {
+		t.Fatalf("unswapped binary rejected: %v", err)
+	}
+}

--- a/cmd/evener-hub/app_update_invocation_test.go
+++ b/cmd/evener-hub/app_update_invocation_test.go
@@ -17,6 +17,7 @@ import (
 // Fails today: hubInstallDirs reads only hubExecutable().
 func TestHubUpdateApplyPrefersInvocationPath(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	root := t.TempDir()
 	shareBin := filepath.Join(root, "share", "evener", "bin")
 	if err := os.MkdirAll(shareBin, 0o755); err != nil {
@@ -70,6 +71,7 @@ func TestHubUpdateApplyPrefersInvocationPath(t *testing.T) {
 // target on Linux), losing the custom BINDIR.
 func TestHubUpdateApplyResolvesBarePathInvocation(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	root := t.TempDir()
 	shareBin := filepath.Join(root, "share", "evener", "bin")
 	if err := os.MkdirAll(shareBin, 0o755); err != nil {

--- a/cmd/evener-hub/app_update_platform_test.go
+++ b/cmd/evener-hub/app_update_platform_test.go
@@ -1,0 +1,36 @@
+package hub
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+// TestHubUpdateApplyRefusesUnsupportedRestart proves apply fails fast when
+// the platform cannot exec-in-place: today hubUpdateApply returns
+// Restarting:true unconditionally, and on !unix the post-response goroutine
+// fails in execHubBinary (= selfupdate.Restart, which always errors there)
+// while the RPC already reported success -- so the frontend polls 30s and
+// times out on an old hub that keeps running. Fails today: no platform
+// guard exists.
+func TestHubUpdateApplyRefusesUnsupportedRestart(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previous := hubRestartSupported
+	hubRestartSupported = func() bool { return false }
+	t.Cleanup(func() { hubRestartSupported = previous })
+
+	upgrades := stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{}, nil
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"})
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Fatalf("err = %v, want an unsupported-platform refusal", err)
+	}
+	if *upgrades != 0 || len(*restarts) != 0 {
+		t.Fatalf("upgrades=%d restarts=%d, want no download and no restart scheduled", *upgrades, len(*restarts))
+	}
+}

--- a/cmd/evener-hub/app_update_platform_test.go
+++ b/cmd/evener-hub/app_update_platform_test.go
@@ -34,3 +34,34 @@ func TestHubUpdateApplyRefusesUnsupportedRestart(t *testing.T) {
 		t.Fatalf("upgrades=%d restarts=%d, want no download and no restart scheduled", *upgrades, len(*restarts))
 	}
 }
+
+// TestHubUpdateApplyReturnsEarlyWhenUpToDate proves the server re-checks
+// before installing: a direct evener/update/apply when the channel is
+// already current must not download, reinstall, or exec — the frontend
+// poll keys on a version change, so a no-op reinstall into an identical
+// version would end in a misleading restart-timeout. Fails today: apply
+// has no server-side guard (only the store refuses).
+func TestHubUpdateApplyReturnsEarlyWhenUpToDate(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateCheck(t, func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		return selfupdate.CheckResult{
+			Channel: "snapshot", LatestTag: "snapshot",
+			LatestCommit:    "3b1c5f8ffffffff",
+			UpdateAvailable: false,
+		}, nil
+	})
+	upgrades := stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{}, nil
+	})
+	restarts := stubScheduleRestart(t)
+	got, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"})
+	if err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if got.Restarting {
+		t.Fatalf("resp = %+v, want Restarting:false for an up-to-date channel", got)
+	}
+	if *upgrades != 0 || len(*restarts) != 0 {
+		t.Fatalf("upgrades=%d restarts=%d, want no download and no restart scheduled", *upgrades, len(*restarts))
+	}
+}

--- a/cmd/evener-hub/app_update_prefix_test.go
+++ b/cmd/evener-hub/app_update_prefix_test.go
@@ -1,0 +1,140 @@
+package hub
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+// TestHubUpdateApplyUpgradesTheRunningPrefix proves a hub executing from a
+// system prefix upgrades that prefix: the apply path derives Prefix,
+// BinDir, and ShareBinDir from the running binary instead of letting
+// Upgrade fall back to ~/.local. Fails today because hubUpdateApply passes
+// no install dirs at all.
+func TestHubUpdateApplyUpgradesTheRunningPrefix(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previousExe := hubExecutable
+	hubExecutable = func() (string, error) { return "/usr/local/share/evener/bin/evener", nil }
+	t.Cleanup(func() { hubExecutable = previousExe })
+
+	var gotOpts selfupdate.Options
+	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return stubInstalledResult(t, "evener", "evener-dev"), nil
+	})
+	stubScheduleRestart(t)
+
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.Prefix != "/usr/local" {
+		t.Fatalf("Prefix = %q, want %q", gotOpts.Prefix, "/usr/local")
+	}
+	if gotOpts.BinDir != "/usr/local/bin" {
+		t.Fatalf("BinDir = %q, want %q", gotOpts.BinDir, "/usr/local/bin")
+	}
+	if gotOpts.ShareBinDir != "/usr/local/share/evener/bin" {
+		t.Fatalf("ShareBinDir = %q, want %q", gotOpts.ShareBinDir, "/usr/local/share/evener/bin")
+	}
+}
+
+// TestHubUpdateApplyResolvesBinSymlinkEntrypoint proves the normal
+// install.sh entrypoint works end to end at the apply layer: a hub launched
+// as <prefix>/bin/evener (a symlink to ../share/evener/bin/evener, as PATH
+// resolves it) upgrades <prefix>. os.Executable reports the symlink path
+// unresolved, so without symlink resolution the derivation falls back to
+// ~/.local and the wrong prefix is upgraded.
+func TestHubUpdateApplyResolvesBinSymlinkEntrypoint(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	root := t.TempDir()
+	shareBin := filepath.Join(root, "share", "evener", "bin")
+	if err := os.MkdirAll(shareBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(shareBin, "evener")
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(binDir, "evener")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	previousExe := hubExecutable
+	hubExecutable = func() (string, error) { return link, nil }
+	t.Cleanup(func() { hubExecutable = previousExe })
+
+	var gotOpts selfupdate.Options
+	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return stubInstalledResult(t, filepath.Join(shareBin, "evener")), nil
+	})
+	stubScheduleRestart(t)
+
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.Prefix != root {
+		t.Fatalf("Prefix = %q, want %q", gotOpts.Prefix, root)
+	}
+	if gotOpts.BinDir != binDir {
+		t.Fatalf("BinDir = %q, want %q", gotOpts.BinDir, binDir)
+	}
+	if gotOpts.ShareBinDir != shareBin {
+		t.Fatalf("ShareBinDir = %q, want %q", gotOpts.ShareBinDir, shareBin)
+	}
+}
+
+// TestHubUpdateApplyDefaultsInstallDirsForUnknownLayouts proves a hub
+// running from a worktree build (no install layout) still upgrades with
+// Upgrade's own defaults: empty install dirs, not garbage.
+func TestHubUpdateApplyDefaultsInstallDirsForUnknownLayouts(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previousExe := hubExecutable
+	hubExecutable = func() (string, error) { return "/tmp/worktree-evener-build/evener-hub", nil }
+	t.Cleanup(func() { hubExecutable = previousExe })
+
+	var gotOpts selfupdate.Options
+	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return stubInstalledResult(t, "evener"), nil
+	})
+	stubScheduleRestart(t)
+
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.Prefix != "" || gotOpts.BinDir != "" || gotOpts.ShareBinDir != "" {
+		t.Fatalf("opts = %+v, want empty install dirs for an unknown layout", gotOpts)
+	}
+}
+
+// TestHubUpgradeUpgradesTheRunningPrefix proves evener/upgrade (the TUI
+// path) gets the same treatment: without it, fixing only apply would leave
+// the older RPC installing into the wrong prefix.
+func TestHubUpgradeUpgradesTheRunningPrefix(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previousExe := hubExecutable
+	hubExecutable = func() (string, error) { return "/usr/local/share/evener/bin/evener", nil }
+	t.Cleanup(func() { hubExecutable = previousExe })
+
+	var gotOpts selfupdate.Options
+	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return stubInstalledResult(t, "evener"), nil
+	})
+
+	if _, err := hubUpgrade(context.Background(), appwire.UpgradeParams{}); err != nil {
+		t.Fatalf("hubUpgrade: %v", err)
+	}
+	if gotOpts.Prefix != "/usr/local" || gotOpts.BinDir != "/usr/local/bin" || gotOpts.ShareBinDir != "/usr/local/share/evener/bin" {
+		t.Fatalf("opts = %+v, want the running /usr/local layout", gotOpts)
+	}
+}

--- a/cmd/evener-hub/app_update_prefix_test.go
+++ b/cmd/evener-hub/app_update_prefix_test.go
@@ -17,6 +17,7 @@ import (
 // no install dirs at all.
 func TestHubUpdateApplyUpgradesTheRunningPrefix(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	previousExe := hubExecutable
 	hubExecutable = func() (string, error) { return "/usr/local/share/evener/bin/evener", nil }
 	t.Cleanup(func() { hubExecutable = previousExe })
@@ -50,6 +51,7 @@ func TestHubUpdateApplyUpgradesTheRunningPrefix(t *testing.T) {
 // ~/.local and the wrong prefix is upgraded.
 func TestHubUpdateApplyResolvesBinSymlinkEntrypoint(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	root := t.TempDir()
 	shareBin := filepath.Join(root, "share", "evener", "bin")
 	if err := os.MkdirAll(shareBin, 0o755); err != nil {
@@ -97,6 +99,7 @@ func TestHubUpdateApplyResolvesBinSymlinkEntrypoint(t *testing.T) {
 // Upgrade's own defaults: empty install dirs, not garbage.
 func TestHubUpdateApplyDefaultsInstallDirsForUnknownLayouts(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	previousExe := hubExecutable
 	hubExecutable = func() (string, error) { return "/tmp/worktree-evener-build/evener-hub", nil }
 	t.Cleanup(func() { hubExecutable = previousExe })

--- a/cmd/evener-hub/app_update_test.go
+++ b/cmd/evener-hub/app_update_test.go
@@ -67,6 +67,21 @@ func stubUpdateCheck(t *testing.T, fn func(context.Context, selfupdate.CheckOpti
 	return &calls
 }
 
+// stubUpdateAvailable stubs the pre-install freshness check hubUpdateApply
+// runs before locking: tests exercising the upgrade seam must not depend on
+// live GitHub (AGENTS.md forbids network in default tests).
+func stubUpdateAvailable(t *testing.T) {
+	t.Helper()
+	stubUpdateCheck(t, func(_ context.Context, opts selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		return selfupdate.CheckResult{
+			Channel:         opts.Channel,
+			LatestTag:       opts.Channel,
+			LatestCommit:    "ffffffffffffffffffffffffffffffffffffffff",
+			UpdateAvailable: true,
+		}, nil
+	})
+}
+
 func stubHubSelfUpgrade(t *testing.T, fn func(context.Context, selfupdate.Options) (selfupdate.Result, error)) *int {
 	t.Helper()
 	calls := 0
@@ -213,6 +228,7 @@ func TestHubUpdateApplyDevBuildRefused(t *testing.T) {
 
 func TestHubUpdateApplyInstallsThenSchedulesRestartWithHubArgs(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	previousArgs := hubProcessArgs
 	hubProcessArgs = func() []string { return []string{"/old/evener", "hub", "-addr", "0.0.0.0:9180"} }
 	t.Cleanup(func() { hubProcessArgs = previousArgs })
@@ -248,6 +264,7 @@ func TestHubUpdateApplyInstallsThenSchedulesRestartWithHubArgs(t *testing.T) {
 
 func TestHubUpdateApplyDefaultChannelIsBuildChannel(t *testing.T) {
 	setBuild(t, "3b1c5f8", "release")
+	stubUpdateAvailable(t)
 	var gotOpts selfupdate.Options
 	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
 		gotOpts = opts
@@ -264,6 +281,7 @@ func TestHubUpdateApplyDefaultChannelIsBuildChannel(t *testing.T) {
 
 func TestHubUpdateApplyUpgradeFailureDoesNotRestart(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
 		return selfupdate.Result{}, errors.New("download failed")
 	})
@@ -279,6 +297,7 @@ func TestHubUpdateApplyUpgradeFailureDoesNotRestart(t *testing.T) {
 
 func TestHubUpdateApplyRejectsResultWithoutInstalledBinary(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
 		return selfupdate.Result{Release: "snapshot", Channel: "snapshot"}, nil
 	})
@@ -294,6 +313,7 @@ func TestHubUpdateApplyRejectsResultWithoutInstalledBinary(t *testing.T) {
 
 func TestHubUpdateApplyPicksEvenerFromInstalled(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	previousArgs := hubProcessArgs
 	hubProcessArgs = func() []string { return []string{"/old/evener", "hub"} }
 	t.Cleanup(func() { hubProcessArgs = previousArgs })
@@ -311,6 +331,7 @@ func TestHubUpdateApplyPicksEvenerFromInstalled(t *testing.T) {
 
 func TestHubUpdateApplyErrorsWhenInstalledHasNoEvener(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
 		return stubInstalledResult(t, "evener-dev"), nil
 	})
@@ -372,6 +393,7 @@ func TestHubUpdateCheckRejectsUnknownChannel(t *testing.T) {
 
 func TestHubUpdateApplySerializesConcurrentCalls(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	block := make(chan struct{})
 	entered := make(chan struct{}, 1)
 	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
@@ -409,6 +431,7 @@ func TestHubUpdateApplySerializesConcurrentCalls(t *testing.T) {
 
 func TestHubUpdateApplyReleasesLockWhenRestartExecFails(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	previousDelay := hubRestartDelay
 	hubRestartDelay = 0
 	t.Cleanup(func() { hubRestartDelay = previousDelay })
@@ -448,6 +471,7 @@ func TestHubUpdateApplyReleasesLockWhenRestartExecFails(t *testing.T) {
 
 func TestHubUpdateApplyRestartsAfterTheResponseIsWritten(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	previousDelay := hubRestartDelay
 	hubRestartDelay = 0
 	t.Cleanup(func() { hubRestartDelay = previousDelay })

--- a/cmd/evener-hub/app_update_test.go
+++ b/cmd/evener-hub/app_update_test.go
@@ -1,0 +1,514 @@
+package hub
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/buildinfo"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+// syncWriter is an io.Writer that closes a channel the first time a write
+// contains match, letting a test wait for a specific log line from the
+// restart goroutine instead of sleeping.
+type syncWriter struct {
+	mu    sync.Mutex
+	match string
+	done  chan struct{}
+	fired bool
+}
+
+func newSyncWriter(match string) *syncWriter {
+	return &syncWriter{match: match, done: make(chan struct{})}
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.fired && strings.Contains(string(p), w.match) {
+		w.fired = true
+		close(w.done)
+	}
+	return len(p), nil
+}
+
+func setBuild(t *testing.T, sha, channel string) {
+	t.Helper()
+	prevSHA, prevChannel := buildinfo.GitSHA, buildinfo.Channel
+	buildinfo.GitSHA, buildinfo.Channel = sha, channel
+	t.Cleanup(func() { buildinfo.GitSHA, buildinfo.Channel = prevSHA, prevChannel })
+	// hubUpdateApply deliberately leaves hubUpdateMu locked after a
+	// successful apply; reset it so tests stay independent of run order.
+	hubUpdateMu = sync.Mutex{}
+}
+
+func stubUpdateCheck(t *testing.T, fn func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error)) *int {
+	t.Helper()
+	calls := 0
+	previous := runHubUpdateCheck
+	runHubUpdateCheck = func(ctx context.Context, opts selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		calls++
+		return fn(ctx, opts)
+	}
+	t.Cleanup(func() { runHubUpdateCheck = previous })
+	return &calls
+}
+
+func stubHubSelfUpgrade(t *testing.T, fn func(context.Context, selfupdate.Options) (selfupdate.Result, error)) *int {
+	t.Helper()
+	calls := 0
+	previous := runHubSelfUpgrade
+	runHubSelfUpgrade = func(ctx context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		calls++
+		return fn(ctx, opts)
+	}
+	t.Cleanup(func() { runHubSelfUpgrade = previous })
+	return &calls
+}
+
+// stubInstalledResult builds a stub upgrade Result whose Installed paths
+// are real temp binaries, so the apply path's digest pinning (which reads
+// the installed bytes) works without special-casing tests. Tests that
+// need fictional paths must set InstalledSHA256 explicitly or expect the
+// missing-digest refusal.
+func stubInstalledResult(t *testing.T, paths ...string) selfupdate.Result {
+	t.Helper()
+	installed := make([]string, 0, len(paths))
+	digests := make(map[string]string, len(paths))
+	for _, p := range paths {
+		var full string
+		if filepath.IsAbs(p) {
+			full = p
+		} else {
+			full = filepath.Join(t.TempDir(), p)
+		}
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte("test binary "+full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		installed = append(installed, full)
+		data, err := os.ReadFile(full)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256(data)
+		digests[full] = hex.EncodeToString(sum[:])
+	}
+	return selfupdate.Result{Release: "snapshot", Channel: "snapshot", Installed: installed, InstalledSHA256: digests, ShareBinDir: filepath.Dir(installed[0])}
+}
+
+type restartCall struct {
+	binary string
+	args   []string
+}
+
+func stubScheduleRestart(t *testing.T) *[]restartCall {
+	t.Helper()
+	var calls []restartCall
+	previous := scheduleHubRestart
+	scheduleHubRestart = func(_ context.Context, _ restartPin, binary string, args []string) {
+		calls = append(calls, restartCall{binary, args})
+	}
+	t.Cleanup(func() { scheduleHubRestart = previous })
+	return &calls
+}
+
+func TestHubUpdateCheckDevBuildIsNotApplicable(t *testing.T) {
+	setBuild(t, "", "")
+	calls := stubUpdateCheck(t, func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		t.Fatal("dev build must not call Check")
+		return selfupdate.CheckResult{}, nil
+	})
+	got, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{})
+	if err != nil {
+		t.Fatalf("hubUpdateCheck: %v", err)
+	}
+	if got.Applicable || got.UpdateAvailable || got.BuildChannel != "dev" || got.CurrentVersion != "dev" {
+		t.Fatalf("got %+v", got)
+	}
+	if *calls != 0 {
+		t.Fatalf("Check called %d times", *calls)
+	}
+}
+
+func TestHubUpdateCheckDefaultsToBuildChannelAndFillsCurrent(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	var gotOpts selfupdate.CheckOptions
+	stubUpdateCheck(t, func(_ context.Context, opts selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		gotOpts = opts
+		return selfupdate.CheckResult{Channel: opts.Channel, LatestTag: "snapshot", LatestCommit: "be70029abc", UpdateAvailable: true}, nil
+	})
+	got, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{})
+	if err != nil {
+		t.Fatalf("hubUpdateCheck: %v", err)
+	}
+	if gotOpts.Channel != "snapshot" || gotOpts.CurrentSHA != "3b1c5f8" {
+		t.Fatalf("opts = %+v", gotOpts)
+	}
+	want := appwire.UpdateCheckResponse{
+		Channel: "snapshot", BuildChannel: "snapshot", CurrentVersion: "3b1c5f8", CurrentCommit: "3b1c5f8",
+		LatestTag: "snapshot", LatestCommit: "be70029abc", UpdateAvailable: true, Applicable: true,
+	}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestHubUpdateCheckHonoursRequestedChannel(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	var gotChannel string
+	stubUpdateCheck(t, func(_ context.Context, opts selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		gotChannel = opts.Channel
+		return selfupdate.CheckResult{Channel: opts.Channel, LatestTag: "v0.1.0", LatestCommit: "3b1c5f8ffff"}, nil
+	})
+	got, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{Channel: "release"})
+	if err != nil {
+		t.Fatalf("hubUpdateCheck: %v", err)
+	}
+	if gotChannel != "release" || got.Channel != "release" || got.UpdateAvailable {
+		t.Fatalf("channel=%q got=%+v", gotChannel, got)
+	}
+}
+
+func TestHubUpdateCheckPropagatesError(t *testing.T) {
+	setBuild(t, "3b1c5f8", "release")
+	stubUpdateCheck(t, func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		return selfupdate.CheckResult{}, errors.New("GET x: 403 Forbidden: API rate limit exceeded")
+	})
+	_, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{})
+	if err == nil || !strings.Contains(err.Error(), "rate limit") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestHubUpdateApplyDevBuildRefused(t *testing.T) {
+	setBuild(t, "", "")
+	upgrades := stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{}, nil
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil || !strings.Contains(err.Error(), "dev build") {
+		t.Fatalf("err = %v", err)
+	}
+	if *upgrades != 0 || len(*restarts) != 0 {
+		t.Fatalf("upgrades=%d restarts=%d", *upgrades, len(*restarts))
+	}
+}
+
+func TestHubUpdateApplyInstallsThenSchedulesRestartWithHubArgs(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previousArgs := hubProcessArgs
+	hubProcessArgs = func() []string { return []string{"/old/evener", "hub", "-addr", "0.0.0.0:9180"} }
+	t.Cleanup(func() { hubProcessArgs = previousArgs })
+
+	var gotOpts selfupdate.Options
+	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return stubInstalledResult(t, "evener", "evener-dev"), nil
+	})
+	restarts := stubScheduleRestart(t)
+
+	got, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"})
+	if err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.Requested != "snapshot" || gotOpts.CurrentChannel != "snapshot" {
+		t.Fatalf("opts = %+v", gotOpts)
+	}
+	if !got.Restarting || got.Release != "snapshot" || len(got.Installed) != 2 {
+		t.Fatalf("got %+v", got)
+	}
+	if len(*restarts) != 1 {
+		t.Fatalf("restarts = %v", *restarts)
+	}
+	call := (*restarts)[0]
+	if filepath.Base(call.binary) != "evener" {
+		t.Fatalf("binary = %q, want the installed evener binary", call.binary)
+	}
+	if strings.Join(call.args, " ") != "hub -addr 0.0.0.0:9180" {
+		t.Fatalf("args = %v", call.args)
+	}
+}
+
+func TestHubUpdateApplyDefaultChannelIsBuildChannel(t *testing.T) {
+	setBuild(t, "3b1c5f8", "release")
+	var gotOpts selfupdate.Options
+	stubHubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return stubInstalledResult(t, "evener", "evener-dev"), nil
+	})
+	stubScheduleRestart(t)
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.Requested != "release" {
+		t.Fatalf("Requested = %q, want release", gotOpts.Requested)
+	}
+}
+
+func TestHubUpdateApplyUpgradeFailureDoesNotRestart(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{}, errors.New("download failed")
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil || !strings.Contains(err.Error(), "download failed") {
+		t.Fatalf("err = %v", err)
+	}
+	if len(*restarts) != 0 {
+		t.Fatalf("restart scheduled after failed upgrade: %v", *restarts)
+	}
+}
+
+func TestHubUpdateApplyRejectsResultWithoutInstalledBinary(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{Release: "snapshot", Channel: "snapshot"}, nil
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil {
+		t.Fatal("expected error for empty Installed")
+	}
+	if len(*restarts) != 0 {
+		t.Fatalf("restart scheduled: %v", *restarts)
+	}
+}
+
+func TestHubUpdateApplyPicksEvenerFromInstalled(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previousArgs := hubProcessArgs
+	hubProcessArgs = func() []string { return []string{"/old/evener", "hub"} }
+	t.Cleanup(func() { hubProcessArgs = previousArgs })
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return stubInstalledResult(t, "evener-dev", "evener"), nil
+	})
+	restarts := stubScheduleRestart(t)
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if len(*restarts) != 1 || filepath.Base((*restarts)[0].binary) != "evener" {
+		t.Fatalf("restarts = %v", *restarts)
+	}
+}
+
+func TestHubUpdateApplyErrorsWhenInstalledHasNoEvener(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return stubInstalledResult(t, "evener-dev"), nil
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil || !strings.Contains(err.Error(), "evener") {
+		t.Fatalf("err = %v", err)
+	}
+	if len(*restarts) != 0 {
+		t.Fatalf("restart scheduled: %v", *restarts)
+	}
+}
+
+func TestHubUpdateApplyRejectsUnknownChannel(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	upgrades := stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		t.Fatal("unknown channel must not reach the upgrade seam")
+		return selfupdate.Result{}, nil
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "v0.0.1"})
+	if err == nil || !strings.Contains(err.Error(), `unknown update channel "v0.0.1"`) {
+		t.Fatalf("err = %v", err)
+	}
+	if *upgrades != 0 || len(*restarts) != 0 {
+		t.Fatalf("upgrades=%d restarts=%d", *upgrades, len(*restarts))
+	}
+}
+
+func TestHubUpdateApplyRejectsNightlyChannel(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	upgrades := stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		t.Fatal("unknown channel must not reach the upgrade seam")
+		return selfupdate.Result{}, nil
+	})
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "nightly"})
+	if err == nil || !strings.Contains(err.Error(), `unknown update channel "nightly"`) {
+		t.Fatalf("err = %v", err)
+	}
+	if *upgrades != 0 {
+		t.Fatalf("upgrades=%d", *upgrades)
+	}
+}
+
+func TestHubUpdateCheckRejectsUnknownChannel(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	calls := stubUpdateCheck(t, func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		t.Fatal("unknown channel must not reach the check seam")
+		return selfupdate.CheckResult{}, nil
+	})
+	_, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{Channel: "v0.0.1"})
+	if err == nil || !strings.Contains(err.Error(), `unknown update channel "v0.0.1"`) {
+		t.Fatalf("err = %v", err)
+	}
+	if *calls != 0 {
+		t.Fatalf("Check called %d times", *calls)
+	}
+}
+
+func TestHubUpdateApplySerializesConcurrentCalls(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	block := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		entered <- struct{}{}
+		<-block
+		return selfupdate.Result{}, errors.New("boom")
+	})
+	stubScheduleRestart(t)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+		done <- err
+	}()
+	<-entered
+
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("second apply err = %v", err)
+	}
+
+	close(block)
+	if firstErr := <-done; firstErr == nil || !strings.Contains(firstErr.Error(), "boom") {
+		t.Fatalf("first apply err = %v", firstErr)
+	}
+
+	// After a failed upgrade the lock must be released so a later apply proceeds.
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return stubInstalledResult(t, "evener"), nil
+	})
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{}); err != nil {
+		t.Fatalf("apply after failure: %v", err)
+	}
+}
+
+func TestHubUpdateApplyReleasesLockWhenRestartExecFails(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previousDelay := hubRestartDelay
+	hubRestartDelay = 0
+	t.Cleanup(func() { hubRestartDelay = previousDelay })
+
+	previousExec := execHubBinary
+	execHubBinary = func(binary string, args []string) error { return errors.New("exec failed") }
+	t.Cleanup(func() { execHubBinary = previousExec })
+
+	stderr := newSyncWriter("restart failed")
+	previousStderr := hubUpdateStderr
+	hubUpdateStderr = stderr
+	t.Cleanup(func() { hubUpdateStderr = previousStderr })
+
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return stubInstalledResult(t, "evener"), nil
+	})
+
+	// This test exercises the real scheduleHubRestartAfterResponse on a
+	// context with no appserver connection -- the fallback that restarts
+	// straight away because there is no response frame to wait for.
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+
+	<-stderr.done // wait for the goroutine to log the failed restart and release the lock
+
+	upgrades := stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{}, errors.New("boom")
+	})
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{}); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("second apply err = %v", err)
+	}
+	if *upgrades != 1 {
+		t.Fatalf("upgrades = %d, want the second apply to reach the upgrade seam", *upgrades)
+	}
+}
+
+func TestHubUpdateApplyRestartsAfterTheResponseIsWritten(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previousDelay := hubRestartDelay
+	hubRestartDelay = 0
+	t.Cleanup(func() { hubRestartDelay = previousDelay })
+
+	execs := make(chan string, 1)
+	previousExec := execHubBinary
+	execHubBinary = func(binary string, _ []string) error {
+		execs <- binary
+		return errors.New("exec failed") // keep this process alive and release hubUpdateMu
+	}
+	t.Cleanup(func() { execHubBinary = previousExec })
+
+	previousStderr := hubUpdateStderr
+	stderr := newSyncWriter("restart failed")
+	hubUpdateStderr = stderr
+	t.Cleanup(func() { hubUpdateStderr = previousStderr })
+
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return stubInstalledResult(t, "evener"), nil
+	})
+
+	// A real appserver round trip: only that gives the handler a context
+	// carrying the connection AfterResponseWritten needs.
+	appServer := newHubAppServer(hubcore.WebConfig{
+		HubStateRoot: t.TempDir(),
+		Past:         hubcore.NewPastIndex(""),
+	}, appsource.NewRegistry())
+	hub := httptest.NewServer(http.HandlerFunc(appServer.ServeWebSocket))
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+
+	resp, err := client.UpdateApply(t.Context(), appwire.UpdateApplyParams{Channel: "snapshot"})
+	if err != nil {
+		t.Fatalf("UpdateApply: %v", err)
+	}
+	if !resp.Restarting {
+		t.Fatalf("apply response = %+v, want Restarting", resp)
+	}
+
+	select {
+	case binary := <-execs:
+		if filepath.Base(binary) != "evener" {
+			t.Fatalf("exec'd %q, want the installed evener binary", binary)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the restart never ran after the apply response reached the transport")
+	}
+
+	// Join the restart goroutine before cleanup restores execHubBinary and
+	// the next test's setBuild resets the shared globals: the exec stub
+	// always fails, so the "restart failed" log line (written after the
+	// Unlock) proves the goroutine is done touching shared state. Without
+	// this the test races the goroutine under -race (cleanup's write to
+	// execHubBinary vs the goroutine's read; next setBuild vs Unlock).
+	select {
+	case <-stderr.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the restart goroutine never finished after exec failed")
+	}
+}

--- a/cmd/evener-hub/app_update_test.go
+++ b/cmd/evener-hub/app_update_test.go
@@ -53,6 +53,20 @@ func setBuild(t *testing.T, sha, channel string) {
 	// hubUpdateApply deliberately leaves hubUpdateMu locked after a
 	// successful apply; reset it so tests stay independent of run order.
 	hubUpdateMu = sync.Mutex{}
+	// Default the check seam to an offline "update available" stub so
+	// hubUpdateApply's pre-install guard never hits live GitHub (AGENTS.md
+	// forbids network in default tests). Tests that need a specific check
+	// result override this via stubUpdateCheck/stubUpdateAvailable.
+	prevCheck := runHubUpdateCheck
+	runHubUpdateCheck = func(_ context.Context, opts selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		return selfupdate.CheckResult{
+			Channel:         opts.Channel,
+			LatestTag:       opts.Channel,
+			LatestCommit:    "ffffffffffffffffffffffffffffffffffffffff",
+			UpdateAvailable: true,
+		}, nil
+	}
+	t.Cleanup(func() { runHubUpdateCheck = prevCheck })
 }
 
 func stubUpdateCheck(t *testing.T, fn func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error)) *int {

--- a/cmd/evener-hub/app_upgrade.go
+++ b/cmd/evener-hub/app_upgrade.go
@@ -10,10 +10,24 @@ import (
 
 var runHubSelfUpgrade = selfupdate.Upgrade
 
+// hubUpgrade answers evener/upgrade: install the requested channel's build
+// without restarting into it (the caller execs manually, unlike
+// evener/update/apply). It takes hubUpdateMu so it can't race
+// hubUpdateApply over selfupdate's fixed .tmp install path, and always
+// releases it before returning since it never execs.
 func hubUpgrade(ctx context.Context, params appwire.UpgradeParams) (appwire.UpgradeResponse, error) {
-	result, err := runHubSelfUpgrade(ctx, selfupdate.Options{
+	if err := tryLockHubUpdate(); err != nil {
+		return appwire.UpgradeResponse{}, err
+	}
+	defer hubUpdateMu.Unlock()
+
+	prefix, binDir, shareBinDir := hubInstallDirs()
+	result, err := runHubSelfUpgradeWithTimeout(ctx, selfupdate.Options{
 		Requested:      params.Requested,
 		CurrentChannel: buildinfo.UpgradeChannel(),
+		Prefix:         prefix,
+		BinDir:         binDir,
+		ShareBinDir:    shareBinDir,
 	})
 	if err != nil {
 		return appwire.UpgradeResponse{}, err

--- a/cmd/evener-hub/app_upgrade_test.go
+++ b/cmd/evener-hub/app_upgrade_test.go
@@ -32,6 +32,7 @@ func TestHubUpgradeRefusedWhileApplyHoldsTheLock(t *testing.T) {
 
 func TestHubUpdateApplyRefusedWhileUpgradeHoldsTheLock(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
+	stubUpdateAvailable(t)
 	if !hubUpdateMu.TryLock() {
 		t.Fatal("failed to take hubUpdateMu")
 	}

--- a/cmd/evener-hub/app_upgrade_test.go
+++ b/cmd/evener-hub/app_upgrade_test.go
@@ -1,0 +1,85 @@
+package hub
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+func TestHubUpgradeRefusedWhileApplyHoldsTheLock(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	if !hubUpdateMu.TryLock() {
+		t.Fatal("failed to take hubUpdateMu")
+	}
+	t.Cleanup(hubUpdateMu.Unlock)
+
+	upgrades := stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		t.Fatal("upgrade seam must not be called while apply holds the lock")
+		return selfupdate.Result{}, nil
+	})
+
+	_, err := hubUpgrade(context.Background(), appwire.UpgradeParams{})
+	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("hubUpgrade err = %v", err)
+	}
+	if *upgrades != 0 {
+		t.Fatalf("upgrades = %d", *upgrades)
+	}
+}
+
+func TestHubUpdateApplyRefusedWhileUpgradeHoldsTheLock(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	if !hubUpdateMu.TryLock() {
+		t.Fatal("failed to take hubUpdateMu")
+	}
+	t.Cleanup(hubUpdateMu.Unlock)
+
+	upgrades := stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		t.Fatal("upgrade seam must not be called while an upgrade holds the lock")
+		return selfupdate.Result{}, nil
+	})
+	restarts := stubScheduleRestart(t)
+
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("hubUpdateApply err = %v", err)
+	}
+	if *upgrades != 0 || len(*restarts) != 0 {
+		t.Fatalf("upgrades=%d restarts=%d", *upgrades, len(*restarts))
+	}
+}
+
+func TestHubUpgradeReleasesTheLockAfterReturning(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return stubInstalledResult(t, "evener"), nil
+	})
+
+	if _, err := hubUpgrade(context.Background(), appwire.UpgradeParams{}); err != nil {
+		t.Fatalf("hubUpgrade: %v", err)
+	}
+
+	if !hubUpdateMu.TryLock() {
+		t.Fatal("hubUpdateMu still locked after hubUpgrade returned")
+	}
+	hubUpdateMu.Unlock()
+}
+
+func TestHubUpgradeReleasesTheLockOnError(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	stubHubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{}, context.Canceled
+	})
+
+	if _, err := hubUpgrade(context.Background(), appwire.UpgradeParams{}); err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !hubUpdateMu.TryLock() {
+		t.Fatal("hubUpdateMu still locked after hubUpgrade returned an error")
+	}
+	hubUpdateMu.Unlock()
+}

--- a/cmd/evener-hub/e2e_turn_control_test.go
+++ b/cmd/evener-hub/e2e_turn_control_test.go
@@ -524,6 +524,10 @@ type hubStack struct {
 	// rendezvous directory rather than having spawned it.
 	home   string
 	binDir string
+	// pid is the hub process's PID, for tests that need to prove the process
+	// survived some operation (e.g. a self-update exec) rather than being
+	// restarted under a new PID.
+	pid int
 }
 
 func (s hubStack) dialRPC(ctx context.Context, t *testing.T) *appwire.Client {
@@ -605,13 +609,24 @@ api_key  = "fakellm-not-a-secret"
 func startHubStackOnProvider(t *testing.T, providersTOML, model string) hubStack {
 	t.Helper()
 
-	home := t.TempDir()
 	repoRoot, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatalf("abs repo root: %v", err)
 	}
 
 	binDir := liveStackBinaries(t, repoRoot)
+	return startHubStackOnProviderWithEvener(t, providersTOML, model, filepath.Join(binDir, "evener"))
+}
+
+// startHubStackOnProviderWithEvener is startHubStackOnProvider with the
+// evener binary left to the caller, so a test can run the hub from a
+// purpose-built binary (e.g. a snapshot-channel build of this branch)
+// instead of the repo build liveStackBinaries produces.
+func startHubStackOnProviderWithEvener(t *testing.T, providersTOML, model, evenerBin string) hubStack {
+	t.Helper()
+
+	home := t.TempDir()
+	binDir := filepath.Dir(evenerBin)
 
 	// XDG_CONFIG_HOME/XDG_STATE_HOME point into the stack's own isolated
 	// HOME, the same convention e2e_test.go's hand-started daemon uses, so
@@ -653,7 +668,7 @@ func startHubStackOnProvider(t *testing.T, providersTOML, model string) hubStack
 		t.Fatalf("release hub port: %v", err)
 	}
 
-	hub := exec.Command(filepath.Join(binDir, "evener"), "hub", "--addr", hubAddr, "--evener", filepath.Join(binDir, "evener"))
+	hub := exec.Command(evenerBin, "hub", "--addr", hubAddr, "--evener", evenerBin)
 	hub.Env = append(os.Environ(),
 		"HOME="+home,
 		"XDG_CONFIG_HOME="+configDir,
@@ -713,6 +728,7 @@ func startHubStackOnProvider(t *testing.T, providersTOML, model string) hubStack
 		model:        model,
 		home:         home,
 		binDir:       binDir,
+		pid:          hub.Process.Pid,
 	}
 }
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/hub.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/hub.tsx
@@ -4,6 +4,7 @@ import { settingsOverviewStore, useSettingsOverviewStore } from "../../../stores
 import { Button, EmptyState, Skeleton } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import styles from "./hub.module.css";
+import { HubUpdates } from "./hubUpdates";
 import { Code, SettingsField } from "./settingsField";
 
 const CLASS = {
@@ -75,6 +76,7 @@ export function HubSection() {
           help="How long the hub waits for a daemon to report ready after spawn before treating it as failed."
         />
       </dl>
+      <HubUpdates />
     </div>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.module.css
@@ -1,0 +1,25 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.heading {
+  margin: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-body);
+  font-weight: var(--font-weight-semibold);
+}
+
+.status {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.test.tsx
@@ -1,0 +1,149 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { WireError } from "../../../protocol/errors";
+import { FakeClient } from "../../../protocol/testing/fakeClient";
+import type { SettingsOverviewResponse, UpdateCheckResponse } from "../../../protocol/types.gen";
+import { connectionStore } from "../../../stores/connection";
+import { APPLY_TIMEOUT_MS, resetHubUpdateStoreForTests } from "../../../stores/hubUpdate";
+import { resetSettingsOverviewStoreForTests, settingsOverviewStore } from "../../../stores/settingsOverview";
+import { HubSection } from "./hub";
+
+function connectFakeClient(): FakeClient {
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+function overview(buildChannel: string): SettingsOverviewResponse {
+  return {
+    hub: {
+      version: "3b1c5f8",
+      commit: "3b1c5f8",
+      buildChannel,
+      listenAddr: "127.0.0.1:9180",
+      runDir: "/tmp/run",
+      spawnTimeout: "30s",
+    },
+  };
+}
+
+const UP_TO_DATE: UpdateCheckResponse = {
+  channel: "snapshot",
+  buildChannel: "snapshot",
+  currentVersion: "3b1c5f8",
+  currentCommit: "3b1c5f8",
+  latestTag: "snapshot",
+  latestCommit: "3b1c5f8ffffffff",
+  updateAvailable: false,
+  applicable: true,
+};
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetSettingsOverviewStoreForTests();
+  resetHubUpdateStoreForTests({ fetchImpl: vi.fn() as unknown as typeof fetch, reload: vi.fn() });
+});
+
+afterEach(cleanup);
+
+test("dev build shows the rebuild note and no update controls", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("dev"));
+
+  render(<HubSection />);
+
+  expect(await screen.findByText(/Dev build/)).toBeTruthy();
+  expect(screen.queryByRole("button", { name: "Check for updates" })).toBeNull();
+  expect(fake.calls.map((c) => c.method)).toEqual(["evener/settings/overview"]);
+});
+
+test("release build checks on mount with the build channel and reports up to date", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("snapshot"));
+  fake.on("evener/update/check", () => UP_TO_DATE);
+
+  render(<HubSection />);
+
+  expect(await screen.findByText(/Up to date on snapshot/)).toBeTruthy();
+  // No Loader is rendered in this (non-restarting) state, so this role="status" match is unambiguous.
+  expect(screen.getByRole("status").textContent).toMatch(/Up to date on snapshot/);
+  expect(fake.calls).toContainEqual({ method: "evener/update/check", params: { channel: "snapshot" } });
+  expect(screen.getByRole("radio", { name: "Snapshot" }).getAttribute("aria-checked")).toBe("true");
+  expect(screen.getByRole("button", { name: "Update and restart" })).toHaveProperty("disabled", true);
+});
+
+test("switching channel re-checks with the new channel", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("snapshot"));
+  fake.on("evener/update/check", (params) => ({
+    ...UP_TO_DATE,
+    channel: params.channel ?? "",
+    latestTag: params.channel === "release" ? "v0.1.0" : "snapshot",
+  }));
+
+  render(<HubSection />);
+  await screen.findByText(/Up to date on snapshot/);
+
+  await userEvent.click(screen.getByRole("radio", { name: "Release" }));
+
+  expect(await screen.findByText(/Up to date on release/)).toBeTruthy();
+  expect(fake.calls).toContainEqual({ method: "evener/update/check", params: { channel: "release" } });
+});
+
+test("update available enables the button; confirming applies and shows restarting", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("snapshot"));
+  fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true, latestCommit: "be7002918fdc" }));
+  fake.on("evener/update/apply", () => new Promise(() => {})); // stays pending: we only assert the request and the busy state
+
+  render(<HubSection />);
+  expect(await screen.findByText(/Update available: snapshot be70029/)).toBeTruthy();
+
+  const button = screen.getByRole("button", { name: "Update and restart" });
+  expect(button).toHaveProperty("disabled", false);
+  await userEvent.click(button);
+  await userEvent.click(await screen.findByRole("button", { name: "Yes, update and restart" }));
+
+  await waitFor(() =>
+    expect(fake.calls).toContainEqual({
+      method: "evener/update/apply",
+      params: { channel: "snapshot" },
+      opts: { timeoutMs: APPLY_TIMEOUT_MS },
+    }),
+  );
+});
+
+test("restarting and timed-out states render their messages", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("snapshot"));
+  fake.on("evener/update/check", () => UP_TO_DATE);
+  render(<HubSection />);
+  await screen.findByText(/Up to date on snapshot/);
+
+  const { hubUpdateStore } = await import("../../../stores/hubUpdate");
+  hubUpdateStore.setState({ restarting: true });
+  expect(await screen.findByText(/Restarting hub/)).toBeTruthy();
+
+  hubUpdateStore.setState({ restarting: false, restartTimedOut: true });
+  expect(await screen.findByText(/didn't come back within 30s/)).toBeTruthy();
+});
+
+test("check failure shows the error and a working Check for updates button", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("release"));
+  let attempts = 0;
+  fake.on("evener/update/check", () => {
+    attempts += 1;
+    if (attempts === 1) throw new WireError("GET x: 403 Forbidden: API rate limit exceeded", -1);
+    return { ...UP_TO_DATE, channel: "release", latestTag: "v0.1.0" };
+  });
+
+  render(<HubSection />);
+  expect(await screen.findByText(/rate limit/)).toBeTruthy();
+
+  await userEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+
+  expect(await screen.findByText(/Up to date on release/)).toBeTruthy();
+  expect(settingsOverviewStore.getState().data).not.toBeNull();
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import { hubUpdateStore, RESTART_TIMEOUT_MS, type UpdateChannel, useHubUpdateStore } from "../../../stores/hubUpdate";
+import { useSettingsOverviewStore } from "../../../stores/settingsOverview";
+import { Button, ConfirmDialog, Loader, RadioGroup } from "../../../widgets";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import styles from "./hubUpdates.module.css";
+import { Code, FieldDim } from "./settingsField";
+
+const CLASS = {
+  root: requireClass(styles.root, "hubUpdates.module.css", "root"),
+  heading: requireClass(styles.heading, "hubUpdates.module.css", "heading"),
+  status: requireClass(styles.status, "hubUpdates.module.css", "status"),
+  actions: requireClass(styles.actions, "hubUpdates.module.css", "actions"),
+};
+
+const CHANNEL_OPTIONS = [
+  { value: "release", label: "Release" },
+  { value: "snapshot", label: "Snapshot" },
+];
+
+function isChannel(value: string | undefined): value is UpdateChannel {
+  return value === "release" || value === "snapshot";
+}
+
+function shortCommit(sha: string): string {
+  return sha.slice(0, 7);
+}
+
+/**
+ * Settings -> Hub -> Updates. Seeds the channel from the overview's
+ * buildChannel (release/snapshot builds only), checks on mount and on
+ * channel change, and gates "Update and restart" behind a confirm dialog.
+ * Dev builds get a note instead of controls: a worktree build must never be
+ * silently replaced by a release binary. If buildChannel hasn't arrived yet
+ * (channel still null - older overview responses, or a value this UI
+ * doesn't recognize), the block shows only the running-build line and no
+ * controls: there is nothing to check or select yet.
+ */
+export function HubUpdates() {
+  const hub = useSettingsOverviewStore((s) => s.data?.hub);
+  const channel = useHubUpdateStore((s) => s.channel);
+  const check = useHubUpdateStore((s) => s.check);
+  const checking = useHubUpdateStore((s) => s.checking);
+  const checkError = useHubUpdateStore((s) => s.checkError);
+  const applying = useHubUpdateStore((s) => s.applying);
+  const applyError = useHubUpdateStore((s) => s.applyError);
+  const restarting = useHubUpdateStore((s) => s.restarting);
+  const restartTimedOut = useHubUpdateStore((s) => s.restartTimedOut);
+  const [confirming, setConfirming] = useState(false);
+
+  const buildChannel = hub?.buildChannel;
+  const isDev = buildChannel === "dev";
+
+  // Seed the selector from the running binary once the overview is here.
+  useEffect(() => {
+    if (channel === null && isChannel(buildChannel)) {
+      hubUpdateStore.getState().setChannel(buildChannel);
+    }
+  }, [channel, buildChannel]);
+
+  // Check whenever a channel is selected (mount and every change).
+  useEffect(() => {
+    if (channel !== null) void hubUpdateStore.getState().runCheck();
+  }, [channel]);
+
+  if (!hub) return null;
+
+  return (
+    <section className={CLASS.root} aria-labelledby="hub-updates-heading">
+      <h3 id="hub-updates-heading" className={CLASS.heading}>
+        Updates
+      </h3>
+      <p className={CLASS.status}>
+        Running {hub.version ?? "unknown"}
+        {hub.commit !== undefined && <FieldDim> ({hub.commit})</FieldDim>}
+        {buildChannel !== undefined && <FieldDim> · {buildChannel}</FieldDim>}
+      </p>
+
+      {isDev && (
+        <p className={CLASS.status}>
+          <FieldDim>
+            Dev build. Rebuild with <Code>make build-hub</Code> to update.
+          </FieldDim>
+        </p>
+      )}
+
+      {!isDev && channel !== null && (
+        <>
+          <RadioGroup
+            label="Channel"
+            value={channel}
+            onChange={(value) => {
+              if (isChannel(value)) hubUpdateStore.getState().setChannel(value);
+            }}
+            options={CHANNEL_OPTIONS}
+            disabled={applying || restarting}
+          />
+
+          <p className={CLASS.status} role="status">
+            {restarting && <Loader label="Restarting hub" />}
+            {!restarting &&
+              restartTimedOut &&
+              `The hub didn't come back within ${RESTART_TIMEOUT_MS / 1000}s. Check its logs.`}
+            {!restarting && !restartTimedOut && checking && "Checking…"}
+            {!restarting && !restartTimedOut && !checking && checkError !== null && (
+              <>Couldn't check for updates: {checkError}</>
+            )}
+            {!restarting &&
+              !restartTimedOut &&
+              !checking &&
+              checkError === null &&
+              check !== null &&
+              (check.updateAvailable
+                ? `Update available: ${check.channel} ${shortCommit(check.latestCommit ?? "")}, running ${check.currentVersion}`
+                : `Up to date on ${check.channel} (${shortCommit(check.latestCommit ?? "")})`)}
+          </p>
+          {applyError !== null && <p className={CLASS.status}>Update failed: {applyError}</p>}
+
+          <div className={CLASS.actions}>
+            <Button
+              size="sm"
+              onClick={() => void hubUpdateStore.getState().runCheck()}
+              disabled={checking || applying || restarting}
+            >
+              Check for updates
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => setConfirming(true)}
+              disabled={!(check?.updateAvailable ?? false) || checking || applying || restarting}
+            >
+              Update and restart
+            </Button>
+          </div>
+
+          <ConfirmDialog
+            open={confirming}
+            title="Update and restart the hub?"
+            confirmLabel="Yes, update and restart"
+            busy={applying}
+            onConfirm={() => {
+              setConfirming(false);
+              void hubUpdateStore.getState().apply();
+            }}
+            onCancel={() => setConfirming(false)}
+          >
+            The hub goes offline for a few seconds while the new binary starts. Running sessions keep going.
+          </ConfirmDialog>
+        </>
+      )}
+    </section>
+  );
+}

--- a/cmd/evener-hub/frontend/src/protocol/errors.ts
+++ b/cmd/evener-hub/frontend/src/protocol/errors.ts
@@ -115,7 +115,7 @@ export class ClientNotReadyError extends Error {
 // recognized client-unreachable rejection gets this, never the error's own
 // text - an arbitrary JS exception's message can name a class, a method, a
 // file path, none of which means anything to the person looking at it.
-const GENERIC_ERROR_MESSAGE = "Something went wrong.";
+export const GENERIC_ERROR_MESSAGE = "Something went wrong.";
 
 // HUB_UNREACHABLE_MESSAGE covers the family of rejections AppwireClient (and
 // its testing/fakeClient.ts stand-in) throws locally when a request is
@@ -123,7 +123,7 @@ const GENERIC_ERROR_MESSAGE = "Something went wrong.";
 // connection dropped, or a call landed before the handshake finished. None
 // of that is meaningful to a person - "the hub" is the concept they
 // understand, not "the client's internal state".
-const HUB_UNREACHABLE_MESSAGE = "Can't reach the hub right now.";
+export const HUB_UNREACHABLE_MESSAGE = "Can't reach the hub right now.";
 
 // CLIENT_UNREACHABLE_PATTERN matches the shape both AppwireClient
 // (protocol/client.ts's request()/close()) and FakeClient (protocol/testing/

--- a/cmd/evener-hub/frontend/src/protocol/testing/fakeClient.ts
+++ b/cmd/evener-hub/frontend/src/protocol/testing/fakeClient.ts
@@ -83,6 +83,7 @@ const DEFAULT_INITIALIZE_RESPONSE: InitializeResponse = {
 export interface RecordedCall {
   method: MethodName;
   params: unknown;
+  opts?: { timeoutMs?: number };
 }
 
 export class FakeClient implements AppwireClientLike {
@@ -146,7 +147,11 @@ export class FakeClient implements AppwireClientLike {
       });
   }
 
-  request<M extends MethodName>(method: M, params: MethodTypes[M]["params"]): Promise<MethodTypes[M]["result"]> {
+  request<M extends MethodName>(
+    method: M,
+    params: MethodTypes[M]["params"],
+    opts?: { timeoutMs?: number },
+  ): Promise<MethodTypes[M]["result"]> {
     // Checked before the ready-gate below: a method the hub does not serve is
     // a bug regardless of connection state, and reporting "not ready" for it
     // would hide the real defect behind a plausible-looking one.
@@ -164,7 +169,11 @@ export class FakeClient implements AppwireClientLike {
     if (this.state !== "ready") {
       return Promise.reject(new Error(`FakeClient: cannot call "${method}" while state is "${this.state}"`));
     }
-    this.calls.push({ method, params });
+    if (opts === undefined) {
+      this.calls.push({ method, params });
+    } else {
+      this.calls.push({ method, params, opts });
+    }
     const handler = this.handlers.get(method);
     if (!handler) {
       return Promise.reject(new Error(`FakeClient: no handler scripted for "${method}"`));

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -1515,6 +1515,7 @@ export interface SettingsAgentEntry {
 export interface SettingsHubOverview {
   version?: string;
   commit?: string;
+  buildChannel?: string;
   listenAddr?: string;
   runDir?: string;
   spawnTimeout?: string;
@@ -2099,6 +2100,32 @@ export interface TurnSteerResponse {
   receipt: MutationReceipt;
 }
 
+export interface UpdateApplyParams {
+  channel?: string;
+}
+
+export interface UpdateApplyResponse {
+  release: string;
+  channel: string;
+  installed: string[];
+  restarting: boolean;
+}
+
+export interface UpdateCheckParams {
+  channel?: string;
+}
+
+export interface UpdateCheckResponse {
+  channel: string;
+  buildChannel: string;
+  currentVersion: string;
+  currentCommit: string;
+  latestTag?: string;
+  latestCommit?: string;
+  updateAvailable: boolean;
+  applicable: boolean;
+}
+
 export interface UpgradeParams {
   requested?: string;
 }
@@ -2176,6 +2203,8 @@ export const METHOD_NAMES = [
   "evener/search",
   "evener/harnesses/list",
   "evener/upgrade",
+  "evener/update/check",
+  "evener/update/apply",
   "evener/auth/status",
   "evener/auth/test",
   "evener/auth/login/start",
@@ -2361,6 +2390,8 @@ export interface MethodTypes {
   "evener/search": { params: SearchParams; result: SearchResponse };
   "evener/harnesses/list": { params: HarnessListParams; result: HarnessListResponse };
   "evener/upgrade": { params: UpgradeParams; result: UpgradeResponse };
+  "evener/update/check": { params: UpdateCheckParams; result: UpdateCheckResponse };
+  "evener/update/apply": { params: UpdateApplyParams; result: UpdateApplyResponse };
   "evener/auth/status": { params: AuthStatusParams; result: AuthStatusResponse };
   "evener/auth/test": { params: AuthTestParams; result: AuthTestResponse };
   "evener/auth/login/start": { params: AuthLoginStartParams; result: AuthLoginStartResponse };

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.test.ts
@@ -275,6 +275,34 @@ describe("apply", () => {
     expect(hubUpdateStore.getState().restarting).toBe(false);
   });
 
+  test("does not poll for a restart the server says is not coming", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const fetchImpl = healthFetch(["be70029"]);
+    resetHubUpdateStoreForTests({ fetchImpl, reload });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true }));
+    // The server re-checked and found nothing to install: no download, no
+    // exec, no version change to wait for.
+    fake.on("evener/update/apply", () => ({
+      release: "snapshot",
+      channel: "snapshot",
+      installed: [],
+      restarting: false,
+    }));
+    hubUpdateStore.getState().setChannel("snapshot");
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    await act(() => hubUpdateStore.getState().apply());
+
+    // Fails today: apply discards the response and always polls into a
+    // restart timeout on an unchanged version.
+    expect(hubUpdateStore.getState().restarting).toBe(false);
+    expect(hubUpdateStore.getState().restartTimedOut).toBe(false);
+    expect(hubUpdateStore.getState().applyError).toBe("Already up to date");
+    expect(reload).not.toHaveBeenCalled();
+  });
+
   test("requests evener/update/apply, then polls /api/health until the version changes and reloads", async () => {
     vi.useFakeTimers();
     const reload = vi.fn();

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.test.ts
@@ -253,6 +253,28 @@ describe("runCheck", () => {
 });
 
 describe("apply", () => {
+  test("refuses to apply when the check says already up to date", async () => {
+    resetHubUpdateStoreForTests();
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => UP_TO_DATE);
+    fake.on("evener/update/apply", () => ({
+      release: "snapshot",
+      channel: "snapshot",
+      installed: ["/x/evener"],
+      restarting: true,
+    }));
+    hubUpdateStore.getState().setChannel("snapshot");
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    await act(() => hubUpdateStore.getState().apply());
+
+    // Fails today: apply only checks channel staleness, so a stored
+    // up-to-date check still issues a full download + exec restart.
+    expect(fake.calls.some((call) => call.method === "evener/update/apply")).toBe(false);
+    expect(hubUpdateStore.getState().applyError).toBe("Already up to date");
+    expect(hubUpdateStore.getState().restarting).toBe(false);
+  });
+
   test("requests evener/update/apply, then polls /api/health until the version changes and reloads", async () => {
     vi.useFakeTimers();
     const reload = vi.fn();

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.test.ts
@@ -1,0 +1,518 @@
+import { act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { GENERIC_ERROR_MESSAGE, HUB_UNREACHABLE_MESSAGE, WireError } from "../protocol/errors";
+import { FakeClient } from "../protocol/testing/fakeClient";
+import type { UpdateCheckResponse } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+import {
+  APPLY_TIMEOUT_MS,
+  hubUpdateStore,
+  RESTART_POLL_MS,
+  RESTART_TIMEOUT_MS,
+  resetHubUpdateStoreForTests,
+} from "./hubUpdate";
+import { resetThreadsStoreForTests } from "./threads";
+
+function connectFakeClient(): FakeClient {
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+const UP_TO_DATE: UpdateCheckResponse = {
+  channel: "snapshot",
+  buildChannel: "snapshot",
+  currentVersion: "be70029",
+  currentCommit: "be70029",
+  latestTag: "snapshot",
+  latestCommit: "be7002918fdc60dbdeab71d9dd17e00d3d006c56",
+  updateAvailable: false,
+  applicable: true,
+};
+
+function healthFetch(versions: string[]): typeof fetch {
+  let i = 0;
+  return vi.fn(async () => {
+    const version = versions[Math.min(i, versions.length - 1)];
+    i += 1;
+    if (version === "DOWN") throw new TypeError("Failed to fetch");
+    return new Response(JSON.stringify({ version }), { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+interface CheckSettler {
+  resolve: (value: UpdateCheckResponse) => void;
+  reject: (err: unknown) => void;
+}
+
+// scriptedChecks holds every evener/update/check in flight so a test can
+// settle them in whatever order it wants.
+function scriptedChecks(fake: FakeClient): CheckSettler[] {
+  const settlers: CheckSettler[] = [];
+  fake.on(
+    "evener/update/check",
+    () =>
+      new Promise<UpdateCheckResponse>((resolve, reject) => {
+        settlers.push({ resolve, reject });
+      }),
+  );
+  return settlers;
+}
+
+function settler(settlers: CheckSettler[], index: number): CheckSettler {
+  const found = settlers[index];
+  if (!found) throw new Error(`no check in flight at index ${index}`);
+  return found;
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetThreadsStoreForTests();
+  resetHubUpdateStoreForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("runCheck", () => {
+  test("requests evener/update/check with the selected channel and stores the result", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => UP_TO_DATE);
+    hubUpdateStore.getState().setChannel("snapshot");
+
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    expect(fake.calls).toEqual([{ method: "evener/update/check", params: { channel: "snapshot" } }]);
+    const state = hubUpdateStore.getState();
+    expect(state.check).toEqual(UP_TO_DATE);
+    expect(state.checking).toBe(false);
+    expect(state.checkError).toBeNull();
+  });
+
+  test("sends an empty channel when none is selected yet", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => UP_TO_DATE);
+
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    expect(fake.calls).toEqual([{ method: "evener/update/check", params: { channel: "" } }]);
+  });
+
+  test("stores the hub's own message and clears the previous result on failure", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => {
+      throw new WireError("GET x: 403 Forbidden: API rate limit exceeded", -1);
+    });
+
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    const state = hubUpdateStore.getState();
+    expect(state.check).toBeNull();
+    expect(state.checkError).toContain("rate limit");
+  });
+
+  test("shows the generic message for a non-WireError rejection, not its raw text", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => {
+      throw new Error("TypeError: cyclic object value");
+    });
+
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    expect(hubUpdateStore.getState().checkError).toBe(GENERIC_ERROR_MESSAGE);
+  });
+
+  test("setChannel clears the stale check result", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => UP_TO_DATE);
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    act(() => hubUpdateStore.getState().setChannel("release"));
+
+    expect(hubUpdateStore.getState().channel).toBe("release");
+    expect(hubUpdateStore.getState().check).toBeNull();
+  });
+
+  test("setChannel clears a stale restartTimedOut flag", () => {
+    hubUpdateStore.setState({ restartTimedOut: true });
+
+    act(() => hubUpdateStore.getState().setChannel("release"));
+
+    expect(hubUpdateStore.getState().restartTimedOut).toBe(false);
+  });
+
+  test("runCheck clears a stale restartTimedOut flag", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => UP_TO_DATE);
+    hubUpdateStore.setState({ restartTimedOut: true });
+
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    expect(hubUpdateStore.getState().restartTimedOut).toBe(false);
+  });
+
+  test("ignores stale runCheck response when channel changed during flight", async () => {
+    vi.useFakeTimers();
+    const fake = connectFakeClient();
+    let resolveCheck: ((value: UpdateCheckResponse) => void) | undefined;
+    const checkPromise = new Promise<UpdateCheckResponse>((resolve) => {
+      resolveCheck = resolve;
+    });
+    fake.on("evener/update/check", () => checkPromise);
+    hubUpdateStore.getState().setChannel("release");
+
+    act(() => {
+      void hubUpdateStore.getState().runCheck();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(hubUpdateStore.getState().checking).toBe(true);
+    act(() => hubUpdateStore.getState().setChannel("snapshot"));
+    expect(hubUpdateStore.getState().checking).toBe(false);
+
+    act(() => {
+      if (resolveCheck) resolveCheck(UP_TO_DATE);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const state = hubUpdateStore.getState();
+    expect(state.check).toBeNull();
+    expect(state.checkError).toBeNull();
+  });
+
+  test("keeps the newest result when two checks on the same channel finish out of order", async () => {
+    vi.useFakeTimers();
+    const fake = connectFakeClient();
+    const settlers = scriptedChecks(fake);
+    hubUpdateStore.getState().setChannel("snapshot");
+
+    act(() => {
+      void hubUpdateStore.getState().runCheck();
+      void hubUpdateStore.getState().runCheck();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const newest = { ...UP_TO_DATE, updateAvailable: true, latestCommit: "3b1c5f8aaaa" };
+    act(() => {
+      settler(settlers, 1).resolve(newest);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => {
+      settler(settlers, 0).resolve(UP_TO_DATE);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const state = hubUpdateStore.getState();
+    expect(state.check).toEqual(newest);
+    expect(state.checking).toBe(false);
+  });
+
+  test("ignores a late failure from a superseded check on the same channel", async () => {
+    vi.useFakeTimers();
+    const fake = connectFakeClient();
+    const settlers = scriptedChecks(fake);
+    hubUpdateStore.getState().setChannel("snapshot");
+
+    act(() => {
+      void hubUpdateStore.getState().runCheck();
+      void hubUpdateStore.getState().runCheck();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    act(() => {
+      settler(settlers, 1).resolve(UP_TO_DATE);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => {
+      settler(settlers, 0).reject(new WireError("GET x: 403 Forbidden: API rate limit exceeded", -1));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const state = hubUpdateStore.getState();
+    expect(state.check).toEqual(UP_TO_DATE);
+    expect(state.checkError).toBeNull();
+  });
+});
+
+describe("apply", () => {
+  test("requests evener/update/apply, then polls /api/health until the version changes and reloads", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const fetchImpl = healthFetch(["be70029", "DOWN", "DOWN", "3b1c5f8"]);
+    resetHubUpdateStoreForTests({ fetchImpl, reload });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true, latestCommit: "3b1c5f8aaaa" }));
+    fake.on("evener/update/apply", () => ({
+      release: "snapshot",
+      channel: "snapshot",
+      installed: ["/x/evener", "/x/evener-dev"],
+      restarting: true,
+    }));
+    hubUpdateStore.getState().setChannel("snapshot");
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    act(() => {
+      void hubUpdateStore.getState().apply();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(fake.calls[1]).toEqual({
+      method: "evener/update/apply",
+      params: { channel: "snapshot" },
+      // The hub may synchronously download + verify for up to five minutes
+      // (selfupdate.defaultUpgradeTimeout); the generic 30s client timeout
+      // would report a slow-but-valid download as failed and never start
+      // the restart poll, so apply carries its own longer deadline.
+      opts: { timeoutMs: APPLY_TIMEOUT_MS },
+    });
+    expect(APPLY_TIMEOUT_MS).toBeGreaterThan(5 * 60_000);
+    expect(hubUpdateStore.getState().restarting).toBe(true);
+    expect(hubUpdateStore.getState().applying).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESTART_POLL_MS * 4);
+    });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(hubUpdateStore.getState().restartTimedOut).toBe(false);
+    // The poll has to see the NEW hub, so it must never be answered from a cache,
+    // and every attempt carries a deadline so a hung fetch cannot outlive the timeout.
+    for (const call of (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(call[0]).toBe("/api/health");
+      expect(call[1]).toMatchObject({ credentials: "same-origin", cache: "no-store" });
+      expect(call[1].signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  test("gives up after RESTART_TIMEOUT_MS when the version never changes", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    resetHubUpdateStoreForTests({ fetchImpl: healthFetch(["be70029"]), reload });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true }));
+    fake.on("evener/update/apply", () => ({
+      release: "snapshot",
+      channel: "snapshot",
+      installed: ["/x/evener"],
+      restarting: true,
+    }));
+    await act(() => hubUpdateStore.getState().runCheck());
+    act(() => {
+      void hubUpdateStore.getState().apply();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESTART_TIMEOUT_MS + RESTART_POLL_MS);
+    });
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(hubUpdateStore.getState().restarting).toBe(false);
+    expect(hubUpdateStore.getState().restartTimedOut).toBe(true);
+  });
+
+  test("aborts a hung health fetch and still times out", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const signals: AbortSignal[] = [];
+    // Never settles on its own; only the store's own deadline can end it.
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (signal) signals.push(signal);
+      return new Promise<Response>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    }) as unknown as typeof fetch;
+    resetHubUpdateStoreForTests({ fetchImpl, reload });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true }));
+    fake.on("evener/update/apply", () => ({
+      release: "snapshot",
+      channel: "snapshot",
+      installed: ["/x/evener"],
+      restarting: true,
+    }));
+    await act(() => hubUpdateStore.getState().runCheck());
+    act(() => {
+      void hubUpdateStore.getState().apply();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESTART_TIMEOUT_MS + RESTART_POLL_MS);
+    });
+
+    expect(signals.length).toBeGreaterThan(0);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+    expect(reload).not.toHaveBeenCalled();
+    expect(hubUpdateStore.getState().restartTimedOut).toBe(true);
+  });
+
+  test("stores applyError and does not poll when the hub refuses", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = healthFetch(["be70029"]);
+    resetHubUpdateStoreForTests({ fetchImpl, reload: vi.fn() });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true }));
+    fake.on("evener/update/apply", () => {
+      throw new WireError("this hub is a dev build", -1);
+    });
+
+    hubUpdateStore.getState().setChannel("snapshot");
+    await act(() => hubUpdateStore.getState().runCheck());
+    await act(() => hubUpdateStore.getState().apply());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESTART_POLL_MS * 2);
+    });
+
+    expect(hubUpdateStore.getState().applyError).toContain("dev build");
+    expect(hubUpdateStore.getState().restarting).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test("shows the hub-unreachable message when apply fails on the transport", async () => {
+    const fetchImpl = healthFetch(["be70029"]);
+    resetHubUpdateStoreForTests({ fetchImpl, reload: vi.fn() });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true }));
+    fake.on("evener/update/apply", () => {
+      throw new Error('AppwireClient: cannot call "evener/update/apply" while state is "closed"');
+    });
+
+    hubUpdateStore.getState().setChannel("snapshot");
+    await act(() => hubUpdateStore.getState().runCheck());
+    await act(() => hubUpdateStore.getState().apply());
+
+    expect(hubUpdateStore.getState().applyError).toBe(HUB_UNREACHABLE_MESSAGE);
+    expect(hubUpdateStore.getState().restarting).toBe(false);
+  });
+
+  test("requires a prior check and rejects apply() without one", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = healthFetch(["be70029"]);
+    resetHubUpdateStoreForTests({ fetchImpl, reload: vi.fn() });
+    const fake = connectFakeClient();
+    fake.on("evener/update/apply", () => ({
+      release: "snapshot",
+      channel: "snapshot",
+      installed: ["/x/evener"],
+      restarting: true,
+    }));
+
+    await act(() => hubUpdateStore.getState().apply());
+
+    expect(fake.calls).toEqual([]);
+    expect(hubUpdateStore.getState().applyError).toContain("Check for updates first");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  test("guards against concurrent apply() calls", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const fetchImpl = healthFetch(["be70029", "DOWN", "DOWN", "3b1c5f8"]);
+    resetHubUpdateStoreForTests({ fetchImpl, reload });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true, latestCommit: "3b1c5f8aaaa" }));
+    fake.on("evener/update/apply", () => ({
+      release: "snapshot",
+      channel: "snapshot",
+      installed: ["/x/evener"],
+      restarting: true,
+    }));
+    hubUpdateStore.getState().setChannel("snapshot");
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    act(() => {
+      void hubUpdateStore.getState().apply();
+      void hubUpdateStore.getState().apply();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const applyCalls = fake.calls.filter((c) => c.method === "evener/update/apply");
+    expect(applyCalls).toHaveLength(1);
+  });
+});
+
+describe("stale check invalidation", () => {
+  test("runCheck clears the previous result while checking", async () => {
+    vi.useFakeTimers();
+    const fake = connectFakeClient();
+    const settlers = scriptedChecks(fake);
+    hubUpdateStore.getState().setChannel("snapshot");
+
+    // First check resolves so a previous result exists.
+    act(() => {
+      void hubUpdateStore.getState().runCheck();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    act(() => {
+      settler(settlers, 0).resolve(UP_TO_DATE);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(hubUpdateStore.getState().check).toEqual(UP_TO_DATE);
+
+    // Second check still in flight: no stale result is shown meanwhile.
+    act(() => {
+      void hubUpdateStore.getState().runCheck();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(hubUpdateStore.getState().checking).toBe(true);
+    expect(hubUpdateStore.getState().check).toBeNull();
+
+    act(() => {
+      settler(settlers, 1).resolve(UP_TO_DATE);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(hubUpdateStore.getState().check).toEqual(UP_TO_DATE);
+  });
+
+  test("apply refuses a check from another channel", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, channel: "snapshot" as const }));
+    hubUpdateStore.getState().setChannel("snapshot");
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    // Channel switched after the check resolved: the stored result is stale.
+    act(() => {
+      hubUpdateStore.setState({ channel: "release" });
+    });
+    await act(() => hubUpdateStore.getState().apply());
+
+    expect(hubUpdateStore.getState().applyError).toBe("That result is stale; run a fresh check first");
+    expect(fake.calls.some((c) => c.method === "evener/update/apply")).toBe(false);
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
@@ -32,6 +32,10 @@ export const RESTART_TIMEOUT_MS = 30_000;
 // poll always starts.
 export const APPLY_TIMEOUT_MS = 6 * 60_000;
 
+// ALREADY_UP_TO_DATE is the message both the store-level guard and the
+// server's restarting:false response surface when the channel is current.
+const ALREADY_UP_TO_DATE = "Already up to date";
+
 export interface HubUpdateStoreState {
   // null until the section seeds it from the overview's buildChannel; the
   // hub then falls back to its own upgrade channel for an empty request.
@@ -163,22 +167,22 @@ export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
     // call too: never issue a download + exec restart for an up-to-date
     // check the button state let through.
     if (!check.updateAvailable) {
-      set({ applyError: "Already up to date" });
+      set({ applyError: ALREADY_UP_TO_DATE });
       return;
     }
     set({ applying: true, applyError: null, restartTimedOut: false });
     const previous = check.currentVersion;
     try {
-      const resp = (await requireClient().request(
+      const resp = await requireClient().request(
         "evener/update/apply",
         { channel: get().channel ?? "" },
         { timeoutMs: APPLY_TIMEOUT_MS },
-      )) as { restarting?: boolean };
+      );
       // The server re-checks before installing and answers restarting:false
       // when the channel was already current: no download, no exec, no new
       // version to poll for. Report it instead of polling into a timeout.
-      if (resp && resp.restarting === false) {
-        set({ applying: false, applyError: "Already up to date" });
+      if (!resp.restarting) {
+        set({ applying: false, applyError: ALREADY_UP_TO_DATE });
         return;
       }
     } catch (err) {

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
@@ -159,6 +159,13 @@ export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
       set({ applyError: "That result is stale; run a fresh check first" });
       return;
     }
+    // The button disables without an available update, but apply is a store
+    // call too: never issue a download + exec restart for an up-to-date
+    // check the button state let through.
+    if (!check.updateAvailable) {
+      set({ applyError: "Already up to date" });
+      return;
+    }
     set({ applying: true, applyError: null, restartTimedOut: false });
     const previous = check.currentVersion;
     try {

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
@@ -1,0 +1,199 @@
+// hubUpdate.ts drives Settings -> Hub -> Updates: pick a release channel,
+// ask the hub whether that channel is ahead of the running build
+// (evener/update/check), and apply it (evener/update/apply). Apply is the
+// interesting half: the hub answers, then execs the new binary in place, so
+// the WebSocket drops and the page has to notice the NEW hub on its own.
+// It does that by polling /api/health (auth-exempt, always registered - see
+// shell/chrome/webNotBuilt.ts's note) until `version` differs from the
+// value the check recorded, then reloads so the SPA bundle matches the
+// backend. Fetch failures while polling are the expected mid-restart state.
+//
+// Like settingsOverview.ts, this store reads connectionStore's current
+// client at call time and holds no subscription of its own.
+
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+import { friendlyErrorMessage } from "../protocol/errors";
+import type { AppwireClientLike } from "../protocol/testing/fakeClient";
+import type { UpdateCheckResponse } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+
+export type UpdateChannel = "release" | "snapshot";
+
+export const RESTART_POLL_MS = 1000;
+export const RESTART_TIMEOUT_MS = 30_000;
+
+// APPLY_TIMEOUT_MS bounds the evener/update/apply RPC itself. The hub
+// enforces one overall hubUpgradeTimeout deadline (4 minutes: archive +
+// checksums downloads, verify, install) over the per-request 5-minute
+// client timeouts that could otherwise stack, so six minutes here clears
+// the server bound with headroom for the exec and response frames. A slow
+// but valid download therefore resolves (not times out) and the restart
+// poll always starts.
+export const APPLY_TIMEOUT_MS = 6 * 60_000;
+
+export interface HubUpdateStoreState {
+  // null until the section seeds it from the overview's buildChannel; the
+  // hub then falls back to its own upgrade channel for an empty request.
+  channel: UpdateChannel | null;
+  check: UpdateCheckResponse | null;
+  checking: boolean;
+  checkError: string | null;
+  applying: boolean;
+  applyError: string | null;
+  restarting: boolean;
+  restartTimedOut: boolean;
+  setChannel(channel: UpdateChannel): void;
+  runCheck(): Promise<void>;
+  apply(): Promise<void>;
+}
+
+interface Deps {
+  fetchImpl: typeof fetch;
+  reload: () => void;
+}
+
+let deps: Deps = { fetchImpl: (...args) => fetch(...args), reload: () => window.location.reload() };
+
+// checkSequence orders overlapping runCheck calls: only the newest request
+// may write its result, so a slow earlier check cannot clobber a later one.
+// setChannel bumps it too, which retires any check still in flight.
+let checkSequence = 0;
+
+function requireClient(): AppwireClientLike {
+  const client = connectionStore.getState().client;
+  if (!client) {
+    throw new Error("hubUpdate store: no client connected; call useConnectionStore.getState().connect(client) first");
+  }
+  return client;
+}
+
+// healthVersion gives up after timeoutMs so a hub that accepts the
+// connection and then never answers cannot outlive RESTART_TIMEOUT_MS.
+async function healthVersion(timeoutMs: number): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await deps.fetchImpl("/api/health", {
+      credentials: "same-origin",
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as { version?: string };
+    return typeof body.version === "string" ? body.version : null;
+  } catch {
+    return null; // the hub is mid-restart or the attempt timed out; keep polling
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// waitForNewHub polls until /api/health reports a version other than
+// previous, then reloads. Resolves after reload() or the timeout.
+async function waitForNewHub(previous: string | null): Promise<void> {
+  const deadline = Date.now() + RESTART_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, RESTART_POLL_MS));
+    const version = await healthVersion(Math.max(0, deadline - Date.now()));
+    if (version !== null && version !== previous) {
+      hubUpdateStore.setState({ restarting: false });
+      deps.reload();
+      return;
+    }
+  }
+  hubUpdateStore.setState({ restarting: false, restartTimedOut: true });
+}
+
+const INITIAL = {
+  channel: null,
+  check: null,
+  checking: false,
+  checkError: null,
+  applying: false,
+  applyError: null,
+  restarting: false,
+  restartTimedOut: false,
+} as const;
+
+export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
+  ...INITIAL,
+
+  setChannel(channel) {
+    checkSequence++;
+    set({ channel, check: null, checking: false, checkError: null, applyError: null, restartTimedOut: false });
+  },
+
+  async runCheck() {
+    // Invalidate the previous result first: a manual re-check must not
+    // leave a stale positive in state while the new check is in flight
+    // (the apply button would otherwise act on it).
+    set({ checking: true, check: null, checkError: null, restartTimedOut: false });
+    const seq = ++checkSequence;
+    try {
+      const check = await requireClient().request("evener/update/check", { channel: get().channel ?? "" });
+      if (seq === checkSequence) {
+        set({ check, checking: false });
+      }
+    } catch (err) {
+      if (seq === checkSequence) {
+        set({ check: null, checking: false, checkError: friendlyErrorMessage(err) });
+      }
+    }
+  },
+
+  async apply() {
+    if (get().applying || get().restarting) {
+      return;
+    }
+    const check = get().check;
+    if (!check) {
+      set({ applyError: "Check for updates first" });
+      return;
+    }
+    // The check must still describe the selected channel: a channel
+    // switch after the check resolved leaves a stale positive that must
+    // not be applied. (The running build cannot change under the page --
+    // a restart reloads it -- so no build comparison is needed.)
+    if (get().channel !== null && check.channel !== get().channel) {
+      set({ applyError: "That result is stale; run a fresh check first" });
+      return;
+    }
+    set({ applying: true, applyError: null, restartTimedOut: false });
+    const previous = check.currentVersion;
+    try {
+      await requireClient().request(
+        "evener/update/apply",
+        { channel: get().channel ?? "" },
+        { timeoutMs: APPLY_TIMEOUT_MS },
+      );
+    } catch (err) {
+      set({ applying: false, applyError: friendlyErrorMessage(err) });
+      return;
+    }
+    set({ applying: false, restarting: true });
+    await waitForNewHub(previous);
+  },
+}));
+
+export function useHubUpdateStore(): HubUpdateStoreState;
+export function useHubUpdateStore<T>(selector: (state: HubUpdateStoreState) => T): T;
+export function useHubUpdateStore<T>(selector?: (state: HubUpdateStoreState) => T): T | HubUpdateStoreState {
+  // Not a real conditional hook call - see stores/connection.ts's own
+  // useConnectionStore for the full explanation (zustand's useStore has a
+  // `selector = identity` JS default param, so both arms run identically).
+  // biome-ignore lint/correctness/useHookAtTopLevel: same hook both arms, JS default param not a real conditional - see stores/connection.ts
+  return selector ? useStore(hubUpdateStore, selector) : useStore(hubUpdateStore);
+}
+
+// resetHubUpdateStoreForTests resets state and lets tests inject the
+// health fetch and reload so the restart poll runs under fake timers with
+// no real network and no real navigation. Production never calls this.
+export function resetHubUpdateStoreForTests(overrides: Partial<Deps> = {}): void {
+  deps = {
+    fetchImpl: overrides.fetchImpl ?? ((...args) => fetch(...args)),
+    reload: overrides.reload ?? (() => window.location.reload()),
+  };
+  checkSequence = 0;
+  hubUpdateStore.setState({ ...INITIAL });
+}

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
@@ -169,11 +169,18 @@ export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
     set({ applying: true, applyError: null, restartTimedOut: false });
     const previous = check.currentVersion;
     try {
-      await requireClient().request(
+      const resp = (await requireClient().request(
         "evener/update/apply",
         { channel: get().channel ?? "" },
         { timeoutMs: APPLY_TIMEOUT_MS },
-      );
+      )) as { restarting?: boolean };
+      // The server re-checks before installing and answers restarting:false
+      // when the channel was already current: no download, no exec, no new
+      // version to poll for. Report it instead of polling into a timeout.
+      if (resp && resp.restarting === false) {
+        set({ applying: false, applyError: "Already up to date" });
+        return;
+      }
     } catch (err) {
       set({ applying: false, applyError: friendlyErrorMessage(err) });
       return;

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
@@ -186,6 +186,20 @@ export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
         return;
       }
     } catch (err) {
+      // A transport disconnect after the server received the apply
+      // request may still result in a successful install + restart —
+      // the response frame is lost, not the work. Treat a mid-request
+      // disconnect as an unknown outcome and poll for the new hub
+      // before declaring failure. A pre-request failure ("cannot call
+      // while state is closed") never reached the server, so it stays
+      // an error.
+      const msg = err instanceof Error ? err.message : String(err);
+      const sentButLost = /disconnect|fetch|network|abort/i.test(msg) && !/cannot call/i.test(msg);
+      if (sentButLost) {
+        set({ applying: false, restarting: true });
+        await waitForNewHub(previous);
+        return;
+      }
       set({ applying: false, applyError: friendlyErrorMessage(err) });
       return;
     }

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
@@ -194,7 +194,12 @@ export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
       // while state is closed") never reached the server, so it stays
       // an error.
       const msg = err instanceof Error ? err.message : String(err);
-      const sentButLost = /disconnect|fetch|network|abort/i.test(msg) && !/cannot call/i.test(msg);
+      // Match the actual transport errors AppwireClient raises when the
+      // socket drops mid-request: "socket closed (code …)", "fetch"
+      // failures, "network" errors, "abort" from a timeout. Exclude
+      // "cannot call … while state is closed" — that's a pre-request
+      // rejection (the client was already disconnected, nothing was sent).
+      const sentButLost = /socket closed|disconnect|fetch|network|abort/i.test(msg) && !/cannot call/i.test(msg);
       if (sentButLost) {
         set({ applying: false, restarting: true });
         await waitForNewHub(previous);

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
@@ -13,7 +13,7 @@
 
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
-import { friendlyErrorMessage } from "../protocol/errors";
+import { friendlyErrorMessage, WireError } from "../protocol/errors";
 import type { AppwireClientLike } from "../protocol/testing/fakeClient";
 import type { UpdateCheckResponse } from "../protocol/types.gen";
 import { connectionStore } from "./connection";
@@ -186,21 +186,19 @@ export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
         return;
       }
     } catch (err) {
-      // A transport disconnect after the server received the apply
-      // request may still result in a successful install + restart —
-      // the response frame is lost, not the work. Treat a mid-request
-      // disconnect as an unknown outcome and poll for the new hub
-      // before declaring failure. A pre-request failure ("cannot call
-      // while state is closed") never reached the server, so it stays
-      // an error.
+      // A transport failure after the server received the apply request
+      // may still result in a successful install + restart — the response
+      // frame is lost, not the work. Classify by error type: a WireError
+      // means the server responded with a failure (not a transport drop),
+      // so it stays an error. A RequestTimeoutError or a plain Error
+      // (socket closed, network unreachable) means the response was lost,
+      // so poll for the new hub before declaring failure. A pre-request
+      // "cannot call … while state is closed" never reached the server,
+      // so it stays an error too.
       const msg = err instanceof Error ? err.message : String(err);
-      // Match the actual transport errors AppwireClient raises when the
-      // socket drops mid-request: "socket closed (code …)", "fetch"
-      // failures, "network" errors, "abort" from a timeout. Exclude
-      // "cannot call … while state is closed" — that's a pre-request
-      // rejection (the client was already disconnected, nothing was sent).
-      const sentButLost = /socket closed|disconnect|fetch|network|abort/i.test(msg) && !/cannot call/i.test(msg);
-      if (sentButLost) {
+      const neverSent = /cannot call/i.test(msg);
+      const serverResponded = err instanceof WireError;
+      if (!neverSent && !serverResponded) {
         set({ applying: false, restarting: true });
         await waitForNewHub(previous);
         return;

--- a/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
+++ b/cmd/evener-hub/frontend/src/stores/hubUpdate.ts
@@ -13,7 +13,7 @@
 
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
-import { friendlyErrorMessage, WireError } from "../protocol/errors";
+import { ConnectionClosedError, friendlyErrorMessage, WireError } from "../protocol/errors";
 import type { AppwireClientLike } from "../protocol/testing/fakeClient";
 import type { UpdateCheckResponse } from "../protocol/types.gen";
 import { connectionStore } from "./connection";
@@ -172,8 +172,18 @@ export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
     }
     set({ applying: true, applyError: null, restartTimedOut: false });
     const previous = check.currentVersion;
+    // Resolve the client before entering the transport handler: a missing
+    // client means no request was sent, so it must surface as an error,
+    // not fall through to restart polling.
+    let client: AppwireClientLike;
     try {
-      const resp = await requireClient().request(
+      client = requireClient();
+    } catch (err) {
+      set({ applying: false, applyError: friendlyErrorMessage(err) });
+      return;
+    }
+    try {
+      const resp = await client.request(
         "evener/update/apply",
         { channel: get().channel ?? "" },
         { timeoutMs: APPLY_TIMEOUT_MS },
@@ -192,11 +202,11 @@ export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
       // means the server responded with a failure (not a transport drop),
       // so it stays an error. A RequestTimeoutError or a plain Error
       // (socket closed, network unreachable) means the response was lost,
-      // so poll for the new hub before declaring failure. A pre-request
-      // "cannot call … while state is closed" never reached the server,
-      // so it stays an error too.
-      const msg = err instanceof Error ? err.message : String(err);
-      const neverSent = /cannot call/i.test(msg);
+      // so poll for the new hub before declaring failure. Errors that mean
+      // the request never reached the server (ConnectionClosedError, the
+      // "cannot call … while state is closed" rejection) stay errors.
+      const neverSent =
+        err instanceof ConnectionClosedError || (err instanceof Error && /cannot call/i.test(err.message));
       const serverResponded = err instanceof WireError;
       if (!neverSent && !serverResponded) {
         set({ applying: false, restarting: true });

--- a/cmd/evener-hub/update_e2e_test.go
+++ b/cmd/evener-hub/update_e2e_test.go
@@ -1,0 +1,149 @@
+//go:build unix
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+)
+
+// TestUpdateApplyEndToEnd builds this branch's own evener binary as a
+// "snapshot" release build, runs it as a real hub, applies an update
+// through the RPC, and proves the process replaced itself in place: same
+// PID, /api/health back with a different version. Opt-in only: it downloads
+// the current public snapshot release from GitHub (AGENTS.md forbids
+// network in default tests).
+//
+// The hub under test is built from this worktree, not downloaded, because
+// the publicly published snapshot release only ever reflects main and this
+// feature has not merged there yet -- a downloaded "current snapshot" would
+// have no evener/update/apply route to call. Building the branch locally
+// with -X buildinfo.Channel=snapshot makes it a non-dev build (so self-update
+// isn't refused) whose version differs from whatever main last published,
+// which is what lets the post-update /api/health read back a different
+// version and prove the exec actually swapped binaries.
+//
+//	EVENER_UPDATE_E2E=1 go test ./cmd/evener-hub/ -run TestUpdateApplyEndToEnd -v
+func TestUpdateApplyEndToEnd(t *testing.T) {
+	if os.Getenv("EVENER_UPDATE_E2E") == "" {
+		t.Skip("set EVENER_UPDATE_E2E=1 to run (downloads from GitHub)")
+	}
+
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs repo root: %v", err)
+	}
+	sha := gitShortSHA(t, repoRoot)
+
+	binDir := t.TempDir()
+	evenerBin := filepath.Join(binDir, "evener")
+	build := exec.Command("go", "build",
+		"-ldflags", "-X primeradiant.com/evener/buildinfo.Channel=snapshot -X primeradiant.com/evener/buildinfo.GitSHA="+sha,
+		"-o", evenerBin, "./cmd/evener/")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build evener (snapshot-channel): %v\n%s", err, out)
+	}
+
+	// No model call is made, so the fake provider only needs to exist in
+	// config -- base_url is never dialed.
+	stack := startHubStackOnProviderWithEvener(t, `
+default = "fake"
+
+[providers.fake]
+base     = "openai-compatible"
+base_url = "http://127.0.0.1:1"
+api_key  = "fakellm-not-a-secret"
+`, "fake/does-not-matter", evenerBin)
+
+	before := healthVersion(t, stack.addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client := stack.dialRPC(ctx, t)
+
+	resp, err := client.UpdateApply(ctx, appwire.UpdateApplyParams{Channel: "snapshot"})
+	if err != nil {
+		t.Fatalf("UpdateApply: %v", err)
+	}
+	if !resp.Restarting {
+		t.Fatalf("resp = %+v", resp)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(500 * time.Millisecond)
+		r, err := http.Get("http://" + stack.addr + "/api/health")
+		if err != nil {
+			continue
+		}
+		var body struct {
+			Version string `json:"version"`
+		}
+		decodeErr := json.NewDecoder(r.Body).Decode(&body)
+		_ = r.Body.Close()
+		if decodeErr != nil || body.Version == "" || body.Version == before {
+			// A version equal to "before" can be the old process answering
+			// in the window before its self-exec fires; keep polling for a
+			// response that can only come from the newly installed binary.
+			continue
+		}
+		if !processAlive(stack.pid) {
+			t.Fatalf("hub pid %d died", stack.pid)
+		}
+		t.Logf("before=%s after=%s pid=%d", before, body.Version, stack.pid)
+
+		installedBin := filepath.Join(stack.home, ".local", "share", "evener", "bin", "evener")
+		if _, statErr := os.Stat(installedBin); statErr != nil {
+			t.Fatalf("installed snapshot binary missing at %s: %v", installedBin, statErr)
+		}
+		return
+	}
+	t.Fatal("hub did not come back with a new version within 30s")
+}
+
+func gitShortSHA(t *testing.T, repoRoot string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", repoRoot, "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse --short HEAD: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func healthVersion(t *testing.T, addr string) string {
+	t.Helper()
+	r, err := http.Get("http://" + addr + "/api/health")
+	if err != nil {
+		t.Fatalf("GET /api/health: %v", err)
+	}
+	defer r.Body.Close()
+	var body struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /api/health: %v", err)
+	}
+	return body.Version
+}
+
+// processAlive reports whether pid still refers to a live process, using the
+// null-signal probe: FindProcess always succeeds on unix, so Signal(0) is
+// what actually checks.
+func processAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/cmd/evener-hub/web_api.go
+++ b/cmd/evener-hub/web_api.go
@@ -74,6 +74,9 @@ func (s *WebServer) handleAPIHealth(w http.ResponseWriter, r *http.Request) {
 		writeAPIError(w, http.StatusMethodNotAllowed, "GET required")
 		return
 	}
+	// The hub self-update poll watches this endpoint for the version the new
+	// binary reports, so a cached answer would hide the restart.
+	w.Header().Set("Cache-Control", "no-store")
 	writeAPIJSON(w, http.StatusOK, hubapi.HealthResponse{
 		Version:          buildinfo.Version(),
 		MobileAPIVersion: hubapi.MobileAPIVersion,

--- a/cmd/evener-hub/web_appwire_fuzz_test.go
+++ b/cmd/evener-hub/web_appwire_fuzz_test.go
@@ -191,6 +191,21 @@ func pinSandboxCWD(raw []byte, cwd string) []byte {
 // this target.
 func FuzzAppWireDispatch(f *testing.F) {
 	stubSelfUpgrade(f)
+	// evener/update/check is in the fuzzed method catalog and performs
+	// real GitHub I/O when built with release/snapshot ldflags; stub it
+	// offline like the upgrade seam so the harness's zero-network oracle
+	// holds for every build configuration.
+	previousUpdateCheck := runHubUpdateCheck
+	runHubUpdateCheck = func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		return selfupdate.CheckResult{}, nil
+	}
+	f.Cleanup(func() { runHubUpdateCheck = previousUpdateCheck })
+	// The self-update apply path execs the process in place; stub it to a
+	// no-op so the fuzz harness can never replace itself, even if built
+	// with release ldflags (isDevBuild would otherwise be the only guard).
+	previousScheduleHubRestart := scheduleHubRestart
+	scheduleHubRestart = func(context.Context, restartPin, string, []string) {}
+	f.Cleanup(func() { scheduleHubRestart = previousScheduleHubRestart })
 	canary := installSandboxAuthSeam(f)
 	deny := installDenyTransportTB(f)
 

--- a/cmd/evener-hub/web_test.go
+++ b/cmd/evener-hub/web_test.go
@@ -900,6 +900,10 @@ func TestWeb_APIHealth(t *testing.T) {
 	if !got.Capabilities.TranscriptFollow {
 		t.Fatalf("missing capabilities: %+v", got.Capabilities)
 	}
+	// The self-update restart poll reads this endpoint to spot the new hub.
+	if cache := rec.Header().Get("Cache-Control"); cache != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", cache)
+	}
 }
 
 func TestWeb_APIHealthExposesAssetIdentity(t *testing.T) {

--- a/cmd/evener/upgrade_test.go
+++ b/cmd/evener/upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,11 @@ func TestUpgradeSubcommandInstallsSnapshot(t *testing.T) {
 	archive := testReleaseArchive(t, "evener_linux_amd64")
 	var gotPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "checksums.txt") {
+			sum := sha256.Sum256(archive)
+			_, _ = fmt.Fprintf(w, "%x  evener_linux_amd64.tar.gz\n", sum)
+			return
+		}
 		gotPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/gzip")
 		_, _ = w.Write(archive)

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -134,6 +134,8 @@ no router (reserved).
 | `evener/search` | hub | `SearchParams` | `SearchResponse` | Searches live and persisted sessions for the hub command palette. |
 | `evener/harnesses/list` | hub | `HarnessListParams` | `HarnessListResponse` | Lists available harness descriptors. |
 | `evener/upgrade` | hub | `UpgradeParams` | `UpgradeResponse` | Performs or reports a evener binary upgrade. |
+| `evener/update/check` | hub | `UpdateCheckParams` | `UpdateCheckResponse` | Compares the running hub build against a release channel's current commit; dev builds report applicable=false without a network request. |
+| `evener/update/apply` | hub | `UpdateApplyParams` | `UpdateApplyResponse` | Downloads and installs a channel's build, then execs it in place of the running hub; refused on dev builds. |
 | `evener/auth/status` | hub | `AuthStatusParams` | `AuthStatusResponse` | Reports auth/credential status for a provider. |
 | `evener/auth/test` | hub | `AuthTestParams` | `AuthTestResponse` | Tests the effective credentials for one configured provider instance without starting a session. |
 | `evener/auth/login/start` | hub | `AuthLoginStartParams` | `AuthLoginStartResponse` | Begins an OAuth login flow; returns a flow ID and URL. |
@@ -2019,6 +2021,44 @@ _(no fields)_
 | Field | Go type | Omitempty | Embedded |
 |-------|---------|-----------|----------|
 | `receipt` | `appwire.MutationReceipt` |  |  |
+
+
+### `UpdateApplyParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `channel` | `string` | yes |  |
+
+
+### `UpdateApplyResponse`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `release` | `string` |  |  |
+| `channel` | `string` |  |  |
+| `installed` | `[]string` |  |  |
+| `restarting` | `bool` |  |  |
+
+
+### `UpdateCheckParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `channel` | `string` | yes |  |
+
+
+### `UpdateCheckResponse`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `channel` | `string` |  |  |
+| `buildChannel` | `string` |  |  |
+| `currentVersion` | `string` |  |  |
+| `currentCommit` | `string` |  |  |
+| `latestTag` | `string` | yes |  |
+| `latestCommit` | `string` | yes |  |
+| `updateAvailable` | `bool` |  |  |
+| `applicable` | `bool` |  |  |
 
 
 ### `UpgradeParams`

--- a/docs/evener-hub.md
+++ b/docs/evener-hub.md
@@ -319,6 +319,44 @@ then verifies health; see
 The hub acquires a `flock` on `hub.lock` in its state root, so one hub process runs
 per `hub_state_root` — one per user under the default layout.
 
+### Updating the hub from Settings
+
+Settings → Hub → Updates shows the running build (version, commit, channel),
+a channel selector (release or snapshot), and whether that channel is ahead
+of the running build. "Update and restart" downloads and installs the
+channel's archive with the same code as `evener upgrade`, then, once the
+apply response has been written to the websocket, the hub `exec`s the
+installed binary in place: same PID, same arguments, same
+environment. That is why it works the same under launchd, systemd, or a
+plain shell, and why nothing needs `KeepAlive`. The `hub.lock` flock and the
+listener are released by the exec and re-acquired by the new process; the
+page polls `/api/health` until the new version answers, then reloads.
+
+The install targets the prefix the running hub was launched from (derived
+from its own binary path, e.g. `/usr/local` for a system install), not
+always `~/.local`. The whole operation runs under a 4-minute overall
+deadline (both downloads, verification, install) so a stalled server fails
+the apply instead of blocking later updates. Before
+extraction, the archive's SHA-256 is checked against the release's
+`checksums.txt` entry (same fail-closed guarantee as `install.sh`); a
+mismatch or missing entry refuses the install. Note the limit: the
+checksums travel over the same GitHub TLS transport as the archive,
+unsigned, so this stops corruption and asset-swaps but not a compromise
+that rewrites both files the way a signature would.
+
+The channel selector has no stored setting. It defaults to the channel the
+running binary was built for, and after an update the installed binary's
+channel becomes the new default.
+
+Dev builds (a worktree `make build-hub`, channel `dev`) are excluded:
+Settings shows a rebuild note instead of the controls, and
+`evener/update/apply` is refused. Use `make build-hub` or
+`scripts/ops/deploy-hub.sh` for those.
+
+Running session daemons keep the binary they were spawned from (see the
+"Existing daemons keep the `evener` binary" note below); restart a session
+to move it to the new build.
+
 ### Trace browser AppWire traffic
 
 Use `--appwire-trace` to diagnose excessive browser WebSocket traffic. The flag

--- a/docs/superpowers/plans/2026-09-07-hub-self-update.md
+++ b/docs/superpowers/plans/2026-09-07-hub-self-update.md
@@ -1,0 +1,1892 @@
+# Hub Self-Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Settings → Hub shows whether a newer evener build exists on the chosen channel and, on one click, downloads it, installs it, and replaces the running hub process with it.
+
+**Architecture:** `internal/selfupdate` gains `Check` (GitHub API, compares the channel's commit to `buildinfo.GitSHA`) and `Restart` (`syscall.Exec` in place). The hub exposes `evener/update/check` and `evener/update/apply` over appwire; apply reuses the existing `selfupdate.Upgrade` then execs the installed binary after the response is flushed. The frontend adds a `hubUpdate` store and an "Updates" block in the Hub settings section that polls `/api/health` until the new hub is up.
+
+**Tech Stack:** Go 1.2x, appwire JSON-RPC catalog (`make generate` → `types.gen.ts`), React + zustand + vitest (`make test-web`).
+
+**Spec:** `docs/superpowers/specs/2026-09-07-hub-self-update-design.md`
+
+## Global Constraints
+
+- Default tests must be deterministic and offline (AGENTS.md). Only the `EVENER_UPDATE_E2E=1` test may touch the network.
+- Dev builds (`buildinfo.BuildChannel() == "dev"`) are never updated: check returns `applicable: false`, apply errors.
+- No stored channel setting. Default channel = `buildinfo.UpgradeChannel()`.
+- Frontend files under `src/` must pass `npx biome check --write` before the gate; no `noNonNullAssertion`, no array-index keys.
+- Go tests use the `previous := seam; seam = fake; t.Cleanup(restore)` pattern already in `cmd/evener-hub/app_rpc_test.go`.
+- Commit after every task. Never `git add -A`.
+- Work in `/home/jesse/git/prime-radiant-inc/evener/.worktrees/hub-self-update` on branch `hub-self-update`.
+
+---
+
+### Task 1: `selfupdate.Check`
+
+**Files:**
+- Create: `internal/selfupdate/check.go`
+- Test: `internal/selfupdate/check_test.go`
+
+**Interfaces:**
+- Produces:
+  ```go
+  type CheckOptions struct {
+      Channel    string       // "release" | "snapshot"
+      CurrentSHA string       // buildinfo.GitSHA (short)
+      RepoURL    string       // default defaultRepoURL
+      APIURL     string       // default "https://api.github.com"
+      HTTPClient *http.Client // default &http.Client{Timeout: 10 * time.Second}
+  }
+  type CheckResult struct {
+      Channel         string `json:"channel"`
+      LatestTag       string `json:"latestTag"`
+      LatestCommit    string `json:"latestCommit"`
+      UpdateAvailable bool   `json:"updateAvailable"`
+  }
+  func Check(ctx context.Context, opts CheckOptions) (CheckResult, error)
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package selfupdate
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeGitHub serves the two GitHub REST endpoints Check uses under
+// /repos/prime-radiant-inc/evener/... and records the paths it saw.
+func fakeGitHub(t *testing.T, latestTag, tagCommit string, status int) (*httptest.Server, *[]string) {
+	t.Helper()
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "API rate limit exceeded"})
+			return
+		}
+		switch {
+		case r.URL.Path == "/repos/prime-radiant-inc/evener/releases/latest":
+			_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": latestTag})
+		case strings.HasPrefix(r.URL.Path, "/repos/prime-radiant-inc/evener/commits/"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"sha": tagCommit})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &paths
+}
+
+func TestCheckSnapshotUpToDate(t *testing.T) {
+	server, paths := fakeGitHub(t, "", "be7002918fdc60dbdeab71d9dd17e00d3d006c56", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "be70029", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	want := CheckResult{Channel: "snapshot", LatestTag: "snapshot", LatestCommit: "be7002918fdc60dbdeab71d9dd17e00d3d006c56", UpdateAvailable: false}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+	if len(*paths) != 1 || (*paths)[0] != "/repos/prime-radiant-inc/evener/commits/snapshot" {
+		t.Fatalf("paths = %v", *paths)
+	}
+}
+
+func TestCheckSnapshotStale(t *testing.T) {
+	server, _ := fakeGitHub(t, "", "be7002918fdc60dbdeab71d9dd17e00d3d006c56", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "3b1c5f8", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !got.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = false, want true: %+v", got)
+	}
+}
+
+func TestCheckReleaseResolvesLatestTagThenCommit(t *testing.T) {
+	server, paths := fakeGitHub(t, "v0.2.0", "0123456789abcdef0123456789abcdef01234567", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "release", CurrentSHA: "0123456", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if got.LatestTag != "v0.2.0" || got.UpdateAvailable {
+		t.Fatalf("got %+v", got)
+	}
+	wantPaths := []string{
+		"/repos/prime-radiant-inc/evener/releases/latest",
+		"/repos/prime-radiant-inc/evener/commits/v0.2.0",
+	}
+	if strings.Join(*paths, ",") != strings.Join(wantPaths, ",") {
+		t.Fatalf("paths = %v, want %v", *paths, wantPaths)
+	}
+}
+
+func TestCheckEmptyCurrentSHAIsStale(t *testing.T) {
+	server, _ := fakeGitHub(t, "", "be7002918fdc60dbdeab71d9dd17e00d3d006c56", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !got.UpdateAvailable {
+		t.Fatal("empty CurrentSHA must report an update")
+	}
+}
+
+func TestCheckRateLimitSurfacesGitHubMessage(t *testing.T) {
+	server, _ := fakeGitHub(t, "", "", http.StatusForbidden)
+	_, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "be70029", APIURL: server.URL})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "403") || !strings.Contains(err.Error(), "API rate limit exceeded") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCheckRejectsUnknownChannel(t *testing.T) {
+	_, err := Check(t.Context(), CheckOptions{Channel: "nightly", CurrentSHA: "abc"})
+	if err == nil || !strings.Contains(err.Error(), "nightly") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCheckUsesRepoURLOwnerAndName(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]string{"sha": "abc"})
+	}))
+	t.Cleanup(server.Close)
+	_, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "abc", APIURL: server.URL, RepoURL: "https://github.com/acme/widgets/"})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if gotPath != "/repos/acme/widgets/commits/snapshot" {
+		t.Fatalf("path = %q", gotPath)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/selfupdate/ -run 'TestCheck' 2>&1 | head`
+Expected: compile error, `undefined: Check`.
+
+- [ ] **Step 3: Implement `check.go`**
+
+```go
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"primeradiant.com/evener/envvars"
+)
+
+const defaultAPIURL = "https://api.github.com"
+
+// CheckOptions configures Check. Channel is required; the rest default.
+type CheckOptions struct {
+	Channel    string
+	CurrentSHA string
+	RepoURL    string
+	APIURL     string
+	HTTPClient *http.Client
+}
+
+// CheckResult reports what the channel currently points at and whether the
+// running build (CurrentSHA) differs from it.
+type CheckResult struct {
+	Channel         string `json:"channel"`
+	LatestTag       string `json:"latestTag"`
+	LatestCommit    string `json:"latestCommit"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+}
+
+// Check resolves the channel's tag to a commit through the GitHub REST API
+// (public repo, unauthenticated) and compares it against CurrentSHA. The
+// snapshot channel is the floating "snapshot" tag; release is the tag behind
+// releases/latest. An empty CurrentSHA is treated as stale: we cannot prove
+// the running build matches, so offer the update.
+func Check(ctx context.Context, opts CheckOptions) (CheckResult, error) {
+	owner, repo, err := repoOwnerName(envvars.FirstNonEmpty(opts.RepoURL, defaultRepoURL))
+	if err != nil {
+		return CheckResult{}, err
+	}
+	apiURL := strings.TrimRight(envvars.FirstNonEmpty(opts.APIURL, defaultAPIURL), "/")
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	base := fmt.Sprintf("%s/repos/%s/%s", apiURL, owner, repo)
+
+	var tag string
+	switch opts.Channel {
+	case "snapshot":
+		tag = "snapshot"
+	case "release":
+		var latest struct {
+			TagName string `json:"tag_name"`
+		}
+		if err := getJSON(ctx, client, base+"/releases/latest", &latest); err != nil {
+			return CheckResult{}, err
+		}
+		if latest.TagName == "" {
+			return CheckResult{}, errors.New("latest release has no tag_name")
+		}
+		tag = latest.TagName
+	default:
+		return CheckResult{}, fmt.Errorf("unknown update channel %q; use release or snapshot", opts.Channel)
+	}
+
+	var commit struct {
+		SHA string `json:"sha"`
+	}
+	if err := getJSON(ctx, client, base+"/commits/"+url.PathEscape(tag), &commit); err != nil {
+		return CheckResult{}, err
+	}
+	if commit.SHA == "" {
+		return CheckResult{}, fmt.Errorf("tag %s resolved to no commit", tag)
+	}
+	return CheckResult{
+		Channel:         opts.Channel,
+		LatestTag:       tag,
+		LatestCommit:    commit.SHA,
+		UpdateAvailable: opts.CurrentSHA == "" || !strings.HasPrefix(commit.SHA, opts.CurrentSHA),
+	}, nil
+}
+
+// repoOwnerName extracts "owner", "repo" from a GitHub repository URL.
+func repoOwnerName(repoURL string) (string, string, error) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", "", fmt.Errorf("parse repo URL %q: %w", repoURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("repo URL %q is not owner/repo", repoURL)
+	}
+	return parts[0], parts[1], nil
+}
+
+// getJSON performs one GET and decodes a 2xx JSON body. Non-2xx responses
+// become an error carrying the status and GitHub's own "message" field, so
+// a rate-limit response reads as such instead of a bare 403.
+func getJSON(ctx context.Context, client *http.Client, u string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", u, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("GET %s: read body: %w", u, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		var gh struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(body, &gh)
+		if gh.Message != "" {
+			return fmt.Errorf("GET %s: %s: %s", u, resp.Status, gh.Message)
+		}
+		return fmt.Errorf("GET %s: %s", u, resp.Status)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("GET %s: decode: %w", u, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/selfupdate/ 2>&1 | tail -3`
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/selfupdate/check.go internal/selfupdate/check_test.go
+git commit -m "selfupdate: Check resolves a channel's commit and reports staleness"
+```
+
+---
+
+### Task 2: `selfupdate.Restart`
+
+**Files:**
+- Create: `internal/selfupdate/restart_unix.go`, `internal/selfupdate/restart_other.go`
+- Test: `internal/selfupdate/restart_unix_test.go`
+
+**Interfaces:**
+- Produces: `func Restart(binary string, args []string) error` — replaces the process image; returns only on failure.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+//go:build unix
+
+package selfupdate
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestRestartHelper is the exec target: when invoked with EVENER_RESTART_HELPER
+// set, it prints its argv and pid, then exits. Otherwise it is a no-op test.
+func TestRestartHelper(t *testing.T) {
+	if os.Getenv("EVENER_RESTART_HELPER") == "" {
+		return
+	}
+	mode := os.Getenv("EVENER_RESTART_HELPER")
+	if mode == "exec" {
+		// First hop: exec ourselves again in "print" mode. The pid must survive.
+		os.Setenv("EVENER_RESTART_HELPER", "print")
+		if err := Restart(os.Args[0], []string{"-test.run=TestRestartHelper", "hub", "-addr", "127.0.0.1:0"}); err != nil {
+			os.Stderr.WriteString("restart failed: " + err.Error())
+			os.Exit(3)
+		}
+	}
+	os.Stdout.WriteString("pid=" + itoa(os.Getpid()) + " argv=" + strings.Join(os.Args[1:], " ") + "\n")
+	os.Exit(0)
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func TestRestartKeepsPIDAndPassesArgs(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestRestartHelper")
+	cmd.Env = append(os.Environ(), "EVENER_RESTART_HELPER=exec")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("helper: %v\n%s", err, out)
+	}
+	if cmd.Process == nil {
+		t.Fatal("no process")
+	}
+	want := "pid=" + itoa(cmd.Process.Pid) + " argv=-test.run=TestRestartHelper hub -addr 127.0.0.1:0\n"
+	if string(out) != want {
+		t.Fatalf("helper output = %q, want %q", out, want)
+	}
+}
+
+func TestRestartMissingBinaryReturnsError(t *testing.T) {
+	err := Restart("/nonexistent/evener", []string{"hub"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/selfupdate/ -run 'TestRestart' 2>&1 | head`
+Expected: compile error, `undefined: Restart`.
+
+- [ ] **Step 3: Implement**
+
+`restart_unix.go`:
+
+```go
+//go:build unix
+
+package selfupdate
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Restart replaces the current process image with binary, keeping the PID,
+// the environment, and args as argv[1:]. Go opens files and sockets with
+// O_CLOEXEC, so the hub's flock and listener are released by the exec and
+// re-acquired by the new image. It only returns when the exec itself fails.
+func Restart(binary string, args []string) error {
+	argv := append([]string{binary}, args...)
+	if err := syscall.Exec(binary, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec %s: %w", binary, err)
+	}
+	return nil
+}
+```
+
+`restart_other.go`:
+
+```go
+//go:build !unix
+
+package selfupdate
+
+import "errors"
+
+// Restart is unsupported outside unix: there is no exec-in-place there.
+func Restart(binary string, args []string) error {
+	return errors.New("in-place restart is not supported on this platform")
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/selfupdate/ 2>&1 | tail -3`
+Expected: `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/selfupdate/restart_unix.go internal/selfupdate/restart_other.go internal/selfupdate/restart_unix_test.go
+git commit -m "selfupdate: Restart execs a binary in place"
+```
+
+---
+
+### Task 3: appwire catalog entries and `BuildChannel` in the overview
+
+**Files:**
+- Modify: `appwire/types.go` (near `UpgradeParams` ~line 2019, `MethodEvenerUpgrade` ~line 74, `SettingsHubOverview` ~line 3134)
+- Modify: `appwire/protocol.go` (after the `MethodEvenerUpgrade` catalog row ~line 160)
+- Modify: `appwire/client.go` (after `Upgrade` ~line 636)
+- Modify: `cmd/evener-hub/app_rpc_settings_overview.go:52`
+- Generated: `cmd/evener-hub/frontend/src/protocol/types.gen.ts`, appwire goldens
+- Test: `cmd/evener-hub/app_rpc_settings_overview_test.go`
+
+**Interfaces:**
+- Produces (Go, `appwire`):
+  ```go
+  const MethodEvenerUpdateCheck = "evener/update/check"
+  const MethodEvenerUpdateApply = "evener/update/apply"
+  type UpdateCheckParams struct { Channel string `json:"channel,omitempty"` }
+  type UpdateCheckResponse struct {
+      Channel         string `json:"channel"`
+      BuildChannel    string `json:"buildChannel"`
+      CurrentVersion  string `json:"currentVersion"`
+      CurrentCommit   string `json:"currentCommit"`
+      LatestTag       string `json:"latestTag,omitempty"`
+      LatestCommit    string `json:"latestCommit,omitempty"`
+      UpdateAvailable bool   `json:"updateAvailable"`
+      Applicable      bool   `json:"applicable"`
+  }
+  type UpdateApplyParams struct { Channel string `json:"channel,omitempty"` }
+  type UpdateApplyResponse struct {
+      Release    string   `json:"release"`
+      Channel    string   `json:"channel"`
+      Installed  []string `json:"installed"`
+      Restarting bool     `json:"restarting"`
+  }
+  func (c *Client) UpdateCheck(ctx, UpdateCheckParams) (UpdateCheckResponse, error)
+  func (c *Client) UpdateApply(ctx, UpdateApplyParams) (UpdateApplyResponse, error)
+  ```
+  and `SettingsHubOverview.BuildChannel string json:"buildChannel,omitempty"`.
+- Produces (TS, generated): `UpdateCheckParams`, `UpdateCheckResponse`, `UpdateApplyParams`, `UpdateApplyResponse`, `MethodTypes["evener/update/check"]`, `MethodTypes["evener/update/apply"]`, `SettingsHubOverview.buildChannel?`.
+
+- [ ] **Step 1: Write the failing overview test**
+
+Append to `cmd/evener-hub/app_rpc_settings_overview_test.go` (match the file's existing imports; it already imports `buildinfo` if a Commit test exists, otherwise add `"primeradiant.com/evener/buildinfo"`):
+
+```go
+func TestSettingsHubOverviewReportsBuildChannel(t *testing.T) {
+	previous := buildinfo.Channel
+	buildinfo.Channel = "snapshot"
+	t.Cleanup(func() { buildinfo.Channel = previous })
+
+	got := settingsHubOverview(hubcore.WebConfig{})
+	if got.BuildChannel != "snapshot" {
+		t.Fatalf("BuildChannel = %q, want snapshot", got.BuildChannel)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./cmd/evener-hub/ -run TestSettingsHubOverviewReportsBuildChannel 2>&1 | head -5`
+Expected: compile error, `got.BuildChannel undefined`.
+
+- [ ] **Step 3: Add the wire types**
+
+In `appwire/types.go`, after `MethodEvenerUpgrade`:
+
+```go
+	MethodEvenerUpdateCheck           = "evener/update/check"
+	MethodEvenerUpdateApply           = "evener/update/apply"
+```
+
+After `UpgradeResponse`:
+
+```go
+// UpdateCheckParams selects the channel to compare the running build against.
+// Empty means the running binary's own upgrade channel.
+type UpdateCheckParams struct {
+	Channel string `json:"channel,omitempty"`
+}
+
+// UpdateCheckResponse reports the running build and what the channel points
+// at. Applicable is false for dev builds, which are never self-updated; the
+// Latest* fields are empty then and no network request was made.
+type UpdateCheckResponse struct {
+	Channel         string `json:"channel"`
+	BuildChannel    string `json:"buildChannel"`
+	CurrentVersion  string `json:"currentVersion"`
+	CurrentCommit   string `json:"currentCommit"`
+	LatestTag       string `json:"latestTag,omitempty"`
+	LatestCommit    string `json:"latestCommit,omitempty"`
+	UpdateAvailable bool   `json:"updateAvailable"`
+	Applicable      bool   `json:"applicable"`
+}
+
+// UpdateApplyParams selects the channel to install. Empty means the running
+// binary's own upgrade channel.
+type UpdateApplyParams struct {
+	Channel string `json:"channel,omitempty"`
+}
+
+// UpdateApplyResponse is returned just before the hub execs the installed
+// binary in place; Restarting is always true on success.
+type UpdateApplyResponse struct {
+	Release    string   `json:"release"`
+	Channel    string   `json:"channel"`
+	Installed  []string `json:"installed"`
+	Restarting bool     `json:"restarting"`
+}
+```
+
+In `SettingsHubOverview`, after `Commit`:
+
+```go
+	// BuildChannel is buildinfo.BuildChannel(): release, snapshot, or dev.
+	BuildChannel string `json:"buildChannel,omitempty"`
+```
+
+In `appwire/protocol.go`, after the `MethodEvenerUpgrade` row:
+
+```go
+	{MethodEvenerUpdateCheck, UpdateCheckParams{}, UpdateCheckResponse{}, ScopeHub, "Compares the running hub build against a release channel's current commit; dev builds report applicable=false without a network request."},
+	{MethodEvenerUpdateApply, UpdateApplyParams{}, UpdateApplyResponse{}, ScopeHub, "Downloads and installs a channel's build, then execs it in place of the running hub; refused on dev builds."},
+```
+
+In `appwire/client.go`, after `Upgrade`:
+
+```go
+func (c *Client) UpdateCheck(ctx context.Context, params UpdateCheckParams) (UpdateCheckResponse, error) {
+	var out UpdateCheckResponse
+	err := c.request(ctx, MethodEvenerUpdateCheck, params, &out)
+	return out, err
+}
+
+func (c *Client) UpdateApply(ctx context.Context, params UpdateApplyParams) (UpdateApplyResponse, error) {
+	var out UpdateApplyResponse
+	err := c.request(ctx, MethodEvenerUpdateApply, params, &out)
+	return out, err
+}
+```
+
+In `cmd/evener-hub/app_rpc_settings_overview.go`, after `Commit: buildinfo.GitSHA,`:
+
+```go
+		BuildChannel:   buildinfo.BuildChannel(),
+```
+
+- [ ] **Step 4: Regenerate and update goldens**
+
+Run: `make generate && go test ./appwire -run '^Test.*Golden$' -update-goldens 2>&1 | tail -2 && go test ./appwire/ ./cmd/evener-hub/ -run 'Golden|Catalog|Protocol|Parity|SettingsHubOverview' 2>&1 | tail -3`
+Expected: `ok` for both. Then `git status --short` should show `types.gen.ts`, golden files, and the four Go files. If a parity test complains that a catalog method has no hub handler, that is expected until Task 4; note it and move on (the handler lands in the next task, same branch).
+
+- [ ] **Step 5: Frontend typecheck**
+
+Run: `cd cmd/evener-hub/frontend && npx tsc --noEmit 2>&1 | tail -3`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add appwire/types.go appwire/protocol.go appwire/client.go cmd/evener-hub/app_rpc_settings_overview.go cmd/evener-hub/app_rpc_settings_overview_test.go cmd/evener-hub/frontend/src/protocol/types.gen.ts appwire/testdata
+git commit -m "appwire: evener/update/check and evener/update/apply; buildChannel in settings overview"
+```
+
+---
+
+### Task 4: hub handlers `hubUpdateCheck` / `hubUpdateApply`
+
+**Files:**
+- Create: `cmd/evener-hub/app_update.go`
+- Modify: `cmd/evener-hub/app_rpc.go:965` (next to the `MethodEvenerUpgrade` registration)
+- Test: `cmd/evener-hub/app_update_test.go`
+
+**Interfaces:**
+- Consumes: `selfupdate.Check`, `selfupdate.Upgrade`, `selfupdate.Restart` (Tasks 1–2), the appwire types (Task 3), `hubProcessArgs` (main.go:46), `runHubSelfUpgrade` (app_upgrade.go).
+- Produces: package vars `runHubUpdateCheck`, `scheduleHubRestart` (test seams).
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+package hub
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/buildinfo"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+func setBuild(t *testing.T, sha, channel string) {
+	t.Helper()
+	prevSHA, prevChannel := buildinfo.GitSHA, buildinfo.Channel
+	buildinfo.GitSHA, buildinfo.Channel = sha, channel
+	t.Cleanup(func() { buildinfo.GitSHA, buildinfo.Channel = prevSHA, prevChannel })
+}
+
+func stubUpdateCheck(t *testing.T, fn func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error)) *int {
+	t.Helper()
+	calls := 0
+	previous := runHubUpdateCheck
+	runHubUpdateCheck = func(ctx context.Context, opts selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		calls++
+		return fn(ctx, opts)
+	}
+	t.Cleanup(func() { runHubUpdateCheck = previous })
+	return &calls
+}
+
+func stubSelfUpgrade(t *testing.T, fn func(context.Context, selfupdate.Options) (selfupdate.Result, error)) *int {
+	t.Helper()
+	calls := 0
+	previous := runHubSelfUpgrade
+	runHubSelfUpgrade = func(ctx context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		calls++
+		return fn(ctx, opts)
+	}
+	t.Cleanup(func() { runHubSelfUpgrade = previous })
+	return &calls
+}
+
+type restartCall struct {
+	binary string
+	args   []string
+}
+
+func stubScheduleRestart(t *testing.T) *[]restartCall {
+	t.Helper()
+	var calls []restartCall
+	previous := scheduleHubRestart
+	scheduleHubRestart = func(binary string, args []string) { calls = append(calls, restartCall{binary, args}) }
+	t.Cleanup(func() { scheduleHubRestart = previous })
+	return &calls
+}
+
+func TestHubUpdateCheckDevBuildIsNotApplicable(t *testing.T) {
+	setBuild(t, "", "")
+	calls := stubUpdateCheck(t, func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		t.Fatal("dev build must not call Check")
+		return selfupdate.CheckResult{}, nil
+	})
+	got, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{})
+	if err != nil {
+		t.Fatalf("hubUpdateCheck: %v", err)
+	}
+	if got.Applicable || got.UpdateAvailable || got.BuildChannel != "dev" || got.CurrentVersion != "dev" {
+		t.Fatalf("got %+v", got)
+	}
+	if *calls != 0 {
+		t.Fatalf("Check called %d times", *calls)
+	}
+}
+
+func TestHubUpdateCheckDefaultsToBuildChannelAndFillsCurrent(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	var gotOpts selfupdate.CheckOptions
+	stubUpdateCheck(t, func(_ context.Context, opts selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		gotOpts = opts
+		return selfupdate.CheckResult{Channel: opts.Channel, LatestTag: "snapshot", LatestCommit: "be70029abc", UpdateAvailable: true}, nil
+	})
+	got, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{})
+	if err != nil {
+		t.Fatalf("hubUpdateCheck: %v", err)
+	}
+	if gotOpts.Channel != "snapshot" || gotOpts.CurrentSHA != "3b1c5f8" {
+		t.Fatalf("opts = %+v", gotOpts)
+	}
+	want := appwire.UpdateCheckResponse{
+		Channel: "snapshot", BuildChannel: "snapshot", CurrentVersion: "3b1c5f8", CurrentCommit: "3b1c5f8",
+		LatestTag: "snapshot", LatestCommit: "be70029abc", UpdateAvailable: true, Applicable: true,
+	}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestHubUpdateCheckHonoursRequestedChannel(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	var gotChannel string
+	stubUpdateCheck(t, func(_ context.Context, opts selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		gotChannel = opts.Channel
+		return selfupdate.CheckResult{Channel: opts.Channel, LatestTag: "v0.1.0", LatestCommit: "3b1c5f8ffff"}, nil
+	})
+	got, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{Channel: "release"})
+	if err != nil {
+		t.Fatalf("hubUpdateCheck: %v", err)
+	}
+	if gotChannel != "release" || got.Channel != "release" || got.UpdateAvailable {
+		t.Fatalf("channel=%q got=%+v", gotChannel, got)
+	}
+}
+
+func TestHubUpdateCheckPropagatesError(t *testing.T) {
+	setBuild(t, "3b1c5f8", "release")
+	stubUpdateCheck(t, func(context.Context, selfupdate.CheckOptions) (selfupdate.CheckResult, error) {
+		return selfupdate.CheckResult{}, errors.New("GET x: 403 Forbidden: API rate limit exceeded")
+	})
+	_, err := hubUpdateCheck(context.Background(), appwire.UpdateCheckParams{})
+	if err == nil || !strings.Contains(err.Error(), "rate limit") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestHubUpdateApplyDevBuildRefused(t *testing.T) {
+	setBuild(t, "", "")
+	upgrades := stubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{}, nil
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil || !strings.Contains(err.Error(), "dev build") {
+		t.Fatalf("err = %v", err)
+	}
+	if *upgrades != 0 || len(*restarts) != 0 {
+		t.Fatalf("upgrades=%d restarts=%d", *upgrades, len(*restarts))
+	}
+}
+
+func TestHubUpdateApplyInstallsThenSchedulesRestartWithHubArgs(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	previousArgs := hubProcessArgs
+	hubProcessArgs = func() []string { return []string{"/old/evener", "hub", "-addr", "0.0.0.0:9180"} }
+	t.Cleanup(func() { hubProcessArgs = previousArgs })
+
+	var gotOpts selfupdate.Options
+	stubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return selfupdate.Result{
+			Release: "snapshot", Channel: "snapshot",
+			Installed: []string{"/home/u/.local/share/evener/bin/evener", "/home/u/.local/share/evener/bin/evener-dev"},
+		}, nil
+	})
+	restarts := stubScheduleRestart(t)
+
+	got, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"})
+	if err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.Requested != "snapshot" || gotOpts.CurrentChannel != "snapshot" {
+		t.Fatalf("opts = %+v", gotOpts)
+	}
+	if !got.Restarting || got.Release != "snapshot" || len(got.Installed) != 2 {
+		t.Fatalf("got %+v", got)
+	}
+	if len(*restarts) != 1 {
+		t.Fatalf("restarts = %v", *restarts)
+	}
+	call := (*restarts)[0]
+	if call.binary != "/home/u/.local/share/evener/bin/evener" {
+		t.Fatalf("binary = %q", call.binary)
+	}
+	if strings.Join(call.args, " ") != "hub -addr 0.0.0.0:9180" {
+		t.Fatalf("args = %v", call.args)
+	}
+}
+
+func TestHubUpdateApplyDefaultChannelIsBuildChannel(t *testing.T) {
+	setBuild(t, "3b1c5f8", "release")
+	var gotOpts selfupdate.Options
+	stubSelfUpgrade(t, func(_ context.Context, opts selfupdate.Options) (selfupdate.Result, error) {
+		gotOpts = opts
+		return selfupdate.Result{Release: "latest", Channel: "release", Installed: []string{"/x/evener", "/x/evener-dev"}}, nil
+	})
+	stubScheduleRestart(t)
+	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{}); err != nil {
+		t.Fatalf("hubUpdateApply: %v", err)
+	}
+	if gotOpts.Requested != "release" {
+		t.Fatalf("Requested = %q, want release", gotOpts.Requested)
+	}
+}
+
+func TestHubUpdateApplyUpgradeFailureDoesNotRestart(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	stubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{}, errors.New("download failed")
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil || !strings.Contains(err.Error(), "download failed") {
+		t.Fatalf("err = %v", err)
+	}
+	if len(*restarts) != 0 {
+		t.Fatalf("restart scheduled after failed upgrade: %v", *restarts)
+	}
+}
+
+func TestHubUpdateApplyRejectsResultWithoutInstalledBinary(t *testing.T) {
+	setBuild(t, "3b1c5f8", "snapshot")
+	stubSelfUpgrade(t, func(context.Context, selfupdate.Options) (selfupdate.Result, error) {
+		return selfupdate.Result{Release: "snapshot", Channel: "snapshot"}, nil
+	})
+	restarts := stubScheduleRestart(t)
+	_, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{})
+	if err == nil {
+		t.Fatal("expected error for empty Installed")
+	}
+	if len(*restarts) != 0 {
+		t.Fatalf("restart scheduled: %v", *restarts)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/evener-hub/ -run 'TestHubUpdate' 2>&1 | head -5`
+Expected: compile errors, `undefined: hubUpdateCheck` etc.
+
+- [ ] **Step 3: Implement `app_update.go`**
+
+```go
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/buildinfo"
+	"primeradiant.com/evener/envvars"
+	"primeradiant.com/evener/internal/selfupdate"
+)
+
+// Test seams: the GitHub check and the exec-in-place restart.
+var (
+	runHubUpdateCheck  = selfupdate.Check
+	scheduleHubRestart = scheduleHubRestartAfterResponse
+)
+
+// hubRestartDelay gives the appwire response time to reach the browser
+// before the process image is replaced; the frontend needs the success
+// result to start its health poll.
+const hubRestartDelay = 500 * time.Millisecond
+
+// isDevBuild reports whether this hub was built without a release channel
+// (a worktree build). Such a hub is never self-updated: replacing it with a
+// release binary would silently discard whatever the developer is running.
+func isDevBuild() bool { return buildinfo.BuildChannel() == "dev" }
+
+func updateChannel(requested string) string {
+	return envvars.FirstNonEmpty(requested, buildinfo.UpgradeChannel())
+}
+
+// hubUpdateCheck answers evener/update/check: compare the running build to
+// the channel's current commit. Dev builds answer locally.
+func hubUpdateCheck(ctx context.Context, params appwire.UpdateCheckParams) (appwire.UpdateCheckResponse, error) {
+	resp := appwire.UpdateCheckResponse{
+		Channel:        updateChannel(params.Channel),
+		BuildChannel:   buildinfo.BuildChannel(),
+		CurrentVersion: buildinfo.Version(),
+		CurrentCommit:  buildinfo.GitSHA,
+	}
+	if isDevBuild() {
+		return resp, nil
+	}
+	result, err := runHubUpdateCheck(ctx, selfupdate.CheckOptions{
+		Channel:    resp.Channel,
+		CurrentSHA: buildinfo.GitSHA,
+	})
+	if err != nil {
+		return appwire.UpdateCheckResponse{}, err
+	}
+	resp.LatestTag = result.LatestTag
+	resp.LatestCommit = result.LatestCommit
+	resp.UpdateAvailable = result.UpdateAvailable
+	resp.Applicable = true
+	return resp, nil
+}
+
+// hubUpdateApply answers evener/update/apply: install the channel's build,
+// then exec it in place once this response has gone out.
+func hubUpdateApply(ctx context.Context, params appwire.UpdateApplyParams) (appwire.UpdateApplyResponse, error) {
+	if isDevBuild() {
+		return appwire.UpdateApplyResponse{}, errors.New("this hub is a dev build; rebuild with make build-hub instead of self-updating")
+	}
+	channel := updateChannel(params.Channel)
+	result, err := runHubSelfUpgrade(ctx, selfupdate.Options{
+		Requested:      channel,
+		CurrentChannel: buildinfo.UpgradeChannel(),
+	})
+	if err != nil {
+		return appwire.UpdateApplyResponse{}, err
+	}
+	if len(result.Installed) == 0 {
+		return appwire.UpdateApplyResponse{}, fmt.Errorf("upgrade to %s installed no binaries", channel)
+	}
+	scheduleHubRestart(result.Installed[0], hubProcessArgs()[1:])
+	return appwire.UpdateApplyResponse{
+		Release:    result.Release,
+		Channel:    result.Channel,
+		Installed:  result.Installed,
+		Restarting: true,
+	}, nil
+}
+
+// scheduleHubRestartAfterResponse execs binary with the hub's own arguments
+// after hubRestartDelay. On exec failure the old hub keeps running and the
+// failure is logged; there is nothing else to roll back.
+func scheduleHubRestartAfterResponse(binary string, args []string) {
+	go func() {
+		time.Sleep(hubRestartDelay)
+		_, _ = fmt.Fprintf(os.Stderr, "[hub] self-update: restarting as %s\n", binary)
+		if err := selfupdate.Restart(binary, args); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "[hub] self-update: restart failed, still running the previous binary: %v\n", err)
+		}
+	}()
+}
+```
+
+Register in `app_rpc.go` right after the `MethodEvenerUpgrade` line:
+
+```go
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerUpdateCheck, hubUpdateCheck)
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerUpdateApply, hubUpdateApply)
+```
+
+- [ ] **Step 4: Run the hub tests**
+
+Run: `go test ./cmd/evener-hub/ 2>&1 | tail -3`
+Expected: `ok` (this package takes ~90s). Any parity test that failed in Task 3 for a missing handler must pass now.
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint 2>&1 | tail -5`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/evener-hub/app_update.go cmd/evener-hub/app_update_test.go cmd/evener-hub/app_rpc.go
+git commit -m "hub: evener/update/check and evener/update/apply with exec-in-place restart"
+```
+
+---
+
+### Task 5: frontend `hubUpdate` store
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/stores/hubUpdate.ts`
+- Test: `cmd/evener-hub/frontend/src/stores/hubUpdate.test.ts`
+
+**Interfaces:**
+- Consumes: `MethodTypes["evener/update/check"]`, `["evener/update/apply"]` from `types.gen.ts` (Task 3); `connectionStore` (`stores/connection.ts`); `errorText` (`protocol/errors.ts`); `FakeClient` (`protocol/testing/fakeClient.ts`).
+- Produces:
+  ```ts
+  export type UpdateChannel = "release" | "snapshot";
+  export interface HubUpdateStoreState {
+    channel: UpdateChannel | null;
+    check: UpdateCheckResponse | null;
+    checking: boolean;
+    checkError: string | null;
+    applying: boolean;
+    applyError: string | null;
+    restarting: boolean;
+    restartTimedOut: boolean;
+    setChannel(channel: UpdateChannel): void;
+    runCheck(): Promise<void>;
+    apply(): Promise<void>;
+  }
+  export const hubUpdateStore; export function useHubUpdateStore(selector?)
+  export const RESTART_POLL_MS = 1000; export const RESTART_TIMEOUT_MS = 30_000;
+  export function resetHubUpdateStoreForTests(deps?: { fetchImpl?: typeof fetch; reload?: () => void }): void;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { FakeClient } from "../protocol/testing/fakeClient";
+import type { UpdateCheckResponse } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+import { RESTART_POLL_MS, RESTART_TIMEOUT_MS, hubUpdateStore, resetHubUpdateStoreForTests } from "./hubUpdate";
+import { resetThreadsStoreForTests } from "./threads";
+
+function connectFakeClient(): FakeClient {
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+const UP_TO_DATE: UpdateCheckResponse = {
+  channel: "snapshot",
+  buildChannel: "snapshot",
+  currentVersion: "be70029",
+  currentCommit: "be70029",
+  latestTag: "snapshot",
+  latestCommit: "be7002918fdc60dbdeab71d9dd17e00d3d006c56",
+  updateAvailable: false,
+  applicable: true,
+};
+
+function healthFetch(versions: string[]): typeof fetch {
+  let i = 0;
+  return vi.fn(async () => {
+    const version = versions[Math.min(i, versions.length - 1)];
+    i += 1;
+    if (version === "DOWN") throw new TypeError("Failed to fetch");
+    return new Response(JSON.stringify({ version }), { status: 200 });
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetThreadsStoreForTests();
+  resetHubUpdateStoreForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("runCheck", () => {
+  test("requests evener/update/check with the selected channel and stores the result", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => UP_TO_DATE);
+    hubUpdateStore.getState().setChannel("snapshot");
+
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    expect(fake.calls).toEqual([{ method: "evener/update/check", params: { channel: "snapshot" } }]);
+    const state = hubUpdateStore.getState();
+    expect(state.check).toEqual(UP_TO_DATE);
+    expect(state.checking).toBe(false);
+    expect(state.checkError).toBeNull();
+  });
+
+  test("sends an empty channel when none is selected yet", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => UP_TO_DATE);
+
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    expect(fake.calls).toEqual([{ method: "evener/update/check", params: { channel: "" } }]);
+  });
+
+  test("stores the error text and clears the previous result on failure", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => {
+      throw new Error("GET x: 403 Forbidden: API rate limit exceeded");
+    });
+
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    const state = hubUpdateStore.getState();
+    expect(state.check).toBeNull();
+    expect(state.checkError).toContain("rate limit");
+  });
+
+  test("setChannel clears the stale check result", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => UP_TO_DATE);
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    act(() => hubUpdateStore.getState().setChannel("release"));
+
+    expect(hubUpdateStore.getState().channel).toBe("release");
+    expect(hubUpdateStore.getState().check).toBeNull();
+  });
+});
+
+describe("apply", () => {
+  test("requests evener/update/apply, then polls /api/health until the version changes and reloads", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    const fetchImpl = healthFetch(["be70029", "DOWN", "DOWN", "3b1c5f8"]);
+    resetHubUpdateStoreForTests({ fetchImpl, reload });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true, latestCommit: "3b1c5f8aaaa" }));
+    fake.on("evener/update/apply", () => ({
+      release: "snapshot",
+      channel: "snapshot",
+      installed: ["/x/evener", "/x/evener-dev"],
+      restarting: true,
+    }));
+    hubUpdateStore.getState().setChannel("snapshot");
+    await act(() => hubUpdateStore.getState().runCheck());
+
+    await act(() => hubUpdateStore.getState().apply());
+
+    expect(fake.calls[1]).toEqual({ method: "evener/update/apply", params: { channel: "snapshot" } });
+    expect(hubUpdateStore.getState().restarting).toBe(true);
+    expect(hubUpdateStore.getState().applying).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESTART_POLL_MS * 4);
+    });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(hubUpdateStore.getState().restartTimedOut).toBe(false);
+  });
+
+  test("gives up after RESTART_TIMEOUT_MS when the version never changes", async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    resetHubUpdateStoreForTests({ fetchImpl: healthFetch(["be70029"]), reload });
+    const fake = connectFakeClient();
+    fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true }));
+    fake.on("evener/update/apply", () => ({ release: "snapshot", channel: "snapshot", installed: ["/x/evener"], restarting: true }));
+    await act(() => hubUpdateStore.getState().runCheck());
+    await act(() => hubUpdateStore.getState().apply());
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESTART_TIMEOUT_MS + RESTART_POLL_MS);
+    });
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(hubUpdateStore.getState().restarting).toBe(false);
+    expect(hubUpdateStore.getState().restartTimedOut).toBe(true);
+  });
+
+  test("stores applyError and does not poll when the hub refuses", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = healthFetch(["be70029"]);
+    resetHubUpdateStoreForTests({ fetchImpl, reload: vi.fn() });
+    const fake = connectFakeClient();
+    fake.on("evener/update/apply", () => {
+      throw new Error("this hub is a dev build");
+    });
+
+    await act(() => hubUpdateStore.getState().apply());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESTART_POLL_MS * 2);
+    });
+
+    expect(hubUpdateStore.getState().applyError).toContain("dev build");
+    expect(hubUpdateStore.getState().restarting).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/stores/hubUpdate.test.ts 2>&1 | tail -5`
+Expected: fails to import `./hubUpdate`.
+
+- [ ] **Step 3: Implement the store**
+
+```ts
+// hubUpdate.ts drives Settings -> Hub -> Updates: pick a release channel,
+// ask the hub whether that channel is ahead of the running build
+// (evener/update/check), and apply it (evener/update/apply). Apply is the
+// interesting half: the hub answers, then execs the new binary in place, so
+// the WebSocket drops and the page has to notice the NEW hub on its own.
+// It does that by polling /api/health (auth-exempt, always registered - see
+// shell/chrome/webNotBuilt.ts's note) until `version` differs from the
+// value the check recorded, then reloads so the SPA bundle matches the
+// backend. Fetch failures while polling are the expected mid-restart state.
+//
+// Like settingsOverview.ts, this store reads connectionStore's current
+// client at call time and holds no subscription of its own.
+
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+import { errorText } from "../protocol/errors";
+import type { AppwireClientLike } from "../protocol/testing/fakeClient";
+import type { UpdateCheckResponse } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+
+export type UpdateChannel = "release" | "snapshot";
+
+export const RESTART_POLL_MS = 1000;
+export const RESTART_TIMEOUT_MS = 30_000;
+
+export interface HubUpdateStoreState {
+  // null until the section seeds it from the overview's buildChannel; the
+  // hub then falls back to its own upgrade channel for an empty request.
+  channel: UpdateChannel | null;
+  check: UpdateCheckResponse | null;
+  checking: boolean;
+  checkError: string | null;
+  applying: boolean;
+  applyError: string | null;
+  restarting: boolean;
+  restartTimedOut: boolean;
+  setChannel(channel: UpdateChannel): void;
+  runCheck(): Promise<void>;
+  apply(): Promise<void>;
+}
+
+interface Deps {
+  fetchImpl: typeof fetch;
+  reload: () => void;
+}
+
+let deps: Deps = { fetchImpl: (...args) => fetch(...args), reload: () => window.location.reload() };
+
+function requireClient(): AppwireClientLike {
+  const client = connectionStore.getState().client;
+  if (!client) {
+    throw new Error("hubUpdate store: no client connected; call useConnectionStore.getState().connect(client) first");
+  }
+  return client;
+}
+
+async function healthVersion(): Promise<string | null> {
+  try {
+    const response = await deps.fetchImpl("/api/health", { credentials: "same-origin" });
+    if (!response.ok) return null;
+    const body = (await response.json()) as { version?: string };
+    return typeof body.version === "string" ? body.version : null;
+  } catch {
+    return null; // the hub is mid-restart; keep polling
+  }
+}
+
+// waitForNewHub polls until /api/health reports a version other than
+// previous, then reloads. Resolves after reload() or the timeout.
+async function waitForNewHub(previous: string | null): Promise<void> {
+  const deadline = Date.now() + RESTART_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, RESTART_POLL_MS));
+    const version = await healthVersion();
+    if (version !== null && version !== previous) {
+      hubUpdateStore.setState({ restarting: false });
+      deps.reload();
+      return;
+    }
+  }
+  hubUpdateStore.setState({ restarting: false, restartTimedOut: true });
+}
+
+const INITIAL = {
+  channel: null,
+  check: null,
+  checking: false,
+  checkError: null,
+  applying: false,
+  applyError: null,
+  restarting: false,
+  restartTimedOut: false,
+} as const;
+
+export const hubUpdateStore = createStore<HubUpdateStoreState>((set, get) => ({
+  ...INITIAL,
+
+  setChannel(channel) {
+    set({ channel, check: null, checkError: null, applyError: null });
+  },
+
+  async runCheck() {
+    set({ checking: true, checkError: null });
+    try {
+      const check = await requireClient().request("evener/update/check", { channel: get().channel ?? "" });
+      set({ check, checking: false });
+    } catch (err) {
+      set({ check: null, checking: false, checkError: errorText(err) });
+    }
+  },
+
+  async apply() {
+    set({ applying: true, applyError: null, restartTimedOut: false });
+    const previous = get().check?.currentVersion ?? null;
+    try {
+      await requireClient().request("evener/update/apply", { channel: get().channel ?? "" });
+    } catch (err) {
+      set({ applying: false, applyError: errorText(err) });
+      return;
+    }
+    set({ applying: false, restarting: true });
+    await waitForNewHub(previous);
+  },
+}));
+
+export function useHubUpdateStore(): HubUpdateStoreState;
+export function useHubUpdateStore<T>(selector: (state: HubUpdateStoreState) => T): T;
+export function useHubUpdateStore<T>(selector?: (state: HubUpdateStoreState) => T): T | HubUpdateStoreState {
+  // Not a real conditional hook call - see stores/connection.ts's own
+  // useConnectionStore for the full explanation (zustand's useStore has a
+  // `selector = identity` JS default param, so both arms run identically).
+  // biome-ignore lint/correctness/useHookAtTopLevel: same hook both arms, JS default param not a real conditional - see stores/connection.ts
+  return selector ? useStore(hubUpdateStore, selector) : useStore(hubUpdateStore);
+}
+
+// resetHubUpdateStoreForTests resets state and lets tests inject the
+// health fetch and reload so the restart poll runs under fake timers with
+// no real network and no real navigation. Production never calls this.
+export function resetHubUpdateStoreForTests(overrides: Partial<Deps> = {}): void {
+  deps = {
+    fetchImpl: overrides.fetchImpl ?? ((...args) => fetch(...args)),
+    reload: overrides.reload ?? (() => window.location.reload()),
+  };
+  hubUpdateStore.setState({ ...INITIAL });
+}
+```
+
+- [ ] **Step 4: Run the tests and Biome**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/stores/hubUpdate.ts src/stores/hubUpdate.test.ts && npx vitest run src/stores/hubUpdate.test.ts 2>&1 | tail -5`
+Expected: all tests pass. If `apply()` awaiting `waitForNewHub` makes the `apply` test hang under fake timers, change the tests' `await act(() => apply())` to `act(() => { void apply(); })` followed by `await act(async () => { await vi.advanceTimersByTimeAsync(0); })`; the store code stays as written.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/frontend/src/stores/hubUpdate.ts cmd/evener-hub/frontend/src/stores/hubUpdate.test.ts
+git commit -m "hub web: hubUpdate store (check, apply, health poll to reload)"
+```
+
+---
+
+### Task 6: Updates block in Settings → Hub
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.tsx`, `hubUpdates.module.css`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections/hub.tsx` (render `<HubUpdates />` after the `<dl>`)
+- Test: `cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.test.tsx`
+
+**Interfaces:**
+- Consumes: `hubUpdateStore`, `useHubUpdateStore`, `resetHubUpdateStoreForTests`, `UpdateChannel` (Task 5); `useSettingsOverviewStore` (`hub.buildChannel`, `hub.version`, `hub.commit`); widgets `Button`, `RadioGroup`, `ConfirmDialog`, `Loader` from `../../../widgets`; `FieldDim`, `Code` from `./settingsField`.
+- Produces: `export function HubUpdates(): JSX.Element`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { FakeClient } from "../../../protocol/testing/fakeClient";
+import type { SettingsOverviewResponse, UpdateCheckResponse } from "../../../protocol/types.gen";
+import { connectionStore } from "../../../stores/connection";
+import { resetHubUpdateStoreForTests } from "../../../stores/hubUpdate";
+import { resetSettingsOverviewStoreForTests, settingsOverviewStore } from "../../../stores/settingsOverview";
+import { HubSection } from "./hub";
+
+function connectFakeClient(): FakeClient {
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+function overview(buildChannel: string): SettingsOverviewResponse {
+  return {
+    hub: {
+      version: "3b1c5f8",
+      commit: "3b1c5f8",
+      buildChannel,
+      listenAddr: "127.0.0.1:9180",
+      runDir: "/tmp/run",
+      spawnTimeout: "30s",
+    },
+  };
+}
+
+const UP_TO_DATE: UpdateCheckResponse = {
+  channel: "snapshot",
+  buildChannel: "snapshot",
+  currentVersion: "3b1c5f8",
+  currentCommit: "3b1c5f8",
+  latestTag: "snapshot",
+  latestCommit: "3b1c5f8ffffffff",
+  updateAvailable: false,
+  applicable: true,
+};
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetSettingsOverviewStoreForTests();
+  resetHubUpdateStoreForTests({ fetchImpl: vi.fn() as unknown as typeof fetch, reload: vi.fn() });
+});
+
+afterEach(cleanup);
+
+test("dev build shows the rebuild note and no update controls", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("dev"));
+
+  render(<HubSection />);
+
+  expect(await screen.findByText(/Dev build/)).toBeTruthy();
+  expect(screen.queryByRole("button", { name: "Check for updates" })).toBeNull();
+  expect(fake.calls.map((c) => c.method)).toEqual(["evener/settings/overview"]);
+});
+
+test("release build checks on mount with the build channel and reports up to date", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("snapshot"));
+  fake.on("evener/update/check", () => UP_TO_DATE);
+
+  render(<HubSection />);
+
+  expect(await screen.findByText(/Up to date on snapshot/)).toBeTruthy();
+  expect(fake.calls).toContainEqual({ method: "evener/update/check", params: { channel: "snapshot" } });
+  expect(screen.getByRole("radio", { name: "Snapshot" })).toHaveProperty("checked", true);
+  expect(screen.getByRole("button", { name: "Update and restart" })).toHaveProperty("disabled", true);
+});
+
+test("switching channel re-checks with the new channel", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("snapshot"));
+  fake.on("evener/update/check", (params) => ({ ...UP_TO_DATE, channel: params.channel, latestTag: params.channel === "release" ? "v0.1.0" : "snapshot" }));
+
+  render(<HubSection />);
+  await screen.findByText(/Up to date on snapshot/);
+
+  await userEvent.click(screen.getByRole("radio", { name: "Release" }));
+
+  expect(await screen.findByText(/Up to date on release/)).toBeTruthy();
+  expect(fake.calls).toContainEqual({ method: "evener/update/check", params: { channel: "release" } });
+});
+
+test("update available enables the button; confirming applies and shows restarting", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("snapshot"));
+  fake.on("evener/update/check", () => ({ ...UP_TO_DATE, updateAvailable: true, latestCommit: "be7002918fdc" }));
+  fake.on("evener/update/apply", () => new Promise(() => {})); // stays pending: we only assert the request and the busy state
+
+  render(<HubSection />);
+  expect(await screen.findByText(/Update available: snapshot be70029/)).toBeTruthy();
+
+  const button = screen.getByRole("button", { name: "Update and restart" });
+  expect(button).toHaveProperty("disabled", false);
+  await userEvent.click(button);
+  await userEvent.click(await screen.findByRole("button", { name: "Update and restart", hidden: false, exact: true }));
+
+  await waitFor(() => expect(fake.calls).toContainEqual({ method: "evener/update/apply", params: { channel: "snapshot" } }));
+});
+
+test("restarting and timed-out states render their messages", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("snapshot"));
+  fake.on("evener/update/check", () => UP_TO_DATE);
+  render(<HubSection />);
+  await screen.findByText(/Up to date on snapshot/);
+
+  const { hubUpdateStore } = await import("../../../stores/hubUpdate");
+  hubUpdateStore.setState({ restarting: true });
+  expect(await screen.findByText(/Restarting hub/)).toBeTruthy();
+
+  hubUpdateStore.setState({ restarting: false, restartTimedOut: true });
+  expect(await screen.findByText(/didn't come back within 30s/)).toBeTruthy();
+});
+
+test("check failure shows the error and a working Check for updates button", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/overview", () => overview("release"));
+  let attempts = 0;
+  fake.on("evener/update/check", () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("GET x: 403 Forbidden: API rate limit exceeded");
+    return { ...UP_TO_DATE, channel: "release", latestTag: "v0.1.0" };
+  });
+
+  render(<HubSection />);
+  expect(await screen.findByText(/rate limit/)).toBeTruthy();
+
+  await userEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+
+  expect(await screen.findByText(/Up to date on release/)).toBeTruthy();
+  expect(settingsOverviewStore.getState().data).not.toBeNull();
+});
+```
+
+Note for the confirm-dialog click in the fourth test: `ConfirmDialog` renders its own confirm button with `confirmLabel`. Use a distinct label for the dialog's button, `"Yes, update and restart"`, and change that test's second click to `screen.findByRole("button", { name: "Yes, update and restart" })`. (This is the intended copy; the line above is superseded by this note.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd cmd/evener-hub/frontend && npx vitest run src/panes/settings/sections/hubUpdates.test.tsx 2>&1 | tail -5`
+Expected: fails (no Updates UI; "Dev build" text not found).
+
+- [ ] **Step 3: Implement `hubUpdates.tsx` and CSS**
+
+`hubUpdates.module.css`:
+
+```css
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 12px);
+  margin-top: var(--space-4, 16px);
+}
+
+.heading {
+  margin: 0;
+  font-size: var(--font-size-md, 14px);
+  font-weight: 600;
+}
+
+.status {
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2, 8px);
+  align-items: center;
+}
+```
+
+Check `hub.module.css`/`general.module.css` and the theme tokens (`grep -rn "\-\-space-" src/theme* | head`) and use the real spacing/font tokens the sibling sections use instead of the fallbacks above if they exist.
+
+`hubUpdates.tsx`:
+
+```tsx
+import { useEffect, useState } from "react";
+import { friendlyErrorMessage } from "../../../protocol/errors";
+import { hubUpdateStore, type UpdateChannel, useHubUpdateStore } from "../../../stores/hubUpdate";
+import { useSettingsOverviewStore } from "../../../stores/settingsOverview";
+import { Button, ConfirmDialog, Loader, RadioGroup } from "../../../widgets";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import styles from "./hubUpdates.module.css";
+import { Code, FieldDim } from "./settingsField";
+
+const CLASS = {
+  root: requireClass(styles.root, "hubUpdates.module.css", "root"),
+  heading: requireClass(styles.heading, "hubUpdates.module.css", "heading"),
+  status: requireClass(styles.status, "hubUpdates.module.css", "status"),
+  actions: requireClass(styles.actions, "hubUpdates.module.css", "actions"),
+};
+
+const CHANNEL_OPTIONS = [
+  { value: "release", label: "Release" },
+  { value: "snapshot", label: "Snapshot" },
+];
+
+function isChannel(value: string | undefined): value is UpdateChannel {
+  return value === "release" || value === "snapshot";
+}
+
+function shortCommit(sha: string): string {
+  return sha.slice(0, 7);
+}
+
+/**
+ * Settings -> Hub -> Updates. Seeds the channel from the overview's
+ * buildChannel (release/snapshot builds only), checks on mount and on
+ * channel change, and gates "Update and restart" behind a confirm dialog.
+ * Dev builds get a note instead of controls: a worktree build must never be
+ * silently replaced by a release binary (design spec, Decisions).
+ */
+export function HubUpdates() {
+  const hub = useSettingsOverviewStore((s) => s.data?.hub);
+  const channel = useHubUpdateStore((s) => s.channel);
+  const check = useHubUpdateStore((s) => s.check);
+  const checking = useHubUpdateStore((s) => s.checking);
+  const checkError = useHubUpdateStore((s) => s.checkError);
+  const applying = useHubUpdateStore((s) => s.applying);
+  const applyError = useHubUpdateStore((s) => s.applyError);
+  const restarting = useHubUpdateStore((s) => s.restarting);
+  const restartTimedOut = useHubUpdateStore((s) => s.restartTimedOut);
+  const [confirming, setConfirming] = useState(false);
+
+  const buildChannel = hub?.buildChannel;
+  const isDev = buildChannel === "dev";
+
+  // Seed the selector from the running binary once the overview is here.
+  useEffect(() => {
+    if (channel === null && isChannel(buildChannel)) {
+      hubUpdateStore.getState().setChannel(buildChannel);
+    }
+  }, [channel, buildChannel]);
+
+  // Check whenever a channel is selected (mount and every change).
+  useEffect(() => {
+    if (channel !== null) void hubUpdateStore.getState().runCheck();
+  }, [channel]);
+
+  if (!hub) return null;
+
+  return (
+    <section className={CLASS.root} aria-labelledby="hub-updates-heading">
+      <h3 id="hub-updates-heading" className={CLASS.heading}>
+        Updates
+      </h3>
+      <p className={CLASS.status}>
+        Running {hub.version ?? "unknown"}
+        {hub.commit !== undefined && <FieldDim> ({hub.commit})</FieldDim>}
+        {buildChannel !== undefined && <FieldDim> · {buildChannel}</FieldDim>}
+      </p>
+
+      {isDev ? (
+        <p className={CLASS.status}>
+          <FieldDim>
+            Dev build. Rebuild with <Code>make build-hub</Code> to update.
+          </FieldDim>
+        </p>
+      ) : (
+        <>
+          <RadioGroup
+            label="Channel"
+            value={channel ?? ""}
+            onChange={(value) => {
+              if (isChannel(value)) hubUpdateStore.getState().setChannel(value);
+            }}
+            options={CHANNEL_OPTIONS}
+            disabled={applying || restarting}
+          />
+
+          <p className={CLASS.status} role="status">
+            {restarting && (
+              <>
+                <Loader label="Restarting hub" /> Restarting hub…
+              </>
+            )}
+            {!restarting && restartTimedOut && "The hub didn't come back within 30s. Check its logs."}
+            {!restarting && !restartTimedOut && checking && "Checking…"}
+            {!restarting && !restartTimedOut && !checking && checkError !== null && (
+              <>Couldn't check for updates: {checkError}</>
+            )}
+            {!restarting && !restartTimedOut && !checking && checkError === null && check !== null && (
+              check.updateAvailable
+                ? `Update available: ${check.channel} ${shortCommit(check.latestCommit ?? "")}, running ${check.currentVersion}`
+                : `Up to date on ${check.channel} (${shortCommit(check.latestCommit ?? "")})`
+            )}
+          </p>
+          {applyError !== null && <p className={CLASS.status}>Update failed: {friendlyErrorMessage(applyError)}</p>}
+
+          <div className={CLASS.actions}>
+            <Button size="sm" onClick={() => void hubUpdateStore.getState().runCheck()} disabled={checking || applying || restarting}>
+              Check for updates
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => setConfirming(true)}
+              disabled={!(check?.updateAvailable ?? false) || applying || restarting}
+            >
+              Update and restart
+            </Button>
+          </div>
+
+          <ConfirmDialog
+            open={confirming}
+            title="Update and restart the hub?"
+            confirmLabel="Yes, update and restart"
+            busy={applying}
+            onConfirm={() => {
+              setConfirming(false);
+              void hubUpdateStore.getState().apply();
+            }}
+            onCancel={() => setConfirming(false)}
+          >
+            The hub goes offline for a few seconds while the new binary starts. Running sessions keep going.
+          </ConfirmDialog>
+        </>
+      )}
+    </section>
+  );
+}
+```
+
+Check `friendlyErrorMessage`'s signature in `protocol/errors.ts` (it may take the raw string; adapt). Check whether `Loader` is exported from `../../../widgets/index.ts`; if not, import it from `../../../widgets/loader`. If `RadioGroup`'s `value` must match an option, render the group only when `channel !== null`.
+
+In `hub.tsx`, add `import { HubUpdates } from "./hubUpdates";` and render `<HubUpdates />` right after the closing `</dl>` inside `CLASS.root`.
+
+- [ ] **Step 4: Run Biome, the test file, and the full web gate**
+
+Run: `cd cmd/evener-hub/frontend && npx biome check --write src/panes/settings/sections/hubUpdates.tsx src/panes/settings/sections/hubUpdates.test.tsx src/panes/settings/sections/hub.tsx && npx vitest run src/panes/settings/sections/ 2>&1 | tail -5 && cd ../../.. && make test-web 2>&1 | tail -4`
+Expected: all pass; `PASS web-typecheck`, `PASS web-test`, `PASS web-lint`. Existing `hub.test.tsx` must still pass: its `SAMPLE_RESPONSE` has no `buildChannel`, so `HubUpdates` renders only the "Running" line and no check request; if its `fake.calls` assertion breaks because a check fired, that is a bug in the seeding guard, not the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.tsx cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.module.css cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.test.tsx cmd/evener-hub/frontend/src/panes/settings/sections/hub.tsx
+git commit -m "hub web: Updates block in Settings -> Hub with channel selector and update-and-restart"
+```
+
+---
+
+### Task 7: Opt-in end-to-end test, docs, full gates
+
+**Files:**
+- Create: `cmd/evener-hub/update_e2e_test.go`
+- Modify: `docs/evener-hub.md` (new subsection after the "deploy-hub.sh" paragraph ~line 310)
+
+**Interfaces:**
+- Consumes: everything above; `install.sh` (`PREFIX`, `EVENER_INSTALL_VERSION`), `/api/health`, `appwire.Client` (`appwire.Dial` or whatever constructor `appwire/client.go` exposes; read it) and the hub's bearer token in `<hub_state_root>/` (`hubedge.TokenFileName`).
+
+- [ ] **Step 1: Write the e2e test**
+
+```go
+//go:build unix
+
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestUpdateApplyEndToEnd installs the current snapshot into a temp prefix,
+// runs that hub, applies an update through the RPC, and proves the process
+// replaced itself in place: same PID, /api/health back. Opt-in only: it
+// downloads from GitHub twice (AGENTS.md forbids network in default tests).
+//
+//	EVENER_UPDATE_E2E=1 go test ./cmd/evener-hub/ -run TestUpdateApplyEndToEnd -v
+func TestUpdateApplyEndToEnd(t *testing.T) {
+	if os.Getenv("EVENER_UPDATE_E2E") == "" {
+		t.Skip("set EVENER_UPDATE_E2E=1 to run (downloads from GitHub)")
+	}
+	root := t.TempDir()
+	prefix := filepath.Join(root, "local")
+	install := exec.Command("sh", repoFile(t, "install.sh"))
+	install.Env = append(os.Environ(), "PREFIX="+prefix, "EVENER_INSTALL_VERSION=snapshot")
+	if out, err := install.CombinedOutput(); err != nil {
+		t.Fatalf("install.sh: %v\n%s", err, out)
+	}
+	binary := filepath.Join(prefix, "bin", "evener")
+
+	stateRoot := filepath.Join(root, "state")
+	hub := exec.Command(binary, "hub", "-addr", "127.0.0.1:0")
+	hub.Env = append(os.Environ(), "EVENER_HUB_STATE_ROOT="+stateRoot, "HOME="+root)
+	hub.Stderr = os.Stderr
+	// The hub prints its bound address; read it from the rendezvous/health
+	// surface the current hub exposes (see runMain's listener log line) —
+	// adapt the discovery below to whatever the hub actually prints.
+	stdout, err := hub.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := hub.Start(); err != nil {
+		t.Fatalf("start hub: %v", err)
+	}
+	t.Cleanup(func() { _ = hub.Process.Kill() })
+	addr := waitForListenAddr(t, stdout)
+	pid := hub.Process.Pid
+
+	before := healthVersion(t, addr)
+	client := dialHubForTest(t, addr, stateRoot)
+	resp, err := client.UpdateApply(context.Background(), appwireUpdateApplyParams("snapshot"))
+	if err != nil {
+		t.Fatalf("UpdateApply: %v", err)
+	}
+	if !resp.Restarting {
+		t.Fatalf("resp = %+v", resp)
+	}
+
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(500 * time.Millisecond)
+		r, err := http.Get("http://" + addr + "/api/health")
+		if err != nil {
+			continue
+		}
+		var body struct{ Version string `json:"version"` }
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = r.Body.Close()
+		if body.Version != "" {
+			if !processAlive(pid) {
+				t.Fatalf("hub pid %d died", pid)
+			}
+			t.Logf("before=%s after=%s pid=%d", before, body.Version, pid)
+			return
+		}
+	}
+	t.Fatal("hub did not come back within 30s")
+}
+```
+
+Then fill in the helpers (`repoFile`, `waitForListenAddr`, `healthVersion`, `dialHubForTest`, `appwireUpdateApplyParams`, `processAlive`) by reading what the package already has: search `cmd/evener-hub/*_test.go` for an existing helper that starts a real hub binary and dials it over appwire (grep `exec.Command` and `appwire.Dial`/`NewClient` in test files, and `EVENER_HUB_STATE_ROOT`/`hubStateRoot` for the env var name). Reuse those helpers rather than writing new ones; if none exist, write the smallest versions that work and keep them in this file. Replace the placeholder names above with the real ones.
+
+- [ ] **Step 2: Run it for real, once**
+
+Run: `EVENER_UPDATE_E2E=1 go test ./cmd/evener-hub/ -run TestUpdateApplyEndToEnd -v 2>&1 | tail -15`
+Expected: PASS with a `before=... after=... pid=...` log line. Then confirm it skips by default: `go test ./cmd/evener-hub/ -run TestUpdateApplyEndToEnd -v 2>&1 | grep -c SKIP` → `1`.
+
+- [ ] **Step 3: Docs**
+
+In `docs/evener-hub.md`, after the `deploy-hub.sh` paragraph, add:
+
+```markdown
+### Updating the hub from Settings
+
+Settings → Hub → Updates shows the running build (version, commit, channel),
+a channel selector (release or snapshot), and whether that channel is ahead
+of the running build. "Update and restart" downloads and installs the
+channel's archive with the same code as `evener upgrade`, then the hub
+`exec`s the installed binary in place: same PID, same arguments, same
+environment. That is why it works the same under launchd, systemd, or a
+plain shell, and why nothing needs `KeepAlive`. The `hub.lock` flock and the
+listener are released by the exec and re-acquired by the new process; the
+page polls `/api/health` until the new version answers, then reloads.
+
+The channel selector has no stored setting. It defaults to the channel the
+running binary was built for, and after an update the installed binary's
+channel becomes the new default.
+
+Dev builds (a worktree `make build-hub`, channel `dev`) are excluded:
+Settings shows a rebuild note instead of the controls, and
+`evener/update/apply` is refused. Use `make build-hub` or
+`scripts/ops/deploy-hub.sh` for those.
+
+Running session daemons keep the binary they were spawned from (see the
+"Existing daemons keep the `evener` binary" note below); restart a session
+to move it to the new build.
+```
+
+- [ ] **Step 4: Full gates**
+
+Run: `make lint 2>&1 | tail -5 && make vet 2>&1 | tail -3 && make test 2>&1 | tail -8`
+Expected: all clean. Fix anything that fails before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/update_e2e_test.go docs/evener-hub.md
+git commit -m "hub: opt-in self-update e2e test and docs"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: Check (T1), Restart (T2), wire types + BuildChannel (T3), hub handlers + registration + restart scheduling (T4), store (T5), Settings UI (T6), e2e + docs (T7). Snapshot-release asset cleanup is a one-off `gh` command done by the plan owner, not a task.
+- Type consistency: `runHubUpdateCheck`/`scheduleHubRestart` names match between T4 code and tests; `UpdateCheckResponse` fields match T3 ↔ T5/T6 (`currentVersion`, `latestCommit`, `updateAvailable`, `applicable`, `buildChannel`); store method is `runCheck` everywhere (not `check`, which is the result field).

--- a/docs/superpowers/specs/2026-09-07-hub-self-update-design.md
+++ b/docs/superpowers/specs/2026-09-07-hub-self-update-design.md
@@ -1,0 +1,232 @@
+# Hub self-update from Settings
+
+Date: 2026-09-07
+
+## Goal
+
+From Settings → Hub, a user can see whether a newer evener build exists on
+their channel, pick the channel (release or snapshot), and click one button
+that downloads the build, installs it, and replaces the running hub process
+with it. No terminal, no supervisor knowledge required.
+
+## What already exists
+
+- `internal/selfupdate.Upgrade` downloads `evener_<os>_<arch>.tar.gz` from the
+  GitHub release for a channel (`latest` or `snapshot`, or a `v*` tag),
+  installs `evener` and `evener-dev` into `<prefix>/share/evener/bin`, and
+  symlinks them from `<prefix>/bin`. Default prefix `~/.local`.
+- The hub exposes that as the `evener/upgrade` RPC; the command palette's
+  "Upgrade Evener" calls it and toasts "restart evener". Neither restarts.
+- `buildinfo` carries `GitSHA` (goreleaser `ShortCommit`), `Channel`
+  (`release`, `snapshot`, or empty = dev). `UpgradeChannel()` maps dev to
+  release.
+- `.github/workflows/binaries.yml` builds on every push to main, force-moves
+  the `snapshot` tag to that commit, and re-uploads the archives to the
+  `snapshot` prerelease. Verified 2026-09-07: the last five main pushes each
+  refreshed the snapshot within ~3 minutes; `refs/tags/snapshot` ==
+  `origin/main`. No workflow change is needed.
+- The repo is public, so unauthenticated GitHub API calls work (60/hour).
+
+## Decisions
+
+- **Restart mechanism: exec-in-place.** After a successful install the hub
+  `syscall.Exec`s the freshly installed `evener` binary with its own original
+  argv (`os.Args[1:]`) and environment. The PID is unchanged, so launchd,
+  systemd, and a bare shell all keep the process they had. Go opens files and
+  sockets `O_CLOEXEC`, so `hub.lock` (flock) and the listener are released by
+  the exec and re-acquired by the new image; Go listeners set `SO_REUSEADDR`
+  so the rebind does not wait on TIME_WAIT. Spawned session daemons are
+  already detached and survive (they keep the old binary until their sessions
+  restart, as documented).
+- **Dev builds are excluded.** When `buildinfo.BuildChannel() == "dev"` the
+  check returns "not applicable" without touching the network, apply is
+  refused, and Settings shows a note instead of the controls. A worktree
+  build must never be silently replaced by a release binary.
+- **No stored channel setting.** The selector defaults to the running
+  binary's `UpgradeChannel()`. After an update, the installed binary's baked
+  channel becomes the new default. The installed binary is the state.
+- **Update detection is by commit.** `updateAvailable` is true when the
+  channel's commit SHA does not have `buildinfo.GitSHA` as a prefix. A tag
+  moved to a different commit, or a newer release tag, both read as an
+  update; a rebuild of the same commit does not.
+
+## Backend
+
+### `internal/selfupdate`
+
+New file `check.go`:
+
+```go
+type CheckOptions struct {
+    Channel    string        // "release" or "snapshot" (required)
+    CurrentSHA string        // buildinfo.GitSHA
+    RepoURL    string        // default https://github.com/prime-radiant-inc/evener
+    APIURL     string        // default https://api.github.com; tests point it at httptest
+    HTTPClient *http.Client  // default: 10s timeout client
+}
+
+type CheckResult struct {
+    Channel         string `json:"channel"`
+    LatestTag       string `json:"latestTag"`    // "snapshot" or "vX.Y.Z"
+    LatestCommit    string `json:"latestCommit"` // full SHA from GitHub
+    UpdateAvailable bool   `json:"updateAvailable"`
+}
+
+func Check(ctx context.Context, opts CheckOptions) (CheckResult, error)
+```
+
+- `snapshot`: `GET {api}/repos/{owner}/{repo}/commits/snapshot` → `.sha`.
+- `release`: `GET {api}/repos/{owner}/{repo}/releases/latest` → `.tag_name`,
+  then `GET .../commits/{tag}` → `.sha`.
+- owner/repo are parsed from `RepoURL` (the existing `defaultRepoURL`).
+- Any other channel value is an error. Non-2xx responses surface as an error
+  carrying the status and the GitHub `message` field when present (rate
+  limit responses say so).
+- `UpdateAvailable = CurrentSHA == "" || !strings.HasPrefix(LatestCommit, CurrentSHA)`.
+  The caller handles dev builds before calling; an empty `CurrentSHA` here
+  is a defensive "assume stale".
+
+New file `restart_unix.go` (build tag `unix`):
+
+```go
+// Restart replaces the current process image with binary, keeping argv[1:]
+// and the environment. It only returns on failure.
+func Restart(binary string, args []string) error
+```
+
+Implemented as `syscall.Exec(binary, append([]string{binary}, args...), os.Environ())`.
+The non-unix file returns an "unsupported platform" error.
+
+### `appwire`
+
+Catalog entries in `protocol.go` (regenerate with `make generate`):
+
+- `evener/update/check` `UpdateCheckParams{Channel string}` →
+  `UpdateCheckResponse{Channel, BuildChannel, CurrentVersion, CurrentCommit,
+  LatestTag, LatestCommit string; UpdateAvailable, Applicable bool}`.
+  `Applicable=false` and `BuildChannel="dev"` for dev builds; the other
+  latest-* fields are empty then.
+- `evener/update/apply` `UpdateApplyParams{Channel string}` →
+  `UpdateApplyResponse{Release, Channel, Installed []string; Restarting bool}`.
+
+Both `ScopeHub`. `SettingsHubOverview` gains `BuildChannel string
+json:"buildChannel"` filled from `buildinfo.BuildChannel()`.
+
+### `cmd/evener-hub`
+
+New file `app_update.go`:
+
+- `hubUpdateCheck(ctx, params)`: empty channel → `buildinfo.UpgradeChannel()`.
+  Dev build → `Applicable:false` response, no network. Otherwise
+  `selfupdate.Check` via a package var `runHubUpdateCheck` (test seam).
+- `hubUpdateApply(ctx, params)`: dev build → error "dev build; rebuild with
+  make build-hub". Otherwise `runHubSelfUpgrade` (the existing seam) with
+  `Requested: channel`, then `scheduleHubRestart(ctx, binary, args)`, where binary is
+  `result.Installed[0]` (the installed `evener`) and args is
+  `hubProcessArgs()[1:]`. Returns `Restarting: true`.
+- `scheduleHubRestart` is a package var. The real one registers the restart
+  with `appserver.AfterResponseWritten(ctx, ...)`, so it runs only once the
+  apply response has reached the transport (or the connection tore down
+  without it) and the browser has the success result it needs; it then starts
+  a goroutine that waits a 500ms flush grace and calls `selfupdate.Restart`.
+  A context with no appserver connection, or one whose send loop has already
+  stopped, restarts immediately. On failure it
+  logs to stderr with the `[hub]` prefix used elsewhere and the hub keeps
+  running on the old binary.
+- Registered in `app_rpc.go` next to `MethodEvenerUpgrade`.
+- The existing `evener/upgrade` RPC and the palette command are unchanged.
+
+## Frontend
+
+### `stores/hubUpdate.ts`
+
+Zustand store, same shape as the other RPC-backed stores:
+
+```
+channel: "release" | "snapshot" | null   // null until overview loads
+check: UpdateCheckResponse | null
+checking: boolean
+checkError: string | null
+applying: boolean
+applyError: string | null
+restarting: boolean
+restartTimedOut: boolean
+setChannel(c), check(), apply()
+```
+
+- `check()` calls `evener/update/check` with the selected channel.
+- `apply()` calls `evener/update/apply`; on success sets `restarting` and
+  starts a health poll: `GET /api/health` every 1s until the returned
+  `version` differs from the pre-update version, then `location.reload()`.
+  After 30s, `restartTimedOut` is set and polling stops. Health fetch failures
+  during the poll are expected (the hub is mid-restart) and are swallowed.
+- Poll timer and `fetch` are injectable so tests use fake timers.
+
+### `panes/settings/sections/hub.tsx`
+
+An "Updates" block after the existing three fields:
+
+- Row "Build": `version (commit) · channel` from the overview.
+- Dev build: a dim note "Dev build. Rebuild with `make build-hub` to update."
+  Nothing else.
+- Otherwise: a `RadioGroup` (existing widget) "Channel" with Release /
+  Snapshot; the `check()` result line ("Up to date on snapshot (be70029)" /
+  "Update available: snapshot be70029, running 3b1c5f8" / the error);
+  buttons "Check for updates" and "Update and restart" (the latter enabled
+  only when `updateAvailable`). "Update and restart" opens the existing
+  `ConfirmDialog` ("The hub will go offline for a few seconds. Sessions keep
+  running."). While `restarting`: "Restarting hub…" with a loader; on
+  `restartTimedOut`: "The hub didn't come back within 30s. Check its logs."
+- `check()` runs once when the section mounts with the default channel, and
+  again when the channel changes.
+
+## Release housekeeping
+
+- Delete the stale `serf_darwin_arm64.tar.gz` and `serf_linux_amd64.tar.gz`
+  assets from the `snapshot` release (`gh release delete-asset snapshot <name>`).
+  One-off; not part of the code change.
+
+## Testing
+
+Default tests stay offline (AGENTS.md).
+
+- `internal/selfupdate/check_test.go`: httptest server standing in for the
+  GitHub API; cases: snapshot up to date, snapshot stale, release resolves
+  tag then commit, 403 rate-limit surfaces the message, unknown channel,
+  empty CurrentSHA.
+- `internal/selfupdate/restart_unix_test.go`: `Restart` into a helper
+  process (`os.Args[0]` with a `GO_WANT_HELPER` env, the stdlib pattern)
+  checks argv and that the PID is preserved; `Restart` on a nonexistent path
+  returns an error.
+- `cmd/evener-hub/app_update_test.go`: dev build → not applicable / refused
+  without calling the seams; check passes the channel through and fills
+  current fields; apply calls upgrade then schedules restart with
+  `Installed[0]` and `hubProcessArgs()[1:]`; upgrade failure → no restart
+  scheduled; default channel = `UpgradeChannel()`.
+- `appwire` golden/catalog tests pick up the new methods via `make generate`
+  and the existing golden update flow.
+- Frontend: `hubUpdate.test.ts` (scripted client: check, apply, health poll
+  to reload, timeout) and `hub.test.tsx` (dev / up to date / available /
+  restarting / timed out renderings, confirm dialog gating apply).
+- Opt-in e2e `EVENER_UPDATE_E2E=1` in `cmd/evener-hub`: build this branch's
+  own `evener` binary as a `snapshot`-channel build (so it isn't refused as a
+  dev build), start it as a hub on `127.0.0.1:0`, call `evener/update/apply`
+  over appwire against the real public snapshot release, and assert the PID
+  is unchanged, `/api/health` comes back, and its version differs from the
+  branch build's. This is the only test that touches GitHub; it downloads
+  the current public snapshot but does not depend on that release carrying
+  this feature, since the hub under test is built locally.
+
+## Docs
+
+`docs/evener-hub.md` gets an "Updating the hub" subsection: the Settings
+flow, the dev-build carve-out, exec-in-place and why it is supervisor
+agnostic, and a cross-link to the note that daemons keep their old binary.
+
+## Out of scope
+
+- Periodic background update checks.
+- Re-pointing the palette "Upgrade Evener" command at the new flow.
+- Windows.
+- Rollback. A failed download or install leaves the old binary running; a
+  failed exec logs and leaves the old binary running.

--- a/internal/appserver/after_write_test.go
+++ b/internal/appserver/after_write_test.go
@@ -1,0 +1,113 @@
+package appserver
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+)
+
+// afterWriteOrder records the interleaving of transport sends and after-write
+// callbacks, so a test can prove the callback runs after the frame reached the
+// transport rather than merely eventually.
+type afterWriteOrder struct {
+	mu     sync.Mutex
+	events []string
+}
+
+func (o *afterWriteOrder) record(event string) {
+	o.mu.Lock()
+	o.events = append(o.events, event)
+	o.mu.Unlock()
+}
+
+func (o *afterWriteOrder) snapshot() []string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]string(nil), o.events...)
+}
+
+type orderRecordingSender struct {
+	order *afterWriteOrder
+}
+
+func (s *orderRecordingSender) Send(context.Context, appwire.Message) error {
+	s.order.record("send")
+	return nil
+}
+
+func TestAfterResponseWrittenRunsAfterTransportSend(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test", Version: "1", SourceID: "local"})
+	conn := server.NewConnection("conn-1")
+	id := appwire.NewIntID(7)
+	ctx := context.WithValue(context.Background(), connectionContextKey{}, conn)
+	ctx = context.WithValue(ctx, requestIDContextKey{}, requestIDKey(id))
+
+	order := &afterWriteOrder{}
+	ran := make(chan struct{})
+	if !AfterResponseWritten(ctx, func() {
+		order.record("callback")
+		close(ran)
+	}) {
+		t.Fatal("AfterResponseWritten reported no connection on a handler context")
+	}
+
+	conn.send <- appwire.ResponseMessage(id, map[string]any{"ok": true})
+	go runWebSocketSendLoopWithTimeout(t.Context(), &orderRecordingSender{order: order}, conn.send, time.Second, conn.responseWritten)
+
+	select {
+	case <-ran:
+	case <-time.After(time.Second):
+		t.Fatal("after-write callback never ran")
+	}
+	if got := order.snapshot(); len(got) != 2 || got[0] != "send" || got[1] != "callback" {
+		t.Fatalf("event order = %v, want the callback after the transport send", got)
+	}
+}
+
+func TestAfterResponseWrittenWithoutConnectionReportsFalse(t *testing.T) {
+	ran := false
+	if AfterResponseWritten(context.Background(), func() { ran = true }) {
+		t.Fatal("AfterResponseWritten reported a connection on a context that carries none")
+	}
+	if ran {
+		t.Fatal("callback ran without a connection")
+	}
+}
+
+func TestRunPendingAfterWriteRunsUnwrittenCallbacks(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test", Version: "1", SourceID: "local"})
+	conn := server.NewConnection("conn-1")
+	ctx := context.WithValue(context.Background(), connectionContextKey{}, conn)
+	ctx = context.WithValue(ctx, requestIDContextKey{}, requestIDKey(appwire.NewIntID(9)))
+
+	calls := 0
+	if !AfterResponseWritten(ctx, func() { calls++ }) {
+		t.Fatal("AfterResponseWritten reported no connection on a handler context")
+	}
+	conn.runPendingAfterWrite()
+	conn.runPendingAfterWrite()
+	if calls != 1 {
+		t.Fatalf("callback ran %d times, want exactly one run", calls)
+	}
+}
+
+func TestAfterResponseWrittenReportsFalseAfterTeardown(t *testing.T) {
+	server := NewServer(ServerConfig{ServerName: "test", Version: "1", SourceID: "local"})
+	conn := server.NewConnection("conn-1")
+	ctx := context.WithValue(context.Background(), connectionContextKey{}, conn)
+	ctx = context.WithValue(ctx, requestIDContextKey{}, requestIDKey(appwire.NewIntID(11)))
+
+	conn.runPendingAfterWrite()
+
+	ran := false
+	if AfterResponseWritten(ctx, func() { ran = true }) {
+		t.Fatal("AfterResponseWritten accepted a callback after the send loop had drained")
+	}
+	conn.runPendingAfterWrite()
+	if ran {
+		t.Fatal("a callback registered after teardown ran")
+	}
+}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -1322,7 +1322,14 @@ func concurrentDispatchMethod(method string) bool {
 		// shared-state writes; running it inline blocks unrelated RPCs
 		// on the connection for up to two 10s GitHub timeouts. The
 		// frontend already discards stale check responses by sequence.
-		appwire.MethodEvenerUpdateCheck:
+		appwire.MethodEvenerUpdateCheck,
+		// evener/update/apply is a multi-minute download, verify, and
+		// install under the overall upgrade deadline; running it inline
+		// holds the connection's serial worker that whole time. Safe
+		// out of order: hubUpdateMu plus the cross-process install lock
+		// fail a concurrent apply fast, and the restart waits on its own
+		// response flush rather than connection order.
+		appwire.MethodEvenerUpdateApply:
 		return true
 	}
 	return false

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -555,6 +555,13 @@ type Connection struct {
 	responseMu        sync.Mutex
 	hydrationMu       sync.Mutex
 	hydrations        map[string]*hydrationResponseFinalizer
+	// afterWrite holds the AfterResponseWritten callbacks, keyed the same way
+	// hydrations is (requestIDKey). afterWriteDrained records that
+	// runPendingAfterWrite has already run, so a callback arriving after the
+	// send loop stopped is refused instead of being retained forever. Both
+	// are guarded by responseMu.
+	afterWrite        map[string]func()
+	afterWriteDrained bool
 }
 
 func (c *Connection) ID() string {
@@ -703,6 +710,39 @@ func (c *Connection) takeAllHydrations() []*hydrationResponseFinalizer {
 	return pending
 }
 
+// responseWritten runs the after-write callback registered for msg's request,
+// if any, now that the frame has reached the transport.
+func (c *Connection) responseWritten(msg appwire.Message) {
+	responseID, _ := responseHydrationOutcome(msg)
+	if responseID == "" {
+		return
+	}
+	c.responseMu.Lock()
+	fn := c.afterWrite[responseID]
+	delete(c.afterWrite, responseID)
+	c.responseMu.Unlock()
+	if fn != nil {
+		fn()
+	}
+}
+
+// runPendingAfterWrite runs every after-write callback whose response was
+// never written, because the send loop stopped first. Callers that only ever
+// act once (a self-update restart) must still act when the browser vanished.
+func (c *Connection) runPendingAfterWrite() {
+	c.responseMu.Lock()
+	pending := make([]func(), 0, len(c.afterWrite))
+	for key, fn := range c.afterWrite {
+		pending = append(pending, fn)
+		delete(c.afterWrite, key)
+	}
+	c.afterWriteDrained = true
+	c.responseMu.Unlock()
+	for _, fn := range pending {
+		fn()
+	}
+}
+
 func responseHydrationOutcome(msg appwire.Message) (string, bool) {
 	switch {
 	case msg.Response != nil:
@@ -827,6 +867,38 @@ func (f *hydrationResponseFinalizer) abortAfterWithdrawal() {
 	if f.handoff.Abort != nil {
 		f.handoff.Abort()
 	}
+}
+
+// AfterResponseWritten runs fn once the response to the request being
+// handled in ctx has been written to the transport, or once the connection
+// tears down without writing it. It reports false, and does not retain fn,
+// when ctx carries no appserver connection or when the connection has
+// already torn down -- a handler that ran long enough for the send loop to
+// stop first must act for itself rather than wait for a callback nothing
+// will ever run.
+//
+// A second registration for the same request replaces the first: callbacks
+// are not chained. One handler owns one response, which is all any caller
+// needs today.
+func AfterResponseWritten(ctx context.Context, fn func()) bool {
+	conn, ok := ctx.Value(connectionContextKey{}).(*Connection)
+	if !ok || conn == nil {
+		return false
+	}
+	responseID, ok := ctx.Value(requestIDContextKey{}).(string)
+	if !ok || responseID == "" {
+		return false
+	}
+	conn.responseMu.Lock()
+	defer conn.responseMu.Unlock()
+	if conn.afterWriteDrained {
+		return false
+	}
+	if conn.afterWrite == nil {
+		conn.afterWrite = map[string]func(){}
+	}
+	conn.afterWrite[responseID] = fn
+	return true
 }
 
 func Subscribe(ctx context.Context, threadID string) bool {
@@ -1245,7 +1317,12 @@ func (c *Connection) setInitialized() {
 // out of order against every other request on the connection.
 func concurrentDispatchMethod(method string) bool {
 	switch method {
-	case appwire.MethodThreadRead, appwire.MethodThreadTurnsList, appwire.MethodEvenerSubagentPreview:
+	case appwire.MethodThreadRead, appwire.MethodThreadTurnsList, appwire.MethodEvenerSubagentPreview,
+		// evener/update/check is a read-only network comparison with no
+		// shared-state writes; running it inline blocks unrelated RPCs
+		// on the connection for up to two 10s GitHub timeouts. The
+		// frontend already discards stale check responses by sequence.
+		appwire.MethodEvenerUpdateCheck:
 		return true
 	}
 	return false

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -165,7 +165,10 @@ func (s *Server) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
 	var transportLoops sync.WaitGroup
 	transportLoops.Go(func() {
 		defer cancel()
-		runWebSocketSendLoopWithTimeout(ctx, transport, conn.send, writeTimeout)
+		// The loop returning means nothing further will be written, so any
+		// callback still waiting on its response runs now.
+		defer conn.runPendingAfterWrite()
+		runWebSocketSendLoopWithTimeout(ctx, transport, conn.send, writeTimeout, conn.responseWritten)
 	})
 	go conn.runWorker(ctx)
 
@@ -248,10 +251,12 @@ func runWebSocketKeepaliveWithTicker(ctx context.Context, conn wsPinger, cancel 
 }
 
 func runWebSocketSendLoop(ctx context.Context, transport webSocketSender, send <-chan appwire.Message) {
-	runWebSocketSendLoopWithTimeout(ctx, transport, send, webSocketWriteTimeout)
+	runWebSocketSendLoopWithTimeout(ctx, transport, send, webSocketWriteTimeout, nil)
 }
 
-func runWebSocketSendLoopWithTimeout(ctx context.Context, transport webSocketSender, send <-chan appwire.Message, writeTimeout time.Duration) {
+// sent, when non-nil, is called with each message the transport accepted, so
+// a handler can act only once its response has actually gone out.
+func runWebSocketSendLoopWithTimeout(ctx context.Context, transport webSocketSender, send <-chan appwire.Message, writeTimeout time.Duration, sent func(appwire.Message)) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -265,6 +270,9 @@ func runWebSocketSendLoopWithTimeout(ctx context.Context, transport webSocketSen
 			cancel()
 			if err != nil {
 				return
+			}
+			if sent != nil {
+				sent(msg)
 			}
 		}
 	}

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -301,6 +301,10 @@ func TestConcurrentDispatchMethodsAreExactlyTheSlowReads(t *testing.T) {
 		appwire.MethodThreadRead:            true,
 		appwire.MethodThreadTurnsList:       true,
 		appwire.MethodEvenerSubagentPreview: true,
+		// evener/update/check does synchronous GitHub I/O (up to two
+		// 10s timeouts); inline dispatch would block unrelated RPCs
+		// on the connection. Read-only, frontend discards stale results.
+		appwire.MethodEvenerUpdateCheck: true,
 	}
 	for _, spec := range appwire.Methods {
 		if got, want := concurrentDispatchMethod(spec.Name), slowReads[spec.Name]; got != want {

--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -305,6 +305,13 @@ func TestConcurrentDispatchMethodsAreExactlyTheSlowReads(t *testing.T) {
 		// 10s timeouts); inline dispatch would block unrelated RPCs
 		// on the connection. Read-only, frontend discards stale results.
 		appwire.MethodEvenerUpdateCheck: true,
+		// evener/update/apply does a multi-minute download, verify, and
+		// install under the overall upgrade deadline; inline dispatch
+		// would hold the connection's serial worker that whole time.
+		// Safe out of order: hubUpdateMu plus the cross-process install
+		// lock fail a concurrent apply fast, and the restart waits on
+		// its own response flush rather than connection order.
+		appwire.MethodEvenerUpdateApply: true,
 	}
 	for _, spec := range appwire.Methods {
 		if got, want := concurrentDispatchMethod(spec.Name), slowReads[spec.Name]; got != want {

--- a/internal/selfupdate/check.go
+++ b/internal/selfupdate/check.go
@@ -1,0 +1,141 @@
+package selfupdate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"primeradiant.com/evener/buildinfo"
+	"primeradiant.com/evener/envvars"
+)
+
+const defaultAPIURL = "https://api.github.com"
+
+// CheckOptions configures Check. Channel is required; the rest default.
+type CheckOptions struct {
+	Channel    string
+	CurrentSHA string
+	RepoURL    string
+	APIURL     string
+	HTTPClient *http.Client
+}
+
+// CheckResult reports what the channel currently points at and whether the
+// running build (CurrentSHA) differs from it.
+type CheckResult struct {
+	Channel         string `json:"channel"`
+	LatestTag       string `json:"latest_tag"`
+	LatestCommit    string `json:"latest_commit"`
+	UpdateAvailable bool   `json:"update_available"`
+}
+
+// Check resolves the channel's tag to a commit through the GitHub REST API
+// (public repo, unauthenticated) and compares it against CurrentSHA. The
+// snapshot channel is the floating "snapshot" tag; release is the tag behind
+// releases/latest. An empty CurrentSHA is treated as stale: we cannot prove
+// the running build matches, so offer the update.
+func Check(ctx context.Context, opts CheckOptions) (CheckResult, error) {
+	owner, repo, err := repoOwnerName(envvars.FirstNonEmpty(opts.RepoURL, defaultRepoURL))
+	if err != nil {
+		return CheckResult{}, err
+	}
+	apiURL := strings.TrimRight(envvars.FirstNonEmpty(opts.APIURL, defaultAPIURL), "/")
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	base := fmt.Sprintf("%s/repos/%s/%s", apiURL, owner, repo)
+
+	var tag string
+	switch opts.Channel {
+	case "snapshot":
+		tag = "snapshot"
+	case "release":
+		var latest struct {
+			TagName string `json:"tag_name"`
+		}
+		if err := getJSON(ctx, client, base+"/releases/latest", &latest); err != nil {
+			return CheckResult{}, err
+		}
+		if latest.TagName == "" {
+			return CheckResult{}, errors.New("latest release has no tag_name")
+		}
+		tag = latest.TagName
+	default:
+		return CheckResult{}, fmt.Errorf("unknown update channel %q; use release or snapshot", opts.Channel)
+	}
+
+	var commit struct {
+		SHA string `json:"sha"`
+	}
+	if err := getJSON(ctx, client, base+"/commits/"+url.PathEscape(tag), &commit); err != nil {
+		return CheckResult{}, err
+	}
+	if commit.SHA == "" {
+		return CheckResult{}, fmt.Errorf("tag %s resolved to no commit", tag)
+	}
+	return CheckResult{
+		Channel:         opts.Channel,
+		LatestTag:       tag,
+		LatestCommit:    commit.SHA,
+		UpdateAvailable: opts.CurrentSHA == "" || !strings.HasPrefix(commit.SHA, opts.CurrentSHA),
+	}, nil
+}
+
+// repoOwnerName extracts "owner", "repo" from a GitHub repository URL.
+func repoOwnerName(repoURL string) (string, string, error) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", "", fmt.Errorf("parse repo URL %q: %w", repoURL, err)
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("repo URL %q is not owner/repo", repoURL)
+	}
+	return parts[0], parts[1], nil
+}
+
+// getJSON performs one GET and decodes a 2xx JSON body. Non-2xx responses
+// become an error carrying the status and GitHub's own "message" field, so
+// a rate-limit response reads as such instead of a bare 403.
+func getJSON(ctx context.Context, client *http.Client, u string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// GitHub requires a User-Agent (403 without one). Go's default
+	// Go-http-client satisfies that today, but a product string
+	// identifies our traffic for rate-limit attribution and survives
+	// transport changes.
+	req.Header.Set("User-Agent", "evener/"+buildinfo.Version())
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", u, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("GET %s: read body: %w", u, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		var gh struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(body, &gh)
+		if gh.Message != "" {
+			return fmt.Errorf("GET %s: %s: %s", u, resp.Status, gh.Message)
+		}
+		return fmt.Errorf("GET %s: %s", u, resp.Status)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("GET %s: decode: %w", u, err)
+	}
+	return nil
+}

--- a/internal/selfupdate/check.go
+++ b/internal/selfupdate/check.go
@@ -17,6 +17,11 @@ import (
 
 const defaultAPIURL = "https://api.github.com"
 
+// minCurrentSHALen is the shortest CurrentSHA that may claim to be current:
+// release builds stamp a 7-char ShortCommit (see .goreleaser.yml), and
+// anything shorter matches exponentially more full SHAs. See Check.
+const minCurrentSHALen = 7
+
 // CheckOptions configures Check. Channel is required; the rest default.
 type CheckOptions struct {
 	Channel    string
@@ -80,11 +85,15 @@ func Check(ctx context.Context, opts CheckOptions) (CheckResult, error) {
 	if commit.SHA == "" {
 		return CheckResult{}, fmt.Errorf("tag %s resolved to no commit", tag)
 	}
+	// A prefix shorter than what release builds stamp (7-char ShortCommit)
+	// cannot prove currency: it matches 16^(7-len) full SHAs, so a
+	// collision would report up to date and hide an available update.
+	// Fail open — such an input is always treated as stale.
 	return CheckResult{
 		Channel:         opts.Channel,
 		LatestTag:       tag,
 		LatestCommit:    commit.SHA,
-		UpdateAvailable: opts.CurrentSHA == "" || !strings.HasPrefix(commit.SHA, opts.CurrentSHA),
+		UpdateAvailable: opts.CurrentSHA == "" || len(opts.CurrentSHA) < minCurrentSHALen || !strings.HasPrefix(commit.SHA, opts.CurrentSHA),
 	}, nil
 }
 

--- a/internal/selfupdate/check_test.go
+++ b/internal/selfupdate/check_test.go
@@ -159,3 +159,19 @@ func TestCheckSendsProductUserAgent(t *testing.T) {
 		}
 	}
 }
+
+// TestCheckShortPrefixIsStale proves a truncated CurrentSHA cannot claim to
+// be current: builds stamp a 7-char short SHA, so a 1-6 char prefix match
+// against the channel's full commit hides an available update on collision.
+// Such a short input must fail open (update available), never up to date.
+// Fails today: any HasPrefix match reports current.
+func TestCheckShortPrefixIsStale(t *testing.T) {
+	server, _, _ := fakeGitHub(t, "", "be7002918fdc60dbdeab71d9dd17e00d3d006c56", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "be70", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !got.UpdateAvailable {
+		t.Fatal("UpdateAvailable = false for a 4-char prefix of the latest commit, want true (too short to prove currency)")
+	}
+}

--- a/internal/selfupdate/check_test.go
+++ b/internal/selfupdate/check_test.go
@@ -1,0 +1,161 @@
+package selfupdate
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeGitHub serves the two GitHub REST endpoints Check uses under
+// /repos/prime-radiant-inc/evener/... and records the paths it saw.
+func fakeGitHub(t *testing.T, latestTag, tagCommit string, status int) (*httptest.Server, *[]string, *[]string) {
+	t.Helper()
+	var paths []string
+	var userAgents []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		userAgents = append(userAgents, r.Header.Get("User-Agent"))
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]string{"message": "API rate limit exceeded"})
+			return
+		}
+		switch {
+		case r.URL.Path == "/repos/prime-radiant-inc/evener/releases/latest":
+			_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": latestTag})
+		case strings.HasPrefix(r.URL.Path, "/repos/prime-radiant-inc/evener/commits/"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"sha": tagCommit})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &paths, &userAgents
+}
+
+func TestCheckSnapshotUpToDate(t *testing.T) {
+	server, paths, _ := fakeGitHub(t, "", "be7002918fdc60dbdeab71d9dd17e00d3d006c56", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "be70029", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	want := CheckResult{Channel: "snapshot", LatestTag: "snapshot", LatestCommit: "be7002918fdc60dbdeab71d9dd17e00d3d006c56", UpdateAvailable: false}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+	if len(*paths) != 1 || (*paths)[0] != "/repos/prime-radiant-inc/evener/commits/snapshot" {
+		t.Fatalf("paths = %v", *paths)
+	}
+}
+
+func TestCheckSnapshotStale(t *testing.T) {
+	server, _, _ := fakeGitHub(t, "", "be7002918fdc60dbdeab71d9dd17e00d3d006c56", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "3b1c5f8", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !got.UpdateAvailable {
+		t.Fatalf("UpdateAvailable = false, want true: %+v", got)
+	}
+}
+
+func TestCheckReleaseResolvesLatestTagThenCommit(t *testing.T) {
+	server, paths, _ := fakeGitHub(t, "v0.2.0", "0123456789abcdef0123456789abcdef01234567", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "release", CurrentSHA: "0123456", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if got.LatestTag != "v0.2.0" || got.UpdateAvailable {
+		t.Fatalf("got %+v", got)
+	}
+	wantPaths := []string{
+		"/repos/prime-radiant-inc/evener/releases/latest",
+		"/repos/prime-radiant-inc/evener/commits/v0.2.0",
+	}
+	if strings.Join(*paths, ",") != strings.Join(wantPaths, ",") {
+		t.Fatalf("paths = %v, want %v", *paths, wantPaths)
+	}
+}
+
+func TestCheckEmptyCurrentSHAIsStale(t *testing.T) {
+	server, _, _ := fakeGitHub(t, "", "be7002918fdc60dbdeab71d9dd17e00d3d006c56", http.StatusOK)
+	got, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "", APIURL: server.URL})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !got.UpdateAvailable {
+		t.Fatal("empty CurrentSHA must report an update")
+	}
+}
+
+func TestCheckRateLimitSurfacesGitHubMessage(t *testing.T) {
+	server, _, _ := fakeGitHub(t, "", "", http.StatusForbidden)
+	_, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "be70029", APIURL: server.URL})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "403") || !strings.Contains(err.Error(), "API rate limit exceeded") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCheckRejectsUnknownChannel(t *testing.T) {
+	_, err := Check(t.Context(), CheckOptions{Channel: "nightly", CurrentSHA: "abc"})
+	if err == nil || !strings.Contains(err.Error(), "nightly") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCheckReleaseEmptyTagNameErrors(t *testing.T) {
+	server, _, _ := fakeGitHub(t, "", "0123456789abcdef0123456789abcdef01234567", http.StatusOK)
+	_, err := Check(t.Context(), CheckOptions{Channel: "release", CurrentSHA: "0123456", APIURL: server.URL})
+	if err == nil || !strings.Contains(err.Error(), "tag_name") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCheckEmptyCommitSHAErrors(t *testing.T) {
+	server, _, _ := fakeGitHub(t, "", "", http.StatusOK)
+	_, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "abc", APIURL: server.URL})
+	if err == nil || !strings.Contains(err.Error(), "resolved to no commit") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCheckUsesRepoURLOwnerAndName(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(map[string]string{"sha": "abc"})
+	}))
+	t.Cleanup(server.Close)
+	_, err := Check(t.Context(), CheckOptions{Channel: "snapshot", CurrentSHA: "abc", APIURL: server.URL, RepoURL: "https://github.com/acme/widgets/"})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if gotPath != "/repos/acme/widgets/commits/snapshot" {
+		t.Fatalf("path = %q", gotPath)
+	}
+}
+
+// TestCheckSendsProductUserAgent proves every GitHub API request carries a
+// stable product User-Agent: GitHub requires a UA (403 otherwise), Go's
+// default Go-http-client/2.0 happens to satisfy that today, but a product
+// string identifies our traffic for rate-limit attribution and survives
+// transport changes. Fails today: getJSON sets only Accept.
+func TestCheckSendsProductUserAgent(t *testing.T) {
+	server, _, agents := fakeGitHub(t, "v0.2.0", "0123456789abcdef0123456789abcdef01234567", http.StatusOK)
+	if _, err := Check(t.Context(), CheckOptions{Channel: "release", CurrentSHA: "nope", APIURL: server.URL}); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if len(*agents) == 0 {
+		t.Fatal("no requests recorded")
+	}
+	for _, ua := range *agents {
+		if !strings.HasPrefix(ua, "evener/") {
+			t.Fatalf("User-Agent = %q, want evener/<version>", ua)
+		}
+	}
+}

--- a/internal/selfupdate/cov_rhub_selfupdate_test.go
+++ b/internal/selfupdate/cov_rhub_selfupdate_test.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -151,7 +153,7 @@ func TestExtractReleaseArchiveMissingBinary(t *testing.T) {
 	if err := os.WriteFile(archivePath, tarGz(t, entries, nil), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	err := extractReleaseArchive(archivePath, root, filepath.Join(t.TempDir(), "out"))
+	err := extractReleaseArchive(t.Context(), archivePath, root, filepath.Join(t.TempDir(), "out"))
 	if err == nil || !strings.Contains(err.Error(), "did not contain") {
 		t.Fatalf("err=%v, want missing-binary error", err)
 	}
@@ -172,7 +174,7 @@ func TestExtractReleaseArchiveRejectsNonRegularFile(t *testing.T) {
 	if err := os.WriteFile(archivePath, tarGz(t, entries, dirs), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	err := extractReleaseArchive(archivePath, root, filepath.Join(t.TempDir(), "out"))
+	err := extractReleaseArchive(t.Context(), archivePath, root, filepath.Join(t.TempDir(), "out"))
 	if err == nil || !strings.Contains(err.Error(), "not a regular file") {
 		t.Fatalf("err=%v, want non-regular-file error", err)
 	}
@@ -183,25 +185,25 @@ func TestExtractReleaseArchiveBadGzip(t *testing.T) {
 	if err := os.WriteFile(archivePath, []byte("not gzip"), 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	if err := extractReleaseArchive(archivePath, "root", filepath.Join(t.TempDir(), "out")); err == nil {
+	if err := extractReleaseArchive(t.Context(), archivePath, "root", filepath.Join(t.TempDir(), "out")); err == nil {
 		t.Fatal("expected gzip error")
 	}
 	// A missing archive file surfaces an open error.
-	if err := extractReleaseArchive(filepath.Join(t.TempDir(), "nope"), "root", t.TempDir()); err == nil {
+	if err := extractReleaseArchive(t.Context(), filepath.Join(t.TempDir(), "nope"), "root", t.TempDir()); err == nil {
 		t.Fatal("expected open error for missing archive")
 	}
 }
 
-func TestCopyExecutableMissingSource(t *testing.T) {
-	err := copyExecutable(filepath.Join(t.TempDir(), "nope"), filepath.Join(t.TempDir(), "dst"))
+func TestStageExecutableMissingSource(t *testing.T) {
+	_, err := stageExecutable(t.Context(), filepath.Join(t.TempDir(), "nope"), t.TempDir(), "evener")
 	if err == nil {
-		t.Fatal("expected error copying a missing source")
+		t.Fatal("expected error staging a missing source")
 	}
 }
 
 func TestInstallExtractedBinariesMissingSource(t *testing.T) {
-	// extractDir has no binaries, so copyExecutable fails on the first one.
-	err := installExtractedBinaries(t.TempDir(), filepath.Join(t.TempDir(), "share"), filepath.Join(t.TempDir(), "bin"))
+	// extractDir has no binaries, so staging fails on the first one.
+	_, err := installExtractedBinaries(t.Context(), t.TempDir(), filepath.Join(t.TempDir(), "share"), filepath.Join(t.TempDir(), "bin"))
 	if err == nil {
 		t.Fatal("expected error when extracted binaries are absent")
 	}
@@ -247,14 +249,30 @@ func TestUpgradeStageFailures(t *testing.T) {
 		}
 	})
 	t.Run("extract", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("bad gzip")) }))
+		bad := []byte("bad gzip")
+		sum := sha256.Sum256(bad)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "checksums.txt") {
+				_, _ = fmt.Fprintf(w, "%x  evener_linux_amd64.tar.gz\n", sum)
+				return
+			}
+			_, _ = w.Write(bad)
+		}))
 		defer server.Close()
 		if _, err := Upgrade(t.Context(), Options{Prefix: t.TempDir(), GOOS: "linux", GOARCH: "amd64", RepoURL: server.URL}); err == nil {
 			t.Fatal("expected error")
 		}
 	})
 	t.Run("install", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(releaseArchive(t, "evener_linux_amd64")) }))
+		archive := releaseArchive(t, "evener_linux_amd64")
+		sum := sha256.Sum256(archive)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasSuffix(r.URL.Path, "checksums.txt") {
+				_, _ = fmt.Fprintf(w, "%x  evener_linux_amd64.tar.gz\n", sum)
+				return
+			}
+			_, _ = w.Write(archive)
+		}))
 		defer server.Close()
 		block := filepath.Join(t.TempDir(), "block")
 		if err := os.WriteFile(block, nil, 0o600); err != nil {
@@ -277,7 +295,7 @@ func TestExtractArchiveErrors(t *testing.T) {
 		if err := os.WriteFile(block, nil, 0o600); err != nil {
 			t.Fatal(err)
 		}
-		if err := extractReleaseArchive(archive, root, filepath.Join(block, "out")); err == nil {
+		if err := extractReleaseArchive(t.Context(), archive, root, filepath.Join(block, "out")); err == nil {
 			t.Fatal("expected error")
 		}
 	})
@@ -288,7 +306,7 @@ func TestExtractArchiveErrors(t *testing.T) {
 		_ = gz.Close()
 		archive := filepath.Join(t.TempDir(), "a")
 		_ = os.WriteFile(archive, buf.Bytes(), 0o600)
-		if err := extractReleaseArchive(archive, root, t.TempDir()); err == nil {
+		if err := extractReleaseArchive(t.Context(), archive, root, t.TempDir()); err == nil {
 			t.Fatal("expected error")
 		}
 	})
@@ -298,14 +316,14 @@ func TestExtractArchiveErrors(t *testing.T) {
 		_ = os.WriteFile(archive, tarGz(t, entries, nil), 0o600)
 		out := t.TempDir()
 		_ = os.WriteFile(filepath.Join(out, installBinaries[0]), nil, 0o600)
-		if err := extractReleaseArchive(archive, root, out); err == nil {
+		if err := extractReleaseArchive(t.Context(), archive, root, out); err == nil {
 			t.Fatal("expected error")
 		}
 	})
 	t.Run("ignores unrelated entry", func(t *testing.T) {
 		archive := filepath.Join(t.TempDir(), "a")
 		_ = os.WriteFile(archive, tarGz(t, map[string][]byte{"unrelated/readme": []byte("x")}, nil), 0o600)
-		if err := extractReleaseArchive(archive, root, t.TempDir()); err == nil || !strings.Contains(err.Error(), "did not contain") {
+		if err := extractReleaseArchive(t.Context(), archive, root, t.TempDir()); err == nil || !strings.Contains(err.Error(), "did not contain") {
 			t.Fatalf("err=%v", err)
 		}
 	})
@@ -318,16 +336,16 @@ func TestInstallDirectoryAndSymlinkErrors(t *testing.T) {
 	}
 	block := filepath.Join(t.TempDir(), "block")
 	_ = os.WriteFile(block, nil, 0o600)
-	if err := installExtractedBinaries(extract, filepath.Join(block, "share"), t.TempDir()); err == nil {
+	if _, err := installExtractedBinaries(t.Context(), extract, filepath.Join(block, "share"), t.TempDir()); err == nil {
 		t.Fatal("share mkdir")
 	}
-	if err := installExtractedBinaries(extract, t.TempDir(), filepath.Join(block, "bin")); err == nil {
+	if _, err := installExtractedBinaries(t.Context(), extract, t.TempDir(), filepath.Join(block, "bin")); err == nil {
 		t.Fatal("bin mkdir")
 	}
 	binDir := t.TempDir()
 	_ = os.Mkdir(filepath.Join(binDir, installBinaries[0]), 0o755)
 	_ = os.WriteFile(filepath.Join(binDir, installBinaries[0], "keep"), nil, 0o600)
-	if err := installExtractedBinaries(extract, t.TempDir(), binDir); err == nil {
+	if _, err := installExtractedBinaries(t.Context(), extract, t.TempDir(), binDir); err == nil {
 		t.Fatal("symlink")
 	}
 }
@@ -387,36 +405,33 @@ func TestExtractCopyAndCloseErrors(t *testing.T) {
 	oldCopy, oldClose := copyStream, closeFile
 	t.Cleanup(func() { copyStream, closeFile = oldCopy, oldClose })
 	copyStream = func(io.Writer, io.Reader) (int64, error) { return 0, errors.New("copy") }
-	if err := extractReleaseArchive(archive, root, t.TempDir()); err == nil {
+	if err := extractReleaseArchive(t.Context(), archive, root, t.TempDir()); err == nil {
 		t.Fatal("copy")
 	}
 	copyStream = oldCopy
 	closeFile = func(*os.File) error { return errors.New("close") }
-	if err := extractReleaseArchive(archive, root, t.TempDir()); err == nil {
+	if err := extractReleaseArchive(t.Context(), archive, root, t.TempDir()); err == nil {
 		t.Fatal("close")
 	}
 }
 
-func TestCopyExecutableIOErrors(t *testing.T) {
-	src := filepath.Join(t.TempDir(), "src")
+func TestStageExecutableIOErrors(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
 	_ = os.WriteFile(src, []byte("body"), 0o755)
-	oldCopy, oldClose, oldRename := copyStream, closeFile, renameFile
-	t.Cleanup(func() { copyStream, closeFile, renameFile = oldCopy, oldClose, oldRename })
+	oldCopy, oldClose := copyStream, closeFile
+	t.Cleanup(func() { copyStream, closeFile = oldCopy, oldClose })
 	copyStream = func(io.Writer, io.Reader) (int64, error) { return 0, errors.New("copy") }
-	if err := copyExecutable(src, filepath.Join(t.TempDir(), "dst")); err == nil {
+	if _, err := stageExecutable(t.Context(), src, dir, "evener"); err == nil {
 		t.Fatal("copy")
 	}
 	copyStream = oldCopy
 	closeFile = func(*os.File) error { return errors.New("close") }
-	if err := copyExecutable(src, filepath.Join(t.TempDir(), "dst")); err == nil {
+	if _, err := stageExecutable(t.Context(), src, dir, "evener"); err == nil {
 		t.Fatal("close")
 	}
 	closeFile = oldClose
-	renameFile = func(string, string) error { return errors.New("rename") }
-	if err := copyExecutable(src, filepath.Join(t.TempDir(), "dst")); err == nil {
-		t.Fatal("rename")
-	}
-	if err := copyExecutable(src, filepath.Join(t.TempDir(), "missing", "dst")); err == nil {
+	if _, err := stageExecutable(t.Context(), src, filepath.Join(dir, "missing"), "evener"); err == nil {
 		t.Fatal("open output")
 	}
 }

--- a/internal/selfupdate/install_lock_other.go
+++ b/internal/selfupdate/install_lock_other.go
@@ -1,0 +1,19 @@
+//go:build !unix
+
+package selfupdate
+
+import "context"
+
+// acquireInstallLock is a no-op where no flock primitive is wired up:
+// concurrent installs from two processes are then serialized only by the
+// atomic renames below (a complete binary or symlink always wins intact),
+// which preserves correctness but not pairing between evener/evener-dev.
+func acquireInstallLock(shareBinDir string) (release func(), err error) {
+	return acquireInstallLockCtx(context.Background(), shareBinDir)
+}
+
+// acquireInstallLockCtx matches the unix signature; with no primitive to
+// wait on there is nothing for ctx to cancel.
+func acquireInstallLockCtx(_ context.Context, _ string) (release func(), err error) {
+	return func() {}, nil
+}

--- a/internal/selfupdate/install_lock_test.go
+++ b/internal/selfupdate/install_lock_test.go
@@ -1,0 +1,92 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestInstallLockSerializesConcurrentUpgrades proves two Upgrade calls
+// against the same prefix do not interleave: the second waits for (or
+// cleanly contends with) the first instead of racing Remove+Symlink pairs
+// into EEXIST holes or mixed-release pairs. Fails today: hubUpdateMu is
+// process-local and installExtractedBinaries takes no lock.
+func TestInstallLockSerializesConcurrentUpgrades(t *testing.T) {
+	archive := releaseArchive(t, "evener_linux_amd64")
+	server := checksumTestServer(t, archive, "")
+	t.Cleanup(server.Close)
+
+	prefix := t.TempDir()
+	opts := func() Options {
+		return Options{
+			Requested: "snapshot", CurrentChannel: "snapshot",
+			Prefix: prefix, GOOS: "linux", GOARCH: "amd64",
+			RepoURL: server.URL,
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 4)
+	for i := range errs {
+		wg.Go(func() {
+			_, errs[i] = Upgrade(t.Context(), opts())
+		})
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Upgrade: %v", err)
+		}
+	}
+	for _, bin := range installBinaries {
+		link := filepath.Join(prefix, "bin", bin)
+		target, err := os.Readlink(link)
+		if err != nil {
+			t.Fatalf("readlink %s: %v", link, err)
+		}
+		if !strings.HasPrefix(target, prefix) {
+			t.Fatalf("symlink %s -> %q, want inside %s", link, target, prefix)
+		}
+		if _, err := os.Stat(target); err != nil {
+			t.Fatalf("symlink target missing: %v", err)
+		}
+	}
+}
+
+// TestSymlinkSwapIsAtomic proves entrypoint replacement never leaves a
+// hole: swapSymlink writes a temp link and renames over the destination,
+// so concurrent readers see the old or the new target, never EEXIST or a
+// missing path. Fails today: Remove+Symlink is two steps.
+func TestSymlinkSwapIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	oldTarget := filepath.Join(dir, "old")
+	newTarget := filepath.Join(dir, "new")
+	for _, p := range []string{oldTarget, newTarget} {
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(oldTarget, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := swapSymlink(newTarget, link); err != nil {
+		t.Fatalf("swapSymlink: %v", err)
+	}
+	got, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if got != newTarget {
+		t.Fatalf("link -> %q, want %q", got, newTarget)
+	}
+	leftovers, err := filepath.Glob(filepath.Join(dir, "link.*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("temp links left behind: %v", leftovers)
+	}
+}

--- a/internal/selfupdate/install_lock_unix.go
+++ b/internal/selfupdate/install_lock_unix.go
@@ -1,0 +1,66 @@
+//go:build unix
+
+package selfupdate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// installLockPollInterval paces ctx-aware lock acquisition: non-blocking
+// try + sleep keeps the wait cancellable without a signalfd/kqueue.
+const installLockPollInterval = 50 * time.Millisecond
+
+// acquireInstallLock takes an exclusive flock on a lock file inside
+// shareBinDir, serializing concurrent installs into one prefix across
+// processes (hub self-update vs `evener upgrade` vs another hub).
+// hubUpdateMu only covers threads of one process. The lock file lives in
+// the managed dir so it moves with custom EVENER_SHARE_BINDIR layouts.
+func acquireInstallLock(shareBinDir string) (release func(), err error) {
+	return acquireInstallLockCtx(context.Background(), shareBinDir)
+}
+
+// acquireInstallLockCtx is acquireInstallLock with ctx-aware waiting: a
+// blocking LOCK_EX would ignore the upgrade's overall deadline and strand
+// the RPC past every timeout while another holder stalls. LOCK_NB polls
+// observe cancellation and return ctx.Err instead.
+func acquireInstallLockCtx(ctx context.Context, shareBinDir string) (release func(), err error) {
+	if err := os.MkdirAll(shareBinDir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir install lock parent: %w", err)
+	}
+	f, err := os.OpenFile(filepath.Join(shareBinDir, ".install.lock"), os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open install lock: %w", err)
+	}
+	for {
+		flockErr := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if flockErr == nil {
+			return func() {
+				_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+				_ = f.Close()
+			}, nil
+		}
+		// Only contention retries: a permission error, bad fd, or
+		// anything else fails fast instead of spinning to the deadline.
+		if !errors.Is(flockErr, unix.EWOULDBLOCK) && !errors.Is(flockErr, unix.EAGAIN) {
+			_ = f.Close()
+			return nil, fmt.Errorf("flock install lock: %w", flockErr)
+		}
+		if err := ctx.Err(); err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+			return nil, ctx.Err()
+		case <-time.After(installLockPollInterval):
+		}
+	}
+}

--- a/internal/selfupdate/install_pair_test.go
+++ b/internal/selfupdate/install_pair_test.go
@@ -223,6 +223,118 @@ func TestInstallPairRollbackRemovesFreshLinks(t *testing.T) {
 	}
 }
 
+// TestInstallPairRestoresOnDigestFailure proves a digest failure after the
+// commit rolls the pair back: committed binaries must not stay live when
+// the install reports an error and no restart follows. Fails today:
+// committed=true is set before digestsUnderLock runs, so a digest error
+// leaves the swapped pair on disk unrestored.
+func TestInstallPairRestoresOnDigestFailure(t *testing.T) {
+	extractDir := t.TempDir()
+	shareBin := filepath.Join(t.TempDir(), "share")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	for _, d := range []string{extractDir, shareBin, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldBody := []byte("old release binary")
+	for _, bin := range installBinaries {
+		if err := os.WriteFile(filepath.Join(extractDir, bin), []byte("new "+bin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(shareBin, bin), oldBody, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join(shareBin, bin), filepath.Join(binDir, bin)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Remove one committed binary before digest time: digestsUnderLock must
+	// fail, and the install must roll back instead of leaving the new pair.
+	previous := renameFile
+	renameFile = func(oldpath, newpath string) error {
+		if err := os.Rename(oldpath, newpath); err != nil {
+			return err
+		}
+		if filepath.Base(newpath) == installBinaries[1] {
+			_ = os.Remove(newpath)
+		}
+		return nil
+	}
+	t.Cleanup(func() { renameFile = previous })
+
+	if _, err := installExtractedBinaries(t.Context(), extractDir, shareBin, binDir); err == nil {
+		t.Fatal("expected a digest error from the removed committed binary")
+	}
+	for _, bin := range installBinaries {
+		got, err := os.ReadFile(filepath.Join(shareBin, bin))
+		if err != nil {
+			t.Fatalf("read %s: %v", bin, err)
+		}
+		if !bytes.Equal(got, oldBody) {
+			t.Fatalf("%s = %q after digest failure, want the old release restored", bin, got)
+		}
+	}
+}
+
+// TestInstallPairPreservesCopiedEntrypoint proves rollback restores a
+// pre-existing non-symlink binDir entry: a copied (not symlinked) binary is
+// a supported layout, and swapSymlink's rename-over destroys it. Fails
+// today: restore() leaves the swapped-in link in place for non-symlinks.
+func TestInstallPairPreservesCopiedEntrypoint(t *testing.T) {
+	extractDir := t.TempDir()
+	shareBin := filepath.Join(t.TempDir(), "share")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	for _, d := range []string{extractDir, shareBin, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldBody := []byte("old release binary")
+	for _, bin := range installBinaries {
+		if err := os.WriteFile(filepath.Join(extractDir, bin), []byte("new "+bin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(shareBin, bin), oldBody, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Copied entrypoint for evener: a regular file, not a symlink.
+	copiedBody := []byte("copied entrypoint binary")
+	if err := os.WriteFile(filepath.Join(binDir, "evener"), copiedBody, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(shareBin, "evener-dev"), filepath.Join(binDir, "evener-dev")); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := renameFile
+	renameFile = func(oldpath, newpath string) error {
+		if filepath.Base(newpath) == installBinaries[1] {
+			return errors.New("injected second-binary failure")
+		}
+		return os.Rename(oldpath, newpath)
+	}
+	t.Cleanup(func() { renameFile = previous })
+
+	if _, err := installExtractedBinaries(t.Context(), extractDir, shareBin, binDir); err == nil {
+		t.Fatal("expected the injected second-binary failure")
+	}
+	got, err := os.ReadFile(filepath.Join(binDir, "evener"))
+	if err != nil {
+		t.Fatalf("read binDir evener: %v", err)
+	}
+	if !bytes.Equal(got, copiedBody) {
+		t.Fatalf("binDir evener = %q after rollback, want the copied entrypoint restored", got)
+	}
+	if fi, err := os.Lstat(filepath.Join(binDir, "evener")); err != nil {
+		t.Fatalf("lstat binDir evener: %v", err)
+	} else if fi.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("binDir evener is a symlink after rollback, want the original regular file")
+	}
+}
+
 // TestUpgradeDigestsUnderLock proves InstalledSHA256 reflects the bytes
 // committed while the install lock was held: a test double swaps one
 // installed binary between commit and digest time would previously poison

--- a/internal/selfupdate/install_pair_test.go
+++ b/internal/selfupdate/install_pair_test.go
@@ -179,6 +179,50 @@ func TestInstallPairRestoresBinDirEntrypoints(t *testing.T) {
 	}
 }
 
+// TestInstallPairRollbackRemovesFreshLinks proves rollback handles the
+// binDir entry independently of hadPrev: on a first-time install (no prior
+// managed binaries) a mid-commit failure must remove the swapped-in link,
+// not leave it dangling after its target is deleted. Fails today:
+// restore() `continue`s past link handling when !hadPrev.
+func TestInstallPairRollbackRemovesFreshLinks(t *testing.T) {
+	extractDir := t.TempDir()
+	shareBin := filepath.Join(t.TempDir(), "share")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	for _, d := range []string{extractDir, shareBin, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// First-time install: extract dir has the new pair, share/bin empty.
+	for _, bin := range installBinaries {
+		if err := os.WriteFile(filepath.Join(extractDir, bin), []byte("new "+bin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	previous := renameFile
+	renameFile = func(oldpath, newpath string) error {
+		if filepath.Base(newpath) == installBinaries[1] {
+			return errors.New("injected second-binary failure")
+		}
+		return os.Rename(oldpath, newpath)
+	}
+	t.Cleanup(func() { renameFile = previous })
+
+	if _, err := installExtractedBinaries(t.Context(), extractDir, shareBin, binDir); err == nil {
+		t.Fatal("expected the injected second-binary failure")
+	}
+	// The first binary committed its dst and swapped its link before the
+	// failure; rollback must undo both, leaving no dangling entrypoint.
+	first := installBinaries[0]
+	if _, err := os.Lstat(filepath.Join(shareBin, first)); !os.IsNotExist(err) {
+		t.Fatalf("managed %s present after failed first-time install (err=%v)", first, err)
+	}
+	if _, err := os.Lstat(filepath.Join(binDir, first)); !os.IsNotExist(err) {
+		t.Fatalf("binDir %s present after failed first-time install (err=%v), want the swapped-in link removed", first, err)
+	}
+}
+
 // TestUpgradeDigestsUnderLock proves InstalledSHA256 reflects the bytes
 // committed while the install lock was held: a test double swaps one
 // installed binary between commit and digest time would previously poison

--- a/internal/selfupdate/install_pair_test.go
+++ b/internal/selfupdate/install_pair_test.go
@@ -1,0 +1,243 @@
+package selfupdate
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestInstallLockHonorsContext proves lock acquisition observes the
+// caller's deadline: with another holder on the lock, an already-expired
+// context fails fast instead of blocking past every timeout. Fails today:
+// LOCK_EX blocks indefinitely with no ctx parameter at all.
+func TestInstallLockHonorsContext(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "share")
+	holder, err := acquireInstallLock(dir)
+	if err != nil {
+		t.Fatalf("acquire holder lock: %v", err)
+	}
+	defer holder()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err = acquireInstallLockCtx(ctx, dir)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected an error acquiring a held lock with an expiring context")
+	}
+	if elapsed > 30*time.Second {
+		t.Fatalf("lock wait took %v with a 100ms context; acquisition ignores ctx", elapsed)
+	}
+}
+
+// TestInstallLockAcquiresWhenFree proves the ctx-aware path still grants
+// an uncontended lock.
+func TestInstallLockAcquiresWhenFree(t *testing.T) {
+	release, err := acquireInstallLockCtx(t.Context(), filepath.Join(t.TempDir(), "share"))
+	if err != nil {
+		t.Fatalf("acquire free lock: %v", err)
+	}
+	release()
+}
+
+// TestInstallPairRollsBackOnSecondFailure proves a failure installing the
+// second binary restores the first: stage-then-commit with rollback, so a
+// cancelled or failed upgrade never leaves evener and evener-dev from
+// different releases. Fails today: sequential commit leaves binary one
+// replaced when binary two errors.
+func TestInstallPairRollsBackOnSecondFailure(t *testing.T) {
+	extractDir := t.TempDir()
+	shareBin := filepath.Join(t.TempDir(), "share")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	for _, d := range []string{extractDir, shareBin, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldBody := []byte("old release binary")
+	for _, bin := range installBinaries {
+		if err := os.WriteFile(filepath.Join(extractDir, bin), []byte("new "+bin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(shareBin, bin), oldBody, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join(shareBin, bin), filepath.Join(binDir, bin)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	previous := renameFile
+	renameFile = func(oldpath, newpath string) error {
+		// Fail the commit of the second binary only.
+		if filepath.Base(newpath) == installBinaries[1] {
+			return errors.New("injected second-binary failure")
+		}
+		return os.Rename(oldpath, newpath)
+	}
+	t.Cleanup(func() { renameFile = previous })
+
+	if _, err := installExtractedBinaries(t.Context(), extractDir, shareBin, binDir); err == nil {
+		t.Fatal("expected the injected second-binary failure")
+	}
+	for _, bin := range installBinaries {
+		got, err := os.ReadFile(filepath.Join(shareBin, bin))
+		if err != nil {
+			t.Fatalf("read %s: %v", bin, err)
+		}
+		if !bytes.Equal(got, oldBody) {
+			t.Fatalf("%s = %q after failed install, want the old release restored (no mixed pair)", bin, got)
+		}
+		link, err := os.Readlink(filepath.Join(binDir, bin))
+		if err != nil {
+			t.Fatalf("readlink %s: %v", bin, err)
+		}
+		if link != filepath.Join(shareBin, bin) {
+			t.Fatalf("link %s -> %q, want the managed binary", bin, link)
+		}
+	}
+}
+
+// TestInstallPairRestoresBinDirEntrypoints proves rollback covers the
+// binDir entrypoints, not just the managed binaries: with a custom symlink
+// for evener and no entry for evener-dev, a mid-commit failure must leave
+// the custom link untouched and no dangling new link. Fails today:
+// restore() only handles shareBinDir files.
+func TestInstallPairRestoresBinDirEntrypoints(t *testing.T) {
+	extractDir := t.TempDir()
+	shareBin := filepath.Join(t.TempDir(), "share")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	for _, d := range []string{extractDir, shareBin, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldBody := []byte("old release binary")
+	for _, bin := range installBinaries {
+		if err := os.WriteFile(filepath.Join(extractDir, bin), []byte("new "+bin), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(shareBin, bin), oldBody, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Custom pre-existing entrypoint for evener only; evener-dev absent.
+	customTarget := filepath.Join(t.TempDir(), "custom-evener")
+	if err := os.WriteFile(customTarget, []byte("custom"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(customTarget, filepath.Join(binDir, "evener")); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := renameFile
+	renameFile = func(oldpath, newpath string) error {
+		if filepath.Base(newpath) == installBinaries[1] {
+			return errors.New("injected second-binary failure")
+		}
+		return os.Rename(oldpath, newpath)
+	}
+	t.Cleanup(func() { renameFile = previous })
+
+	if _, err := installExtractedBinaries(t.Context(), extractDir, shareBin, binDir); err == nil {
+		t.Fatal("expected the injected second-binary failure")
+	}
+	// Custom evener link must be untouched.
+	got, err := os.Readlink(filepath.Join(binDir, "evener"))
+	if err != nil {
+		t.Fatalf("readlink evener: %v", err)
+	}
+	if got != customTarget {
+		t.Fatalf("evener link -> %q, want custom %q restored", got, customTarget)
+	}
+	// Absent evener-dev entry must not dangle: either removed or pointing
+	// at a live managed binary.
+	if got, err := os.Readlink(filepath.Join(binDir, "evener-dev")); err == nil {
+		if _, statErr := os.Stat(got); statErr != nil && !filepath.IsAbs(got) {
+			t.Fatalf("evener-dev link dangles at %q", got)
+		}
+		if _, statErr := os.Stat(filepath.Join(binDir, "evener-dev")); statErr != nil {
+			t.Fatalf("evener-dev entry unusable: %v", statErr)
+		}
+	}
+	// Managed pair still the old release (existing rollback guarantee).
+	for _, bin := range installBinaries {
+		data, err := os.ReadFile(filepath.Join(shareBin, bin))
+		if err != nil {
+			t.Fatalf("read %s: %v", bin, err)
+		}
+		if !bytes.Equal(data, oldBody) {
+			t.Fatalf("%s = %q, want old release restored", bin, data)
+		}
+	}
+}
+
+// TestUpgradeDigestsUnderLock proves InstalledSHA256 reflects the bytes
+// committed while the install lock was held: a test double swaps one
+// installed binary between commit and digest time would previously poison
+// the pin. Here Upgrade itself computes digests post-commit; this test
+// pins the contract that digests match committed bytes by upgrading
+// normally and re-hashing each Installed path.
+func TestUpgradeDigestsMatchCommittedBytes(t *testing.T) {
+	archive := releaseArchive(t, "evener_linux_amd64")
+	server := checksumTestServer(t, archive, "")
+	t.Cleanup(server.Close)
+
+	prefix := t.TempDir()
+	result, err := Upgrade(t.Context(), Options{
+		Requested: "snapshot", CurrentChannel: "snapshot",
+		Prefix: prefix, GOOS: "linux", GOARCH: "amd64",
+		RepoURL: server.URL,
+	})
+	if err != nil {
+		t.Fatalf("Upgrade: %v", err)
+	}
+	if len(result.InstalledSHA256) != len(result.Installed) {
+		t.Fatalf("digests cover %d of %d installed paths", len(result.InstalledSHA256), len(result.Installed))
+	}
+	for _, path := range result.Installed {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		sum := sha256.Sum256(data)
+		if got, want := result.InstalledSHA256[path], hex.EncodeToString(sum[:]); got != want {
+			t.Fatalf("digest mismatch for %s", path)
+		}
+	}
+}
+
+// TestRelockVerifyExecSerializesAgainstInstaller proves the exported
+// relock helper grants the install lock (and reports contention while
+// held): the restart goroutine uses it to close the verify->exec window
+// against a concurrent installer.
+func TestRelockVerifyExecSerializesAgainstInstaller(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "share")
+	holder, err := acquireInstallLock(dir)
+	if err != nil {
+		t.Fatalf("acquire holder: %v", err)
+	}
+	defer holder()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if _, err := AcquireInstallLockForVerify(ctx, dir); err == nil {
+		t.Fatal("expected a context error while the install lock is held")
+	}
+	if elapsed := time.Since(start); elapsed > 30*time.Second {
+		t.Fatalf("contended acquire took %v with a 200ms context", elapsed)
+	}
+	holder()
+	release, err := AcquireInstallLockForVerify(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+	release()
+}

--- a/internal/selfupdate/installdirs_custom_test.go
+++ b/internal/selfupdate/installdirs_custom_test.go
@@ -1,0 +1,177 @@
+package selfupdate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInstallDirsPreservesCustomBinDir proves a hub launched through a
+// custom BINDIR entrypoint keeps it: install.sh supports BINDIR (symlink
+// dir) independently of the prefix, so deriving binDir as <prefix>/bin
+// from the resolved share path would write symlinks to the wrong place
+// (or fail on permissions). The unresolved entrypoint directory -- the
+// dir holding the launched name -- is the binDir. Fails today: resolution
+// drops the entrypoint and reconstructs <prefix>/bin.
+func TestInstallDirsPreservesCustomBinDir(t *testing.T) {
+	root := t.TempDir()
+	shareBin := filepath.Join(root, "share", "evener", "bin")
+	if err := os.MkdirAll(shareBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(shareBin, "evener")
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	customBin := filepath.Join(t.TempDir(), "custom-bin")
+	if err := os.MkdirAll(customBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(customBin, "evener")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix, binDir, gotShare := InstallDirsFromExecutable(link)
+	if prefix != root {
+		t.Fatalf("prefix = %q, want %q", prefix, root)
+	}
+	if binDir != customBin {
+		t.Fatalf("binDir = %q, want the entrypoint dir %q", binDir, customBin)
+	}
+	if gotShare != shareBin {
+		t.Fatalf("shareBinDir = %q, want %q", gotShare, shareBin)
+	}
+}
+
+// TestInstallDirsFromPreresolvedShareBinary covers Linux, where
+// os.Executable resolves /proc/self/exe to the TARGET: exe arrives
+// already resolved as <prefix>/share/evener/bin/<name>, so the
+// entrypoint dir IS the share dir. The sibling check must not treat
+// that as a live custom BINDIR -- returning binDir==shareBinDir makes
+// installExtractedBinaries Remove the just-installed binary and
+// symlink it to itself. Fails today: sibling==candidate trivially.
+func TestInstallDirsFromPreresolvedShareBinary(t *testing.T) {
+	root := t.TempDir()
+	shareBin := filepath.Join(root, "share", "evener", "bin")
+	if err := os.MkdirAll(shareBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exe := filepath.Join(shareBin, "evener")
+	if err := os.WriteFile(exe, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix, binDir, gotShare := InstallDirsFromExecutable(exe)
+	if prefix != root {
+		t.Fatalf("prefix = %q, want %q", prefix, root)
+	}
+	if gotShare != shareBin {
+		t.Fatalf("shareBinDir = %q, want %q", gotShare, shareBin)
+	}
+	if binDir == shareBin {
+		t.Fatalf("binDir = shareBinDir (%q): install would remove the binary and self-symlink", binDir)
+	}
+	if want := filepath.Join(root, "bin"); binDir != want {
+		t.Fatalf("binDir = %q, want standard %q", binDir, want)
+	}
+}
+
+// TestInstallDirsFromArbitraryShareLayout proves a fully custom
+// installation (BINDIR + EVENER_SHARE_BINDIR both non-standard) derives
+// directly from the launch symlink: entry dir as binDir, resolved target
+// dir as shareBinDir, with no ~/.local fallback. Fails today: neither
+// suffix matches, so all-empty selects Upgrade's defaults and the hub
+// restarts from an unrelated copy.
+func TestInstallDirsFromArbitraryShareLayout(t *testing.T) {
+	customShare := filepath.Join(t.TempDir(), "custom", "share")
+	if err := os.MkdirAll(customShare, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(customShare, "evener")
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	customBin := filepath.Join(t.TempDir(), "custom", "bin")
+	if err := os.MkdirAll(customBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(customBin, "evener")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix, binDir, shareBinDir := InstallDirsFromExecutable(link)
+	// The prefix is unknowable for a non-standard layout (best effort,
+	// may be empty); what matters is both install dirs are exact, so no
+	// ~/.local fallback and the restart binary is the managed one.
+	_ = prefix
+	if binDir != customBin {
+		t.Fatalf("binDir = %q, want the entrypoint dir %q", binDir, customBin)
+	}
+	if shareBinDir != customShare {
+		t.Fatalf("shareBinDir = %q, want the resolved target dir %q", shareBinDir, customShare)
+	}
+}
+
+// NOTE: hardlink and copy entrypoints in a custom BINDIR are deliberately
+// unsupported: with no symlink the derivation cannot tell a managed custom
+// dir from an unrelated copy, and guessing wrong redirects symlinks (or
+// refuses a valid update). install.sh always installs a symlink at BINDIR,
+// so the symlink case above is the supported custom layout.
+
+// TestInstallPairRemovesStagedOnCommitFailure proves a failed commit does
+// not leak staged temp files: the pair commit removes the staged file
+// whose rename failed. (Supersedes the old copyExecutable rename test;
+// staging owns temp lifecycle now.)
+func TestInstallPairRemovesStagedOnCommitFailure(t *testing.T) {
+	extractDir := t.TempDir()
+	shareBin := filepath.Join(t.TempDir(), "share")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	for _, d := range []string{extractDir, shareBin, binDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, bin := range installBinaries {
+		if err := os.WriteFile(filepath.Join(extractDir, bin), []byte("new"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	previous := renameFile
+	renameFile = func(_, _ string) error { return errors.New("rename failed") }
+	t.Cleanup(func() { renameFile = previous })
+
+	if _, err := installExtractedBinaries(t.Context(), extractDir, shareBin, binDir); err == nil ||
+		!strings.Contains(err.Error(), "rename failed") {
+		t.Fatalf("err = %v, want the rename error", err)
+	}
+	leftovers, err := filepath.Glob(filepath.Join(shareBin, "*.stage"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("staged files left behind after commit failure: %v", leftovers)
+	}
+}
+
+// TestInstallDirsAcceptsFilesystemRootPrefix proves PREFIX=/ is a valid
+// installation root: /share/evener/bin/<name> CutSuffixes to an empty
+// prefix, which the old empty-check rejected into the ~/.local fallback.
+// Fails today: all-empty for the root layout.
+func TestInstallDirsAcceptsFilesystemRootPrefix(t *testing.T) {
+	sep := string(filepath.Separator)
+	prefix, binDir, shareOut := InstallDirsFromExecutable(filepath.Join(sep, "share", "evener", "bin", "evener"))
+	if prefix != sep {
+		t.Fatalf("prefix = %q, want the filesystem root", prefix)
+	}
+	if binDir != filepath.Join(sep, "bin") {
+		t.Fatalf("binDir = %q, want /bin", binDir)
+	}
+	if shareOut != filepath.Join(sep, "share", "evener", "bin") {
+		t.Fatalf("shareBinDir = %q", shareOut)
+	}
+}

--- a/internal/selfupdate/installdirs_symlink_test.go
+++ b/internal/selfupdate/installdirs_symlink_test.go
@@ -1,0 +1,105 @@
+package selfupdate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestInstallDirsFromExecutableResolvesBinSymlink proves the normal
+// install.sh entrypoint works: a hub launched as <prefix>/bin/evener (a
+// symlink to ../share/evener/bin/evener) upgrades <prefix>, not ~/.local.
+// os.Executable returns the symlink path unresolved (proven with a probe
+// binary), so the derivation must resolve symlinks itself and accept the
+// bin layout as well as the share layout. Fails today: raw path matches
+// neither layout... and even EvalSymlinks alone would land in the share
+// dir only if the link target is the share binary -- the bin dir itself
+// must map back to the prefix.
+func TestInstallDirsFromExecutableResolvesBinSymlink(t *testing.T) {
+	root := t.TempDir()
+	shareBin := filepath.Join(root, "share", "evener", "bin")
+	if err := os.MkdirAll(shareBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(shareBin, "evener")
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(binDir, "evener")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix, gotBin, gotShare := InstallDirsFromExecutable(link)
+	if prefix != root {
+		t.Fatalf("prefix = %q, want %q", prefix, root)
+	}
+	if gotBin != binDir {
+		t.Fatalf("binDir = %q, want %q", gotBin, binDir)
+	}
+	if gotShare != shareBin {
+		t.Fatalf("shareBinDir = %q, want %q", gotShare, shareBin)
+	}
+}
+
+// TestInstallDirsFromExecutableAcceptsBinDirDirectly covers a hub launched
+// via a hardlink or copy sitting straight in <prefix>/bin: no symlink to
+// resolve, but the bin layout must still map back to the prefix.
+func TestInstallDirsFromExecutableAcceptsBinDirDirectly(t *testing.T) {
+	root := t.TempDir()
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(filepath.Join(root, "share", "evener", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exe := filepath.Join(binDir, "evener")
+	if err := os.WriteFile(exe, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix, gotBin, gotShare := InstallDirsFromExecutable(exe)
+	if prefix != root {
+		t.Fatalf("prefix = %q, want %q", prefix, root)
+	}
+	if gotBin != binDir {
+		t.Fatalf("binDir = %q, want %q", gotBin, binDir)
+	}
+	if gotShare != filepath.Join(root, "share", "evener", "bin") {
+		t.Fatalf("shareBinDir = %q, want the prefix share dir", gotShare)
+	}
+}
+
+// TestInstallDirsFromExecutableResolvesShareSymlink covers the share binary
+// itself reached through a symlink (e.g. /usr/local/bin/evener -> the
+// share path on systems where both exist): resolution must land on the
+// share layout, not fail on the link's own directory.
+func TestInstallDirsFromExecutableResolvesShareSymlink(t *testing.T) {
+	root := t.TempDir()
+	shareBin := filepath.Join(root, "share", "evener", "bin")
+	if err := os.MkdirAll(shareBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(shareBin, "evener")
+	if err := os.WriteFile(target, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	elsewhere := t.TempDir()
+	link := filepath.Join(elsewhere, "evener-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	prefix, _, gotShare := InstallDirsFromExecutable(link)
+	if prefix != root {
+		t.Fatalf("prefix = %q, want %q", prefix, root)
+	}
+	if gotShare != shareBin {
+		t.Fatalf("shareBinDir = %q, want %q", gotShare, shareBin)
+	}
+}

--- a/internal/selfupdate/installdirs_test.go
+++ b/internal/selfupdate/installdirs_test.go
@@ -1,0 +1,52 @@
+package selfupdate
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestInstallDirsFromExecutableDerivesSystemPrefix proves the hub upgrades
+// the installation it actually runs from: a hub executing as
+// /usr/local/share/evener/bin/evener must install into /usr/local, not the
+// ~/.local default. Fails today because the hub passes no Prefix at all.
+func TestInstallDirsFromExecutableDerivesSystemPrefix(t *testing.T) {
+	prefix, binDir, shareBinDir := InstallDirsFromExecutable("/usr/local/share/evener/bin/evener")
+	if prefix != "/usr/local" {
+		t.Fatalf("prefix = %q, want %q", prefix, "/usr/local")
+	}
+	if shareBinDir != "/usr/local/share/evener/bin" {
+		t.Fatalf("shareBinDir = %q, want %q", shareBinDir, "/usr/local/share/evener/bin")
+	}
+	if binDir != "/usr/local/bin" {
+		t.Fatalf("binDir = %q, want %q", binDir, "/usr/local/bin")
+	}
+}
+
+// TestInstallDirsFromExecutableDerivesHomePrefix covers the standard
+// user-local install: ~/.local/share/evener/bin/evener maps back to
+// ~/.local with matching bin and share dirs.
+func TestInstallDirsFromExecutableDerivesHomePrefix(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	exe := filepath.Join(home, ".local", "share", "evener", "bin", "evener")
+	prefix, binDir, shareBinDir := InstallDirsFromExecutable(exe)
+	if prefix != filepath.Join(home, ".local") {
+		t.Fatalf("prefix = %q, want %q", prefix, filepath.Join(home, ".local"))
+	}
+	if shareBinDir != filepath.Join(home, ".local", "share", "evener", "bin") {
+		t.Fatalf("shareBinDir = %q, want the running share dir", shareBinDir)
+	}
+	if binDir != filepath.Join(home, ".local", "bin") {
+		t.Fatalf("binDir = %q, want %q", binDir, filepath.Join(home, ".local", "bin"))
+	}
+}
+
+// TestInstallDirsFromExecutableFallsBackToDefaults covers binaries running
+// from anywhere else (a worktree build, a temp dir): there is no install
+// layout to infer, so empty strings select Upgrade's own defaults.
+func TestInstallDirsFromExecutableFallsBackToDefaults(t *testing.T) {
+	prefix, binDir, shareBinDir := InstallDirsFromExecutable(filepath.Join(t.TempDir(), "evener"))
+	if prefix != "" || binDir != "" || shareBinDir != "" {
+		t.Fatalf("got (%q, %q, %q), want all empty for an unknown layout", prefix, binDir, shareBinDir)
+	}
+}

--- a/internal/selfupdate/package_union_fuzz_test.go
+++ b/internal/selfupdate/package_union_fuzz_test.go
@@ -25,7 +25,7 @@ func FuzzPackageUnion(f *testing.F) {
 		t.Run("TestExtractReleaseArchiveMissingBinary", TestExtractReleaseArchiveMissingBinary)
 		t.Run("TestExtractReleaseArchiveRejectsNonRegularFile", TestExtractReleaseArchiveRejectsNonRegularFile)
 		t.Run("TestExtractReleaseArchiveBadGzip", TestExtractReleaseArchiveBadGzip)
-		t.Run("TestCopyExecutableMissingSource", TestCopyExecutableMissingSource)
+		t.Run("TestStageExecutableMissingSource", TestStageExecutableMissingSource)
 		t.Run("TestInstallExtractedBinariesMissingSource", TestInstallExtractedBinariesMissingSource)
 		t.Run("TestUpgradeDownloadFailurePropagates", TestUpgradeDownloadFailurePropagates)
 		t.Run("TestUpgradeStageFailures", TestUpgradeStageFailures)
@@ -33,6 +33,6 @@ func FuzzPackageUnion(f *testing.F) {
 		t.Run("TestInstallDirectoryAndSymlinkErrors", TestInstallDirectoryAndSymlinkErrors)
 		t.Run("TestDownloadTransportAndIOErrors", TestDownloadTransportAndIOErrors)
 		t.Run("TestExtractCopyAndCloseErrors", TestExtractCopyAndCloseErrors)
-		t.Run("TestCopyExecutableIOErrors", TestCopyExecutableIOErrors)
+		t.Run("TestStageExecutableIOErrors", TestStageExecutableIOErrors)
 	})
 }

--- a/internal/selfupdate/restart_other.go
+++ b/internal/selfupdate/restart_other.go
@@ -8,3 +8,6 @@ import "errors"
 func Restart(binary string, args []string) error {
 	return errors.New("in-place restart is not supported on this platform")
 }
+
+// RestartSupported reports whether Restart can exec in place on this build.
+func RestartSupported() bool { return false }

--- a/internal/selfupdate/restart_other.go
+++ b/internal/selfupdate/restart_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package selfupdate
+
+import "errors"
+
+// Restart is unsupported outside unix: there is no exec-in-place there.
+func Restart(binary string, args []string) error {
+	return errors.New("in-place restart is not supported on this platform")
+}

--- a/internal/selfupdate/restart_unix.go
+++ b/internal/selfupdate/restart_unix.go
@@ -19,3 +19,6 @@ func Restart(binary string, args []string) error {
 	}
 	return nil
 }
+
+// RestartSupported reports whether Restart can exec in place on this build.
+func RestartSupported() bool { return true }

--- a/internal/selfupdate/restart_unix.go
+++ b/internal/selfupdate/restart_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package selfupdate
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Restart replaces the current process image with binary, keeping the PID,
+// the environment, and args as argv[1:]. Go opens files and sockets with
+// O_CLOEXEC, so the hub's flock and listener are released by the exec and
+// re-acquired by the new image. It only returns when the exec itself fails.
+func Restart(binary string, args []string) error {
+	argv := append([]string{binary}, args...)
+	if err := syscall.Exec(binary, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec %s: %w", binary, err)
+	}
+	return nil
+}

--- a/internal/selfupdate/restart_unix_test.go
+++ b/internal/selfupdate/restart_unix_test.go
@@ -1,0 +1,53 @@
+//go:build unix
+
+package selfupdate
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestRestartHelper is the exec target: when invoked with EVENER_RESTART_HELPER
+// set, it prints its argv and pid, then exits. Otherwise it is a no-op test.
+func TestRestartHelper(t *testing.T) {
+	if os.Getenv("EVENER_RESTART_HELPER") == "" {
+		return
+	}
+	mode := os.Getenv("EVENER_RESTART_HELPER")
+	if mode == "exec" {
+		// First hop: exec ourselves again in "print" mode. The pid must survive.
+		os.Setenv("EVENER_RESTART_HELPER", "print")
+		if err := Restart(os.Args[0], []string{"-test.run=TestRestartHelper", "hub", "-addr", "127.0.0.1:0"}); err != nil {
+			os.Stderr.WriteString("restart failed: " + err.Error())
+			os.Exit(3)
+		}
+	}
+	os.Stdout.WriteString("pid=" + strconv.Itoa(os.Getpid()) + " argv=" + strings.Join(os.Args[1:], " ") + "\n")
+	os.Exit(0)
+}
+
+func TestRestartKeepsPIDAndPassesArgs(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestRestartHelper")
+	cmd.Env = append(os.Environ(), "EVENER_RESTART_HELPER=exec")
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("helper: %v\n%s", err, out)
+	}
+	if cmd.Process == nil {
+		t.Fatal("no process")
+	}
+	want := "pid=" + strconv.Itoa(cmd.Process.Pid) + " argv=-test.run=TestRestartHelper hub -addr 127.0.0.1:0\n"
+	if string(out) != want {
+		t.Fatalf("helper output = %q, want %q", out, want)
+	}
+}
+
+func TestRestartMissingBinaryReturnsError(t *testing.T) {
+	err := Restart("/nonexistent/evener", []string{"hub"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -607,18 +607,15 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 	}()
 	restore := func() {
 		for _, s := range stagedBins {
-			dst := filepath.Join(shareBinDir, s.bin)
-			if !s.hadPrev {
-				_ = os.Remove(dst)
-				continue
-			}
-			_ = os.WriteFile(dst, s.previous, 0o755)
+			// The binDir entry is restored independently of hadPrev:
+			// the commit loop swaps the link even on a first-time
+			// install (no prior managed binary), so a mid-commit
+			// failure must remove the swapped-in link rather than
+			// leave it dangling after its target is deleted.
 			link := filepath.Join(binDir, s.bin)
 			if !s.linkHadEntry {
 				_ = os.Remove(link)
-				continue
-			}
-			if s.linkIsLink {
+			} else if s.linkIsLink {
 				_ = os.Remove(link)
 				_ = os.Symlink(s.linkTarget, link)
 			}
@@ -626,6 +623,12 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 			// cannot be reconstructed: swapSymlink replaced it via
 			// rename-over, so the bytes are gone. Leave the new link
 			// pointing at the restored binary rather than guessing.
+			dst := filepath.Join(shareBinDir, s.bin)
+			if !s.hadPrev {
+				_ = os.Remove(dst)
+				continue
+			}
+			_ = os.WriteFile(dst, s.previous, 0o755)
 		}
 	}
 	for _, s := range stagedBins {

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -561,12 +561,13 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 		previous []byte // pre-install content, nil when dst is new
 		hadPrev  bool
 		// linkHadEntry reports a pre-install binDir entry; linkTarget and
-		// linkIsLink describe it (symlink target, or "" for a regular
-		// file/dir which rollback cannot reconstruct byte-exact -- it
-		// removes a swapped-in link instead of guessing).
+		// linkIsLink describe it. linkFile holds the bytes of a regular
+		// file entry (a copied executable is a supported layout), so
+		// rollback can restore it after swapSymlink's rename-over.
 		linkHadEntry bool
 		linkTarget   string
 		linkIsLink   bool
+		linkFile     []byte
 	}
 	var stagedBins []staged
 	rollback := func() {
@@ -595,6 +596,12 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 				if target, rerr := os.Readlink(filepath.Join(binDir, bin)); rerr == nil {
 					s.linkTarget = target
 				}
+			} else if fi.Mode().IsRegular() {
+				// Snapshot now: the commit loop's rename-over destroys
+				// these bytes, and rollback must restore them.
+				if data, rerr := os.ReadFile(filepath.Join(binDir, bin)); rerr == nil {
+					s.linkFile = data
+				}
 			}
 		}
 		stagedBins = append(stagedBins, s)
@@ -613,16 +620,23 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 			// failure must remove the swapped-in link rather than
 			// leave it dangling after its target is deleted.
 			link := filepath.Join(binDir, s.bin)
-			if !s.linkHadEntry {
+			switch {
+			case !s.linkHadEntry:
 				_ = os.Remove(link)
-			} else if s.linkIsLink {
+			case s.linkIsLink:
 				_ = os.Remove(link)
 				_ = os.Symlink(s.linkTarget, link)
+			case s.linkFile != nil:
+				// A copied executable: restore the snapshotted bytes
+				// over the swapped-in link.
+				_ = os.Remove(link)
+				_ = os.WriteFile(link, s.linkFile, 0o755)
+			default:
+				// A non-regular entry (dir and friends) cannot be
+				// reconstructed after rename-over destroyed it; leave
+				// the new link pointing at the restored binary rather
+				// than guessing.
 			}
-			// A pre-existing non-symlink entry (regular file, dir)
-			// cannot be reconstructed: swapSymlink replaced it via
-			// rename-over, so the bytes are gone. Leave the new link
-			// pointing at the restored binary rather than guessing.
 			dst := filepath.Join(shareBinDir, s.bin)
 			if !s.hadPrev {
 				_ = os.Remove(dst)
@@ -647,8 +661,16 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 			return nil, err
 		}
 	}
+	// Digest before committing the transaction: a digest failure must roll
+	// back the swapped pair like any other commit error, not leave the new
+	// binaries live while the install reports failure and no restart runs.
+	digests, err := digestsUnderLock(shareBinDir)
+	if err != nil {
+		restore()
+		return nil, err
+	}
 	committed = true
-	return digestsUnderLock(shareBinDir)
+	return digests, nil
 }
 
 // digestsUnderLock hashes each committed managed binary. Callers must

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -484,6 +484,18 @@ func extractReleaseArchive(ctx context.Context, archivePath, root, destRoot stri
 		}
 		bin, ok := want[header.Name]
 		if !ok {
+			// Drain skipped entries through the same budget: Next()
+			// discards the previous entry's body on the following
+			// call, so an unbounded `continue` would decompress a
+			// giant ignored member outside the cap and ctx checks.
+			n, err := io.Copy(io.Discard, ctxReader(ctx, io.LimitReader(tr, maxExtractedBytes-extractedTotal+1)))
+			if err != nil {
+				return err
+			}
+			extractedTotal += n
+			if extractedTotal > maxExtractedBytes {
+				return fmt.Errorf("release archive expands past %d bytes, refusing a decompression bomb", maxExtractedBytes)
+			}
 			continue
 		}
 		if header.Typeflag != tar.TypeReg {

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -237,7 +237,12 @@ func InstallDirsFromExecutable(exe string) (prefix, binDir, shareBinDir string) 
 				entry = abs
 			}
 			sibling := filepath.Join(entry, filepath.Base(exe))
-			if entry != dir {
+			// Compare resolved directory identities, not path strings: a
+			// symlinked ancestor makes different strings name the same
+			// directory, and binDir==shareBinDir corrupts the install.
+			entryResolved, err1 := filepath.EvalSymlinks(entry)
+			dirResolved, err2 := filepath.EvalSymlinks(dir)
+			if err1 == nil && err2 == nil && entryResolved != dirResolved {
 				if resolved, err := filepath.EvalSymlinks(sibling); err == nil && resolved == candidate {
 					return prefix, entry, dir
 				}
@@ -251,7 +256,9 @@ func InstallDirsFromExecutable(exe string) (prefix, binDir, shareBinDir string) 
 	// binary, derive both dirs directly from the link instead of matching
 	// suffixes -- the prefix is unknowable, so return it empty and let the
 	// caller use binDir/shareBinDir as given.
-	if entryDir != dir {
+	entryResolved, errE := filepath.EvalSymlinks(entryDir)
+	dirResolved, errD := filepath.EvalSymlinks(dir)
+	if errE == nil && errD == nil && entryResolved != dirResolved {
 		sibling := filepath.Join(entryDir, filepath.Base(exe))
 		if abs, err := filepath.Abs(entryDir); err == nil {
 			if resolved, err := filepath.EvalSymlinks(sibling); err == nil && resolved == candidate {
@@ -604,7 +611,7 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 		}
 		prev, statErr := os.ReadFile(dst)
 		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
-			rollback()
+			_ = os.Remove(tmp)
 			return nil, fmt.Errorf("read existing %s: %w", dst, statErr)
 		}
 		s := staged{bin: bin, tmp: tmp, previous: prev, hadPrev: statErr == nil}
@@ -696,10 +703,15 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 		// Snapshot a regular-file entrypoint just before swapSymlink
 		// destroys it: deferred from stage time so an earlier abort
 		// (ctx error, this rename failure) never pays the read.
+		// Abort if the read fails — silently ignoring it destroys an
+		// unbackupable entrypoint.
 		if s.linkIsRegular && s.linkFile == nil {
-			if data, rerr := os.ReadFile(filepath.Join(binDir, s.bin)); rerr == nil {
-				s.linkFile = data
+			data, rerr := os.ReadFile(filepath.Join(binDir, s.bin))
+			if rerr != nil {
+				restore()
+				return nil, fmt.Errorf("snapshot entrypoint %s: %w", filepath.Join(binDir, s.bin), rerr)
 			}
+			s.linkFile = data
 		}
 		if err := swapSymlink(dst, filepath.Join(binDir, s.bin)); err != nil {
 			restore()

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -445,6 +445,18 @@ func download(ctx context.Context, client *http.Client, url, dest string) error 
 	return nil
 }
 
+// chargeExtractionBudget adds n decompressed bytes to the running total and
+// refuses a decompression bomb when the cumulative extraction exceeds the
+// cap. Shared by the drain (ignored entries) and copy (wanted entries) paths
+// so both observe the same bound.
+func chargeExtractionBudget(total *int64, n int64) error {
+	*total += n
+	if *total > maxExtractedBytes {
+		return fmt.Errorf("release archive expands past %d bytes, refusing a decompression bomb", maxExtractedBytes)
+	}
+	return nil
+}
+
 func extractReleaseArchive(ctx context.Context, archivePath, root, destRoot string) error {
 	file, err := os.Open(archivePath)
 	if err != nil {
@@ -488,13 +500,15 @@ func extractReleaseArchive(ctx context.Context, archivePath, root, destRoot stri
 			// discards the previous entry's body on the following
 			// call, so an unbounded `continue` would decompress a
 			// giant ignored member outside the cap and ctx checks.
-			n, err := io.Copy(io.Discard, ctxReader(ctx, io.LimitReader(tr, maxExtractedBytes-extractedTotal+1)))
+			// Use copyStream (the test seam) so failure-injection
+			// covers the drain path too.
+			remaining := maxExtractedBytes - extractedTotal
+			n, err := copyStream(io.Discard, ctxReader(ctx, io.LimitReader(tr, remaining+1)))
 			if err != nil {
 				return err
 			}
-			extractedTotal += n
-			if extractedTotal > maxExtractedBytes {
-				return fmt.Errorf("release archive expands past %d bytes, refusing a decompression bomb", maxExtractedBytes)
+			if err := chargeExtractionBudget(&extractedTotal, n); err != nil {
+				return err
 			}
 			continue
 		}
@@ -518,9 +532,8 @@ func extractReleaseArchive(ctx context.Context, archivePath, root, destRoot stri
 		if closeErr != nil {
 			return closeErr
 		}
-		extractedTotal += n
-		if extractedTotal > maxExtractedBytes {
-			return fmt.Errorf("release archive expands past %d bytes, refusing a decompression bomb", maxExtractedBytes)
+		if err := chargeExtractionBudget(&extractedTotal, n); err != nil {
+			return err
 		}
 		seen[bin] = true
 	}
@@ -561,13 +574,15 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 		previous []byte // pre-install content, nil when dst is new
 		hadPrev  bool
 		// linkHadEntry reports a pre-install binDir entry; linkTarget and
-		// linkIsLink describe it. linkFile holds the bytes of a regular
-		// file entry (a copied executable is a supported layout), so
-		// rollback can restore it after swapSymlink's rename-over.
-		linkHadEntry bool
-		linkTarget   string
-		linkIsLink   bool
-		linkFile     []byte
+		// linkIsLink describe it. linkIsRegular marks a regular-file entry
+		// (a copied executable is a supported layout) for lazy snapshot:
+		// linkFile is read just before swapSymlink destroys it, so a commit
+		// that aborts earlier never pays the I/O.
+		linkHadEntry  bool
+		linkTarget    string
+		linkIsLink    bool
+		linkIsRegular bool
+		linkFile      []byte
 	}
 	var stagedBins []staged
 	rollback := func() {
@@ -597,11 +612,10 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 					s.linkTarget = target
 				}
 			} else if fi.Mode().IsRegular() {
-				// Snapshot now: the commit loop's rename-over destroys
-				// these bytes, and rollback must restore them.
-				if data, rerr := os.ReadFile(filepath.Join(binDir, bin)); rerr == nil {
-					s.linkFile = data
-				}
+				// Mark for lazy snapshot: the commit loop reads the
+				// bytes just before swapSymlink destroys them, so a
+				// commit that aborts earlier never pays the I/O.
+				s.linkIsRegular = true
 			}
 		}
 		stagedBins = append(stagedBins, s)
@@ -626,7 +640,7 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 			case s.linkIsLink:
 				_ = os.Remove(link)
 				_ = os.Symlink(s.linkTarget, link)
-			case s.linkFile != nil:
+			case s.linkIsRegular && s.linkFile != nil:
 				// A copied executable: restore the snapshotted bytes
 				// over the swapped-in link.
 				_ = os.Remove(link)
@@ -645,7 +659,8 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 			_ = os.WriteFile(dst, s.previous, 0o755)
 		}
 	}
-	for _, s := range stagedBins {
+	for i := range stagedBins {
+		s := &stagedBins[i]
 		if err := ctx.Err(); err != nil {
 			restore()
 			return nil, err
@@ -655,6 +670,14 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 			_ = os.Remove(s.tmp)
 			restore()
 			return nil, err
+		}
+		// Snapshot a regular-file entrypoint just before swapSymlink
+		// destroys it: deferred from stage time so an earlier abort
+		// (ctx error, this rename failure) never pays the read.
+		if s.linkIsRegular && s.linkFile == nil {
+			if data, rerr := os.ReadFile(filepath.Join(binDir, s.bin)); rerr == nil {
+				s.linkFile = data
+			}
 		}
 		if err := swapSymlink(dst, filepath.Join(binDir, s.bin)); err != nil {
 			restore()

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -612,6 +612,7 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 		prev, statErr := os.ReadFile(dst)
 		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
 			_ = os.Remove(tmp)
+			rollback()
 			return nil, fmt.Errorf("read existing %s: %w", dst, statErr)
 		}
 		s := staged{bin: bin, tmp: tmp, previous: prev, hadPrev: statErr == nil}

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -13,11 +15,23 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"primeradiant.com/evener/envvars"
 )
 
 const defaultRepoURL = "https://github.com/prime-radiant-inc/evener"
+
+// defaultUpgradeTimeout bounds the whole release-archive download when the
+// caller passes no HTTP client. Archives are ~40MB; a stalled connection
+// must fail instead of holding the hub's hubUpdateMu forever. A var so
+// tests can shorten it.
+var defaultUpgradeTimeout = 5 * time.Minute
+
+// defaultMaxArchiveBytes caps one release-archive download. Archives are
+// ~40MB; an unbounded copy lets a compromised response fill the disk before
+// the checksum ever runs. A var so tests can shrink it.
+var defaultMaxArchiveBytes = int64(128 << 20)
 
 var installBinaries = []string{"evener", "evener-dev"}
 
@@ -46,15 +60,20 @@ type Target struct {
 }
 
 type Result struct {
-	Release        string   `json:"release"`
-	Channel        string   `json:"channel"`
-	URL            string   `json:"url"`
-	Archive        string   `json:"archive"`
-	Prefix         string   `json:"prefix"`
-	BinDir         string   `json:"bin_dir"`
-	ShareBinDir    string   `json:"share_bin_dir"`
-	Installed      []string `json:"installed"`
-	RestartMessage string   `json:"restart_message"`
+	Release     string   `json:"release"`
+	Channel     string   `json:"channel"`
+	URL         string   `json:"url"`
+	Archive     string   `json:"archive"`
+	Prefix      string   `json:"prefix"`
+	BinDir      string   `json:"bin_dir"`
+	ShareBinDir string   `json:"share_bin_dir"`
+	Installed   []string `json:"installed"`
+	// InstalledSHA256 maps each Installed path to the hex SHA-256 of the
+	// bytes committed there, computed while the install lock is held. A
+	// restart can re-verify the binary after the lock releases instead
+	// of trusting a path a concurrent installer may have swapped.
+	InstalledSHA256 map[string]string `json:"installed_sha256"`
+	RestartMessage  string            `json:"restart_message"`
 }
 
 func ResolveTarget(requested, currentChannel string) (Target, error) {
@@ -99,7 +118,7 @@ func Upgrade(ctx context.Context, opts Options) (Result, error) {
 	url := releaseURL(repoURL, target.Release, asset)
 	client := opts.HTTPClient
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{Timeout: defaultUpgradeTimeout}
 	}
 
 	tmpDir, err := os.MkdirTemp("", "evener-upgrade-*")
@@ -114,11 +133,18 @@ func Upgrade(ctx context.Context, opts Options) (Result, error) {
 	if err := download(ctx, client, url, archivePath); err != nil {
 		return Result{}, err
 	}
-	extractDir := filepath.Join(tmpDir, root)
-	if err := extractReleaseArchive(archivePath, root, extractDir); err != nil {
+	if err := verifyArchiveChecksum(ctx, client, repoURL, target.Release, asset, archivePath); err != nil {
 		return Result{}, err
 	}
-	if err := installExtractedBinaries(extractDir, shareBinDir, binDir); err != nil {
+	extractDir := filepath.Join(tmpDir, root)
+	if err := extractReleaseArchive(ctx, archivePath, root, extractDir); err != nil {
+		return Result{}, err
+	}
+	// The digests come back from inside the install lock: they pin
+	// exactly the bytes this install committed, so a concurrent
+	// installer swapping paths afterwards cannot poison the restart.
+	digests, err := installExtractedBinaries(ctx, extractDir, shareBinDir, binDir)
+	if err != nil {
 		return Result{}, err
 	}
 
@@ -127,15 +153,16 @@ func Upgrade(ctx context.Context, opts Options) (Result, error) {
 		installed = append(installed, filepath.Join(shareBinDir, bin))
 	}
 	return Result{
-		Release:        target.Release,
-		Channel:        target.Channel,
-		URL:            url,
-		Archive:        asset,
-		Prefix:         prefix,
-		BinDir:         binDir,
-		ShareBinDir:    shareBinDir,
-		Installed:      installed,
-		RestartMessage: "Restart evener to use the upgraded binary.",
+		Release:         target.Release,
+		Channel:         target.Channel,
+		URL:             url,
+		Archive:         asset,
+		Prefix:          prefix,
+		BinDir:          binDir,
+		ShareBinDir:     shareBinDir,
+		Installed:       installed,
+		InstalledSHA256: digests,
+		RestartMessage:  "Restart evener to use the upgraded binary.",
 	}, nil
 }
 
@@ -161,11 +188,224 @@ func installPrefix(prefix string) (string, error) {
 	return filepath.Join(home, ".local"), nil
 }
 
+// InstallDirsFromExecutable derives the install layout (prefix, binDir,
+// shareBinDir) from the path of the running binary, so a hub installed
+// under /usr/local upgrades /usr/local instead of the ~/.local default.
+//
+// The managed binary lives at <prefix>/share/evener/bin/<name>; the
+// install.sh entrypoint is <prefix>/bin/<name> (a symlink there), and
+// install.sh, building.mk, and `evener upgrade` all accept BINDIR /
+// EVENER_SHARE_BINDIR overrides that decouple those dirs from the prefix.
+// os.Executable reports the symlink path unresolved, so the executable is
+// first resolved through symlinks (a name that resolves against nothing
+// falls back to itself) to find the managed binary and the prefix -- but
+// the UNRESOLVED entrypoint directory is kept as the binDir, because that
+// is where this installation's symlinks live, custom or standard. The
+// share layout resolves the shareBinDir; a bare bin-layout path (hardlink
+// or copy with no resolvable share target) maps back to the prefix with
+// the standard share dir. Anything else (a worktree build, an ad-hoc
+// path) returns all "" and Upgrade's own defaults apply.
+func InstallDirsFromExecutable(exe string) (prefix, binDir, shareBinDir string) {
+	entryDir := filepath.Dir(exe)
+	candidate := exe
+	if resolved, err := filepath.EvalSymlinks(candidate); err == nil {
+		candidate = resolved
+	}
+	dir := filepath.Dir(candidate)
+	const shareSuffix = string(filepath.Separator) + "share" + string(filepath.Separator) + "evener" + string(filepath.Separator) + "bin"
+	if rest, ok := strings.CutSuffix(dir, shareSuffix); ok {
+		// The filesystem root is a valid prefix: cutting the suffix
+		// off a root-joined dir leaves "" which means separator.
+		// Only a bare relative dir or "." means no install layout.
+		if prefix = rest; prefix == "" {
+			prefix = string(filepath.Separator)
+		}
+		if prefix != "." {
+			// The entrypoint dir is this installation's symlink dir --
+			// custom BINDIR included -- but only when it holds a live
+			// entrypoint distinct from the managed binary: a sibling
+			// there with the launched name that resolves to the managed
+			// binary. On Linux os.Executable pre-resolves /proc/self/exe
+			// to the share target itself, so entry==dir and the sibling
+			// check would trivially pass -- and returning binDir==dir
+			// makes the installer Remove the just-copied binary and
+			// symlink it to itself. A synthetic exe path (or a different
+			// binary's dir) must not redirect symlinks elsewhere either:
+			// fall back to the standard <prefix>/bin in all these cases.
+			entry := entryDir
+			if abs, err := filepath.Abs(entry); err == nil {
+				entry = abs
+			}
+			sibling := filepath.Join(entry, filepath.Base(exe))
+			if entry != dir {
+				if resolved, err := filepath.EvalSymlinks(sibling); err == nil && resolved == candidate {
+					return prefix, entry, dir
+				}
+			}
+			return prefix, filepath.Join(prefix, "bin"), dir
+		}
+		return "", "", ""
+	}
+	// Non-standard share layout (custom EVENER_SHARE_BINDIR): when the
+	// launch entrypoint itself is a symlink resolving into the managed
+	// binary, derive both dirs directly from the link instead of matching
+	// suffixes -- the prefix is unknowable, so return it empty and let the
+	// caller use binDir/shareBinDir as given.
+	if entryDir != dir {
+		sibling := filepath.Join(entryDir, filepath.Base(exe))
+		if abs, err := filepath.Abs(entryDir); err == nil {
+			if resolved, err := filepath.EvalSymlinks(sibling); err == nil && resolved == candidate {
+				return "", abs, dir
+			}
+		}
+	}
+	const binSuffix = string(filepath.Separator) + "bin"
+	if rest, ok := strings.CutSuffix(dir, binSuffix); ok {
+		if prefix = rest; prefix != "" {
+			return prefix, dir, filepath.Join(prefix, "share", "evener", "bin")
+		}
+	}
+	return "", "", ""
+}
+
 func releaseURL(repoURL, release, asset string) string {
 	if release == "latest" {
 		return repoURL + "/releases/latest/download/" + asset
 	}
 	return repoURL + "/releases/download/" + release + "/" + asset
+}
+
+// maxExtractedBytes caps total uncompressed output across one archive
+// extraction. Binaries are ~100MB installed; a highly compressible entry
+// could otherwise expand the 128MB download cap into disk exhaustion while
+// ignoring the operation deadline inside a single entry copy.
+const maxExtractedBytes = int64(512 << 20)
+
+// ctxReader returns a reader that stops the copy when ctx expires, so a
+// single large entry cannot outlive the overall upgrade deadline.
+func ctxReader(ctx context.Context, r io.Reader) io.Reader {
+	return &ctxReaderT{ctx: ctx, r: r}
+}
+
+type ctxReaderT struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (c *ctxReaderT) Read(p []byte) (int, error) {
+	if err := c.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return c.r.Read(p)
+}
+
+// verifyArchiveChecksum fails closed unless the downloaded archive's
+// SHA-256 matches the release's checksums.txt entry for it, mirroring
+// install.sh's "refusing to install an unverified archive" guarantee. It
+// runs after download and before extraction, so a tampered archive never
+// reaches the install prefix, let alone an exec.
+//
+// Limitation, stated plainly: checksums.txt is fetched over the same
+// transport as the archive (GitHub TLS), unsigned. This stops
+// bit-rot, CDN corruption, and asset-swaps that leave checksums.txt
+// intact; it does not survive a compromise that rewrites both files the
+// way a signature would.
+func verifyArchiveChecksum(ctx context.Context, client *http.Client, repoURL, release, asset, archivePath string) error {
+	checksumsURL := releaseURL(repoURL, release, "checksums.txt")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumsURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("download %s: HTTP %d", checksumsURL, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("read %s: %w", checksumsURL, err)
+	}
+	var matches []string
+	for line := range strings.SplitSeq(string(body), "\n") {
+		if sum := parseChecksumEntry(line, asset); sum != "" {
+			matches = append(matches, sum)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return fmt.Errorf("checksums.txt has no entry for %s; refusing to install an unverified archive", asset)
+	case 1:
+		// The one vouched digest; compare below.
+	default:
+		return fmt.Errorf("checksums.txt has more than one entry for %s; refusing to install an ambiguous archive", asset)
+	}
+	return verifyChecksumFile(archivePath, "", asset, matches[0])
+}
+
+// verifyChecksumFile compares a downloaded archive against one vouched hex
+// digest, streaming the file through the hash so a ~40MB archive never
+// sits fully in memory next to the copy already made. want may come from
+// the matches slice verifyArchiveChecksum parsed, or be empty to parse
+// checksumsPath for the asset instead (tests).
+func verifyChecksumFile(archivePath, checksumsPath, asset, want string) error {
+	if want == "" {
+		body, err := os.ReadFile(checksumsPath)
+		if err != nil {
+			return err
+		}
+		for line := range strings.SplitSeq(string(body), "\n") {
+			if sum := parseChecksumEntry(line, asset); sum != "" {
+				if want != "" {
+					return fmt.Errorf("checksums.txt has more than one entry for %s; refusing to install an ambiguous archive", asset)
+				}
+				want = sum
+			}
+		}
+		if want == "" {
+			return fmt.Errorf("checksums.txt has no entry for %s; refusing to install an unverified archive", asset)
+		}
+	}
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, io.LimitReader(file, defaultMaxArchiveBytes+1)); err != nil {
+		return err
+	}
+	if got := hex.EncodeToString(hash.Sum(nil)); !strings.EqualFold(got, want) {
+		return fmt.Errorf("checksum mismatch for %s: refusing to install a tampered archive", asset)
+	}
+	return nil
+}
+
+// parseChecksumEntry extracts the hex digest from one checksums.txt line
+// for asset, or "" when the line is for another file or malformed. Format:
+// 64 hex digits, whitespace, then the archive name, tolerating goreleaser's
+// "dist/<name>" spelling the way install.sh does.
+func parseChecksumEntry(line, asset string) string {
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) != 2 {
+		return ""
+	}
+	sum, name := fields[0], strings.TrimPrefix(fields[1], "dist/")
+	if len(sum) != 64 || name != asset {
+		return ""
+	}
+	for _, c := range sum {
+		if !strings.ContainsRune("0123456789abcdefABCDEF", c) {
+			return ""
+		}
+	}
+	return sum
 }
 
 func download(ctx context.Context, client *http.Client, url, dest string) error {
@@ -187,16 +427,25 @@ func download(ctx context.Context, client *http.Client, url, dest string) error 
 	if err != nil {
 		return err
 	}
-	if _, err := copyStream(file, resp.Body); err != nil {
+	if _, err := copyStream(file, io.LimitReader(resp.Body, defaultMaxArchiveBytes+1)); err != nil {
 		if closeErr := closeFile(file); closeErr != nil {
 			return errors.Join(err, closeErr)
 		}
 		return err
 	}
-	return closeFile(file)
+	if err := closeFile(file); err != nil {
+		return err
+	}
+	if info, err := os.Stat(dest); err != nil {
+		return err
+	} else if info.Size() > defaultMaxArchiveBytes {
+		_ = os.Remove(dest)
+		return fmt.Errorf("download %s: archive larger than %d bytes, refusing a response that would exhaust the disk", url, defaultMaxArchiveBytes)
+	}
+	return nil
 }
 
-func extractReleaseArchive(archivePath, root, destRoot string) error {
+func extractReleaseArchive(ctx context.Context, archivePath, root, destRoot string) error {
 	file, err := os.Open(archivePath)
 	if err != nil {
 		return err
@@ -221,7 +470,11 @@ func extractReleaseArchive(archivePath, root, destRoot string) error {
 	if err := os.MkdirAll(destRoot, 0o755); err != nil {
 		return err
 	}
+	var extractedTotal int64
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		header, err := tr.Next()
 		if errors.Is(err, io.EOF) {
 			break
@@ -241,13 +494,21 @@ func extractReleaseArchive(archivePath, root, destRoot string) error {
 		if err != nil {
 			return err
 		}
-		_, copyErr := copyStream(file, tr)
+		// Bound each entry and the running total: a compressible entry
+		// must not expand past disk sense, and the copy observes ctx
+		// so one giant entry cannot outlive the deadline either.
+		remaining := maxExtractedBytes - extractedTotal
+		n, copyErr := copyStream(file, ctxReader(ctx, io.LimitReader(tr, remaining+1)))
 		closeErr := closeFile(file)
 		if copyErr != nil {
 			return copyErr
 		}
 		if closeErr != nil {
 			return closeErr
+		}
+		extractedTotal += n
+		if extractedTotal > maxExtractedBytes {
+			return fmt.Errorf("release archive expands past %d bytes, refusing a decompression bomb", maxExtractedBytes)
 		}
 		seen[bin] = true
 	}
@@ -259,50 +520,208 @@ func extractReleaseArchive(archivePath, root, destRoot string) error {
 	return nil
 }
 
-func installExtractedBinaries(extractDir, shareBinDir, binDir string) error {
+func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binDir string) (map[string]string, error) {
 	if err := os.MkdirAll(shareBinDir, 0o755); err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
-		return err
+		return nil, err
+	}
+	// Cross-process mutual exclusion: hubUpdateMu covers one process's
+	// threads, but `evener upgrade` or another hub may install into the
+	// same prefix concurrently. The lock file lives in the managed dir
+	// so custom share layouts lock the right place. The wait observes
+	// ctx so a stuck holder cannot strand the RPC past the overall
+	// upgrade deadline.
+	release, err := acquireInstallLockCtx(ctx, shareBinDir)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	// Stage then commit: copy both new binaries to temp names first, so
+	// a failure before the commit point leaves the live pair untouched.
+	// Commit renames each staged file over its destination and swaps
+	// both symlinks; a commit failure rolls back to the pre-install
+	// binaries captured below, never leaving a mixed-release pair.
+	type staged struct {
+		bin      string
+		tmp      string
+		previous []byte // pre-install content, nil when dst is new
+		hadPrev  bool
+		// linkHadEntry reports a pre-install binDir entry; linkTarget and
+		// linkIsLink describe it (symlink target, or "" for a regular
+		// file/dir which rollback cannot reconstruct byte-exact -- it
+		// removes a swapped-in link instead of guessing).
+		linkHadEntry bool
+		linkTarget   string
+		linkIsLink   bool
+	}
+	var stagedBins []staged
+	rollback := func() {
+		for _, s := range stagedBins {
+			_ = os.Remove(s.tmp)
+		}
 	}
 	for _, bin := range installBinaries {
+		if err := ctx.Err(); err != nil {
+			rollback()
+			return nil, err
+		}
 		src := filepath.Join(extractDir, bin)
 		dst := filepath.Join(shareBinDir, bin)
-		if err := copyExecutable(src, dst); err != nil {
-			return err
+		tmp, err := stageExecutable(ctx, src, shareBinDir, bin)
+		if err != nil {
+			rollback()
+			return nil, err
 		}
-		link := filepath.Join(binDir, bin)
-		_ = os.Remove(link)
-		if err := os.Symlink(dst, link); err != nil {
-			return err
+		prev, statErr := os.ReadFile(dst)
+		s := staged{bin: bin, tmp: tmp, previous: prev, hadPrev: statErr == nil}
+		if fi, lerr := os.Lstat(filepath.Join(binDir, bin)); lerr == nil {
+			s.linkHadEntry = true
+			if fi.Mode()&os.ModeSymlink != 0 {
+				s.linkIsLink = true
+				if target, rerr := os.Readlink(filepath.Join(binDir, bin)); rerr == nil {
+					s.linkTarget = target
+				}
+			}
+		}
+		stagedBins = append(stagedBins, s)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			rollback()
+		}
+	}()
+	restore := func() {
+		for _, s := range stagedBins {
+			dst := filepath.Join(shareBinDir, s.bin)
+			if !s.hadPrev {
+				_ = os.Remove(dst)
+				continue
+			}
+			_ = os.WriteFile(dst, s.previous, 0o755)
+			link := filepath.Join(binDir, s.bin)
+			if !s.linkHadEntry {
+				_ = os.Remove(link)
+				continue
+			}
+			if s.linkIsLink {
+				_ = os.Remove(link)
+				_ = os.Symlink(s.linkTarget, link)
+			}
+			// A pre-existing non-symlink entry (regular file, dir)
+			// cannot be reconstructed: swapSymlink replaced it via
+			// rename-over, so the bytes are gone. Leave the new link
+			// pointing at the restored binary rather than guessing.
 		}
 	}
-	return nil
+	for _, s := range stagedBins {
+		if err := ctx.Err(); err != nil {
+			restore()
+			return nil, err
+		}
+		dst := filepath.Join(shareBinDir, s.bin)
+		if err := renameFile(s.tmp, dst); err != nil {
+			_ = os.Remove(s.tmp)
+			restore()
+			return nil, err
+		}
+		if err := swapSymlink(dst, filepath.Join(binDir, s.bin)); err != nil {
+			restore()
+			return nil, err
+		}
+	}
+	committed = true
+	return digestsUnderLock(shareBinDir)
 }
 
-func copyExecutable(src, dst string) error {
+// digestsUnderLock hashes each committed managed binary. Callers must
+// hold the install lock: the digests pin exactly the bytes committed by
+// this install, so a concurrent installer swapping paths afterwards
+// cannot poison a restart pin computed from them.
+func digestsUnderLock(shareBinDir string) (map[string]string, error) {
+	digests := make(map[string]string, len(installBinaries))
+	for _, bin := range installBinaries {
+		data, err := os.ReadFile(filepath.Join(shareBinDir, bin))
+		if err != nil {
+			return nil, err
+		}
+		sum := sha256.Sum256(data)
+		digests[filepath.Join(shareBinDir, bin)] = hex.EncodeToString(sum[:])
+	}
+	return digests, nil
+}
+
+// stageExecutable copies src into a temp file beside the managed dir and
+// returns its path; the caller commits it with renameFile or removes it.
+// Staging (not direct copy) keeps a failed install from touching the live
+// pair before the commit point.
+func stageExecutable(ctx context.Context, src, shareBinDir, bin string) (string, error) {
 	in, err := os.Open(src)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer func() {
 		_ = in.Close()
 	}()
-	tmp := dst + ".tmp"
-	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+	out, err := os.CreateTemp(shareBinDir, bin+".*.stage")
 	if err != nil {
-		return err
+		return "", err
+	}
+	tmp := out.Name()
+	if err := out.Chmod(0o755); err != nil { // CreateTemp opens 0600
+		_ = closeFile(out)
+		_ = os.Remove(tmp)
+		return "", err
+	}
+	if err := ctx.Err(); err != nil {
+		_ = closeFile(out)
+		_ = os.Remove(tmp)
+		return "", err
 	}
 	_, copyErr := copyStream(out, in)
 	closeErr := closeFile(out)
 	if copyErr != nil {
 		_ = os.Remove(tmp)
-		return copyErr
+		return "", copyErr
 	}
 	if closeErr != nil {
 		_ = os.Remove(tmp)
-		return closeErr
+		return "", closeErr
 	}
-	return renameFile(tmp, dst)
+	return tmp, nil
+}
+
+// swapSymlink atomically points link at target via a temp link + rename:
+// concurrent readers (or a racing installer) see the old or the new
+// target, never a missing path or EEXIST from Remove+Symlink racing.
+func swapSymlink(target, link string) error {
+	tmp, err := os.CreateTemp(filepath.Dir(link), filepath.Base(link)+".*.link")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	_ = tmp.Close()
+	_ = os.Remove(tmpName) // symlink(2) needs a free path; CreateTemp reserved the name
+	if err := os.Symlink(target, tmpName); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := renameFile(tmpName, link); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return nil
+}
+
+// AcquireInstallLockForVerify re-acquires the cross-process install lock
+// for a share dir, for the restart path's verify+exec critical section.
+// Upgrade's lock releases at return while the exec runs later; holding
+// the lock across verify+Exec closes the swap window a digest check alone
+// leaves open (verify-then-exec is itself racy). The fd is O_CLOEXEC so a
+// successful Exec drops the lock exactly when the new image takes over;
+// on any failure the caller releases and the old process keeps running.
+func AcquireInstallLockForVerify(ctx context.Context, shareBinDir string) (release func(), err error) {
+	return acquireInstallLockCtx(ctx, shareBinDir)
 }

--- a/internal/selfupdate/update.go
+++ b/internal/selfupdate/update.go
@@ -603,6 +603,10 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 			return nil, err
 		}
 		prev, statErr := os.ReadFile(dst)
+		if statErr != nil && !errors.Is(statErr, os.ErrNotExist) {
+			rollback()
+			return nil, fmt.Errorf("read existing %s: %w", dst, statErr)
+		}
 		s := staged{bin: bin, tmp: tmp, previous: prev, hadPrev: statErr == nil}
 		if fi, lerr := os.Lstat(filepath.Join(binDir, bin)); lerr == nil {
 			s.linkHadEntry = true
@@ -656,7 +660,25 @@ func installExtractedBinaries(ctx context.Context, extractDir, shareBinDir, binD
 				_ = os.Remove(dst)
 				continue
 			}
-			_ = os.WriteFile(dst, s.previous, 0o755)
+			// Restore via temp+rename: truncating the live path with
+			// WriteFile loses to ETXTBSY if a process already launched
+			// the new binary, and a partial write leaves mixed bytes.
+			// Use os.Rename directly (not the renameFile seam) so a
+			// test stub that injects commit failures doesn't block
+			// rollback.
+			tmp, err := os.CreateTemp(shareBinDir, s.bin+".*.restore")
+			if err != nil {
+				continue
+			}
+			tmpName := tmp.Name()
+			_ = os.Chmod(tmpName, 0o755)
+			_, werr := tmp.Write(s.previous)
+			_ = closeFile(tmp)
+			if werr != nil {
+				_ = os.Remove(tmpName)
+				continue
+			}
+			_ = os.Rename(tmpName, dst)
 		}
 	}
 	for i := range stagedBins {

--- a/internal/selfupdate/update_test.go
+++ b/internal/selfupdate/update_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -89,6 +90,11 @@ func TestUpgradeInstallsReleaseArchive(t *testing.T) {
 	archive := releaseArchive(t, "evener_linux_amd64")
 	var gotPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "checksums.txt") {
+			sum := sha256.Sum256(archive)
+			_, _ = fmt.Fprintf(w, "%x  evener_linux_amd64.tar.gz\n", sum)
+			return
+		}
 		gotPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/gzip")
 		_, _ = w.Write(archive)
@@ -156,6 +162,11 @@ func TestUpgradeReleaseChannelUsesLatestDownloadURL(t *testing.T) {
 	archive := releaseArchive(t, "evener_linux_amd64")
 	var gotPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "checksums.txt") {
+			sum := sha256.Sum256(archive)
+			_, _ = fmt.Fprintf(w, "%x  evener_linux_amd64.tar.gz\n", sum)
+			return
+		}
 		gotPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/gzip")
 		_, _ = w.Write(archive)
@@ -200,6 +211,87 @@ func TestUpgradeRejectsUnsupportedPlatform(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported platform darwin-amd64") {
 		t.Fatalf("error = %q, want unsupported platform", err.Error())
+	}
+}
+
+func TestStageExecutableLeavesNoTempFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.WriteFile(src, []byte("binary body"), 0o644); err != nil {
+		t.Fatalf("write src: %v", err)
+	}
+
+	tmp, err := stageExecutable(t.Context(), src, dir, "evener")
+	if err != nil {
+		t.Fatalf("stageExecutable: %v", err)
+	}
+
+	body, err := os.ReadFile(tmp)
+	if err != nil {
+		t.Fatalf("read staged: %v", err)
+	}
+	if string(body) != "binary body" {
+		t.Fatalf("staged = %q, want %q", string(body), "binary body")
+	}
+	info, err := os.Stat(tmp)
+	if err != nil {
+		t.Fatalf("stat staged: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("staged mode = %v, want 0755", info.Mode().Perm())
+	}
+	_ = os.Remove(tmp)
+	leftovers, err := filepath.Glob(filepath.Join(dir, "*.stage"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("temp files left behind: %v", leftovers)
+	}
+}
+
+// Concurrent stages (a hub self-update and an `evener upgrade` in another
+// process) must not share one temp path and interleave writes: each stages
+// a complete file of its own under a unique name.
+func TestStageExecutableConcurrentStagesNeverMix(t *testing.T) {
+	dir := t.TempDir()
+	first := strings.Repeat("A", 1<<20)
+	second := strings.Repeat("B", 1<<20)
+	srcA := filepath.Join(dir, "srcA")
+	srcB := filepath.Join(dir, "srcB")
+	if err := os.WriteFile(srcA, []byte(first), 0o644); err != nil {
+		t.Fatalf("write srcA: %v", err)
+	}
+	if err := os.WriteFile(srcB, []byte(second), 0o644); err != nil {
+		t.Fatalf("write srcB: %v", err)
+	}
+	tmps := make([]string, 2)
+	for j, src := range []string{srcA, srcB} {
+		var err error
+		tmps[j], err = stageExecutable(t.Context(), src, dir, "evener")
+		if err != nil {
+			t.Fatalf("stageExecutable: %v", err)
+		}
+	}
+	if tmps[0] == tmps[1] {
+		t.Fatalf("both stages share temp path %q", tmps[0])
+	}
+	for j, want := range []string{first, second} {
+		body, err := os.ReadFile(tmps[j])
+		if err != nil {
+			t.Fatalf("read staged: %v", err)
+		}
+		if string(body) != want {
+			t.Fatalf("staged %d has unexpected content (len %d)", j, len(body))
+		}
+		_ = os.Remove(tmps[j])
+	}
+	leftovers, err := filepath.Glob(filepath.Join(dir, "*.stage"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("temp files left behind: %v", leftovers)
 	}
 }
 

--- a/internal/selfupdate/upgrade_bounds_test.go
+++ b/internal/selfupdate/upgrade_bounds_test.go
@@ -1,0 +1,125 @@
+package selfupdate
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func sha256Hex(t *testing.T, data []byte) string {
+	t.Helper()
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestUpgradeRefusesOversizedArchive proves the download is size-bounded: a
+// server that streams endless bytes fails instead of filling the disk.
+// Fails today because download copies the body with no size cap.
+func TestUpgradeRefusesOversizedArchive(t *testing.T) {
+	previous := defaultMaxArchiveBytes
+	defaultMaxArchiveBytes = 1 << 20 // 1MB for the test; production is larger
+	t.Cleanup(func() { defaultMaxArchiveBytes = previous })
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "checksums.txt") {
+			_, _ = w.Write([]byte(strings.Repeat("a", 64) + "  evener_linux_amd64.tar.gz\n"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		// Stream 8x the cap; the client must stop early, not buffer it all.
+		chunk := make([]byte, 1<<20)
+		for range 8 {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := Upgrade(t.Context(), upgradeForChecksumTest(t.TempDir(), server.URL))
+	if err == nil || !strings.Contains(err.Error(), "larger than") {
+		t.Fatalf("err = %v, want an oversize-archive error", err)
+	}
+}
+
+// TestDefaultMaxArchiveBytesIsBounded pins the shipped default: archives
+// are ~40MB, so the cap must be comfortably above that but finite.
+func TestDefaultMaxArchiveBytesIsBounded(t *testing.T) {
+	if defaultMaxArchiveBytes <= 64<<20 {
+		t.Fatalf("defaultMaxArchiveBytes = %d, want headroom above the ~40MB archives", defaultMaxArchiveBytes)
+	}
+	if defaultMaxArchiveBytes > 1<<30 {
+		t.Fatalf("defaultMaxArchiveBytes = %d, want a real bound, not ~infinity", defaultMaxArchiveBytes)
+	}
+}
+
+// TestVerifyChecksumStreamsFromDisk proves verification hashes the file on
+// disk instead of loading it fully into memory: it writes a valid archive
+// plus checksums through a stub transport and checks the byte-exact digest
+// path accepts it. (The behavioral half -- tampered archives rejected --
+// is TestUpgradeRejectsTamperedArchive; this pins the streaming helper the
+// production path now uses.)
+func TestVerifyChecksumStreamsFromDisk(t *testing.T) {
+	archive := releaseArchive(t, "evener_linux_amd64")
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "evener_linux_amd64.tar.gz")
+	if err := os.WriteFile(archivePath, archive, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256Hex(t, archive)
+	checksumsPath := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(checksumsPath, []byte(sum+"  evener_linux_amd64.tar.gz\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyChecksumFile(archivePath, checksumsPath, "evener_linux_amd64.tar.gz", ""); err != nil {
+		t.Fatalf("verifyChecksumFile on a valid pair: %v", err)
+	}
+	if err := os.WriteFile(archivePath, append(archive, 0), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyChecksumFile(archivePath, checksumsPath, "evener_linux_amd64.tar.gz", ""); err == nil ||
+		!strings.Contains(err.Error(), "mismatch") {
+		t.Fatalf("err = %v, want a mismatch error after tampering", err)
+	}
+}
+
+// TestUpgradeHonorsCancellationDuringInstall proves the overall deadline
+// reaches extraction and installation, not just the downloads: with an
+// already-cancelled context, Upgrade fails instead of installing.
+func TestUpgradeHonorsCancellationDuringInstall(t *testing.T) {
+	archive := releaseArchive(t, "evener_linux_amd64")
+	server := checksumTestServer(t, archive, "")
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := Upgrade(ctx, upgradeForChecksumTest(t.TempDir(), server.URL))
+	if err == nil {
+		t.Fatal("expected Upgrade to honor an already-cancelled context")
+	}
+}
+
+// TestExtractRefusesDecompressionBomb proves extraction caps total
+// uncompressed output: a highly compressible entry fails instead of
+// filling the disk. Fails today: per-entry copies are unbounded.
+func TestExtractRefusesDecompressionBomb(t *testing.T) {
+	// 600MB of zeros compresses to ~600KB: realistic zip-bomb shape.
+	big := make([]byte, 600<<20)
+	archivePath := filepath.Join(t.TempDir(), "bomb.tar.gz")
+	if err := os.WriteFile(archivePath, tarGz(t, map[string][]byte{"evener_linux_amd64/evener": big}, nil), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractReleaseArchive(t.Context(), archivePath, "evener_linux_amd64", t.TempDir()); err == nil ||
+		!strings.Contains(err.Error(), "expands past") {
+		t.Fatalf("err = %v, want a decompression-bomb refusal", err)
+	}
+}

--- a/internal/selfupdate/upgrade_bounds_test.go
+++ b/internal/selfupdate/upgrade_bounds_test.go
@@ -123,3 +123,23 @@ func TestExtractRefusesDecompressionBomb(t *testing.T) {
 		t.Fatalf("err = %v, want a decompression-bomb refusal", err)
 	}
 }
+
+// TestExtractCountsIgnoredEntries proves skipped (unwanted) tar entries
+// charge the extraction budget too: a 600MB-compressible ignored member
+// fails instead of decompressing unbounded between ctx checks. Fails
+// today: `continue` lets Next() drain it outside the cap and ctxReader.
+func TestExtractCountsIgnoredEntries(t *testing.T) {
+	big := make([]byte, 600<<20)
+	entries := map[string][]byte{
+		"evener_linux_amd64/evener":       []byte("tiny"),
+		"evener_linux_amd64/ignored-blob": big,
+	}
+	archivePath := filepath.Join(t.TempDir(), "bomb.tar.gz")
+	if err := os.WriteFile(archivePath, tarGz(t, entries, nil), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := extractReleaseArchive(t.Context(), archivePath, "evener_linux_amd64", t.TempDir()); err == nil ||
+		!strings.Contains(err.Error(), "expands past") {
+		t.Fatalf("err = %v, want a decompression-bomb refusal covering ignored entries", err)
+	}
+}

--- a/internal/selfupdate/upgrade_checksum_test.go
+++ b/internal/selfupdate/upgrade_checksum_test.go
@@ -1,0 +1,147 @@
+package selfupdate
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// checksumTestServer serves a release archive plus its checksums.txt, with
+// hooks to tamper with either. It returns the server and the correct hex
+// digest of the archive it serves.
+func checksumTestServer(t *testing.T, archive []byte, checksums string) *httptest.Server {
+	t.Helper()
+	sum := sha256.Sum256(archive)
+	correct := hex.EncodeToString(sum[:])
+	if checksums == "" {
+		checksums = correct + "  evener_linux_amd64.tar.gz\n"
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "checksums.txt"):
+			_, _ = w.Write([]byte(checksums))
+		case strings.HasSuffix(r.URL.Path, ".tar.gz"):
+			_, _ = w.Write(archive)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func upgradeForChecksumTest(prefix, repoURL string) Options {
+	return Options{
+		Requested:      "snapshot",
+		CurrentChannel: "snapshot",
+		Prefix:         prefix,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		RepoURL:        repoURL,
+	}
+}
+
+// TestUpgradeVerifiesArchiveChecksum proves a downloaded archive installs
+// only when its SHA-256 matches the release's checksums.txt entry: the
+// happy path installs, and the installed bytes are the served archive.
+func TestUpgradeVerifiesArchiveChecksum(t *testing.T) {
+	archive := releaseArchive(t, "evener_linux_amd64")
+	server := checksumTestServer(t, archive, "")
+	t.Cleanup(server.Close)
+
+	prefix := filepath.Join(t.TempDir(), ".local")
+	if _, err := Upgrade(t.Context(), upgradeForChecksumTest(prefix, server.URL)); err != nil {
+		t.Fatalf("Upgrade with matching checksum: %v", err)
+	}
+	installed, err := os.ReadFile(filepath.Join(prefix, "share", "evener", "bin", "evener"))
+	if err != nil {
+		t.Fatalf("read installed binary: %v", err)
+	}
+	if !strings.Contains(string(installed), "archive evener") {
+		t.Fatalf("installed binary has unexpected content %q", string(installed))
+	}
+}
+
+// TestUpgradeRejectsTamperedArchive proves an archive whose bytes differ
+// from the checksums.txt entry is refused BEFORE extraction or install:
+// no binary lands in the prefix and the error names the mismatch.
+func TestUpgradeRejectsTamperedArchive(t *testing.T) {
+	archive := releaseArchive(t, "evener_linux_amd64")
+	sum := sha256.Sum256(archive)
+	correct := hex.EncodeToString(sum[:])
+	// checksums.txt vouches for different bytes than the server sends.
+	server := checksumTestServer(t, append(archive, byte(0)), correct+"  evener_linux_amd64.tar.gz\n")
+	t.Cleanup(server.Close)
+
+	prefix := filepath.Join(t.TempDir(), ".local")
+	_, err := Upgrade(t.Context(), upgradeForChecksumTest(prefix, server.URL))
+	if err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("err = %v, want a checksum mismatch error", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(prefix, "share", "evener", "bin", "evener")); !os.IsNotExist(statErr) {
+		t.Fatalf("tampered archive was installed: stat err = %v", statErr)
+	}
+}
+
+// TestUpgradeRefusesMissingChecksumEntry proves fail-closed behavior when
+// checksums.txt has no line for the archive: same guarantee install.sh
+// makes ("refusing to install an unverified archive").
+func TestUpgradeRefusesMissingChecksumEntry(t *testing.T) {
+	archive := releaseArchive(t, "evener_linux_amd64")
+	server := checksumTestServer(t, archive, "deadbeef  some-other-file.tar.gz\n")
+	t.Cleanup(server.Close)
+
+	prefix := filepath.Join(t.TempDir(), ".local")
+	_, err := Upgrade(t.Context(), upgradeForChecksumTest(prefix, server.URL))
+	if err == nil || !strings.Contains(err.Error(), "checksums.txt has no entry") {
+		t.Fatalf("err = %v, want a missing-entry error", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(prefix, "share", "evener", "bin")); !os.IsNotExist(statErr) {
+		t.Fatalf("unverified archive was installed: stat err = %v", statErr)
+	}
+}
+
+// TestUpgradeRefusesAmbiguousChecksumEntry proves two lines for the same
+// archive also fail closed rather than picking one.
+func TestUpgradeRefusesAmbiguousChecksumEntry(t *testing.T) {
+	archive := releaseArchive(t, "evener_linux_amd64")
+	sum := sha256.Sum256(archive)
+	correct := hex.EncodeToString(sum[:])
+	dup := correct + "  evener_linux_amd64.tar.gz\n" + correct + "  evener_linux_amd64.tar.gz\n"
+	server := checksumTestServer(t, archive, dup)
+	t.Cleanup(server.Close)
+
+	if _, err := Upgrade(t.Context(), upgradeForChecksumTest(t.TempDir(), server.URL)); err == nil ||
+		!strings.Contains(err.Error(), "more than one entry") {
+		t.Fatalf("err = %v, want an ambiguous-entry error", err)
+	}
+}
+
+// TestParseChecksumEntry pins the accepted line format: 64 hex digits,
+// whitespace, then the bare archive name, tolerating goreleaser's
+// "dist/<name>" spelling the way install.sh does.
+func TestParseChecksumEntry(t *testing.T) {
+	sum := strings.Repeat("a", 64)
+	for _, tc := range []struct {
+		name  string
+		line  string
+		asset string
+		want  string
+	}{
+		{"bare", sum + "  evener_linux_amd64.tar.gz", "evener_linux_amd64.tar.gz", sum},
+		{"dist prefixed", sum + "  dist/evener_linux_amd64.tar.gz", "evener_linux_amd64.tar.gz", sum},
+		{"tab separated", sum + "\tevener_linux_amd64.tar.gz", "evener_linux_amd64.tar.gz", sum},
+		{"other archive", sum + "  evener_darwin_arm64.tar.gz", "evener_linux_amd64.tar.gz", ""},
+		{"short hash", "abc  evener_linux_amd64.tar.gz", "evener_linux_amd64.tar.gz", ""},
+		{"no filename", sum, "evener_linux_amd64.tar.gz", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseChecksumEntry(tc.line, tc.asset); got != tc.want {
+				t.Fatalf("parseChecksumEntry(%q) = %q, want %q", tc.line, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/selfupdate/upgrade_timeout_test.go
+++ b/internal/selfupdate/upgrade_timeout_test.go
@@ -1,0 +1,58 @@
+package selfupdate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestUpgradeStalledDownloadDoesNotHangForever proves the apply path cannot
+// hold hubUpdateMu indefinitely when the release server accepts the
+// connection and then never answers: Upgrade with no caller-supplied client
+// must still bound the download. Fails today because Upgrade falls back to
+// http.DefaultClient, which has no timeout.
+func TestUpgradeStalledDownloadDoesNotHangForever(t *testing.T) {
+	stalled := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Accept the request, then never write a byte -- the client must
+		// give up on its own. Waiting on the request context (not select{})
+		// so the handler exits when the test server closes.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(stalled.Close)
+
+	previous := defaultUpgradeTimeout
+	defaultUpgradeTimeout = 5 * time.Second
+	t.Cleanup(func() { defaultUpgradeTimeout = previous })
+
+	prefix := t.TempDir()
+	done := make(chan error, 1)
+	go func() {
+		_, err := Upgrade(t.Context(), Options{
+			Requested:      "snapshot",
+			CurrentChannel: "snapshot",
+			Prefix:         prefix,
+			GOOS:           "linux",
+			GOARCH:         "amd64",
+			RepoURL:        stalled.URL,
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Upgrade against a stalled server succeeded, want a timeout error")
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("Upgrade hung for 60s against a stalled server: no download deadline")
+	}
+}
+
+// TestDefaultUpgradeTimeoutIsBounded pins the shipped default: a caller that
+// passes no HTTP client must still get a finite download deadline.
+func TestDefaultUpgradeTimeoutIsBounded(t *testing.T) {
+	if defaultUpgradeTimeout <= 0 {
+		t.Fatalf("defaultUpgradeTimeout = %v, want a positive download deadline", defaultUpgradeTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

Settings → Hub → Updates lets a user pick a channel (release / snapshot), see whether that channel is ahead of the running build, and click **Update and restart**. The hub downloads and installs the channel archive with the existing `selfupdate.Upgrade`, then `syscall.Exec`s the installed `evener` binary in place: same PID, same argv, same environment, so launchd / systemd / a bare shell all keep the process they had. The page polls `/api/health` until the version changes, then reloads.

- `internal/selfupdate`: `Check` (GitHub API commit vs `buildinfo.GitSHA`) and `Restart` (exec in place, unix only).
- `appwire`: `evener/update/check`, `evener/update/apply`; `SettingsHubOverview.buildChannel`.
- `cmd/evener-hub/app_update.go`: handlers; dev builds refused; channel validated to release/snapshot; apply serialized with a mutex; restart scheduled 500ms after the response is flushed. Exec failure logs and leaves the old hub running.
- Frontend: `stores/hubUpdate.ts` + `panes/settings/sections/hubUpdates.tsx` (channel selector, check, confirm dialog, restart poll with 30s timeout).
- No stored channel setting: the installed binary's baked channel is the default.
- Docs: `docs/evener-hub.md` "Updating the hub from Settings". Spec and plan under `docs/superpowers/`.

## Testing

- `make lint`, `make vet`, `make test`, `make test-web` all green.
- Opt-in live e2e `EVENER_UPDATE_E2E=1 go test ./cmd/evener-hub/ -run TestUpdateApplyEndToEnd`: builds this branch stamped as a snapshot build, runs it with a temp HOME, applies, and verifies the real snapshot was downloaded and exec'd in place: `before=f0a97a5e3 after=be70029 pid=143116`.
- Default tests stay offline; `FuzzAppWireDispatch` stubs `scheduleHubRestart` so the fuzz harness can never exec itself.

## Not in scope

Periodic background checks, re-pointing the palette "Upgrade Evener" command, Windows, rollback.