### PR TITLE
fix(navigation): reconstruct deltas for entity-less resources

### DIFF
--- a/cmd/evener-hub/navigation_delta.go
+++ b/cmd/evener-hub/navigation_delta.go
@@ -1,10 +1,10 @@
 package hub
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"slices"
 	"sort"
 
@@ -75,7 +75,7 @@ func diffNavigationSnapshots(key navigationResourceKey, baseVersion, currentVers
 	}
 	expected := current
 	hubapi.SortNavigationSnapshot(&expected)
-	if !reflect.DeepEqual(applied, expected) {
+	if !navigationSnapshotsEqual(applied, expected) {
 		return hubapi.NavigationDelta{}, errors.New("navigation delta does not reconstruct current snapshot")
 	}
 	return delta, nil
@@ -114,4 +114,17 @@ func applyNavigationDelta(base hubapi.NavigationSnapshot, delta hubapi.Navigatio
 	}
 	hubapi.SortNavigationSnapshot(&applied)
 	return applied, nil
+}
+
+// navigationSnapshotsEqual compares two sorted snapshots by the same record
+// identity the diff uses, so a resource whose projection has no entities (a
+// nil slice) still matches its reconstruction (an empty slice).
+func navigationSnapshotsEqual(left, right hubapi.NavigationSnapshot) bool {
+	return bytes.Equal(left.Metadata, right.Metadata) &&
+		slices.EqualFunc(left.Entities, right.Entities, func(a, b hubapi.NavigationEntityRecord) bool {
+			return a.Key == b.Key && a.Kind == b.Kind && bytes.Equal(a.Value, b.Value)
+		}) &&
+		slices.EqualFunc(left.Containers, right.Containers, func(a, b hubapi.NavigationOrderContainer) bool {
+			return a.Key == b.Key && a.Owner == b.Owner && slices.Equal(a.Children, b.Children)
+		})
 }

--- a/cmd/evener-hub/navigation_delta_test.go
+++ b/cmd/evener-hub/navigation_delta_test.go
@@ -105,3 +105,60 @@ func TestNavigationHistoryEvictsOldestGlobally(t *testing.T) {
 		t.Fatal("oldest version remained retained")
 	}
 }
+
+func TestNavigationDeltaReconstructsResourcesWithoutEntities(t *testing.T) {
+	sectionKey := navigationResourceKey{Kind: navigationResourceLive, Limit: 50}
+	cases := []struct {
+		name    string
+		key     navigationResourceKey
+		base    any
+		current any
+	}{
+		{
+			name:    "manifest",
+			key:     navigationResourceKey{Kind: navigationResourceManifest},
+			base:    hubapi.NavigationManifest{GenerationID: "g", Revision: 1},
+			current: hubapi.NavigationManifest{GenerationID: "g", Revision: 2, Sections: hubapi.NavigationSections{Live: hubapi.NavigationResourceDescriptor{Count: 1}}},
+		},
+		{
+			name: "section emptied",
+			key:  sectionKey,
+			base: hubapi.NavigationSectionResource{GenerationID: "g", Revision: 1, Sessions: hubapi.NavigationArray[hubapi.NavigationSessionSummary]{
+				navigationSchemaSession("local:s1", "s1"),
+			}},
+			current: hubapi.NavigationSectionResource{GenerationID: "g", Revision: 2},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base, err := normalizeNavigationResource(tc.key, tc.base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			current, err := normalizeNavigationResource(tc.key, tc.current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if current.Entities != nil {
+				t.Fatalf("test setup: current snapshot has entities %+v, want an entity-less resource", current.Entities)
+			}
+			baseVersion := appwire.NavigationReadBase{GenerationID: "g", Revision: 1, ETag: "tag-1"}
+			currentVersion := appwire.NavigationReadBase{GenerationID: "g", Revision: 2, ETag: "tag-2"}
+			history := newNavigationHistory(4, 1<<20)
+			if err := history.Remember(tc.key, baseVersion, &base); err != nil {
+				t.Fatal(err)
+			}
+			retained, ok := history.Lookup(tc.key, baseVersion)
+			if !ok {
+				t.Fatal("base snapshot was not retained")
+			}
+			delta, err := diffNavigationSnapshots(tc.key, baseVersion, currentVersion, retained, current)
+			if err != nil {
+				t.Fatalf("diff entity-less current snapshot: %v", err)
+			}
+			if len(delta.UpsertedEntities) != 0 || len(delta.RemovedEntityKeys) != len(base.Entities) {
+				t.Fatalf("delta = %+v, want removals only for %d base entities", delta, len(base.Entities))
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/navigation_service_test.go
+++ b/cmd/evener-hub/navigation_service_test.go
@@ -2497,3 +2497,49 @@ func TestNavigationSnapshotBoundaryUsesNearest24HourOr14DayCutover(t *testing.T)
 		t.Fatalf("14d boundary = %v, want %v", got, want)
 	}
 }
+
+func TestNavigationReadV2DeltaForResourceThatLosesAllEntities(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	source := newTestNavigationSource(now)
+	source.mu.Lock()
+	source.inputs.Tree.Live = append([]hubcore.TreeNode(nil), source.inputs.Tree.Projects[0].Current...)
+	source.mu.Unlock()
+	service := newTestNavigationService(t, source)
+	manifestKey := navigationResourceKey{Kind: navigationResourceManifest}
+	liveKey := navigationResourceKey{Kind: navigationResourceLive, Limit: maxNavigationSectionRows}
+
+	bases := map[navigationResourceKind]appwire.NavigationReadBase{}
+	for _, key := range []navigationResourceKey{manifestKey, liveKey} {
+		initial, err := service.readV2(t.Context(), key, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bases[key.Kind] = appwire.NavigationReadBase{GenerationID: initial.Response.GenerationID, Revision: initial.Response.Revision, ETag: initial.Response.ETag}
+	}
+
+	source.mu.Lock()
+	source.inputs.Tree.Live = nil
+	source.revision++
+	source.mu.Unlock()
+	if _, err := service.Refresh(t.Context(), navigationChangeHint{}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range []navigationResourceKey{manifestKey, liveKey} {
+		base := bases[key.Kind]
+		changed, err := service.readV2(t.Context(), key, &base)
+		if err != nil {
+			t.Fatalf("%s delta read: %v", key.Kind, err)
+		}
+		if changed.Response.Status != "ok" || changed.Response.Representation != appwire.NavigationRepresentationDelta || changed.Response.Base == nil || *changed.Response.Base != base {
+			t.Fatalf("%s response = %+v, want ok delta against exact base", key.Kind, changed.Response)
+		}
+		var delta hubapi.NavigationDelta
+		if err := json.Unmarshal(changed.Response.Data, &delta); err != nil {
+			t.Fatal(err)
+		}
+		if key.Kind == navigationResourceLive && len(delta.RemovedEntityKeys) != 1 {
+			t.Fatalf("live delta = %+v, want the one removed session", delta)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The hub was logging this on every delta read of a resource with no entities:

```
[hub] navigation read failed: navigation delta does not reconstruct current snapshot
```

`diffNavigationSnapshots` verified its delta with `reflect.DeepEqual`. The normalizer leaves `Entities` as a nil slice whenever a resource has no entities (the manifest always, plus any emptied section, catalog, or project page), while `applyNavigationDelta` always builds an empty non-nil slice. `reflect.DeepEqual` treats those as different, so the reconstruction check failed and the read surfaced as an internal error. Introduced with entity deltas in #846; the existing conditional-read test never sent a base on its "changed" read, so the manifest delta path was untested.

## Fix

Compare the reconstruction with the same record identity the diff itself uses (`navigationSnapshotsEqual`), so nil and empty collections are equivalent, matching what `NavigationSnapshot.MarshalJSON` already does on the wire.

## Regression tests

- `TestNavigationDeltaReconstructsResourcesWithoutEntities`: diff-level, manifest and emptied section, base round-tripped through `navigationHistory` as in production.
- `TestNavigationReadV2DeltaForResourceThatLosesAllEntities`: service-level `readV2` with a base for the manifest and live section after the last session disappears.

All three cases failed with the exact production error before the fix.

## Verification

- `make lint`, `make vet` pass
- `go test ./cmd/evener-hub/... ./hubapi/...` pass
- roborev branch review (job 150): no issues found
