### PR TITLE
fix(navigation): serve a snapshot when a delta cannot be built

### DIFF
--- a/cmd/evener-hub/app_navigation.go
+++ b/cmd/evener-hub/app_navigation.go
@@ -42,6 +42,9 @@ func navigationReadWithFields(ctx context.Context, server *appserver.Server, nav
 	if err != nil {
 		return appwire.NavigationReadResponse{}, navigationReadError(server, err)
 	}
+	if result.DeltaFallback != nil {
+		server.Logf("navigation delta fallback: %v", result.DeltaFallback)
+	}
 	return result.Response, nil
 }
 

--- a/cmd/evener-hub/app_navigation_test.go
+++ b/cmd/evener-hub/app_navigation_test.go
@@ -613,3 +613,42 @@ func assertNavigationWireError(t *testing.T, err error, wantCode int, wantInfo a
 func uint32Pointer(value uint32) *uint32 {
 	return new(value)
 }
+
+func TestHubNavigationFailedDeltaServesSnapshotAndLogs(t *testing.T) {
+	var logs []string
+	source := newTestNavigationSource(testNavigationNow())
+	service := newTestNavigationService(t, source)
+	server := appserver.NewServer(appserver.ServerConfig{
+		ServerName: "test",
+		Logf: func(format string, args ...any) {
+			logs = append(logs, fmt.Sprintf(format, args...))
+		},
+	})
+	registerNavigationReadHandler(server, service)
+
+	limit := uint32(1)
+	params := appwire.NavigationReadParams{Resource: "project_page", ProjectKey: "p1", Tier: "current", Limit: &limit, RepresentationVersion: 2}
+	first := dispatchNavigationRead(t, server, params)
+	if first.Status != "ok" || first.Representation != appwire.NavigationRepresentationSnapshot {
+		t.Fatalf("initial response = %+v, want ok snapshot", first)
+	}
+	base := appwire.NavigationReadBase{GenerationID: first.GenerationID, Revision: first.Revision, ETag: first.ETag}
+	key := navigationResourceKey{Kind: navigationResourceProjectPage, ProjectKey: "p1", Tier: "current", Limit: limit}
+	corruptRetainedNavigationBase(t, service.history, key, base)
+	source.changeTitle("handler delta fallback")
+	if _, err := service.Refresh(t.Context(), navigationChangeHint{Projects: []string{"p1"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	params.Base = &base
+	changed, err := dispatchNavigationReadResult(t, server, params)
+	if err != nil {
+		t.Fatalf("read with unreconstructable base: %v", err)
+	}
+	if changed.Status != "ok" || changed.Representation != appwire.NavigationRepresentationSnapshot || changed.Base != nil {
+		t.Fatalf("response = %+v, want ok snapshot without Base", changed)
+	}
+	if joined := strings.Join(logs, "\n"); !strings.Contains(joined, "navigation delta fallback:") {
+		t.Errorf("server diagnostics did not record the abandoned delta: %q", logs)
+	}
+}

--- a/cmd/evener-hub/navigation_delta.go
+++ b/cmd/evener-hub/navigation_delta.go
@@ -1,10 +1,10 @@
 package hub
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"slices"
 	"sort"
 
@@ -75,7 +75,7 @@ func diffNavigationSnapshots(key navigationResourceKey, baseVersion, currentVers
 	}
 	expected := current
 	hubapi.SortNavigationSnapshot(&expected)
-	if !reflect.DeepEqual(applied, expected) {
+	if !navigationSnapshotsEqual(applied, expected) {
 		return hubapi.NavigationDelta{}, errors.New("navigation delta does not reconstruct current snapshot")
 	}
 	return delta, nil
@@ -114,4 +114,17 @@ func applyNavigationDelta(base hubapi.NavigationSnapshot, delta hubapi.Navigatio
 	}
 	hubapi.SortNavigationSnapshot(&applied)
 	return applied, nil
+}
+
+// navigationSnapshotsEqual compares two sorted snapshots by the same record
+// identity the diff uses, so a resource whose projection has no entities (a
+// nil slice) still matches its reconstruction (an empty slice).
+func navigationSnapshotsEqual(left, right hubapi.NavigationSnapshot) bool {
+	return bytes.Equal(left.Metadata, right.Metadata) &&
+		slices.EqualFunc(left.Entities, right.Entities, func(a, b hubapi.NavigationEntityRecord) bool {
+			return a.Key == b.Key && a.Kind == b.Kind && bytes.Equal(a.Value, b.Value)
+		}) &&
+		slices.EqualFunc(left.Containers, right.Containers, func(a, b hubapi.NavigationOrderContainer) bool {
+			return a.Key == b.Key && a.Owner == b.Owner && slices.Equal(a.Children, b.Children)
+		})
 }

--- a/cmd/evener-hub/navigation_delta_test.go
+++ b/cmd/evener-hub/navigation_delta_test.go
@@ -105,3 +105,60 @@ func TestNavigationHistoryEvictsOldestGlobally(t *testing.T) {
 		t.Fatal("oldest version remained retained")
 	}
 }
+
+func TestNavigationDeltaReconstructsResourcesWithoutEntities(t *testing.T) {
+	sectionKey := navigationResourceKey{Kind: navigationResourceLive, Limit: 50}
+	cases := []struct {
+		name    string
+		key     navigationResourceKey
+		base    any
+		current any
+	}{
+		{
+			name:    "manifest",
+			key:     navigationResourceKey{Kind: navigationResourceManifest},
+			base:    hubapi.NavigationManifest{GenerationID: "g", Revision: 1},
+			current: hubapi.NavigationManifest{GenerationID: "g", Revision: 2, Sections: hubapi.NavigationSections{Live: hubapi.NavigationResourceDescriptor{Count: 1}}},
+		},
+		{
+			name: "section emptied",
+			key:  sectionKey,
+			base: hubapi.NavigationSectionResource{GenerationID: "g", Revision: 1, Sessions: hubapi.NavigationArray[hubapi.NavigationSessionSummary]{
+				navigationSchemaSession("local:s1", "s1"),
+			}},
+			current: hubapi.NavigationSectionResource{GenerationID: "g", Revision: 2},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			base, err := normalizeNavigationResource(tc.key, tc.base)
+			if err != nil {
+				t.Fatal(err)
+			}
+			current, err := normalizeNavigationResource(tc.key, tc.current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if current.Entities != nil {
+				t.Fatalf("test setup: current snapshot has entities %+v, want an entity-less resource", current.Entities)
+			}
+			baseVersion := appwire.NavigationReadBase{GenerationID: "g", Revision: 1, ETag: "tag-1"}
+			currentVersion := appwire.NavigationReadBase{GenerationID: "g", Revision: 2, ETag: "tag-2"}
+			history := newNavigationHistory(4, 1<<20)
+			if err := history.Remember(tc.key, baseVersion, &base); err != nil {
+				t.Fatal(err)
+			}
+			retained, ok := history.Lookup(tc.key, baseVersion)
+			if !ok {
+				t.Fatal("base snapshot was not retained")
+			}
+			delta, err := diffNavigationSnapshots(tc.key, baseVersion, currentVersion, retained, current)
+			if err != nil {
+				t.Fatalf("diff entity-less current snapshot: %v", err)
+			}
+			if len(delta.UpsertedEntities) != 0 || len(delta.RemovedEntityKeys) != len(base.Entities) {
+				t.Fatalf("delta = %+v, want removals only for %d base entities", delta, len(base.Entities))
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/navigation_service.go
+++ b/cmd/evener-hub/navigation_service.go
@@ -314,6 +314,10 @@ func (s *NavigationService) VersionedKey(ctx context.Context, key navigationReso
 
 type navigationReadResult struct {
 	Response appwire.NavigationReadResponse
+	// DeltaFallback is set when a retained base was found but the delta
+	// representation had to be abandoned, so the response is a full snapshot
+	// and the caller should log why.
+	DeltaFallback error
 }
 
 func (s *NavigationService) versionedCore(ctx context.Context, key navigationResourceKey) (*navigationBuildFlight, navigationResourceKey, navigationProjection, error) {
@@ -349,7 +353,9 @@ func (s *NavigationService) versionedCore(ctx context.Context, key navigationRes
 
 // readV2 captures one authoritative projection and reconciles it against an
 // exact retained base. A history miss is deliberately a normal full snapshot;
-// it is never reported as a transport error.
+// it is never reported as a transport error. A delta the service cannot build
+// is served the same way, with the reason on DeltaFallback for the caller to
+// log, because the snapshot has already passed full validation.
 func (s *NavigationService) readV2(ctx context.Context, key navigationResourceKey, base *appwire.NavigationReadBase) (navigationReadResult, error) {
 	_, versioned, projection, err := s.versionedCore(ctx, key)
 	if err != nil {
@@ -385,24 +391,14 @@ func (s *NavigationService) readV2(ctx context.Context, key navigationResourceKe
 		return navigationReadResult{}, err
 	}
 	currentBase := appwire.NavigationReadBase{GenerationID: generation, Revision: revision, ETag: etag}
+	var deltaFallback error
 	if base != nil {
 		if previous, ok := s.history.Lookup(view, *base); ok {
-			delta, diffErr := diffNavigationSnapshots(view, *base, currentBase, previous, snapshot)
-			if diffErr != nil {
-				return navigationReadResult{}, diffErr
-			}
-			deltaResponse := response
-			deltaResponse.Representation = appwire.NavigationRepresentationDelta
-			deltaResponse.Base = base
-			deltaResponse.Data, err = json.Marshal(delta)
-			if err != nil {
-				return navigationReadResult{}, err
-			}
-			fits, fitErr := navigationV2ResponseFits(deltaResponse, limit)
-			if fitErr != nil {
-				return navigationReadResult{}, fitErr
-			}
-			if fits {
+			deltaResponse, fits, deltaErr := navigationDeltaResponse(view, *base, currentBase, previous, snapshot, response, limit)
+			switch {
+			case deltaErr != nil:
+				deltaFallback = deltaErr
+			case fits:
 				_ = s.history.Remember(view, currentBase, &snapshot)
 				return navigationReadResult{Response: deltaResponse}, nil
 			}
@@ -411,7 +407,35 @@ func (s *NavigationService) readV2(ctx context.Context, key navigationResourceKe
 	response.Representation = appwire.NavigationRepresentationSnapshot
 	response.Data = snapshotData
 	_ = s.history.Remember(view, currentBase, &snapshot)
-	return navigationReadResult{Response: response}, nil
+	return navigationReadResult{Response: response, DeltaFallback: deltaFallback}, nil
+}
+
+// navigationDeltaResponse builds the delta representation of snapshot against
+// a retained base. It reports fits=false when the encoded delta exceeds the
+// response budget and an error when the delta machinery rejects its own
+// output; in both cases the caller still holds a validated snapshot to serve.
+func navigationDeltaResponse(
+	view navigationResourceKey,
+	base, currentBase appwire.NavigationReadBase,
+	previous, snapshot hubapi.NavigationSnapshot,
+	response appwire.NavigationReadResponse,
+	limit int,
+) (appwire.NavigationReadResponse, bool, error) {
+	delta, err := diffNavigationSnapshots(view, base, currentBase, previous, snapshot)
+	if err != nil {
+		return appwire.NavigationReadResponse{}, false, err
+	}
+	response.Representation = appwire.NavigationRepresentationDelta
+	response.Base = &base
+	response.Data, err = json.Marshal(delta)
+	if err != nil {
+		return appwire.NavigationReadResponse{}, false, err
+	}
+	fits, err := navigationV2ResponseFits(response, limit)
+	if err != nil {
+		return appwire.NavigationReadResponse{}, false, err
+	}
+	return response, fits, nil
 }
 
 // Refresh always requests a new source capture, but all concurrent callers join

--- a/cmd/evener-hub/navigation_service_test.go
+++ b/cmd/evener-hub/navigation_service_test.go
@@ -2543,3 +2543,57 @@ func TestNavigationReadV2DeltaForResourceThatLosesAllEntities(t *testing.T) {
 		}
 	}
 }
+
+// corruptRetainedNavigationBase rewrites one retained history entry so it still
+// decodes but no longer validates against its own version, which makes the next
+// delta attempt against that base fail inside diffNavigationSnapshots.
+func corruptRetainedNavigationBase(t *testing.T, history *navigationHistory, view navigationResourceKey, base appwire.NavigationReadBase) {
+	t.Helper()
+	history.mu.Lock()
+	defer history.mu.Unlock()
+	element, ok := history.entries[history.key(view, base)]
+	if !ok {
+		t.Fatalf("base %+v was not retained", base)
+	}
+	entry := element.Value.(navigationHistoryEntry)
+	want := []byte(fmt.Sprintf(`"revision":%d`, base.Revision))
+	tampered := bytes.Replace(entry.data, want, []byte(fmt.Sprintf(`"revision":%d`, base.Revision+1000)), 1)
+	if bytes.Equal(tampered, entry.data) {
+		t.Fatalf("retained snapshot %s did not carry %s", entry.data, want)
+	}
+	entry.data = tampered
+	element.Value = entry
+}
+
+func TestNavigationReadV2FailedDeltaFallsBackToSnapshot(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	source := newTestNavigationSource(now)
+	service := newTestNavigationService(t, source)
+	key := navigationResourceKey{Kind: navigationResourceProjectPage, ProjectKey: "p1", Tier: "current", Limit: 1}
+	initial, err := service.readV2(t.Context(), key, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := appwire.NavigationReadBase{GenerationID: initial.Response.GenerationID, Revision: initial.Response.Revision, ETag: initial.Response.ETag}
+	corruptRetainedNavigationBase(t, service.history, key, base)
+	source.changeTitle("delta fallback")
+	if _, err := service.Refresh(t.Context(), navigationChangeHint{Projects: []string{"p1"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := service.readV2(t.Context(), key, &base)
+	if err != nil {
+		t.Fatalf("read with unreconstructable base: %v", err)
+	}
+	if changed.Response.Status != "ok" || changed.Response.Representation != appwire.NavigationRepresentationSnapshot || changed.Response.Base != nil {
+		t.Fatalf("response = %+v, want ok snapshot without Base", changed.Response)
+	}
+	if changed.DeltaFallback == nil {
+		t.Fatal("result did not report why the delta was abandoned")
+	}
+	assertNavigationV2ResponseBudget(t, key, changed.Response)
+	currentBase := appwire.NavigationReadBase{GenerationID: changed.Response.GenerationID, Revision: changed.Response.Revision, ETag: changed.Response.ETag}
+	if _, ok := service.history.Lookup(key, currentBase); !ok {
+		t.Fatal("fallback snapshot was not retained as the next delta base")
+	}
+}

--- a/cmd/evener-hub/navigation_service_test.go
+++ b/cmd/evener-hub/navigation_service_test.go
@@ -2497,3 +2497,49 @@ func TestNavigationSnapshotBoundaryUsesNearest24HourOr14DayCutover(t *testing.T)
 		t.Fatalf("14d boundary = %v, want %v", got, want)
 	}
 }
+
+func TestNavigationReadV2DeltaForResourceThatLosesAllEntities(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	source := newTestNavigationSource(now)
+	source.mu.Lock()
+	source.inputs.Tree.Live = append([]hubcore.TreeNode(nil), source.inputs.Tree.Projects[0].Current...)
+	source.mu.Unlock()
+	service := newTestNavigationService(t, source)
+	manifestKey := navigationResourceKey{Kind: navigationResourceManifest}
+	liveKey := navigationResourceKey{Kind: navigationResourceLive, Limit: maxNavigationSectionRows}
+
+	bases := map[navigationResourceKind]appwire.NavigationReadBase{}
+	for _, key := range []navigationResourceKey{manifestKey, liveKey} {
+		initial, err := service.readV2(t.Context(), key, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bases[key.Kind] = appwire.NavigationReadBase{GenerationID: initial.Response.GenerationID, Revision: initial.Response.Revision, ETag: initial.Response.ETag}
+	}
+
+	source.mu.Lock()
+	source.inputs.Tree.Live = nil
+	source.revision++
+	source.mu.Unlock()
+	if _, err := service.Refresh(t.Context(), navigationChangeHint{}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, key := range []navigationResourceKey{manifestKey, liveKey} {
+		base := bases[key.Kind]
+		changed, err := service.readV2(t.Context(), key, &base)
+		if err != nil {
+			t.Fatalf("%s delta read: %v", key.Kind, err)
+		}
+		if changed.Response.Status != "ok" || changed.Response.Representation != appwire.NavigationRepresentationDelta || changed.Response.Base == nil || *changed.Response.Base != base {
+			t.Fatalf("%s response = %+v, want ok delta against exact base", key.Kind, changed.Response)
+		}
+		var delta hubapi.NavigationDelta
+		if err := json.Unmarshal(changed.Response.Data, &delta); err != nil {
+			t.Fatal(err)
+		}
+		if key.Kind == navigationResourceLive && len(delta.RemovedEntityKeys) != 1 {
+			t.Fatalf("live delta = %+v, want the one removed session", delta)
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #961; the diff shrinks to one commit once that merges.

## Problem

When `diffNavigationSnapshots` rejected its own delta, `readV2` failed the whole read and the client saw an internal error, even though the full snapshot it had just built was already validated and within the response budget. The #961 bug therefore broke the sidebar instead of degrading to the representation the service already had in hand.

## Fix

Treat an unbuildable delta like a history miss or an oversize delta: serve the snapshot, retain it as the next base, and report the reason on `navigationReadResult.DeltaFallback` so the AppWire handler logs it as `navigation delta fallback: ...`. The delta attempt moves into `navigationDeltaResponse` so `readV2` reads as one decision per outcome.

## Tests

- `TestNavigationReadV2FailedDeltaFallsBackToSnapshot`: corrupts the retained base so the diff rejects it, then asserts an ok snapshot with no `Base`, the fallback reason set, and the new snapshot retained for the next delta.
- `TestHubNavigationFailedDeltaServesSnapshotAndLogs`: same setup through the AppWire handler, asserting the client gets a snapshot and the server log records the abandoned delta.

Both failed before the change: the service returned the diff error and the handler mapped it to an internal error.

## Verification

- `make lint`, `make vet` pass
- `go test ./cmd/evener-hub/... ./hubapi/...` pass
- roborev branch review (job 152, based on #961's branch): no issues found
