### PR TITLE
perf(dashboard-filter): single-pass filter with precomputed haystack

### DIFF
--- a/cmd/evener-tui/hub_dashboard.go
+++ b/cmd/evener-tui/hub_dashboard.go
@@ -490,10 +490,6 @@ func dashboardGroupKey(row hubRow) string {
 	return row.projectKey
 }
 
-func rowMatchesFilter(row hubRow, query string) bool {
-	return strings.Contains(rowFilterHaystack(row), query)
-}
-
 func rowFilterHaystack(row hubRow) string {
 	return strings.ToLower(strings.Join([]string{
 		row.title,

--- a/cmd/evener-tui/hub_dashboard.go
+++ b/cmd/evener-tui/hub_dashboard.go
@@ -442,10 +442,12 @@ func filterHubRows(rows []hubRow, query string) []hubRow {
 	if query == "" {
 		return rows
 	}
+	matched := make([]bool, len(rows))
 	projectMatches := map[string]bool{}
 	childMatches := map[string]bool{}
-	for _, row := range rows {
-		if rowMatchesFilter(row, query) {
+	for i, row := range rows {
+		if strings.Contains(rowFilterHaystack(row), query) {
+			matched[i] = true
 			groupKey := dashboardGroupKey(row)
 			if row.kind == hubRowProject {
 				projectMatches[groupKey] = true
@@ -455,7 +457,7 @@ func filterHubRows(rows []hubRow, query string) []hubRow {
 		}
 	}
 	filtered := make([]hubRow, 0, len(rows))
-	for _, row := range rows {
+	for i, row := range rows {
 		groupKey := dashboardGroupKey(row)
 		if row.kind == hubRowProject {
 			if projectMatches[groupKey] || childMatches[groupKey] {
@@ -463,7 +465,7 @@ func filterHubRows(rows []hubRow, query string) []hubRow {
 			}
 			continue
 		}
-		if projectMatches[groupKey] || rowMatchesFilter(row, query) {
+		if projectMatches[groupKey] || matched[i] {
 			filtered = append(filtered, row)
 		}
 	}
@@ -489,7 +491,11 @@ func dashboardGroupKey(row hubRow) string {
 }
 
 func rowMatchesFilter(row hubRow, query string) bool {
-	haystack := strings.ToLower(strings.Join([]string{
+	return strings.Contains(rowFilterHaystack(row), query)
+}
+
+func rowFilterHaystack(row hubRow) string {
+	return strings.ToLower(strings.Join([]string{
 		row.title,
 		row.project,
 		row.projectKey,
@@ -498,7 +504,6 @@ func rowMatchesFilter(row hubRow, query string) bool {
 		row.state,
 		row.age,
 	}, " "))
-	return strings.Contains(haystack, query)
 }
 
 func (m *hubModel) clampSelection() {


### PR DESCRIPTION
Filter did 2x Join+ToLower per row per keystroke (rowMatchesFilter called twice per row in filterHubRows). Now precomputes the lowercase haystack once per row, single pass with stored group decision. UI-only pure function; field set, lowercasing, and substring semantics preserved exactly.

Verification (serial runner): gofmt clean; Dashboard/HubDashboard/Filter tests across cmd/evener-tui all ok.
Risk: low.