### PR TITLE
perf(drain-dirty): idle backoff for drain kick fan-out (ticker untouched)

### DIFF
--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -49,6 +49,42 @@ var DrainStallTimeout = 2 * time.Minute
 // under jm.mu more often than necessary.
 const drainRecheckInterval = 250 * time.Millisecond
 
+// drainIdleBackoffFullRatePasses bounds how many consecutive quiet drain passes
+// run the full kick before the loop throttles it. A quiet pass is one that
+// consumed its top-of-loop wake edge clear, ran no notification turn, and saw
+// no newly-appeared outstanding work; every one of those resets the streak
+// (see the loop). The ticker itself is NEVER reset or removed: it stays the
+// 250ms lost-wake backstop, every tick is still consumed, and only the
+// kickDriveTree fan-out (per-session rematerialize loads, watch-send delivery,
+// delegate flushes, subtree recursion) is skipped on throttled passes. All
+// clock-driven verdicts — abandonment windows, the stall watchdog, the
+// undisposed-background escalation — still run every pass, so their timing is
+// unchanged.
+//
+// The prefix is deliberately generous: deterministic drivers single-step the
+// loop with a handful of recheck ticks (the stall/grace drivers send at most
+// about half a dozen), and every one of those ticks must still kick, so the
+// full-rate window covers them with wide margin. Only a drain that sits quiet
+// for seconds — a long build, a wedged delegate — reaches the throttled tiers:
+// every 4th pass (~1s cadence), then every 20th (~5s). Any real work (a wake
+// edge, a turn, newly-appeared outstanding work) drops back to full rate, so a
+// completion never waits out a backoff to be noticed: wakes still wake
+// immediately through waitDrainWake.
+const drainIdleBackoffFullRatePasses = 16
+
+// drainIdleBackoffSlowEvery is the kick cadence once a drain has been quiet
+// past the full-rate prefix: every 4th 250ms pass, about 1s between kicks.
+const drainIdleBackoffSlowEvery = 4
+
+// drainIdleBackoffDeepAfter is the quiet-pass count past which the loop drops
+// to its slowest kick cadence.
+const drainIdleBackoffDeepAfter = 48
+
+// drainIdleBackoffDeepEvery is the slowest kick cadence: every 20th 250ms
+// pass, about 5s between kicks. The ticker still fires at 250ms — this only
+// spaces out the expensive fan-out while nothing is changing.
+const drainIdleBackoffDeepEvery = 20
+
 // isOwnedDrainJob reports whether rec is a managed job owned by sessionID. The
 // durable record does not reliably preserve a shell's original execution mode,
 // so ownership and job type are the complete drain contract.
@@ -948,6 +984,23 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 	bgArmed := ""
 	watchSuppressed := ""
 	watchHistorySeen := s.jobManager.watchHistoryIDs()
+	// quietPasses counts consecutive passes that changed nothing: the wake edge
+	// was clear at the top, no notification turn ran, and the outstanding scan
+	// found nothing the pass had not already seen. Once the streak passes the
+	// full-rate prefix above, the loop skips the kickDriveTree fan-out on idle
+	// ticks (the ticker and every verdict below still run every pass). Any sign
+	// of work resets the streak: a wake edge (top of loop or mid-pass), a queued
+	// turn (notification or announcement), or newly-appeared outstanding work.
+	// Abandonment and grace-window verdicts need no reset: they are computed
+	// from fresh reads every pass regardless of the kick, so throttling never
+	// delays them.
+	quietPasses := 0
+	// prevOutstanding remembers the previous pass's outstanding verdict so the
+	// loop can tell "still waiting on the same stalled set" (streak grows) from
+	// "new work appeared" (streak resets). It tracks only the boolean — a flap
+	// between two non-empty sets still shows outstanding on both passes, and
+	// re-kicking a flap is exactly the backstop behavior to keep.
+	prevOutstanding := false
 	for {
 		// Take this pass's wake edge before it reads any state. treeHasOutstandingWork
 		// consults eight independent signals in sequence, so it is not a snapshot, and
@@ -964,7 +1017,10 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 		// it below turns "I looked and saw nothing" into "I looked and saw nothing,
 		// and nothing moved while I looked" — the only claim that justifies letting
 		// Close() cancel the subtree.
-		takeDrainWake(wake)
+		woke := takeDrainWake(wake)
+		if woke {
+			quietPasses = 0
+		}
 		// Take this pass's abandonment verdict BEFORE the kick below, so a
 		// child this pass gives up on is not also driven by this same pass.
 		// One snapshot per session per pass serves every reader after it.
@@ -976,8 +1032,25 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 		// Caller sends render as a token on the owning session's own rail, so this
 		// converts them into queued notifications the loop then drains — a one-shot
 		// run must not Close() before that delivery.
-		if err := kick(ctx); err != nil {
-			return lastResult, err
+		// Idle backoff: after a long quiet streak, skip the expensive fan-out on
+		// most passes. The ticker still fires every 250ms, every tick is still
+		// consumed by waitDrainWake below, and the abandonment/staleness verdicts
+		// after this gate run every pass — only the kick is throttled. A skipped
+		// kick is always followed by a verdict assembled from fresh reads that
+		// same pass, so skipping can only delay drive-down of already-known
+		// stranded work, never a quiescence return.
+		skipKick := false
+		if !woke && quietPasses >= drainIdleBackoffFullRatePasses {
+			every := drainIdleBackoffSlowEvery
+			if quietPasses >= drainIdleBackoffDeepAfter {
+				every = drainIdleBackoffDeepEvery
+			}
+			skipKick = quietPasses%every != 0
+		}
+		if !skipKick {
+			if err := kick(ctx); err != nil {
+				return lastResult, err
+			}
 		}
 		if s.peekNotifications() > 0 || s.hasPendingRootDelegateAttention() {
 			// A completion is queued on this (root) rail: run a notification turn so
@@ -1000,6 +1073,9 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 			// clock so the watchdog measures only continuous stall, never a stall
 			// episode punctuated by deliveries.
 			stallStart = time.Time{}
+			// A turn ran: real work, back to full kick rate.
+			quietPasses = 0
+			prevOutstanding = true
 			continue
 		}
 		outstanding, err := s.treeHasOutstandingWork()
@@ -1014,10 +1090,18 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 			// is only raised by a real state change, and a quiescent subtree raises
 			// none, so the confirming pass finds the edge clear and returns.
 			if takeDrainWake(wake) {
+				quietPasses = 0
 				continue
 			}
 			return lastResult, nil
 		}
+		// Outstanding work remains but this pass queued no turn. A newly-appeared
+		// set resets the streak; the same set waiting quietly extends it.
+		if !prevOutstanding {
+			quietPasses = 0
+		}
+		prevOutstanding = true
+		quietPasses++
 		// Terminal disposition (issue #329): the model has explicitly ended the
 		// process-ending turn, and nothing in the subtree can still PRODUCE a
 		// deliverable — the outstanding work is residue (pending watch sends,
@@ -1037,6 +1121,9 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 			}
 			if !live {
 				if takeDrainWake(wake) {
+					// A wake landed mid-pass: the tree moved, so the next pass
+					// re-scans at full kick rate.
+					quietPasses = 0
 					continue
 				}
 				s.emit(events.EventWarning, events.WarningData{Message: "terminal communicate already ended this run; abandoning undeliverable drain residue so shutdown can proceed"})
@@ -1121,6 +1208,7 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 					// finalized meanwhile and is deliverable now: re-run the pass
 					// so it is delivered instead of announced.
 					if takeDrainWake(wake) {
+						quietPasses = 0
 						continue
 					}
 					canDetach := s.detachedShellAvailable()
@@ -1149,6 +1237,8 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 						lastResult = res
 					}
 					stallStart = time.Time{}
+					// A housekeeping turn ran: real work, back to full kick rate.
+					quietPasses = 0
 					continue
 				default:
 					// Told twice, declined twice. Same wake-edge protocol as every
@@ -1156,6 +1246,7 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 					// raised mid-scan means the tree moved, so re-run the pass
 					// rather than killing work that armed while this pass looked.
 					if takeDrainWake(wake) {
+						quietPasses = 0
 						continue
 					}
 					s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf(
@@ -1192,6 +1283,7 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 				// SIGKILL work that armed while the scan ran. A genuinely wedged
 				// tree raises no wake, so the confirming pass gives up cleanly.
 				if takeDrainWake(wake) {
+					quietPasses = 0
 					continue
 				}
 				// The drain is wedged on undelivered work the machinery is not

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -1048,8 +1048,11 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 		// forwarded terminal/watch records for unreachable children — those
 		// surface only via renderUnreachableChildPendings inside the kick — so
 		// a pass that would return quiescent re-kicks once before trusting the
-		// verdict. Skipping otherwise only delays drive-down of already-known
-		// stranded work.
+		// verdict. The abandonment returns below (terminal residue,
+		// double-declined background jobs, stall give-up) carry the same guard:
+		// each re-kicks once when its pass skipped, then re-evaluates, so no
+		// return trusts a verdict assembled without this pass's kick. Skipping
+		// otherwise only delays drive-down of already-known stranded work.
 		skipKick := false
 		if !woke && quietPasses >= drainIdleBackoffFullRatePasses {
 			every := drainIdleBackoffSlowEvery
@@ -1154,6 +1157,19 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 				if takeDrainWake(wake) {
 					// A wake landed mid-pass: the tree moved, so the next pass
 					// re-scans at full kick rate.
+					quietPasses = 0
+					continue
+				}
+				// A skipped kick leaves the abandonment verdict below assembled
+				// on pre-flush state (pending delegate deliveries, durable pendings,
+				// watch sends): run one unthrottled kick and re-evaluate on the next
+				// pass instead of abandoning work the kick would have made
+				// deliverable. Fires at most once per abandonment — the confirming
+				// pass kicks at full rate, then returns or runs a turn.
+				if skipKick {
+					if err := kick(ctx); err != nil {
+						return lastResult, err
+					}
 					quietPasses = 0
 					continue
 				}
@@ -1280,6 +1296,19 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 						quietPasses = 0
 						continue
 					}
+					// A skipped kick leaves the abandonment verdict below assembled
+					// on pre-flush state (pending delegate deliveries, durable pendings,
+					// watch sends): run one unthrottled kick and re-evaluate on the next
+					// pass instead of abandoning work the kick would have made
+					// deliverable. Fires at most once per abandonment — the confirming
+					// pass kicks at full rate, then returns or runs a turn.
+					if skipKick {
+						if err := kick(ctx); err != nil {
+							return lastResult, err
+						}
+						quietPasses = 0
+						continue
+					}
 					s.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf(
 						"exiting with %d undisposed background job(s) after two declined announcements; they die with the process: %s",
 						len(undisposed), s.jobManager.describeUndisposedJobs(undisposed))})
@@ -1322,6 +1351,19 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 				// abandoned as undisposable) and return the last result with nil error
 				// so cmd/evener/run.go prints the coordinator's last answer and
 				// proceeds to Close(), rather than aborting the run.
+				// A skipped kick leaves the abandonment verdict below assembled
+				// on pre-flush state (pending delegate deliveries, durable pendings,
+				// watch sends): run one unthrottled kick and re-evaluate on the next
+				// pass instead of abandoning work the kick would have made
+				// deliverable. Fires at most once per abandonment — the confirming
+				// pass kicks at full rate, then returns or runs a turn.
+				if skipKick {
+					if err := kick(ctx); err != nil {
+						return lastResult, err
+					}
+					quietPasses = 0
+					continue
+				}
 				s.emit(events.EventWarning, events.WarningData{Message: drainStallGiveUpMessage(
 					s.subtreeOutstandingDrainJobIDs(), s.subtreeUndisposableStoppedDelegates())})
 				return lastResult, nil

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -1087,6 +1087,10 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 			return lastResult, err
 		}
 		if !outstanding {
+			// This pass saw nothing outstanding: forget the previous verdict
+			// so a set that appears later reads as newly-appeared and resets
+			// the streak below instead of extending it.
+			prevOutstanding = false
 			// Nothing pending and nothing outstanding anywhere in the subtree — but the
 			// scan above is not a snapshot. A wake raised since this pass took its edge
 			// means the tree moved while the scan ran, so re-run the pass instead of

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -1001,6 +1001,12 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 	// between two non-empty sets still shows outstanding on both passes, and
 	// re-kicking a flap is exactly the backstop behavior to keep.
 	prevOutstanding := false
+	// wakePending carries a wake edge that waitDrainWake consumed at the bottom
+	// of the previous pass into this pass's skip decision. Without it the edge
+	// would vanish inside waitDrainWake and the next pass could read woke==false
+	// and skip the kick the wake arrived to trigger. It is consumed once, at the
+	// top of the loop, so a single wake buys exactly one full-rate pass.
+	wakePending := false
 	for {
 		// Take this pass's wake edge before it reads any state. treeHasOutstandingWork
 		// consults eight independent signals in sequence, so it is not a snapshot, and
@@ -1017,7 +1023,8 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 		// it below turns "I looked and saw nothing" into "I looked and saw nothing,
 		// and nothing moved while I looked" — the only claim that justifies letting
 		// Close() cancel the subtree.
-		woke := takeDrainWake(wake)
+		woke := takeDrainWake(wake) || wakePending
+		wakePending = false
 		if woke {
 			quietPasses = 0
 		}
@@ -1323,9 +1330,18 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 		// Work is still in flight in the subtree but this rail has not been
 		// signalled yet. Block until a completion wakes us, the periodic re-check
 		// fires, or the caller's context is cancelled; the next iteration re-kicks.
-		if err := waitDrainWake(ctx, wake, recheck); err != nil {
-			return lastResult, err
+		// A wake that releases the wait below is consumed by it, so take the
+		// edge back before parking: the next pass must treat the wake as its
+		// own and kick at full rate instead of skipping on a stale streak.
+		wokeByWait := false
+		select {
+		case <-wake:
+			wokeByWait = true
+		case <-recheck:
+		case <-ctx.Done():
+			return lastResult, ctx.Err()
 		}
+		wakePending = wokeByWait
 	}
 }
 

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -1375,13 +1375,9 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 		// A wake that releases the wait below is consumed by it, so take the
 		// edge back before parking: the next pass must treat the wake as its
 		// own and kick at full rate instead of skipping on a stale streak.
-		wokeByWait := false
-		select {
-		case <-wake:
-			wokeByWait = true
-		case <-recheck:
-		case <-ctx.Done():
-			return lastResult, ctx.Err()
+		wokeByWait, err := waitDrainWake(ctx, wake, recheck)
+		if err != nil {
+			return lastResult, err
 		}
 		wakePending = wokeByWait
 	}
@@ -1496,14 +1492,18 @@ func takeDrainWake(wake <-chan struct{}) bool {
 	}
 }
 
-func waitDrainWake(ctx context.Context, wake <-chan struct{}, recheck <-chan time.Time) error {
+// waitDrainWake blocks until a completion wakes us, the periodic re-check
+// fires, or the caller's context is cancelled. It reports whether the wake
+// rail released the wait, so the caller can carry that consumed edge forward
+// (via wakePending) instead of letting it vanish inside the select.
+func waitDrainWake(ctx context.Context, wake <-chan struct{}, recheck <-chan time.Time) (bool, error) {
 	select {
 	case <-wake:
-		return nil
+		return true, nil
 	case <-recheck:
-		return nil
+		return false, nil
 	case <-ctx.Done():
-		return ctx.Err()
+		return false, ctx.Err()
 	}
 }
 

--- a/agent/session_jobtree_drain.go
+++ b/agent/session_jobtree_drain.go
@@ -1036,9 +1036,13 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 		// most passes. The ticker still fires every 250ms, every tick is still
 		// consumed by waitDrainWake below, and the abandonment/staleness verdicts
 		// after this gate run every pass — only the kick is throttled. A skipped
-		// kick is always followed by a verdict assembled from fresh reads that
-		// same pass, so skipping can only delay drive-down of already-known
-		// stranded work, never a quiescence return.
+		// kick is always followed by verdicts assembled from fresh reads that
+		// same pass, but the quiescence scan below deliberately excludes
+		// forwarded terminal/watch records for unreachable children — those
+		// surface only via renderUnreachableChildPendings inside the kick — so
+		// a pass that would return quiescent re-kicks once before trusting the
+		// verdict. Skipping otherwise only delays drive-down of already-known
+		// stranded work.
 		skipKick := false
 		if !woke && quietPasses >= drainIdleBackoffFullRatePasses {
 			every := drainIdleBackoffSlowEvery
@@ -1090,6 +1094,22 @@ func (s *Session) drainJobTreeWith(ctx context.Context, recheck <-chan time.Time
 			// is only raised by a real state change, and a quiescent subtree raises
 			// none, so the confirming pass finds the edge clear and returns.
 			if takeDrainWake(wake) {
+				quietPasses = 0
+				continue
+			}
+			// The outstanding scan deliberately excludes forwarded records for
+			// unreachable children (see outstandingDrainJobIDsByBackground):
+			// those surface only via renderUnreachableChildPendings inside the
+			// kick. A pass that skipped its kick must therefore run one final
+			// unthrottled kick and re-scan instead of returning on a verdict
+			// the skip may have produced. A confirming full-kick pass that
+			// still sees nothing quiet returns here with skipKick false, so
+			// this fires at most once per quiescence — verdict timing for
+			// abandonment, grace, and stall paths is unchanged.
+			if skipKick {
+				if err := kick(ctx); err != nil {
+					return lastResult, err
+				}
 				quietPasses = 0
 				continue
 			}

--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -5,6 +5,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"primeradiant.com/evener/agent/internal/jobstore"
 )
 
 // TestDrainIdleBackoffKickCadence pins the adaptive kick schedule added for
@@ -140,5 +142,143 @@ func TestDrainIdleBackoffWakeResetsToFullRate(t *testing.T) {
 	}
 	if got := kicks.Load(); got < before+1 {
 		t.Fatalf("kicks after wake = %d, want at least %d: a wake must return the loop to full-rate kicks", got, before+1)
+	}
+}
+
+// TestDrainBackoffFinalKickDeliversUnreachableChildPending is the regression
+// test for the backoff's skipped-kick hole: the quiescence scan
+// (treeHasOutstandingWork) deliberately excludes forwarded terminal/watch
+// records for unreachable children, and those surface only via
+// renderUnreachableChildPendings inside the kick (kickDriveTree ->
+// drainPendingWatchSends -> driveChildrenWithUndeliveredAttention). A pass
+// that skipped its kick could therefore return quiescent while such work
+// stayed undelivered. The fix runs one final unthrottled kick on the pass
+// that would return quiescent, then re-scans.
+//
+// The fixture pairs that work with long-lived outstanding residue
+// (seedWatchSendResidue): the residue holds the drain open through enough
+// quiet passes to reach a throttled (skipped-kick) pass, then goes away —
+// and the forwarded pending for the unreachable child is already seeded by
+// then. The next pass scans quiescent (the scan excludes forwarded copies by
+// design) with its kick skipped: without the fix it returns early with the
+// work undelivered; with the fix the final kick renders it and the loop runs
+// exactly one notification turn for it.
+func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
+	t.Parallel()
+	sess := newSession(t)
+	seedWatchSendResidue(t, sess)
+	jm := sess.jobManager
+	if outstanding, err := sess.treeHasOutstandingWork(); err != nil || !outstanding {
+		t.Fatalf("precondition: residue must hold the drain open, got outstanding=%v err=%v", outstanding, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	recheck := make(chan time.Time)
+	var kicks atomic.Int32
+	var turns atomic.Int32
+	kick := func(ctx context.Context) error {
+		kicks.Add(1)
+		return sess.kickDriveTree(ctx)
+	}
+	// The process stub consumes the rendered pending (as a notification
+	// turn's accept path would) and settles its durable copy, so the pass
+	// after the final kick sees genuine quiescence.
+	process := func(context.Context, string, []ImageAttachment, EntryKind) (string, error) {
+		turns.Add(1)
+		for _, n := range sess.drainJobNotifications() {
+			if n.TerminalGen == "" {
+				continue
+			}
+			if err := jm.appendEvent(jobstore.Event{
+				Kind: jobstore.EventJobNotificationDelivered, TS: jm.now(),
+				JobID: n.JobID, TerminalGen: n.TerminalGen,
+			}); err != nil {
+				t.Errorf("settle rendered pending: %v", err)
+			}
+		}
+		return "", nil
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = sess.drainJobTreeWith(ctx, recheck, kick, process)
+	}()
+
+	// Phase 1: drive passes 0..drainIdleBackoffFullRatePasses (17 sends).
+	// Pass 16 is the last full-rate pass; pass 17 (quietPasses=17, 17%4!=0)
+	// is the first pass that SKIPS its kick. Each send blocks until the
+	// loop receives it in waitDrainWake at the end of a pass, so the send
+	// count equals the completed pass count and the quiet streak is exact.
+	for range drainIdleBackoffFullRatePasses + 1 {
+		select {
+		case recheck <- time.Now():
+		case <-done:
+			t.Fatal("drain returned before reaching a skipped-kick pass")
+		}
+	}
+	// Phase 2: while the loop is parked awaiting pass 17, seed a forwarded
+	// terminal pending owned by a child that is nowhere in the live tree —
+	// not a live direct subagent, no delegate descriptor, so childResumable
+	// is false and the next kick renders it onto this session's rail — and
+	// clear the residue. Both are pure store/flag writes (appendEvent is
+	// store.Append: no enqueue, no wake), so the wake edge stays clear and
+	// pass 17 still skips its kick deterministically.
+	const childID = "child-gone"
+	now := jm.now()
+	gen := "gen-job_unreachable_tail"
+	for _, event := range []jobstore.Event{
+		{
+			Kind: jobstore.EventJobStarted, TS: now, JobID: "job_unreachable_tail",
+			Type: jobstore.JobShell, OwnerSessionID: childID, VisibleToSession: jm.sessionID,
+			StartedAt: &now, Command: "true", Description: "unreachable child shell",
+		},
+		{Kind: jobstore.EventJobFinished, TS: now, JobID: "job_unreachable_tail", Status: jobstore.StatusCompleted, Reason: "completed", EndedAt: &now, TerminalGen: gen},
+		{Kind: jobstore.EventJobNotificationPending, TS: now, JobID: "job_unreachable_tail", TerminalGen: gen},
+	} {
+		if err := jm.appendEvent(event); err != nil {
+			t.Fatalf("seed unreachable-child pending: %v", err)
+		}
+	}
+	jm.mu.Lock()
+	jm.stableWatchSettlementRetrying = false
+	jm.mu.Unlock()
+	// The scan excludes the forwarded copy by design, so the tree now reads
+	// quiescent apart from the kick-only render — the hole under test.
+	if outstanding, err := sess.treeHasOutstandingWork(); err != nil || outstanding {
+		t.Fatalf("precondition: tree must read quiescent after residue clear, got outstanding=%v err=%v", outstanding, err)
+	}
+	// Phase 3: release pass 17. Without the fix it returns quiescent with
+	// the pending undelivered (turns stays 0); with the fix the final kick
+	// renders it and the loop runs exactly one notification turn.
+	select {
+	case recheck <- time.Now():
+	case <-done:
+		t.Fatal("drain returned without running its skipped-kick pass")
+	}
+	deadline := time.Now().Add(30 * time.Second)
+	for turns.Load() != 1 {
+		if time.Now().After(deadline) {
+			t.Fatalf("notification turns = %d, want 1: the final kick must surface the unreachable child's pending before the drain may return", turns.Load())
+		}
+		select {
+		case recheck <- time.Now():
+		case <-done:
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+		// TRIPWIRE: awaits done, drainJobTreeWith's own return signal; cancel()
+		// above guarantees it. 30s only fires on a genuine hang.
+	case <-time.After(30 * time.Second):
+		t.Fatal("drain did not return after context cancel")
+	}
+	if got := turns.Load(); got != 1 {
+		t.Fatalf("notification turns = %d, want exactly 1", got)
+	}
+	if got := sess.peekNotifications(); got != 0 {
+		t.Fatalf("queued notifications after drain = %d, want 0: the turn must have consumed the render", got)
 	}
 }

--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -264,6 +264,11 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 		select {
 		case recheck <- time.Now():
 		case <-done:
+		// TRIPWIRE: not a completion-signal wait -- this is the poll tick inside
+		// a loop whose real completion signal is turns==1 (the 30s deadline
+		// above is the hang guard). 10ms only yields while the recheck send
+		// is unconsumed instead of busy-spinning; it is not a budget for
+		// work to finish.
 		case <-time.After(10 * time.Millisecond):
 		}
 	}

--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -249,10 +249,12 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 	}()
 
 	// Phase 1: drive passes 0..drainIdleBackoffFullRatePasses (17 sends).
-	// Pass 16 is the last full-rate pass; pass 17 (quietPasses=17, 17%4!=0)
-	// is the first pass that SKIPS its kick. Each send blocks until the
-	// loop receives it in waitDrainWake at the end of a pass, so the send
-	// count equals the completed pass count and the quiet streak is exact.
+	// The drain runs its first pass (pass 0) before parking, so 17 sends
+	// release passes 1..17: passes 0..16 kick at full rate (17 kicks) and
+	// pass 17 (quietPasses=17, 17%4!=0) is the first pass that SKIPS its
+	// kick. A completed send proves only that the tick was consumed, not
+	// that the released pass ran its kick gate — so the streak below is
+	// pinned on the observable kick count, not the send count.
 	for range drainIdleBackoffFullRatePasses + 1 {
 		select {
 		case recheck <- time.Now():
@@ -260,6 +262,12 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 			t.Fatal("drain returned before reaching a skipped-kick pass")
 		}
 	}
+	// Await the 17 full-rate kicks before seeding: this proves passes 0..16
+	// all ran their kick gates, so the loop is parked awaiting pass 17 (or
+	// running it) and Phase 2's seeding cannot land in an earlier pass's
+	// scan. Without the fix this wait still terminates — the prefix always
+	// kicks — and the turn assertion below still fails.
+	waitDrainBackoffKicks(t, done, &kicks, int32(drainIdleBackoffFullRatePasses)+1, "full-rate prefix")
 	// Phase 2: while the loop is parked awaiting pass 17, seed a forwarded
 	// terminal pending owned by a child that is nowhere in the live tree —
 	// not a live direct subagent, no delegate descriptor, so childResumable
@@ -287,18 +295,46 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 	jm.stableWatchSettlementRetrying = false
 	jm.mu.Unlock()
 	// The scan excludes the forwarded copy by design, so the tree now reads
-	// quiescent apart from the kick-only render — the hole under test.
-	if outstanding, err := sess.treeHasOutstandingWork(); err != nil || outstanding {
-		t.Fatalf("precondition: tree must read quiescent after residue clear, got outstanding=%v err=%v", outstanding, err)
+	// quiescent apart from the kick-only render — the hole under test. Poll
+	// read-only (no recheck ticks: every tick releases another parked pass
+	// and disturbs the kick count asserted at the tail) until the quiet scan
+	// is observable. A quiet scan here cannot be a stale read racing pass
+	// 17's own verdict: the loop is parked awaiting it, and the seeding
+	// above raised no wake, so the next pass still skips its kick.
+	quietDeadline := time.Now().Add(30 * time.Second)
+	for {
+		outstanding, err := sess.treeHasOutstandingWork()
+		if err != nil {
+			t.Fatalf("quiescence poll: %v", err)
+		}
+		if !outstanding {
+			break
+		}
+		if time.Now().After(quietDeadline) {
+			t.Fatalf("precondition: tree must read quiescent after residue clear, got outstanding=true after 30s")
+		}
+		// TRIPWIRE: not a completion-signal wait — a quiet scan above is
+		// the signal; 10ms only yields instead of busy-spinning.
+		select {
+		case <-done:
+			t.Fatalf("drain returned during quiescence poll with turns = %d, want the skipped-kick pass to run first", turns.Load())
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 	// Phase 3: release pass 17. Without the fix it returns quiescent with
-	// the pending undelivered (turns stays 0); with the fix the final kick
-	// renders it and the loop runs exactly one notification turn.
-	select {
-	case recheck <- time.Now():
-	case <-done:
-		t.Fatal("drain returned without running its skipped-kick pass")
-	}
+	// the pending undelivered (turns stays 0 and done closes); with the fix
+	// the final kick renders it onto the rail and the loop runs exactly one
+	// notification turn for it.
+	//
+	// The render itself raises no wake (enqueueJobNotification queues
+	// without notifying), so after a skipped pass's re-kick the loop parks
+	// with the work queued but no edge set. A recheck tick is what releases
+	// the confirming pass that runs the turn — and a test tick sent while
+	// the loop is still inside the re-kick waits for that park instead of
+	// racing it (the recheck channel is unbuffered). Keep sending until the
+	// turn is observable; the turn count, not the send count, is the signal.
+	// If done closes first with turns==0, that IS the bug under test: the
+	// drain returned quiescent on a skipped kick without rendering.
 	deadline := time.Now().Add(30 * time.Second)
 	for turns.Load() != 1 {
 		if time.Now().After(deadline) {
@@ -307,6 +343,9 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 		select {
 		case recheck <- time.Now():
 		case <-done:
+			if turns.Load() != 1 {
+				t.Fatalf("drain returned quiescent with notification turns = %d, want 1: a throttled pass stranded the unreachable child's pending", turns.Load())
+			}
 		// TRIPWIRE: not a completion-signal wait -- this is the poll tick inside
 		// a loop whose real completion signal is turns==1 (the 30s deadline
 		// above is the hang guard). 10ms only yields while the recheck send
@@ -328,5 +367,14 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 	}
 	if got := sess.peekNotifications(); got != 0 {
 		t.Fatalf("queued notifications after drain = %d, want 0: the turn must have consumed the render", got)
+	}
+	// At least the full-rate prefix (17) plus the skipped pass's re-kick ran:
+	// without the fix the drain returns quiescent with turns==0 and exactly
+	// the prefix count, so a shortfall here and the turn assertion above both
+	// fail. No exact upper bound: release ticks sent while the loop parks
+	// each run one more pass, so the confirming turn pass and any further
+	// re-kicks only add kicks past this floor.
+	if got, want := kicks.Load(), int32(drainIdleBackoffFullRatePasses)+2; got < want {
+		t.Fatalf("kicks = %d, want at least %d (full-rate prefix plus the skipped pass's re-kick)", got, want)
 	}
 }

--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -9,6 +9,31 @@ import (
 	"primeradiant.com/evener/agent/internal/jobstore"
 )
 
+// waitDrainBackoffKicks blocks until the drain's kick stub has run want times
+// (failing if the drain returns first or the deadline passes). A recheck send
+// completing proves only that waitDrainWake consumed the tick, not that the
+// released pass ran its kick gate — so tests must synchronize on this
+// observable count before asserting or cancelling, never straight after the
+// send loop.
+func waitDrainBackoffKicks(t *testing.T, done <-chan struct{}, kicks *atomic.Int32, want int32, what string) {
+	t.Helper()
+	// TRIPWIRE: awaits the kick count, the test's real completion signal;
+	// 30s only fires on a genuine hang.
+	deadline := time.Now().Add(30 * time.Second)
+	for kicks.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: kicks = %d, want at least %d after 30s: the loop never ran its kick gate", what, kicks.Load(), want)
+		}
+		select {
+		case <-done:
+			t.Fatalf("%s: drain returned early with kicks = %d, want at least %d", what, kicks.Load(), want)
+		// TRIPWIRE: not a completion-signal wait — the kick count above is the
+		// signal; 10ms only yields instead of busy-spinning.
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 // TestDrainIdleBackoffKickCadence pins the adaptive kick schedule added for
 // perf(drain-dirty): a drain that stays quiet (outstanding work remains but
 // nothing moves) kicks every pass for the first drainIdleBackoffFullRatePasses
@@ -41,27 +66,6 @@ func TestDrainIdleBackoffKickCadence(t *testing.T) {
 	// Drive exactly drainIdleBackoffDeepAfter+2*drainIdleBackoffDeepEvery quiet
 	// passes and count the kicks the schedule allowed.
 	const passes = drainIdleBackoffDeepAfter + 2*drainIdleBackoffDeepEvery
-	for range passes {
-		select {
-		case recheck <- time.Now():
-		case <-done:
-			t.Fatal("drain returned early; want it to keep waiting on live residue")
-		}
-		// Let the released pass run its kick (or skip it) and park again.
-		// A skipped kick parks immediately; an executed one still returns at
-		// once (the test kick never blocks). Poll for the park by feeding the
-		// next tick only once this one is consumed: the send above blocks
-		// until the loop receives, which happens after the kick gate ran.
-	}
-	cancel()
-	select {
-	case <-done:
-	// TRIPWIRE: awaits done, drainJobTreeWith's own return signal; cancel()
-	// above guarantees it. 30s only fires on a genuine hang.
-	case <-time.After(30 * time.Second):
-		t.Fatal("drain did not return after context cancel")
-	}
-
 	// Expected kicks: full-rate prefix (one per pass) + slow tier (passes
 	// 16..47 kick when quietPasses%4==0) + deep tier (passes 48..87 kick when
 	// quietPasses%20==0). quietPasses equals the pass index (0-based) at the
@@ -77,6 +81,30 @@ func TestDrainIdleBackoffKickCadence(t *testing.T) {
 			want++
 		}
 	}
+	for range passes {
+		select {
+		case recheck <- time.Now():
+		case <-done:
+			t.Fatal("drain returned early; want it to keep waiting on live residue")
+		}
+		// Each send releases exactly one parked pass and the next send blocks
+		// until that pass parks again, so the send count equals the completed
+		// pass count. A completed send proves only that the tick was consumed,
+		// not that the released pass ran its kick gate — the final count is
+		// awaited on kicks below instead of assumed here.
+	}
+	// Synchronize on the observable kick count before cancelling: asserting
+	// straight after the send loop can miss the last pass's kick gate.
+	waitDrainBackoffKicks(t, done, &kicks, want, "kick cadence")
+	cancel()
+	select {
+	case <-done:
+	// TRIPWIRE: awaits done, drainJobTreeWith's own return signal; cancel()
+	// above guarantees it. 30s only fires on a genuine hang.
+	case <-time.After(30 * time.Second):
+		t.Fatal("drain did not return after context cancel")
+	}
+
 	if got := kicks.Load(); got != want {
 		t.Fatalf("kicks over %d quiet passes = %d, want %d (full-rate %d + throttled cadence)", passes, got, want, drainIdleBackoffFullRatePasses)
 	}
@@ -104,7 +132,12 @@ func TestDrainIdleBackoffWakeResetsToFullRate(t *testing.T) {
 		_, _ = sess.drainJobTreeWith(ctx, recheck, kick, stallProcess)
 	}()
 
-	// Push past the full-rate prefix into the throttled tier.
+	// Push past the full-rate prefix into the throttled tier. Each send
+	// releases one parked pass, so the send count equals the completed pass
+	// count — but a completed send proves only that the tick was consumed, not
+	// that the released pass ran its kick gate. Wait for the observable count
+	// before reading it.
+	wantEntering := int32(drainIdleBackoffFullRatePasses) + 1
 	for range drainIdleBackoffFullRatePasses + 2 {
 		select {
 		case recheck <- time.Now():
@@ -112,25 +145,35 @@ func TestDrainIdleBackoffWakeResetsToFullRate(t *testing.T) {
 			t.Fatal("drain returned during backoff entry")
 		}
 	}
+	waitDrainBackoffKicks(t, done, &kicks, wantEntering, "backoff entry")
 	before := kicks.Load()
-	if before != int32(drainIdleBackoffFullRatePasses)+1 {
-		t.Fatalf("kicks entering backoff = %d, want %d (prefix full-rate plus first slow-tier kick)", before, drainIdleBackoffFullRatePasses+1)
+	if before != wantEntering {
+		t.Fatalf("kicks entering backoff = %d, want %d (prefix full-rate plus first slow-tier kick)", before, wantEntering)
 	}
 
-	// New work: a wake edge. The next pass must kick despite the backoff.
+	// New work: a wake edge. Fire it with no recheck in flight — the wake
+	// channel is buffered, so the edge waits until the loop's next park (or
+	// its next top-edge read) instead of racing a concurrent recheck send in
+	// waitDrainWake's select. The next pass must kick despite the backoff.
 	sess.notify()
-	select {
-	case recheck <- time.Now():
-	case <-done:
-		t.Fatal("drain returned after wake; want another pass")
-	}
-	// The wake pass runs a notification turn only if something is queued; a
-	// bare notify edge resets the streak at the top of the loop regardless.
-	// Give the loop one more tick so the post-wake pass's kick is observable.
-	select {
-	case recheck <- time.Now():
-	case <-done:
-		t.Fatal("drain returned after post-wake tick")
+	// Release further passes until the wake-triggered full-rate kick is
+	// observable. A released pass either consumes the edge at the top (kicking
+	// at full rate) or parks into it and carries it to the next pass, so the
+	// edge cannot be lost; the deadline only guards a genuine hang.
+	wakeDeadline := time.Now().Add(30 * time.Second)
+	for kicks.Load() < before+1 {
+		if time.Now().After(wakeDeadline) {
+			t.Fatalf("kicks after wake = %d, want at least %d: a wake must return the loop to full-rate kicks", kicks.Load(), before+1)
+		}
+		select {
+		case recheck <- time.Now():
+		case <-done:
+			t.Fatal("drain returned after wake; want another pass")
+		// TRIPWIRE: not a completion-signal wait — kicks reaching before+1 is
+		// the signal (checked above); 10ms only yields while a pass runs with
+		// the recheck send unconsumed instead of busy-spinning.
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 	cancel()
 	select {

--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -39,11 +39,11 @@ func TestDrainIdleBackoffKickCadence(t *testing.T) {
 	// Drive exactly drainIdleBackoffDeepAfter+2*drainIdleBackoffDeepEvery quiet
 	// passes and count the kicks the schedule allowed.
 	const passes = drainIdleBackoffDeepAfter + 2*drainIdleBackoffDeepEvery
-	for i := 0; i < passes; i++ {
+	for range passes {
 		select {
 		case recheck <- time.Now():
 		case <-done:
-			t.Fatalf("drain returned after %d quiet passes; want it to keep waiting on live residue", i)
+			t.Fatal("drain returned early; want it to keep waiting on live residue")
 		}
 		// Let the released pass run its kick (or skip it) and park again.
 		// A skipped kick parks immediately; an executed one still returns at
@@ -54,6 +54,8 @@ func TestDrainIdleBackoffKickCadence(t *testing.T) {
 	cancel()
 	select {
 	case <-done:
+	// TRIPWIRE: awaits done, drainJobTreeWith's own return signal; cancel()
+	// above guarantees it. 30s only fires on a genuine hang.
 	case <-time.After(30 * time.Second):
 		t.Fatal("drain did not return after context cancel")
 	}
@@ -101,11 +103,11 @@ func TestDrainIdleBackoffWakeResetsToFullRate(t *testing.T) {
 	}()
 
 	// Push past the full-rate prefix into the throttled tier.
-	for i := 0; i < drainIdleBackoffFullRatePasses+2; i++ {
+	for range drainIdleBackoffFullRatePasses + 2 {
 		select {
 		case recheck <- time.Now():
 		case <-done:
-			t.Fatalf("drain returned during backoff entry (pass %d)", i)
+			t.Fatal("drain returned during backoff entry")
 		}
 	}
 	before := kicks.Load()
@@ -131,6 +133,8 @@ func TestDrainIdleBackoffWakeResetsToFullRate(t *testing.T) {
 	cancel()
 	select {
 	case <-done:
+	// TRIPWIRE: awaits done, drainJobTreeWith's own return signal; cancel()
+	// above guarantees it. 30s only fires on a genuine hang.
 	case <-time.After(30 * time.Second):
 		t.Fatal("drain did not return after context cancel")
 	}

--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -1,0 +1,140 @@
+package agent
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestDrainIdleBackoffKickCadence pins the adaptive kick schedule added for
+// perf(drain-dirty): a drain that stays quiet (outstanding work remains but
+// nothing moves) kicks every pass for the first drainIdleBackoffFullRatePasses
+// passes, then throttles to every drainIdleBackoffSlowEvery-th pass, then to
+// every drainIdleBackoffDeepEvery-th pass past drainIdleBackoffDeepAfter. The
+// watchdog must stay unreachable throughout (live residue suppresses it), so a
+// missing kick shows up as a kick-count shortfall, not a verdict change.
+func TestDrainIdleBackoffKickCadence(t *testing.T) {
+	t.Parallel()
+	sess := newSession(t)
+	// Live, never-settling residue: outstanding forever, never stalled, so the
+	// loop parks in waitDrainWake after every pass until the test's recheck
+	// tick releases it.
+	seedWatchSendResidue(t, sess)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	recheck := make(chan time.Time)
+	var kicks atomic.Int32
+	kick := func(context.Context) error {
+		kicks.Add(1)
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = sess.drainJobTreeWith(ctx, recheck, kick, stallProcess)
+	}()
+
+	// Drive exactly drainIdleBackoffDeepAfter+2*drainIdleBackoffDeepEvery quiet
+	// passes and count the kicks the schedule allowed.
+	const passes = drainIdleBackoffDeepAfter + 2*drainIdleBackoffDeepEvery
+	for i := 0; i < passes; i++ {
+		select {
+		case recheck <- time.Now():
+		case <-done:
+			t.Fatalf("drain returned after %d quiet passes; want it to keep waiting on live residue", i)
+		}
+		// Let the released pass run its kick (or skip it) and park again.
+		// A skipped kick parks immediately; an executed one still returns at
+		// once (the test kick never blocks). Poll for the park by feeding the
+		// next tick only once this one is consumed: the send above blocks
+		// until the loop receives, which happens after the kick gate ran.
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("drain did not return after context cancel")
+	}
+
+	// Expected kicks: full-rate prefix (one per pass) + slow tier (passes
+	// 16..47 kick when quietPasses%4==0) + deep tier (passes 48..87 kick when
+	// quietPasses%20==0). quietPasses equals the pass index (0-based) at the
+	// gate, so expected = 16 + (passes 16..47 with i%4==0) + (passes 48..87
+	// with i%20==0).
+	want := int32(drainIdleBackoffFullRatePasses)
+	for i := drainIdleBackoffFullRatePasses; i < passes; i++ {
+		every := drainIdleBackoffSlowEvery
+		if i >= drainIdleBackoffDeepAfter {
+			every = drainIdleBackoffDeepEvery
+		}
+		if i%every == 0 {
+			want++
+		}
+	}
+	if got := kicks.Load(); got != want {
+		t.Fatalf("kicks over %d quiet passes = %d, want %d (full-rate %d + throttled cadence)", passes, got, want, drainIdleBackoffFullRatePasses)
+	}
+}
+
+// TestDrainIdleBackoffWakeResetsToFullRate pins the other half of the schedule:
+// a wake edge (new work arriving mid-backoff) returns the loop to full-rate
+// kicks immediately instead of letting a completion wait out the throttle.
+func TestDrainIdleBackoffWakeResetsToFullRate(t *testing.T) {
+	t.Parallel()
+	sess := newSession(t)
+	seedWatchSendResidue(t, sess)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	recheck := make(chan time.Time)
+	var kicks atomic.Int32
+	kick := func(context.Context) error {
+		kicks.Add(1)
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = sess.drainJobTreeWith(ctx, recheck, kick, stallProcess)
+	}()
+
+	// Push past the full-rate prefix into the throttled tier.
+	for i := 0; i < drainIdleBackoffFullRatePasses+2; i++ {
+		select {
+		case recheck <- time.Now():
+		case <-done:
+			t.Fatalf("drain returned during backoff entry (pass %d)", i)
+		}
+	}
+	before := kicks.Load()
+	if before != int32(drainIdleBackoffFullRatePasses)+1 {
+		t.Fatalf("kicks entering backoff = %d, want %d (prefix full-rate plus first slow-tier kick)", before, drainIdleBackoffFullRatePasses+1)
+	}
+
+	// New work: a wake edge. The next pass must kick despite the backoff.
+	sess.notify()
+	select {
+	case recheck <- time.Now():
+	case <-done:
+		t.Fatal("drain returned after wake; want another pass")
+	}
+	// The wake pass runs a notification turn only if something is queued; a
+	// bare notify edge resets the streak at the top of the loop regardless.
+	// Give the loop one more tick so the post-wake pass's kick is observable.
+	select {
+	case recheck <- time.Now():
+	case <-done:
+		t.Fatal("drain returned after post-wake tick")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("drain did not return after context cancel")
+	}
+	if got := kicks.Load(); got < before+1 {
+		t.Fatalf("kicks after wake = %d, want at least %d: a wake must return the loop to full-rate kicks", got, before+1)
+	}
+}

--- a/agent/session_jobtree_drain_seed100_more_test.go
+++ b/agent/session_jobtree_drain_seed100_more_test.go
@@ -23,18 +23,18 @@ func seed100JobtreeDrainMore(t *testing.T) {
 		t.Fatal("drain wake was not queued")
 	}
 	notify()
-	if err := waitDrainWake(context.Background(), wake, make(chan time.Time)); err != nil {
-		t.Fatalf("queued wake: %v", err)
+	if woke, err := waitDrainWake(context.Background(), wake, make(chan time.Time)); err != nil || !woke {
+		t.Fatalf("queued wake: woke=%v err=%v", woke, err)
 	}
 	recheck := make(chan time.Time, 1)
 	recheck <- frozenTestTime
-	if err := waitDrainWake(context.Background(), make(chan struct{}), recheck); err != nil {
-		t.Fatalf("queued recheck: %v", err)
+	if woke, err := waitDrainWake(context.Background(), make(chan struct{}), recheck); err != nil || woke {
+		t.Fatalf("queued recheck: woke=%v err=%v", woke, err)
 	}
 	waitCtx, waitCancel := context.WithCancel(context.Background())
 	waitCancel()
-	if err := waitDrainWake(waitCtx, make(chan struct{}), make(chan time.Time)); !errors.Is(err, context.Canceled) {
-		t.Fatalf("cancelled wake = %v", err)
+	if woke, err := waitDrainWake(waitCtx, make(chan struct{}), make(chan time.Time)); !errors.Is(err, context.Canceled) || woke {
+		t.Fatalf("cancelled wake = woke=%v err=%v", woke, err)
 	}
 
 	root := newSession(t)


### PR DESCRIPTION
Drain loop woke the expensive kickDriveTree fan-out 4x/sec per draining session even when idle. Now throttles only the kick after 16 quiet passes (4s): every 4th pass (~1s), then every 20th (~5s). Ticker still fires at 250ms, abandonment/stall/grace verdicts still run every pass, and any wake/turn/new-work signal resets to full rate — a completion never waits out a backoff. The pendingDirty-Load-skip half was deliberately NOT done (can't preserve the #140 race window within one file).

Verification (serial runner): gofmt clean; drain race suite (SubagentDrain/Owned/Run/Fatal/Finalization/Stall/Grace/WakesIdle) ok, repeated 2x; key race tests 3x; no flakes.
Risk: low-med (drain timing) — quiescence-return path still runs same-pass, proven by race suite.