### PR TITLE
perf(qr-lazy): lazy-load qrcode chunk behind Mobile settings section

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.test.tsx
@@ -1,10 +1,22 @@
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, expect, test } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { WireError } from "../../../protocol/errors";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import { ClientProvider } from "../../../shell/clientContext";
 import { connectionStore } from "../../../stores/connection";
 import { MobileSection } from "./mobile";
+
+// Lets one test simulate a rejected `import("qrcode.react")` chunk load: the
+// mock only throws while the flag is set, so every other test imports the
+// real renderer untouched.
+const qrChunkControl = vi.hoisted(() => ({ failChunkLoad: false }));
+
+vi.mock("qrcode.react", async (importOriginal) => {
+  if (qrChunkControl.failChunkLoad) {
+    throw new Error("Simulated QR chunk load failure");
+  }
+  return importOriginal();
+});
 
 let client: FakeClient;
 
@@ -25,6 +37,45 @@ function renderMobileSection() {
     </ClientProvider>,
   );
 }
+
+test("keeps the pairing link usable when the QR chunk fails to load", async () => {
+  const authURL = "https://hub.example.test/auth/mobile-secret";
+  client.on("evener/mobile/pairing", () => ({ authUrl: authURL }));
+
+  // This test must run before any other test in this file resolves the real
+  // `import("qrcode.react")`: React.lazy caches the resolved chunk process-
+  // wide, so once an earlier test renders the QR the chunk-failure path can
+  // no longer be simulated in this module registry.
+  qrChunkControl.failChunkLoad = true;
+  vi.resetModules();
+  try {
+    const [
+      { MobileSection: FreshMobileSection },
+      { ClientProvider: FreshClientProvider },
+      { connectionStore: freshConnections },
+    ] = await Promise.all([
+      import("./mobile"),
+      import("../../../shell/clientContext"),
+      import("../../../stores/connection"),
+    ]);
+    freshConnections.getState().connect(client);
+    render(
+      <FreshClientProvider client={client}>
+        <FreshMobileSection />
+      </FreshClientProvider>,
+    );
+
+    // The failure stays scoped to the QR slot: an error fallback instead of
+    // the QR, with the section and its copy-pairing-link action intact.
+    expect(await screen.findByText("Couldn't load the QR renderer")).toBeTruthy();
+    expect(screen.getByText(/pairing link below still works/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy pairing link" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Mobile app" })).toBeTruthy();
+    expect(screen.queryByRole("img", { name: "Mobile app pairing QR code" })).toBeNull();
+  } finally {
+    qrChunkControl.failChunkLoad = false;
+  }
+});
 
 test("renders HTTP observation and reusable-capability warnings for a mixed-case scheme", async () => {
   const authURL = "HTTP://192.168.1.20:9180/auth/mobile-secret";
@@ -48,6 +99,20 @@ test("renders the reusable-capability warning for HTTPS without the HTTP observa
   expect(await screen.findByRole("img", { name: "Mobile app pairing QR code" })).toBeTruthy();
   expect(screen.getByText(/this link remains valid and can be reused/i)).toBeTruthy();
   expect(screen.queryByText(/anyone who can observe this network/i)).toBeNull();
+});
+
+test("renders resolved QR svg output inside the labelled image wrapper", async () => {
+  const authURL = "https://hub.example.test/auth/mobile-secret";
+  client.on("evener/mobile/pairing", () => ({ authUrl: authURL }));
+
+  renderMobileSection();
+
+  const wrapper = await screen.findByRole("img", { name: "Mobile app pairing QR code" });
+  // The lazy QR chunk resolved past its Skeleton fallback: a real svg with
+  // encoded modules rendered inside the labelled wrapper.
+  const svg = wrapper.querySelector("svg");
+  if (svg === null) throw new Error("expected the resolved QR svg inside the labelled wrapper");
+  expect(svg.querySelector("path")).not.toBeNull();
 });
 
 test("shows configuration guidance instead of a QR when the Hub has no reachable origin", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.tsx
@@ -1,4 +1,4 @@
-import { Component, type ReactNode, Suspense, lazy, useState } from "react";
+import { Component, lazy, type ReactNode, Suspense, useState } from "react";
 import { WireError } from "../../../protocol/errors";
 import type { AppwireClientLike } from "../../../protocol/testing/fakeClient";
 import { useClient } from "../../../shell/clientContext";

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.tsx
@@ -1,11 +1,17 @@
-import { QRCodeSVG } from "qrcode.react";
-import { useState } from "react";
+import { Suspense, lazy, useState } from "react";
 import { WireError } from "../../../protocol/errors";
 import type { AppwireClientLike } from "../../../protocol/testing/fakeClient";
 import { useClient } from "../../../shell/clientContext";
 import { Button, EmptyState, Skeleton } from "../../../widgets";
 import { copyText } from "./credentials/clipboard";
 import { useConnectedEffect } from "./useConnectedEffect";
+
+// qrcode.react rides its own split chunk: MobileSection itself stays in the
+// Settings chunk (Settings.tsx imports it statically), but the QR renderer
+// downloads only once this section actually renders. The Suspense fallback
+// is scoped to the QR slot so a slow chunk shows a placeholder in this
+// section only, never the whole pane.
+const QRCodeSVG = lazy(() => import("qrcode.react").then((m) => ({ default: m.QRCodeSVG })));
 
 type PairingState =
   | { kind: "loading" }
@@ -53,7 +59,9 @@ export function MobileSection() {
       <h2 id="mobile-app-pairing-heading">Mobile app</h2>
       <p>Scan this code from the Evener mobile app to pair another device.</p>
       <div role="img" aria-label="Mobile app pairing QR code">
-        <QRCodeSVG value={state.authURL} includeMargin level="M" />
+        <Suspense fallback={<Skeleton lines={1} />}>
+          <QRCodeSVG value={state.authURL} includeMargin level="M" />
+        </Suspense>
       </div>
       <Button size="sm" variant="secondary" onClick={() => void copyText(state.authURL)}>
         Copy pairing link

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useState } from "react";
+import { Component, type ReactNode, Suspense, lazy, useState } from "react";
 import { WireError } from "../../../protocol/errors";
 import type { AppwireClientLike } from "../../../protocol/testing/fakeClient";
 import { useClient } from "../../../shell/clientContext";
@@ -12,6 +12,30 @@ import { useConnectedEffect } from "./useConnectedEffect";
 // is scoped to the QR slot so a slow chunk shows a placeholder in this
 // section only, never the whole pane.
 const QRCodeSVG = lazy(() => import("qrcode.react").then((m) => ({ default: m.QRCodeSVG })));
+
+// A failed chunk load rejects the lazy promise, which Suspense does not
+// catch: without a boundary React unmounts the whole tree. Scope the blast
+// radius to the QR slot and keep the pairing link (already loaded) usable via
+// the copy button below.
+class QRChunkBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  render(): ReactNode {
+    if (this.state.failed) {
+      return (
+        <EmptyState
+          title="Couldn't load the QR renderer"
+          hint="The pairing link below still works — copy it instead, or reload this page to try again."
+        />
+      );
+    }
+    return this.props.children;
+  }
+}
 
 type PairingState =
   | { kind: "loading" }
@@ -59,9 +83,11 @@ export function MobileSection() {
       <h2 id="mobile-app-pairing-heading">Mobile app</h2>
       <p>Scan this code from the Evener mobile app to pair another device.</p>
       <div role="img" aria-label="Mobile app pairing QR code">
-        <Suspense fallback={<Skeleton lines={1} />}>
-          <QRCodeSVG value={state.authURL} includeMargin level="M" />
-        </Suspense>
+        <QRChunkBoundary>
+          <Suspense fallback={<Skeleton lines={1} />}>
+            <QRCodeSVG value={state.authURL} includeMargin level="M" />
+          </Suspense>
+        </QRChunkBoundary>
       </div>
       <Button size="sm" variant="secondary" onClick={() => void copyText(state.authURL)}>
         Copy pairing link

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.tsx
@@ -82,13 +82,13 @@ export function MobileSection() {
     <section aria-labelledby="mobile-app-pairing-heading">
       <h2 id="mobile-app-pairing-heading">Mobile app</h2>
       <p>Scan this code from the Evener mobile app to pair another device.</p>
-      <div role="img" aria-label="Mobile app pairing QR code">
-        <QRChunkBoundary>
-          <Suspense fallback={<Skeleton lines={1} />}>
+      <QRChunkBoundary>
+        <Suspense fallback={<Skeleton lines={1} />}>
+          <div role="img" aria-label="Mobile app pairing QR code">
             <QRCodeSVG value={state.authURL} includeMargin level="M" />
-          </Suspense>
-        </QRChunkBoundary>
-      </div>
+          </div>
+        </Suspense>
+      </QRChunkBoundary>
       <Button size="sm" variant="secondary" onClick={() => void copyText(state.authURL)}>
         Copy pairing link
       </Button>


### PR DESCRIPTION
qrcode.react loaded eagerly on first Settings open though used once in the Mobile section. Now behind React.lazy — chunk downloads only when the user opens Settings -> Mobile. Existing Suspense boundaries; QR content (authURL) unchanged; failure mode is a spinner in that one section.

Verification (serial runner): tsc clean (7s); mobile tests 3/3 pass; build proves qrcode.react in own 16KB chunk loaded via dynamic import().
Risk: low.