### PR TITLE
perf(clock-tick): scope live ticks to leaf labels (ActivityTree, Spawn)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
@@ -1,9 +1,9 @@
 import {
-  Fragment,
   createContext,
+  Fragment,
   forwardRef,
-  memo,
   type KeyboardEvent,
+  memo,
   type ReactNode,
   useCallback,
   useContext,
@@ -470,7 +470,9 @@ const ContinuationStripView = memo(function ContinuationStripView({
 }: ContinuationStripViewProps): ReactNode {
   return (
     <div className={CLASS.rowActions}>
-      <span className={CLASS.rowContinuation}>{failure ?? strip.branchError ?? "This branch is partially retained."}</span>
+      <span className={CLASS.rowContinuation}>
+        {failure ?? strip.branchError ?? "This branch is partially retained."}
+      </span>
       {strip.token && (
         <Button
           variant="quiet"
@@ -706,68 +708,68 @@ export const ActivityTree = forwardRef<ActivityTreeHandle, ActivityTreeProps>(fu
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>, row: ActivityRow): void => {
-    const index = indexByID.get(row.id);
-    if (index === undefined) return;
-    // Alt/Ctrl/Meta mean the key belongs elsewhere: Alt+ArrowUp/Down and
-    // Alt+Home/End are the global transcript scroll/jump chords, and the
-    // dispatcher's editable test does not shield them from these row divs -
-    // a blanket preventDefault here would swallow them (roborev PR #884
-    // round 3). Shift stays: coarse-step and range conventions aside, the
-    // tree's own behavior is unchanged by it.
-    if (event.altKey || event.ctrlKey || event.metaKey) return;
-    switch (event.key) {
-      case "ArrowDown": {
-        event.preventDefault();
-        const next = rows[index + 1];
-        if (next) focusRow(next.id);
-        break;
-      }
-      case "ArrowUp": {
-        event.preventDefault();
-        const previous = rows[index - 1];
-        if (previous) focusRow(previous.id);
-        break;
-      }
-      case "ArrowRight": {
-        event.preventDefault();
-        if (row.kind === "fold") {
-          if (!expandedFolds.has(row.id)) onToggleFold(row.id);
-        } else {
-          setDetailOpen(row, true);
+      const index = indexByID.get(row.id);
+      if (index === undefined) return;
+      // Alt/Ctrl/Meta mean the key belongs elsewhere: Alt+ArrowUp/Down and
+      // Alt+Home/End are the global transcript scroll/jump chords, and the
+      // dispatcher's editable test does not shield them from these row divs -
+      // a blanket preventDefault here would swallow them (roborev PR #884
+      // round 3). Shift stays: coarse-step and range conventions aside, the
+      // tree's own behavior is unchanged by it.
+      if (event.altKey || event.ctrlKey || event.metaKey) return;
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          const next = rows[index + 1];
+          if (next) focusRow(next.id);
+          break;
         }
-        break;
-      }
-      case "ArrowLeft": {
-        event.preventDefault();
-        if (row.kind === "fold") {
-          if (expandedFolds.has(row.id)) onToggleFold(row.id);
-        } else if (isDetailOpen(row)) {
-          setDetailOpen(row, false);
-        } else if (row.parentID && indexByID.has(row.parentID)) {
-          // parentID is the delegate ROW's id for child-session rows (Task 5
-          // contract), so it resolves through the row index directly; root
-          // rows' parentID is a session node id, which is never a row.
-          focusRow(row.parentID);
+        case "ArrowUp": {
+          event.preventDefault();
+          const previous = rows[index - 1];
+          if (previous) focusRow(previous.id);
+          break;
         }
-        break;
+        case "ArrowRight": {
+          event.preventDefault();
+          if (row.kind === "fold") {
+            if (!expandedFolds.has(row.id)) onToggleFold(row.id);
+          } else {
+            setDetailOpen(row, true);
+          }
+          break;
+        }
+        case "ArrowLeft": {
+          event.preventDefault();
+          if (row.kind === "fold") {
+            if (expandedFolds.has(row.id)) onToggleFold(row.id);
+          } else if (isDetailOpen(row)) {
+            setDetailOpen(row, false);
+          } else if (row.parentID && indexByID.has(row.parentID)) {
+            // parentID is the delegate ROW's id for child-session rows (Task 5
+            // contract), so it resolves through the row index directly; root
+            // rows' parentID is a session node id, which is never a row.
+            focusRow(row.parentID);
+          }
+          break;
+        }
+        case "Enter":
+        case " ":
+        case "Spacebar":
+        case "Space": {
+          // Enter/Space from a nested control (the chevron button, the Load
+          // more button) is that control's own activation; the row must not
+          // fire a second activation for it. Arrows, by contrast, always mean
+          // row navigation even when focus sits on a nested control (Firefox
+          // and Safari focus buttons on click).
+          if (event.target !== event.currentTarget) return;
+          event.preventDefault();
+          activateRow(row);
+          break;
+        }
+        default:
+          break;
       }
-      case "Enter":
-      case " ":
-      case "Spacebar":
-      case "Space": {
-        // Enter/Space from a nested control (the chevron button, the Load
-        // more button) is that control's own activation; the row must not
-        // fire a second activation for it. Arrows, by contrast, always mean
-        // row navigation even when focus sits on a nested control (Firefox
-        // and Safari focus buttons on click).
-        if (event.target !== event.currentTarget) return;
-        event.preventDefault();
-        activateRow(row);
-        break;
-      }
-      default:
-        break;
-    }
     },
     [activateRow, expandedFolds, focusRow, indexByID, isDetailOpen, onToggleFold, rows, setDetailOpen],
   );

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
@@ -1,9 +1,12 @@
 import {
   Fragment,
+  createContext,
   forwardRef,
+  memo,
   type KeyboardEvent,
   type ReactNode,
   useCallback,
+  useContext,
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
@@ -252,6 +255,355 @@ function collectContinuations(
   return strips;
 }
 
+// TreeNowContext carries the live rows' ticking clock. TreeTickProvider is
+// the only setInterval in this file, and only context consumers (the live
+// meta cluster and live detail strips) re-render on each tick: memoized rows
+// and the tree chrome never subscribe, so a tick touches live leaves only.
+const TreeNowContext = createContext<number>(0);
+
+function TreeTickProvider({ live, children }: { live: boolean; children: ReactNode }): ReactNode {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!live) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [live]);
+  return <TreeNowContext.Provider value={now}>{children}</TreeNowContext.Provider>;
+}
+
+function RowSegments({ segments }: { segments: MetaSegment[] }): ReactNode {
+  return (
+    <span className={CLASS.denseMeta}>
+      {segments.map((segment, index) => (
+        <Fragment key={segment.key}>
+          {index > 0 ? " · " : null}
+          <span
+            className={
+              segment.tone === "failed" ? CLASS.denseFailed : segment.tone === "quiet" ? CLASS.denseQuiet : undefined
+            }
+          >
+            {segment.text}
+          </span>
+        </Fragment>
+      ))}
+    </span>
+  );
+}
+
+// LiveMetaSegments is the per-row tick subscriber for live rows: it reads the
+// clock straight from context so the memoized row above it stays asleep.
+function LiveMetaSegments({ row }: { row: ActivityJobRow | ActivityDelegateRow }): ReactNode {
+  const now = useContext(TreeNowContext);
+  const segments = row.kind === "job" ? jobMetaSegments(row, now) : delegateMetaSegments(row, now);
+  return <RowSegments segments={segments} />;
+}
+
+// Terminal rows never read the clock - terminalSegment derives the duration
+// from startedAt/endedAt, never from `now` - so the static cluster renders
+// once per row and holds no subscription. The 0 only fills `now`'s slot.
+const StaticMetaSegments = memo(function StaticMetaSegments({
+  row,
+}: {
+  row: ActivityJobRow | ActivityDelegateRow;
+}): ReactNode {
+  const segments = row.kind === "job" ? jobMetaSegments(row, 0) : delegateMetaSegments(row, 0);
+  return <RowSegments segments={segments} />;
+});
+
+function LiveRowDetail({ row }: { row: ActivityJobRow | ActivityDelegateRow }): ReactNode {
+  const now = useContext(TreeNowContext);
+  return <ActivityRowDetail row={row} now={now} />;
+}
+
+// Static detail strips carry no running age (metaText's terminal line has no
+// clock term), so they render once with a dummy instant and never subscribe.
+const RowDetail = memo(function RowDetail({ row }: { row: ActivityJobRow | ActivityDelegateRow }): ReactNode {
+  if (!row.live) return <ActivityRowDetail row={row} now={0} />;
+  return <LiveRowDetail row={row} />;
+});
+
+interface FoldRowViewProps {
+  row: ActivityFoldRow;
+  expanded: boolean;
+  tabIndex: number;
+  onToggleFold: (foldID: string) => void;
+  onFocusRow: (id: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>, row: ActivityRow) => void;
+  registerRowRef: (id: string, element: HTMLDivElement | null) => void;
+}
+
+// Fold rows carry no clock text, so a memoized view with no subscription
+// renders once per (row, expanded, focus) and sleeps through every tick.
+const FoldRowView = memo(function FoldRowView({
+  row,
+  expanded,
+  tabIndex,
+  onToggleFold,
+  onFocusRow,
+  onKeyDown,
+  registerRowRef,
+}: FoldRowViewProps): ReactNode {
+  const label = `${row.inactiveCount} inactive`;
+  const accessibleLabel = row.failedCount > 0 ? `${label} · ${row.failedCount} failed` : label;
+  return (
+    <div
+      ref={(element) => {
+        registerRowRef(row.id, element);
+      }}
+      role="treeitem"
+      aria-label={accessibleLabel}
+      aria-level={row.level}
+      aria-expanded={expanded}
+      tabIndex={tabIndex}
+      className={CLASS.foldRow}
+      onFocus={() => onFocusRow(row.id)}
+      onKeyDown={(event) => onKeyDown(event, row)}
+      onClick={() => onToggleFold(row.id)}
+    >
+      <button
+        type="button"
+        tabIndex={-1}
+        aria-label={`${expanded ? "Collapse" : "Expand"} inactive entries`}
+        className={CLASS.rowToggle}
+        onClick={(event) => {
+          event.stopPropagation();
+          onToggleFold(row.id);
+        }}
+      >
+        <Chevron direction={expanded ? "down" : "right"} size={12} />
+      </button>
+      <span className={CLASS.denseName}>
+        {label}
+        {row.failedCount > 0 && <span className={CLASS.denseFailed}>{` · ${row.failedCount} failed`}</span>}
+      </span>
+    </div>
+  );
+});
+
+interface DenseRowViewProps {
+  row: ActivityJobRow | ActivityDelegateRow;
+  detailOpen: boolean;
+  tabIndex: number;
+  onSetDetailOpen: (row: ActivityJobRow | ActivityDelegateRow, open: boolean) => void;
+  onFocusRow: (id: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>, row: ActivityRow) => void;
+  registerRowRef: (id: string, element: HTMLDivElement | null) => void;
+}
+
+// The row chrome (name, glyph, transcript button, focus, disclosure) is all
+// snapshot data, so the memoized view re-renders only when its own props
+// change; the ticking pieces live one level down in LiveMetaSegments (the
+// quiet-age cluster) and RowDetail (the open strip), which subscribe alone.
+const DenseRowView = memo(function DenseRowView({
+  row,
+  detailOpen,
+  tabIndex,
+  onSetDetailOpen,
+  onFocusRow,
+  onKeyDown,
+  registerRowRef,
+}: DenseRowViewProps): ReactNode {
+  const name = row.kind === "job" ? row.job.description : delegateName(row.delegate);
+  const statusText = row.kind === "job" ? row.job.status : delegateStatusText(row.delegate);
+  const target = transcriptTarget(row);
+  const kindState = jobStatusDotState(statusText, row.live ? undefined : true);
+  const kindClass = kindStateClass(kindState);
+  return (
+    <Fragment>
+      <div
+        ref={(element) => {
+          registerRowRef(row.id, element);
+        }}
+        role="treeitem"
+        aria-label={name}
+        aria-level={row.level}
+        aria-expanded={detailOpen}
+        tabIndex={tabIndex}
+        className={CLASS.denseRow}
+        onFocus={() => onFocusRow(row.id)}
+        onKeyDown={(event) => onKeyDown(event, row)}
+        // Clicking the title toggles the disclosure, same as the chevron;
+        // the transcript opens only from the row's open button.
+        onClick={() => onSetDetailOpen(row, !detailOpen)}
+      >
+        <button
+          type="button"
+          tabIndex={-1}
+          aria-label={`${detailOpen ? "Hide" : "Show"} details for ${name}`}
+          aria-expanded={detailOpen}
+          className={CLASS.rowToggle}
+          onClick={(event) => {
+            event.stopPropagation();
+            onSetDetailOpen(row, !detailOpen);
+          }}
+        >
+          <Chevron direction={detailOpen ? "down" : "right"} size={12} />
+        </button>
+        <span
+          role="img"
+          aria-label={KIND_STATE_LABEL[kindState] ?? kindState}
+          className={kindClass ? `${CLASS.denseKind} ${kindClass}` : CLASS.denseKind}
+        >
+          {row.kind === "delegate" ? "⌘" : "$"}
+        </span>
+        <span className={row.live ? `${CLASS.denseName} ${CLASS.denseNameLive}` : CLASS.denseName}>{name}</span>
+        {target && <OpenTranscriptButton transcriptRef={target} parentRef={row.parentRef} tabIndex={-1} />}
+        {row.live ? <LiveMetaSegments row={row} /> : <StaticMetaSegments row={row} />}
+      </div>
+      {detailOpen && <RowDetail row={row} />}
+    </Fragment>
+  );
+});
+
+interface ContinuationStripViewProps {
+  strip: ContinuationStrip;
+  failure: string | undefined;
+  loadingContinuationID?: string;
+  onContinue: (targetID: string, continuation: string) => void;
+}
+
+const ContinuationStripView = memo(function ContinuationStripView({
+  strip,
+  failure,
+  loadingContinuationID,
+  onContinue,
+}: ContinuationStripViewProps): ReactNode {
+  return (
+    <div className={CLASS.rowActions}>
+      <span className={CLASS.rowContinuation}>{failure ?? strip.branchError ?? "This branch is partially retained."}</span>
+      {strip.token && (
+        <Button
+          variant="quiet"
+          size="xs"
+          tabIndex={-1}
+          disabled={loadingContinuationID === strip.targetID}
+          onClick={(event) => {
+            event.stopPropagation();
+            onContinue(strip.targetID, strip.token ?? "");
+          }}
+        >
+          {loadingContinuationID === strip.targetID ? "Loading…" : "Load more"}
+        </Button>
+      )}
+    </div>
+  );
+});
+
+interface RowBlockProps {
+  slice: ActivityRow[];
+  stripsByAfterRowID: Map<string, ContinuationStrip[]>;
+  expandedFolds: Set<string>;
+  effectiveFocusedID: string | null;
+  isDetailOpen: (row: ActivityJobRow | ActivityDelegateRow) => boolean;
+  onToggleFold: (foldID: string) => void;
+  onSetDetailOpen: (row: ActivityJobRow | ActivityDelegateRow, open: boolean) => void;
+  onFocusRow: (id: string) => void;
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>, row: ActivityRow) => void;
+  registerRowRef: (id: string, element: HTMLDivElement | null) => void;
+  continuationFailures: Record<string, string | undefined>;
+  loadingContinuationID?: string;
+  onContinue?: (targetID: string, continuation: string) => void;
+}
+
+// Rows arrive flat with levels; a delegate's child-session rows are the
+// contiguous deeper-level block right after it and nest one group deeper. A
+// plain (unmemoized) component: it holds no clock itself, and the tree only
+// re-renders it on real data/focus/detail changes - never on a tick.
+function RowBlock({
+  slice,
+  stripsByAfterRowID,
+  expandedFolds,
+  effectiveFocusedID,
+  isDetailOpen,
+  onToggleFold,
+  onSetDetailOpen,
+  onFocusRow,
+  onKeyDown,
+  registerRowRef,
+  continuationFailures,
+  loadingContinuationID,
+  onContinue,
+}: RowBlockProps): ReactNode[] {
+  const out: ReactNode[] = [];
+  let cursor = 0;
+  while (cursor < slice.length) {
+    const row = slice[cursor];
+    if (!row) break;
+    const tabIndex = row.id === effectiveFocusedID ? 0 : -1;
+    if (row.kind === "fold") {
+      out.push(
+        <FoldRowView
+          key={row.id}
+          row={row}
+          expanded={expandedFolds.has(row.id)}
+          tabIndex={tabIndex}
+          onToggleFold={onToggleFold}
+          onFocusRow={onFocusRow}
+          onKeyDown={onKeyDown}
+          registerRowRef={registerRowRef}
+        />,
+      );
+    } else {
+      out.push(
+        <DenseRowView
+          key={row.id}
+          row={row}
+          detailOpen={isDetailOpen(row)}
+          tabIndex={tabIndex}
+          onSetDetailOpen={onSetDetailOpen}
+          onFocusRow={onFocusRow}
+          onKeyDown={onKeyDown}
+          registerRowRef={registerRowRef}
+        />,
+      );
+    }
+    for (const strip of stripsByAfterRowID.get(row.id) ?? []) {
+      out.push(
+        onContinue ? (
+          <ContinuationStripView
+            key={`${strip.targetID}-continuation`}
+            strip={strip}
+            failure={continuationFailures[strip.targetID]}
+            loadingContinuationID={loadingContinuationID}
+            onContinue={onContinue}
+          />
+        ) : null,
+      );
+    }
+    let end = cursor + 1;
+    while (end < slice.length) {
+      const candidate = slice[end];
+      if (!candidate || candidate.level <= row.level) break;
+      end++;
+    }
+    if (end > cursor + 1) {
+      out.push(
+        // role="group" is the WAI-ARIA treeview pattern's nested-children container.
+        // biome-ignore lint/a11y/useSemanticElements: role="group" is deliberate tree semantics
+        <div role="group" className={CLASS.indentGuide} key={`${row.id}-group`}>
+          <RowBlock
+            slice={slice.slice(cursor + 1, end)}
+            stripsByAfterRowID={stripsByAfterRowID}
+            expandedFolds={expandedFolds}
+            effectiveFocusedID={effectiveFocusedID}
+            isDetailOpen={isDetailOpen}
+            onToggleFold={onToggleFold}
+            onSetDetailOpen={onSetDetailOpen}
+            onFocusRow={onFocusRow}
+            onKeyDown={onKeyDown}
+            registerRowRef={registerRowRef}
+            continuationFailures={continuationFailures}
+            loadingContinuationID={loadingContinuationID}
+            onContinue={onContinue}
+          />
+        </div>,
+      );
+    }
+    cursor = end;
+  }
+  return out;
+}
+
 export const ActivityTree = forwardRef<ActivityTreeHandle, ActivityTreeProps>(function ActivityTree(
   { tree, expandedFoldIDs, onToggleFold, continuationFailures = {}, onContinue, loadingContinuationID },
   ref,
@@ -263,27 +615,27 @@ export const ActivityTree = forwardRef<ActivityTreeHandle, ActivityTreeProps>(fu
   // rows stay inert - they are only ever read for rows the current tree
   // actually renders.
   const [detailOverrides, setDetailOverrides] = useState<ReadonlyMap<string, boolean>>(new Map());
-  const [now, setNow] = useState(() => Date.now());
   const rows = useMemo(() => buildActivityRows(tree, new Set(expandedFoldIDs)), [tree, expandedFoldIDs]);
 
-  function isDetailOpen(row: ActivityJobRow | ActivityDelegateRow): boolean {
-    return detailOverrides.get(row.id) ?? row.defaultDetailOpen;
-  }
+  // Stable callbacks so the memoized row views below only re-render when
+  // their own row's data, disclosure, or focus actually changes.
+  const isDetailOpen = useCallback(
+    (row: ActivityJobRow | ActivityDelegateRow): boolean => detailOverrides.get(row.id) ?? row.defaultDetailOpen,
+    [detailOverrides],
+  );
 
-  function setDetailOpen(row: ActivityJobRow | ActivityDelegateRow, open: boolean): void {
+  const setDetailOpen = useCallback((row: ActivityJobRow | ActivityDelegateRow, open: boolean): void => {
     setDetailOverrides((current) => {
       const next = new Map(current);
       next.set(row.id, open);
       return next;
     });
-  }
+  }, []);
   const expandedFolds = useMemo(() => new Set(expandedFoldIDs), [expandedFoldIDs]);
+  // The ticking clock lives in TreeTickProvider below, gated on this same
+  // flag: no live rows, no interval - the old effect's contract, minus the
+  // tree-wide setNow that re-rendered every row each second.
   const hasLive = rows.some((row) => row.kind !== "fold" && row.live);
-  useEffect(() => {
-    if (!hasLive) return;
-    const timer = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(timer);
-  }, [hasLive]);
 
   const strips = useMemo(
     () => collectContinuations(tree, rows, continuationFailures),
@@ -328,17 +680,32 @@ export const ActivityTree = forwardRef<ActivityTreeHandle, ActivityTreeProps>(fu
     rowRefs.current.get(id)?.focus();
   });
 
-  function activateRow(row: ActivityRow): void {
-    if (row.kind === "fold") {
-      onToggleFold(row.id);
-      return;
-    }
-    // Row activation is the disclosure, same as the chevron: the transcript
-    // opens only from the row's own open button, never from the title.
-    setDetailOpen(row, !isDetailOpen(row));
-  }
+  // Stable identities so memoized rows only re-render when their own row's
+  // props (data, disclosure, focus) actually change - never on a tick.
+  const registerRowRef = useCallback((id: string, element: HTMLDivElement | null): void => {
+    if (element) rowRefs.current.set(id, element);
+    else rowRefs.current.delete(id);
+  }, []);
 
-  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>, row: ActivityRow): void {
+  const focusRowByID = useCallback((id: string): void => {
+    setFocusedID(id);
+  }, []);
+
+  const activateRow = useCallback(
+    (row: ActivityRow): void => {
+      if (row.kind === "fold") {
+        onToggleFold(row.id);
+        return;
+      }
+      // Row activation is the disclosure, same as the chevron: the transcript
+      // opens only from the row's own open button, never from the title.
+      setDetailOpen(row, !isDetailOpen(row));
+    },
+    [isDetailOpen, onToggleFold, setDetailOpen],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>, row: ActivityRow): void => {
     const index = indexByID.get(row.id);
     if (index === undefined) return;
     // Alt/Ctrl/Meta mean the key belongs elsewhere: Alt+ArrowUp/Down and
@@ -401,185 +768,29 @@ export const ActivityTree = forwardRef<ActivityTreeHandle, ActivityTreeProps>(fu
       default:
         break;
     }
-  }
-
-  function renderSegments(segments: MetaSegment[]): ReactNode {
-    return (
-      <span className={CLASS.denseMeta}>
-        {segments.map((segment, index) => (
-          <Fragment key={segment.key}>
-            {index > 0 ? " · " : null}
-            <span
-              className={
-                segment.tone === "failed" ? CLASS.denseFailed : segment.tone === "quiet" ? CLASS.denseQuiet : undefined
-              }
-            >
-              {segment.text}
-            </span>
-          </Fragment>
-        ))}
-      </span>
-    );
-  }
-
-  function renderContinuationStrip(strip: ContinuationStrip): ReactNode {
-    if (!onContinue) return null;
-    const failure = continuationFailures[strip.targetID];
-    return (
-      <div className={CLASS.rowActions} key={`${strip.targetID}-continuation`}>
-        <span className={CLASS.rowContinuation}>
-          {failure ?? strip.branchError ?? "This branch is partially retained."}
-        </span>
-        {strip.token && (
-          <Button
-            variant="quiet"
-            size="xs"
-            tabIndex={-1}
-            disabled={loadingContinuationID === strip.targetID}
-            onClick={(event) => {
-              event.stopPropagation();
-              onContinue(strip.targetID, strip.token ?? "");
-            }}
-          >
-            {loadingContinuationID === strip.targetID ? "Loading…" : "Load more"}
-          </Button>
-        )}
-      </div>
-    );
-  }
-
-  function renderFoldRow(row: ActivityFoldRow): ReactNode {
-    const expanded = expandedFolds.has(row.id);
-    const label = `${row.inactiveCount} inactive`;
-    const accessibleLabel = row.failedCount > 0 ? `${label} · ${row.failedCount} failed` : label;
-    return (
-      <div
-        key={row.id}
-        ref={(element) => {
-          if (element) rowRefs.current.set(row.id, element);
-          else rowRefs.current.delete(row.id);
-        }}
-        role="treeitem"
-        aria-label={accessibleLabel}
-        aria-level={row.level}
-        aria-expanded={expanded}
-        tabIndex={row.id === effectiveFocusedID ? 0 : -1}
-        className={CLASS.foldRow}
-        onFocus={() => setFocusedID(row.id)}
-        onKeyDown={(event) => handleKeyDown(event, row)}
-        onClick={() => onToggleFold(row.id)}
-      >
-        <button
-          type="button"
-          tabIndex={-1}
-          aria-label={`${expanded ? "Collapse" : "Expand"} inactive entries`}
-          className={CLASS.rowToggle}
-          onClick={(event) => {
-            event.stopPropagation();
-            onToggleFold(row.id);
-          }}
-        >
-          <Chevron direction={expanded ? "down" : "right"} size={12} />
-        </button>
-        <span className={CLASS.denseName}>
-          {label}
-          {row.failedCount > 0 && <span className={CLASS.denseFailed}>{` · ${row.failedCount} failed`}</span>}
-        </span>
-      </div>
-    );
-  }
-
-  function renderDenseRow(row: ActivityJobRow | ActivityDelegateRow): ReactNode {
-    const name = row.kind === "job" ? row.job.description : delegateName(row.delegate);
-    const statusText = row.kind === "job" ? row.job.status : delegateStatusText(row.delegate);
-    const target = transcriptTarget(row);
-    const detailOpen = isDetailOpen(row);
-    const segments = row.kind === "job" ? jobMetaSegments(row, now) : delegateMetaSegments(row, now);
-    const kindState = jobStatusDotState(statusText, row.live ? undefined : true);
-    const kindClass = kindStateClass(kindState);
-    return (
-      <Fragment key={row.id}>
-        <div
-          ref={(element) => {
-            if (element) rowRefs.current.set(row.id, element);
-            else rowRefs.current.delete(row.id);
-          }}
-          role="treeitem"
-          aria-label={name}
-          aria-level={row.level}
-          aria-expanded={detailOpen}
-          tabIndex={row.id === effectiveFocusedID ? 0 : -1}
-          className={CLASS.denseRow}
-          onFocus={() => setFocusedID(row.id)}
-          onKeyDown={(event) => handleKeyDown(event, row)}
-          // Clicking the title toggles the disclosure, same as the chevron;
-          // the transcript opens only from the row's open button.
-          onClick={() => setDetailOpen(row, !detailOpen)}
-        >
-          <button
-            type="button"
-            tabIndex={-1}
-            aria-label={`${detailOpen ? "Hide" : "Show"} details for ${name}`}
-            aria-expanded={detailOpen}
-            className={CLASS.rowToggle}
-            onClick={(event) => {
-              event.stopPropagation();
-              setDetailOpen(row, !detailOpen);
-            }}
-          >
-            <Chevron direction={detailOpen ? "down" : "right"} size={12} />
-          </button>
-          <span
-            role="img"
-            aria-label={KIND_STATE_LABEL[kindState] ?? kindState}
-            className={kindClass ? `${CLASS.denseKind} ${kindClass}` : CLASS.denseKind}
-          >
-            {row.kind === "delegate" ? "⌘" : "$"}
-          </span>
-          <span className={row.live ? `${CLASS.denseName} ${CLASS.denseNameLive}` : CLASS.denseName}>{name}</span>
-          {target && <OpenTranscriptButton transcriptRef={target} parentRef={row.parentRef} tabIndex={-1} />}
-          {renderSegments(segments)}
-        </div>
-        {detailOpen && <ActivityRowDetail row={row} now={now} />}
-      </Fragment>
-    );
-  }
-
-  // Rows arrive flat with levels; a delegate's child-session rows are the
-  // contiguous deeper-level block right after it and nest one group deeper.
-  function renderRowBlock(slice: ActivityRow[]): ReactNode[] {
-    const out: ReactNode[] = [];
-    let cursor = 0;
-    while (cursor < slice.length) {
-      const row = slice[cursor];
-      if (!row) break;
-      out.push(row.kind === "fold" ? renderFoldRow(row) : renderDenseRow(row));
-      for (const strip of stripsByAfterRowID.get(row.id) ?? []) {
-        out.push(renderContinuationStrip(strip));
-      }
-      let end = cursor + 1;
-      while (end < slice.length) {
-        const candidate = slice[end];
-        if (!candidate || candidate.level <= row.level) break;
-        end++;
-      }
-      if (end > cursor + 1) {
-        out.push(
-          // role="group" is the WAI-ARIA treeview pattern's nested-children container.
-          // biome-ignore lint/a11y/useSemanticElements: role="group" is deliberate tree semantics
-          <div role="group" className={CLASS.indentGuide} key={`${row.id}-group`}>
-            {renderRowBlock(slice.slice(cursor + 1, end))}
-          </div>,
-        );
-      }
-      cursor = end;
-    }
-    return out;
-  }
+    },
+    [activateRow, expandedFolds, focusRow, indexByID, isDetailOpen, onToggleFold, rows, setDetailOpen],
+  );
 
   return (
-    <div ref={treeRef} role="tree" className={CLASS.tree}>
-      {renderRowBlock(rows)}
-    </div>
+    <TreeTickProvider live={hasLive}>
+      <div ref={treeRef} role="tree" className={CLASS.tree}>
+        <RowBlock
+          slice={rows}
+          stripsByAfterRowID={stripsByAfterRowID}
+          expandedFolds={expandedFolds}
+          effectiveFocusedID={effectiveFocusedID}
+          isDetailOpen={isDetailOpen}
+          onToggleFold={onToggleFold}
+          onSetDetailOpen={setDetailOpen}
+          onFocusRow={focusRowByID}
+          onKeyDown={handleKeyDown}
+          registerRowRef={registerRowRef}
+          continuationFailures={continuationFailures}
+          loadingContinuationID={loadingContinuationID}
+          onContinue={onContinue}
+        />
+      </div>
+    </TreeTickProvider>
   );
 });

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -149,11 +149,7 @@ const MODEL_CHOOSE_LABEL = "Choose a model";
 // (label "Starting", startedAt as stamped by the submit). Mounted only while
 // `busy`, so the interval exists exactly as long as the old pane-level effect
 // ran it - but a tick re-renders this leaf alone, never the whole pane.
-const StartingLoader = memo(function StartingLoader({
-  startedAt,
-}: {
-  startedAt: number;
-}): JSX.Element {
+const StartingLoader = memo(function StartingLoader({ startedAt }: { startedAt: number }): JSX.Element {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 1000);

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -1,7 +1,7 @@
 // Session creation keeps the project directory above the prompt and the
 // less frequently changed launch settings below it. The directory picker
 // commits once, so browsing does not churn directory-dependent configuration.
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { type JSX, memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { friendlyLaunchErrorMessage } from "../../protocol/errors";
 import type {
   HarnessDescriptor,
@@ -144,6 +144,24 @@ const CLASS = {
 // ("model is required", app_threadlifecycle.go).
 const MODEL_CHOOSE_LABEL = "Choose a model";
 
+// StartingLoader owns the busy elapsed clock: it ticks its own `now` once a
+// second while mounted and renders the SAME Loader the pane rendered inline
+// (label "Starting", startedAt as stamped by the submit). Mounted only while
+// `busy`, so the interval exists exactly as long as the old pane-level effect
+// ran it - but a tick re-renders this leaf alone, never the whole pane.
+const StartingLoader = memo(function StartingLoader({
+  startedAt,
+}: {
+  startedAt: number;
+}): JSX.Element {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+  return <Loader label="Starting" startedAt={startedAt} now={now} />;
+});
+
 export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   const client = useClient();
   const toasts = useToasts();
@@ -176,10 +194,9 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // Loader's elapsed readout is pure-render (widgets/loader's own doc
   // comment - no internal timer, so it can't drift or fake liveness): the
   // caller owns the clock. busyStartedAt is stamped once, at the submit that
-  // flips busy true; the 1s ticker effect below feeds it a fresh `now` for
-  // as long as busy stays true, and stops the instant it doesn't.
+  // flips busy true; StartingLoader below owns the 1s tick and mounts only
+  // while busy, so no interval runs with nothing on screen reading it.
   const [busyStartedAt, setBusyStartedAt] = useState<number | null>(null);
-  const [now, setNow] = useState(() => Date.now());
   // kata xgk8: true only once evener/launch/resolve has CONFIRMED the hub has
   // no default model for this cwd (Effective.Model resolves empty with no
   // overrides) - never set on a rejection or before cwd is chosen, so an
@@ -467,15 +484,6 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
   }, []);
-
-  // Feeds the busy Loader's elapsed readout a fresh `now` once a second -
-  // only while busy, so the wait for a resolved cwd/model spawn never runs a
-  // timer with nothing on screen reading it.
-  useEffect(() => {
-    if (!busy) return undefined;
-    const id = window.setInterval(() => setNow(Date.now()), 1000);
-    return () => window.clearInterval(id);
-  }, [busy]);
 
   // Pane-level merged catalog for the Effort select's per-model ladder: the
   // same model/list catalog the pickers load on demand. Reloads with the
@@ -1044,7 +1052,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
                   disabled={busy || modelRequired || providerRequired || pluginSelectionBlocked}
                 >
                   {busy ? (
-                    <Loader label="Starting" startedAt={busyStartedAt ?? now} now={now} />
+                    <StartingLoader startedAt={busyStartedAt ?? Date.now()} />
                   ) : (
                     <span className={CLASS.submitLabel}>Start</span>
                   )}


### PR DESCRIPTION
setNow lived at component/pane level so every 1s tick re-rendered whole trees. Now a TreeNowContext provider + memoized rows: only live leaves subscribe. Cadence deliberately UNCHANGED at 1s — both ticks feed true seconds readouts (formatQuietAge '12s', Loader mm:ss), so 3s would visibly coarsen them.

Verification (serial runner): ActivityTree + Spawn suites 114/114 pass.
Risk: med-low. Caveat for reviewers: ActivityTree diff is large (context+memo refactor); watch for memo staleness and the terminal-row now=0 path. No render-count profiler evidence gathered — welcome as review follow-up.