### PR TITLE
perf(img-lazy): lazy-load and async-decode gallery thumbnails

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/ImageGallery.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/ImageGallery.tsx
@@ -144,6 +144,20 @@ export function ImageGallery({ images: supplied, size }: ImageGalleryProps) {
               className={size === "large" ? `${CLASS.thumbImg} ${CLASS.thumbImgLarge}` : CLASS.thumbImg}
               src={image.src}
               alt={altFor(i, total)}
+              // Decode-scheduling only: thumbnails below the fold must not
+              // force the browser to fetch/decode full bytes up front. The
+              // lightbox img below stays eager - opening it is an explicit
+              // user request for the full image. src/onError/data-URI
+              // handling is unchanged.
+              loading="lazy"
+              decoding="async"
+              // Reserve the 96px box before CSS/decode so lazy thumbnails
+              // don't shift layout on load. Only the default cover-crop
+              // thumbnails have a fixed box - size="large" preserves each
+              // image's own aspect ratio (unknown up front), so no attrs
+              // there (React omits undefined attributes).
+              width={size === "large" ? undefined : 96}
+              height={size === "large" ? undefined : 96}
               onError={() => markUnloadable(image.src)}
             />
             {caption !== undefined && (


### PR DESCRIPTION
Gallery decoded full image bytes for every 96px CSS thumbnail. Now loading=lazy + decoding=async + reserved 96px box (no layout shift); lightbox stays eager; src/onError/data-URI handling unchanged. Decode-scheduling only.

Verification (serial runner): ImageGallery + ToolCallItem + UserMessageItem suites 135/135 pass.
Risk: low.