### PR TITLE
perf(ci-workflows): Go cache, retention cap, fewer CI lanes

### DIFF
--- a/.github/actions/setup-toolchain/action.yml
+++ b/.github/actions/setup-toolchain/action.yml
@@ -8,6 +8,11 @@ runs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: go.work
+        cache: true
+        cache-dependency-path: |
+          go.work
+          go.work.sum
+          **/go.sum
 
     - uses: actions/setup-node@v6
       with:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -47,6 +47,10 @@ jobs:
             dist/*.tar.gz
             dist/checksums.txt
           if-no-files-found: error
+          # The snapshot channel is republished to the `snapshot` release on
+          # every green main build; the intermediate artifact is consumed
+          # within minutes, so the 90-day default is pure storage.
+          retention-days: 14
 
   release:
     name: Publish release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,11 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.work
+          cache: true
+          cache-dependency-path: |
+            go.work
+            go.work.sum
+            **/go.sum
 
       - name: Install golangci-lint
         run: |
@@ -76,6 +81,11 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.work
+          cache: true
+          cache-dependency-path: |
+            go.work
+            go.work.sum
+            **/go.sum
 
       - name: Install golangci-lint
         run: |
@@ -93,6 +103,11 @@ jobs:
       - uses: actions/setup-go@v7
         with:
           go-version-file: go.work
+          cache: true
+          cache-dependency-path: |
+            go.work
+            go.work.sum
+            **/go.sum
 
       - name: Install gitleaks
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,25 +73,9 @@ jobs:
       - name: Lint (golangci-lint across all go.work modules)
         run: make lint-golangci
 
-  lint-tagged:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.work
-          cache: true
-          cache-dependency-path: |
-            go.work
-            go.work.sum
-            **/go.sum
-
-      - name: Install golangci-lint
-        run: |
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-          make tools-golangci
-
+      # The tagged compile floors use the same golangci-lint binary, so they
+      # share this lane's install instead of paying a second checkout,
+      # toolchain setup, and `go install` on a parallel runner.
       - name: Lint tagged compile floors (evenerfuzz and eval)
         run: make lint-evenerfuzz lint-eval
 
@@ -121,7 +105,7 @@ jobs:
 
   static:
     if: always()
-    needs: [static-build, lint-golangci, lint-tagged, lint-repository]
+    needs: [static-build, lint-golangci, lint-repository]
     runs-on: ubuntu-latest
     steps:
       - name: Require every static lane

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,6 @@ jobs:
       - name: Vet (GOOS=windows — Unix-only sources must carry a build tag)
         run: GOOS=windows make vet
 
-      - name: Fuzz gap check (every decode/parse package has a target — static, fast)
-        run: make fuzz-gap-check
-
   lint-golangci:
     runs-on: ubuntu-latest
     steps:
@@ -101,11 +98,36 @@ jobs:
       - name: Lint repository structure, generated output, formatting, and secrets
         env:
           EVENER_GITLEAKS_REQUIRED: "1"
-        run: make lint-generated lint-naming lint-gofmt lint-internal lint-fuzz-registry secret-scan
+        run: make lint-generated lint-naming lint-gofmt lint-internal secret-scan
+
+  # Both fuzz consistency checks are fast, static AST analyses over the same
+  # target manifest and registry inputs; running them in one lane pays a
+  # single checkout and toolchain setup instead of two. Each make target runs
+  # its own script directly and fails the lane on its own verdict, so both
+  # gates keep their teeth.
+  fuzz-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.work
+          cache: true
+          cache-dependency-path: |
+            go.work
+            go.work.sum
+            **/go.sum
+
+      - name: Fuzz gap check (every decode/parse package has a target — static, fast)
+        run: make fuzz-gap-check
+
+      - name: Fuzz registry check (manifest matches AST-discovered targets)
+        run: make fuzz-registry-check
 
   static:
     if: always()
-    needs: [static-build, lint-golangci, lint-repository]
+    needs: [static-build, lint-golangci, lint-repository, fuzz-checks]
     runs-on: ubuntu-latest
     steps:
       - name: Require every static lane


### PR DESCRIPTION
Four CI-only commits: (1) Go build/module cache in setup-toolchain + 3 setup-go sites (cache-only, no test semantics); (2) snapshot artifact retention-days:14 (was 90d default); (3) tagged lint floors folded into the golangci lane, one install; (4) fuzz-gap-check + fuzz-registry-check in one fuzz-checks lane, both verdicts kept.

Verification: YAML parses; static.needs references all-defined jobs; all 10 make targets exist. Full CI on this PR is the real gate.

MERGER ACTION REQUIRED: branch protection may pin the deleted lint-tagged job or the moved fuzz-gap/fuzz-registry check names — update required-checks settings or PRs block. No product code touched.