### PR TITLE
perf(build-cache): rebuild linux closure instead of wiping Go cache

### DIFF
--- a/docs/developing-evener/building.md
+++ b/docs/developing-evener/building.md
@@ -65,7 +65,7 @@ the same way the ordinary runtime build does.
 | Command | Summary |
 | --- | --- |
 | `make build-runtime` | The actual recipe `build` runs: builds evener via scripts/ops/build-runtime-pair.sh. |
-| `make build-linux` | Cross-compile evener-linux-amd64 for Linux eval deployments. Starts by running `go clean -cache`, which wipes the whole Go build cache. |
+| `make build-linux` | Cross-compile evener-linux-amd64 for Linux eval deployments, forcing a rebuild of the linux target closure (`go build -a`) so embedded files stay fresh without wiping the shared Go build cache. |
 | `make build-hub` | Alias for build-runtime. |
 | `make build-llmcall` | Build the llmcall standalone CLI binary. |
 | `make build-dev` | Build the evener-dev dev/test infrastructure binary (agent-shards, module-lint, fuzz-harvest, fuzzcov, fuzzregistry, internalcheck, tomlcheck, transcript-v2-upgrade). Not installed for end users; used by make targets and go run ./cmd/evener-dev/bin. |

--- a/make/building.mk
+++ b/make/building.mk
@@ -32,13 +32,14 @@ build: build-runtime
 build-runtime: build-web
 	LDFLAGS="$(LDFLAGS)" scripts/ops/build-runtime-pair.sh
 
-# Cross-compile for Linux (eval deployments). Invalidates the agent package
-# cache to ensure embedded files (templates, sections, agent .md) are fresh.
-## Cross-compile evener-linux-amd64 for Linux eval deployments. Starts by
-## running `go clean -cache`, which wipes the whole Go build cache.
+# Cross-compile for Linux (eval deployments). Rebuilds the linux target
+# closure from source (`go build -a`) so embedded files (templates,
+# sections, agent .md, frontend dist) are re-read from disk and stay fresh.
+## Cross-compile evener-linux-amd64 for Linux eval deployments, forcing a
+## rebuild of the linux target closure (`go build -a`) so embedded files
+## stay fresh without wiping the shared Go build cache.
 build-linux:
-	go clean -cache 2>/dev/null && \
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o evener-linux-amd64 ./cmd/evener/
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags "$(LDFLAGS)" -o evener-linux-amd64 ./cmd/evener/
 
 ## Alias for build-runtime.
 build-hub: build-runtime


### PR DESCRIPTION
build-linux ran go clean -cache (whole cache wipe; every later build/test recompiles from zero) to keep embedded files fresh. Now go build -a for the linux closure: embeds re-read from disk, host-GOOS cache preserved.

Verification: review-only (diff: 7 insertions, 6 deletions, one recipe).
Risk: low. Caveat: -a still recompiles the whole linux closure each run — CPU cost stays; the win is cache preservation. Follow-up candidate: content-hash freshness check instead of -a.