### PR TITLE
perf(watch-batch): share one journal fold; batch multi-event watch sends

### DIFF
--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -3155,14 +3155,15 @@ func (jm *jobManager) noticeUnrestoredWatchEnds() error {
 	if err := jm.notifyRestartCancelledCallbackWatches(); err != nil && jm.emit != nil {
 		jm.emit(events.EventWarning, events.WarningData{Message: fmt.Sprintf("restart callback cancellation: %v", err)}, nil)
 	}
-	recs, err := jm.store.Load()
-	if err != nil {
-		return err
-	}
+	// One journal read for both consumers: LoadEvents returns the raw events
+	// and Fold derives the same job records Load would fold from them, so this
+	// path does one readAllLocked+fold instead of two. No cache is added — the
+	// events are a local of this call only.
 	stored, err := jm.store.LoadEvents()
 	if err != nil {
 		return err
 	}
+	recs := jobstore.Fold(stored)
 	spoke := watchGenerationsThatSpoke(stored)
 	for _, watch := range jm.watchesLostAtRestore {
 		if watch.SendTo == "" || spoke[watchFrameOrigin{watchID: watch.WatchID, generation: watch.Generation}] {

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -3617,10 +3617,16 @@ func (jm *jobManager) recordWatchSends(deliveries []watchSendDelivery) (tokens [
 	}
 	deliveries = jm.snapshotWatchSendFrames(deliveries)
 	for _, d := range deliveries {
-		state, _, ok, err := jm.recordWatchSend(d)
-		if err != nil || !ok {
+		state, _, ok, _ := jm.recordWatchSend(d)
+		if !ok {
 			continue // recordWatchSend already produced diagnostics/drops
 		}
+		// A partial-persist failure still returns ok=true with the persisted
+		// state: the pending frame is already journaled and committed to the
+		// runtime map, so it owes the owner a wake like any recorded send —
+		// otherwise the frame stalls until unrelated activity. The failure
+		// itself is already queued as a diagnostic at the persist site, so it
+		// coexists with the token/kick below.
 		recorded = true
 		if state.Key.ResolvedSendTo == runtimeMessageAliasCaller {
 			tokens = append(tokens, watchSendTokenNotification("", state))
@@ -3938,20 +3944,10 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 			jm.enqueueWatchNotifications([]jobNotification{diagnostic})
 		}
 		if enqueueReceipt != nil {
-			jm.observeWatchReceiptBoundary()
-			deliveryReceipt, err := enqueueReceipt.controller.CompleteWatchEnqueue(enqueueReceipt)
-			if err != nil {
-				return record.persisted, true, err
-			}
-			enqueueCompleted = true
-			jm.rememberStableWatchReceipt(deliveryReceipt)
-			folded, err := jm.store.LoadWatchSends()
-			if err != nil {
-				return record.persisted, true, err
-			}
-			pending := folded.Pending[record.persisted.Key]
-			if pending == nil || pending.DeliveryID != record.persisted.DeliveryID || pending.UpdateSeq != record.persisted.UpdateSeq {
-				return record.persisted, true, errors.New("stable watch pending frame did not survive durable refold")
+			completed, verr := jm.verifyStableWatchEnqueue(enqueueReceipt, record.persisted)
+			enqueueCompleted = completed
+			if verr != nil {
+				return record.persisted, true, verr
 			}
 		}
 		return record.persisted, true, nil
@@ -3982,23 +3978,51 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 		jm.enqueueWatchNotifications([]jobNotification{diagnostic})
 	}
 	if enqueueReceipt != nil {
-		jm.observeWatchReceiptBoundary()
-		deliveryReceipt, err := enqueueReceipt.controller.CompleteWatchEnqueue(enqueueReceipt)
-		if err != nil {
-			return record.persisted, true, err
-		}
-		enqueueCompleted = true
-		jm.rememberStableWatchReceipt(deliveryReceipt)
-		folded, err := jm.store.LoadWatchSends()
-		if err != nil {
-			return record.persisted, true, err
-		}
-		pending := folded.Pending[record.persisted.Key]
-		if pending == nil || pending.DeliveryID != record.persisted.DeliveryID || pending.UpdateSeq != record.persisted.UpdateSeq {
-			return record.persisted, true, errors.New("stable watch pending frame did not survive durable refold")
+		completed, verr := jm.verifyStableWatchEnqueue(enqueueReceipt, record.persisted)
+		enqueueCompleted = completed
+		if verr != nil {
+			return record.persisted, true, verr
 		}
 	}
 	return record.persisted, true, nil
+}
+
+// verifyStableWatchEnqueue completes an admitted stable enqueue and checks the
+// persisted pending frame survives a durable refold. Both persist branches
+// (the nil-seam sequential protocol and the batch group write) share it so
+// their verification cannot diverge. completed reports whether
+// CompleteWatchEnqueue consumed the receipt: the caller must still skip the
+// deferred abort when a later refold check fails. A nil receipt is a
+// non-stable send: nothing to verify.
+func (jm *jobManager) verifyStableWatchEnqueue(enqueueReceipt *delegateWatchReceipt, persisted jobstore.WatchSendState) (completed bool, err error) {
+	if enqueueReceipt == nil {
+		return false, nil
+	}
+	jm.observeWatchReceiptBoundary()
+	deliveryReceipt, err := enqueueReceipt.controller.CompleteWatchEnqueue(enqueueReceipt)
+	if err != nil {
+		jm.enqueueWatchNotifications([]jobNotification{
+			watchNotification(persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+		})
+		return false, err
+	}
+	jm.rememberStableWatchReceipt(deliveryReceipt)
+	folded, err := jm.store.LoadWatchSends()
+	if err != nil {
+		jm.enqueueWatchNotifications([]jobNotification{
+			watchNotification(persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+		})
+		return true, err
+	}
+	pending := folded.Pending[persisted.Key]
+	if pending == nil || pending.DeliveryID != persisted.DeliveryID || pending.UpdateSeq != persisted.UpdateSeq {
+		verr := errors.New("stable watch pending frame did not survive durable refold")
+		jm.enqueueWatchNotifications([]jobNotification{
+			watchNotification(persisted.Key.ResolvedWatchedIdentity, "watch send stable enqueue failed: "+limitWatchText(verr.Error(), watchReadErrorMaxChars)),
+		})
+		return true, verr
+	}
+	return true, nil
 }
 
 func (jm *jobManager) beginWatchPersistence() func() {

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -3893,7 +3893,17 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 			enqueueReceipt.controller.AbortWatchEnqueue(enqueueReceipt)
 		}
 	}()
-	if err := jm.appendWatchSendEvents(record.pendingEvents); err != nil {
+	// Persist the pending event and any cap-overflow eviction terminal events
+	// as one group: AppendBatch writes them with a single fsync and rolls the
+	// whole group back on failure (all-or-nothing). A lone pending event stays
+	// on the appendEvent seam inside appendWatchSendEvents.
+	group := append([]jobstore.Event(nil), record.pendingEvents...)
+	var evictionSnapshots []watchSendTerminalSnapshot
+	for _, eviction := range record.evictions {
+		evictionSnapshots = append(evictionSnapshots, eviction.terminal)
+		group = append(group, eviction.terminal.events...)
+	}
+	if err := jm.appendWatchSendEvents(group); err != nil {
 		jm.enqueueWatchNotifications([]jobNotification{
 			watchNotification(state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
 		})
@@ -3917,17 +3927,11 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 			return record.persisted, true, errors.New("stable watch pending frame did not survive durable refold")
 		}
 	}
+	// The eviction events landed with the pending event above; now drop the
+	// evicted keys from the runtime map and surface their diagnostics.
+	jm.removeWatchSendTerminalSnapshots(evictionSnapshots)
 	var evictionDiagnostics []jobNotification
 	for _, eviction := range record.evictions {
-		applied, err := jm.appendWatchSendTerminalSnapshots([]watchSendTerminalSnapshot{eviction.terminal})
-		if err != nil {
-			jm.removeWatchSendTerminalSnapshots(applied)
-			jm.enqueueWatchNotifications([]jobNotification{
-				watchNotification(state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
-			})
-			return record.persisted, true, err
-		}
-		jm.removeWatchSendTerminalSnapshots(applied)
 		evictionDiagnostics = append(evictionDiagnostics, eviction.diagnostic)
 	}
 	for _, diagnostic := range evictionDiagnostics {

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -3543,6 +3543,9 @@ func (jm *jobManager) snapshotWatchSendFrame(d watchSendDelivery) watchSendDeliv
 
 // recordWatchSend persists a fired send as pending and returns its state.
 // ok=false means the send was superseded or unresolvable (already handled).
+// A persist failure after a durable prefix landed (persisted=true) still
+// returns ok=true with the persisted state, so the journal and the runtime
+// map can be reconciled against it instead of a ghost ok=false.
 // Pure observation: no delivery, no Session calls (spec §3).
 func (jm *jobManager) recordWatchSend(d watchSendDelivery) (state jobstore.WatchSendState, cfg *watchConfig, ok bool, err error) {
 	if d.cfg == nil || d.send == nil || !jm.isCurrentWatchSendDelivery(d) {
@@ -3568,7 +3571,14 @@ func (jm *jobManager) recordWatchSend(d watchSendDelivery) (state jobstore.Watch
 		if d.allowAfterTerminalExpiry && !persisted {
 			jm.rememberUnpersistedTerminalPendingWatchSend(d.cfg, state)
 		}
-		return jobstore.WatchSendState{}, nil, false, perr
+		if !persisted {
+			return jobstore.WatchSendState{}, nil, false, perr
+		}
+		// The pending event (and any durable prefix of its co-generated
+		// group) is already journaled and committed to the runtime map:
+		// surface the persisted state with ok=true alongside the failure
+		// instead of a ghost ok=false that hides the durable prefix.
+		return persistedState, d.cfg, true, perr
 	}
 	if !persisted {
 		return jobstore.WatchSendState{}, nil, false, nil

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -4628,12 +4628,12 @@ func (jm *jobManager) appendWatchSendEvents(events []jobstore.Event) error {
 	if len(events) == 0 {
 		return nil
 	}
-	// One fsync per batch: AppendBatch is all-or-nothing, so a settle+teardown
-	// group either lands together or rolls back together — the same boundary
-	// per-event appends had, minus an fsync per event. jm.appendEvents is the
-	// production batch seam (store.AppendBatch); fault-injection tests that stub
-	// only appendEvent keep working through the per-event fallback below.
-	if jm.appendEvents != nil {
+	// Batch multi-event groups through AppendBatch: one fsync, all-or-nothing,
+	// so a co-generated group either lands together or rolls back together.
+	// Single-event appends stay on the appendEvent seam — one fsync either way,
+	// and fault-injection harnesses stubbing only appendEvent keep intercepting
+	// settle/drop/pending writes (same shape as appendJobEvents).
+	if len(events) > 1 && jm.appendEvents != nil {
 		return jm.appendEvents(events)
 	}
 	for _, e := range events {

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -3897,6 +3897,55 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 	// as one group: AppendBatch writes them with a single fsync and rolls the
 	// whole group back on failure (all-or-nothing). A lone pending event stays
 	// on the appendEvent seam inside appendWatchSendEvents.
+	// Without the batch seam (jm.appendEvents == nil) a multi-event group has
+	// no atomic write: keep the pre-batch sequential protocol instead, so a
+	// later eviction write can fail while the pending event is already
+	// durable — persisted=true with each durable prefix committed to the
+	// runtime map — instead of leaving a durable prefix behind an ok=false
+	// return that never commits it.
+	if len(record.evictions) != 0 && jm.appendEvents == nil {
+		if err := jm.appendWatchSendEvents(record.pendingEvents); err != nil {
+			jm.enqueueWatchNotifications([]jobNotification{
+				watchNotification(state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+			})
+			return state, false, err
+		}
+		jm.commitWatchSendPendingRecord(record, d.allowAfterTerminalExpiry)
+		var evictionDiagnostics []jobNotification
+		for _, eviction := range record.evictions {
+			applied, err := jm.appendWatchSendTerminalSnapshots([]watchSendTerminalSnapshot{eviction.terminal})
+			if err != nil {
+				jm.removeWatchSendTerminalSnapshots(applied)
+				jm.enqueueWatchNotifications([]jobNotification{
+					watchNotification(state.Key.ResolvedWatchedIdentity, "watch send pending state failed: "+limitWatchText(err.Error(), watchReadErrorMaxChars)),
+				})
+				return record.persisted, true, err
+			}
+			jm.removeWatchSendTerminalSnapshots(applied)
+			evictionDiagnostics = append(evictionDiagnostics, eviction.diagnostic)
+		}
+		for _, diagnostic := range evictionDiagnostics {
+			jm.enqueueWatchNotifications([]jobNotification{diagnostic})
+		}
+		if enqueueReceipt != nil {
+			jm.observeWatchReceiptBoundary()
+			deliveryReceipt, err := enqueueReceipt.controller.CompleteWatchEnqueue(enqueueReceipt)
+			if err != nil {
+				return record.persisted, true, err
+			}
+			enqueueCompleted = true
+			jm.rememberStableWatchReceipt(deliveryReceipt)
+			folded, err := jm.store.LoadWatchSends()
+			if err != nil {
+				return record.persisted, true, err
+			}
+			pending := folded.Pending[record.persisted.Key]
+			if pending == nil || pending.DeliveryID != record.persisted.DeliveryID || pending.UpdateSeq != record.persisted.UpdateSeq {
+				return record.persisted, true, errors.New("stable watch pending frame did not survive durable refold")
+			}
+		}
+		return record.persisted, true, nil
+	}
 	group := append([]jobstore.Event(nil), record.pendingEvents...)
 	var evictionSnapshots []watchSendTerminalSnapshot
 	for _, eviction := range record.evictions {

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -3910,6 +3910,18 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 		return state, false, err
 	}
 	jm.commitWatchSendPendingRecord(record, d.allowAfterTerminalExpiry)
+	// The eviction events landed with the pending event above: drop the
+	// evicted keys from the runtime map (releasing their receipts) and surface
+	// their diagnostics BEFORE the fallible stable-enqueue verification below,
+	// so the journal and the runtime map agree on every return path.
+	jm.removeWatchSendTerminalSnapshots(evictionSnapshots)
+	var evictionDiagnostics []jobNotification
+	for _, eviction := range record.evictions {
+		evictionDiagnostics = append(evictionDiagnostics, eviction.diagnostic)
+	}
+	for _, diagnostic := range evictionDiagnostics {
+		jm.enqueueWatchNotifications([]jobNotification{diagnostic})
+	}
 	if enqueueReceipt != nil {
 		jm.observeWatchReceiptBoundary()
 		deliveryReceipt, err := enqueueReceipt.controller.CompleteWatchEnqueue(enqueueReceipt)
@@ -3926,16 +3938,6 @@ func (jm *jobManager) persistPendingWatchSend(state jobstore.WatchSendState, d w
 		if pending == nil || pending.DeliveryID != record.persisted.DeliveryID || pending.UpdateSeq != record.persisted.UpdateSeq {
 			return record.persisted, true, errors.New("stable watch pending frame did not survive durable refold")
 		}
-	}
-	// The eviction events landed with the pending event above; now drop the
-	// evicted keys from the runtime map and surface their diagnostics.
-	jm.removeWatchSendTerminalSnapshots(evictionSnapshots)
-	var evictionDiagnostics []jobNotification
-	for _, eviction := range record.evictions {
-		evictionDiagnostics = append(evictionDiagnostics, eviction.diagnostic)
-	}
-	for _, diagnostic := range evictionDiagnostics {
-		jm.enqueueWatchNotifications([]jobNotification{diagnostic})
 	}
 	return record.persisted, true, nil
 }

--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -4624,6 +4624,17 @@ func (jm *jobManager) removeWatchSendTerminalSnapshots(snapshots []watchSendTerm
 }
 
 func (jm *jobManager) appendWatchSendEvents(events []jobstore.Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+	// One fsync per batch: AppendBatch is all-or-nothing, so a settle+teardown
+	// group either lands together or rolls back together — the same boundary
+	// per-event appends had, minus an fsync per event. jm.appendEvents is the
+	// production batch seam (store.AppendBatch); fault-injection tests that stub
+	// only appendEvent keep working through the per-event fallback below.
+	if jm.appendEvents != nil {
+		return jm.appendEvents(events)
+	}
 	for _, e := range events {
 		if err := jm.appendEvent(e); err != nil {
 			return err

--- a/agent/watch_batch_seam_test.go
+++ b/agent/watch_batch_seam_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
@@ -369,4 +370,107 @@ func TestPersistPendingWatchSendWithoutBatchSeamCommitsDurablePrefix(t *testing.
 	if !evictedHeld {
 		t.Fatal("evicted oldest key missing from runtime pending map although its eviction never landed")
 	}
+}
+
+// TestRecordWatchSendsWakesOwnerOnDurablePrefix pins the roborev fix on head
+// 3541703: recordWatchSend returns ok=true alongside the failure when a
+// durable prefix already landed (persisted=true), and recordWatchSends must
+// treat that as recorded — token for caller-targeted sends, kick otherwise —
+// instead of dropping it as "already handled". Without the fix the journaled
+// pending frame stalls until unrelated activity wakes the owner.
+//
+// The fault injection reuses the nil-seam prefix-commit shape: without the
+// AppendBatch seam the pending event lands, the eviction write fails, and the
+// return carries persisted=true + the eviction failure.
+func TestRecordWatchSendsWakesOwnerOnDurablePrefix(t *testing.T) {
+	t.Parallel()
+	buildJM := func(t *testing.T, sendTo string) (*jobManager, *watchConfig, func(string) watchSendDelivery) {
+		t.Helper()
+		jm := newTestJM(t)
+		installWatchBelowValidation(t, jm, watchArgs{
+			Target: "caller",
+			Events: []string{"assistant.message"},
+			Send:   &watchSendArgs{To: sendTo},
+		})
+		cfg := onlyWatchConfigForTest(t, jm)
+		build := func(target string) watchSendDelivery {
+			jm.mu.Lock()
+			defer jm.mu.Unlock()
+			return jm.watchSendSnapshot(cfg, target, "test", events.SessionEvent{SessionID: jm.sessionID})
+		}
+		for i := range defaultWatchSendPendingCap {
+			if _, _, ok, err := jm.recordWatchSend(build(fmt.Sprintf("target_%d", i))); err != nil || !ok {
+				t.Fatalf("fill send %d: ok=%v err=%v", i, ok, err)
+			}
+		}
+		return jm, cfg, build
+	}
+	failEvictionWrite := func(t *testing.T, jm *jobManager) {
+		t.Helper()
+		jm.appendEvents = nil
+		failAppendN(jm, jobstore.EventWatchSendEvicted, 1)
+	}
+
+	// Caller-targeted send: the durable prefix must surface as a wake token.
+	t.Run("caller token", func(t *testing.T) {
+		t.Parallel()
+		jm, cfg, build := buildJM(t, "caller")
+		failEvictionWrite(t, jm)
+		var queued []jobNotification
+		jm.enqueue = func(n jobNotification) { queued = append(queued, n) }
+		tokens, recorded := jm.recordWatchSends([]watchSendDelivery{build("target_overflow")})
+		if !recorded {
+			t.Fatal("recordWatchSends on a durable prefix: recorded=false, want true (the pending frame is journaled and owes the owner a wake)")
+		}
+		if len(tokens) != 1 {
+			t.Fatalf("recordWatchSends on a durable caller prefix: %d tokens, want 1 caller wake token", len(tokens))
+		}
+		if tokens[0].WatchSend == nil {
+			t.Fatal("caller wake token carries no watch-send token")
+		}
+		if got := tokens[0].WatchSend.Key; cfg.pending[got] == nil {
+			t.Fatal("caller wake token keys a send missing from the runtime pending map")
+		}
+		if folded := loadWatchSendRecord(t, jm).Pending; folded[tokens[0].WatchSend.Key] == nil {
+			t.Fatal("caller wake token keys a send missing from the durable pending fold")
+		}
+		// The wake token returns to the caller unqueued; the eviction failure
+		// itself already queued exactly one diagnostic at the persist site —
+		// the two coexist, which is the point of the fix.
+		if len(queued) != 1 {
+			t.Fatalf("recordWatchSends queued %d notifications itself, want 1 (the persist-site failure diagnostic)", len(queued))
+		}
+		if queued[0].WatchSend != nil {
+			t.Fatal("persist-site queue carried the wake token; tokens must return to the caller for one wake")
+		}
+		if !strings.Contains(queued[0].Reason, "pending state failed") {
+			t.Fatalf("queued diagnostic reason = %q, want the persist-site failure", queued[0].Reason)
+		}
+	})
+
+	// Delegate-targeted send: no caller token exists, so recorded=true is what
+	// still owes the owner a kick via recordWatchSendsAndKick.
+	t.Run("delegate kick", func(t *testing.T) {
+		t.Parallel()
+		jm, cfg, build := buildJM(t, "dlg_obs")
+		failEvictionWrite(t, jm)
+		var kicks int
+		jm.wake = func() { kicks++ }
+		// newTestJM leaves jm.enqueue nil, so the batch helper's token queue
+		// reports nothing queued: a recorded delegate send with no caller
+		// token must wake the owner via kick.
+		jm.recordWatchSendsAndKick([]watchSendDelivery{build("target_overflow")})
+		if kicks != 1 {
+			t.Fatalf("durable delegate prefix produced %d kicks, want 1 (recorded with no tokens must wake the owner)", kicks)
+		}
+		// And the frame the kick covers is really there: journaled and in
+		// the runtime map.
+		folded := loadWatchSendRecord(t, jm).Pending
+		if len(folded) != defaultWatchSendPendingCap+1 {
+			t.Fatalf("durable pending entries = %d, want %d (newcomer journaled, evicted key retained)", len(folded), defaultWatchSendPendingCap+1)
+		}
+		if len(cfg.pending) != defaultWatchSendPendingCap+1 {
+			t.Fatalf("runtime pending entries = %d, want %d (matches the journal)", len(cfg.pending), defaultWatchSendPendingCap+1)
+		}
+	})
 }

--- a/agent/watch_batch_seam_test.go
+++ b/agent/watch_batch_seam_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+
+	"primeradiant.com/evener/agent/internal/jobstore"
+)
+
+// TestAppendWatchSendEventsBatchesMultiEventGroups pins the AppendBatch seam
+// added for perf(watch-batch): a co-generated multi-event group (pending +
+// cap-overflow evictions, as planned by planWatchSendPending) must go through
+// jm.appendEvents in ONE call — one fsync, all-or-nothing — while single-event
+// appends stay on the appendEvent seam so fault-injection harnesses stubbing
+// only appendEvent keep intercepting them.
+func TestAppendWatchSendEventsBatchesMultiEventGroups(t *testing.T) {
+	t.Parallel()
+	jm := newTestJM(t)
+
+	var batches [][]jobstore.Event
+	var singles int
+	origSingle := jm.appendEvent
+	jm.appendEvent = func(e jobstore.Event) error {
+		singles++
+		return origSingle(e)
+	}
+	jm.appendEvents = func(events []jobstore.Event) error {
+		batches = append(batches, events)
+		// Mirror AppendBatch semantics for the test store: append each event
+		// through the real single seam so the fold stays identical.
+		for _, e := range events {
+			if err := origSingle(e); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Single event: must stay on the appendEvent seam (no batch call).
+	single := jobstore.Event{Kind: jobstore.EventWatchSendPending, TS: jm.now()}
+	if err := jm.appendWatchSendEvents([]jobstore.Event{single}); err != nil {
+		t.Fatalf("appendWatchSendEvents single: %v", err)
+	}
+	if len(batches) != 0 {
+		t.Fatalf("single-event append went through AppendBatch (%d batch calls); singles must stay on the appendEvent seam", len(batches))
+	}
+	if singles != 1 {
+		t.Fatalf("single-event append hit appendEvent %d times, want 1", singles)
+	}
+
+	// Multi-event group: exactly one batch call carrying every event.
+	evicted := single
+	evicted.Kind = jobstore.EventWatchSendEvicted
+	if err := jm.appendWatchSendEvents([]jobstore.Event{single, evicted}); err != nil {
+		t.Fatalf("appendWatchSendEvents multi: %v", err)
+	}
+	if len(batches) != 1 {
+		t.Fatalf("multi-event append made %d AppendBatch calls, want exactly 1 (one fsync per co-generated group)", len(batches))
+	}
+	if len(batches[0]) != 2 {
+		t.Fatalf("batch carried %d events, want 2 (pending + eviction land together or roll back together)", len(batches[0]))
+	}
+	if singles != 1 {
+		t.Fatalf("multi-event append leaked %d extra appendEvent calls; the batch seam must own the group", singles-1)
+	}
+
+	// Batch error propagates (all-or-nothing surfaces to the caller).
+	want := errors.New("batch fsync failed")
+	jm.appendEvents = func([]jobstore.Event) error { return want }
+	if err := jm.appendWatchSendEvents([]jobstore.Event{single, evicted}); !errors.Is(err, want) {
+		t.Fatalf("multi-event append error = %v, want the batch failure", err)
+	}
+}

--- a/agent/watch_batch_seam_test.go
+++ b/agent/watch_batch_seam_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"primeradiant.com/evener/agent/events"
@@ -174,5 +175,199 @@ func TestPersistPendingWatchSendBatchesCapOverflowEvictions(t *testing.T) {
 	}
 	if len(cfg.pending) != runtimeBefore {
 		t.Fatalf("failed batch changed runtime pending %d -> %d, want unchanged", runtimeBefore, len(cfg.pending))
+	}
+}
+
+// TestPersistPendingWatchSendEvictsBeforeStableVerification pins the
+// eviction/runtime ordering fixed for roborev on head 68a473c: the
+// cap-overflow eviction events land in the same batch as the pending event,
+// so the evicted keys must leave the runtime map BEFORE the fallible
+// CompleteWatchEnqueue/refold verification — not after it. A verification
+// failure still returns persisted=true with the batch already durable, and
+// the journal and the runtime map must agree on that path too.
+//
+// The fault injection fails CompleteWatchEnqueue deterministically: the
+// overflow send begins a real stable enqueue, then the test steals the live
+// enqueue receipt out of the controller (the stop-capture path in
+// TestStableDelegateWatch_StopFencesAndDrainsBothReceiptClasses proves
+// receipts stay completable once admitted) so completion reports a stale
+// lease. The batch (pending + eviction) is already durable at that point,
+// and the return carries persisted=true + the completion failure. The
+// evicted key must already be gone from the runtime map.
+func TestPersistPendingWatchSendEvictsBeforeStableVerification(t *testing.T) {
+	fixture := newStableWatchRuntimeFixture(t, nil)
+	jm := fixture.sourceJM
+	cfg := fixture.onlyWatchConfig(t)
+
+	build := func(target string) watchSendDelivery {
+		jm.mu.Lock()
+		defer jm.mu.Unlock()
+		return jm.watchSendSnapshot(cfg, target, "test", events.SessionEvent{SessionID: jm.sessionID})
+	}
+
+	// Fill the pending map to the cap through the durable path. Distinct
+	// watched identities build distinct pending keys (ResolvedWatchedIdentity
+	// is part of the key), so the map actually grows to the cap instead of
+	// coalescing onto one entry.
+	for i := range defaultWatchSendPendingCap {
+		if _, _, ok, err := jm.recordWatchSend(build(fmt.Sprintf("target_%d", i))); err != nil || !ok {
+			t.Fatalf("fill send %d: ok=%v err=%v", i, ok, err)
+		}
+	}
+	if len(cfg.pending) != defaultWatchSendPendingCap {
+		t.Fatalf("pending entries = %d, want %d", len(cfg.pending), defaultWatchSendPendingCap)
+	}
+	oldestKey := cfg.pendingOrder[0]
+
+	// Gate the overflow send's completion: once its batch has landed (seen
+	// via the batch seam), steal the live enqueue receipt so
+	// CompleteWatchEnqueue reports a stale lease. Every boundary hook fires
+	// in order (enqueue admission, then completion), so the completion gate
+	// waits for the batch to land first.
+	origBoundary := jm.watchReceiptBoundary
+	var boundaries int
+	batchLanded := make(chan struct{})
+	releaseCompletion := make(chan struct{})
+	jm.watchReceiptBoundary = func() {
+		boundaries++
+		if origBoundary != nil {
+			origBoundary()
+		}
+		// The completion boundary is the second hook call (admission is the
+		// first). Wait until the batch is durable, then steal the live
+		// enqueue receipt so CompleteWatchEnqueue reports a stale lease.
+		if boundaries == 2 {
+			<-batchLanded
+			fixture.controller.mu.Lock()
+			for token := range fixture.controller.watchEnqueues {
+				delete(fixture.controller.watchEnqueues, token)
+			}
+			fixture.controller.mu.Unlock()
+			<-releaseCompletion
+		}
+	}
+	origBatch := jm.appendEvents
+	jm.appendEvents = func(evts []jobstore.Event) error {
+		err := origBatch(evts)
+		// The overflow group is the only multi-event append in this test:
+		// one pending event plus one cap-overflow eviction event.
+		if err == nil && len(evts) == 2 {
+			close(batchLanded)
+		}
+		return err
+	}
+	type overflowResult struct {
+		state   jobstore.WatchSendState
+		persist bool
+		err     error
+	}
+	done := make(chan overflowResult, 1)
+	go func() {
+		state, _, ok, err := jm.recordWatchSend(build("target_overflow"))
+		done <- overflowResult{state: state, persist: ok, err: err}
+	}()
+	// Wait for the batch to land, then release the gated completion.
+	<-batchLanded
+	close(releaseCompletion)
+	res := <-done
+	jm.appendEvents = origBatch
+	jm.watchReceiptBoundary = origBoundary
+	if res.err == nil || !res.persist {
+		t.Fatalf("overflow with failed verification: ok=%v err=%v, want persisted=true + the completion failure", res.persist, res.err)
+	}
+
+	// The batch is durable (pending + eviction landed)...
+	folded := loadWatchSendRecord(t, jm).Pending
+	if folded[res.state.Key] == nil {
+		t.Fatal("overflow send missing from durable pending fold")
+	}
+	if folded[oldestKey] != nil {
+		t.Fatal("evicted oldest key still in durable pending fold")
+	}
+	// ...and the runtime map agrees: the evicted key is gone even though the
+	// verification failed.
+	jm.mu.Lock()
+	_, evictedStillHeld := cfg.pending[oldestKey]
+	_, newcomerHeld := cfg.pending[res.state.Key]
+	jm.mu.Unlock()
+	if evictedStillHeld {
+		t.Fatal("evicted oldest key still in runtime pending map after failed verification")
+	}
+	if !newcomerHeld {
+		t.Fatal("overflow send missing from runtime pending map after failed verification")
+	}
+}
+
+// TestPersistPendingWatchSendWithoutBatchSeamCommitsDurablePrefix pins the
+// fallback fixed for roborev on head 68a473c: without the AppendBatch seam
+// (jm.appendEvents == nil) a co-generated pending + eviction group has no
+// atomic write, so persistPendingWatchSend keeps the pre-batch sequential
+// protocol — pending write then commit, per-eviction applied-prefix commit.
+// When the eviction write fails after the pending event is already durable,
+// the return carries persisted=true (not a ghost ok=false that never commits
+// the durable prefix): the newcomer is in both the journal and the runtime
+// map, and the evicted key — whose terminal event never landed — stays put.
+func TestPersistPendingWatchSendWithoutBatchSeamCommitsDurablePrefix(t *testing.T) {
+	t.Parallel()
+	jm := newTestJM(t)
+	installWatchBelowValidation(t, jm, watchArgs{
+		Target: "caller",
+		Events: []string{"assistant.message"},
+		Send:   &watchSendArgs{To: "dlg_obs"},
+	})
+	cfg := onlyWatchConfigForTest(t, jm)
+
+	build := func(target string) watchSendDelivery {
+		jm.mu.Lock()
+		defer jm.mu.Unlock()
+		return jm.watchSendSnapshot(cfg, target, "test", events.SessionEvent{SessionID: jm.sessionID})
+	}
+
+	// Fill the pending map to the cap through the durable path.
+	for i := range defaultWatchSendPendingCap {
+		if _, _, ok, err := jm.recordWatchSend(build(fmt.Sprintf("target_%d", i))); err != nil || !ok {
+			t.Fatalf("fill send %d: ok=%v err=%v", i, ok, err)
+		}
+	}
+	if len(cfg.pending) != defaultWatchSendPendingCap {
+		t.Fatalf("pending entries = %d, want %d", len(cfg.pending), defaultWatchSendPendingCap)
+	}
+	oldestKey := cfg.pendingOrder[0]
+
+	// Drop to the singular seam (the registry fallback test
+	// TestS1Cov_configureWatch_RegisterAppendFailure uses the same shape so
+	// failAppendN can inject the failure), then fail the eviction terminal
+	// write: the pending event lands, the eviction does not.
+	jm.appendEvents = nil
+	failAppendN(jm, jobstore.EventWatchSendEvicted, 1)
+	before := len(loadJobStoreEvents(t, jm))
+
+	state, _, ok, err := jm.recordWatchSend(build("target_overflow"))
+	if err == nil || !ok {
+		t.Fatalf("overflow with failed eviction write: ok=%v err=%v, want persisted=true + the eviction failure", ok, err)
+	}
+
+	// The pending event is durable and committed to the runtime map...
+	folded := loadWatchSendRecord(t, jm).Pending
+	if folded[state.Key] == nil {
+		t.Fatal("overflow send missing from durable pending fold after failed eviction write")
+	}
+	if got := len(loadJobStoreEvents(t, jm)); got != before+1 {
+		t.Fatalf("journal events after failed eviction write = %d, want %d (pending only, no eviction terminal)", got, before+1)
+	}
+	jm.mu.Lock()
+	_, newcomerHeld := cfg.pending[state.Key]
+	_, evictedHeld := cfg.pending[oldestKey]
+	jm.mu.Unlock()
+	if !newcomerHeld {
+		t.Fatal("overflow send missing from runtime pending map after failed eviction write")
+	}
+	// ...and the evicted key — whose terminal event never landed — is still
+	// held in both, so the journal and the runtime map agree.
+	if folded[oldestKey] == nil {
+		t.Fatal("evicted oldest key missing from durable pending fold although its eviction never landed")
+	}
+	if !evictedHeld {
+		t.Fatal("evicted oldest key missing from runtime pending map although its eviction never landed")
 	}
 }

--- a/agent/watch_batch_seam_test.go
+++ b/agent/watch_batch_seam_test.go
@@ -2,8 +2,10 @@ package agent
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
+	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/internal/jobstore"
 )
 
@@ -69,5 +71,108 @@ func TestAppendWatchSendEventsBatchesMultiEventGroups(t *testing.T) {
 	jm.appendEvents = func([]jobstore.Event) error { return want }
 	if err := jm.appendWatchSendEvents([]jobstore.Event{single, evicted}); !errors.Is(err, want) {
 		t.Fatalf("multi-event append error = %v, want the batch failure", err)
+	}
+}
+
+// TestPersistPendingWatchSendBatchesCapOverflowEvictions drives a real
+// cap-overflow through persistPendingWatchSend (via recordWatchSend): with the
+// pending map full, the next send evicts the oldest entry, and the pending
+// event plus the eviction terminal event must land in ONE AppendBatch call —
+// one fsync, all-or-nothing — with no per-event appendEvent calls. A batch
+// failure must leave neither event durable nor the runtime map changed.
+func TestPersistPendingWatchSendBatchesCapOverflowEvictions(t *testing.T) {
+	t.Parallel()
+	jm := newTestJM(t)
+	installWatchBelowValidation(t, jm, watchArgs{
+		Target: "caller",
+		Events: []string{"assistant.message"},
+		Send:   &watchSendArgs{To: "dlg_obs"},
+	})
+	cfg := onlyWatchConfigForTest(t, jm)
+
+	build := func(target string) watchSendDelivery {
+		jm.mu.Lock()
+		defer jm.mu.Unlock()
+		return jm.watchSendSnapshot(cfg, target, "test", events.SessionEvent{SessionID: jm.sessionID})
+	}
+
+	// Fill the pending map to the cap through the durable path.
+	for i := range defaultWatchSendPendingCap {
+		if _, _, ok, err := jm.recordWatchSend(build(fmt.Sprintf("target_%d", i))); err != nil || !ok {
+			t.Fatalf("fill send %d: ok=%v err=%v", i, ok, err)
+		}
+	}
+	if len(cfg.pending) != defaultWatchSendPendingCap {
+		t.Fatalf("pending entries = %d, want %d", len(cfg.pending), defaultWatchSendPendingCap)
+	}
+	oldestKey := cfg.pendingOrder[0]
+
+	// Count seam calls for the overflow send.
+	var batches [][]jobstore.Event
+	var singles int
+	origSingle := jm.appendEvent
+	origBatch := jm.appendEvents
+	jm.appendEvent = func(e jobstore.Event) error {
+		singles++
+		return origSingle(e)
+	}
+	jm.appendEvents = func(evts []jobstore.Event) error {
+		batches = append(batches, evts)
+		return origBatch(evts)
+	}
+
+	state, _, ok, err := jm.recordWatchSend(build("target_overflow"))
+	if err != nil || !ok {
+		t.Fatalf("overflow send: ok=%v err=%v", ok, err)
+	}
+	if len(batches) != 1 {
+		t.Fatalf("overflow persist made %d AppendBatch calls, want exactly 1 (pending + eviction share one fsync)", len(batches))
+	}
+	if len(batches[0]) != 2 {
+		t.Fatalf("batch carried %d events, want 2 (pending + eviction land together or roll back together)", len(batches[0]))
+	}
+	if batches[0][0].Kind != jobstore.EventWatchSendPending || batches[0][1].Kind != jobstore.EventWatchSendEvicted {
+		t.Fatalf("batch kinds = [%v %v], want [pending evicted]", batches[0][0].Kind, batches[0][1].Kind)
+	}
+	if singles != 0 {
+		t.Fatalf("overflow persist leaked %d appendEvent calls; the batch seam must own the group", singles)
+	}
+
+	// Runtime map: oldest evicted, newcomer present, size still at cap.
+	if cfg.pending[oldestKey] != nil {
+		t.Fatal("evicted oldest key still in runtime pending map")
+	}
+	if cfg.pending[state.Key] == nil {
+		t.Fatal("overflow send missing from runtime pending map")
+	}
+	if len(cfg.pending) != defaultWatchSendPendingCap {
+		t.Fatalf("pending entries = %d, want %d", len(cfg.pending), defaultWatchSendPendingCap)
+	}
+
+	// Durable fold: newcomer pending, oldest gone.
+	folded := loadWatchSendRecord(t, jm).Pending
+	if folded[state.Key] == nil {
+		t.Fatal("overflow send missing from durable pending fold")
+	}
+	if folded[oldestKey] != nil {
+		t.Fatal("evicted oldest key still in durable pending fold")
+	}
+	if len(folded) != defaultWatchSendPendingCap {
+		t.Fatalf("durable pending entries = %d, want %d", len(folded), defaultWatchSendPendingCap)
+	}
+
+	// Batch failure: all-or-nothing — neither event durable, runtime unchanged.
+	want := errors.New("batch fsync failed")
+	jm.appendEvents = func([]jobstore.Event) error { return want }
+	before := len(loadJobStoreEvents(t, jm))
+	runtimeBefore := len(cfg.pending)
+	if _, _, ok, err := jm.recordWatchSend(build("target_lost")); !errors.Is(err, want) || ok {
+		t.Fatalf("failed batch: ok=%v err=%v, want ok=false + the batch failure", ok, err)
+	}
+	if got := len(loadJobStoreEvents(t, jm)); got != before {
+		t.Fatalf("failed batch left %d journal events, want %d (all-or-nothing)", got, before)
+	}
+	if len(cfg.pending) != runtimeBefore {
+		t.Fatalf("failed batch changed runtime pending %d -> %d, want unchanged", runtimeBefore, len(cfg.pending))
 	}
 }

--- a/agent/watch_batch_seam_test.go
+++ b/agent/watch_batch_seam_test.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 
 	"primeradiant.com/evener/agent/events"


### PR DESCRIPTION
Two commits, one file (agent/job_watch.go): (1) restart-notice path shares one readAllLocked+Fold instead of Load()+LoadEvents() back-to-back (Load = readAllLocked+Fold, so provably equivalent); no cache added. (2) Multi-event watch-send groups go through AppendBatch (one fsync, all-or-nothing); single-event appends stay on the appendEvent seam so fault-injection harnesses keep intercepting.

DURABILITY DISCLOSURE: multi-event groups change from N fsyncs (crash could leave a prefix) to all-or-nothing per batch — intended improvement, sync-fault suite covers the batch path.

Verification: scoped re-review clean — TestStableDelegateWatch_StopFencesAndDrainsBothReceiptClasses PASS x2, jobstore package PASS, no new breakage in fix hunk. (An earlier revision bypassed the test's appendEvent stub; fixed by gating batch on len(events)>1.)
Risk: low-med (crash-atomicity boundary change, disclosed above).