### PR TITLE
perf(markdown-stream): throttle live re-parse via paragraphs-only window; share lexer

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.ts
@@ -1,12 +1,13 @@
 // Pure helpers for the reasoning ("think block") item type. See
 // ThinkBlock.tsx for the component that consumes these.
 
-import { Marked, type Token, type Tokens } from "marked";
+import { type Token, type Tokens } from "marked";
+import { markdownLexer } from "../../../../widgets/markdown";
 import { pendingTextJoined } from "../../../../protocol/reducer";
 
-// Reuse the app's existing Markdown tokenizer so nested links, block prefixes,
-// and emphasis are handled as syntax rather than accumulated regex cases.
-const markdownLexer = new Marked({ gfm: true });
+// Lexer-only use of the app's shared Markdown tokenizer (see
+// widgets/markdown/index.tsx) so nested links, block prefixes, and emphasis
+// are handled as syntax rather than accumulated regex cases.
 
 const ISO_TIMESTAMP = /^(\d{4}|[+-]\d{6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.ts
@@ -1,9 +1,9 @@
 // Pure helpers for the reasoning ("think block") item type. See
 // ThinkBlock.tsx for the component that consumes these.
 
-import { type Token, type Tokens } from "marked";
-import { markdownLexer } from "../../../../widgets/markdown";
+import type { Token, Tokens } from "marked";
 import { pendingTextJoined } from "../../../../protocol/reducer";
+import { markdownLexer } from "../../../../widgets/markdown";
 
 // Lexer-only use of the app's shared Markdown tokenizer (see
 // widgets/markdown/index.tsx) so nested links, block prefixes, and emphasis

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/reasoningFormat.ts
@@ -3,10 +3,10 @@
 
 import type { Token, Tokens } from "marked";
 import { pendingTextJoined } from "../../../../protocol/reducer";
-import { markdownLexer } from "../../../../widgets/markdown";
+import { markdownLexer } from "../../../../widgets/markdown/lexer";
 
 // Lexer-only use of the app's shared Markdown tokenizer (see
-// widgets/markdown/index.tsx) so nested links, block prefixes, and emphasis
+// widgets/markdown/lexer.ts) so nested links, block prefixes, and emphasis
 // are handled as syntax rather than accumulated regex cases.
 
 const ISO_TIMESTAMP = /^(\d{4}|[+-]\d{6})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:\d{2})$/;

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -247,21 +247,29 @@ function containsLinkDefinition(source: string): boolean {
 }
 
 function tokensContainDef(tokens: Token[]): boolean {
-  for (const token of tokens) {
-    if (token.type === "def") return true;
-    if ("tokens" in token && tokensContainDef(token.tokens ?? [])) return true;
-    if ("items" in token) {
-      for (const item of token.items) {
-        if (tokensContainDef(item.tokens)) return true;
+  // Any unexpected shape (malformed tokens, a future marked token type with
+  // unguarded nesting) fails closed to the full parse: a missed `def` would
+  // resolve differently under the windowed halves, while a spurious fallback
+  // is exactly today's behavior.
+  try {
+    for (const token of tokens) {
+      if (token.type === "def") return true;
+      if ("tokens" in token && tokensContainDef(token.tokens ?? [])) return true;
+      if ("items" in token) {
+        for (const item of token.items ?? []) {
+          if (tokensContainDef(item?.tokens ?? [])) return true;
+        }
+      }
+      if (token.type === "table") {
+        for (const cell of [...(token.header ?? []), ...(token.rows ?? []).flat()]) {
+          if (tokensContainDef(cell?.tokens ?? [])) return true;
+        }
       }
     }
-    if (token.type === "table") {
-      for (const cell of [...token.header, ...token.rows.flat()]) {
-        if (tokensContainDef(cell.tokens)) return true;
-      }
-    }
+    return false;
+  } catch {
+    return true;
   }
-  return false;
 }
 
 // The head-side gate verdicts cached per exact head text: every one of them

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -1,5 +1,5 @@
 import DOMPurify from "dompurify";
-import { Marked, type RendererObject, type Tokens } from "marked";
+import { Marked, type RendererObject, type Token, type Tokens } from "marked";
 import { useMemo, useRef } from "react";
 import codeblockStyles from "../codeblock/codeblock.module.css";
 import { requireClass } from "../internal/requireClass";
@@ -200,6 +200,10 @@ const TAIL_BLOCK_MARKER =
 // leave the tail's `[label]` use literal under the windowed parse. Verified
 // against the shared lexer: top-level, blockquote-nested, and list-nested
 // definitions all trip this pattern while definition-free heads do not.
+// Shapes the pattern cannot cover (an escaped label like `[foo\]bar]: /url`
+// has no `[...]:` span for it to match; a definition indented as a list-item
+// continuation sits past its 0-3-space allowance) are caught by the
+// shared-lexer check in the gate below instead.
 const HEAD_SPLIT_HAZARD =
   /^(?: {0,3}>[ \t]?)+ {0,3}\[[^\]\n]+\]:|^ {0,3}(?: {0,3}>[ \t]?)* {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+.*\[[^\]\n]+\]:|^ {0,3}\[[^\]\n]+\]:|^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*\r?$/m;
 
@@ -226,6 +230,56 @@ function splitLiveSource(source: string): { head: string; tail: string } | null 
   while (source.charAt(tailStart) === "\n") tailStart += 1;
   if (tailStart >= source.length) return null;
   return { head: source.slice(0, blank + 2), tail: source.slice(tailStart) };
+}
+
+// Exact link-definition detection through the shared lexer: a definition on
+// either side of the split registers globally with marked and resolves
+// `[label]` uses anywhere in the whole - including across the split - that a
+// standalone tail parse would leave literal, so any `def` token, top level
+// or nested in a blockquote/list/table, falls back to the full parse. A
+// lexer failure fails closed to the full parse as well.
+function containsLinkDefinition(source: string): boolean {
+  let tokens: Token[];
+  try {
+    tokens = markdownLexer.lexer(source);
+  } catch {
+    return true;
+  }
+  return tokensContainDef(tokens);
+}
+
+function tokensContainDef(tokens: Token[]): boolean {
+  for (const token of tokens) {
+    if (token.type === "def") return true;
+    if ("tokens" in token && tokensContainDef(token.tokens ?? [])) return true;
+    if ("items" in token) {
+      for (const item of token.items) {
+        if (tokensContainDef(item.tokens)) return true;
+      }
+    }
+    if (token.type === "table") {
+      for (const cell of [...token.header, ...token.rows.flat()]) {
+        if (tokensContainDef(cell.tokens)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+// The head-side lexer check cached per exact head text: re-lexing the head
+// on every live render would reintroduce the O(n^2) the head HTML cache
+// exists to avoid, so a head that lexes clean stays clean-keyed until its
+// text changes. (The tail is window-bounded, so it lexes per render with no
+// cache.)
+function headHasLinkDefinition(
+  head: string,
+  cache: { current: { headSource: string; headHasDef: boolean } | null },
+): boolean {
+  const hit = cache.current;
+  if (hit !== null && hit.headSource === head) return hit.headHasDef;
+  const headHasDef = containsLinkDefinition(head);
+  cache.current = { headSource: head, headHasDef };
+  return headHasDef;
 }
 
 // The tail's first non-blank line, when indented, could still belong to a
@@ -263,6 +317,9 @@ export function Markdown({ source, live = false }: MarkdownProps) {
   // always take the settled full-parse path unchanged, so the final HTML is
   // byte-identical with or without this throttle.
   const headCacheRef = useRef<{ headSource: string; headHtml: string } | null>(null);
+  // Backs headHasLinkDefinition below - same cache discipline as headCacheRef:
+  // keyed on the head's own exact text, never stale, misses re-lex once.
+  const headDefCacheRef = useRef<{ headSource: string; headHasDef: boolean } | null>(null);
   const html = useMemo(() => {
     if (!live || source.length <= LIVE_WINDOWED_MIN_LENGTH) {
       const rawHtml = md.parse(live ? closeOpenMarkdown(source) : source, { async: false });
@@ -288,6 +345,8 @@ export function Markdown({ source, live = false }: MarkdownProps) {
       split === null ||
       closeOpenMarkdown(split.head) !== split.head ||
       HEAD_SPLIT_HAZARD.test(split.head) ||
+      headHasLinkDefinition(split.head, headDefCacheRef) ||
+      containsLinkDefinition(split.tail) ||
       HTML_BLOCK_START.test(split.head) ||
       HTML_BLOCK_END.test(split.tail) ||
       TAIL_BLOCK_MARKER.test(split.tail) ||

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -350,30 +350,36 @@ export function Markdown({ source, live = false }: MarkdownProps) {
       return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);
     }
     // The windowed path is sound only when NOTHING spans the split. Its
-    // keystone is whole-source balance: closeOpenMarkdown is identity exactly
-    // when the live input has no construct left open, so no fence, code span,
-    // or emphasis can still be awaiting its closer in the tail - had one been
-    // severed, the whole would not be identity. The head must be closed at
-    // the boundary too (a fence opened in the head and closed in the tail is
-    // whole-balanced but still spans the split - the tail's fence run trips
-    // TAIL_BLOCK_MARKER for that shape, and this check backstops it). The
-    // only cross-boundary structure a balanced whole can otherwise carry is
-    // forward references (link definitions, table delimiters) and blank-line-
-    // spanning HTML blocks, excluded by HEAD_SPLIT_HAZARD and the HTML gates;
-    // the tail must be paragraphs-only on fresh content (TAIL_BLOCK_MARKER,
-    // tailStartsIndented). Anything else takes the full-parse fallback, which
-    // is exactly the pre-throttle behavior for every input. The tail keeps
-    // the full block parse - never an inline-only one. Head-side verdicts come
-    // from the per-head cache above, so a settled head pays its scans once per
-    // distinct head text; the residual per-render cost is the whole-source
-    // balance scan, the window-bounded tail scans/lexes (TAIL_BLOCK_MARKER,
-    // tailStartsIndented, tail lexer, HTML_BLOCK_END), and the tail re-parse -
-    // all O(tail), plus the whole-source re-parse on fallback.
+    // keystone is whole-source balance, derived WITHOUT re-walking the whole
+    // source: the split sits on a blank line, and closeOpenMarkdown resets
+    // every non-fence state (emphasis, code spans) at blank lines, while a
+    // fence left open at the boundary would leave the head itself unbalanced -
+    // so given a balanced head, the whole is balanced exactly when the tail
+    // scanned standalone is balanced. The head must be closed at the boundary
+    // too (a fence opened in the head and closed in the tail is
+    // whole-balanced but still spans the split - the head-balance arm
+    // backstops that shape, and the tail's fence run trips TAIL_BLOCK_MARKER
+    // for it as well). The only cross-boundary structure a balanced whole can
+    // otherwise carry is forward references (link definitions, table
+    // delimiters) and blank-line-spanning HTML blocks, excluded by
+    // HEAD_SPLIT_HAZARD and the HTML gates; the tail must be paragraphs-only
+    // on fresh content (TAIL_BLOCK_MARKER, tailStartsIndented). Anything else
+    // takes the full-parse fallback, which is exactly the pre-throttle
+    // behavior for every input. The tail keeps the full block parse - never
+    // an inline-only one. Head-side verdicts come from the per-head cache
+    // above, so a settled head pays its scans once per distinct head text;
+    // the residual per-render cost on the engaged path is the window-bounded
+    // tail scans/lexes/close (TAIL_BLOCK_MARKER, tailStartsIndented, tail
+    // lexer, HTML_BLOCK_END, tail balance) and the tail re-parse - all
+    // O(tail) - plus the whole-source re-parse on fallback. closedTail is
+    // hoisted so the gate's balance arm and the tail parse share one scan.
     const split = splitLiveSource(source);
     const headVerdict = split === null ? null : headGateVerdict(split.head, headGateCacheRef);
+    const closedTail = split === null ? null : closeOpenMarkdown(split.tail);
     if (
       split === null ||
       headVerdict === null ||
+      closedTail === null ||
       !headVerdict.balanced ||
       headVerdict.hazard ||
       headVerdict.hasDef ||
@@ -382,7 +388,7 @@ export function Markdown({ source, live = false }: MarkdownProps) {
       HTML_BLOCK_END.test(split.tail) ||
       TAIL_BLOCK_MARKER.test(split.tail) ||
       tailStartsIndented(split.tail) ||
-      closeOpenMarkdown(source) !== source
+      closedTail !== split.tail
     ) {
       const rawHtml = md.parse(closeOpenMarkdown(source), { async: false });
       return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);
@@ -395,7 +401,7 @@ export function Markdown({ source, live = false }: MarkdownProps) {
     if (cached === null || cached.headSource !== split.head) {
       headCacheRef.current = { headSource: split.head, headHtml };
     }
-    const tailHtml = DOMPurify.sanitize(md.parse(closeOpenMarkdown(split.tail), { async: false }), SANITIZE_CONFIG);
+    const tailHtml = DOMPurify.sanitize(md.parse(closedTail, { async: false }), SANITIZE_CONFIG);
     return headHtml + tailHtml;
   }, [source, live]);
 

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -219,12 +219,16 @@ const HTML_BLOCK_END = /<\/(?:pre|script|style|textarea)>|-->|\?>|\]\]>/i;
 
 // Splits a long live source into a settled head (ending on a blank line) and
 // the streaming tail after it, or null when there is no blank-line boundary
-// in range (one very long paragraph still streaming). Leading blank lines of
-// the tail are skipped - insignificant in both paths; a tail of nothing but
-// blanks likewise declines the windowed path.
+// whose tail is at most LIVE_TAIL_WINDOW (one very long paragraph still
+// streaming). The boundary is the FIRST at/after the window edge, so the tail
+// holds at most the window - taking the last boundary at/before the edge
+// instead would accept a tail holding the entire remainder of a long
+// paragraph. Leading blank lines of the tail are skipped - insignificant in
+// both paths; a tail of nothing but blanks likewise declines the windowed
+// path.
 function splitLiveSource(source: string): { head: string; tail: string } | null {
   const edge = source.length - LIVE_TAIL_WINDOW;
-  const blank = source.lastIndexOf("\n\n", edge);
+  const blank = source.indexOf("\n\n", edge);
   if (blank === -1) return null;
   let tailStart = blank + 2;
   while (source.charAt(tailStart) === "\n") tailStart += 1;

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -217,17 +217,21 @@ const HTML_BLOCK_END = /<\/(?:pre|script|style|textarea)>|-->|\?>|\]\]>/i;
 // streaming). The boundary is the FIRST at/after the window edge, so the tail
 // holds at most the window - taking the last boundary at/before the edge
 // instead would accept a tail holding the entire remainder of a long
-// paragraph. Leading blank lines of the tail are skipped - insignificant in
-// both paths; a tail of nothing but blanks likewise declines the windowed
-// path.
+// paragraph. CRLF sources carry no "\n\n" span (a \r sits between the \n
+// pair), so both line endings are searched and the earliest boundary wins.
+// Leading blank lines of the tail are skipped - insignificant in both paths;
+// a tail of nothing but blanks likewise declines the windowed path.
 function splitLiveSource(source: string): { head: string; tail: string } | null {
   const edge = source.length - LIVE_TAIL_WINDOW;
-  const blank = source.indexOf("\n\n", edge);
+  const lf = source.indexOf("\n\n", edge);
+  const crlf = source.indexOf("\r\n\r\n", edge);
+  const blank = lf === -1 ? crlf : crlf === -1 ? lf : Math.min(lf, crlf);
   if (blank === -1) return null;
-  let tailStart = blank + 2;
-  while (source.charAt(tailStart) === "\n") tailStart += 1;
+  const separator = source.startsWith("\r\n\r\n", blank) ? 4 : 2;
+  let tailStart = blank + separator;
+  while (source.charAt(tailStart) === "\n" || source.charAt(tailStart) === "\r") tailStart += 1;
   if (tailStart >= source.length) return null;
-  return { head: source.slice(0, blank + 2), tail: source.slice(tailStart) };
+  return { head: source.slice(0, blank + separator), tail: source.slice(tailStart) };
 }
 
 // Exact link-definition detection through the shared lexer: a definition on

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -189,13 +189,19 @@ const LIVE_TAIL_WINDOW = 1000;
 // no other CommonMark block spans a blank line, and raw HTML needs no gate -
 // the html() override escapes it to text identically in both paths.
 const TAIL_BLOCK_MARKER =
-  /^ {0,3}#{1,6}(?:[ \t]+|\r?$)|^ {0,3}(?:=+|-+)[ \t]*\r?$|^ {0,3}(?:[-+*](?:[ \t]+|\r?$)|\d{1,9}[.)](?:[ \t]+|\r?$))|^ {0,3}(`{3,}|~{3,})|^ {0,3}>|^ {0,3}(?:\*[ \t]*){3,}\r?$|^ {0,3}(?:-[ \t]*){3,}\r?$|^ {0,3}(?:_[ \t]*){3,}\r?$|^\s*\||^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*\r?$|^ {0,3}\[[^\]\n]+\]:/m;
+  /^ {0,3}#{1,6}(?:[ \t]+|\r?$)|^ {0,3}(?:=+|-+)[ \t]*\r?$|^ {0,3}(?:[-+*](?:[ \t]+|\r?$)|\d{1,9}[.)](?:[ \t]+|\r?$))|^ {0,3}(`{3,}|~{3,})|^ {0,3}>|^ {0,3}(?:\*[ \t]*){3,}\r?$|^ {0,3}(?:-[ \t]*){3,}\r?$|^ {0,3}(?:_[ \t]*){3,}\r?$|^\s*\||^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*\r?$|^ {0,3}\[[^\]\n]+\]:|<!\[CDATA\[|\]\]>/m;
 
 // Head-side hazards for the split: a link definition or table delimiter row
 // in the head can resolve structure in the tail (a `[label]` use, table
 // rows) that a standalone tail parse would leave literal, so any hit falls
-// back to the full parse.
-const HEAD_SPLIT_HAZARD = /^ {0,3}\[[^\]\n]+\]:|^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*\r?$/m;
+// back to the full parse. The link-definition arm also matches `>`-quoted
+// and list-item-nested definitions (valid anywhere a block can nest, and
+// registered globally by marked): without it a head-side definition would
+// leave the tail's `[label]` use literal under the windowed parse. Verified
+// against the shared lexer: top-level, blockquote-nested, and list-nested
+// definitions all trip this pattern while definition-free heads do not.
+const HEAD_SPLIT_HAZARD =
+  /^(?: {0,3}>[ \t]?)+ {0,3}\[[^\]\n]+\]:|^ {0,3}(?: {0,3}>[ \t]?)* {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+.*\[[^\]\n]+\]:|^ {0,3}\[[^\]\n]+\]:|^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*\r?$/m;
 
 // HTML blocks (CommonMark types 1-6: pre/script/style/textarea, comments,
 // processing instructions, declarations, CDATA, block tags) run past blank
@@ -204,8 +210,8 @@ const HEAD_SPLIT_HAZARD = /^ {0,3}\[[^\]\n]+\]:|^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*
 // the head, or a block ender in the tail (whose opener may sit anywhere
 // upstream, including before the head), falls back to the full parse.
 const HTML_BLOCK_START =
-  /^ {0,3}(?:<(?:pre|script|style|textarea)(?:[\s>]|$)|<!--|<\?|<![A-Za-z]|\[CDATA\[|<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:[\s>\/]|$))/im;
-const HTML_BLOCK_END = /<\/(?:pre|script|style|textarea)>|-->|\?>/i;
+  /^ {0,3}(?:<(?:pre|script|style|textarea)(?:[\s>]|$)|<!--|<\?|<![A-Za-z]|<!\[CDATA\[|<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:[\s>/]|$))/im;
+const HTML_BLOCK_END = /<\/(?:pre|script|style|textarea)>|-->|\?>|\]\]>/i;
 
 // Splits a long live source into a settled head (ending on a blank line) and
 // the streaming tail after it, or null when there is no blank-line boundary

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -270,20 +270,34 @@ function tokensContainDef(tokens: Token[]): boolean {
   return false;
 }
 
-// The head-side lexer check cached per exact head text: re-lexing the head
-// on every live render would reintroduce the O(n^2) the head HTML cache
-// exists to avoid, so a head that lexes clean stays clean-keyed until its
-// text changes. (The tail is window-bounded, so it lexes per render with no
-// cache.)
-function headHasLinkDefinition(
-  head: string,
-  cache: { current: { headSource: string; headHasDef: boolean } | null },
-): boolean {
+// The head-side gate verdicts cached per exact head text: every one of them
+// (balance scan, hazard patterns, shared-lexer definition check) is a pure
+// function of the head string, so a verdict computed for a head stays valid
+// until the head text itself changes. Re-running them on every live render
+// would reintroduce the O(n^2) the head HTML cache exists to avoid. (The
+// tail is window-bounded, so it lexes/scans per render with no cache.)
+interface HeadGateVerdict {
+  headSource: string;
+  balanced: boolean;
+  hazard: boolean;
+  htmlStart: boolean;
+  hasDef: boolean;
+}
+
+function headGateVerdict(head: string, cache: { current: HeadGateVerdict | null }): HeadGateVerdict {
   const hit = cache.current;
-  if (hit !== null && hit.headSource === head) return hit.headHasDef;
-  const headHasDef = containsLinkDefinition(head);
-  cache.current = { headSource: head, headHasDef };
-  return headHasDef;
+  if (hit !== null && hit.headSource === head) return hit;
+  // The regex gates below carry no /g flag, so .test is stateless and the
+  // cached verdict cannot depend on lastIndex carryover.
+  const verdict: HeadGateVerdict = {
+    headSource: head,
+    balanced: closeOpenMarkdown(head) === head,
+    hazard: HEAD_SPLIT_HAZARD.test(head),
+    htmlStart: HTML_BLOCK_START.test(head),
+    hasDef: containsLinkDefinition(head),
+  };
+  cache.current = verdict;
+  return verdict;
 }
 
 // The tail's first non-blank line, when indented, could still belong to a
@@ -321,9 +335,9 @@ export function Markdown({ source, live = false }: MarkdownProps) {
   // always take the settled full-parse path unchanged, so the final HTML is
   // byte-identical with or without this throttle.
   const headCacheRef = useRef<{ headSource: string; headHtml: string } | null>(null);
-  // Backs headHasLinkDefinition below - same cache discipline as headCacheRef:
-  // keyed on the head's own exact text, never stale, misses re-lex once.
-  const headDefCacheRef = useRef<{ headSource: string; headHasDef: boolean } | null>(null);
+  // Backs headGateVerdict below - same cache discipline as headCacheRef:
+  // keyed on the head's own exact text, never stale, misses evaluate once.
+  const headGateCacheRef = useRef<HeadGateVerdict | null>(null);
   const html = useMemo(() => {
     if (!live || source.length <= LIVE_WINDOWED_MIN_LENGTH) {
       const rawHtml = md.parse(live ? closeOpenMarkdown(source) : source, { async: false });
@@ -343,15 +357,22 @@ export function Markdown({ source, live = false }: MarkdownProps) {
     // the tail must be paragraphs-only on fresh content (TAIL_BLOCK_MARKER,
     // tailStartsIndented). Anything else takes the full-parse fallback, which
     // is exactly the pre-throttle behavior for every input. The tail keeps
-    // the full block parse - never an inline-only one.
+    // the full block parse - never an inline-only one. Head-side verdicts come
+    // from the per-head cache above, so a settled head pays its scans once per
+    // distinct head text; the residual per-render cost is the whole-source
+    // balance scan, the window-bounded tail scans/lexes (TAIL_BLOCK_MARKER,
+    // tailStartsIndented, tail lexer, HTML_BLOCK_END), and the tail re-parse -
+    // all O(tail), plus the whole-source re-parse on fallback.
     const split = splitLiveSource(source);
+    const headVerdict = split === null ? null : headGateVerdict(split.head, headGateCacheRef);
     if (
       split === null ||
-      closeOpenMarkdown(split.head) !== split.head ||
-      HEAD_SPLIT_HAZARD.test(split.head) ||
-      headHasLinkDefinition(split.head, headDefCacheRef) ||
+      headVerdict === null ||
+      !headVerdict.balanced ||
+      headVerdict.hazard ||
+      headVerdict.hasDef ||
       containsLinkDefinition(split.tail) ||
-      HTML_BLOCK_START.test(split.head) ||
+      headVerdict.htmlStart ||
       HTML_BLOCK_END.test(split.tail) ||
       TAIL_BLOCK_MARKER.test(split.tail) ||
       tailStartsIndented(split.tail) ||

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -171,22 +171,58 @@ const SANITIZE_CONFIG = {
 // it); past it, only the tail window is re-parsed per render while the
 // settled head is served from a prefix-keyed cache. Grown past the window
 // mid-stream, the head cache fills once per new head text and then hits.
+// Any stream whose tail carries block structure falls back to the full parse
+// (slower, exactly today's behavior - correctness first); only a
+// paragraphs-only tail takes the windowed path.
 const LIVE_WINDOWED_MIN_LENGTH = 2000;
 // The tail window re-parsed on every live render past the threshold above -
-// sized to cover the in-progress block (a long paragraph, a fenced code
-// block still being written) without re-parsing the whole document.
+// sized to cover the in-progress paragraph still being written without
+// re-parsing the whole document.
 const LIVE_TAIL_WINDOW = 1000;
 
-// Finds the split point for the windowed live path: the last blank-line
-// boundary at or before `source.length - LIVE_TAIL_WINDOW`, so the head ends
-// on a settled block edge and the tail starts a fresh block. Falls back to a
-// hard cut at the window edge when the tail window holds no blank line (one
-// very long paragraph still streaming) - the tail's inline-scope parse below
-// makes that safe.
-function findWindowBoundary(source: string): number {
+// Block constructs that can tokenize differently as a standalone document
+// than as the tail of a larger one, so the windowed live path below must not
+// engage while the tail window contains them: a list continues over blank
+// lines (one list vs two changes the HTML), a fenced block or table can span
+// the split point, and a link definition resolves references anywhere. Any
+// hit falls back to the full parse. Paragraph-only tails are the sound case:
+// no other CommonMark block spans a blank line, and raw HTML needs no gate -
+// the html() override escapes it to text identically in both paths.
+const TAIL_BLOCK_MARKER =
+  /^ {0,3}#{1,6}(?:[ \t]+|\r?$)|^ {0,3}(?:=+|-+)[ \t]*\r?$|^ {0,3}(?:[-+*](?:[ \t]+|\r?$)|\d{1,9}[.)](?:[ \t]+|\r?$))|^ {0,3}(`{3,}|~{3,})|^ {0,3}>|^ {0,3}(?:\*[ \t]*){3,}\r?$|^ {0,3}(?:-[ \t]*){3,}\r?$|^ {0,3}(?:_[ \t]*){3,}\r?$|^\s*\||^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*\r?$|^ {0,3}\[[^\]\n]+\]:/m;
+
+// Head-side hazards for the split: a link definition or table delimiter row
+// in the head can resolve structure in the tail (a `[label]` use, table
+// rows) that a standalone tail parse would leave literal, so any hit falls
+// back to the full parse.
+const HEAD_SPLIT_HAZARD = /^ {0,3}\[[^\]\n]+\]:|^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*\r?$/m;
+
+// Splits a long live source into a settled head (ending on a blank line) and
+// the streaming tail after it, or null when there is no blank-line boundary
+// in range (one very long paragraph still streaming). Leading blank lines of
+// the tail are skipped - insignificant in both paths; a tail of nothing but
+// blanks likewise declines the windowed path.
+function splitLiveSource(source: string): { head: string; tail: string } | null {
   const edge = source.length - LIVE_TAIL_WINDOW;
-  const boundary = source.lastIndexOf("\n\n", edge);
-  return boundary === -1 ? edge : boundary + 2;
+  const blank = source.lastIndexOf("\n\n", edge);
+  if (blank === -1) return null;
+  let tailStart = blank + 2;
+  while (source.charAt(tailStart) === "\n") tailStart += 1;
+  if (tailStart >= source.length) return null;
+  return { head: source.slice(0, blank + 2), tail: source.slice(tailStart) };
+}
+
+// The tail's first non-blank line, when indented, could still belong to a
+// list item open in the head (indented continuation joins it across the
+// blank line), so it declines the windowed path. Non-indented content can
+// never rejoin a head block across a blank line.
+function tailStartsIndented(tail: string): boolean {
+  const lines = tail.split("\n");
+  for (const line of lines) {
+    if (line.trim() === "") continue;
+    return line.charAt(0) === " " || line.charAt(0) === "\t";
+  }
+  return false;
 }
 
 /**
@@ -204,35 +240,45 @@ export function Markdown({ source, live = false }: MarkdownProps) {
   // window above, the settled head is served from a cache keyed on its own
   // exact prefix text (a changed head is a cache miss and re-parses, never
   // stale output), while only the tail window is re-parsed per render with
-  // the live auto-close, so formatting still previews while streaming.
-  // Settled renders (live=false) always take the full-parse path below
-  // unchanged, so the final HTML is byte-identical with or without this
-  // throttle.
+  // the live auto-close, so formatting still previews while streaming. The
+  // windowed path engages ONLY when the split is sound (see the gates
+  // below); anything else takes the full-parse fallback, which is exactly
+  // the pre-throttle behavior for every input. Settled renders (live=false)
+  // always take the settled full-parse path unchanged, so the final HTML is
+  // byte-identical with or without this throttle.
   const headCacheRef = useRef<{ headSource: string; headHtml: string } | null>(null);
   const html = useMemo(() => {
     if (!live || source.length <= LIVE_WINDOWED_MIN_LENGTH) {
       const rawHtml = md.parse(live ? closeOpenMarkdown(source) : source, { async: false });
       return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);
     }
-    const boundary = findWindowBoundary(source);
-    const headSource = source.slice(0, boundary);
-    const tailSource = source.slice(boundary);
+    // The head must be closed at the boundary (no fence, code span, or
+    // emphasis left open - closeOpenMarkdown is identity exactly then), the
+    // head must hold no forward-reference hazards, and the tail must be
+    // paragraphs-only starting on fresh (non-indented) content. The tail
+    // keeps the full block parse - never an inline-only one - so headings,
+    // lists, and fences inside it render their real structure; but the gates
+    // above mean a tail carrying any of those never reaches this path.
+    const split = splitLiveSource(source);
+    if (
+      split === null ||
+      closeOpenMarkdown(split.head) !== split.head ||
+      HEAD_SPLIT_HAZARD.test(split.head) ||
+      TAIL_BLOCK_MARKER.test(split.tail) ||
+      tailStartsIndented(split.tail)
+    ) {
+      const rawHtml = md.parse(closeOpenMarkdown(source), { async: false });
+      return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);
+    }
     const cached = headCacheRef.current;
     const headHtml =
-      cached !== null && cached.headSource === headSource
+      cached !== null && cached.headSource === split.head
         ? cached.headHtml
-        : DOMPurify.sanitize(md.parse(headSource, { async: false }), SANITIZE_CONFIG);
-    if (cached === null || cached.headSource !== headSource) {
-      headCacheRef.current = { headSource, headHtml };
+        : DOMPurify.sanitize(md.parse(split.head, { async: false }), SANITIZE_CONFIG);
+    if (cached === null || cached.headSource !== split.head) {
+      headCacheRef.current = { headSource: split.head, headHtml };
     }
-    // The tail is a live preview, not a reopenable document: parsing it
-    // standalone can leave block structure open at its start (a list item, a
-    // fence), so it is kept to inline scope - the tail's own block boundary
-    // (see findWindowBoundary) plus closeOpenMarkdown already closed its
-    // emphasis/code spans, and any block wrapper marked emits here is
-    // dropped in favor of its inner content.
-    const tailClosed = closeOpenMarkdown(tailSource);
-    const tailHtml = DOMPurify.sanitize(md.parseInline(tailClosed, { async: false }) as string, SANITIZE_CONFIG);
+    const tailHtml = DOMPurify.sanitize(md.parse(closeOpenMarkdown(split.tail), { async: false }), SANITIZE_CONFIG);
     return headHtml + tailHtml;
   }, [source, live]);
 

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -197,6 +197,16 @@ const TAIL_BLOCK_MARKER =
 // back to the full parse.
 const HEAD_SPLIT_HAZARD = /^ {0,3}\[[^\]\n]+\]:|^\s*:?-+:?(?:\s*\|\s*:?-+:?)+\s*\r?$/m;
 
+// HTML blocks (CommonMark types 1-6: pre/script/style/textarea, comments,
+// processing instructions, declarations, CDATA, block tags) run past blank
+// lines until their terminator, so a split inside one severs it with no
+// markdown marker in the tail for TAIL_BLOCK_MARKER to trip. A block start in
+// the head, or a block ender in the tail (whose opener may sit anywhere
+// upstream, including before the head), falls back to the full parse.
+const HTML_BLOCK_START =
+  /^ {0,3}(?:<(?:pre|script|style|textarea)(?:[\s>]|$)|<!--|<\?|<![A-Za-z]|\[CDATA\[|<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|meta|nav|noframes|ol|optgroup|option|p|param|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:[\s>\/]|$))/im;
+const HTML_BLOCK_END = /<\/(?:pre|script|style|textarea)>|-->|\?>/i;
+
 // Splits a long live source into a settled head (ending on a blank line) and
 // the streaming tail after it, or null when there is no blank-line boundary
 // in range (one very long paragraph still streaming). Leading blank lines of
@@ -252,20 +262,31 @@ export function Markdown({ source, live = false }: MarkdownProps) {
       const rawHtml = md.parse(live ? closeOpenMarkdown(source) : source, { async: false });
       return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);
     }
-    // The head must be closed at the boundary (no fence, code span, or
-    // emphasis left open - closeOpenMarkdown is identity exactly then), the
-    // head must hold no forward-reference hazards, and the tail must be
-    // paragraphs-only starting on fresh (non-indented) content. The tail
-    // keeps the full block parse - never an inline-only one - so headings,
-    // lists, and fences inside it render their real structure; but the gates
-    // above mean a tail carrying any of those never reaches this path.
+    // The windowed path is sound only when NOTHING spans the split. Its
+    // keystone is whole-source balance: closeOpenMarkdown is identity exactly
+    // when the live input has no construct left open, so no fence, code span,
+    // or emphasis can still be awaiting its closer in the tail - had one been
+    // severed, the whole would not be identity. The head must be closed at
+    // the boundary too (a fence opened in the head and closed in the tail is
+    // whole-balanced but still spans the split - the tail's fence run trips
+    // TAIL_BLOCK_MARKER for that shape, and this check backstops it). The
+    // only cross-boundary structure a balanced whole can otherwise carry is
+    // forward references (link definitions, table delimiters) and blank-line-
+    // spanning HTML blocks, excluded by HEAD_SPLIT_HAZARD and the HTML gates;
+    // the tail must be paragraphs-only on fresh content (TAIL_BLOCK_MARKER,
+    // tailStartsIndented). Anything else takes the full-parse fallback, which
+    // is exactly the pre-throttle behavior for every input. The tail keeps
+    // the full block parse - never an inline-only one.
     const split = splitLiveSource(source);
     if (
       split === null ||
       closeOpenMarkdown(split.head) !== split.head ||
       HEAD_SPLIT_HAZARD.test(split.head) ||
+      HTML_BLOCK_START.test(split.head) ||
+      HTML_BLOCK_END.test(split.tail) ||
       TAIL_BLOCK_MARKER.test(split.tail) ||
-      tailStartsIndented(split.tail)
+      tailStartsIndented(split.tail) ||
+      closeOpenMarkdown(source) !== source
     ) {
       const rawHtml = md.parse(closeOpenMarkdown(source), { async: false });
       return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -93,6 +93,17 @@ const renderer: RendererObject = {
 // consumer of the `marked` package that might get added to this app later.
 const md = new Marked({ gfm: true, renderer });
 
+// The app's shared default-options lexer: the same GFM tokenizer the widget
+// parses with, minus the widget's custom renderer (lexer output never renders
+// - renderer choice cannot change the token stream). Lexer-only consumers
+// import this instead of constructing their own `new Marked({ gfm: true })`,
+// so the tokenizer is initialized once. Kept in this module rather than a
+// new one so the single constructible-`marked` comment above stays true in
+// exactly one place; this instance carries no renderer, so it cannot leak
+// widget markup anywhere. Pure `marked` (no DOMPurify, no CSS, no React), so
+// node-environment suites can import it freely.
+export const markdownLexer = new Marked({ gfm: true });
+
 // Sanitizes the OUTPUT html, not the markdown source - this is DOMPurify's
 // documented pairing with marked (marked itself performs no sanitization).
 // The allowlist is every tag/attribute marked's defaults or the overrides

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -3,6 +3,7 @@ import { Marked, type RendererObject, type Token, type Tokens } from "marked";
 import { useMemo, useRef } from "react";
 import codeblockStyles from "../codeblock/codeblock.module.css";
 import { requireClass } from "../internal/requireClass";
+import { markdownLexer } from "./lexer";
 import styles from "./markdown.module.css";
 import { closeOpenMarkdown } from "./streaming";
 
@@ -93,16 +94,9 @@ const renderer: RendererObject = {
 // consumer of the `marked` package that might get added to this app later.
 const md = new Marked({ gfm: true, renderer });
 
-// The app's shared default-options lexer: the same GFM tokenizer the widget
-// parses with, minus the widget's custom renderer (lexer output never renders
-// - renderer choice cannot change the token stream). Lexer-only consumers
-// import this instead of constructing their own `new Marked({ gfm: true })`,
-// so the tokenizer is initialized once. Kept in this module rather than a
-// new one so the single constructible-`marked` comment above stays true in
-// exactly one place; this instance carries no renderer, so it cannot leak
-// widget markup anywhere. Pure `marked` (no DOMPurify, no CSS, no React), so
-// node-environment suites can import it freely.
-export const markdownLexer = new Marked({ gfm: true });
+// Re-exported so existing `widgets/markdown` import sites keep working; the
+// instance lives in ./lexer.ts (UI-free, no renderer to leak widget markup).
+export { markdownLexer } from "./lexer";
 
 // Sanitizes the OUTPUT html, not the markdown source - this is DOMPurify's
 // documented pairing with marked (marked itself performs no sanitization).

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -1,6 +1,6 @@
 import DOMPurify from "dompurify";
 import { Marked, type RendererObject, type Tokens } from "marked";
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import codeblockStyles from "../codeblock/codeblock.module.css";
 import { requireClass } from "../internal/requireClass";
 import styles from "./markdown.module.css";
@@ -154,6 +154,30 @@ const SANITIZE_CONFIG = {
   ALLOWED_ATTR: ["href", "title", "target", "rel", "class", "align"],
 };
 
+// Live re-parse throttle: a full marked + DOMPurify pass per streamed token
+// is O(n^2) over a long stream. Below this source length every live render
+// takes the same full-parse path as before (all existing live tests stay on
+// it); past it, only the tail window is re-parsed per render while the
+// settled head is served from a prefix-keyed cache. Grown past the window
+// mid-stream, the head cache fills once per new head text and then hits.
+const LIVE_WINDOWED_MIN_LENGTH = 2000;
+// The tail window re-parsed on every live render past the threshold above -
+// sized to cover the in-progress block (a long paragraph, a fenced code
+// block still being written) without re-parsing the whole document.
+const LIVE_TAIL_WINDOW = 1000;
+
+// Finds the split point for the windowed live path: the last blank-line
+// boundary at or before `source.length - LIVE_TAIL_WINDOW`, so the head ends
+// on a settled block edge and the tail starts a fresh block. Falls back to a
+// hard cut at the window edge when the tail window holds no blank line (one
+// very long paragraph still streaming) - the tail's inline-scope parse below
+// makes that safe.
+function findWindowBoundary(source: string): number {
+  const edge = source.length - LIVE_TAIL_WINDOW;
+  const boundary = source.lastIndexOf("\n\n", edge);
+  return boundary === -1 ? edge : boundary + 2;
+}
+
 /**
  * Renders a markdown source string: marked tokenizes and generates HTML,
  * DOMPurify sanitizes it against a fixed allowlist, and the result is set
@@ -164,9 +188,41 @@ const SANITIZE_CONFIG = {
  * closed before parsing (see streaming.ts).
  */
 export function Markdown({ source, live = false }: MarkdownProps) {
+  // Live streams re-render per streamed token, and each render re-parses the
+  // whole message (marked + DOMPurify) - O(n^2) over a long stream. Past the
+  // window above, the settled head is served from a cache keyed on its own
+  // exact prefix text (a changed head is a cache miss and re-parses, never
+  // stale output), while only the tail window is re-parsed per render with
+  // the live auto-close, so formatting still previews while streaming.
+  // Settled renders (live=false) always take the full-parse path below
+  // unchanged, so the final HTML is byte-identical with or without this
+  // throttle.
+  const headCacheRef = useRef<{ headSource: string; headHtml: string } | null>(null);
   const html = useMemo(() => {
-    const rawHtml = md.parse(live ? closeOpenMarkdown(source) : source, { async: false });
-    return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);
+    if (!live || source.length <= LIVE_WINDOWED_MIN_LENGTH) {
+      const rawHtml = md.parse(live ? closeOpenMarkdown(source) : source, { async: false });
+      return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);
+    }
+    const boundary = findWindowBoundary(source);
+    const headSource = source.slice(0, boundary);
+    const tailSource = source.slice(boundary);
+    const cached = headCacheRef.current;
+    const headHtml =
+      cached !== null && cached.headSource === headSource
+        ? cached.headHtml
+        : DOMPurify.sanitize(md.parse(headSource, { async: false }), SANITIZE_CONFIG);
+    if (cached === null || cached.headSource !== headSource) {
+      headCacheRef.current = { headSource, headHtml };
+    }
+    // The tail is a live preview, not a reopenable document: parsing it
+    // standalone can leave block structure open at its start (a list item, a
+    // fence), so it is kept to inline scope - the tail's own block boundary
+    // (see findWindowBoundary) plus closeOpenMarkdown already closed its
+    // emphasis/code spans, and any block wrapper marked emits here is
+    // dropped in favor of its inner content.
+    const tailClosed = closeOpenMarkdown(tailSource);
+    const tailHtml = DOMPurify.sanitize(md.parseInline(tailClosed, { async: false }) as string, SANITIZE_CONFIG);
+    return headHtml + tailHtml;
   }, [source, live]);
 
   // Reviewed: this is the narrow, legitimate case for dangerouslySetInnerHTML

--- a/cmd/evener-hub/frontend/src/widgets/markdown/lexer.ts
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/lexer.ts
@@ -1,0 +1,14 @@
+import { Marked } from "marked";
+
+// The app's shared default-options lexer: the same GFM tokenizer the Markdown
+// widget parses with, minus the widget's custom renderer (lexer output never
+// renders - renderer choice cannot change the token stream). Lexer-only
+// consumers import this instead of constructing their own
+// `new Marked({ gfm: true })`, so the tokenizer is initialized once.
+//
+// This module is UI-free by design: it imports only `marked` (no React, no
+// DOMPurify, no CSS), so node-environment suites and non-widget modules like
+// panes/session/transcript/messages/reasoningFormat.ts can import it without
+// pulling the widget's browser dependencies. index.tsx re-exports it so
+// existing `widgets/markdown` import sites keep working.
+export const markdownLexer = new Marked({ gfm: true });

--- a/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
@@ -277,6 +277,31 @@ test("live matches settled when the definition sits in the tail", () => {
   expectLiveMatchesSettled(source, "/url");
 });
 
+// Companion to the link-definition fallback cases above: this source is
+// paragraphs-only, balanced, and definition-free past the live-window
+// threshold, so the live path takes the windowed branch (settled head served
+// from cache, tail window re-parsed) instead of the full-parse fallback each
+// of the cases above forces. Rerendering the same mounted component with a
+// tail-only append keeps the split head byte-identical, so the second render
+// serves the head from cache (a hit) while re-parsing just the grown tail -
+// and each render asserts the live output is byte-identical to the settled
+// full parse, so the test cannot pass vacuously on a degraded path.
+test("live matches settled on a long definition-free source across tail-growth rerenders (windowed path)", () => {
+  const sentence = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ";
+  const head = `${sentence.repeat(12).trim()}\n\n${sentence.repeat(12).trim()}\n\n`;
+  const first = head + sentence.repeat(20).trim();
+  expect(first.length).toBeGreaterThan(2000);
+  const live = render(<Markdown source={first} live />);
+  const settledFirst = render(<Markdown source={first} />);
+  expect(live.container.innerHTML).toBe(settledFirst.container.innerHTML);
+  // Tail-only growth: no new blank line crosses the split, so the head is
+  // unchanged and the cached head HTML is reused.
+  const second = `${first} ${sentence.trim()}`;
+  live.rerender(<Markdown source={second} live />);
+  const settledSecond = render(<Markdown source={second} />);
+  expect(live.container.innerHTML).toBe(settledSecond.container.innerHTML);
+});
+
 // The table chrome lives in the stylesheet, not on a class the component
 // writes, so - like the ink/font-size assertions above - this reads the
 // stylesheet's own source. Guards the table styling contract: a header band

--- a/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
@@ -289,7 +289,10 @@ test("live matches settled when the definition sits in the tail", () => {
 test("live matches settled on a long definition-free source across tail-growth rerenders (windowed path)", () => {
   const sentence = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ";
   const head = `${sentence.repeat(12).trim()}\n\n${sentence.repeat(12).trim()}\n\n`;
-  const first = head + sentence.repeat(20).trim();
+  // The tail carries its own paragraph break inside the window, so the split
+  // boundary sits at most LIVE_TAIL_WINDOW from the end (see splitLiveSource:
+  // only the first boundary at/after the window edge engages the path).
+  const first = `${head + sentence.repeat(10).trim()}\n\n${sentence.repeat(5).trim()}`;
   expect(first.length).toBeGreaterThan(2000);
   const live = render(<Markdown source={first} live />);
   const settledFirst = render(<Markdown source={first} />);

--- a/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
@@ -2,12 +2,16 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, expect, test } from "vitest";
+import DOMPurify from "dompurify";
+import { afterEach, expect, test, vi } from "vitest";
 import codeblockStyles from "../codeblock/codeblock.module.css";
 import { requireClass } from "../internal/requireClass";
 import { Markdown } from "./index";
 
 afterEach(cleanup);
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const CODEBLOCK_PRE_CLASS = requireClass(codeblockStyles.pre, "codeblock.module.css", "pre");
 const CODEBLOCK_CODE_CLASS = requireClass(codeblockStyles.code, "codeblock.module.css", "code");
@@ -294,15 +298,53 @@ test("live matches settled on a long definition-free source across tail-growth r
   // only the first boundary at/after the window edge engages the path).
   const first = `${head + sentence.repeat(10).trim()}\n\n${sentence.repeat(5).trim()}`;
   expect(first.length).toBeGreaterThan(2000);
+  // Engagement proof, not just output equality: the windowed path parses head
+  // and tail separately while the full-parse fallback parses once, so the
+  // sanitize-call count separates them (live==settled alone holds on either
+  // path and could not catch a regression to the fallback).
+  const sanitizeSpy = vi.spyOn(DOMPurify, "sanitize");
   const live = render(<Markdown source={first} live />);
   const settledFirst = render(<Markdown source={first} />);
   expect(live.container.innerHTML).toBe(settledFirst.container.innerHTML);
+  // Live first render parses head and tail separately (two calls) and the
+  // settled render once: three total. The full-parse fallback would give two
+  // (one live + one settled), so this count proves the windowed path engaged.
+  expect(sanitizeSpy.mock.calls.length).toBe(3);
+  sanitizeSpy.mockClear();
   // Tail-only growth: no new blank line crosses the split, so the head is
   // unchanged and the cached head HTML is reused.
   const second = `${first} ${sentence.trim()}`;
   live.rerender(<Markdown source={second} live />);
   const settledSecond = render(<Markdown source={second} />);
   expect(live.container.innerHTML).toBe(settledSecond.container.innerHTML);
+  // Head HTML served from cache: the live rerender sanitizes only the grown
+  // tail (one call), and the settled render sanitizes once - two total. A
+  // fallback would parse the whole live source too (still two), so this count
+  // alone proves the cached-head shape only together with the first render's
+  // three; either count dropping to the settled-only shape fails loudly.
+  expect(sanitizeSpy.mock.calls.length).toBe(2);
+});
+
+// CRLF twin of the windowed-path case: a source whose only paragraph breaks
+// are "\r\n\r\n" must split the same way - "\n\n" never appears in it, so a
+// split search on LF alone would decline to the fallback instead of engaging.
+test("live matches settled on a long CRLF source across tail-growth rerenders (windowed path)", () => {
+  const sentence = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ";
+  const head = `${sentence.repeat(12).trim()}\r\n\r\n${sentence.repeat(12).trim()}\r\n\r\n`;
+  const first = `${head + sentence.repeat(10).trim()}\r\n\r\n${sentence.repeat(5).trim()}`;
+  expect(first).not.toContain("\n\n");
+  expect(first.length).toBeGreaterThan(2000);
+  const sanitizeSpy = vi.spyOn(DOMPurify, "sanitize");
+  const live = render(<Markdown source={first} live />);
+  const settledFirst = render(<Markdown source={first} />);
+  expect(live.container.innerHTML).toBe(settledFirst.container.innerHTML);
+  expect(sanitizeSpy.mock.calls.length).toBe(3);
+  sanitizeSpy.mockClear();
+  const second = `${first} ${sentence.trim()}`;
+  live.rerender(<Markdown source={second} live />);
+  const settledSecond = render(<Markdown source={second} />);
+  expect(live.container.innerHTML).toBe(settledSecond.container.innerHTML);
+  expect(sanitizeSpy.mock.calls.length).toBe(2);
 });
 
 // The table chrome lives in the stylesheet, not on a class the component

--- a/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/markdown.test.tsx
@@ -238,6 +238,45 @@ test("renders GFM column alignment via the align attribute", () => {
   expect(tds.map((td) => td.getAttribute("align"))).toEqual(["left", "center", "right"]);
 });
 
+// --- windowed live path: link definitions across the split ------------------
+// Past the live-window threshold the live path may serve the head from cache
+// and re-parse only the tail - but a link definition on either side of the
+// split registers globally with marked, so the halves must never parse
+// independently while one is present. These shapes all evade the
+// HEAD_SPLIT_HAZARD / TAIL_BLOCK_MARKER line patterns (an escaped label like
+// `[foo\]bar]` has no `[...]:` span for them to match; a definition indented
+// as a list-item continuation sits past their 0-3-space allowance) and are
+// caught by the shared-lexer gate instead. Each case asserts the live render
+// matches the settled render exactly, and that the settled render really
+// resolves the reference - so the test cannot pass vacuously with the link
+// left literal in both.
+function expectLiveMatchesSettled(source: string, url: string) {
+  const live = render(<Markdown source={source} live />);
+  const settled = render(<Markdown source={source} />);
+  expect(settled.container.querySelector(`a[href="${url}"]`)).not.toBeNull();
+  expect(live.container.innerHTML).toBe(settled.container.innerHTML);
+}
+
+test("live matches settled when an escaped-label definition sits in the head", () => {
+  const source = `${"x".repeat(1200)}\n\n[foo\\]bar]: /url\n\nsee [foo\\]bar] here ${"y".repeat(1050)}`;
+  expectLiveMatchesSettled(source, "/url");
+});
+
+test("live matches settled when a list-continuation-indented definition sits in the head", () => {
+  const source = `${"x".repeat(1100)}\n\n- item\n\n    [lbl]: /url\n\nsee [lbl] here ${"y".repeat(1050)}`;
+  expectLiveMatchesSettled(source, "/url");
+});
+
+test("live matches settled when a blockquote-nested escaped-label definition sits in the head", () => {
+  const source = `${"x".repeat(1100)}\n\n> [q\\]z]: /url\n\nsee [q\\]z] here ${"y".repeat(1050)}`;
+  expectLiveMatchesSettled(source, "/url");
+});
+
+test("live matches settled when the definition sits in the tail", () => {
+  const source = `${"z".repeat(1150)}\n\nsee [t\\]d] here\n\n[t\\]d]: /url\n${"w".repeat(1050)}`;
+  expectLiveMatchesSettled(source, "/url");
+});
+
 // The table chrome lives in the stylesheet, not on a class the component
 // writes, so - like the ink/font-size assertions above - this reads the
 // stylesheet's own source. Guards the table styling contract: a header band


### PR DESCRIPTION
Two wins: (1) shared default-options markdownLexer for reasoningFormat (renderer stays private to the widget instance — lexer output never renders). (2) Live re-parse throttle: past 2000 chars with a paragraphs-only streaming tail, the settled head is served from a prefix-keyed cache and only the tail window re-parses per render; anything with block structure (headings/lists/fences/tables/HTML blocks/link-defs, whole-source imbalance) falls back to the exact pre-throttle full parse. Settled path (live=false) byte-untouched.

An earlier revision rendered tails via parseInline and degraded block content mid-stream; fixed by gating + full block parse in the tail. Mid-stream previews on the windowed path show paragraph content only — final HTML always identical.

Verification (scoped re-review at b8d2c8bc): tsc clean; 125/125 scoped suites pass; mixed 40-section fixture IDENTICAL via fallback (14586/14586); paragraphs-only long stream IDENTICAL via windowed path (12124/12124) — fast path proven taken AND correct. No new breakage in fix hunks.
Risk: med (streaming render path) — gates are conservative (fallback = today's behavior).