### PR TITLE
Allow explicit verified force stop of local session daemons

### DIFF
--- a/agent/execenv/sandbox_lifecycle_test.go
+++ b/agent/execenv/sandbox_lifecycle_test.go
@@ -252,13 +252,13 @@ func TestCleanupRetainsOwnedTmpAfterChildGrace(t *testing.T) {
 	sentinel := filepath.Join(dir, "tmp-was-present")
 	ready := filepath.Join(dir, "trap-installed")
 
-	// The child touches READY only AFTER the TERM trap is installed, so the test can
-	// wait for readiness before signaling — otherwise Cleanup could SIGTERM the child
-	// before its trap exists (the default action would terminate it, masking the
-	// ordering under test).
-	script := `trap 'if [ -d "$WATCH" ]; then : > "$SENTINEL"; fi; exit 0' TERM
+	// Publish readiness after starting the sleeper and installing the trap. Bash
+	// can defer TERM during asynchronous child startup, so no fork may remain
+	// between READY and wait: readiness must cover the entire signal setup.
+	script := `sleep 300 &
+trap 'if [ -d "$WATCH" ]; then : > "$SENTINEL"; fi; exit 0' TERM
 : > "$READY"
-sleep 300 & wait`
+wait`
 	h, err := env.StreamCommand(context.Background(), script, dir,
 		map[string]string{"WATCH": tmp.Dir, "SENTINEL": sentinel, "READY": ready}, io.Discard)
 	if err != nil {

--- a/agent/status.go
+++ b/agent/status.go
@@ -3,7 +3,9 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"time"
@@ -279,6 +281,75 @@ func SessionOwnsDelegate(ctx context.Context, stateDir, parentSessionID, childSe
 		return false, fmt.Errorf("delegate ownership journal has an incomplete trailing batch: %s", path)
 	}
 	return false, nil
+}
+
+// SessionOwnedDelegateIDs reads the session's subtree in the root-owned
+// delegate journal without loading transcripts. Fork provenance is not ownership.
+func SessionOwnedDelegateIDs(ctx context.Context, stateDir, sessionID string) ([]string, error) {
+	if err := schema.ValidateSessionID(sessionID); err != nil {
+		return nil, err
+	}
+	rootID := sessionID
+	meta, err := schema.LoadSessionMeta(stateDir, sessionID)
+	if err == nil {
+		rootID = activityRootIDFromMeta(sessionID, meta)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	if err := schema.ValidateSessionID(rootID); err != nil {
+		return nil, err
+	}
+	path := filepath.Join(jobsDir(stateDir, rootID), "delegates.jsonl")
+	result, err := historicalDelegateFoldCache.Get(ctx, path, extendHistoricalDelegateFold)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	// Committed descriptors remain ownership evidence after interrupted writes.
+	// A killed daemon may leave an incomplete trailing batch; it is not replayed.
+	children := make(map[string][]string)
+	var pending []string
+	for delegateID, aggregate := range result.Value.state {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if aggregate == nil || aggregate.Descriptor.OwnerSessionID != rootID {
+			continue
+		}
+		children[aggregate.Descriptor.ParentDelegateID] = append(children[aggregate.Descriptor.ParentDelegateID], delegateID)
+		if sessionID == rootID || aggregate.Descriptor.ChildSessionID == sessionID {
+			pending = append(pending, delegateID)
+		}
+	}
+	ids := make(map[string]bool)
+	visited := make(map[string]bool)
+	for len(pending) != 0 {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		delegateID := pending[len(pending)-1]
+		pending = pending[:len(pending)-1]
+		if visited[delegateID] {
+			continue
+		}
+		visited[delegateID] = true
+		id := result.Value.state[delegateID].Descriptor.ChildSessionID
+		if err := schema.ValidateSessionID(id); err != nil {
+			return nil, err
+		}
+		if id != sessionID {
+			ids[id] = true
+		}
+		pending = append(pending, children[delegateID]...)
+	}
+	out := make([]string, 0, len(ids))
+	for id := range ids {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 // LoadSessionDelegateStatus projects a cold session's stable delegate rows

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -126,6 +126,7 @@ var Methods = []MethodSpec{
 	{MethodThreadReasoningEffortSet, ThreadReasoningEffortSetParams{}, EmptyResponse{}, ScopeBoth, "Sets reasoning effort, normalizing and validating the value."},
 	{MethodThreadVisionModelSet, ThreadVisionModelSetParams{}, EmptyResponse{}, ScopeBoth, "Sets the vision side-channel routing (\"\", \"off\", or a model ref)."},
 	{MethodThreadCompactStart, ThreadCompactStartParams{}, EmptyResponse{}, ScopeBoth, "Starts a context-compaction pass on the session."},
+	{MethodEvenerThreadForceStop, ThreadForceStopParams{}, EmptyResponse{}, ScopeHub, "Explicitly terminates a verified local daemon and confirms exit; saved session data is retained."},
 	{MethodThreadShutdown, ThreadShutdownParams{}, EmptyResponse{}, ScopeBoth, "Shuts the session down (the daemon runs it asynchronously)."},
 	{MethodTurnStart, TurnStartParams{}, TurnStartResponse{}, ScopeBoth, "Starts a new user turn and reserves a turn ID."},
 	{MethodTurnSteer, TurnSteerParams{}, TurnSteerResponse{}, ScopeBoth, "Injects a steering message into the active turn."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -46,6 +46,7 @@ const (
 	MethodThreadVisionModelSet        = "thread/vision-model/set"
 	MethodThreadCompactStart          = "thread/compact/start"
 	MethodThreadShutdown              = "thread/shutdown"
+	MethodEvenerThreadForceStop       = "evener/thread/forceStop"
 	MethodTurnStart                   = "turn/start"
 	MethodTurnSteer                   = "turn/steer"
 	MethodTurnInterrupt               = "turn/interrupt"
@@ -597,11 +598,14 @@ type TaskAggregate struct {
 }
 
 type EvenerThread struct {
-	Ref        string `json:"ref"`
-	InstanceID string `json:"instanceId,omitempty"`
-	ParentRef  string `json:"parentRef,omitempty"`
-	Kind       string `json:"kind,omitempty"`
-	Profile    string `json:"profile,omitempty"`
+	// ResumeRequired means recovery stopped this session and automatic actions
+	// must wait for an explicit thread/resume. Saved transcripts remain readable.
+	ResumeRequired bool   `json:"resumeRequired,omitempty"`
+	Ref            string `json:"ref"`
+	InstanceID     string `json:"instanceId,omitempty"`
+	ParentRef      string `json:"parentRef,omitempty"`
+	Kind           string `json:"kind,omitempty"`
+	Profile        string `json:"profile,omitempty"`
 	// TurnCount is the daemon's total completed model-response count. It stays
 	// independent of Turns so a bounded metadata read never loads the transcript.
 	TurnCount        int                `json:"turnCount,omitempty"`
@@ -1663,6 +1667,10 @@ type TurnCancelQueuedResponse struct {
 }
 
 type ThreadCompactStartParams struct {
+	Ref string `json:"ref"`
+}
+
+type ThreadForceStopParams struct {
 	Ref string `json:"ref"`
 }
 

--- a/cmd/evener-hub/app_compact.go
+++ b/cmd/evener-hub/app_compact.go
@@ -39,7 +39,7 @@ func compactThreadWithResume(ctx context.Context, cfg hubcore.WebConfig, sources
 	if !shouldResumeAfterSessionUnavailable(err) {
 		return err
 	}
-	if _, resumeErr := hubThreadResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref}); resumeErr != nil {
+	if _, resumeErr := hubThreadAutoResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref}); resumeErr != nil {
 		return resumeErr
 	}
 	return compactThreadOnce(ctx, cfg, sources, params)

--- a/cmd/evener-hub/app_force_stop.go
+++ b/cmd/evener-hub/app_force_stop.go
@@ -1,0 +1,344 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"slices"
+	"time"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/daemonprocess"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/rendezvous"
+)
+
+// forceStopThread bypasses daemon RPC only after verifying the local process.
+// The session remains reserved until the exact process has exited.
+func forceStopThread(ctx context.Context, cfg hubcore.WebConfig, params appwire.ThreadForceStopParams, sources *appsource.Registry) (stopErr error) {
+	ref, err := appwire.ParseRef(params.Ref)
+	if err != nil || ref.SourceID != "local" {
+		return appwire.InvalidParams("force stop requires a local session ref")
+	}
+	if cfg.RunDir == "" || cfg.ResumeLocks == nil {
+		return appwire.Unavailable("local session ownership is not configured")
+	}
+	recoveryTarget := cfg.ResumeLocks.RecoveryState(ref.ThreadID).ResumeSessionID
+	entry, err := forceStopEntry(cfg.RunDir, ref.ThreadID, cfg.DaemonProcesses, nil, recoveryTarget)
+	if err != nil {
+		return appwire.Unavailable(err.Error())
+	}
+	// Verify the process before interrupting RPCs. Kill verifies this retained
+	// process handle again after ownership and deletion reservations are held.
+	controller := cfg.DaemonProcesses
+	if controller == nil {
+		controller = daemonprocess.NewController()
+	}
+	sessionID := entry.SessionID
+	if sessionID == "" {
+		sessionID = entry.ThreadID
+	}
+	target := daemonprocess.Target{PID: entry.PID, SessionID: sessionID, StateDir: entry.StateDir, StartedAt: entry.StartedAt}
+	process, err := controller.Open(target)
+	exited := errors.Is(err, daemonprocess.ErrExited)
+	if err != nil && !exited {
+		return appwire.Unavailable(fmt.Sprintf("cannot verify daemon for force stop: %v", err))
+	}
+	defer func() {
+		if process == nil {
+			return
+		}
+		if err := process.Close(); err != nil {
+			log.Printf("force stop process handle cleanup: %v", err)
+		}
+	}()
+	if exited && recoveryTarget != "" && sessionID != recoveryTarget {
+		return appwire.Unavailable("exited daemon claim does not match session recovery authority")
+	}
+	// Descendants share the stopped process, but keep independent transcript
+	// identities. Their old requests must expire even after root ownership clears.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	fenced := make(map[string]bool)
+	var descendantFinishes []func(bool)
+	defer func() {
+		for _, finish := range descendantFinishes {
+			finish(false)
+		}
+	}()
+	fenceDescendants := func(scanCtx context.Context) error {
+		if entry.StateDir == "" {
+			return nil
+		}
+		ids, err := agent.SessionOwnedDelegateIDs(scanCtx, entry.StateDir, sessionID)
+		if err != nil {
+			return appwire.Unavailable(fmt.Sprintf("read daemon delegates: %v", err))
+		}
+		var added []string
+		for _, id := range ids {
+			if !fenced[id] {
+				fenced[id] = true
+				added = append(added, id)
+			}
+		}
+		if len(added) != 0 {
+			descendantFinishes = append(descendantFinishes, cfg.ResumeLocks.BeginForceStop(added))
+		}
+		return nil
+	}
+	// These are admission fences, not aliases or durable resume targets. Hub
+	// restart drops the old connections and queued requests altogether.
+	if err := fenceDescendants(ctx); err != nil {
+		return err
+	}
+	aliases := forceStopAliases(entry)
+	finishRecovery := cfg.ResumeLocks.BeginForceStop(aliases)
+	defer func() { finishRecovery(stopErr == nil) }()
+	if sources != nil {
+		if source, ok := sources.Source("local"); ok {
+			if local, ok := source.(*appsource.LocalDaemonSource); ok {
+				release := local.BeginRecovery(entry)
+				defer release()
+			}
+		}
+	}
+	// Clear gives one daemon stable and current session aliases. Lock both so
+	// resume or deletion through either alias cannot race exit confirmation.
+	for _, id := range aliases {
+		cfg.ResumeLocks.For(id).Lock()
+	}
+	defer func() {
+		for _, alias := range slices.Backward(aliases) {
+			cfg.ResumeLocks.For(alias).Unlock()
+		}
+	}()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	currentTarget := cfg.ResumeLocks.RecoveryState(ref.ThreadID).ResumeSessionID
+	if currentTarget != recoveryTarget {
+		return appwire.Unavailable("session recovery authority changed; retry force stop")
+	}
+	if err := forceStopOwnershipUnchanged(cfg.RunDir, ref.ThreadID, entry, cfg.DaemonProcesses, currentTarget); err != nil {
+		return appwire.Unavailable(err.Error())
+	}
+	if err := deletionFenceError(cfg, params.Ref, ref.ThreadID, ""); err != nil {
+		return err
+	}
+	if exited {
+		// There is no retained process handle to reverify. An unchanged marker
+		// alone cannot confirm absence after waiting for ownership.
+		process, err = controller.Open(target)
+		if !errors.Is(err, daemonprocess.ErrExited) {
+			if err == nil {
+				err = errors.New("daemon is live after initial exit observation")
+			}
+			return appwire.Unavailable(fmt.Sprintf("daemon exit is not confirmed: %v", err))
+		}
+		// An exited claim cannot replace newer authority held by any alias
+		// it would overwrite, even when the requested alias still names it.
+		for _, alias := range aliases {
+			authority := cfg.ResumeLocks.RecoveryState(alias).ResumeSessionID
+			if authority != "" && authority != sessionID {
+				return appwire.Unavailable("exited daemon claim conflicts with alias recovery authority")
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	// Commit recovery authority before the signal can take effect. Interrupted
+	// signaling conservatively retains the explicit-Resume requirement.
+	if err := cfg.ResumeLocks.PersistForceStop(aliases, sessionID); err != nil {
+		return appwire.Unavailable(fmt.Sprintf("persist session recovery: %v", err))
+	}
+	if exited {
+		if err := cfg.ResumeLocks.ConfirmForceStop(sessionID); err != nil {
+			return appwire.Unavailable(fmt.Sprintf("persist confirmed daemon exit: %v", err))
+		}
+		refreshAfterForceStop(ctx, cfg)
+		return nil
+	}
+	if err := process.Kill(); err != nil && !errors.Is(err, daemonprocess.ErrExited) {
+		return appwire.Unavailable(fmt.Sprintf("cannot force stop daemon: %v", err))
+	}
+	exitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := process.Wait(exitCtx); err != nil {
+		return appwire.Unavailable(fmt.Sprintf("daemon exit is not confirmed: %v", err))
+	}
+	// Exit makes the ownership journal stable. Capture delegates created while
+	// termination was in progress before releasing any recovery admission fence.
+	scanCtx, cancelScan := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancelScan()
+	if err := fenceDescendants(scanCtx); err != nil {
+		return err
+	}
+	if err := cfg.ResumeLocks.ConfirmForceStop(sessionID); err != nil {
+		return appwire.Unavailable(fmt.Sprintf("persist confirmed daemon exit: %v", err))
+	}
+	refreshAfterForceStop(ctx, cfg)
+	return nil
+}
+
+// forceStopOwnershipUnchanged revalidates discovery after acquiring every
+// alias lock, before signaling the verified process.
+func forceStopOwnershipUnchanged(runDir, sessionID string, previous rendezvous.Entry, controller daemonprocess.Controller, recoveryTarget string) error {
+	current, err := forceStopEntry(runDir, sessionID, controller, &previous, recoveryTarget)
+	if err != nil {
+		return err
+	}
+	if !sameForceStopEntry(current, previous) {
+		return errors.New("daemon ownership changed; refresh the session before force stopping")
+	}
+	return nil
+}
+
+// sameForceStopEntry compares persisted ownership values; timestamp location
+// pointers may differ across reads even when they represent the same instant.
+func sameForceStopEntry(a, b rendezvous.Entry) bool {
+	if !a.StartedAt.Equal(b.StartedAt) {
+		return false
+	}
+	b.StartedAt = a.StartedAt
+	return a == b
+}
+
+func forceStopEntry(runDir, sessionID string, controller daemonprocess.Controller, previous *rendezvous.Entry, recoveryTarget string) (rendezvous.Entry, error) {
+	entries, err := rendezvous.ListStrict(runDir)
+	if err != nil {
+		return rendezvous.Entry{}, err
+	}
+	// Retained crash markers are evidence, not competing live ownership. Only
+	// inspect overlapping claims, and retain every unresolved process identity.
+	var targetAliases []string
+	for _, entry := range entries {
+		if slices.Contains(forceStopAliases(entry), sessionID) {
+			targetAliases = append(targetAliases, forceStopAliases(entry)...)
+		}
+	}
+	overlaps := func(entry rendezvous.Entry) bool {
+		for _, alias := range forceStopAliases(entry) {
+			if slices.Contains(targetAliases, alias) {
+				return true
+			}
+		}
+		return false
+	}
+	claims := 0
+	for _, entry := range entries {
+		if overlaps(entry) {
+			claims++
+		}
+	}
+	if claims > 1 {
+		if controller == nil {
+			controller = daemonprocess.NewController()
+		}
+		var exitedMatches []rendezvous.Entry
+		entries = slices.DeleteFunc(entries, func(entry rendezvous.Entry) bool {
+			if !overlaps(entry) {
+				return false
+			}
+			id := entry.SessionID
+			if id == "" {
+				id = entry.ThreadID
+			}
+			process, err := controller.Open(daemonprocess.Target{PID: entry.PID, SessionID: id, StateDir: entry.StateDir, StartedAt: entry.StartedAt})
+			if err == nil {
+				_ = process.Close()
+			}
+			exited := errors.Is(err, daemonprocess.ErrExited)
+			if exited && slices.Contains(forceStopAliases(entry), sessionID) {
+				exitedMatches = append(exitedMatches, entry)
+			}
+			return exited
+		})
+		// Exited markers cannot establish which transcript is current. Durable
+		// authority resolves differing targets; without it every direct claim
+		// must agree. A reserved process is preferred only within that target.
+		if len(exitedMatches) > 0 && !slices.ContainsFunc(entries, overlaps) {
+			var selected rendezvous.Entry
+			var selectedID string
+			found := false
+			for _, entry := range exitedMatches {
+				id := entry.SessionID
+				if id == "" {
+					id = entry.ThreadID
+				}
+				if recoveryTarget != "" && id != recoveryTarget {
+					continue
+				}
+				if found && id != selectedID {
+					return rendezvous.Entry{}, errors.New("exited daemons claim different transcripts; cannot choose a force-stop target")
+				}
+				if !found || (previous != nil && sameForceStopEntry(entry, *previous)) {
+					selected, selectedID = entry, id
+				}
+				found = true
+			}
+			if !found {
+				return rendezvous.Entry{}, errors.New("no exited daemon claim matches session recovery authority")
+			}
+			entries = append(entries, selected)
+		}
+	}
+	var match rendezvous.Entry
+	found := false
+	for _, entry := range entries {
+		if entry.SessionID != sessionID && entry.ThreadID != sessionID && entry.WorkspaceRef != "local:"+sessionID {
+			continue
+		}
+		if entry.SourceID != "" && entry.SourceID != "local" {
+			return rendezvous.Entry{}, errors.New("daemon claims a foreign session source")
+		}
+		if found {
+			return rendezvous.Entry{}, errors.New("multiple daemons claim this session; cannot choose a force-stop target")
+		}
+		match, found = entry, true
+	}
+	if !found {
+		return rendezvous.Entry{}, errors.New("no direct daemon ownership claim for this session")
+	}
+	aliases := forceStopAliases(match)
+	claims = 0
+	for _, entry := range entries {
+		for _, alias := range forceStopAliases(entry) {
+			if slices.Contains(aliases, alias) {
+				claims++
+				break
+			}
+		}
+	}
+	if claims != 1 {
+		return rendezvous.Entry{}, errors.New("multiple daemons claim this session; cannot choose a force-stop target")
+	}
+	return match, nil
+}
+
+func forceStopAliases(entry rendezvous.Entry) []string {
+	aliases := []string{entry.SessionID, entry.ThreadID}
+	if workspace, err := appwire.ParseRef(entry.WorkspaceRef); err == nil && workspace.SourceID == "local" {
+		aliases = append(aliases, workspace.ThreadID)
+	}
+	slices.Sort(aliases)
+	return slices.DeleteFunc(slices.Compact(aliases), func(id string) bool { return id == "" })
+}
+
+func refreshAfterForceStop(ctx context.Context, cfg hubcore.WebConfig) {
+	if cfg.Roster != nil {
+		if err := hubRosterRefresh(ctx, cfg.Roster); err != nil {
+			log.Printf("daemon stopped; roster refresh remains incomplete: %v", err)
+		}
+	}
+	if cfg.Inputs != nil {
+		cfg.Inputs.Bump()
+	}
+	if cfg.PokeAttention != nil {
+		cfg.PokeAttention()
+	}
+}

--- a/cmd/evener-hub/app_force_stop_descendant_test.go
+++ b/cmd/evener-hub/app_force_stop_descendant_test.go
@@ -1,0 +1,325 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/agent/schema"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/daemonprocess"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestForceStopInvalidatesQueuedOwnedChild(t *testing.T) {
+	stateDir, runDir := t.TempDir(), t.TempDir()
+	parent := buildRPCParentSession(t, stateDir)
+	child := buildUpgradeDelegate(t, stateDir, parent)
+	fork, err := agent.ForkSession(stateDir, parent, 1, "fork", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	locks := hubcore.NewResumeLocks()
+	cfg := hubcore.WebConfig{StateDir: stateDir, RunDir: runDir, ResumeLocks: locks,
+		DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return nil, daemonprocess.ErrExited })}
+	ctx := admitSessionConnection(t.Context(), cfg)
+	epoch := sessionRequestRecoveryEpoch(ctx, cfg, "local:"+child, "")
+	forkEpoch := sessionRequestRecoveryEpoch(ctx, cfg, "local:"+fork, "")
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: parent, ThreadID: parent, StateDir: stateDir})
+	if err := forceStopThread(context.Background(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + parent}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := sessionActionRecoveryError(ctx, cfg, "local:"+child, "", epoch); err == nil {
+		t.Fatal("queued child action survived owner force stop")
+	}
+	if err := sessionActionRecoveryError(ctx, cfg, "local:"+fork, "", forkEpoch); err != nil {
+		t.Fatalf("independent fork fenced: %v", err)
+	}
+	launches := 0
+	cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		launches++
+		if req.SessionID != child {
+			t.Errorf("child redirected to %s", req.SessionID)
+		}
+		return rendezvous.Entry{}, errors.New("launcher observed")
+	}}
+	if _, err := hubThreadResume(ctx, cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + child}); !isSessionRecoveryAdmissionError(err) {
+		t.Fatalf("stale resume error=%v", err)
+	}
+	if launches != 0 {
+		t.Fatal("stale resume launched")
+	}
+	fresh := admitSessionConnection(t.Context(), cfg)
+	if err := sessionActionRecoveryError(fresh, cfg, "local:"+child, "", locks.RecoveryState(child).Epoch); err != nil {
+		t.Fatalf("fresh child intent blocked: %v", err)
+	}
+	_, _ = hubThreadResume(fresh, cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + child})
+	if launches != 1 {
+		t.Fatalf("fresh child resume launches=%d", launches)
+	}
+	if state := locks.RecoveryState(child); state.ResumeRequired || state.ResumeSessionID != "" {
+		t.Fatalf("child acquired root resume authority: %+v", state)
+	}
+
+}
+
+func TestForceStopFencesDelegateCreatedDuringTermination(t *testing.T) {
+	stateDir, runDir := t.TempDir(), t.TempDir()
+	parent := buildRPCParentSession(t, stateDir)
+	locks := hubcore.NewResumeLocks()
+	var events []string
+	var child string
+	cfg := hubcore.WebConfig{StateDir: stateDir, RunDir: runDir, ResumeLocks: locks,
+		DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+			return &forceStopProcess{events: &events, onWait: func() { child = buildUpgradeDelegate(t, stateDir, parent) }}, nil
+		})}
+	old := admitSessionConnection(t.Context(), cfg)
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: parent, ThreadID: parent, StateDir: stateDir})
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + parent}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if child == "" {
+		t.Fatal("fixture did not create child")
+	}
+	if err := sessionConnectionRecoveryError(old, cfg, "local:"+child, ""); err == nil {
+		t.Fatal("late child escaped recovery fence")
+	}
+}
+
+func TestForceStopFencesDelegateAfterFailedExitConfirmation(t *testing.T) {
+	stateDir, runDir := t.TempDir(), t.TempDir()
+	parent := buildRPCParentSession(t, stateDir)
+	locks := hubcore.NewResumeLocks()
+	var events []string
+	var child string
+	cfg := hubcore.WebConfig{StateDir: stateDir, RunDir: runDir, ResumeLocks: locks,
+		DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+			return &forceStopProcess{events: &events, waitErr: context.DeadlineExceeded, onWait: func() { child = buildUpgradeDelegate(t, stateDir, parent) }}, nil
+		})}
+	old := admitSessionConnection(t.Context(), cfg)
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: parent, ThreadID: parent, StateDir: stateDir})
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + parent}, nil); err == nil {
+		t.Fatal("expected exit confirmation failure")
+	}
+	if child == "" {
+		t.Fatal("fixture did not create child")
+	}
+	if err := sessionConnectionRecoveryError(old, cfg, "local:"+child, ""); err == nil {
+		t.Fatal("late child escaped recovery fence")
+	}
+}
+
+func TestForceStopFencesDelegateCreatedAfterFailedConfirmation(t *testing.T) {
+	stateDir, runDir := t.TempDir(), t.TempDir()
+	parent := buildRPCParentSession(t, stateDir)
+	locks := hubcore.NewResumeLocks()
+	var events []string
+	var child string
+	cfg := hubcore.WebConfig{StateDir: stateDir, RunDir: runDir, ResumeLocks: locks,
+		DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+			return &forceStopProcess{events: &events, waitErr: context.DeadlineExceeded, onWait: func() {}}, nil
+		})}
+	old := admitSessionConnection(t.Context(), cfg)
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: parent, ThreadID: parent, StateDir: stateDir})
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + parent}, nil); err == nil {
+		t.Fatal("expected exit confirmation failure")
+	}
+	child = buildUpgradeDelegate(t, stateDir, parent)
+	if child == "" {
+		t.Fatal("fixture did not create child")
+	}
+	if err := sessionConnectionRecoveryError(old, cfg, "local:"+child, ""); err == nil {
+		t.Fatal("late child escaped recovery fence")
+	}
+}
+
+func TestForceStopConfirmsExitedOwnerWithTornDelegateTail(t *testing.T) {
+	stateDir, runDir := t.TempDir(), t.TempDir()
+	parent := buildRPCParentSession(t, stateDir)
+	child := buildUpgradeDelegate(t, stateDir, parent)
+	path := filepath.Join(stateDir, "sessions", parent, "delegates.jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("{\"events\":["); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	locks := hubcore.NewResumeLocks()
+	cfg := hubcore.WebConfig{StateDir: stateDir, RunDir: runDir, ResumeLocks: locks,
+		DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return nil, daemonprocess.ErrExited })}
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: parent, ThreadID: parent, StateDir: stateDir})
+	for range 2 {
+		old := admitSessionConnection(t.Context(), cfg)
+		if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + parent}, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := sessionConnectionRecoveryError(old, cfg, "local:"+child, ""); err == nil {
+			t.Fatal("committed child escaped fence")
+		}
+	}
+}
+
+func TestForceStopResumedDelegateFencesHistoricalDescendants(t *testing.T) {
+	stateDir, runDir := t.TempDir(), t.TempDir()
+	root := buildRPCParentSession(t, stateDir)
+	resumed := buildUpgradeDelegate(t, stateDir, root)
+	seq := 1
+	addDelegate := func(parent, parentEdge, edge string) string {
+		t.Helper()
+		child, err := agent.ForkSession(stateDir, parent, 1, "nested delegate", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta, err := schema.LoadSessionMeta(stateDir, child)
+		if err != nil {
+			t.Fatal(err)
+		}
+		meta.IsSubagent, meta.JobTreeRootSessionID = true, root
+		if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+			t.Fatal(err)
+		}
+		seq++
+		descriptor := map[string]any{"child_session_id": child, "transcript_ref": "local:" + child, "owner_session_id": root, "parent_delegate_id": parentEdge, "task": "nested", "agent_type": "explorer", "tool_name_ceiling": []string{"communicate"}, "resumable": true, "config": map[string]any{}}
+		batch, err := json.Marshal(map[string]any{"events": []map[string]any{{"kind": "delegate_created", "seq": seq, "delegate_id": edge, "created": map[string]any{"descriptor": descriptor}}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		journal, err := os.OpenFile(filepath.Join(stateDir, "sessions", root, "delegates.jsonl"), os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := journal.Write(append(batch, '\n')); err != nil {
+			t.Fatal(err)
+		}
+		if err := journal.Close(); err != nil {
+			t.Fatal(err)
+		}
+		return child
+	}
+	child := addDelegate(resumed, "dlg_upgrade", "dlg_nested")
+	grandchild := addDelegate(child, "dlg_nested", "dlg_deep")
+	sibling := addDelegate(root, "", "dlg_sibling")
+	ids, err := agent.SessionOwnedDelegateIDs(t.Context(), stateDir, resumed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{child, grandchild}
+	slices.Sort(want)
+	if !slices.Equal(ids, want) {
+		t.Fatalf("resumed owner descendants=%v, want %v", ids, want)
+	}
+	locks := hubcore.NewResumeLocks()
+	var events []string
+	var late string
+	cfg := hubcore.WebConfig{StateDir: stateDir, RunDir: runDir, ResumeLocks: locks, DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+		return &forceStopProcess{events: &events, onWait: func() { late = addDelegate(child, "dlg_nested", "dlg_late") }}, nil
+	})}
+	old := admitSessionConnection(t.Context(), cfg)
+	epochs := map[string]uint64{}
+	for _, id := range want {
+		epochs[id] = sessionRequestRecoveryEpoch(old, cfg, "local:"+id, "")
+	}
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: resumed, ThreadID: resumed, StateDir: stateDir})
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + resumed}, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range want {
+		if locks.RecoveryState(id).Epoch == epochs[id] {
+			t.Fatal("historical descendant admission epoch did not advance")
+		}
+		if err := sessionActionRecoveryError(old, cfg, "local:"+id, "", epochs[id]); err == nil {
+			t.Fatal("queued historical descendant survived force stop")
+		}
+	}
+	if late == "" {
+		t.Fatal("late descendant not created")
+	}
+	if err := sessionConnectionRecoveryError(old, cfg, "local:"+late, ""); err == nil {
+		t.Fatal("late descendant escaped resumed owner fence")
+	}
+	for _, id := range []string{root, sibling} {
+		if locks.RecoveryState(id).Epoch != 0 {
+			t.Fatal("unrelated controller or sibling was fenced")
+		}
+		if err := sessionConnectionRecoveryError(old, cfg, "local:"+id, ""); err != nil {
+			t.Fatalf("unrelated session rejected: %v", err)
+		}
+	}
+}
+
+func TestForceStopFailedTerminationBlocksFreshDescendantActions(t *testing.T) {
+	for _, failure := range []string{"kill", "wait", "late"} {
+		t.Run(failure, func(t *testing.T) {
+			stateDir, runDir, recoveryDir := t.TempDir(), t.TempDir(), t.TempDir()
+			parent := buildRPCParentSession(t, stateDir)
+			child := ""
+			if failure != "late" {
+				child = buildUpgradeDelegate(t, stateDir, parent)
+			}
+			locks, err := hubcore.NewPersistentResumeLocks(recoveryDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var events []string
+			process := &forceStopProcess{events: &events}
+			if failure == "kill" {
+				process.killErr = errors.New("signal failed")
+			} else {
+				process.waitErr = context.DeadlineExceeded
+			}
+			cfg := hubcore.WebConfig{StateDir: stateDir, RunDir: runDir, ResumeLocks: locks,
+				DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return process, nil })}
+			writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: parent, ThreadID: parent, StateDir: stateDir})
+			if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + parent}, nil); err == nil {
+				t.Fatal("expected failed termination")
+			}
+			if failure == "late" {
+				child = buildUpgradeDelegate(t, stateDir, parent)
+			}
+			for _, restart := range []bool{false, true} {
+				if restart {
+					cfg.ResumeLocks, err = hubcore.NewPersistentResumeLocks(recoveryDir)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				fresh := admitSessionConnection(t.Context(), cfg)
+				called := false
+				_, err := withSessionActionOwnership(fresh, cfg, "local:"+child, "", func() (bool, error) { called = true; return true, nil })
+				if called || !isSessionRecoveryAdmissionError(err) {
+					t.Fatalf("restart=%v descendant action ran=%v error=%v", restart, called, err)
+				}
+				if state := cfg.ResumeLocks.RecoveryState(child); state.ResumeSessionID != "" {
+					t.Fatalf("child acquired root identity: %+v", state)
+				}
+			}
+			process.killErr, process.waitErr = nil, nil
+			if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + parent}, nil); err != nil {
+				t.Fatal(err)
+			}
+			cfg.ResumeLocks, err = hubcore.NewPersistentResumeLocks(recoveryDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fresh := admitSessionConnection(t.Context(), cfg)
+			if err := sessionActionRecoveryError(fresh, cfg, "local:"+child, "", cfg.ResumeLocks.RecoveryState(child).Epoch); err != nil {
+				t.Fatalf("confirmed stop still blocks child: %v", err)
+			}
+			if !cfg.ResumeLocks.RecoveryState(parent).ResumeRequired {
+				t.Fatal("exit confirmation acknowledged root Resume")
+			}
+
+		})
+	}
+}

--- a/cmd/evener-hub/app_force_stop_test.go
+++ b/cmd/evener-hub/app_force_stop_test.go
@@ -1,0 +1,1632 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"slices"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/daemonprocess"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/rendezvous"
+)
+
+type forceStopControllerFunc func(daemonprocess.Target) (daemonprocess.Process, error)
+
+func (f forceStopControllerFunc) Open(target daemonprocess.Target) (daemonprocess.Process, error) {
+	return f(target)
+}
+
+type forceStopProcess struct {
+	events           *[]string
+	killErr, waitErr error
+	onWait           func()
+}
+
+func (p *forceStopProcess) Kill() error { *p.events = append(*p.events, "kill"); return p.killErr }
+func (p *forceStopProcess) Wait(context.Context) error {
+	*p.events = append(*p.events, "wait")
+	if p.onWait != nil {
+		p.onWait()
+	}
+	return p.waitErr
+}
+func (p *forceStopProcess) Close() error { *p.events = append(*p.events, "close"); return nil }
+
+func TestHubForceStopConfirmsExitAndPreservesSavedData(t *testing.T) {
+	for _, protocol := range []string{"evener-appwire-v3", appwire.ProtocolVersion} {
+		t.Run(protocol, func(t *testing.T) {
+			stateDir, runDir := t.TempDir(), t.TempDir()
+			sessionID := buildRPCParentSession(t, stateDir)
+			saved, err := os.ReadDir(filepath.Join(stateDir, "sessions"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			contents := map[string][]byte{}
+			for _, file := range saved {
+				if !file.IsDir() {
+					contents[file.Name()], err = os.ReadFile(filepath.Join(stateDir, "sessions", file.Name()))
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			entry := rendezvous.Entry{PID: 4242, SessionID: sessionID, ThreadID: sessionID, WorkspaceRef: "local:" + sessionID, StateDir: stateDir, Protocol: protocol, Endpoint: "ws://127.0.0.1:1/rpc", StartedAt: time.Now()}
+			writeRendezvous(t, runDir, entry)
+			var events []string
+			controller := forceStopControllerFunc(func(target daemonprocess.Target) (daemonprocess.Process, error) {
+				events = append(events, "open")
+				if target.PID != entry.PID || target.SessionID != sessionID || target.StateDir != stateDir || !target.StartedAt.Equal(entry.StartedAt) {
+					t.Errorf("target=%+v", target)
+				}
+				return &forceStopProcess{events: &events}, nil
+			})
+			hub := newHubRPCTestServer(t, hubcore.WebConfig{RunDir: runDir, ResumeLocks: hubcore.NewResumeLocks(), DaemonProcesses: controller})
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			var response appwire.EmptyResponse
+			if err := client.Request(t.Context(), "evener/thread/forceStop", map[string]string{"ref": "local:" + sessionID}, &response); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(events, []string{"open", "kill", "wait", "close"}) {
+				t.Fatalf("events=%v", events)
+			}
+			for name, want := range contents {
+				got, err := os.ReadFile(filepath.Join(stateDir, "sessions", name))
+				if err != nil || !reflect.DeepEqual(got, want) {
+					t.Errorf("saved file %s changed: %v", name, err)
+				}
+			}
+			if entries, err := rendezvous.ListStrict(runDir); err != nil || len(entries) != 1 {
+				t.Fatalf("stop removed ownership data instead of confirming exit: %v %v", entries, err)
+			}
+		})
+	}
+}
+
+func TestForceStopRevalidatesExitedProcessUnderOwnership(t *testing.T) {
+	for _, current := range []string{"exited", "live", "ambiguous"} {
+		t.Run(current, func(t *testing.T) {
+			runDir := t.TempDir()
+			entry := rendezvous.Entry{PID: 4242, SessionID: "current", ThreadID: "current", WorkspaceRef: "local:stable", StateDir: t.TempDir(), StartedAt: time.Now()}
+			writeRendezvous(t, runDir, entry)
+			locks := hubcore.NewResumeLocks()
+			var events []string
+			opens := 0
+			controller := forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+				opens++
+				if opens == 1 {
+					return nil, daemonprocess.ErrExited
+				}
+				for _, alias := range []string{"stable", "current"} {
+					if locks.For(alias).TryLock() {
+						locks.For(alias).Unlock()
+						t.Errorf("exit revalidation did not hold %s ownership", alias)
+					}
+				}
+				switch current {
+				case "live":
+					return &forceStopProcess{events: &events}, nil
+				case "ambiguous":
+					return nil, errors.New("process identity is unresolved")
+				default:
+					return nil, daemonprocess.ErrExited
+				}
+			})
+			cfg := hubcore.WebConfig{RunDir: runDir, ResumeLocks: locks, DaemonProcesses: controller}
+			err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:stable"}, nil)
+			if opens != 2 || (err == nil) != (current == "exited") {
+				t.Fatalf("exit result ignored current process: opens=%d err=%v", opens, err)
+			}
+			var want []string
+			if current == "live" {
+				want = []string{"close"}
+			}
+			if !reflect.DeepEqual(events, want) {
+				t.Fatalf("unexpected generation was signaled or leaked: %v", events)
+			}
+			if state := locks.RecoveryState("stable"); state.Stopping != 0 || state.ResumeRequired != (current == "exited") {
+				t.Fatalf("false recovery success: %+v", state)
+			}
+		})
+	}
+}
+
+func TestForceStopFailuresDoNotPretendExit(t *testing.T) {
+	for _, stage := range []string{"identity", "signal", "exit", "alreadyExited"} {
+		t.Run(stage, func(t *testing.T) {
+			runDir := t.TempDir()
+			entry := rendezvous.Entry{PID: 4242, SessionID: webTestSessionID, ThreadID: webTestSessionID, StateDir: t.TempDir(), StartedAt: time.Now()}
+			writeRendezvous(t, runDir, entry)
+			var events []string
+			controller := forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+				events = append(events, "open")
+				if stage == "identity" {
+					return nil, errors.New("identity changed")
+				}
+				if stage == "alreadyExited" {
+					return nil, daemonprocess.ErrExited
+				}
+				p := &forceStopProcess{events: &events}
+				if stage == "signal" {
+					p.killErr = errors.New("signal denied")
+				}
+				if stage == "exit" {
+					p.waitErr = context.DeadlineExceeded
+				}
+				return p, nil
+			})
+			cfg := hubcore.WebConfig{RunDir: runDir, ResumeLocks: hubcore.NewResumeLocks(), DaemonProcesses: controller}
+			err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + webTestSessionID}, nil)
+			state := cfg.ResumeLocks.RecoveryState(webTestSessionID)
+			if state.Stopping != 0 || state.ResumeRequired != (stage == "signal" || stage == "exit" || stage == "alreadyExited") {
+				t.Fatalf("incorrect recovery requirement after %s: %+v", stage, state)
+			}
+			if (err == nil) != (stage == "alreadyExited") {
+				t.Fatalf("error=%v", err)
+			}
+			want := map[string][]string{"identity": {"open"}, "signal": {"open", "kill", "close"}, "exit": {"open", "kill", "wait", "close"}, "alreadyExited": {"open", "open"}}[stage]
+			if !reflect.DeepEqual(events, want) {
+				t.Fatalf("events=%v want=%v", events, want)
+			}
+		})
+	}
+}
+
+func TestForceStopRejectsAmbiguousAndForeignTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name, ref string
+		entries   []rendezvous.Entry
+	}{
+		{"foreign", "remote:owner", nil}, {"invalid", "owner", nil}, {"missing", "local:owner", nil},
+		{"multiple", "local:owner", []rendezvous.Entry{{PID: 4242, SessionID: "owner"}, {PID: 4243, SessionID: "owner"}}},
+		{"overlapping aliases", "local:stable", []rendezvous.Entry{{PID: 4242, SessionID: "current", ThreadID: "current", WorkspaceRef: "local:stable"}, {PID: 4243, SessionID: "current", ThreadID: "current"}}},
+		{"foreign claim", "local:owner", []rendezvous.Entry{{PID: 4242, SessionID: "owner", SourceID: "remote"}}},
+		{"descendant", "local:child", []rendezvous.Entry{{PID: 4242, SessionID: "owner", ThreadID: "owner"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runDir := t.TempDir()
+			for _, entry := range tc.entries {
+				writeRendezvous(t, runDir, entry)
+			}
+			controller := forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+				if tc.name != "multiple" && tc.name != "overlapping aliases" {
+					t.Error("unsafe target reached process controller")
+				}
+				return nil, errors.New("unexpected")
+			})
+			if err := forceStopThread(t.Context(), hubcore.WebConfig{RunDir: runDir, ResumeLocks: hubcore.NewResumeLocks(), DaemonProcesses: controller}, appwire.ThreadForceStopParams{Ref: tc.ref}, nil); err == nil {
+				t.Fatal("unsafe target accepted")
+			}
+		})
+	}
+}
+
+type waitingForceStopProcess struct {
+	entered, release chan struct{}
+	confirmed        atomic.Bool
+}
+
+func (p *waitingForceStopProcess) Kill() error { return nil }
+func (p *waitingForceStopProcess) Wait(ctx context.Context) error {
+	close(p.entered)
+	select {
+	case <-p.release:
+		p.confirmed.Store(true)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+func (p *waitingForceStopProcess) Close() error { return nil }
+
+func TestForceStopRevalidationComparesTimestampInstants(t *testing.T) {
+	runDir := t.TempDir()
+	entry := rendezvous.Entry{PID: 4242, SessionID: "current", WorkspaceRef: "local:stable", StartedAt: time.Date(2026, 9, 7, 12, 0, 0, 0, time.FixedZone("offset", 1200))}
+	writeRendezvous(t, runDir, entry)
+	previous, err := forceStopEntry(runDir, "stable", nil, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := forceStopOwnershipUnchanged(runDir, "stable", previous, nil, ""); err != nil {
+		t.Fatalf("identical persisted timestamp rejected: %v", err)
+	}
+	entry.StartedAt = entry.StartedAt.Add(time.Second)
+	writeRendezvous(t, runDir, entry)
+	if err := forceStopOwnershipUnchanged(runDir, "stable", previous, nil, ""); err == nil {
+		t.Fatal("changed start instant accepted")
+	}
+}
+
+func TestForceStopRejectsDiscoveryChangeDuringLockedRevalidation(t *testing.T) {
+	runDir := t.TempDir()
+	entry := rendezvous.Entry{PID: 4242, SessionID: "current", WorkspaceRef: "local:stable"}
+	writeRendezvous(t, runDir, entry)
+	previous, err := forceStopEntry(runDir, "stable", nil, nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry.InstanceID = "replacement"
+	writeRendezvous(t, runDir, entry)
+	if err := forceStopOwnershipUnchanged(runDir, "stable", previous, nil, ""); err == nil {
+		t.Fatal("changed discovery accepted")
+	}
+}
+
+// A failed ancillary discovery refresh cannot undo the verified exit.
+func TestForceStopPreservesSuccessAfterRosterRefreshFailure(t *testing.T) {
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: "owner"})
+	roster := hubcore.NewRoster(runDir, failedRPCProber{})
+	poked := false
+	var events []string
+	cfg := hubcore.WebConfig{RunDir: runDir, ResumeLocks: hubcore.NewResumeLocks(), Roster: roster,
+		PokeAttention: func() { poked = true },
+		DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+			return &forceStopProcess{events: &events, onWait: func() {
+				if err := os.WriteFile(filepath.Join(runDir, "4243.json"), []byte("{"), 0600); err != nil {
+					t.Error(err)
+				}
+			}}, nil
+		}),
+	}
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:owner"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(events, []string{"kill", "wait", "close"}) {
+		t.Fatalf("stop events=%v", events)
+	}
+	if !poked {
+		t.Fatal("successful stop did not invalidate attention")
+	}
+	if err := roster.RefreshAndWait(t.Context()); err == nil {
+		t.Fatal("fixture did not fail discovery")
+	}
+}
+
+type forceStopProberFunc func(rendezvous.Entry) hubcore.ProbeResult
+
+func (f forceStopProberFunc) Probe(entry rendezvous.Entry) hubcore.ProbeResult { return f(entry) }
+
+type fixtureExitProcess struct {
+	input   io.Closer
+	command *exec.Cmd
+}
+
+func (p *fixtureExitProcess) Kill() error                { return p.input.Close() }
+func (p *fixtureExitProcess) Wait(context.Context) error { return p.command.Wait() }
+func (p *fixtureExitProcess) Close() error               { return nil }
+
+func TestHubForceStopUnconfirmedRootReadAndExplicitResume(t *testing.T) {
+	var sessionID string
+	shutdownCalls := 0
+	cfg, sid, resumes := parityResumeFixture(t, func(daemon *appserver.Server) {
+		appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+			return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: sessionID, SessionID: sessionID, Source: "local", Status: appwire.ThreadStatus{Type: "idle"}, Evener: appwire.EvenerThread{Ref: params.Ref, InstanceID: sessionID, Capabilities: appwire.ThreadCapabilities{Send: true, Shutdown: true}}}}, nil
+		})
+		appserver.HandleTyped(daemon.Router(), appwire.MethodThreadShutdown, func(context.Context, appwire.ThreadShutdownParams) (appwire.EmptyResponse, error) {
+			shutdownCalls++
+			return appwire.EmptyResponse{}, nil
+		})
+	})
+	sessionID = sid
+	// cat owns only this test's pipe and exits when the fake controller closes
+	// it. Real process liveness drives the roster's unconfirmed/crash states.
+	command := exec.CommandContext(t.Context(), "cat")
+	input, err := command.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = input.Close()
+		if command.ProcessState == nil {
+			_ = command.Wait()
+		}
+	})
+	pe, _ := cfg.Past.Find(sessionID)
+	entry := rendezvous.Entry{PID: command.Process.Pid, SessionID: sessionID, ThreadID: sessionID, WorkspaceRef: "local:" + sessionID, StateDir: pe.StateDir, Protocol: appwire.ProtocolVersion, StartedAt: time.Now()}
+	writeRendezvous(t, cfg.RunDir, entry)
+	cfg.Roster = hubcore.NewRoster(cfg.RunDir, forceStopProberFunc(func(e rendezvous.Entry) hubcore.ProbeResult {
+		if e.PID == entry.PID {
+			return hubcore.ProbeResult{}
+		}
+		return hubcore.ProbeResult{OK: true, SessionID: sessionID, Status: "idle"}
+	}))
+	cfg.ResumeLocks = hubcore.NewResumeLocks()
+	opens := 0
+	cfg.DaemonProcesses = forceStopControllerFunc(func(target daemonprocess.Target) (daemonprocess.Process, error) {
+		opens++
+		if target.PID == 106 {
+			return &forceStopProcess{events: new([]string)}, nil
+		}
+		if target.PID == command.Process.Pid && command.ProcessState != nil {
+			return nil, daemonprocess.ErrExited
+		}
+		if target.PID != command.Process.Pid {
+			t.Fatalf("unexpected target: %+v", target)
+		}
+		return &fixtureExitProcess{input: input, command: command}, nil
+	})
+	hub := newHubRPCTestServer(t, cfg)
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	ref := "local:" + sessionID
+	if _, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref, IncludeTurns: true}); err == nil {
+		t.Fatal("unconfirmed live root unexpectedly hydrated")
+	}
+	var stopped appwire.EmptyResponse
+	if err := client.Request(t.Context(), "evener/thread/forceStop", appwire.ThreadForceStopParams{Ref: ref}, &stopped); err != nil {
+		t.Fatal(err)
+	}
+	read, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref, IncludeTurns: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Thread.Status.Type != "notLoaded" || len(read.Thread.Turns) != 2 || read.Thread.Evener.Capabilities.Send || !read.Thread.Evener.ResumeRequired {
+		t.Fatalf("stopped read: %+v", read.Thread)
+	}
+	if *resumes != 0 {
+		t.Fatal("stop/read automatically resumed")
+	}
+	entries, err := rendezvous.ListStrict(cfg.RunDir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("retained crash marker=%v err=%v", entries, err)
+	}
+	client = dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: ref}); err != nil {
+		t.Fatal(err)
+	}
+	if *resumes != 1 {
+		t.Fatalf("explicit resumes=%d", *resumes)
+	}
+	if err := client.ThreadShutdown(t.Context(), appwire.ThreadShutdownParams{Ref: ref}); err != nil {
+		t.Fatal(err)
+	}
+	if shutdownCalls != 1 || opens != 1 {
+		t.Fatalf("normal shutdown route=%d process opens=%d", shutdownCalls, opens)
+	}
+	if err := client.Request(t.Context(), appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: ref}, nil); err != nil {
+		t.Fatalf("stop after explicit resume: %v", err)
+	}
+	if *resumes != 1 {
+		t.Fatalf("second stop resumed: %d", *resumes)
+	}
+}
+
+func TestForceStopSerializesResumeAndDeletionEntryPoints(t *testing.T) {
+	for _, operation := range []string{"resume", "delete"} {
+		for _, savedAlias := range []string{"stable", "current"} {
+			t.Run(operation+"/"+savedAlias, func(t *testing.T) {
+				stateDir := filepath.Join(t.TempDir(), "force-stop-0000000000")
+				sessionID := buildRPCParentSession(t, stateDir)
+				past := hubcore.NewPastIndex(stateDir)
+				if _, err := past.Rebuild(); err != nil {
+					t.Fatal(err)
+				}
+				currentID, stableID := sessionID, "02wMz5Txv1C3Hut0M8GCeC"
+				if savedAlias == "stable" {
+					currentID, stableID = stableID, currentID
+				}
+				runDir := t.TempDir()
+				writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: currentID, ThreadID: currentID, WorkspaceRef: "local:" + stableID, StateDir: stateDir})
+				process := &waitingForceStopProcess{entered: make(chan struct{}), release: make(chan struct{})}
+				spawned := make(chan struct{}, 1)
+				cfg := hubcore.WebConfig{RunDir: runDir, Past: past, ResumeLocks: hubcore.NewResumeLocks(),
+					DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return process, nil }),
+					Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+						if !process.confirmed.Load() {
+							t.Error("resume spawned before exit confirmation")
+						}
+						spawned <- struct{}{}
+						return rendezvous.Entry{}, errors.New("fixture spawn boundary")
+					}},
+				}
+				web := NewWebServer(cfg)
+				stopped := make(chan error, 1)
+				go func() {
+					stopped <- forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + stableID}, nil)
+				}()
+				<-process.entered
+				for _, alias := range []string{currentID, stableID} {
+					lock := cfg.ResumeLocks.For(alias)
+					if lock.TryLock() {
+						lock.Unlock()
+						t.Errorf("%s lock released before exit", alias)
+					}
+				}
+				started, finished := make(chan struct{}), make(chan struct{})
+				resumeResult := make(chan error, 1)
+				go func() {
+					defer close(finished)
+					close(started)
+					if operation == "resume" {
+						_, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + sessionID})
+						resumeResult <- err
+					} else {
+						response, err := web.sessionDelete(t.Context(), appwire.SessionDeleteParams{Ref: "local:" + sessionID})
+						if err != nil || len(response.Deleted) != 1 {
+							t.Errorf("delete response=%+v err=%v", response, err)
+						}
+						if !process.confirmed.Load() {
+							t.Error("deletion completed before exit confirmation")
+						}
+					}
+				}()
+				<-started
+				if _, err := os.Stat(filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl")); err != nil {
+					t.Fatal(err)
+				}
+				select {
+				case <-spawned:
+					t.Error("spawned while force stop holds ownership")
+				default:
+				}
+				close(process.release)
+				if err := <-stopped; err != nil {
+					t.Fatal(err)
+				}
+				<-finished
+				if operation == "resume" {
+					// The overlapping resume can observe active recovery between
+					// ownership unlock and completion of the recovery fence.
+					wantOverlap := appwire.ErrorActionUnavailable
+					select {
+					case <-spawned:
+						wantOverlap = appwire.ErrorHubLaunch
+					default:
+					}
+					overlapErr := <-resumeResult
+					if overlapErr == nil || evenerErrorInfoFromData(appserver.WireError(overlapErr).Data) != string(wantOverlap) {
+						t.Fatalf("overlapping resume error=%v want=%s", overlapErr, wantOverlap)
+					}
+					_, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + sessionID})
+					if err == nil || evenerErrorInfoFromData(appserver.WireError(err).Data) != string(appwire.ErrorHubLaunch) {
+						t.Fatalf("fresh resume did not return fixture spawn error: %v", err)
+					}
+					select {
+					case <-spawned:
+					default:
+						t.Error("fresh resume never reached spawner after force stop returned")
+					}
+				} else if _, err := os.Stat(filepath.Join(stateDir, "sessions", sessionID+".transcript.jsonl")); !os.IsNotExist(err) {
+					t.Fatalf("delete did not remove saved data: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestHubForceStopInterruptsStalledRPCOnSameConnection(t *testing.T) {
+	for _, method := range []string{appwire.MethodThreadShutdown, appwire.MethodThreadModelSet} {
+		t.Run(method, func(t *testing.T) {
+			var sessionID string
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			defer close(release)
+			cfg, sid, resumes := parityResumeFixture(t, func(daemon *appserver.Server) {
+				appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+					return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: sessionID, SessionID: sessionID, Source: "local", Evener: appwire.EvenerThread{Ref: params.Ref, InstanceID: sessionID, Capabilities: appwire.ThreadCapabilities{Shutdown: true, ChangeModel: true}}}}, nil
+				})
+				daemon.Router().Handle(method, func(ctx context.Context, _ json.RawMessage) (any, error) {
+					close(entered)
+					select {
+					case <-ctx.Done():
+					case <-release:
+					}
+					return appwire.EmptyResponse{}, ctx.Err()
+				})
+			})
+			sessionID = sid
+			cfg.ResumeLocks = hubcore.NewResumeLocks()
+			var events []string
+			cfg.DaemonProcesses = forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+				return &forceStopProcess{events: &events}, nil
+			})
+			hub := newHubRPCTestServer(t, cfg)
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			ref := "local:" + sessionID
+			if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: ref}); err != nil {
+				t.Fatal(err)
+			}
+			shutdown := make(chan error, 1)
+			go func() {
+				shutdown <- client.Request(t.Context(), method, appwire.ThreadModelSetParams{Ref: ref, ModelProvider: "test", Model: "test"}, nil)
+			}()
+			select {
+			case <-entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("shutdown never reached daemon")
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer cancel()
+			if err := client.Request(ctx, appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: ref}, nil); err != nil {
+				t.Fatalf("force stop behind stalled shutdown: %v", err)
+			}
+			select {
+			case err := <-shutdown:
+				if err == nil {
+					t.Fatal("interrupted RPC returned success")
+				}
+			case <-ctx.Done():
+				t.Fatal("stalled shutdown did not return")
+			}
+			if !reflect.DeepEqual(events, []string{"kill", "wait", "close"}) {
+				t.Fatalf("process events=%v", events)
+			}
+			if *resumes != 1 {
+				t.Fatalf("recovery automatically resumed session: %d", *resumes)
+			}
+		})
+	}
+}
+
+func TestForceStopSkipsVerifiedExitedClaims(t *testing.T) {
+	for _, aliasOnly := range []bool{false, true} {
+		t.Run(strconv.FormatBool(aliasOnly), func(t *testing.T) {
+			runDir := t.TempDir()
+			old := rendezvous.Entry{PID: 4242, SessionID: "stable", ThreadID: "current", StateDir: t.TempDir(), StartedAt: time.Now()}
+			writeRendezvous(t, runDir, old)
+			var events []string
+			dead := map[int]bool{}
+			cfg := hubcore.WebConfig{RunDir: runDir, ResumeLocks: hubcore.NewResumeLocks(), DaemonProcesses: forceStopControllerFunc(func(target daemonprocess.Target) (daemonprocess.Process, error) {
+				if dead[target.PID] {
+					return nil, daemonprocess.ErrExited
+				}
+				return &forceStopProcess{events: &events, onWait: func() { dead[target.PID] = true }}, nil
+			})}
+			params := appwire.ThreadForceStopParams{Ref: "local:stable"}
+			if err := forceStopThread(t.Context(), cfg, params, nil); err != nil {
+				t.Fatal(err)
+			}
+			resumed := old
+			resumed.PID++
+			if aliasOnly {
+				resumed.SessionID = "resumed"
+				params.Ref = "local:resumed"
+			}
+			writeRendezvous(t, runDir, resumed)
+			if err := forceStopThread(t.Context(), cfg, params, nil); err != nil {
+				t.Fatalf("second force stop: %v", err)
+			}
+			if err := forceStopThread(t.Context(), cfg, params, nil); err != nil {
+				t.Fatalf("retry with all owners exited: %v", err)
+			}
+			entries, err := rendezvous.ListStrict(runDir)
+			if err != nil || len(entries) != 2 {
+				t.Fatalf("crash markers not preserved: %v %v", entries, err)
+			}
+		})
+	}
+}
+
+func TestHubForceStopInterruptsStalledSpawnedResumeRead(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	cfg, sessionID, resumes := parityResumeFixture(t, func(daemon *appserver.Server) {
+		appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, _ appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+			close(entered)
+			select {
+			case <-ctx.Done():
+			case <-release:
+			}
+			return appwire.ThreadReadResponse{}, ctx.Err()
+		})
+	})
+	spawner := cfg.Spawner.(*fakeRPCSpawner)
+	spawn := spawner.resume
+	spawner.resume = func(ctx context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		entry, err := spawn(ctx, req)
+		entry.StartedAt = time.Now()
+		entry.StateDir = req.StateDir
+		writeRendezvous(t, cfg.RunDir, entry)
+		return entry, err
+	}
+	cfg.Roster = hubcore.NewRoster(cfg.RunDir, forceStopProberFunc(func(rendezvous.Entry) hubcore.ProbeResult { return hubcore.ProbeResult{} }))
+	cfg.ResumeLocks = hubcore.NewResumeLocks()
+	var events []string
+	cfg.DaemonProcesses = forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+		return &forceStopProcess{events: &events}, nil
+	})
+	hub := newHubRPCTestServer(t, cfg)
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	ref := "local:" + sessionID
+	resume := make(chan error, 1)
+	go func() {
+		_, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: ref})
+		resume <- err
+	}()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("spawned read never reached daemon")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	if err := client.Request(ctx, appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: ref}, nil); err != nil {
+		t.Fatalf("force stop behind spawned read: %v", err)
+	}
+	select {
+	case err := <-resume:
+		if err == nil {
+			t.Fatal("canceled resume succeeded")
+		}
+	case <-ctx.Done():
+		t.Fatal("resume retained ownership")
+	}
+	if *resumes != 1 {
+		t.Fatalf("spawns=%d", *resumes)
+	}
+	if !reflect.DeepEqual(events, []string{"kill", "wait", "close"}) {
+		t.Fatalf("process events=%v", events)
+	}
+}
+
+func TestHubForceStopCancelsStartupWithoutReplayingInput(t *testing.T) {
+	for _, stalled := range []string{"read", "initial turn"} {
+		t.Run(stalled, func(t *testing.T) {
+			var turns atomic.Int32
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			defer close(release)
+			cfg, sessionID, spawns := parityResumeFixture(t, func(daemon *appserver.Server) {
+				appserver.HandleTyped(daemon.Router(), appwire.MethodTurnStart, func(ctx context.Context, _ appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
+					turns.Add(1)
+					if stalled == "initial turn" {
+						close(entered)
+						select {
+						case <-ctx.Done():
+						case <-release:
+						}
+						return appwire.TurnStartResponse{}, ctx.Err()
+					}
+					return appwire.TurnStartResponse{Turn: appwire.Turn{ID: "unexpected"}}, nil
+				})
+				appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+					if stalled == "initial turn" {
+						ref, err := appwire.ParseRef(params.Ref)
+						if err != nil {
+							return appwire.ThreadReadResponse{}, err
+						}
+						return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: ref.ThreadID, SessionID: ref.ThreadID, Evener: appwire.EvenerThread{Ref: params.Ref, InstanceID: ref.ThreadID}}}, nil
+					}
+					close(entered)
+					select {
+					case <-ctx.Done():
+					case <-release:
+					}
+					return appwire.ThreadReadResponse{}, ctx.Err()
+				})
+			})
+			spawner := cfg.Spawner.(*fakeRPCSpawner)
+			spawn := spawner.resume
+			past, _ := cfg.Past.Find(sessionID)
+			spawner.spawn = func(ctx context.Context, _ hubcore.SpawnRequest) (rendezvous.Entry, error) {
+				req := hubcore.ResumeRequest{SessionID: sessionID, StateDir: past.StateDir, WorkingDir: past.Meta.EnvInfo.WorkingDir}
+				entry, err := spawn(ctx, req)
+				entry.StartedAt = time.Now()
+				entry.StateDir = req.StateDir
+				writeRendezvous(t, cfg.RunDir, entry)
+				return entry, err
+			}
+			cfg.Roster = hubcore.NewRoster(cfg.RunDir, forceStopProberFunc(func(rendezvous.Entry) hubcore.ProbeResult { return hubcore.ProbeResult{} }))
+			cfg.ResumeLocks = hubcore.NewResumeLocks()
+			var events []string
+			cfg.DaemonProcesses = forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+				return &forceStopProcess{events: &events}, nil
+			})
+			hub := newHubRPCTestServer(t, cfg)
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			ref := "local:" + sessionID
+			startResult := make(chan error, 1)
+			go func() {
+				_, err := client.ThreadStart(t.Context(), appwire.ThreadStartParams{Model: "openai/gpt-5", CWD: past.Meta.EnvInfo.WorkingDir, Input: []appwire.InputItem{{Type: "text", Text: "must not reach stopped daemon"}}})
+				startResult <- err
+			}()
+			select {
+			case <-entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("startup RPC never reached daemon")
+			}
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer cancel()
+			if err := client.Request(ctx, appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: ref}, nil); err != nil {
+				t.Fatalf("force stop behind startup RPC: %v", err)
+			}
+			select {
+			case err := <-startResult:
+				wantTurns := int32(0)
+				if stalled == "initial turn" {
+					wantTurns = 1
+				}
+				if err == nil || turns.Load() != wantTurns {
+					t.Fatalf("canceled start dispatched initial input: err=%v turns=%d", err, turns.Load())
+				}
+			case <-ctx.Done():
+				t.Fatal("start retained ownership")
+			}
+			if *spawns != 1 {
+				t.Fatalf("spawns=%d", *spawns)
+			}
+			if !reflect.DeepEqual(events, []string{"kill", "wait", "close"}) {
+				t.Fatalf("process events=%v", events)
+			}
+		})
+	}
+}
+
+func TestHubForceStopRejectsWaitingMutationUntilExplicitResume(t *testing.T) {
+	for _, method := range []string{appwire.MethodThreadModelSet, appwire.MethodThreadCompactStart} {
+		t.Run(method, func(t *testing.T) {
+			var sessionID string
+			var stopped atomic.Bool
+			cfg, sid, resumes := parityResumeFixture(t, func(daemon *appserver.Server) {
+				appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+					if stopped.Load() {
+						return appwire.ThreadReadResponse{}, appwire.SessionUnavailable("daemon exited")
+					}
+					return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: sessionID, SessionID: sessionID, Source: "local", Status: appwire.ThreadStatus{Type: "idle"}, Evener: appwire.EvenerThread{Ref: params.Ref, InstanceID: sessionID, Capabilities: appwire.ThreadCapabilities{Send: true, ChangeModel: true, Compact: true}}}}, nil
+				})
+				daemon.Router().Handle(method, func(context.Context, json.RawMessage) (any, error) { return appwire.EmptyResponse{}, nil })
+			})
+			sessionID = sid
+			spawner := cfg.Spawner.(*fakeRPCSpawner)
+			spawn := spawner.resume
+			spawner.resume = func(ctx context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				stopped.Store(false)
+				entry, err := spawn(ctx, req)
+				process := exec.CommandContext(ctx, "true")
+				if err := process.Run(); err != nil {
+					return rendezvous.Entry{}, err
+				}
+				if err := os.Remove(filepath.Join(cfg.RunDir, strconv.Itoa(entry.PID)+".json")); err != nil {
+					return rendezvous.Entry{}, err
+				}
+				entry.PID = process.Process.Pid
+				entry.StartedAt = time.Now()
+				writeRendezvous(t, cfg.RunDir, entry)
+				return entry, err
+			}
+			cfg.Roster = hubcore.NewRoster(cfg.RunDir, forceStopProberFunc(func(rendezvous.Entry) hubcore.ProbeResult {
+				if stopped.Load() {
+					return hubcore.ProbeResult{}
+				}
+				return hubcore.ProbeResult{OK: true, SessionID: sessionID, Status: "idle"}
+			}))
+			cfg.ResumeLocks = hubcore.NewResumeLocks()
+			waiting := make(chan struct{})
+			exit := make(chan struct{})
+			process := &waitingForceStopProcess{entered: waiting, release: exit}
+			cfg.DaemonProcesses = forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return process, nil })
+			hub := newHubRPCTestServer(t, cfg)
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			ref := "local:" + sessionID
+			if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: ref}); err != nil {
+				t.Fatal(err)
+			}
+			stop := make(chan error, 1)
+			go func() {
+				stop <- client.Request(t.Context(), appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: ref}, nil)
+			}()
+			select {
+			case <-waiting:
+			case err := <-stop:
+				t.Fatalf("force stop returned before confirmation: %v", err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("force stop did not reach exit confirmation")
+			}
+			mutation := make(chan error, 1)
+			started := make(chan struct{})
+			sources := newHubSourceRegistry(cfg)
+			go func() {
+				close(started)
+				if method == appwire.MethodThreadModelSet {
+					mutation <- setThreadModelWithResume(t.Context(), cfg, sources, appwire.ThreadModelSetParams{Ref: ref, Model: "test", ModelProvider: "test"})
+				} else {
+					mutation <- compactThreadWithResume(t.Context(), cfg, sources, appwire.ThreadCompactStartParams{Ref: ref})
+				}
+			}()
+			<-started
+			stopped.Store(true)
+			close(exit)
+			if err := <-stop; err != nil {
+				t.Fatal(err)
+			}
+			if err := <-mutation; err == nil {
+				t.Fatal("waiting mutation resumed after force stop")
+			}
+			if *resumes != 1 {
+				t.Fatalf("automatic resumes after stop=%d", *resumes-1)
+			}
+			read, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if read.Thread.Status.Type != "notLoaded" || !read.Thread.Evener.ResumeRequired || read.Thread.Evener.Capabilities.Send {
+				t.Fatalf("stopped snapshot=%+v", read.Thread)
+			}
+			// An outside controller can restart the process without acknowledging
+			// the hub's action fence. Live reads must still advertise that fence.
+			req, err := resumeRequestForConfig(cfg, sessionID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := cfg.Spawner.Resume(t.Context(), req); err != nil {
+				t.Fatal(err)
+			}
+			if err := cfg.Roster.RefreshAndWait(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			live, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if live.Thread.Status.Type != "idle" || !live.Thread.Evener.ResumeRequired || live.Thread.Evener.Capabilities.Send {
+				t.Fatalf("live fenced snapshot=%+v", live.Thread)
+			}
+			oldClient := client
+			client = dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: ref}); err != nil {
+				t.Fatalf("explicit resume: %v", err)
+			}
+			staleRead, err := oldClient.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref})
+			if err != nil || !staleRead.Thread.Evener.ResumeRequired || staleRead.Thread.Evener.Capabilities.Send {
+				t.Fatalf("old connection lost Resume after another client resumed: %+v %v", staleRead.Thread, err)
+			}
+			fresh, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if fresh.Thread.Evener.ResumeRequired || !fresh.Thread.Evener.Capabilities.Send {
+				t.Fatalf("explicit resume did not clear live fence: %+v", fresh.Thread)
+			}
+
+			if err := client.Request(t.Context(), method, appwire.ThreadModelSetParams{Ref: ref, Model: "test", ModelProvider: "test"}, nil); err != nil {
+				t.Fatalf("fresh action after explicit resume: %v", err)
+			}
+		})
+	}
+}
+
+func TestSessionRecoveryRejectsOldActionsAfterExplicitResume(t *testing.T) {
+	cfg := hubcore.WebConfig{ResumeLocks: hubcore.NewResumeLocks()}
+	oldEpoch := sessionRecoveryState(cfg, "local:stable", "").Epoch
+	finish := cfg.ResumeLocks.BeginForceStop([]string{"stable", "current"})
+	if err := cfg.ResumeLocks.PersistForceStop([]string{"stable", "current"}, "current"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	epoch := sessionRecoveryState(cfg, "local:current", "").Epoch
+	if err := cfg.ResumeLocks.ExplicitResumeCompleted("current", epoch); err != nil {
+		t.Fatal(err)
+	}
+	if state := sessionRecoveryState(cfg, "local:stable", ""); state.ResumeRequired || state.Stopping != 0 {
+		t.Fatalf("stable alias still fenced after explicit resume: %+v", state)
+	}
+	if err := sessionActionRecoveryError(t.Context(), cfg, "local:stable", "", oldEpoch); err == nil {
+		t.Fatal("old ownership waiter admitted after explicit resume")
+	}
+	if err := sessionActionRecoveryError(t.Context(), cfg, "local:current", "", epoch); err != nil {
+		t.Fatalf("fresh action refused: %v", err)
+	}
+	finish = cfg.ResumeLocks.BeginForceStop([]string{"stable", "current"})
+	finish(false)
+	if state := sessionRecoveryState(cfg, "local:stable", ""); state.ResumeRequired || state.Stopping != 0 {
+		t.Fatalf("failed stop declared session stopped: %+v", state)
+	}
+}
+
+func TestTurnStartDoesNotRetryRecoveryRejectionAfterExplicitResume(t *testing.T) {
+	cfg := hubcore.WebConfig{ResumeLocks: hubcore.NewResumeLocks()}
+	const ref = "local:recovery-waiter"
+	oldEpoch := sessionRecoveryState(cfg, ref, "").Epoch
+	finish := cfg.ResumeLocks.BeginForceStop([]string{"recovery-waiter"})
+	if err := cfg.ResumeLocks.PersistForceStop([]string{"recovery-waiter"}, "recovery-waiter"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	if err := cfg.ResumeLocks.ExplicitResumeCompleted("recovery-waiter", cfg.ResumeLocks.RecoveryState("recovery-waiter").Epoch); err != nil {
+		t.Fatal(err)
+	}
+	stale := sessionActionRecoveryError(t.Context(), cfg, ref, "", oldEpoch)
+	if stale == nil {
+		t.Fatal("fixture did not reject the stale admission")
+	}
+	oldResolve, oldResume := resolveTurnStartSource, resumeTurnStartThread
+	t.Cleanup(func() { resolveTurnStartSource, resumeTurnStartThread = oldResolve, oldResume })
+	resolved, resumed, submitted := 0, 0, 0
+	source := &scriptedAppSource{id: "local", startTurn: func(context.Context, appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
+		submitted++
+		return appwire.TurnStartResponse{}, nil
+	}}
+	resolveTurnStartSource = func(*appsource.Registry, string, string) (appsource.Source, error) {
+		resolved++
+		if resolved == 1 {
+			return nil, stale
+		}
+		return source, nil
+	}
+	resumeTurnStartThread = func(context.Context, hubcore.WebConfig, *appsource.Registry, appwire.ThreadResumeParams) (appwire.ThreadResumeResponse, error) {
+		resumed++
+		return appwire.ThreadResumeResponse{}, nil
+	}
+	server := newHubAppServer(cfg, appsource.NewRegistry())
+	_, err := exactDispatch(t.Context(), t, server, appwire.MethodTurnStart, appwire.TurnStartParams{Ref: ref, ClientMutationID: "pending-before-recovery", Input: []appwire.InputItem{{Type: "text", Text: "old queued input"}}})
+	if err == nil {
+		t.Fatal("stale turn/start was accepted after explicit resume")
+	}
+	wire := appserver.WireError(err)
+	if wire.Code != appwire.CodeUnavailable || evenerErrorInfoFromData(wire.Data) != string(appwire.ErrorActionUnavailable) {
+		t.Fatalf("recovery rejection lost wire classification: %+v", wire)
+	}
+	if wire.Message != stale.Error() {
+		t.Fatalf("wire message changed: %q vs %q", wire.Message, stale.Error())
+	}
+	if resumed != 0 || submitted != 0 || resolved != 1 {
+		t.Fatalf("stale input retried: resolutions=%d resumes=%d submissions=%d", resolved, resumed, submitted)
+	}
+}
+
+func TestHubForceStopRejectsRequestsQueuedBeforeRecovery(t *testing.T) {
+	stateDir, runDir := filepath.Join(t.TempDir(), "queued-recovery-0000000000"), t.TempDir()
+	sessionID := buildRPCParentSession(t, stateDir)
+	past := hubcore.NewPastIndex(stateDir)
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 4242, SessionID: sessionID, ThreadID: sessionID, StateDir: stateDir, StartedAt: time.Now()})
+	var events []string
+	var resumes atomic.Int32
+	cfg := hubcore.WebConfig{RunDir: runDir, Past: past, ResumeLocks: hubcore.NewResumeLocks(),
+		DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+			return &forceStopProcess{events: &events}, nil
+		}),
+		Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+			resumes.Add(1)
+			return rendezvous.Entry{}, errors.New("fixture spawn boundary")
+		}},
+	}
+	hub, web := newHubRPCTestServerWithWeb(t, cfg)
+	defer hub.Close()
+	entered, release := make(chan struct{}), make(chan struct{})
+	defer func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}()
+	appserver.HandleTyped(web.appRPC.Router(), appwire.MethodThreadList, func(ctx context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		close(entered)
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return appwire.ThreadListResponse{}, nil
+	})
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	transport, err := appwire.DialWebSocket(ctx, "ws"+hub.URL[len("http"):]+"/rpc", hub.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer transport.Close()
+	send := func(id int64, method string, params any) {
+		t.Helper()
+		if err := transport.Send(ctx, appwire.RequestMessage(appwire.NewIntID(id), method, params)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	receive := func(id int64) appwire.Message {
+		t.Helper()
+		for {
+			message, err := transport.Recv(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if message.Response != nil && message.Response.ID.String() == strconv.FormatInt(id, 10) || message.Error != nil && message.Error.ID.String() == strconv.FormatInt(id, 10) {
+				return message
+			}
+		}
+	}
+	send(1, appwire.MethodInitialize, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion})
+	if message := receive(1); message.Error != nil {
+		t.Fatal(message.Error.Error)
+	}
+	send(2, appwire.MethodThreadList, appwire.ThreadListParams{})
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("serial request did not start")
+	}
+	ref := "local:" + sessionID
+	send(3, appwire.MethodThreadResume, map[string]any{"sessionId": sessionID, "threadId": "ignored-extra-field"})
+	send(4, appwire.MethodThreadModelSet, appwire.ThreadModelSetParams{Ref: ref, Model: "test", ModelProvider: "test"})
+	send(5, appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: ref})
+	if message := receive(5); message.Error != nil {
+		t.Fatalf("force stop: %+v", message.Error)
+	}
+	close(release)
+	if message := receive(3); message.Error == nil {
+		t.Fatal("pre-recovery resume was accepted")
+	}
+	if message := receive(4); message.Error == nil {
+		t.Fatal("pre-recovery model action was accepted")
+	}
+	if resumes.Load() != 0 {
+		t.Fatalf("queued requests restarted daemon %d times after recovery", resumes.Load())
+	}
+	send(6, appwire.MethodThreadResume, appwire.ThreadResumeParams{Ref: ref})
+	if message := receive(6); message.Error == nil || resumes.Load() != 0 {
+		t.Fatal("old connection acknowledged recovery")
+	}
+	fresh := dialHubRPC(t, hub)
+	defer fresh.Close()
+	if _, err := fresh.Initialize(ctx, appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	_ = fresh.Request(ctx, appwire.MethodThreadResume, appwire.ThreadResumeParams{Ref: ref}, nil)
+	if resumes.Load() != 1 {
+		t.Fatalf("fresh explicit resume did not reach spawn boundary: %d", resumes.Load())
+	}
+}
+
+func TestRecoveryAdmissionUsesNativeTargetAndPreservesRetryEpoch(t *testing.T) {
+	for _, tc := range []struct {
+		name, method, target string
+		params               any
+	}{
+		{"resume ignores threadId", appwire.MethodThreadResume, "B", map[string]any{"sessionId": "B", "threadId": "A"}},
+		{"resume sessionId precedence", appwire.MethodThreadResume, "B", map[string]any{"sessionId": "B", "ref": "local:A", "threadId": "ignored"}},
+		{"turn ref precedence", appwire.MethodTurnStart, "B", map[string]any{"ref": "local:B", "threadId": "A"}},
+		{"turn threadId", appwire.MethodTurnStart, "B", map[string]any{"threadId": "B", "sessionId": "ignored"}},
+		{"sandbox ref precedence", appwire.MethodEvenerSandboxEscalationResolve, "B", map[string]any{"ref": "local:B", "threadId": "A"}},
+		{"sandbox threadId", appwire.MethodEvenerSandboxEscalationResolve, "B", map[string]any{"threadId": "B"}},
+		{"sandbox ignores mutation ID", appwire.MethodEvenerSandboxEscalationResolve, "B", map[string]any{"ref": "local:B", "clientMutationId": []string{"ignored"}}},
+		{"sandbox invalid target", appwire.MethodEvenerSandboxEscalationResolve, "", map[string]any{"threadId": []string{"invalid"}}},
+		{"model ignores unknown field types", appwire.MethodThreadModelSet, "B", map[string]any{"ref": "local:B", "threadId": []string{"ignored"}}},
+		{"unknown method", "unknown", "", map[string]any{"ref": "local:B"}},
+		{"foreign ref", appwire.MethodThreadResume, "", map[string]any{"ref": "remote:B", "sessionId": "A"}},
+		{"malformed ref", appwire.MethodThreadResume, "", map[string]any{"ref": "bad", "sessionId": "B"}},
+		{"invalid supported field", appwire.MethodThreadResume, "", map[string]any{"sessionId": []string{"bad"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := hubcore.WebConfig{ResumeLocks: hubcore.NewResumeLocks()}
+			ctx := admitSessionRecovery(t.Context(), cfg, appwire.RequestMessage(appwire.NewIntID(1), tc.method, tc.params))
+			admission, ok := ctx.Value(sessionRecoveryAdmissionKey{}).(sessionRecoveryAdmission)
+			if tc.target == "" {
+				if ok {
+					t.Fatalf("invalid or unrelated request admitted: %+v", admission)
+				}
+				return
+			}
+			if !ok || admission.sessionID != tc.target {
+				t.Fatalf("admission=%+v present=%v", admission, ok)
+			}
+			other := cfg.ResumeLocks.BeginForceStop([]string{"unrelated"})
+			if err := cfg.ResumeLocks.PersistForceStop([]string{"unrelated"}, "unrelated"); err != nil {
+				t.Fatal(err)
+			}
+			other(true)
+			if err := sessionActionRecoveryError(t.Context(), cfg, "", tc.target, sessionRequestRecoveryEpoch(ctx, cfg, "", tc.target)); err != nil {
+				t.Fatalf("another session invalidated this admission: %v", err)
+			}
+			finish := cfg.ResumeLocks.BeginForceStop([]string{tc.target})
+			if err := cfg.ResumeLocks.PersistForceStop([]string{tc.target}, tc.target); err != nil {
+				t.Fatal(err)
+			}
+			finish(true)
+			if err := cfg.ResumeLocks.ExplicitResumeCompleted(tc.target, cfg.ResumeLocks.RecoveryState(tc.target).Epoch); err != nil {
+				t.Fatal(err)
+			}
+			if err := sessionActionRecoveryError(t.Context(), cfg, "", tc.target, sessionRequestRecoveryEpoch(ctx, cfg, "", tc.target)); err == nil {
+				t.Fatal("retry replaced the request's admission epoch")
+			}
+			if epoch := sessionRequestRecoveryEpoch(t.Context(), cfg, "", tc.target); epoch != cfg.ResumeLocks.RecoveryState(tc.target).Epoch {
+				t.Fatal("direct handler did not use execution snapshot")
+			}
+		})
+	}
+}
+
+// recoveryReasoningSource records the externally visible setting application.
+type recoveryReasoningSource struct {
+	relayLifecycleSource
+	applied int
+}
+
+func (s *recoveryReasoningSource) ID() string { return "local" }
+func (s *recoveryReasoningSource) SetThreadReasoningEffort(context.Context, appwire.ThreadReasoningEffortSetParams) error {
+	s.applied++
+	return nil
+}
+
+type recoverySandboxSource struct {
+	relayLifecycleSource
+	approvals []appwire.SandboxEscalationResolveParams
+}
+
+func (s *recoverySandboxSource) ID() string { return "local" }
+func (s *recoverySandboxSource) ResolveSandboxEscalation(_ context.Context, params appwire.SandboxEscalationResolveParams) error {
+	s.approvals = append(s.approvals, params)
+	return nil
+}
+
+func TestSandboxApprovalCannotCrossSessionRecovery(t *testing.T) {
+	for _, unread := range []bool{false, true} {
+		for _, target := range []appwire.SandboxEscalationResolveParams{
+			{Ref: "local:owner", ThreadID: "ignored", EscalationID: "approval", Approve: true},
+			{ThreadID: "owner", EscalationID: "approval", Approve: true},
+		} {
+			t.Run(fmt.Sprintf("unread=%v/ref=%s", unread, target.Ref), func(t *testing.T) {
+				cfg := hubcore.WebConfig{ResumeLocks: hubcore.NewResumeLocks()}
+				source := &recoverySandboxSource{}
+				sources := appsource.NewRegistry()
+				sources.Add(source)
+				server := newHubAppServer(cfg, sources)
+				// A queued request retains its admission epoch; unread socket input
+				// retains the connection generation even when admitted after resume.
+				ctx := t.Context()
+				message := appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodEvenerSandboxEscalationResolve, target)
+				if unread {
+					ctx = admitSessionConnection(ctx, cfg)
+				} else {
+					ctx = admitSessionRecovery(ctx, cfg, message)
+				}
+				finish := cfg.ResumeLocks.BeginForceStop([]string{"owner"})
+				if err := cfg.ResumeLocks.PersistForceStop([]string{"owner"}, "owner"); err != nil {
+					t.Fatal(err)
+				}
+				finish(true)
+				if err := cfg.ResumeLocks.ExplicitResumeCompleted("owner", cfg.ResumeLocks.RecoveryState("owner").Epoch); err != nil {
+					t.Fatal(err)
+				}
+				if unread {
+					ctx = admitSessionRecovery(ctx, cfg, message)
+				}
+				_, err := exactDispatch(ctx, t, server, appwire.MethodEvenerSandboxEscalationResolve, target)
+				if !isSessionRecoveryAdmissionError(err) || len(source.approvals) != 0 {
+					t.Fatalf("old approval reached replacement: err=%v approvals=%v", err, source.approvals)
+				}
+				wire := appserver.WireError(err)
+				raw, err := json.Marshal(wire.Data)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var data appwire.ErrorData
+				if err := json.Unmarshal(raw, &data); err != nil {
+					t.Fatal(err)
+				}
+				if data.ClientMutationID != "" || data.MutationOutcome != "" {
+					t.Fatalf("non-durable approval acquired mutation metadata: %+v", data)
+				}
+				fresh := admitSessionRecovery(admitSessionConnection(t.Context(), cfg), cfg, message)
+				if _, err := exactDispatch(fresh, t, server, appwire.MethodEvenerSandboxEscalationResolve, target); err != nil {
+					t.Fatal(err)
+				}
+				if len(source.approvals) != 1 || source.approvals[0] != target {
+					t.Fatalf("fresh approval not delivered exactly once: %v", source.approvals)
+				}
+			})
+		}
+	}
+}
+
+func TestCapturedSessionActionsRejectAdmissionBeforeRecovery(t *testing.T) {
+	for _, method := range []string{
+		appwire.MethodTurnStart, appwire.MethodTurnSteer, appwire.MethodTurnInterrupt,
+		appwire.MethodThreadModelSet, appwire.MethodThreadVisionModelSet,
+		appwire.MethodThreadReasoningEffortSet, appwire.MethodThreadCompactStart,
+		appwire.MethodThreadClear, appwire.MethodThreadShutdown, appwire.MethodGoalSet,
+		appwire.MethodTurnQueue, appwire.MethodTurnDrainAsSteer,
+		appwire.MethodTurnPromoteQueuedAsSteer, appwire.MethodTurnCancelQueued,
+	} {
+		t.Run(method, func(t *testing.T) {
+			cfg := hubcore.WebConfig{ResumeLocks: hubcore.NewResumeLocks()}
+			source := &recoveryReasoningSource{}
+			sources := appsource.NewRegistry()
+			sources.Add(source)
+			server := newHubAppServer(cfg, sources)
+			params := map[string]any{
+				"ref": "local:admitted-session", "clientMutationId": "old-action",
+				"expectedInstanceId": "instance", "expectedEntryId": "entry", "index": 0,
+				"input":           []appwire.InputItem{{Type: "text", Text: "queued input"}},
+				"reasoningEffort": "high", "model": "test", "modelProvider": "test",
+			}
+			ctx := admitSessionRecovery(t.Context(), cfg, appwire.RequestMessage(appwire.NewIntID(1), method, params))
+			finish := cfg.ResumeLocks.BeginForceStop([]string{"admitted-session"})
+			if err := cfg.ResumeLocks.PersistForceStop([]string{"admitted-session"}, "admitted-session"); err != nil {
+				t.Fatal(err)
+			}
+			finish(true)
+			if err := cfg.ResumeLocks.ExplicitResumeCompleted("admitted-session", cfg.ResumeLocks.RecoveryState("admitted-session").Epoch); err != nil {
+				t.Fatal(err)
+			}
+			_, err := exactDispatch(ctx, t, server, method, params)
+			if !isSessionRecoveryAdmissionError(err) {
+				t.Fatalf("old action crossed recovery admission: err=%v applied=%d", err, source.applied)
+			}
+			if source.applied != 0 {
+				t.Fatal("old reasoning setting applied to resumed session")
+			}
+			if method == appwire.MethodThreadReasoningEffortSet {
+				fresh := admitSessionRecovery(t.Context(), cfg, appwire.RequestMessage(appwire.NewIntID(2), method, params))
+				if _, err := exactDispatch(fresh, t, server, method, params); err != nil || source.applied != 1 {
+					t.Fatalf("fresh reasoning setting failed: err=%v applied=%d", err, source.applied)
+				}
+			}
+		})
+	}
+}
+
+func TestForceStopUnconfirmedSignalRequiresExplicitResume(t *testing.T) {
+	for _, failure := range []error{context.Canceled, context.DeadlineExceeded} {
+		t.Run(failure.Error(), func(t *testing.T) {
+			runDir := t.TempDir()
+			entry := rendezvous.Entry{PID: 4242, SessionID: "current", ThreadID: "current", WorkspaceRef: "local:stable", StateDir: t.TempDir(), StartedAt: time.Now()}
+			writeRendezvous(t, runDir, entry)
+			var events []string
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			var process daemonprocess.Process = &forceStopProcess{events: &events, waitErr: failure}
+			if errors.Is(failure, context.Canceled) {
+				waiting := &waitingForceStopProcess{entered: make(chan struct{}), release: make(chan struct{})}
+				process = waiting
+				go func() {
+					select {
+					case <-waiting.entered:
+						cancel()
+					case <-ctx.Done():
+					}
+				}()
+			}
+			cfg := hubcore.WebConfig{RunDir: runDir, ResumeLocks: hubcore.NewResumeLocks(), DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+				return process, nil
+			})}
+			if err := forceStopThread(ctx, cfg, appwire.ThreadForceStopParams{Ref: "local:stable"}, nil); err == nil {
+				t.Fatal("unconfirmed exit reported success")
+			}
+			for _, alias := range []string{"stable", "current"} {
+				state := cfg.ResumeLocks.RecoveryState(alias)
+				if !state.ResumeRequired || state.Stopping != 0 {
+					t.Fatalf("signaled alias lost explicit resume requirement: %s %+v", alias, state)
+				}
+				if _, err := hubThreadAutoResume(t.Context(), cfg, appsource.NewRegistry(), appwire.ThreadResumeParams{Session: alias}); err == nil {
+					t.Fatal("automatic resume accepted after unconfirmed termination")
+				}
+				thread := applyThreadResumeRequirement(t.Context(), cfg, "", alias, appwire.Thread{})
+				if !thread.Evener.ResumeRequired {
+					t.Fatal("fresh client cannot discover explicit resume requirement")
+				}
+			}
+		})
+	}
+}
+
+func TestConnectionRecoveryFenceIncludesUnreadActionsAndConnectionsBornDuringStop(t *testing.T) {
+	cfg := hubcore.WebConfig{ResumeLocks: hubcore.NewResumeLocks()}
+	before := admitSessionConnection(t.Context(), cfg)
+	finish := cfg.ResumeLocks.BeginForceStop([]string{"stable", "current"})
+	during := admitSessionConnection(t.Context(), cfg)
+	if err := cfg.ResumeLocks.PersistForceStop([]string{"stable", "current"}, "current"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	if err := cfg.ResumeLocks.ExplicitResumeCompleted("stable", cfg.ResumeLocks.RecoveryState("stable").Epoch); err != nil {
+		t.Fatal(err)
+	}
+	sources := appsource.NewRegistry()
+	source := &recoveryReasoningSource{}
+	sources.Add(source)
+	server := newHubAppServer(cfg, sources)
+	for name, ctx := range map[string]context.Context{"before": before, "during": during} {
+		t.Run(name, func(t *testing.T) {
+			for _, alias := range []string{"stable", "current"} {
+				for _, method := range []string{appwire.MethodThreadResume, appwire.MethodThreadReasoningEffortSet, appwire.MethodTurnStart} {
+					params := map[string]any{"ref": "local:" + alias, "clientMutationId": "old-action", "input": []appwire.InputItem{{Type: "text", Text: "unread input"}}}
+					admitted := admitSessionRecovery(ctx, cfg, appwire.RequestMessage(appwire.NewIntID(1), method, params))
+					if _, err := exactDispatch(admitted, t, server, method, params); !isSessionRecoveryAdmissionError(err) {
+						t.Fatalf("%s unread request escaped connection fence: %v", method, err)
+					}
+				}
+				thread := applyThreadResumeRequirement(ctx, cfg, "", alias, appwire.Thread{Evener: appwire.EvenerThread{Capabilities: appwire.ThreadCapabilities{Send: true}}})
+				if !thread.Evener.ResumeRequired || thread.Evener.Capabilities.Send {
+					t.Fatal("stale connection read lost actionable Resume after another client resumed")
+				}
+			}
+			unrelated := appwire.ThreadReasoningEffortSetParams{Ref: "local:unrelated", ReasoningEffort: "high"}
+			admitted := admitSessionRecovery(ctx, cfg, appwire.RequestMessage(appwire.NewIntID(2), appwire.MethodThreadReasoningEffortSet, unrelated))
+			beforeApplied := source.applied
+			if _, err := exactDispatch(admitted, t, server, appwire.MethodThreadReasoningEffortSet, unrelated); err != nil || source.applied != beforeApplied+1 {
+				t.Fatalf("unrelated target action invalidated: %v", err)
+			}
+		})
+	}
+	fresh := admitSessionConnection(t.Context(), cfg)
+	if sessionConnectionRecoveryError(fresh, cfg, "", "current") != nil {
+		t.Fatal("fresh connection remained stale")
+	}
+	finish = cfg.ResumeLocks.BeginForceStop([]string{"current"})
+	if err := cfg.ResumeLocks.PersistForceStop([]string{"current"}, "current"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	fresh = admitSessionConnection(t.Context(), cfg)
+	if _, err := hubThreadAutoResume(fresh, cfg, appsource.NewRegistry(), appwire.ThreadResumeParams{Session: "current"}); err == nil {
+		t.Fatal("fresh connection automatically cleared explicit resume requirement")
+	}
+}
+
+func TestRecoveryAdmissionNamesBlockedDurableMutation(t *testing.T) {
+	for _, recovery := range []string{"active", "completed", "failed"} {
+		t.Run(recovery, func(t *testing.T) {
+			cfg := hubcore.WebConfig{ResumeLocks: hubcore.NewResumeLocks()}
+			ctx := admitSessionConnection(t.Context(), cfg)
+			hub := newHubRPCTestServer(t, cfg)
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			finish := cfg.ResumeLocks.BeginForceStop([]string{"owner"})
+			if recovery == "active" {
+				defer finish(false)
+			} else {
+				finish(recovery == "completed")
+			}
+			server := newHubAppServer(cfg, appsource.NewRegistry())
+			params := appwire.TurnStartParams{Ref: "local:owner", ClientMutationID: "preserved-intent", ExpectedInstanceID: "known-instance", Input: []appwire.InputItem{{Type: "text", Text: "keep this input"}}}
+			_, err := exactDispatch(ctx, t, server, appwire.MethodTurnStart, params)
+			if !isSessionRecoveryAdmissionError(err) {
+				t.Fatalf("lost terminal admission classification: %v", err)
+			}
+			wireErr := client.Request(t.Context(), appwire.MethodTurnStart, params, nil)
+			for boundary, rejection := range map[string]error{"handler": err, "WebSocket": wireErr} {
+				wire := appserver.WireError(rejection)
+				raw, marshalErr := json.Marshal(wire.Data)
+				if marshalErr != nil {
+					t.Fatal(marshalErr)
+				}
+				var data appwire.ErrorData
+				if err := json.Unmarshal(raw, &data); err != nil {
+					t.Fatal(err)
+				}
+				if wire.Code != appwire.CodeUnavailable || data.EvenerErrorInfo != appwire.ErrorActionUnavailable || data.ClientMutationID != params.ClientMutationID || data.MutationOutcome != appwire.MutationOutcomeUnknown || data.RetryDisposition != appwire.RetryDispositionBlocked {
+					t.Fatalf("%s recovery rejection cannot settle dispatcher state: %+v", boundary, wire)
+				}
+			}
+		})
+	}
+}
+
+func TestBlockedAdmissionMetadataPreservesWrappedRecoveryCause(t *testing.T) {
+	for _, wrapped := range []bool{false, true} {
+		original := map[string]any{"evenerErrorInfo": string(appwire.ErrorActionUnavailable), "cause": "sessionRecovery", "detail": "retained"}
+		var rejection error = sessionRecoveryAdmissionError{appwire.WireError{Code: appwire.CodeUnavailable, Message: "resume required", Data: original}}
+		if wrapped {
+			rejection = errors.Join(errors.New("request context"), rejection)
+		}
+		blocked := blockedAdmissionMutationError(rejection, "mutation-owner")
+		if !isSessionRecoveryAdmissionError(blocked) {
+			t.Fatalf("wrapped=%v lost terminal marker", wrapped)
+		}
+		wire := appserver.WireError(blocked)
+		data, ok := wire.Data.(map[string]any)
+		if !ok || wire.Code != appwire.CodeUnavailable || wire.Message != "resume required" || data["cause"] != "sessionRecovery" || data["detail"] != "retained" || data["clientMutationId"] != "mutation-owner" || data["mutationOutcome"] != string(appwire.MutationOutcomeUnknown) || data["retryDisposition"] != string(appwire.RetryDispositionBlocked) {
+			t.Fatalf("wrapped=%v metadata=%+v", wrapped, wire.Data)
+		}
+		if _, changed := original["clientMutationId"]; changed {
+			t.Fatal("annotation mutated original error data")
+		}
+	}
+}
+
+func TestHubForceStopUnconfirmedExitReadAfterOwnershipDisappears(t *testing.T) {
+	cfg, sessionID, resumes := parityResumeFixture(t, func(*appserver.Server) {})
+	cfg.ResumeLocks = hubcore.NewResumeLocks()
+	entry := rendezvous.Entry{PID: 4242, SessionID: sessionID, ThreadID: sessionID, StateDir: t.TempDir(), StartedAt: time.Now()}
+	writeRendezvous(t, cfg.RunDir, entry)
+	var events []string
+	cfg.DaemonProcesses = forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+		return &forceStopProcess{events: &events, waitErr: context.DeadlineExceeded}, nil
+	})
+	ref := "local:" + sessionID
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: ref}, nil); err == nil {
+		t.Fatal("unconfirmed exit reported success")
+	}
+	if !slices.Contains(events, "kill") {
+		t.Fatal("termination was not requested")
+	}
+	// Exit can finish after the caller's confirmation deadline.
+	if err := rendezvous.Remove(cfg.RunDir, entry.PID); err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, cfg)
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	read, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref, IncludeTurns: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if read.Thread.Status.Type != "notLoaded" || !read.Thread.Evener.ResumeRequired || read.Thread.Evener.Capabilities.Send || len(read.Thread.Turns) == 0 {
+		t.Fatalf("unconfirmed stopped snapshot = %+v", read.Thread)
+	}
+	if *resumes != 0 {
+		t.Fatal("read automatically resumed a stopped session")
+	}
+}
+
+func TestForceStopRepeatedSharedAliasPreservesDurableTarget(t *testing.T) {
+	for _, retryAlias := range []string{"A", "B"} {
+		t.Run(retryAlias, func(t *testing.T) {
+			root, runDir := t.TempDir(), t.TempDir()
+			locks, err := hubcore.NewPersistentResumeLocks(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var events []string
+			dead := map[int]bool{}
+			cfg := hubcore.WebConfig{RunDir: runDir, ResumeLocks: locks, DaemonProcesses: forceStopControllerFunc(func(target daemonprocess.Target) (daemonprocess.Process, error) {
+				if dead[target.PID] {
+					return nil, daemonprocess.ErrExited
+				}
+				return &forceStopProcess{events: &events, onWait: func() { dead[target.PID] = true }}, nil
+			})}
+			writeRendezvous(t, runDir, rendezvous.Entry{PID: 101, SessionID: "B", ThreadID: "B", WorkspaceRef: "local:A"})
+			if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:A"}, nil); err != nil {
+				t.Fatal(err)
+			}
+			writeRendezvous(t, runDir, rendezvous.Entry{PID: 102, SessionID: "C", ThreadID: "C", WorkspaceRef: "local:B"})
+			if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:B"}, nil); err != nil {
+				t.Fatal(err)
+			}
+			cfg.ResumeLocks, err = hubcore.NewPersistentResumeLocks(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + retryAlias}, nil)
+			if retryAlias == "A" && err == nil {
+				t.Error("superseded alias stop accepted")
+			}
+			if retryAlias == "B" && err != nil {
+				t.Fatal(err)
+			}
+			cfg.ResumeLocks, err = hubcore.NewPersistentResumeLocks(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := cfg.ResumeLocks.RecoveryState("B").ResumeSessionID; got != "C" {
+				t.Fatalf("repeated stop replaced current target with %q", got)
+			}
+			called := false
+			cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				called = true
+				if req.SessionID != "C" {
+					t.Errorf("launched historical session %q", req.SessionID)
+				}
+				return rendezvous.Entry{}, errors.New("launcher observed")
+			}}
+			_, _ = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:B"})
+			if !called {
+				t.Fatal("current target did not reach launcher")
+			}
+		})
+	}
+}
+
+func TestForceStopRejectsExitedConflictingTargetsWithoutAuthority(t *testing.T) {
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: hubcore.NewResumeLocks(), DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return nil, daemonprocess.ErrExited })}
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, SessionID: "B", ThreadID: "B", WorkspaceRef: "local:A"})
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 102, SessionID: "C", ThreadID: "C", WorkspaceRef: "local:B"})
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:B"}, nil); err == nil {
+		t.Fatal("ambiguous exited transcripts accepted")
+	}
+	if cfg.ResumeLocks.RecoveryState("B").ResumeRequired {
+		t.Fatal("ambiguous lookup established recovery authority")
+	}
+}
+
+func TestForceStopRejectsRecoveryAuthorityChangedAfterDiscovery(t *testing.T) {
+	locks := hubcore.NewResumeLocks()
+	finish := locks.BeginForceStop([]string{"A", "B"})
+	if err := locks.PersistForceStop([]string{"A", "B"}, "B"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	runDir := t.TempDir()
+	writeRendezvous(t, runDir, rendezvous.Entry{PID: 101, SessionID: "B", ThreadID: "B", WorkspaceRef: "local:A"})
+	var events []string
+	cfg := hubcore.WebConfig{RunDir: runDir, ResumeLocks: locks, DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+		// A competing stop commits new authority after discovery, before this
+		// request acquires its alias reservations.
+		finish := locks.BeginForceStop([]string{"B", "C"})
+		if err := locks.PersistForceStop([]string{"B", "C"}, "C"); err != nil {
+			t.Fatal(err)
+		}
+		finish(true)
+		return &forceStopProcess{events: &events}, nil
+	})}
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:B"}, nil); err == nil {
+		t.Fatal("stale recovery target accepted")
+	}
+	if slices.Contains(events, "kill") {
+		t.Fatal("stale target signaled")
+	}
+	if got := locks.RecoveryState("B").ResumeSessionID; got != "C" {
+		t.Fatalf("new authority overwritten: %q", got)
+	}
+}
+
+func TestForceStopRejectsSoleExitedMarkerForSupersededTarget(t *testing.T) {
+	locks := hubcore.NewResumeLocks()
+	finish := locks.BeginForceStop([]string{"B", "C"})
+	if err := locks.PersistForceStop([]string{"B", "C"}, "C"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks, DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return nil, daemonprocess.ErrExited })}
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, SessionID: "B", ThreadID: "B", WorkspaceRef: "local:A"})
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:B"}, nil); err == nil {
+		t.Fatal("superseded marker accepted after current marker removal")
+	}
+	if got := locks.RecoveryState("B").ResumeSessionID; got != "C" {
+		t.Fatalf("durable current target overwritten: %q", got)
+	}
+}

--- a/cmd/evener-hub/app_fork_recovery_test.go
+++ b/cmd/evener-hub/app_fork_recovery_test.go
@@ -1,0 +1,55 @@
+package hub
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestForkRespectsSourceRecoveryAdmission(t *testing.T) {
+	for _, aside := range []bool{false, true} {
+		name := "fork"
+		if aside {
+			name = "aside"
+		}
+		t.Run(name, func(t *testing.T) {
+			stateDir := t.TempDir()
+			parent := buildRPCParentSession(t, stateDir)
+			locks := hubcore.NewResumeLocks()
+			cfg := hubcore.WebConfig{StateDir: stateDir, ResumeLocks: locks}
+			params := appwire.ThreadForkParams{Ref: localAppRef(parent), Aside: aside}
+			if !aside {
+				params.SourceTurnID, params.DeferInput = "turn_1", true
+			}
+			queued := admitSessionRecovery(t.Context(), cfg, appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodThreadFork, params))
+			finish := locks.BeginForceStop([]string{parent})
+			if err := locks.PersistForceStop([]string{parent}, parent); err != nil {
+				t.Fatal(err)
+			}
+			assertBlocked := func() {
+				t.Helper()
+				if _, err := hubThreadFork(queued, cfg, nil, params); !isSessionRecoveryAdmissionError(err) {
+					t.Fatalf("fork recovery error = %v, want recovery admission refusal", err)
+				}
+				metas, err := schema.ListSessionMetas(stateDir)
+				if err != nil || len(metas) != 1 {
+					t.Fatalf("blocked fork created session metadata: count=%d err=%v", len(metas), err)
+				}
+			}
+			assertBlocked()
+			finish(true)
+			assertBlocked()
+			if err := locks.ExplicitResumeCompleted(parent, locks.RecoveryState(parent).Epoch); err != nil {
+				t.Fatal(err)
+			}
+			assertBlocked()
+			fresh := admitSessionRecovery(t.Context(), cfg, appwire.RequestMessage(appwire.NewIntID(2), appwire.MethodThreadFork, params))
+			response, err := hubThreadFork(fresh, cfg, nil, params)
+			if err != nil || response.Thread.ID == "" || response.Thread.ID == parent {
+				t.Fatalf("fresh fork after recovery = %+v, %v", response, err)
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/app_model.go
+++ b/cmd/evener-hub/app_model.go
@@ -19,7 +19,7 @@ func setThreadModelWithResume(ctx context.Context, cfg hubcore.WebConfig, source
 	if !shouldResumeAfterSessionUnavailable(err) {
 		return err
 	}
-	if _, resumeErr := hubThreadResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref}); resumeErr != nil {
+	if _, resumeErr := hubThreadAutoResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref}); resumeErr != nil {
 		return resumeErr
 	}
 	return setThreadModelOnce(ctx, cfg, sources, params)

--- a/cmd/evener-hub/app_recovery_initialization_test.go
+++ b/cmd/evener-hub/app_recovery_initialization_test.go
@@ -1,0 +1,60 @@
+package hub
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/daemonprocess"
+	"primeradiant.com/evener/rendezvous"
+
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestWebRejectsRequestsWhenRecoveryAuthorityCannotLoad(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "recovery"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "recovery", "state.json"), []byte("corrupt"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	web := NewWebServer(hubcore.WebConfig{HubStateRoot: root})
+	response := httptest.NewRecorder()
+	web.Handler().ServeHTTP(response, httptest.NewRequest(http.MethodGet, "/", nil))
+	if response.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want unavailable before request admission", response.Code)
+	}
+}
+
+func TestForceStopRejectsUncommittedRecoveryIntent(t *testing.T) {
+	root := t.TempDir()
+	locks, err := hubcore.NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "recovery"), []byte("not a directory"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	runDir := t.TempDir()
+	entry := rendezvous.Entry{PID: 4242, SessionID: "saved", ThreadID: "saved", StateDir: t.TempDir(), StartedAt: time.Now()}
+	writeRendezvous(t, runDir, entry)
+	var events []string
+	cfg := hubcore.WebConfig{RunDir: runDir, ResumeLocks: locks, DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+		return &forceStopProcess{events: &events}, nil
+	})}
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:saved"}, nil); err == nil {
+		t.Fatal("stop succeeded without committed recovery intent")
+	}
+	if !reflect.DeepEqual(events, []string{"close"}) {
+		t.Fatalf("uncommitted stop process events=%v", events)
+	}
+	if state := locks.RecoveryState("saved"); state.ResumeRequired || state.Stopping != 0 {
+		t.Fatalf("uncommitted recovery=%+v", state)
+	}
+}

--- a/cmd/evener-hub/app_recovery_persistence_test.go
+++ b/cmd/evener-hub/app_recovery_persistence_test.go
@@ -1,0 +1,205 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/daemonprocess"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/rendezvous"
+)
+
+type durableRecoveryProcess struct {
+	beforeKill   func() error
+	waitErr      error
+	waitObserved *atomic.Bool
+}
+
+func (p *durableRecoveryProcess) Kill() error { return p.beforeKill() }
+func (p *durableRecoveryProcess) Wait(context.Context) error {
+	p.waitObserved.Store(true)
+	return p.waitErr
+}
+func (*durableRecoveryProcess) Close() error { return nil }
+
+func TestHubRecoveryRequirementSurvivesRecreation(t *testing.T) {
+	for _, outcome := range []string{"exited", "wait failed", "already exited", "signal denied", "clear write failed"} {
+		t.Run(outcome, func(t *testing.T) {
+			var sessionID string
+			cfg, id, resumes := parityResumeFixture(t, func(daemon *appserver.Server) {
+				thread := func(ref string) appwire.Thread {
+					return appwire.Thread{ID: sessionID, SessionID: sessionID, Source: "local", Status: appwire.ThreadStatus{Type: "idle"}, Evener: appwire.EvenerThread{Ref: ref, InstanceID: sessionID, MutationStateAuthoritative: true, Capabilities: appwire.ThreadCapabilities{Send: true}}}
+				}
+				appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+					return appwire.ThreadReadResponse{Thread: thread(params.Ref)}, nil
+				})
+				appserver.HandleTyped(daemon.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+					return appwire.ThreadListResponse{Data: []appwire.Thread{thread(localAppRef(sessionID))}}, nil
+				})
+			})
+			sessionID = id
+			cfg.HubStateRoot = t.TempDir()
+			if cfg.ResumeLocks != nil {
+				t.Fatal("fixture injected in-memory recovery state")
+			}
+			ref := "local:" + sessionID
+			entry := rendezvous.Entry{PID: 4242, SessionID: sessionID, ThreadID: sessionID, StateDir: t.TempDir(), StartedAt: time.Now()}
+			writeRendezvous(t, cfg.RunDir, entry)
+			var killObserved, waitObserved atomic.Bool
+			cfg.DaemonProcesses = forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+				if outcome == "already exited" {
+					return nil, daemonprocess.ErrExited
+				}
+				process := &durableRecoveryProcess{waitObserved: &waitObserved, beforeKill: func() error {
+					// A separately constructed registry must already fence recovery before
+					// the external process signal can take effect.
+					recreated := NewWebServer(cfg)
+					if state := recreated.cfg.ResumeLocks.RecoveryState(sessionID); !state.ResumeRequired || state.ResumeSessionID != sessionID {
+						return errors.New("recreated hub lost recovery requirement before Kill")
+					}
+					killObserved.Store(true)
+					if outcome == "signal denied" {
+						return errors.New("signal denied")
+					}
+					return nil
+				}}
+				if outcome == "wait failed" {
+					process.waitErr = context.DeadlineExceeded
+				}
+				return process, nil
+			})
+			hub := newHubRPCTestServer(t, cfg)
+			defer hub.Close()
+			client := dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			err := client.Request(t.Context(), appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: ref}, nil)
+			client.Close()
+			hub.Close()
+			if (err != nil) != (outcome == "wait failed" || outcome == "signal denied") {
+				t.Fatalf("force stop outcome=%s error=%v", outcome, err)
+			}
+			if killObserved.Load() != (outcome != "already exited") || waitObserved.Load() != (outcome != "already exited" && outcome != "signal denied") {
+				t.Fatalf("termination was not durably fenced: %v", err)
+			}
+			if err := rendezvous.Remove(cfg.RunDir, entry.PID); err != nil {
+				t.Fatal(err)
+			}
+
+			// Recreate from the same disk root, without sharing the WebServer's locks.
+			cfg.Roster = hubcore.NewRoster(cfg.RunDir, nil)
+			hub = newHubRPCTestServer(t, cfg)
+			defer hub.Close()
+			client = dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			read, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref, IncludeTurns: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !read.Thread.Evener.ResumeRequired || read.Thread.Status.Type != "notLoaded" || read.Thread.Evener.Capabilities.Send || len(read.Thread.Turns) == 0 {
+				t.Fatalf("recreated recovery snapshot=%+v", read.Thread)
+			}
+			if err := client.Request(t.Context(), appwire.MethodThreadModelSet, appwire.ThreadModelSetParams{Ref: ref, Model: "test"}, nil); err == nil {
+				t.Fatal("automatic action escaped durable recovery requirement")
+			}
+			if *resumes != 0 {
+				t.Fatalf("automatic resume calls=%d", *resumes)
+			}
+			if outcome == "clear write failed" {
+				restore := obstructRecoveryDirectory(t, cfg.HubStateRoot)
+				if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: ref}); err == nil {
+					t.Fatal("resume hid durable-clear failure")
+				}
+				restore()
+				client.Close()
+				hub.Close()
+				cfg.Roster = hubcore.NewRoster(cfg.RunDir, nil)
+				hub = newHubRPCTestServer(t, cfg)
+				defer hub.Close()
+				client = dialHubRPC(t, hub)
+				defer client.Close()
+				if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+					t.Fatal(err)
+				}
+				read, err := client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !read.Thread.Evener.ResumeRequired || read.Thread.Evener.Capabilities.Send {
+					t.Fatalf("failed clear lost durable authority: %+v", read.Thread)
+				}
+				if err := client.Request(t.Context(), appwire.MethodThreadModelSet, appwire.ThreadModelSetParams{Ref: ref, Model: "test"}, nil); err == nil {
+					t.Fatal("automatic action escaped failed durable clear")
+				}
+				if *resumes != 1 {
+					t.Fatalf("failed-clear automatic launches=%d", *resumes)
+				}
+			}
+			resumed, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resumed.Thread.Evener.ResumeRequired || *resumes != 1 {
+				t.Fatalf("explicit resume=%+v launches=%d", resumed.Thread, *resumes)
+			}
+			client.Close()
+			hub.Close()
+
+			cfg.Roster = hubcore.NewRoster(cfg.RunDir, nil)
+			hub = newHubRPCTestServer(t, cfg)
+			defer hub.Close()
+			client = dialHubRPC(t, hub)
+			defer client.Close()
+			if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+				t.Fatal(err)
+			}
+			read, err = client.ThreadRead(t.Context(), appwire.ThreadReadParams{Ref: ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if read.Thread.Evener.ResumeRequired || !read.Thread.Evener.Capabilities.Send || *resumes != 1 {
+				t.Fatalf("completed resume was not durable: thread=%+v launches=%d", read.Thread, *resumes)
+			}
+		})
+	}
+}
+
+// Keep the committed snapshot intact while making the next atomic write fail.
+func obstructRecoveryDirectory(t *testing.T, root string) func() {
+	t.Helper()
+	dir := filepath.Join(root, "recovery")
+	held := filepath.Join(root, "held-recovery")
+	if err := os.Rename(dir, held); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir, []byte("blocked directory"), 0600); err != nil {
+		_ = os.Rename(held, dir)
+		t.Fatal(err)
+	}
+	var once sync.Once
+	restore := func() {
+		once.Do(func() {
+			if err := os.Remove(dir); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Rename(held, dir); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	t.Cleanup(restore)
+	return restore
+}

--- a/cmd/evener-hub/app_rename.go
+++ b/cmd/evener-hub/app_rename.go
@@ -38,11 +38,12 @@ func setThreadName(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 		return appwire.EmptyResponse{}, appwire.InvalidParams("name is required")
 	}
 
+	epoch := sessionRequestRecoveryEpoch(ctx, cfg, params.Ref, "")
 	mutation, err := withDeletionTargetOwnership(ctx, cfg, params.Ref, "", "", func() (threadNameMutation, error) {
 		if err := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, "", ""); err != nil {
 			return threadNameMutation{}, err
 		}
-		return mutateThreadName(ctx, cfg, sources, ref, params)
+		return mutateThreadName(ctx, cfg, sources, ref, params, epoch)
 	})
 	if err != nil {
 		return appwire.EmptyResponse{}, err
@@ -51,20 +52,20 @@ func setThreadName(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 	return appwire.EmptyResponse{}, nil
 }
 
-func mutateThreadName(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, ref appwire.Ref, params appwire.ThreadNameSetParams) (threadNameMutation, error) {
+func mutateThreadName(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, ref appwire.Ref, params appwire.ThreadNameSetParams, epoch uint64) (threadNameMutation, error) {
 	if ref.SourceID != "local" || threadNameIsLive(cfg, ref.ThreadID) || cfg.Past == nil {
-		return renameLiveThread(ctx, cfg, sources, ref, params)
+		return renameLiveThread(ctx, cfg, sources, ref, params, epoch)
 	}
 	entry, ok := cfg.Past.Find(ref.ThreadID)
 	if !ok {
-		return renameLiveThread(ctx, cfg, sources, ref, params)
+		return renameLiveThread(ctx, cfg, sources, ref, params, epoch)
 	}
 	meta, err := loadSessionMetaForRename(entry.StateDir, entry.ID)
 	if err != nil {
 		return threadNameMutation{}, appwire.InternalError("load meta: " + err.Error())
 	}
 	if threadNameIsLive(cfg, ref.ThreadID) {
-		return renameLiveThread(ctx, cfg, sources, ref, params)
+		return renameLiveThread(ctx, cfg, sources, ref, params, epoch)
 	}
 	meta.Name = params.Name
 	meta.NameSource = "user"
@@ -79,7 +80,10 @@ func mutateThreadName(ctx context.Context, cfg hubcore.WebConfig, sources *appso
 	return threadNameMutation{projectKey: projectKeyForStateDir(entry.StateDir)}, nil
 }
 
-func renameLiveThread(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, ref appwire.Ref, params appwire.ThreadNameSetParams) (threadNameMutation, error) {
+func renameLiveThread(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, ref appwire.Ref, params appwire.ThreadNameSetParams, epoch uint64) (threadNameMutation, error) {
+	if err := sessionActionRecoveryError(ctx, cfg, params.Ref, "", epoch); err != nil {
+		return threadNameMutation{}, err
+	}
 	source, err := sourceForThread(sources, params.Ref, "")
 	if err != nil {
 		return threadNameMutation{}, appwire.Unavailable(err.Error())

--- a/cmd/evener-hub/app_rename_test.go
+++ b/cmd/evener-hub/app_rename_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -432,5 +433,74 @@ func TestRenameLiveWorkspaceAliasReachesDaemon(t *testing.T) {
 	}
 	if meta.Name != "saved name" {
 		t.Fatalf("hub bypassed daemon and wrote metadata: %q", meta.Name)
+	}
+}
+
+func TestLiveRenameRejectsRecoveryAdmission(t *testing.T) {
+	for _, unread := range []bool{false, true} {
+		t.Run(strconv.FormatBool(unread), func(t *testing.T) {
+			cfg := hubcore.WebConfig{ResumeLocks: hubcore.NewResumeLocks()}
+			live := &renameNavigationSource{scriptedAppSource: &scriptedAppSource{id: "local", thread: appwire.Thread{ID: "owner", Name: "replacement", Evener: appwire.EvenerThread{Ref: "local:owner", Capabilities: appwire.ThreadCapabilities{Rename: true}}}}}
+			registry := appsource.NewRegistry()
+			registry.Add(live)
+			server := newHubAppServer(cfg, registry)
+			params := appwire.ThreadNameSetParams{Ref: "local:owner", Name: "stale"}
+			message := appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodEvenerThreadNameSet, params)
+			ctx := t.Context()
+			if unread {
+				ctx = admitSessionConnection(ctx, cfg)
+			} else {
+				ctx = admitSessionRecovery(ctx, cfg, message)
+			}
+			finish := cfg.ResumeLocks.BeginForceStop([]string{"owner"})
+			if err := cfg.ResumeLocks.PersistForceStop([]string{"owner"}, "owner"); err != nil {
+				t.Fatal(err)
+			}
+			finish(true)
+			if err := cfg.ResumeLocks.ExplicitResumeCompleted("owner", cfg.ResumeLocks.RecoveryState("owner").Epoch); err != nil {
+				t.Fatal(err)
+			}
+			if unread {
+				ctx = admitSessionRecovery(ctx, cfg, message)
+			}
+			if _, err := exactDispatch(ctx, t, server, appwire.MethodEvenerThreadNameSet, params); !isSessionRecoveryAdmissionError(err) || live.thread.Name != "replacement" {
+				t.Fatalf("stale rename changed replacement: err=%v name=%q", err, live.thread.Name)
+			}
+			fresh := admitSessionRecovery(admitSessionConnection(t.Context(), cfg), cfg, message)
+			params.Name = "fresh"
+			if _, err := exactDispatch(fresh, t, server, appwire.MethodEvenerThreadNameSet, params); err != nil || live.thread.Name != "fresh" {
+				t.Fatalf("fresh rename failed: err=%v name=%q", err, live.thread.Name)
+			}
+		})
+	}
+}
+
+func TestSavedRenameRemainsAvailableAfterRecovery(t *testing.T) {
+	root := t.TempDir()
+	stateDir := filepath.Join(root, "project-0123456789")
+	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{ID: "02wMz5Txv1C3Hut0M8GCeB", Name: "before"}); err != nil {
+		t.Fatal(err)
+	}
+	past := hubcore.NewPastIndexWithDB(stateDir, filepath.Join(root, "index.db"))
+	if _, err := past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := hubcore.WebConfig{Past: past, ResumeLocks: hubcore.NewResumeLocks()}
+	ctx := admitSessionConnection(t.Context(), cfg)
+	finish := cfg.ResumeLocks.BeginForceStop([]string{"02wMz5Txv1C3Hut0M8GCeB"})
+	if err := cfg.ResumeLocks.PersistForceStop([]string{"02wMz5Txv1C3Hut0M8GCeB"}, "02wMz5Txv1C3Hut0M8GCeB"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	server := newHubAppServer(cfg, appsource.NewRegistry())
+	if _, err := exactDispatch(ctx, t, server, appwire.MethodEvenerThreadNameSet, appwire.ThreadNameSetParams{Ref: "local:02wMz5Txv1C3Hut0M8GCeB", Name: "saved"}); err != nil {
+		t.Fatal(err)
+	}
+	meta, err := schema.LoadSessionMeta(stateDir, "02wMz5Txv1C3Hut0M8GCeB")
+	if err != nil || meta.Name != "saved" {
+		t.Fatalf("saved rename: meta=%+v err=%v", meta, err)
+	}
+	if !cfg.ResumeLocks.RecoveryState("02wMz5Txv1C3Hut0M8GCeB").ResumeRequired {
+		t.Fatal("rename cleared explicit resume requirement")
 	}
 }

--- a/cmd/evener-hub/app_restart_required.go
+++ b/cmd/evener-hub/app_restart_required.go
@@ -238,7 +238,7 @@ func refreshDaemonRestartRequiredError(ctx context.Context, cfg hubcore.WebConfi
 		if err := hubRosterRefresh(ctx, cfg.Roster); err != nil {
 			wire := appwire.Unavailable(err.Error())
 			if mutationID != "" {
-				return restartRequiredMutationError(wire, mutationID)
+				return blockedAdmissionMutationError(wire, mutationID)
 			}
 			return wire
 		}
@@ -257,7 +257,7 @@ func daemonRestartRequiredError(ctx context.Context, cfg hubcore.WebConfig, ref,
 	if err != nil {
 		wire := appwire.Unavailable(err.Error())
 		if mutationID != "" {
-			return restartRequiredMutationError(wire, mutationID)
+			return blockedAdmissionMutationError(wire, mutationID)
 		}
 		return wire
 	}
@@ -266,7 +266,7 @@ func daemonRestartRequiredError(ctx context.Context, cfg hubcore.WebConfig, ref,
 	}
 	wire := appwire.WireError{Code: appwire.CodeConflict, Message: fmt.Sprintf("Session restart required: daemon pid %d uses an incompatible protocol; this hub requires %s. Stop the daemon, then resume this session. Stopping interrupts active work.", entry.PID, appwire.ProtocolVersion), Data: appwire.ErrorData{EvenerErrorInfo: appwire.ErrorConflict, Cause: "daemonRestartRequired"}}
 	if mutationID != "" {
-		return restartRequiredMutationError(wire, mutationID)
+		return blockedAdmissionMutationError(wire, mutationID)
 	}
 	return wire
 }
@@ -286,9 +286,9 @@ func isDaemonRestartRequiredError(err error) bool {
 	}
 }
 
-// A retry may name a mutation accepted before the protocol upgrade. Without
-// its daemon's receipt history, the hub cannot claim that ID was rejected.
-func restartRequiredMutationError(err error, mutationID string) error {
+// Admission fences cannot resolve an earlier acceptance of the same mutation.
+// Preserve the original cause and block retries until receipt reconciliation.
+func blockedAdmissionMutationError(err error, mutationID string) error {
 	var wire appwire.WireError
 	if !errors.As(err, &wire) {
 		return err
@@ -305,6 +305,9 @@ func restartRequiredMutationError(err error, mutationID string) error {
 		updated["mutationOutcome"] = string(appwire.MutationOutcomeUnknown)
 		updated["retryDisposition"] = string(appwire.RetryDispositionBlocked)
 		wire.Data = updated
+	}
+	if isSessionRecoveryAdmissionError(err) {
+		return sessionRecoveryAdmissionError{wire}
 	}
 	return wire
 }

--- a/cmd/evener-hub/app_resume_alias_test.go
+++ b/cmd/evener-hub/app_resume_alias_test.go
@@ -1,0 +1,937 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/daemonprocess"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubtest"
+	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestResumeUsesRetainedCurrentSessionAndReservesAliases(t *testing.T) {
+	for _, recreated := range []bool{false, true} {
+		t.Run(map[bool]string{false: "same hub", true: "recreated hub"}[recreated], func(t *testing.T) {
+			root := t.TempDir()
+			locks, err := hubcore.NewPersistentResumeLocks(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			aliases := []string{"a-stable", "z-current"}
+			finish := locks.BeginForceStop(aliases)
+			if err := locks.PersistForceStop(aliases, "z-current"); err != nil {
+				t.Fatal(err)
+			}
+			finish(true)
+			if recreated {
+				locks, err = hubcore.NewPersistentResumeLocks(root)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks}
+			writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 4242, SessionID: "z-current", ThreadID: "z-current", WorkspaceRef: "local:a-stable"})
+			reached := errors.New("launcher observed")
+			var launches atomic.Int32
+			cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				launches.Add(1)
+				if req.SessionID != "z-current" {
+					t.Errorf("launched superseded alias %q", req.SessionID)
+				}
+				for _, id := range aliases {
+					lock := locks.For(id)
+					if lock.TryLock() {
+						lock.Unlock()
+						t.Errorf("resume did not reserve alias %s", id)
+					}
+				}
+				return rendezvous.Entry{}, reached
+			}}
+			// Both real lifecycle calls exercise their shared ownership reservation.
+			var wg sync.WaitGroup
+			for _, id := range aliases {
+				wg.Go(func() {
+					_, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + id})
+					if err == nil {
+						t.Error("launcher failure lost")
+					}
+				})
+			}
+			wg.Wait()
+			if launches.Load() != 2 {
+				t.Fatalf("launcher calls=%d", launches.Load())
+			}
+		})
+	}
+}
+
+func TestResumeMissingMarkerUsesDurableRecoveryTarget(t *testing.T) {
+	for _, recreated := range []bool{false, true} {
+		for _, multiple := range []bool{false, true} {
+			t.Run(map[bool]string{false: "same", true: "recreated"}[recreated]+map[bool]string{false: " single", true: " aliases"}[multiple], func(t *testing.T) {
+				root := t.TempDir()
+				locks, err := hubcore.NewPersistentResumeLocks(root)
+				if err != nil {
+					t.Fatal(err)
+				}
+				aliases := []string{"a-stable"}
+				if multiple {
+					aliases = append(aliases, "z-current")
+				}
+				target := "a-stable"
+				if multiple {
+					target = "z-current"
+				}
+				finish := locks.BeginForceStop(aliases)
+				if err := locks.PersistForceStop(aliases, target); err != nil {
+					t.Fatal(err)
+				}
+				finish(true)
+				if recreated {
+					locks, err = hubcore.NewPersistentResumeLocks(root)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+				called := false
+				cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks, Spawner: &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+					called = true
+					want := "a-stable"
+					if multiple {
+						want = "z-current"
+					}
+					if req.SessionID != want {
+						t.Errorf("resume target=%s want=%s", req.SessionID, want)
+					}
+					return rendezvous.Entry{}, errors.New("launcher observed")
+				}}}
+				for _, alias := range aliases {
+					called = false
+					_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + alias})
+					if err == nil {
+						t.Fatal("expected launcher error")
+					}
+					if !called {
+						t.Fatalf("alias %s did not launch: %v", alias, err)
+					}
+				}
+
+				if !locks.RecoveryState("a-stable").ResumeRequired {
+					t.Fatal("failed resume cleared recovery")
+				}
+			})
+		}
+	}
+}
+
+func TestConcurrentAliasResumeSpawnsOneCurrentDaemon(t *testing.T) {
+	var current string
+	cfg, id, calls := parityResumeFixture(t, func(daemon *appserver.Server) {
+		appserver.HandleTyped(daemon.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+			return appwire.ThreadListResponse{Data: []appwire.Thread{{ID: current, SessionID: current, Source: "local", Status: appwire.ThreadStatus{Type: "idle"}, Evener: appwire.EvenerThread{Ref: "local:" + current, InstanceID: current}}}}, nil
+		})
+		appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(_ context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+			return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: current, SessionID: current, Source: "local", Status: appwire.ThreadStatus{Type: "idle"}, Evener: appwire.EvenerThread{Ref: params.Ref, InstanceID: current}}}, nil
+		})
+	})
+	current = id
+	cfg.Roster = hubcore.NewRoster(cfg.RunDir, &hubcore.StatusProber{}).SetProcessAlive(func(int) bool { return false })
+	stable := "stable-workspace"
+	root := t.TempDir()
+	locks, err := hubcore.NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.ResumeLocks = locks
+	cfg.DaemonProcesses = forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return nil, daemonprocess.ErrExited })
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 106, StartedAt: time.Now().Add(-365 * 24 * time.Hour), SessionID: current, ThreadID: current, WorkspaceRef: "local:" + stable})
+	if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + stable}, nil); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := rendezvous.ListStrict(cfg.RunDir)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("expired crash marker retained: %v %v", entries, err)
+	}
+	// Recreate authority after force stop's refresh removed the expired marker.
+	cfg.ResumeLocks, err = hubcore.NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original := cfg.Spawner
+	entered := make(chan struct{})
+	var enterOnce sync.Once
+	release := make(chan struct{})
+	cfg.Spawner = &fakeRPCSpawner{resume: func(ctx context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		for _, alias := range []string{stable, current} {
+			lock := cfg.ResumeLocks.For(alias)
+			if lock.TryLock() {
+				lock.Unlock()
+				t.Errorf("launcher did not reserve %s", alias)
+			}
+		}
+		enterOnce.Do(func() { close(entered) })
+		<-release
+		entry, err := original.Resume(ctx, req)
+		if err == nil {
+			entry.WorkspaceRef = "local:" + stable
+			writeRendezvous(t, cfg.RunDir, entry)
+		}
+		return entry, err
+	}}
+	hub := newHubRPCTestServer(t, cfg)
+	defer hub.Close()
+	first := dialHubRPC(t, hub)
+	defer first.Close()
+	second := dialHubRPC(t, hub)
+	defer second.Close()
+	if _, err := first.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := second.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 2)
+	go func() {
+		_, err := first.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + stable})
+		done <- err
+	}()
+	select {
+	case <-entered:
+	case err := <-done:
+		t.Fatalf("first resume did not launch: %v", err)
+	}
+	go func() {
+		_, err := second.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + current})
+		done <- err
+	}()
+	close(release)
+	for range 2 {
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if *calls != 1 {
+		t.Fatalf("resume launches=%d", *calls)
+	}
+	for _, alias := range []string{stable, current} {
+		if cfg.ResumeLocks.RecoveryState(alias).ResumeRequired {
+			t.Fatalf("successful resume retained recovery for %s", alias)
+		}
+	}
+	// Normal daemon shutdown removes its marker after recovery completed. Both
+	// identities must remain resumable without recreating the hub's lock registry.
+	for _, alias := range []string{stable, current} {
+		if err := rendezvous.Remove(cfg.RunDir, 106); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := first.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + alias}); err != nil {
+			t.Fatalf("resume after marker removal through %s: %v", alias, err)
+		}
+	}
+	if *calls != 3 {
+		t.Fatalf("repeated markerless launches=%d", *calls)
+	}
+
+}
+
+func TestResumeRejectsConflictingRetainedTranscriptIdentities(t *testing.T) {
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: hubcore.NewResumeLocks()}
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, SessionID: "first-current", ThreadID: "first-current", WorkspaceRef: "local:stable"})
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 102, SessionID: "second-current", ThreadID: "second-current", WorkspaceRef: "local:stable"})
+	cfg.Spawner = &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		t.Error("ambiguous transcript reached launcher")
+		return rendezvous.Entry{}, errors.New("launcher observed")
+	}}
+	if _, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:stable"}); err == nil {
+		t.Fatal("ambiguous retained transcripts accepted")
+	}
+}
+
+func TestResumeIgnoresOnlyVerifiedExitedTranscriptClaims(t *testing.T) {
+	for _, oldState := range []string{"exited", "unverified", "live"} {
+		t.Run(oldState+" old and live current", func(t *testing.T) {
+			cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: hubcore.NewResumeLocks()}
+			// A previous force-stop and Resume obligation is already cleared. A later
+			// daemon clear keeps the workspace alias but advances its current transcript.
+			finish := cfg.ResumeLocks.BeginForceStop([]string{"stable", "old"})
+			if err := cfg.ResumeLocks.PersistForceStop([]string{"stable", "old"}, "old"); err != nil {
+				t.Fatal(err)
+			}
+			finish(true)
+			if err := cfg.ResumeLocks.ExplicitResumeCompleted("stable", cfg.ResumeLocks.RecoveryState("stable").Epoch); err != nil {
+				t.Fatal(err)
+			}
+			cfg.ResumeLocks.RecordResolvedSession("stable", "old", cfg.ResumeLocks.RecoveryState("stable").Epoch)
+			writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, SessionID: "old", ThreadID: "old", WorkspaceRef: "local:stable"})
+			writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 102, SessionID: "current", ThreadID: "current", WorkspaceRef: "local:stable"})
+			cfg.DaemonProcesses = forceStopControllerFunc(func(target daemonprocess.Target) (daemonprocess.Process, error) {
+				if target.PID == 101 {
+					if oldState == "unverified" {
+						return nil, errors.New("unverified identity")
+					}
+					if oldState == "exited" {
+						return nil, daemonprocess.ErrExited
+					}
+				}
+				return &forceStopProcess{events: new([]string)}, nil
+			})
+			called := false
+			cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				called = true
+				if req.SessionID != "current" {
+					t.Errorf("launched %q", req.SessionID)
+				}
+				return rendezvous.Entry{}, errors.New("launcher observed")
+			}}
+			if _, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:stable"}); err == nil {
+				t.Fatal("expected launcher error or refusal")
+			}
+			if called != (oldState == "exited") {
+				t.Fatalf("launch=%v old state=%s", called, oldState)
+			}
+		})
+	}
+}
+
+func TestResumeRejectsTargetRedirectedByNewerRecovery(t *testing.T) {
+	root := t.TempDir()
+	locks, err := hubcore.NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish := locks.BeginForceStop([]string{"A", "B"})
+	if err := locks.PersistForceStop([]string{"A", "B"}, "A"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	finish = locks.BeginForceStop([]string{"A", "C"})
+	if err := locks.PersistForceStop([]string{"A", "C"}, "C"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	locks, err = hubcore.NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks, Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		t.Error("superseded recovery target reached launcher")
+		return rendezvous.Entry{}, errors.New("launcher observed")
+	}}}
+	if _, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:B"}); err == nil {
+		t.Fatal("redirected old target accepted")
+	}
+	for _, alias := range []string{"A", "B", "C"} {
+		if !locks.RecoveryState(alias).ResumeRequired {
+			t.Fatalf("failed resume cleared %s", alias)
+		}
+	}
+}
+
+func TestResumeUsesDurableTargetWhenAllRetainedClaimsExited(t *testing.T) {
+	root := t.TempDir()
+	locks, err := hubcore.NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish := locks.BeginForceStop([]string{"stable", "current"})
+	if err := locks.PersistForceStop([]string{"stable", "current"}, "current"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	locks, err = hubcore.NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks, DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return nil, daemonprocess.ErrExited })}
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, SessionID: "old", ThreadID: "old", WorkspaceRef: "local:stable"})
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 102, SessionID: "current", ThreadID: "current", WorkspaceRef: "local:stable"})
+	called := false
+	cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		called = true
+		if req.SessionID != "current" {
+			t.Errorf("launched %q", req.SessionID)
+		}
+		return rendezvous.Entry{}, errors.New("launcher observed")
+	}}
+	if _, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:stable"}); err == nil {
+		t.Fatal("expected launcher error")
+	}
+	if !called {
+		t.Fatal("persisted current target did not reach launcher")
+	}
+}
+
+func TestAliasResumeHonorsRequestedAndResolvedDeletionFences(t *testing.T) {
+	for _, deletedTarget := range []bool{false, true} {
+		t.Run(map[bool]string{false: "requested alias", true: "resolved target"}[deletedTarget], func(t *testing.T) {
+			stable, current := hubtest.SessionID(t), hubtest.SessionID(t)
+			store, err := hubcore.NewDeletionStore(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			deleted := stable
+			if deletedTarget {
+				deleted = current
+			}
+			if _, err := store.Begin(filepath.Base(hubtest.ProjectDir(t, t.TempDir(), "deleted")), []hubcore.DeletionTarget{{Ref: "local:" + deleted, ThreadID: deleted}}); err != nil {
+				t.Fatal(err)
+			}
+			cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: hubcore.NewResumeLocks(), DeletionStore: store}
+			writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, SessionID: current, ThreadID: current, WorkspaceRef: "local:" + stable})
+			launches := 0
+			cfg.Spawner = &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				launches++
+				return rendezvous.Entry{}, errors.New("deleted session reached launcher")
+			}}
+			_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + stable})
+			var wire appwire.WireError
+			if !errors.As(err, &wire) {
+				t.Fatalf("deletion fence error=%v", err)
+			}
+			data, ok := wire.Data.(appwire.ErrorData)
+			if !ok || data.MutationOutcome != appwire.MutationOutcomeTargetDeleted {
+				t.Errorf("deletion outcome=%#v", wire.Data)
+			}
+			if launches != 0 {
+				t.Fatalf("deleted target launch count=%d", launches)
+			}
+		})
+	}
+}
+
+func TestCompletedResumeMappingDefersToCurrentIdentity(t *testing.T) {
+	for _, newerRecovery := range []bool{false, true} {
+		t.Run(map[bool]string{false: "fresh marker", true: "newer recovery"}[newerRecovery], func(t *testing.T) {
+			locks := hubcore.NewResumeLocks()
+			finish := locks.BeginForceStop([]string{"stable", "B"})
+			if err := locks.PersistForceStop([]string{"stable", "B"}, "B"); err != nil {
+				t.Fatal(err)
+			}
+			finish(true)
+			epoch := locks.RecoveryState("stable").Epoch
+			if err := locks.ExplicitResumeCompleted("stable", epoch); err != nil {
+				t.Fatal(err)
+			}
+			locks.RecordResolvedSession("stable", "B", epoch)
+			cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks}
+			if newerRecovery {
+				finish := locks.BeginForceStop([]string{"B", "C"})
+				if err := locks.PersistForceStop([]string{"B", "C"}, "C"); err != nil {
+					t.Fatal(err)
+				}
+				finish(true)
+			} else {
+				writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, ThreadID: "B", SessionID: "C"})
+			}
+			launches := 0
+			cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				launches++
+				if req.SessionID != "C" {
+					t.Errorf("remembered B overrode current target: %s", req.SessionID)
+				}
+				return rendezvous.Entry{}, errors.New("launcher observed")
+			}}
+			if _, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:stable"}); err == nil {
+				t.Fatal("expected launcher error or newer recovery refusal")
+			}
+			want := 1
+			if newerRecovery {
+				want = 0
+			}
+			if launches != want {
+				t.Fatalf("launches=%d want=%d", launches, want)
+			}
+		})
+	}
+}
+
+func TestResumeConflictingRefSessionChecksDeletionIdentities(t *testing.T) {
+	for _, distinctTarget := range []bool{false, true} {
+		for _, deletedIdentity := range []string{"ref", "session", "target"} {
+			t.Run(map[bool]string{false: "direct ", true: "redirected "}[distinctTarget]+deletedIdentity, func(t *testing.T) {
+				refID, sessionID := hubtest.SessionID(t), hubtest.SessionID(t)
+				targetID := sessionID
+				if distinctTarget {
+					targetID = hubtest.SessionID(t)
+				}
+				deleted := map[string]string{"ref": refID, "session": sessionID, "target": targetID}[deletedIdentity]
+				store, err := hubcore.NewDeletionStore(t.TempDir())
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := store.Begin(filepath.Base(hubtest.ProjectDir(t, t.TempDir(), "deleted")), []hubcore.DeletionTarget{{Ref: "local:" + deleted, ThreadID: deleted}}); err != nil {
+					t.Fatal(err)
+				}
+				cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: hubcore.NewResumeLocks(), DeletionStore: store}
+				writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, ThreadID: sessionID, SessionID: targetID, WorkspaceRef: "local:" + refID})
+				launches := 0
+				cfg.Spawner = &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+					launches++
+					return rendezvous.Entry{}, errors.New("deleted session reached launcher")
+				}}
+				_, err = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + refID, Session: sessionID})
+				var wire appwire.WireError
+				if !errors.As(err, &wire) {
+					t.Fatalf("deletion error=%v", err)
+				}
+				data, ok := wire.Data.(appwire.ErrorData)
+				if !ok || data.MutationOutcome != appwire.MutationOutcomeTargetDeleted {
+					t.Errorf("deletion outcome=%#v", wire.Data)
+				}
+				if launches != 0 {
+					t.Fatalf("deleted identity reached launcher %d times", launches)
+				}
+			})
+		}
+	}
+}
+
+func TestResumeTraversesTwoCompletedRecoveryCycles(t *testing.T) {
+	a, b, c := hubtest.SessionID(t), hubtest.SessionID(t), hubtest.SessionID(t)
+	endpoints := make(map[string]string)
+	for _, id := range []string{b, c} {
+		daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+		thread := appwire.Thread{ID: id, SessionID: id, Source: "local", Status: appwire.ThreadStatus{Type: "idle"}, Evener: appwire.EvenerThread{Ref: "local:" + id, InstanceID: id}}
+		appserver.HandleTyped(daemon.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+			return appwire.ThreadListResponse{Data: []appwire.Thread{thread}}, nil
+		})
+		appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+			return appwire.ThreadReadResponse{Thread: thread}, nil
+		})
+		server := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+		t.Cleanup(server.Close)
+		endpoints[id] = "ws" + strings.TrimPrefix(server.URL, "http")
+	}
+	locks, err := hubcore.NewPersistentResumeLocks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks}
+	cfg.Roster = hubcore.NewRoster(cfg.RunDir, &hubcore.StatusProber{})
+	cfg.DaemonProcesses = forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+		return &forceStopProcess{events: new([]string)}, nil
+	})
+	launches := 0
+	cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		launches++
+		want := c
+		if launches == 1 {
+			want = b
+		}
+		if req.SessionID != want {
+			return rendezvous.Entry{}, fmt.Errorf("launched superseded transcript %s, want %s", req.SessionID, want)
+		}
+		if launches == 3 {
+			for _, alias := range []string{a, b, c} {
+				lock := locks.For(alias)
+				if lock.TryLock() {
+					lock.Unlock()
+					t.Errorf("traversed alias %s was not reserved", alias)
+				}
+			}
+		}
+		entry := rendezvous.Entry{PID: 103, SessionID: req.SessionID, ThreadID: req.SessionID, Protocol: appwire.ProtocolVersion, Endpoint: endpoints[req.SessionID], SourceID: "local", StartedAt: time.Now()}
+		writeRendezvous(t, cfg.RunDir, entry)
+		return entry, nil
+	}}
+	hub := newHubRPCTestServer(t, cfg)
+	defer hub.Close()
+	for _, pair := range [][2]string{{a, b}, {b, c}} {
+		// Clear advances the daemon's transcript and stable workspace identity.
+		writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, SessionID: pair[1], ThreadID: pair[1], WorkspaceRef: "local:" + pair[0], StartedAt: time.Now()})
+		if err := forceStopThread(t.Context(), cfg, appwire.ThreadForceStopParams{Ref: "local:" + pair[0]}, nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := rendezvous.Remove(cfg.RunDir, 101); err != nil {
+			t.Fatal(err)
+		}
+		client := dialHubRPC(t, hub)
+		if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+			t.Fatal(err)
+		}
+		_, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + pair[0]})
+		client.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := rendezvous.Remove(cfg.RunDir, 103); err != nil {
+			t.Fatal(err)
+		}
+	}
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + a}); err != nil {
+		t.Fatal(err)
+	}
+	if launches != 3 {
+		t.Fatalf("resume launches=%d", launches)
+	}
+}
+
+func TestResumeRejectsCompletedRedirectCycle(t *testing.T) {
+	locks := hubcore.NewResumeLocks()
+	for _, pair := range [][2]string{{"A", "B"}, {"B", "C"}, {"C", "A"}} {
+		finish := locks.BeginForceStop([]string{pair[0]})
+		if err := locks.PersistForceStop([]string{pair[0]}, pair[0]); err != nil {
+			t.Fatal(err)
+		}
+		finish(true)
+		epoch := locks.RecoveryState(pair[0]).Epoch
+		if err := locks.ExplicitResumeCompleted(pair[0], epoch); err != nil {
+			t.Fatal(err)
+		}
+		locks.RecordResolvedSession(pair[0], pair[1], epoch)
+	}
+	launches := 0
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks, Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		launches++
+		return rendezvous.Entry{}, errors.New("cyclic target reached launcher")
+	}}}
+	if _, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:A"}); err == nil {
+		t.Fatal("completed redirect cycle accepted")
+	}
+	if launches != 0 {
+		t.Fatalf("cycle reached launcher %d times", launches)
+	}
+}
+
+func TestResumeCompletedChainRefusesNewPendingRecovery(t *testing.T) {
+	for _, stopping := range []bool{false, true} {
+		t.Run(map[bool]string{false: "stopped", true: "stopping"}[stopping], func(t *testing.T) {
+			locks := hubcore.NewResumeLocks()
+			for _, pair := range [][2]string{{"A", "B"}, {"B", "C"}} {
+				finish := locks.BeginForceStop([]string{pair[0], pair[1]})
+				if err := locks.PersistForceStop([]string{pair[0], pair[1]}, pair[1]); err != nil {
+					t.Fatal(err)
+				}
+				finish(true)
+				epoch := locks.RecoveryState(pair[0]).Epoch
+				if err := locks.ExplicitResumeCompleted(pair[0], epoch); err != nil {
+					t.Fatal(err)
+				}
+				locks.RecordResolvedSession(pair[0], pair[1], epoch)
+			}
+			finish := locks.BeginForceStop([]string{"C", "D"})
+			if err := locks.PersistForceStop([]string{"C", "D"}, "D"); err != nil {
+				t.Fatal(err)
+			}
+			if stopping {
+				defer finish(true)
+			} else {
+				finish(true)
+			}
+			before := locks.RecoveryState("C")
+			launches := 0
+			cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks, Spawner: &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				launches++
+				return rendezvous.Entry{}, errors.New("pending chained recovery reached launcher")
+			}}}
+			if _, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:A"}); err == nil {
+				t.Fatal("new pending recovery accepted through old chain")
+			}
+			if launches != 0 {
+				t.Fatalf("pending recovery reached launcher %d times", launches)
+			}
+			after := locks.RecoveryState("C")
+			if !after.ResumeRequired || after.Epoch != before.Epoch || after.Stopping != before.Stopping {
+				t.Fatalf("old chain changed newer recovery: before=%+v after=%+v", before, after)
+			}
+		})
+	}
+}
+
+func TestResumeCompletedChainPreservesConnectionAdmission(t *testing.T) {
+	locks := hubcore.NewResumeLocks()
+	for _, pair := range [][2]string{{"A", "B"}, {"B", "C"}} {
+		finish := locks.BeginForceStop([]string{pair[0], pair[1]})
+		if err := locks.PersistForceStop([]string{pair[0], pair[1]}, pair[1]); err != nil {
+			t.Fatal(err)
+		}
+		finish(true)
+		epoch := locks.RecoveryState(pair[0]).Epoch
+		if err := locks.ExplicitResumeCompleted(pair[0], epoch); err != nil {
+			t.Fatal(err)
+		}
+		locks.RecordResolvedSession(pair[0], pair[1], epoch)
+	}
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks}
+	stale := admitSessionConnection(t.Context(), cfg)
+	finish := locks.BeginForceStop([]string{"C"})
+	if err := locks.PersistForceStop([]string{"C"}, "C"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	epoch := locks.RecoveryState("C").Epoch
+	if err := locks.ExplicitResumeCompleted("C", epoch); err != nil {
+		t.Fatal(err)
+	}
+	locks.RecordResolvedSession("C", "C", epoch)
+	launches := 0
+	cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		launches++
+		if req.SessionID != "C" {
+			t.Errorf("target=%s", req.SessionID)
+		}
+		return rendezvous.Entry{}, errors.New("launcher observed")
+	}}
+	if _, err := hubThreadResume(stale, cfg, nil, appwire.ThreadResumeParams{Ref: "local:A"}); err == nil {
+		t.Fatal("stale connection admitted through completed chain")
+	}
+	if launches != 0 {
+		t.Fatalf("stale connection launches=%d", launches)
+	}
+	if _, err := hubThreadResume(admitSessionConnection(t.Context(), cfg), cfg, nil, appwire.ThreadResumeParams{Ref: "local:A"}); err == nil {
+		t.Fatal("expected launcher error")
+	}
+	if launches != 1 {
+		t.Fatalf("fresh connection launches=%d", launches)
+	}
+}
+
+type aliasRecoveryDaemon struct {
+	*fixtureExitProcess
+	server  *httptest.Server
+	session atomic.Value
+	entry   rendezvous.Entry
+}
+
+func (d *aliasRecoveryDaemon) Kill() error {
+	d.server.Close()
+	return d.fixtureExitProcess.Kill()
+}
+
+func startAliasRecoveryDaemon(t *testing.T, sessionID, workspaceID string) *aliasRecoveryDaemon {
+	t.Helper()
+	command := exec.CommandContext(t.Context(), "cat")
+	input, err := command.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	fixture := &aliasRecoveryDaemon{fixtureExitProcess: &fixtureExitProcess{input: input, command: command}}
+	fixture.session.Store(sessionID)
+	t.Cleanup(func() {
+		_ = input.Close()
+		if command.ProcessState == nil {
+			_ = command.Wait()
+		}
+	})
+	daemon := appserver.NewServer(appserver.ServerConfig{ServerName: "daemon", SourceID: "local"})
+	thread := func() appwire.Thread {
+		id := fixture.session.Load().(string)
+		return appwire.Thread{ID: id, SessionID: id, Source: "local", Status: appwire.ThreadStatus{Type: "idle"}, Evener: appwire.EvenerThread{Ref: "local:" + id, InstanceID: id}}
+	}
+	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadList, func(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+		return appwire.ThreadListResponse{Data: []appwire.Thread{thread()}}, nil
+	})
+	appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+		return appwire.ThreadReadResponse{Thread: thread()}, nil
+	})
+	fixture.server = httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+	t.Cleanup(fixture.server.Close)
+	fixture.entry = rendezvous.Entry{PID: command.Process.Pid, SessionID: sessionID, ThreadID: sessionID, WorkspaceRef: "local:" + workspaceID, Protocol: appwire.ProtocolVersion, Endpoint: "ws" + strings.TrimPrefix(fixture.server.URL, "http"), SourceID: "local", StartedAt: time.Now()}
+	return fixture
+}
+
+func TestRepeatedRecoveryRetainsCrashMarkersAndPendingGroups(t *testing.T) {
+	for _, clear := range []bool{true, false} {
+		t.Run(map[bool]string{true: "clear to a new transcript", false: "stop the same transcript"}[clear], func(t *testing.T) {
+			a, b, c := hubtest.SessionID(t), hubtest.SessionID(t), hubtest.SessionID(t)
+			cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: hubcore.NewResumeLocks()}
+			cfg.Roster = hubcore.NewRoster(cfg.RunDir, &hubcore.StatusProber{})
+			initial := startAliasRecoveryDaemon(t, b, a)
+			writeRendezvous(t, cfg.RunDir, initial.entry)
+			var mu sync.Mutex
+			daemons := map[int]*aliasRecoveryDaemon{initial.entry.PID: initial}
+			current := initial
+			cfg.DaemonProcesses = forceStopControllerFunc(func(target daemonprocess.Target) (daemonprocess.Process, error) {
+				mu.Lock()
+				defer mu.Unlock()
+				daemon := daemons[target.PID]
+				if daemon == nil {
+					return nil, errors.New("unknown fixture process")
+				}
+				if daemon.command.ProcessState != nil {
+					return nil, daemonprocess.ErrExited
+				}
+				return daemon, nil
+			})
+			launches := 0
+			cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+				daemon := startAliasRecoveryDaemon(t, req.SessionID, req.SessionID)
+				mu.Lock()
+				launches++
+				current = daemon
+				daemons[daemon.entry.PID] = daemon
+				mu.Unlock()
+				writeRendezvous(t, cfg.RunDir, daemon.entry)
+				return daemon.entry, nil
+			}}
+			hub := newHubRPCTestServer(t, cfg)
+			defer hub.Close()
+			connect := func() *appwire.Client {
+				client := dialHubRPC(t, hub)
+				t.Cleanup(func() { _ = client.Close() })
+				if _, err := client.Initialize(t.Context(), appwire.InitializeParams{}); err != nil {
+					t.Fatal(err)
+				}
+				return client
+			}
+			client := connect()
+			if err := client.Request(t.Context(), appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: "local:" + a}, nil); err != nil {
+				t.Fatal(err)
+			}
+			client = connect()
+			if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + a}); err != nil {
+				t.Fatal(err)
+			}
+			if clear {
+				mu.Lock()
+				current.session.Store(c)
+				current.entry.SessionID = c
+				current.entry.ThreadID = c
+				current.entry.WorkspaceRef = "local:" + b
+				entry := current.entry
+				mu.Unlock()
+				writeRendezvous(t, cfg.RunDir, entry)
+			}
+			if err := client.Request(t.Context(), appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: "local:" + b}, nil); err != nil {
+				t.Fatal(err)
+			}
+			before := cfg.ResumeLocks.RecoveryState(b)
+			if !clear {
+				if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + a}); err == nil {
+					t.Fatal("stale connection crossed newer stop")
+				}
+				client = connect()
+				if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + a}); err == nil {
+					t.Error("older alias acknowledged a different pending group")
+				}
+				mu.Lock()
+				got := launches
+				mu.Unlock()
+				if got != 1 {
+					t.Errorf("older alias spawned through newer group: launches=%d", got)
+				}
+				after := cfg.ResumeLocks.RecoveryState(b)
+				if !after.ResumeRequired || before.Epoch != after.Epoch {
+					t.Fatalf("older alias changed pending recovery: before=%+v after=%+v", before, after)
+				}
+			}
+			client = connect()
+			if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + b}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := client.ThreadResume(t.Context(), appwire.ThreadResumeParams{Ref: "local:" + a}); err != nil {
+				t.Fatalf("retained crash markers blocked completed alias: %v", err)
+			}
+			mu.Lock()
+			got := launches
+			target := current.entry.SessionID
+			mu.Unlock()
+			want := b
+			if clear {
+				want = c
+			}
+			if got != 2 || target != want {
+				t.Fatalf("launches=%d target=%s want=%s", got, target, want)
+			}
+			entries, err := rendezvous.ListStrict(cfg.RunDir)
+			if err != nil || len(entries) != 3 {
+				t.Fatalf("crash markers were not retained: entries=%v err=%v", entries, err)
+			}
+			if cfg.ResumeLocks.RecoveryState(want).ResumeRequired {
+				t.Fatal("successful owning-session recovery left target fenced")
+			}
+		})
+	}
+}
+
+func TestCompletedSelfTargetDoesNotOverrideUnresolvedExitedSuccessor(t *testing.T) {
+	locks := hubcore.NewResumeLocks()
+	finish := locks.BeginForceStop([]string{"A", "B"})
+	if err := locks.PersistForceStop([]string{"A", "B"}, "B"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	epoch := locks.RecoveryState("A").Epoch
+	if err := locks.ExplicitResumeCompleted("A", epoch); err != nil {
+		t.Fatal(err)
+	}
+	locks.RecordResolvedSession("A", "B", epoch)
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks, DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) { return nil, daemonprocess.ErrExited })}
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 101, SessionID: "B", ThreadID: "B", WorkspaceRef: "local:A"})
+	writeRendezvous(t, cfg.RunDir, rendezvous.Entry{PID: 102, SessionID: "C", ThreadID: "C", WorkspaceRef: "local:B"})
+	launches := 0
+	cfg.Spawner = &fakeRPCSpawner{resume: func(context.Context, hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		launches++
+		return rendezvous.Entry{}, errors.New("superseded transcript reached launcher")
+	}}
+	if _, err := hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:A"}); err == nil {
+		t.Fatal("unresolved exited successor accepted")
+	}
+	if launches != 0 {
+		t.Fatalf("completed self-target launched superseded B %d times", launches)
+	}
+}
+
+func TestFailedForceStopPreservesCompletedRoutingAfterMarkerRemoval(t *testing.T) {
+	locks := hubcore.NewResumeLocks()
+	finish := locks.BeginForceStop([]string{"stable", "current"})
+	if err := locks.PersistForceStop([]string{"stable", "current"}, "current"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	epoch := locks.RecoveryState("stable").Epoch
+	if err := locks.ExplicitResumeCompleted("stable", epoch); err != nil {
+		t.Fatal(err)
+	}
+	locks.RecordResolvedSession("stable", "current", epoch)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	cfg := hubcore.WebConfig{RunDir: t.TempDir(), ResumeLocks: locks, DaemonProcesses: forceStopControllerFunc(func(daemonprocess.Target) (daemonprocess.Process, error) {
+		cancel()
+		return nil, daemonprocess.ErrExited
+	})}
+	entry := rendezvous.Entry{PID: 101, SessionID: "current", ThreadID: "current", WorkspaceRef: "local:stable"}
+	writeRendezvous(t, cfg.RunDir, entry)
+	if err := forceStopThread(ctx, cfg, appwire.ThreadForceStopParams{Ref: "local:stable"}, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("stop error=%v", err)
+	}
+	if err := rendezvous.Remove(cfg.RunDir, entry.PID); err != nil {
+		t.Fatal(err)
+	}
+	launches := 0
+	cfg.Spawner = &fakeRPCSpawner{resume: func(_ context.Context, req hubcore.ResumeRequest) (rendezvous.Entry, error) {
+		launches++
+		if req.SessionID != "current" {
+			t.Errorf("launched superseded target %q", req.SessionID)
+		}
+		return rendezvous.Entry{}, errors.New("launcher observed")
+	}}
+	for _, alias := range []string{"stable", "current"} {
+		_, _ = hubThreadResume(t.Context(), cfg, nil, appwire.ThreadResumeParams{Ref: "local:" + alias})
+	}
+	if launches != 2 {
+		t.Fatalf("failed stop lost completed routing: launches=%d", launches)
+	}
+}

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -75,7 +75,7 @@ func newHubSourceRegistry(cfg hubcore.WebConfig) *appsource.Registry {
 
 var (
 	resolveTurnStartSource = sourceForThread
-	resumeTurnStartThread  = hubThreadResume
+	resumeTurnStartThread  = hubThreadAutoResume
 	authLoginComplete      = func(c *hubAuthController, ctx context.Context, p appwire.AuthLoginCompleteParams) (appwire.AuthLoginCompleteResponse, error) {
 		return c.LoginComplete(ctx, p)
 	}
@@ -156,8 +156,8 @@ func listItemTurns(
 }
 
 func blockedUnknownMutationError(clientMutationID string, err error) error {
-	if isDaemonRestartRequiredError(err) {
-		return restartRequiredMutationError(err, clientMutationID)
+	if isDaemonRestartRequiredError(err) || isSessionRecoveryAdmissionError(err) {
+		return blockedAdmissionMutationError(err, clientMutationID)
 	}
 	return appwire.WireError{
 		Code:    appwire.CodeInternalError,
@@ -237,6 +237,12 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 		Navigation:           capability,
 		NavigationCapability: capabilityProvider,
 		Logf:                 hubLogf,
+		ConnectionAdmissionContext: func(ctx context.Context) context.Context {
+			return admitSessionConnection(ctx, cfg)
+		},
+		RequestAdmissionContext: func(ctx context.Context, message appwire.Message) context.Context {
+			return admitSessionRecovery(ctx, cfg, message)
+		},
 		SubscriptionAdmissionResolverV2: func(msg appwire.Message) appserver.SubscriptionAdmissionResolution {
 			notSubscribe := appserver.SubscriptionAdmissionResolution{Intent: appserver.SubscriptionAdmissionNotSubscribe}
 			if msg.Request == nil || (msg.Request.Method != appwire.MethodThreadRead && msg.Request.Method != appwire.MethodThreadUnsubscribe) {
@@ -470,6 +476,7 @@ func registerThreadHandlers(
 			}
 		}
 		resp.Thread, err = mergePastThreadForRead(ctx, cfg, params, resp.Thread)
+		resp.Thread = applyThreadResumeRequirement(ctx, cfg, params.Ref, params.ThreadID, resp.Thread)
 		if err != nil {
 			read.finish(false)
 			return appwire.ThreadReadResponse{}, err
@@ -703,7 +710,7 @@ func registerThreadHandlers(
 			if wire, ok := errors.AsType[appwire.WireError](err); ok && wire.Code == appwire.CodeInvalidParams {
 				return appwire.TurnStartResponse{}, err
 			}
-			if isTargetDeletedError(err) || isDaemonRestartRequiredError(err) {
+			if isTargetDeletedError(err) || isDaemonRestartRequiredError(err) || isSessionRecoveryAdmissionError(err) {
 				return appwire.TurnStartResponse{}, err
 			}
 			if _, resumeErr := resumeTurnStartThread(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref, Session: params.ThreadID}); resumeErr != nil {
@@ -752,7 +759,7 @@ func registerThreadHandlers(
 		})
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSandboxEscalationResolve, func(ctx context.Context, params appwire.SandboxEscalationResolveParams) (appwire.EmptyResponse, error) {
-		return withDeletionTargetOwnership(ctx, cfg, params.Ref, params.ThreadID, "", func() (appwire.EmptyResponse, error) {
+		return withSessionActionOwnership(ctx, cfg, params.Ref, params.ThreadID, func() (appwire.EmptyResponse, error) {
 			if err := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, params.ThreadID, ""); err != nil {
 				return appwire.EmptyResponse{}, err
 			}
@@ -841,6 +848,9 @@ func registerThreadHandlers(
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadCompactStart, func(ctx context.Context, params appwire.ThreadCompactStartParams) (appwire.EmptyResponse, error) {
 		return appwire.EmptyResponse{}, compactThreadWithResume(ctx, cfg, sources, params)
 	})
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerThreadForceStop, func(ctx context.Context, params appwire.ThreadForceStopParams) (appwire.EmptyResponse, error) {
+		return appwire.EmptyResponse{}, forceStopThread(ctx, cfg, params, sources)
+	})
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadShutdown, func(ctx context.Context, params appwire.ThreadShutdownParams) (appwire.EmptyResponse, error) {
 		return appwire.EmptyResponse{}, shutdownThreadTolerateExited(ctx, cfg, sources, params)
 	})
@@ -851,7 +861,7 @@ func registerThreadHandlers(
 		return appwire.EmptyResponse{}, setThreadVisionModelWithResume(ctx, cfg, sources, params)
 	})
 	appserver.HandleTyped(server.Router(), appwire.MethodThreadReasoningEffortSet, func(ctx context.Context, params appwire.ThreadReasoningEffortSetParams) (appwire.EmptyResponse, error) {
-		return withDeletionTargetOwnership(ctx, cfg, params.Ref, "", "", func() (appwire.EmptyResponse, error) {
+		return withSessionActionOwnership(ctx, cfg, params.Ref, "", func() (appwire.EmptyResponse, error) {
 			if err := refreshDaemonRestartRequiredError(ctx, cfg, params.Ref, "", ""); err != nil {
 				return appwire.EmptyResponse{}, err
 			}

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11720,6 +11720,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodThreadClear,
 		appwire.MethodThreadCompactStart,
 		appwire.MethodThreadShutdown,
+		appwire.MethodEvenerThreadForceStop,
 		appwire.MethodThreadModelSet,
 		appwire.MethodThreadVisionModelSet,
 		appwire.MethodEvenerThreadNameSet,

--- a/cmd/evener-hub/app_session_resume.go
+++ b/cmd/evener-hub/app_session_resume.go
@@ -42,8 +42,11 @@ func withSessionResume[R any](
 	if ref != "" && !hubKnowsRef(cfg, ref) {
 		return resp, err
 	}
-	if _, resumeErr := hubThreadResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: ref}); resumeErr != nil {
+	if _, resumeErr := hubThreadAutoResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: ref}); resumeErr != nil {
 		var zero R
+		if clientMutationID != "" {
+			return zero, blockedUnknownMutationError(clientMutationID, resumeErr)
+		}
 		return zero, resumeErr
 	}
 	return attempt()

--- a/cmd/evener-hub/app_session_resume_recovery_test.go
+++ b/cmd/evener-hub/app_session_resume_recovery_test.go
@@ -1,0 +1,73 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/appserver"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestAutomaticResumePreservesRecoveryMutationError(t *testing.T) {
+	for _, method := range []string{appwire.MethodTurnStart, appwire.MethodThreadClear} {
+		t.Run(method, func(t *testing.T) {
+			stateDir := filepath.Join(t.TempDir(), "recovery-0000000000")
+			sessionID := buildRPCParentSession(t, stateDir)
+			ref := localAppRef(sessionID)
+			past := hubcore.NewPastIndex(stateDir)
+			if _, err := past.Rebuild(); err != nil {
+				t.Fatal(err)
+			}
+			cfg := hubcore.WebConfig{Past: past, ResumeLocks: hubcore.NewResumeLocks()}
+			attempted := make(chan struct{})
+			failAttempt := make(chan struct{})
+			daemon := appserver.NewServer(appserver.ServerConfig{SourceID: "local"})
+			appserver.HandleTyped(daemon.Router(), appwire.MethodThreadRead, func(context.Context, appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
+				return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: sessionID, SessionID: sessionID, Evener: appwire.EvenerThread{Ref: ref, InstanceID: sessionID, Capabilities: appwire.ThreadCapabilities{Clear: true, Send: true}}}}, nil
+			})
+			appserver.HandleTyped(daemon.Router(), method, func(context.Context, appwire.EmptyParams) (appwire.EmptyResponse, error) {
+				close(attempted)
+				<-failAttempt
+				return appwire.EmptyResponse{}, appwire.SessionUnavailable("daemon exited")
+			})
+			peer := httptest.NewServer(http.HandlerFunc(daemon.ServeWebSocket))
+			defer peer.Close()
+			entry := rendezvous.Entry{Protocol: appwire.ProtocolVersion, SessionID: sessionID, ThreadID: sessionID, SourceID: "local", Endpoint: "ws" + strings.TrimPrefix(peer.URL, "http")}
+			sources := appsource.NewRegistry()
+			sources.Add(appsource.NewLocalDaemonSource("local", func() []rendezvous.Entry { return []rendezvous.Entry{entry} }, peer.Client()))
+			hub := newHubAppServer(cfg, sources)
+			result := make(chan error, 1)
+			go func() {
+				_, err := exactDispatch(t.Context(), t, hub, method, map[string]any{"ref": ref, "clientMutationId": "pending-mutation", "expectedInstanceId": sessionID, "input": []appwire.InputItem{{Type: "text", Text: "pending input"}}})
+				result <- err
+			}()
+			<-attempted
+			finish := cfg.ResumeLocks.BeginForceStop([]string{sessionID})
+			finish(true)
+			close(failAttempt)
+			err := <-result
+			if !isSessionRecoveryAdmissionError(err) {
+				t.Errorf("automatic resume lost recovery classification: %T %v", err, err)
+			}
+			var wire appwire.WireError
+			if !errors.As(err, &wire) {
+				t.Fatalf("expected recovery wire error, got %v", err)
+			}
+			data, ok := wire.Data.(appwire.ErrorData)
+			if !ok || wire.Code != appwire.CodeUnavailable || data.EvenerErrorInfo != appwire.ErrorActionUnavailable || data.ClientMutationID != "pending-mutation" || data.MutationOutcome != appwire.MutationOutcomeUnknown || data.RetryDisposition != appwire.RetryDispositionBlocked || data.Cause == "persistenceUnavailable" {
+				t.Errorf("automatic resume lost recovery mutation data: %+v", wire)
+			}
+			if !cfg.ResumeLocks.RecoveryState(sessionID).ResumeRequired {
+				t.Fatal("automatic resume acknowledged explicit recovery requirement")
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/app_sources.go
+++ b/cmd/evener-hub/app_sources.go
@@ -2,9 +2,11 @@ package hub
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 
+	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
@@ -48,6 +50,7 @@ func withDeletionTargetOwnership[R any](
 	ref, threadID, clientMutationID string,
 	action func() (R, error),
 ) (R, error) {
+	epoch := sessionRequestRecoveryEpoch(ctx, cfg, ref, threadID)
 	unlock := lockDeletionTarget(cfg, ref, threadID)
 	defer unlock()
 	if err := deletionFenceError(cfg, ref, threadID, clientMutationID); err != nil {
@@ -55,6 +58,10 @@ func withDeletionTargetOwnership[R any](
 		return zero, err
 	}
 	if clientMutationID != "" {
+		if err := sessionActionRecoveryError(ctx, cfg, ref, threadID, epoch); err != nil {
+			var zero R
+			return zero, blockedAdmissionMutationError(err, clientMutationID)
+		}
 		if err := daemonRestartRequiredError(ctx, cfg, ref, threadID, clientMutationID); err != nil {
 			var zero R
 			return zero, err
@@ -73,7 +80,12 @@ func withDeletionTargetOwnership[R any](
 // withSessionActionOwnership guards actions that have no durable mutation ID.
 // Reads share deletion locking but must remain available for incompatible owners.
 func withSessionActionOwnership[R any](ctx context.Context, cfg hubcore.WebConfig, ref, threadID string, action func() (R, error)) (R, error) {
+	epoch := sessionRequestRecoveryEpoch(ctx, cfg, ref, threadID)
 	return withDeletionTargetOwnership(ctx, cfg, ref, threadID, "", func() (R, error) {
+		if err := sessionActionRecoveryError(ctx, cfg, ref, threadID, epoch); err != nil {
+			var zero R
+			return zero, err
+		}
 		if err := daemonRestartRequiredError(ctx, cfg, ref, threadID, ""); err != nil {
 			var zero R
 			return zero, err
@@ -159,4 +171,188 @@ func deletionThreadID(ref, threadID string) string {
 func hubKnowsRef(cfg hubcore.WebConfig, ref string) bool {
 	_, ok, _ := pastThreadForRead(context.Background(), cfg, appwire.ThreadReadParams{Ref: ref})
 	return ok
+}
+
+func sessionRecoveryState(cfg hubcore.WebConfig, ref, threadID string) hubcore.SessionRecoveryState {
+	if ref != "" {
+		parsed, err := appwire.ParseRef(ref)
+		if err != nil || parsed.SourceID != "local" {
+			return hubcore.SessionRecoveryState{}
+		}
+	}
+	if cfg.ResumeLocks == nil {
+		return hubcore.SessionRecoveryState{}
+	}
+	id := deletionThreadID(ref, threadID)
+	if id == "" {
+		return hubcore.SessionRecoveryState{}
+	}
+	return cfg.ResumeLocks.RecoveryState(id)
+}
+
+// sessionRecoveryAdmissionError is terminal for an action already rejected by
+// recovery, even if another request explicitly resumes before retry routing.
+// Unwrap preserves the existing wire-level action-unavailable response.
+type sessionRecoveryAdmissionError struct{ appwire.WireError }
+
+func (err sessionRecoveryAdmissionError) Unwrap() error { return err.WireError }
+
+func isSessionRecoveryAdmissionError(err error) bool {
+	_, ok := errors.AsType[sessionRecoveryAdmissionError](err)
+	return ok
+}
+
+func sessionActionRecoveryError(ctx context.Context, cfg hubcore.WebConfig, ref, threadID string, epoch uint64) error {
+	if err := sessionConnectionRecoveryError(ctx, cfg, ref, threadID); err != nil {
+		return err
+	}
+	state := sessionRecoveryState(cfg, ref, threadID)
+	if state.Stopping > 0 || state.ResumeRequired {
+		return sessionRecoveryAdmissionError{appwire.Unavailable("session recovery requires an explicit thread/resume before submitting another action")}
+	}
+	if state.Epoch != epoch {
+		return sessionRecoveryAdmissionError{appwire.Unavailable("session recovery canceled this pending action; submit it again")}
+	}
+	return nil
+}
+
+type sessionRecoveryAdmissionKey struct{}
+
+type sessionRecoveryAdmission struct {
+	sessionID string
+	epoch     uint64
+}
+
+// admitSessionRecovery captures only the requested local identity; it performs
+// no ownership discovery and leaves malformed or foreign targets to handlers.
+func admitSessionRecovery(ctx context.Context, cfg hubcore.WebConfig, message appwire.Message) context.Context {
+	if message.Request == nil || cfg.ResumeLocks == nil {
+		return ctx
+	}
+	var rawRef, id string
+	switch message.Request.Method {
+	case appwire.MethodThreadResume:
+		var params appwire.ThreadResumeParams
+		if json.Unmarshal(message.Request.Params, &params) != nil {
+			return ctx
+		}
+		rawRef, id = params.Ref, strings.TrimSpace(params.Session)
+	case appwire.MethodTurnStart, appwire.MethodTurnSteer, appwire.MethodTurnInterrupt:
+		var params appwire.TurnInterruptParams
+		if json.Unmarshal(message.Request.Params, &params) != nil {
+			return ctx
+		}
+		rawRef, id = params.Ref, strings.TrimSpace(params.ThreadID)
+	case appwire.MethodEvenerSandboxEscalationResolve:
+		var params appwire.SandboxEscalationResolveParams
+		if json.Unmarshal(message.Request.Params, &params) != nil {
+			return ctx
+		}
+		rawRef, id = params.Ref, strings.TrimSpace(params.ThreadID)
+	case appwire.MethodThreadFork, appwire.MethodEvenerThreadNameSet, appwire.MethodThreadModelSet, appwire.MethodThreadVisionModelSet,
+		appwire.MethodThreadReasoningEffortSet, appwire.MethodThreadCompactStart,
+		appwire.MethodThreadClear, appwire.MethodThreadShutdown, appwire.MethodGoalSet,
+		appwire.MethodTurnQueue, appwire.MethodTurnDrainAsSteer,
+		appwire.MethodTurnPromoteQueuedAsSteer, appwire.MethodTurnCancelQueued:
+		var params struct {
+			Ref string `json:"ref"`
+		}
+		if json.Unmarshal(message.Request.Params, &params) != nil {
+			return ctx
+		}
+		rawRef = params.Ref
+	default:
+		return ctx
+	}
+	if rawRef != "" {
+		ref, err := appwire.ParseRef(rawRef)
+		if err != nil || ref.SourceID != "local" {
+			return ctx
+		}
+		// Resume's explicit sessionId takes precedence; other handlers resolve ref
+		// before their optional threadId. Ignored extra fields cannot change this.
+		if message.Request.Method != appwire.MethodThreadResume || id == "" {
+			id = ref.ThreadID
+		}
+	}
+	if id == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, sessionRecoveryAdmissionKey{}, sessionRecoveryAdmission{sessionID: id, epoch: cfg.ResumeLocks.RecoveryState(id).Epoch})
+}
+
+func sessionRequestRecoveryEpoch(ctx context.Context, cfg hubcore.WebConfig, ref, threadID string) uint64 {
+	if admission, ok := ctx.Value(sessionRecoveryAdmissionKey{}).(sessionRecoveryAdmission); ok && admission.sessionID == deletionThreadID(ref, threadID) {
+		return admission.epoch
+	}
+	return sessionRecoveryState(cfg, ref, threadID).Epoch
+}
+
+type sessionConnectionRecoveryKey struct{}
+
+func admitSessionConnection(ctx context.Context, cfg hubcore.WebConfig) context.Context {
+	if cfg.ResumeLocks == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, sessionConnectionRecoveryKey{}, cfg.ResumeLocks.RecoverySequence())
+}
+
+func sessionConnectionRecoveryError(ctx context.Context, cfg hubcore.WebConfig, ref, threadID string) error {
+	sequence, ok := ctx.Value(sessionConnectionRecoveryKey{}).(uint64)
+	if cfg.ResumeLocks == nil {
+		return nil
+	}
+	stale := func() error {
+		return sessionRecoveryAdmissionError{appwire.Unavailable("session recovery requires Resume on a fresh connection before submitting another action")}
+	}
+	if ok && sessionRecoveryState(cfg, ref, threadID).LastRecoverySequence > sequence {
+		return stale()
+	}
+	if (!ok || cfg.ResumeLocks.RecoverySequence() <= sequence) && !cfg.ResumeLocks.HasUnconfirmedRecovery() {
+		return nil
+	}
+	if ref != "" {
+		parsed, err := appwire.ParseRef(ref)
+		if err != nil {
+			return err
+		}
+		if parsed.SourceID != "local" {
+			return nil
+		}
+		threadID = parsed.ThreadID
+	}
+	// A failed exit wait can leave the owner creating delegates after its last
+	// scan. Verify their ancestry at use time against the retained recovery
+	// sequence; a journal descriptor, not fork provenance, establishes ownership.
+	seen := make(map[string]bool)
+	for threadID != "" && !seen[threadID] {
+		seen[threadID] = true
+		child, found, err := ownershipEntry(ctx, cfg, threadID)
+		if err != nil {
+			return err
+		}
+		if !found || (!child.Meta.IsSubagent && (child.Meta.JobTreeRootSessionID == "" || child.Meta.JobTreeRootSessionID == threadID)) {
+			return nil
+		}
+		parent := child.Meta.ParentSessionID
+		if parent == "" {
+			return nil
+		}
+		owned, err := agent.SessionOwnsDelegate(ctx, child.StateDir, parent, threadID)
+		if err != nil {
+			return err
+		}
+		if !owned {
+			return nil
+		}
+		state := cfg.ResumeLocks.RecoveryState(parent)
+		if state.Stopping > 0 || (state.ResumeRequired && !state.ExitConfirmed) {
+			return sessionRecoveryAdmissionError{appwire.Unavailable("delegate owner exit is unconfirmed; recover the owner before submitting another action")}
+		}
+		if ok && state.LastRecoverySequence > sequence {
+			return stale()
+		}
+		threadID = parent
+	}
+	return nil
 }

--- a/cmd/evener-hub/app_threadlifecycle.go
+++ b/cmd/evener-hub/app_threadlifecycle.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/daemonprocess"
 	"primeradiant.com/evener/cmd/evener-hub/internal/fspaths"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/cmd/evener-hub/internal/launchconfig"
@@ -190,12 +192,8 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 	ref := localSpawnWorkspaceRef(entry)
 	var source appsource.Source
 	if canUseSpawnEntry {
-		// SpawnDaemon already returned this exact, freshly published rendezvous
-		// entry. Route the initial read and turn through it directly instead of
-		// depending on a concurrent roster status probe to admit the new daemon.
-		source = appsource.NewLocalDaemonSource("local", func() []rendezvous.Entry {
-			return []rendezvous.Entry{entry}
-		}, nil)
+		// Exact-entry RPCs share the persistent source's recovery cancellation.
+		source, err = spawnedLocalDaemonSource(sources)
 	} else {
 		source, err = sourceForThread(sources, ref, "")
 	}
@@ -216,7 +214,11 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 		annotateThreadProjects([]appwire.Thread{thread})
 		return appwire.ThreadStartResponse{Thread: thread}, nil
 	}
+	startEpoch := sessionRecoveryState(cfg, ref, "").Epoch
 	read := func(ctx context.Context) (appwire.ThreadReadResponse, error) {
+		if canUseSpawnEntry {
+			return readSpawnedLocalThread(ctx, sources, entry)
+		}
 		return source.ReadThread(ctx, appwire.ThreadReadParams{Ref: ref})
 	}
 	var threadResp appwire.ThreadReadResponse
@@ -232,6 +234,9 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 	} else {
 		threadResp, err = read(ctx)
 	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || isSessionRecoveryAdmissionError(err) {
+		return appwire.ThreadStartResponse{}, err
+	}
 	if err != nil {
 		threadResp.Thread = appwire.Thread{
 			ID: entry.ThreadID, SessionID: entry.SessionID, CWD: workingDir,
@@ -246,11 +251,24 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 		if err != nil {
 			return appwire.ThreadStartResponse{}, appwire.InternalError("create initial turn mutation id: " + err.Error())
 		}
-		turnResp, err := source.StartTurn(ctx, appwire.TurnStartParams{
+		turnParams := appwire.TurnStartParams{
 			Ref:                ref,
 			ClientMutationID:   clientMutationID,
 			ExpectedInstanceID: expectedInstanceID,
 			Input:              params.Input,
+		}
+		turnResp, err := withDeletionTargetOwnership(ctx, cfg, ref, "", clientMutationID, func() (appwire.TurnStartResponse, error) {
+			if err := sessionActionRecoveryError(ctx, cfg, ref, "", startEpoch); err != nil {
+				return appwire.TurnStartResponse{}, err
+			}
+			if canUseSpawnEntry {
+				local, err := spawnedLocalDaemonSource(sources)
+				if err != nil {
+					return appwire.TurnStartResponse{}, err
+				}
+				return local.StartTurnAtEntry(ctx, entry, turnParams)
+			}
+			return source.StartTurn(ctx, turnParams)
 		})
 		if err != nil {
 			return appwire.ThreadStartResponse{}, err
@@ -297,11 +315,21 @@ func launchSourceID(params appwire.ThreadStartParams) string {
 }
 
 func hubThreadResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadResumeParams) (appwire.ThreadResumeResponse, error) {
+	return resumeThread(ctx, cfg, sources, params, false)
+}
+
+func hubThreadAutoResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadResumeParams) (appwire.ThreadResumeResponse, error) {
+	return resumeThread(ctx, cfg, sources, params, true)
+}
+
+func resumeThread(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadResumeParams, automatic bool) (response appwire.ThreadResumeResponse, resumeErr error) {
+	requestedRefID := ""
 	if params.Ref != "" {
 		ref, err := appwire.ParseRef(params.Ref)
 		if err != nil {
 			return appwire.ThreadResumeResponse{}, err
 		}
+		requestedRefID = ref.ThreadID
 		if ref.SourceID != "local" {
 			source, err := sourceForThread(sources, params.Ref, "")
 			if err != nil {
@@ -319,14 +347,72 @@ func hubThreadResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsou
 	if sessionID == "" {
 		return appwire.ThreadResumeResponse{}, appwire.InvalidParams("sessionId or ref is required")
 	}
+	requestedID := sessionID
 	if cfg.ResumeLocks != nil {
-		lock := cfg.ResumeLocks.For(sessionID)
-		lock.Lock()
-		defer lock.Unlock()
+		epoch := sessionRequestRecoveryEpoch(ctx, cfg, "", requestedID)
+		if err := sessionConnectionRecoveryError(ctx, cfg, "", requestedID); err != nil {
+			return appwire.ThreadResumeResponse{}, err
+		}
+		target, aliases, err := resumeOwnership(cfg, requestedID, requestedRefID)
+		if err != nil {
+			return appwire.ThreadResumeResponse{}, appwire.Unavailable(err.Error())
+		}
+		epochs := make(map[string]uint64, len(aliases))
+		for _, id := range aliases {
+			epochs[id] = sessionRequestRecoveryEpoch(ctx, cfg, "", id)
+		}
+		epochs[requestedID] = epoch
+		// Use force stop's sorted ownership order, retaining the original mutexes.
+		for _, id := range aliases {
+			cfg.ResumeLocks.For(id).Lock()
+		}
+		defer func() {
+			for _, id := range slices.Backward(aliases) {
+				cfg.ResumeLocks.For(id).Unlock()
+			}
+		}()
+		for _, id := range aliases {
+			if err := sessionConnectionRecoveryError(ctx, cfg, "", id); err != nil {
+				return appwire.ThreadResumeResponse{}, err
+			}
+			state := cfg.ResumeLocks.RecoveryState(id)
+			if state.Epoch != epochs[id] || state.Stopping > 0 || (automatic && state.ResumeRequired) {
+				return appwire.ThreadResumeResponse{}, sessionRecoveryAdmissionError{appwire.Unavailable("session recovery requires a fresh explicit thread/resume request")}
+			}
+		}
+		currentTarget, currentAliases, err := resumeOwnership(cfg, requestedID, requestedRefID)
+		if err != nil {
+			return appwire.ThreadResumeResponse{}, appwire.Unavailable(err.Error())
+		}
+		if currentTarget != target || !slices.Equal(currentAliases, aliases) {
+			return appwire.ThreadResumeResponse{}, appwire.Unavailable("session ownership changed; refresh before resuming")
+		}
+		sessionID = target
+		defer func() {
+			if resumeErr != nil {
+				return
+			}
+			if !automatic {
+				if err := cfg.ResumeLocks.ExplicitResumeCompleted(requestedID, epoch); err != nil {
+					response = appwire.ThreadResumeResponse{}
+					resumeErr = appwire.Unavailable("persist completed session recovery: " + err.Error())
+					return
+				}
+			}
+			cfg.ResumeLocks.RecordResolvedSession(requestedID, sessionID, epoch)
+		}()
+
 	}
-	if err := deletionFenceError(cfg, params.Ref, sessionID, ""); err != nil {
+
+	if err := deletionFenceError(cfg, params.Ref, requestedID, ""); err != nil {
 		return appwire.ThreadResumeResponse{}, err
 	}
+	for _, id := range []string{requestedID, sessionID} {
+		if err := deletionFenceError(cfg, "", id, ""); err != nil {
+			return appwire.ThreadResumeResponse{}, err
+		}
+	}
+
 	var discoveryErr error
 	if cfg.Roster != nil {
 		discoveryErr = hubRosterRefresh(ctx, cfg.Roster)
@@ -390,11 +476,8 @@ func hubThreadResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsou
 			// A successful scan can still miss an owner whose status probe
 			// failed. Confirm the exact spawned endpoint through its read before
 			// relying on the shared roster for subsequent requests.
-			source := appsource.NewLocalDaemonSource("local", func() []rendezvous.Entry {
-				return []rendezvous.Entry{entry}
-			}, nil)
 			read, err := cfg.Roster.ReadSpawnedThread(ctx, entry, func(ctx context.Context) (appwire.ThreadReadResponse, error) {
-				return source.ReadThread(ctx, appwire.ThreadReadParams{Ref: localSpawnWorkspaceRef(entry)})
+				return readSpawnedLocalThread(ctx, sources, entry)
 			})
 			if err != nil {
 				return appwire.ThreadResumeResponse{}, appwire.Unavailable(errors.Join(refreshErr, err).Error())
@@ -407,6 +490,171 @@ func hubThreadResume(ctx context.Context, cfg hubcore.WebConfig, sources *appsou
 		}
 	}
 	return hubResumedThreadResponse(ctx, sources, entry.SessionID, entry.ThreadID)
+}
+
+// resumeOwnership keeps the verified stopped transcript authoritative even when
+// roster cleanup removes its marker, and reserves every retained ownership alias.
+func resumeOwnership(cfg hubcore.WebConfig, requestedID, requestedRefID string) (string, []string, error) {
+	var aliases []string
+	visited := make(map[string]bool)
+	current := requestedID
+	for {
+		if cfg.ResumeLocks.HasSeparatePendingRecovery(requestedID, current) {
+			return "", nil, errors.New("resume target has a newer pending recovery; resume the current owning session")
+		}
+		if visited[current] {
+			return "", nil, errors.New("completed session aliases contain a cycle; refresh session ownership before resuming")
+		}
+		visited[current] = true
+		target, groupAliases, err := resumeOwnershipStep(cfg, current)
+		if err != nil {
+			return "", nil, err
+		}
+		aliases = append(aliases, groupAliases...)
+		if target == current {
+			break
+		}
+		current = target
+	}
+	if requestedRefID != "" {
+		aliases = append(aliases, requestedRefID)
+	}
+	slices.Sort(aliases)
+	return current, slices.Compact(aliases), nil
+}
+
+// Each completed group can lead to a newer group after daemon clear. Keep every
+// hop's ownership aliases so one reservation covers the complete resolved path.
+func resumeOwnershipStep(cfg hubcore.WebConfig, requestedID string) (string, []string, error) {
+	aliases := cfg.ResumeLocks.RecoveryAliases(requestedID)
+	durableTarget := cfg.ResumeLocks.RecoveryState(requestedID).ResumeSessionID
+	target := durableTarget
+	found := target != ""
+	resolvedTarget := cfg.ResumeLocks.ResolvedSessionID(requestedID)
+	referenceTarget := durableTarget
+	if referenceTarget == "" {
+		referenceTarget = resolvedTarget
+	}
+	var entries []rendezvous.Entry
+	if cfg.RunDir != "" {
+		var err error
+		entries, err = rendezvous.ListStrict(cfg.RunDir)
+		if err != nil {
+			// Preserve normal discovery's partial-failure recording and direct probe.
+			if cfg.Roster == nil {
+				return "", nil, err
+			}
+			if owner, ok := liveDaemonForThread(cfg.Roster, requestedID); ok {
+				entries = []rendezvous.Entry{owner.Entry}
+			}
+		}
+	}
+	var claims []rendezvous.Entry
+	for _, entry := range entries {
+		if !slices.Contains(forceStopAliases(entry), requestedID) && (referenceTarget == "" || !slices.Contains(forceStopAliases(entry), referenceTarget)) {
+			continue
+		}
+		if entry.SourceID != "" && entry.SourceID != "local" {
+			return "", nil, errors.New("daemon claims a foreign session source")
+		}
+		claims = append(claims, entry)
+		aliases = append(aliases, forceStopAliases(entry)...)
+	}
+	if len(claims) > 0 {
+		// A completed self-target cannot settle a conflicting exited successor.
+		// Only a redirect can advance traversal toward a separately resolved group.
+		completedRedirect := resolvedTarget
+		if completedRedirect == requestedID {
+			completedRedirect = ""
+		}
+		current, err := resumeClaimTarget(cfg, claims, durableTarget, completedRedirect)
+		if err != nil {
+			return "", nil, err
+		}
+		target, found = current, true
+	}
+	if !found && resolvedTarget != "" {
+		target, found = resolvedTarget, true
+	}
+	if !found {
+		if len(aliases) > 1 {
+			return "", nil, errors.New("current session identity is missing for this recovery group; restore its daemon rendezvous marker before resuming")
+		}
+		target = requestedID
+	}
+	// An older partially overlapping group cannot revive a transcript redirected
+	// by a newer stop. Its obligation remains until its own recovery is resolved.
+	if state := cfg.ResumeLocks.RecoveryState(target); state.ResumeRequired && state.ResumeSessionID != "" && state.ResumeSessionID != target {
+		return "", nil, errors.New("resume target belongs to a newer recovery; resume the current owning session")
+	}
+	aliases = append(aliases, requestedID, target)
+	return target, aliases, nil
+}
+
+// Distinct retained transcripts need process evidence: old crash markers are
+// not live owners, and an unverified process is never proof that a target is free.
+func resumeClaimTarget(cfg hubcore.WebConfig, claims []rendezvous.Entry, durableTarget, resolvedTarget string) (string, error) {
+	target := durableTarget
+	conflict := false
+	for _, entry := range claims {
+		current := entry.SessionID
+		if current == "" {
+			current = entry.ThreadID
+		}
+		if current == "" {
+			return "", errors.New("retained daemon has no current session identity")
+		}
+		if target != "" && target != current {
+			conflict = true
+		}
+		if target == "" {
+			target = current
+		}
+	}
+	if !conflict {
+		return target, nil
+	}
+	controller := cfg.DaemonProcesses
+	if controller == nil {
+		controller = daemonprocess.NewController()
+	}
+	liveTarget := ""
+	for _, entry := range claims {
+		current := entry.SessionID
+		if current == "" {
+			current = entry.ThreadID
+		}
+		process, err := controller.Open(daemonprocess.Target{PID: entry.PID, SessionID: current, StateDir: entry.StateDir, StartedAt: entry.StartedAt})
+		if errors.Is(err, daemonprocess.ErrExited) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("cannot verify retained daemon ownership: %w", err)
+		}
+		if err := process.Close(); err != nil {
+			return "", fmt.Errorf("close retained daemon ownership: %w", err)
+		}
+		if liveTarget != "" && liveTarget != current {
+			return "", errors.New("multiple live daemons claim different current sessions")
+		}
+		liveTarget = current
+	}
+	if liveTarget != "" {
+		if durableTarget != "" && durableTarget != liveTarget {
+			return "", errors.New("live daemon conflicts with the persisted recovery target")
+		}
+		return liveTarget, nil
+	}
+	if durableTarget != "" {
+		return durableTarget, nil
+	}
+	// Completed aliases guide the next hop only after all competing claims are
+	// verified exited. A live or unverified process never loses to this fallback.
+	if resolvedTarget != "" {
+		return resolvedTarget, nil
+	}
+
+	return "", errors.New("retained exited daemons have ambiguous current sessions and no persisted recovery target")
 }
 
 // resumeFailureError explains a failed replacement spawn when the daemon this
@@ -520,9 +768,13 @@ func hubThreadFork(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 			return source.ForkThread(ctx, params)
 		})
 	}
+	epoch := sessionRequestRecoveryEpoch(ctx, cfg, params.Ref, ref.ThreadID)
 	unlockDeletionTarget := lockDeletionTarget(cfg, params.Ref, ref.ThreadID)
 	defer unlockDeletionTarget()
 	if err := deletionFenceError(cfg, params.Ref, ref.ThreadID, ""); err != nil {
+		return appwire.ThreadForkResponse{}, err
+	}
+	if err := sessionActionRecoveryError(ctx, cfg, params.Ref, ref.ThreadID, epoch); err != nil {
 		return appwire.ThreadForkResponse{}, err
 	}
 	if params.Aside {
@@ -619,4 +871,24 @@ func parseSourceTurnID(raw string) (int, error) {
 		return 0, errors.New("sourceTurnId must be a positive turn number")
 	}
 	return turn, nil
+}
+
+// readSpawnedLocalThread keeps pre-admission reads in the same recovery scope
+// as ordinary calls so a stalled read cannot retain resume ownership forever.
+func readSpawnedLocalThread(ctx context.Context, sources *appsource.Registry, entry rendezvous.Entry) (appwire.ThreadReadResponse, error) {
+	local, err := spawnedLocalDaemonSource(sources)
+	if err != nil {
+		return appwire.ThreadReadResponse{}, err
+	}
+	return local.ReadThreadAtEntry(ctx, entry, appwire.ThreadReadParams{Ref: localSpawnWorkspaceRef(entry)})
+}
+
+func spawnedLocalDaemonSource(sources *appsource.Registry) (*appsource.LocalDaemonSource, error) {
+	source, ok := sources.Source("local")
+	if ok {
+		if local, ok := source.(*appsource.LocalDaemonSource); ok {
+			return local, nil
+		}
+	}
+	return nil, appwire.Unavailable("local daemon source is not configured")
 }

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -521,6 +521,7 @@ func pastEntryThread(ctx context.Context, cfg hubcore.WebConfig, entry hubcore.P
 			// expose the in-process child's turn start time.
 		},
 	}
+	thread = applyThreadResumeRequirement(ctx, cfg, ref, entry.Meta.ID, thread)
 	if _, required, ownershipErr := restartRequiredDaemon(ctx, cfg, ref, entry.Meta.ID); ownershipErr != nil {
 		if !isDaemonDiscoveryError(ownershipErr) {
 			return appwire.Thread{}, ownershipErr
@@ -978,4 +979,15 @@ func isTerminalHistoricalJobStatus(status string) bool {
 	default:
 		return false
 	}
+}
+
+// applyThreadResumeRequirement projects the hub-owned action fence on both
+// saved snapshots and daemons started by another controller.
+func applyThreadResumeRequirement(ctx context.Context, cfg hubcore.WebConfig, ref, threadID string, thread appwire.Thread) appwire.Thread {
+	recovery := sessionRecoveryState(cfg, ref, threadID)
+	if recovery.ResumeRequired || recovery.Stopping > 0 || sessionConnectionRecoveryError(ctx, cfg, ref, threadID) != nil {
+		thread.Evener.ResumeRequired = true
+		thread.Evener.Capabilities.Send = false
+	}
+	return thread
 }

--- a/cmd/evener-hub/app_vision_model.go
+++ b/cmd/evener-hub/app_vision_model.go
@@ -19,7 +19,7 @@ func setThreadVisionModelWithResume(ctx context.Context, cfg hubcore.WebConfig, 
 	if !shouldResumeAfterSessionUnavailable(err) {
 		return err
 	}
-	if _, resumeErr := hubThreadResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref}); resumeErr != nil {
+	if _, resumeErr := hubThreadAutoResume(ctx, cfg, sources, appwire.ThreadResumeParams{Ref: params.Ref}); resumeErr != nil {
 		return resumeErr
 	}
 	return setThreadVisionModelOnce(ctx, cfg, sources, params)

--- a/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
@@ -4,12 +4,15 @@ import { fileURLToPath } from "node:url";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { IDBFactory, IDBObjectStore } from "fake-indexeddb";
-import { StrictMode } from "react";
+import { StrictMode, useSyncExternalStore } from "react";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { AppwireClient } from "../../protocol/client";
 import { WireError } from "../../protocol/errors";
 import { FakeClient } from "../../protocol/testing/fakeClient";
+import { FakeSocket } from "../../protocol/testing/fakeSocket";
 import type { AnyNotification, Thread, ThreadCapabilities, ThreadReadResponse } from "../../protocol/types.gen";
 import { ClientProvider } from "../../shell/clientContext";
+import { urlToPane } from "../../shell/routing";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../../shell/workspace";
 import { connectionStore } from "../../stores/connection";
 import { MutationOutboxIndexedDB } from "../../stores/mutationOutboxIndexedDB";
@@ -388,14 +391,14 @@ test("falls back to the raw ref as the title when the thread has no name yet", a
   await waitFor(() => expect(screen.getByText("ref_a")).toBeTruthy());
 });
 
-function setNavigationTitle(ref: string, title: string): void {
+function setNavigationTitle(ref: string, title: string, topLevel = true): void {
   const key = { kind: "location", ref } as const;
   const data = {
     generation_id: "generation_test",
     revision: 1,
     ref,
-    top_level_ref: ref,
-    top_level: true,
+    top_level_ref: topLevel ? ref : "local:continuation",
+    top_level: topLevel,
     session: {
       ref,
       host_id: "local",
@@ -403,7 +406,7 @@ function setNavigationTitle(ref: string, title: string): void {
       title,
       project: "test-project",
       state: "idle",
-      kind: "session",
+      kind: topLevel ? "session" : "fork",
       live: true,
       children: [],
     },
@@ -2097,8 +2100,119 @@ test.each([false, true])("restart-required empty transcript suppresses first-sen
   expect(screen.getByText("Session unavailable until restart")).toBeTruthy();
 });
 
+test("explicit Resume follows the returned identity through transcript and new sends", async ({ onTestFinished }) => {
+  onTestFinished(stubSessionSlots);
+  vi.mocked(ComposerModule.Composer).mockRestore();
+  const stableRef = "local:stable-a";
+  const currentRef = "local:current-b";
+  let stopped = false;
+  let resumed = false;
+  const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+  const currentThread = () =>
+    readResponse(currentRef, {
+      status: { type: "idle" },
+      turns: [turnFixture("current-turn", "Current transcript after clear")],
+    });
+  const client = new AppwireClient({
+    url: "ws://hub/rpc",
+    socketFactory: () => {
+      const socket = new FakeSocket({ autoInitialize: true });
+      const send = socket.send.bind(socket);
+      socket.send = (raw) => {
+        send(raw);
+        const request = JSON.parse(raw);
+        if (!request.id || request.method === "initialize" || request.method === "ping") return;
+        requests.push(request);
+        let result: unknown = {};
+        switch (request.method) {
+          case "thread/read":
+            result =
+              request.params.ref === currentRef
+                ? currentThread()
+                : readResponse(stableRef, {
+                    status: { type: stopped ? "notLoaded" : "restartRequired" },
+                    turns: [turnFixture("old-turn", "Saved transcript before clear")],
+                    evener: {
+                      ref: stableRef,
+                      capabilities: CAPABILITIES,
+                      resumeRequired: true,
+                      mutationStateAuthoritative: false,
+                      queue: { revision: 0 },
+                    },
+                  });
+            break;
+          case "evener/thread/forceStop":
+            stopped = true;
+            break;
+          case "thread/resume":
+            resumed = true;
+            result = currentThread();
+            break;
+          case "thread/turns/list":
+            result = { data: [], nextCursor: null };
+            break;
+          case "turn/start":
+            result = { turn: { id: "new-turn", status: "inProgress", itemsView: "full" } };
+            break;
+        }
+        socket.receive({ id: request.id, result });
+      };
+      queueMicrotask(() => socket.open());
+      return socket;
+    },
+  });
+  onTestFinished(() => client.close());
+  connectionStore.getState().connect(client);
+  await client.connect();
+  window.history.replaceState({}, "", "/s/local%3Astable-a");
+  const subscribe = (notify: () => void) => {
+    window.addEventListener("popstate", notify);
+    return () => window.removeEventListener("popstate", notify);
+  };
+  function RoutedSession() {
+    const pathname = useSyncExternalStore(subscribe, () => window.location.pathname);
+    const route = urlToPane(pathname);
+    if (route?.type !== "session") throw new Error("expected session route");
+    return <Session params={route.params as { ref: string }} paneId="p1" focused={true} />;
+  }
+  render(
+    <ClientProvider client={client}>
+      <RoutedSession />
+    </ClientProvider>,
+  );
+  await screen.findByText("Saved transcript before clear");
+  let uncertain = "";
+  await act(async () => {
+    uncertain = await seedPendingSend(stableRef);
+    await mutationStorage.markUnknown(uncertain, "blockedUnknown");
+    await refreshPendingTurnsProjection(stableRef);
+  });
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Force stop…" }));
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  expect(resumed).toBe(false);
+  await user.click(screen.getByRole("button", { name: "Resume session" }));
+  await screen.findByText("Current transcript after clear");
+  expect(window.location.pathname).toBe("/s/local%3Acurrent-b");
+  expect(screen.queryByText("Saved transcript before clear")).toBeNull();
+  expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
+  expect(requests.filter(({ method }) => method === "turn/start")).toHaveLength(0);
+  expect(await mutationStorage.listOutbox(stableRef)).toEqual([
+    expect.objectContaining({ clientMutationId: uncertain, state: "blockedUnknown" }),
+  ]);
+  expect(await mutationStorage.listOutbox(currentRef)).toHaveLength(0);
+  await user.type(screen.getByRole("textbox", { name: /^message$/i }), "Follow up on current transcript");
+  await user.click(screen.getByRole("button", { name: "Send" }));
+  await waitFor(() => expect(requests.filter(({ method }) => method === "turn/start")).toHaveLength(1));
+  expect(requests.find(({ method }) => method === "turn/start")?.params).toEqual(
+    expect.objectContaining({ ref: currentRef }),
+  );
+});
+
 test("offers explicit resume after restart even without pending messages", async () => {
   const fake = connectFakeClient();
+  const resumeTransport = vi.spyOn(fake, "resumeThread");
   let status = "restartRequired";
   fake.on("thread/read", () => readResponse("ref_a", { status: { type: status } }));
   fake.on("thread/resume", () => {
@@ -2118,6 +2232,149 @@ test("offers explicit resume after restart even without pending messages", async
   fireEvent.click(resume);
   await waitFor(() => expect(threadsStore.getState().threads.get("ref_a")?.status.type).toBe("idle"));
   expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(1);
+  expect(resumeTransport).toHaveBeenCalledWith("ref_a");
+});
+
+test.each(["success", "refused"])(
+  "failed initial read has confirmed recovery without navigation: %s",
+  async (outcome) => {
+    const fake = connectFakeClient();
+    const ref = "local:unconfirmed";
+    let stopped = false;
+    fake.on("thread/read", () => {
+      if (!stopped) throw new Error("ownership unconfirmed");
+      return readResponse(ref, { status: { type: "notLoaded" } });
+    });
+    fake.on("evener/thread/forceStop", () => {
+      if (outcome === "refused") throw new Error("no direct daemon ownership claim");
+      stopped = true;
+      return {};
+    });
+    render(
+      <ClientProvider client={fake}>
+        <Session params={{ ref }} paneId="p1" focused={true} />
+      </ClientProvider>,
+    );
+    await waitFor(() => expect(fake.calls.some((call) => call.method === "thread/read")).toBe(true));
+    expect(threadsStore.getState().threads.has(ref)).toBe(false);
+    const refresh = vi.spyOn(threadsStore.getState(), "refreshThread");
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Force stop…" }));
+    expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+    await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+    expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+    await user.click(screen.getByRole("button", { name: "Force stop…" }));
+    await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+    if (outcome === "success") {
+      expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
+      // Hydration publishes Resume before storage reconciliation completes.
+      // The dialog closes only when the complete refresh promise settles.
+      expect(refresh).toHaveBeenCalledWith(ref);
+      await act(async () => {
+        await refresh.mock.results[0]?.value;
+      });
+      expect(screen.queryByRole("dialog")).toBeNull();
+    } else {
+      expect(await screen.findByText("no direct daemon ownership claim")).toBeTruthy();
+      expect(
+        (within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }) as HTMLButtonElement).disabled,
+      ).toBe(false);
+    }
+    expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(1);
+    expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+  },
+);
+
+test.each(["success", "refused"])("hydrated restart recovery works without navigation: %s", async (outcome) => {
+  const fake = connectFakeClient();
+  const ref = "local:incompatible-root";
+  let status = "restartRequired";
+  fake.on("thread/read", () => readResponse(ref, { status: { type: status } }));
+  fake.on("evener/thread/forceStop", () => {
+    if (outcome === "refused") throw new Error("no direct daemon ownership claim");
+    status = "notLoaded";
+    return {};
+  });
+  fake.on("thread/resume", () => {
+    status = "idle";
+    return readResponse(ref, { status: { type: status } });
+  });
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  await screen.findByRole("button", { name: "Refresh session" });
+  const refresh = vi.spyOn(threadsStore.getState(), "refreshThread");
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Force stop…" }));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+  await user.click(screen.getByRole("button", { name: "Force stop…" }));
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+    { method: "evener/thread/forceStop", params: { ref } },
+  ]);
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+  if (outcome === "refused") {
+    expect(await screen.findByText("no direct daemon ownership claim")).toBeTruthy();
+    expect(
+      (within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+    expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("restartRequired");
+  } else {
+    const resume = await screen.findByRole("button", { name: "Resume session" });
+    // Hydration publishes Resume before storage reconciliation completes.
+    // The dialog closes only when the complete refresh promise settles.
+    expect(refresh).toHaveBeenCalledWith(ref);
+    await act(async () => {
+      await refresh.mock.results[0]?.value;
+    });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
+    await user.click(resume);
+    await waitFor(() => expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("idle"));
+    expect(fake.calls.filter((call) => call.method === "thread/resume")).toEqual([
+      { method: "thread/resume", params: { ref } },
+    ]);
+  }
+});
+
+test("confirmed force stop refreshes the session and exposes explicit Resume", async ({ onTestFinished }) => {
+  onTestFinished(stubSessionSlots);
+  vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
+  const fake = connectFakeClient();
+  const ref = "local:force-stop-resume";
+  setNavigationTitle(ref, "Force stop recovery");
+  let status = "restartRequired";
+  fake.on("thread/read", () => readResponse(ref, { status: { type: status } }));
+  fake.on("evener/thread/forceStop", () => {
+    status = "notLoaded";
+    return {};
+  });
+  fake.on("thread/resume", () => {
+    status = "idle";
+    return readResponse(ref, { status: { type: status } });
+  });
+  render(
+    <ClientProvider client={fake}>
+      <SessionChromeModule.SessionChrome ref={ref} />
+      <Session params={{ ref }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  const user = userEvent.setup();
+  await user.click(await screen.findByRole("button", { name: /session actions/i }));
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+  const resume = await screen.findByRole("button", { name: "Resume session" });
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+  await user.click(resume);
+  await waitFor(() => expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("idle"));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(1);
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toEqual([
+    { method: "thread/resume", params: { ref } },
+  ]);
 });
 
 test.each(["notLoaded", "active", "idle"])(
@@ -2213,16 +2470,16 @@ test("keeps recovery failure visible on a compatible session until reconciliatio
 });
 
 test.each(["active", "idle"])("retained %s child preserves uncertainty until its owner releases it", async (status) => {
-  const mutationId = await seedPendingSend();
+  const mutationId = await seedPendingSend("local:retained-child");
   await mutationStorage.markUnknown(mutationId, "blockedUnknown");
   const fake = connectFakeClient();
   let resumed = false;
   let owned = true;
   fake.on("thread/read", () =>
-    readResponse("ref_a", {
+    readResponse("local:retained-child", {
       status: { type: resumed ? "idle" : owned ? status : "notLoaded" },
       evener: {
-        ref: "ref_a",
+        ref: "local:retained-child",
         capabilities: CAPABILITIES,
         kind: "subagent",
         parentRef: owned ? "local:parent" : undefined,
@@ -2233,24 +2490,25 @@ test.each(["active", "idle"])("retained %s child preserves uncertainty until its
   );
   fake.on("thread/resume", () => {
     resumed = true;
-    return readResponse("ref_a", { status: { type: status } });
+    return readResponse("local:retained-child", { status: { type: status } });
   });
   render(
     <ClientProvider client={fake}>
-      <Session params={{ ref: "ref_a" }} paneId="p1" focused={true} />
+      <Session params={{ ref: "local:retained-child" }} paneId="p1" focused={true} />
     </ClientProvider>,
   );
   const refresh = await screen.findByRole("button", { name: "Refresh session" });
   expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
   expect(screen.getByRole("link", { name: "Open owning session" }).getAttribute("href")).toContain("parent");
   expect(threadsStore.getState().restartBlockingObligations.size).toBe(0);
-  expect(threadsStore.getState().mutationAuthorityRefs.has("ref_a")).toBe(false);
+  expect(threadsStore.getState().mutationAuthorityRefs.has("local:retained-child")).toBe(false);
   expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
   expect(fake.calls.filter((call) => call.method === "thread/resume" || call.method === "turn/start")).toHaveLength(0);
   fireEvent.click(refresh);
   await waitFor(() => expect((refresh as HTMLButtonElement).disabled).toBe(false));
   expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
   expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+  expect(screen.queryByRole("button", { name: /Force stop/ })).toBeNull();
   owned = false;
   fireEvent.click(refresh);
   const resume = await screen.findByRole("button", { name: "Resume session" });
@@ -2260,3 +2518,391 @@ test.each(["active", "idle"])("retained %s child preserves uncertainty until its
   expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(1);
   expect(fake.calls.filter((call) => call.method === "turn/start")).toHaveLength(0);
 });
+
+test.each(["idle", "active"])(
+  "hydrated %s session keeps recovery when subsequent reads stall without navigation",
+  async (status) => {
+    const fake = connectFakeClient();
+    const ref = "local:retained-unresponsive";
+    let stopped = false;
+    let reads = 0;
+    let finishRead: (() => void) | undefined;
+    fake.on("thread/read", () => {
+      reads++;
+      if (reads === 2)
+        return new Promise((resolve) => {
+          finishRead = () => resolve(readResponse(ref, { status: { type: "notLoaded" } }));
+        });
+      return readResponse(ref, { status: { type: stopped ? "notLoaded" : status } });
+    });
+    fake.on("evener/thread/forceStop", () => {
+      stopped = true;
+      finishRead?.();
+      return {};
+    });
+    render(
+      <ClientProvider client={fake}>
+        <Session params={{ ref }} paneId="p1" focused={true} />
+      </ClientProvider>,
+    );
+    await waitFor(() => expect(threadsStore.getState().threads.get(ref)?.status.type).toBe(status));
+    act(() => {
+      void threadsStore.getState().refreshThread(ref);
+    });
+    await waitFor(() => expect(reads).toBe(2));
+    expect(threadsStore.getState().threads.get(ref)?.status.type).toBe(status);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Force stop…" }));
+    expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+    await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+    expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
+    expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+      { method: "evener/thread/forceStop", params: { ref } },
+    ]);
+    expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+  },
+);
+
+test("a fresh client offers explicit Resume for a server-fenced stopped session", async () => {
+  const fake = connectFakeClient();
+  const ref = "local:stopped-on-another-client";
+  let resumed = false;
+  fake.on("thread/read", () => {
+    const response = readResponse(ref, { status: { type: resumed ? "idle" : "notLoaded" } });
+    response.thread.evener.resumeRequired = !resumed;
+    return response;
+  });
+  fake.on("thread/resume", () => {
+    resumed = true;
+    return readResponse(ref, { status: { type: "idle" } });
+  });
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref }} paneId="p1" focused={true} />
+    </ClientProvider>,
+  );
+  const user = userEvent.setup();
+  await user.click(await screen.findByRole("button", { name: "Resume session" }));
+  await waitFor(() => expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("idle"));
+  await waitFor(() => expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull());
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toEqual([
+    { method: "thread/resume", params: { ref } },
+  ]);
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+});
+
+test.each(["pending", "failed"])(
+  "saved session retains confirmed recovery when resumed daemon read is %s",
+  async (outcome) => {
+    const fake = connectFakeClient();
+    const ref = "local:saved-resume-stall";
+    let daemonStarted = false;
+    let rejectRead: (error: Error) => void = () => {};
+    const resumedRead = new Promise<ReturnType<typeof readResponse>>((_, reject) => {
+      rejectRead = reject;
+    });
+    fake.on("thread/read", () => {
+      const response = readResponse(ref, { status: { type: "notLoaded" } });
+      response.thread.evener.resumeRequired = true;
+      return response;
+    });
+    fake.on("thread/resume", () => {
+      daemonStarted = true;
+      return resumedRead;
+    });
+    fake.on("evener/thread/forceStop", () => {
+      expect(daemonStarted).toBe(true);
+      rejectRead(new Error("resumed daemon read canceled"));
+      return {};
+    });
+    try {
+      render(
+        <ClientProvider client={fake}>
+          <Session params={{ ref }} paneId="p1" focused={true} />
+        </ClientProvider>,
+      );
+      const user = userEvent.setup();
+      const resume = await screen.findByRole("button", { name: "Resume session" });
+      expect(screen.getAllByRole("button", { name: "Force stop…" })).toHaveLength(1);
+      await user.click(resume);
+      expect(daemonStarted).toBe(true);
+      if (outcome === "failed") {
+        act(() => rejectRead(new Error("resumed daemon read failed")));
+        await screen.findByText("resumed daemon read failed");
+      } else expect((resume as HTMLButtonElement).disabled).toBe(true);
+      expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
+      await user.click(await screen.findByRole("button", { name: "Force stop…" }));
+      expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+      await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+      await waitFor(() =>
+        expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+          { method: "evener/thread/forceStop", params: { ref } },
+        ]),
+      );
+      expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(1);
+    } finally {
+      await act(async () => rejectRead(new Error("fixture cleanup")));
+    }
+  },
+);
+
+test("recovery rejection blocks durable dispatch and refreshes the Resume control", async () => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  try {
+    const fake = connectFakeClient();
+    const ref = "local:failed-stop-recovery";
+    let fenced = false;
+    let reads = 0;
+    let mutationId = "";
+    fake.on("thread/read", () => {
+      reads++;
+      const response = readResponse(ref, { status: { type: "idle" } });
+      response.thread.evener.resumeRequired = fenced;
+      response.thread.evener.capabilities = { ...CAPABILITIES, send: !fenced };
+      response.thread.evener.instanceId = "known-instance";
+      response.thread.evener.mutationStateAuthoritative = true;
+      return response;
+    });
+    fake.on("turn/queue", (params) => {
+      mutationId = params.clientMutationId;
+      fenced = true;
+      throw new WireError("session recovery requires Resume on a fresh connection", -32014, {
+        evenerErrorInfo: "actionUnavailable",
+        clientMutationId: params.clientMutationId,
+        mutationOutcome: "unknown",
+        retryDisposition: "blocked",
+      });
+    });
+    render(
+      <ClientProvider client={fake}>
+        <Session params={{ ref }} paneId="p1" focused={true} />
+      </ClientProvider>,
+    );
+    await waitFor(() => expect(threadsStore.getState().mutationAuthorityRefs.has(ref)).toBe(true));
+    await act(async () => {
+      await threadsStore.getState().refreshThread(ref);
+    });
+    await act(async () => {
+      await threadsStore.getState().queue(ref, "preserve this uncertain message");
+    });
+    await waitFor(async () => expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown"));
+    expect(threadsStore.getState().mutationAuthorityRefs.has(ref)).toBe(false);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
+    expect(reads).toBeGreaterThan(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect((await mutationStorage.getOutbox(mutationId))?.composerText).toBe("preserve this uncertain message");
+    expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(true);
+    expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+    expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test.each(["pending", "failed"])(
+  "saved Send exposes confirmed recovery when automatic resume is %s",
+  async (outcome) => {
+    const fake = connectFakeClient();
+    const ref = "local:saved-auto-resume";
+    let daemonStarted = false;
+    let stopped = false;
+    let mutationId = "";
+    let rejectRead: (error: Error) => void = () => {};
+    const resumedRead = new Promise<never>((_, reject) => {
+      rejectRead = reject;
+    });
+    const blocked = () =>
+      new WireError("resumed daemon read unavailable", -32014, {
+        evenerErrorInfo: "mutationOutcomeUnknown",
+        clientMutationId: mutationId,
+        mutationOutcome: "unknown",
+        retryDisposition: "blocked",
+      });
+    fake.on("thread/read", () => {
+      const response = readResponse(ref, { status: { type: "notLoaded" } });
+      response.thread.evener.instanceId = "saved-instance";
+      response.thread.evener.mutationStateAuthoritative = false;
+      response.thread.evener.resumeRequired = stopped;
+      return response;
+    });
+    fake.on("turn/start", (params) => {
+      mutationId = params.clientMutationId;
+      daemonStarted = true;
+      return resumedRead;
+    });
+    fake.on("evener/thread/forceStop", () => {
+      expect(daemonStarted).toBe(true);
+      stopped = true;
+      rejectRead(blocked());
+      return {};
+    });
+    try {
+      render(
+        <ClientProvider client={fake}>
+          <Session params={{ ref }} paneId="p1" focused={true} />
+        </ClientProvider>,
+      );
+      await waitFor(() => expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded"));
+      await act(async () => {
+        await threadsStore.getState().refreshThread(ref);
+      });
+      expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(false);
+      expect(screen.getAllByRole("button", { name: "Force stop…" })).toHaveLength(1);
+      await act(async () => {
+        await threadsStore.getState().send(ref, "continue the saved conversation");
+      });
+      await waitFor(() => expect(daemonStarted).toBe(true));
+      if (outcome === "failed") {
+        await act(async () => rejectRead(blocked()));
+        await waitFor(async () => expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown"));
+      }
+      expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
+      const user = userEvent.setup();
+      await user.click(await screen.findByRole("button", { name: "Force stop…" }));
+      expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+      await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+      await waitFor(() => expect(stopped).toBe(true));
+      expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
+      expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+        { method: "evener/thread/forceStop", params: { ref } },
+      ]);
+      expect(fake.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
+      expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+      expect((await mutationStorage.getOutbox(mutationId))?.composerText).toBe("continue the saved conversation");
+    } finally {
+      await act(async () => rejectRead(blocked()));
+    }
+  },
+);
+
+test.each(["model", "compact"])(
+  "saved %s action retains recovery while automatic resume stalls without navigation",
+  async (action) => {
+    const fake = connectFakeClient();
+    const ref = "local:saved-action";
+    let daemonStarted = false;
+    let stopped = false;
+    let rejectAction: (error: Error) => void = () => {};
+    const pendingAction = new Promise<never>((_, reject) => {
+      rejectAction = reject;
+    });
+    void pendingAction.catch(() => {});
+    fake.on("thread/read", () => {
+      const saved = readResponse(ref, { status: { type: "notLoaded" } });
+      saved.thread.evener.resumeRequired = stopped;
+      return saved;
+    });
+    const method = action === "model" ? "thread/model/set" : "thread/compact/start";
+    fake.on(method, () => {
+      daemonStarted = true;
+      return pendingAction;
+    });
+    fake.on("evener/thread/forceStop", () => {
+      expect(daemonStarted).toBe(true);
+      stopped = true;
+      rejectAction(new Error("resumed daemon read canceled"));
+      return {};
+    });
+    render(
+      <ClientProvider client={fake}>
+        <Session params={{ ref }} paneId="p1" focused={true} />
+      </ClientProvider>,
+    );
+    await waitFor(() => expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded"));
+    const user = userEvent.setup();
+    try {
+      // A saved snapshot cannot establish whether an automatic resume has launched a daemon.
+      await user.click(screen.getByRole("button", { name: "Force stop…" }));
+      await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+      expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+      const request =
+        action === "model"
+          ? threadsStore.getState().setModel(ref, "openai", "next-model")
+          : threadsStore.getState().compact(ref);
+      const settled = request.catch((error: unknown) => error);
+      await waitFor(() => expect(daemonStarted).toBe(true));
+      expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
+      expect(screen.getAllByRole("button", { name: "Force stop…" })).toHaveLength(1);
+      await user.click(screen.getByRole("button", { name: "Force stop…" }));
+      expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+      await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+      await settled;
+      expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
+      expect(screen.getAllByRole("button", { name: "Force stop…" })).toHaveLength(1);
+      expect(fake.calls.filter((call) => call.method === method)).toHaveLength(1);
+      expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+        { method: "evener/thread/forceStop", params: { ref } },
+      ]);
+      expect(fake.calls.filter((call) => call.method === "thread/resume" || call.method === "turn/start")).toHaveLength(
+        0,
+      );
+    } finally {
+      rejectAction(new Error("fixture cleanup"));
+    }
+  },
+);
+
+test.each(["idle", "active"])(
+  "independent nested fork keeps confirmed recovery during stalled %s reads",
+  async (status) => {
+    const fake = connectFakeClient();
+    const ref = "local:original-fork";
+    setNavigationTitle(ref, "Original fork", false);
+    let stopped = false;
+    let held = false;
+    let finishRead: (() => void) | undefined;
+    fake.on("thread/read", () => {
+      const snapshot = readResponse(ref, { status: { type: stopped ? "notLoaded" : status } });
+      snapshot.thread.evener.parentRef = "local:continuation";
+      snapshot.thread.evener.mutationStateAuthoritative = !stopped;
+      snapshot.thread.evener.resumeRequired = stopped;
+      if (held)
+        return new Promise((resolve) => {
+          finishRead = () => resolve(snapshot);
+        });
+      return snapshot;
+    });
+    fake.on("evener/thread/forceStop", () => {
+      stopped = true;
+      held = false;
+      return {};
+    });
+    render(
+      <ClientProvider client={fake}>
+        <Session params={{ ref }} paneId="p1" focused={true} />
+      </ClientProvider>,
+    );
+    await waitFor(() => expect(threadsStore.getState().mutationAuthorityRefs.has(ref)).toBe(true));
+    held = true;
+    let refreshing: Promise<void> | undefined;
+    act(() => {
+      refreshing = threadsStore.getState().refreshThread(ref);
+    });
+    try {
+      await waitFor(() => expect(finishRead).toBeTypeOf("function"));
+      expect(threadsStore.getState().threads.get(ref)?.status.type).toBe(status);
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: "Force stop…" }));
+      await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+      expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+      await user.click(screen.getByRole("button", { name: "Force stop…" }));
+      await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+      expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
+      expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+        { method: "evener/thread/forceStop", params: { ref } },
+      ]);
+      expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+    } finally {
+      held = false;
+      finishRead?.();
+      await act(async () => {
+        await refreshing;
+      });
+    }
+  },
+);

--- a/cmd/evener-hub/frontend/src/panes/session/Session.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.tsx
@@ -25,6 +25,7 @@ import { useStore } from "zustand";
 import type { ThreadModel } from "../../protocol/model";
 import type { PaneProps } from "../../shell/paneRegistry";
 import { navigate, paneToURL } from "../../shell/routing";
+import { ForceStopDialog } from "../../shell/sessionMenu/ForceStopDialog";
 import { workspaceStore } from "../../shell/workspace";
 import { connectionStore } from "../../stores/connection";
 import { useNavigationStore } from "../../stores/navigation/store";
@@ -119,12 +120,18 @@ function RestartRequiredNotice({
     setRefreshing(true);
     setError(null);
     try {
+      let refreshedRef = sessionRef;
       if (resumeRequired) {
         const { client, state } = connectionStore.getState();
         if (!client || state !== "ready") throw new Error("Connect to the hub before resuming this session.");
-        await client.request("thread/resume", { ref: sessionRef });
+        const { thread } = await client.resumeThread(sessionRef);
+        refreshedRef = thread.evener.ref;
+        if (refreshedRef !== sessionRef) {
+          const url = paneToURL("session", { ref: refreshedRef });
+          if (url !== null) navigate(url, { replace: true });
+        }
       }
-      await threadsStore.getState().refreshThread(sessionRef);
+      await threadsStore.getState().refreshThread(refreshedRef);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -136,7 +143,7 @@ function RestartRequiredNotice({
       {ownerRef
         ? "This session is retained by its owning session. Its uncertain messages cannot be checked here until the owner releases it."
         : resumeRequired
-          ? "Resume this session to check whether its uncertain messages were delivered."
+          ? "Resume this session before continuing. Any uncertain messages will be checked before sending."
           : "Session restart required. Stop the older daemon, then refresh this session. Stopping interrupts active work."}
       {ownerRef && <a href={paneToURL("session", { ref: ownerRef }) ?? undefined}>Open owning session</a>}
       <Button disabled={refreshing} onClick={() => void refresh()}>
@@ -144,6 +151,34 @@ function RestartRequiredNotice({
       </Button>
       {error && <span>{error}</span>}
     </div>
+  );
+}
+
+function SessionForceStopRecovery({ sessionRef }: { sessionRef: string }) {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const stop = async () => {
+    setError(null);
+    try {
+      await threadsStore.getState().forceStop(sessionRef);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+    try {
+      await threadsStore.getState().refreshThread(sessionRef);
+    } catch (err) {
+      setError(`Session stopped; couldn't refresh its view: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+  return (
+    <>
+      <Button variant="quiet" onClick={() => setOpen(true)}>
+        Force stop…
+      </Button>
+      <ForceStopDialog open={open} onClose={() => setOpen(false)} onConfirm={stop} />
+      {error && <span role="alert">{error}</span>}
+    </>
   );
 }
 
@@ -339,7 +374,15 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
     }
     return (
       <PaneScaffold paneId={paneId} focused={paneFocused} scaffoldMarker={`session:${ref}`} title={title}>
-        <EmptyState title="Loading transcript…" />
+        <EmptyState
+          title="Loading transcript…"
+          hint={
+            ref.startsWith("local:")
+              ? "If the session is unresponsive, you can stop its process to recover it."
+              : undefined
+          }
+          action={ref.startsWith("local:") ? <SessionForceStopRecovery sessionRef={ref} /> : undefined}
+        />
       </PaneScaffold>
     );
   }
@@ -351,6 +394,11 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
     model.parentRef?.startsWith("local:")
       ? model.parentRef
       : undefined;
+
+  const showRestartNotice =
+    model.status.type === "restartRequired" ||
+    restartPending ||
+    (blockedMutations.length > 0 && (model.status.type === "notLoaded" || !mutationStateAuthoritative));
 
   const cadence = <Cadence state={cadenceStateForStatus(model.status.type)} frameTimes={frameTimes} now={now} />;
 
@@ -438,14 +486,15 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
               retry={model.modelRetry}
               primaryModel={model.model}
             />
-            {(model.status.type === "restartRequired" ||
-              restartPending ||
-              (blockedMutations.length > 0 && (model.status.type === "notLoaded" || !mutationStateAuthoritative))) && (
+            {showRestartNotice && (
               <RestartRequiredNotice
                 sessionRef={ref}
                 ownerRef={recoveryOwnerRef}
                 resumeRequired={model.status.type !== "restartRequired" && !recoveryOwnerRef}
               />
+            )}
+            {ref.startsWith("local:") && !recoveryOwnerRef && model.status.type !== "closed" && (
+              <SessionForceStopRecovery sessionRef={ref} />
             )}
             {reconciliationFailed && (
               <div role="alert">Message recovery has not completed. Sending will resume after recovery succeeds.</div>

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.edge.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.edge.test.tsx
@@ -428,3 +428,59 @@ test("delete with skipped sessions shows a warning toast", async () => {
 
   expect(await screen.findByText('Couldn\'t delete "Skip Session": still in use')).toBeTruthy();
 });
+
+test.each(["success", "failure"])("force stop requires confirmation and waits for exit: %s", async (outcome) => {
+  const user = userEvent.setup();
+  const ref = "local:force-stop";
+  const fake = connectFakeClient();
+  setLocation(ref);
+  let stopped = false;
+  fake.on("thread/read", () =>
+    readResponse(ref, {
+      status: { type: stopped ? "notLoaded" : "restartRequired" },
+      evener: { ref, capabilities: { ...CAPABILITIES, shutdown: false }, queue: { revision: 0 } },
+    }),
+  );
+  let finish: (() => void) | undefined;
+  fake.on(
+    "evener/thread/forceStop",
+    () =>
+      new Promise((resolve, reject) => {
+        finish = () => {
+          if (outcome === "failure") reject(new Error("exit not confirmed"));
+          else {
+            stopped = true;
+            resolve({});
+          }
+        };
+      }),
+  );
+  await threadsStore.getState().ensureThread(ref);
+  renderWithToast(<SessionChrome ref={ref} />);
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+    expect.objectContaining({ params: { ref } }),
+  ]);
+  expect(
+    (within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }) as HTMLButtonElement).disabled,
+  ).toBe(true);
+  expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("restartRequired");
+  finish?.();
+  if (outcome === "success") {
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
+  } else {
+    expect(await screen.findByText("Couldn't force stop session: exit not confirmed")).toBeTruthy();
+    expect(
+      (within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+  }
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+});

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
@@ -212,6 +212,27 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
                   throw err;
                 }
               },
+              onForceStop:
+                sessionRef.startsWith("local:") &&
+                menuSession?.host_id === "local" &&
+                menuSession.top_level !== false &&
+                model.status.type !== "notLoaded" &&
+                model.status.type !== "closed"
+                  ? async () => {
+                      try {
+                        await threadsStore.getState().forceStop(sessionRef);
+                      } catch (err) {
+                        toasts.push("error", sessionActionError("Couldn't force stop session", err));
+                        throw err;
+                      }
+                      try {
+                        await threadsStore.getState().refreshThread(sessionRef);
+                      } catch (err) {
+                        toasts.push("error", sessionActionError("Session stopped; couldn't refresh its view", err));
+                      }
+                    }
+                  : undefined,
+
               onShutdown: async () => {
                 const convergence = buildShutdownConvergence(sessionRef, {
                   pinSectionId: menuSession?.pin_section_id,

--- a/cmd/evener-hub/frontend/src/protocol/client.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.test.ts
@@ -590,3 +590,160 @@ describe("AppwireClient", () => {
     expect(readyCount).toBe(1);
   });
 });
+
+describe("independent force-stop connection", () => {
+  test("slow recovery connection leaves the full request window for the hub response", async () => {
+    const recovery = new FakeSocket({ autoInitialize: true });
+    const client = new AppwireClient({ url: "ws://hub/rpc", socketFactory: () => recovery });
+    const stopped = client.forceStop("local:owner");
+    const outcome = stopped.then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(25_000);
+    recovery.open();
+    await flushUntil(() => sentFrames(recovery).some((frame) => frame.method === "evener/thread/forceStop"));
+    await vi.advanceTimersByTimeAsync(10_000);
+    recovery.receive({ id: lastSentFrame(recovery).id, error: { code: -32000, message: "exit unconfirmed" } });
+    expect(await outcome).toMatchObject({ message: "exit unconfirmed" });
+    expect(recovery.closeRequests).toHaveLength(1);
+    expect(vi.getTimerCount()).toBe(0);
+    client.close();
+  });
+
+  test("bypasses primary backlog, bounds overlap and closes after confirmed recovery", async () => {
+    const sockets: FakeSocket[] = [];
+    const client = new AppwireClient({
+      url: "wss://hub/rpc?auth=fixture",
+      socketFactory: (url) => {
+        expect(url).toBe("wss://hub/rpc?auth=fixture");
+        const socket = new FakeSocket({ autoInitialize: true });
+        sockets.push(socket);
+        return socket;
+      },
+    });
+    const connected = client.connect();
+    const primary = sockets[0];
+    if (!primary) throw new Error("missing primary");
+    primary.open();
+    await connected;
+    const backlog = Array.from({ length: 66 }, () => client.request("thread/list", {}).catch(() => undefined));
+    const stopped = client.forceStop("local:owner");
+    const recovery = sockets[1];
+    if (!recovery) throw new Error("missing independent recovery connection");
+    await expect(client.forceStop("local:other")).rejects.toThrow();
+    recovery.open();
+    await flushUntil(() => sentFrames(recovery).some((frame) => frame.method === "evener/thread/forceStop"));
+    const request = lastSentFrame(recovery);
+    expect(request.method).toBe("evener/thread/forceStop");
+    expect(request.params).toEqual({ ref: "local:owner" });
+    expect(sentFrames(primary).some((frame) => frame.method === "evener/thread/forceStop")).toBe(false);
+    recovery.receive({ id: request.id, result: {} });
+    await stopped;
+    expect(recovery.closeRequests).toHaveLength(1);
+    expect(client.state).toBe("ready");
+    expect(primary.closeRequests).toHaveLength(0);
+    client.close();
+    await Promise.all(backlog);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test.each(["disconnect", "rejected", "handshake timeout", "owner close"])(
+    "cleans up on %s without a recovery retry",
+    async (failure) => {
+      const sockets: FakeSocket[] = [];
+      const client = new AppwireClient({
+        url: "ws://hub/rpc",
+        socketFactory: () => {
+          const socket = new FakeSocket({ autoInitialize: true });
+          sockets.push(socket);
+          return socket;
+        },
+      });
+      const stopped = client.forceStop("local:owner");
+      const rejected = expect(stopped).rejects.toThrow();
+      const recovery = sockets[0];
+      if (!recovery) throw new Error("missing recovery connection");
+      if (failure === "disconnect" || failure === "rejected") {
+        recovery.open();
+        await flushUntil(() => sentFrames(recovery).some((frame) => frame.method === "evener/thread/forceStop"));
+        if (failure === "disconnect") recovery.closeFromServer(1006);
+        else recovery.receive({ id: lastSentFrame(recovery).id, error: { code: -32000, message: "exit unconfirmed" } });
+      } else if (failure === "owner close") {
+        client.close();
+      } else {
+        await vi.advanceTimersByTimeAsync(30_000);
+      }
+      await rejected;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(sockets).toHaveLength(1);
+      expect(vi.getTimerCount()).toBe(0);
+      client.close();
+    },
+  );
+});
+
+test("explicit Resume replaces the primary transport and never replays old requests", async () => {
+  const sockets: FakeSocket[] = [];
+  const client = new AppwireClient({
+    url: "ws://hub/rpc",
+    socketFactory: () => {
+      const socket = new FakeSocket({ autoInitialize: true });
+      sockets.push(socket);
+      return socket;
+    },
+  });
+  const connected = client.connect();
+  const primary = sockets[0];
+  if (!primary) throw new Error("missing primary");
+  primary.open();
+  await connected;
+  const oldMutation = client.request("thread/reasoning-effort/set", { ref: "local:owner", reasoningEffort: "high" });
+  const oldRejected = expect(oldMutation).rejects.toThrow();
+  const resumed = client.resumeThread("local:owner");
+  const replacement = sockets[1];
+  if (!replacement) throw new Error("missing fresh primary");
+  await oldRejected;
+  expect(primary.closeRequests).toHaveLength(1);
+  await expect(client.resumeThread("local:owner")).rejects.toThrow();
+  replacement.open();
+  await flushUntil(() => sentFrames(replacement).some((frame) => frame.method === "thread/resume"));
+  expect(sentFrames(replacement).some((frame) => frame.method === "thread/reasoning-effort/set")).toBe(false);
+  const request = lastSentFrame(replacement);
+  expect(request.method).toBe("thread/resume");
+  replacement.receive({ id: request.id, result: {} });
+  await resumed;
+  expect(client.state).toBe("ready");
+  client.close();
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+test.each(["closed", "rejected"])("explicit Resume releases its waiters when %s", async (outcome) => {
+  const sockets: FakeSocket[] = [];
+  const client = new AppwireClient({
+    url: "ws://hub/rpc",
+    socketFactory: () => {
+      const socket = new FakeSocket({ autoInitialize: true });
+      sockets.push(socket);
+      return socket;
+    },
+  });
+  const connected = client.connect();
+  const primary = sockets[0];
+  if (!primary) throw new Error("missing primary");
+  primary.open();
+  await connected;
+  const resumed = client.resumeThread("local:owner");
+  const rejected = expect(resumed).rejects.toThrow();
+  const replacement = sockets[1];
+  if (!replacement) throw new Error("missing replacement");
+  if (outcome === "closed") client.close();
+  else {
+    replacement.open();
+    await flushUntil(() => sentFrames(replacement).some((frame) => frame.method === "thread/resume"));
+    replacement.receive({ id: lastSentFrame(replacement).id, error: { code: -32000, message: "resume refused" } });
+  }
+  await rejected;
+  client.close();
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/cmd/evener-hub/frontend/src/protocol/client.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.ts
@@ -110,6 +110,8 @@ export class AppwireClient {
   private readonly clientInfo: { name: string; version: string };
 
   private socket: WebSocketLike | null = null;
+  private recoveryClient: AppwireClient | null = null;
+  private resumePending = false;
   private connectionState: ConnectionState = "idle";
   private nextId = 1;
   private readonly pending = new Map<number, PendingRequest>();
@@ -182,6 +184,7 @@ export class AppwireClient {
   }
 
   close(): void {
+    this.recoveryClient?.close();
     if (this.connectionState === "closed") return;
     const socket = this.socket;
     this.socket = null;
@@ -207,6 +210,70 @@ export class AppwireClient {
     this.disarmReconnect();
     this.failAllPending(new ConnectionClosedError("AppwireClient: closed"));
     this.setState("closed");
+  }
+
+  // Explicit Resume discards the old transport backlog before acknowledging
+  // recovery. Pending requests fail normally; they are never replayed here.
+  async resumeThread(ref: string): Promise<MethodTypes["thread/resume"]["result"]> {
+    if (this.resumePending) throw new Error("A session resume is already pending");
+    const socket = this.socket;
+    if (this.connectionState !== "ready" || !socket) throw new Error("Connect to the hub before resuming this session");
+    this.resumePending = true;
+    let stopReady = () => {};
+    let stopState = () => {};
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const connected = new Promise<void>((resolve, reject) => {
+      stopReady = this.onReady(() => resolve());
+      stopState = this.onStateChange((state) => {
+        if (state === "closed") reject(new ConnectionClosedError("AppwireClient: closed"));
+      });
+      timeout = setTimeout(
+        () => reject(new Error("Connection refresh timed out; try Resume again")),
+        DEFAULT_REQUEST_TIMEOUT_MS,
+      );
+    });
+    try {
+      this.handleSocketLoss(socket, 1000);
+      try {
+        socket.close();
+      } catch {
+        /* The retired transport is already detached. */
+      }
+      this.retryNow();
+      await connected;
+      return await this.request("thread/resume", { ref });
+    } finally {
+      clearTimeout(timeout);
+      stopReady();
+      stopState();
+      this.resumePending = false;
+    }
+  }
+
+  // Recovery owns one short-lived connection so a saturated primary request
+  // queue cannot prevent the user's stop request from reaching the hub.
+  async forceStop(ref: string): Promise<void> {
+    if (this.isClosed()) throw new ConnectionClosedError("AppwireClient: closed");
+    if (this.recoveryClient) throw new Error("A force stop is already pending");
+    const recovery = new AppwireClient({
+      url: this.url,
+      socketFactory: this.socketFactory,
+      now: this.now,
+      clientInfo: this.clientInfo,
+    });
+    this.recoveryClient = recovery;
+    // Bound socket-open and handshake waits. The RPC owns a separate timeout
+    // so connection setup cannot consume its response window.
+    const timeout = setTimeout(() => recovery.close(), DEFAULT_REQUEST_TIMEOUT_MS);
+    try {
+      await recovery.connect();
+      clearTimeout(timeout);
+      await recovery.request("evener/thread/forceStop", { ref });
+    } finally {
+      clearTimeout(timeout);
+      recovery.close();
+      this.recoveryClient = null;
+    }
   }
 
   request<M extends MethodName>(

--- a/cmd/evener-hub/frontend/src/protocol/testing/fakeClient.ts
+++ b/cmd/evener-hub/frontend/src/protocol/testing/fakeClient.ts
@@ -40,6 +40,8 @@ const KNOWN_NOTIFICATIONS: ReadonlySet<string> = new Set(NOTIFICATION_NAMES);
 export interface AppwireClientLike {
   connect: AppwireClient["connect"];
   request: AppwireClient["request"];
+  forceStop: AppwireClient["forceStop"];
+  resumeThread: AppwireClient["resumeThread"];
   onNotification: AppwireClient["onNotification"];
   onReady: AppwireClient["onReady"];
   onStateChange: AppwireClient["onStateChange"];
@@ -195,6 +197,14 @@ export class FakeClient implements AppwireClientLike {
   retryNowCalls = 0;
   retryNow(): void {
     this.retryNowCalls += 1;
+  }
+
+  async resumeThread(ref: string): ReturnType<AppwireClient["resumeThread"]> {
+    return this.request("thread/resume", { ref });
+  }
+
+  async forceStop(ref: string): Promise<void> {
+    await this.request("evener/thread/forceStop", { ref });
   }
 
   // --- test-side injection: simulates the server/transport side ---

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -369,6 +369,7 @@ export interface EvenerSubagentPreviewResponse {
 }
 
 export interface EvenerThread {
+  resumeRequired?: boolean;
   ref: string;
   instanceId?: string;
   parentRef?: string;
@@ -1642,6 +1643,10 @@ export interface ThreadCompactStartParams {
   ref: string;
 }
 
+export interface ThreadForceStopParams {
+  ref: string;
+}
+
 export interface ThreadForkParams {
   ref: string;
   sourceTurnId: string;
@@ -2129,6 +2134,7 @@ export const METHOD_NAMES = [
   "thread/reasoning-effort/set",
   "thread/vision-model/set",
   "thread/compact/start",
+  "evener/thread/forceStop",
   "thread/shutdown",
   "turn/start",
   "turn/steer",
@@ -2313,6 +2319,7 @@ export interface MethodTypes {
   "thread/reasoning-effort/set": { params: ThreadReasoningEffortSetParams; result: EmptyResponse };
   "thread/vision-model/set": { params: ThreadVisionModelSetParams; result: EmptyResponse };
   "thread/compact/start": { params: ThreadCompactStartParams; result: EmptyResponse };
+  "evener/thread/forceStop": { params: ThreadForceStopParams; result: EmptyResponse };
   "thread/shutdown": { params: ThreadShutdownParams; result: EmptyResponse };
   "turn/start": { params: TurnStartParams; result: TurnStartResponse };
   "turn/steer": { params: TurnSteerParams; result: TurnSteerResponse };

--- a/cmd/evener-hub/frontend/src/shell/clientContext.tsx
+++ b/cmd/evener-hub/frontend/src/shell/clientContext.tsx
@@ -1,6 +1,7 @@
 // React context for the single AppwireClientLike the whole app shares
 // (Global Constraints: "One AppwireClient per window, owned by the shell,
-// injected via context"). AppShell constructs the real client and provides
+// injected via context", with one bounded temporary recovery connection owned
+// by that client for force stop). AppShell constructs the real client and provides
 // it here; everything below the shell reads it via useClient() instead of
 // reaching into connectionStore.getState().client, which exists only as a
 // seam for stores that have no connect() path of their own (see

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, fireEvent, render as renderUI, screen, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render as renderUI, screen, waitFor, within } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { FakeClient } from "../../protocol/testing/fakeClient";
@@ -20,7 +20,7 @@ import {
   type ResourceKey,
   type ResourceState,
 } from "../../stores/navigation/types";
-import { threadsStore } from "../../stores/threads";
+import { resetThreadsStoreForTests, threadsStore } from "../../stores/threads";
 import { getToasts, resetToastStoreForTests } from "../../widgets/toast/store";
 import { ClientProvider } from "../clientContext";
 import { resetWorkspaceStoreForTests } from "../workspace";
@@ -1065,11 +1065,11 @@ describe("resource-backed Rail", () => {
     const consumed = vi.fn();
     const first = resource(
       { kind: "location", ref: "missing" },
-      { generation_id: "g1", revision: 1, ref: "missing", top_level_ref: "missing", top_level: true },
+      { generation_id: "g1", revision: 1, ref: "missing", top_level_ref: "missing" },
     );
     const second = resource(
       { kind: "location", ref: "missing-2" },
-      { generation_id: "g1", revision: 1, ref: "missing-2", top_level_ref: "missing-2", top_level: true },
+      { generation_id: "g1", revision: 1, ref: "missing-2", top_level_ref: "missing-2" },
     );
     installState([first, second]);
     const view = render(<Rail revealTarget="missing" onRevealConsumed={consumed} />);
@@ -1355,6 +1355,39 @@ describe("resource-backed Rail", () => {
     await act(async () => undefined);
     expect(client.calls).toContainEqual({ method: "evener/session/delete", params: { ref: "local:a" } });
     expect(applyNavigationMutation).toHaveBeenCalledTimes(2);
+  });
+  test("force stop is reachable after initial thread hydration fails and preserves success on refresh failure", async () => {
+    resetThreadsStoreForTests();
+    const client = new FakeClient("ready");
+    connectionStore.getState().connect(client);
+    const failedRead = deferred<void>();
+    client.on("thread/read", () => {
+      failedRead.resolve();
+      throw new Error("daemon unavailable");
+    });
+    client.on("evener/thread/forceStop", () => ({}));
+    const hydration = threadsStore.getState().ensureThread("local:a");
+    await failedRead.promise;
+    expect(threadsStore.getState().threads.has("local:a")).toBe(false);
+    installState([
+      catalogResource([{ key: "p", name: "Project", session_count: 1 }]),
+      projectResource("p", [summary({ title: "Unresponsive", state: "unknown", live: false })]),
+    ]);
+    render(<Rail />, client);
+    fireEvent.click(screen.getByText("Project"));
+    fireEvent.click(screen.getByRole("button", { name: /actions for unresponsive/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Force stop…" }));
+    expect(client.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(client.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+      { method: "evener/thread/forceStop", params: { ref: "local:a" } },
+    ]);
+    expect(getToasts().some((toast) => toast.text.includes("Session stopped"))).toBe(true);
+    expect(client.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+    threadsStore.getState().releaseThread("local:a");
+    await hydration;
+    resetThreadsStoreForTests();
   });
   test("keeps AppWire shutdown pending through unrelated invalidation and until relevant target authority", async () => {
     const event = deferred<NavigationInvalidatedPayload>();

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -1128,6 +1128,18 @@ function NavigationRail({
           { kind: "sessionTitle", ref: session.ref, title: name },
           true,
         ),
+      onForceStopSession: async (session) => {
+        await runAction(
+          () => threadsStore.getState().forceStop(session.ref),
+          "Couldn't force stop session",
+          undefined,
+          true,
+        );
+        await runAction(
+          () => threadsStore.getState().refreshThread(session.ref),
+          "Session stopped; couldn't refresh its view",
+        );
+      },
       onShutdownSession: async (session) => {
         const convergence = buildShutdownConvergence(session.ref, {
           pinSectionId: session.pin_section_id,

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -188,6 +188,7 @@ function actions(overrides: Partial<RailRowActions> = {}): RailRowActions {
     onOpenSessionPane: vi.fn(),
     onRenameSession: vi.fn().mockResolvedValue(undefined),
     onShutdownSession: vi.fn().mockResolvedValue(undefined),
+    onForceStopSession: vi.fn().mockResolvedValue(undefined),
     onPinSession: vi.fn().mockResolvedValue(undefined),
     onUnpinRequest: vi.fn().mockResolvedValue(undefined),
     onToggleArchiveSession: vi.fn().mockResolvedValue(undefined),
@@ -1336,6 +1337,7 @@ describe("session row", () => {
       "Pin this session…",
       "Archive",
       "Shut down",
+      "Force stop…",
       "Delete…",
     ]);
   });

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -283,6 +283,7 @@ export interface RailRowActions {
   onOpenSessionPane(session: RailSession, pane: SessionPanelKind): void;
   onRenameSession(session: RailSession, name: string): Promise<void>;
   onShutdownSession(session: RailSession): Promise<void>;
+  onForceStopSession(session: RailSession): Promise<void>;
   onPinSession(
     session: RailSession,
     target: PinTarget,
@@ -493,6 +494,14 @@ function SessionMenuRow({ session, actions }: { session: RailSession; actions: R
         onOpenPane: (pane) => actions.onOpenSessionPane(session, pane),
         onRename: (name) => actions.onRenameSession(session, name),
         onShutdown: () => actions.onShutdownSession(session),
+        onForceStop:
+          ref.startsWith("local:") &&
+          session.host_id === "local" &&
+          session.kind === "session" &&
+          session.state !== "notLoaded" &&
+          session.state !== "closed"
+            ? () => actions.onForceStopSession(session)
+            : undefined,
         onPin: (target, section) => actions.onPinSession(session, target, section),
         onUnpin: () => actions.onUnpinRequest(session),
         onToggleArchive: () => actions.onToggleArchiveSession(session),

--- a/cmd/evener-hub/frontend/src/shell/sessionMenu/ForceStopDialog.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/sessionMenu/ForceStopDialog.test.tsx
@@ -1,0 +1,29 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, expect, test, vi } from "vitest";
+import { ForceStopDialog } from "./ForceStopDialog";
+
+afterEach(cleanup);
+
+test("retains pending confirmation through Cancel and Escape, then permits retry after failure", async () => {
+  let rejectStop: (error: Error) => void = () => {};
+  const pending = new Promise<void>((_, reject) => {
+    rejectStop = reject;
+  });
+  const onConfirm = vi.fn(() => pending);
+  const onClose = vi.fn();
+  render(<ForceStopDialog open onClose={onClose} onConfirm={onConfirm} />);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Force stop" }));
+  expect(onConfirm).toHaveBeenCalledTimes(1);
+  const cancel = screen.getByRole("button", { name: "Cancel" });
+  expect((cancel as HTMLButtonElement).disabled).toBe(true);
+  await user.click(cancel);
+  await user.keyboard("{Escape}");
+  expect(onClose).not.toHaveBeenCalled();
+  await act(async () => rejectStop(new Error("exit unconfirmed")));
+  await waitFor(() => expect((cancel as HTMLButtonElement).disabled).toBe(false));
+  expect((screen.getByRole("button", { name: "Force stop" }) as HTMLButtonElement).disabled).toBe(false);
+  await user.click(cancel);
+  expect(onClose).toHaveBeenCalledTimes(1);
+});

--- a/cmd/evener-hub/frontend/src/shell/sessionMenu/ForceStopDialog.tsx
+++ b/cmd/evener-hub/frontend/src/shell/sessionMenu/ForceStopDialog.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { Button, Dialog } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
+import styles from "./sessionmenu.module.css";
+
+export function ForceStopDialog({
+  open,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  onClose(): void;
+  onConfirm(): Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const confirm = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onConfirm();
+      onClose();
+    } catch {
+      // The action adapter reports the failure; retain confirmation for retry.
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <Dialog
+      open={open}
+      onClose={() => {
+        if (!busy) onClose();
+      }}
+      title="Force stop this session?"
+      footer={
+        <div className={requireClass(styles.footer, "sessionmenu.module.css", "footer")}>
+          <Button variant="quiet" disabled={busy} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="danger" disabled={busy} onClick={() => void confirm()}>
+            Force stop
+          </Button>
+        </div>
+      }
+    >
+      <p className={requireClass(styles.body, "sessionmenu.module.css", "body")}>
+        Active turns and jobs may be interrupted. Saved transcripts are retained. You can resume the session after its
+        process stops.
+      </p>
+    </Dialog>
+  );
+}

--- a/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
+++ b/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
@@ -16,6 +16,7 @@ import { Button, Dialog, Input } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { Menu, type MenuEntry } from "../../widgets/menu";
 import { PinSectionPicker } from "../rail/PinSectionPicker";
+import { ForceStopDialog } from "./ForceStopDialog";
 import styles from "./sessionmenu.module.css";
 
 export type PinTarget = { section_id: string } | { section_name: string };
@@ -35,6 +36,7 @@ export interface SessionMenuActions {
   onOpenPane(pane: SessionPanelKind): void;
   onRename(name: string): Promise<void>;
   onShutdown(): Promise<void>;
+  onForceStop?(): Promise<void>;
   onPin(target: PinTarget, section?: PinSectionInfo): Promise<void>;
   onUnpin(): Promise<void>;
   onToggleArchive(): Promise<void>;
@@ -88,6 +90,7 @@ export function SessionMenu({
   const [renameOpen, setRenameOpen] = useState(false);
   const [renameValue, setRenameValue] = useState("");
   const [shutdownOpen, setShutdownOpen] = useState(false);
+  const [forceStopOpen, setForceStopOpen] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
@@ -160,6 +163,9 @@ export function SessionMenu({
       onSelect: () => setShutdownOpen(true),
     },
   ];
+  if (actions.onForceStop) {
+    destructiveItems.push({ id: "force-stop", label: "Force stop…", onSelect: () => setForceStopOpen(true) });
+  }
   if (deleteEligible) {
     destructiveItems.push({ id: "delete", label: "Delete…", onSelect: () => setDeleteOpen(true) });
   }
@@ -244,6 +250,10 @@ export function SessionMenu({
           The agent process for this session will stop. You can still read the transcript afterward.
         </p>
       </Dialog>
+
+      {actions.onForceStop && (
+        <ForceStopDialog open={forceStopOpen} onClose={() => setForceStopOpen(false)} onConfirm={actions.onForceStop} />
+      )}
 
       <Dialog
         open={deleteOpen}

--- a/cmd/evener-hub/frontend/src/stores/threads.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.test.ts
@@ -8879,6 +8879,19 @@ test("clear response fences goal responses from the previous instance", async ()
   expect(threadsStore.getState().watchedThreads.get("ref_a")?.goal?.objective).toBe("new objective");
 });
 
+test("force stop uses the independent recovery API and fences uncertain outcomes", async () => {
+  const fake = new FakeClient();
+  connectionStore.setState({ client: fake, state: "ready" });
+  const recover = vi.spyOn(fake, "forceStop").mockRejectedValueOnce(new Error("exit unconfirmed"));
+  await expect(threadsStore.getState().forceStop("local:owner")).rejects.toThrow("exit unconfirmed");
+  expect(threadsStore.getState().restartBlockingObligations.has("local:owner")).toBe(true);
+  recover.mockResolvedValueOnce(undefined);
+  await threadsStore.getState().forceStop("local:owner");
+  expect(recover).toHaveBeenNthCalledWith(2, "local:owner");
+  expect(threadsStore.getState().restartBlockingObligations.has("local:owner")).toBe(true);
+  expect(fake.calls.some((call) => call.method === "evener/thread/forceStop")).toBe(false);
+});
+
 test("clear permits explicit fresh recovery without replaying old-instance input", async () => {
   const storage = new MutationOutboxIndexedDB();
   setMutationStorageForTests(storage);
@@ -8934,4 +8947,70 @@ test("clear permits explicit fresh recovery without replaying old-instance input
     });
   });
   expect(fake.calls.filter((call) => call.method === "turn/queue")).toHaveLength(1);
+});
+
+test.each([false, true])(
+  "failed force stop reconciles without hiding the original error (read fails: %s)",
+  async (readFails) => {
+    const ref = "local:owner";
+    const storage = new MutationOutboxIndexedDB();
+    setMutationStorageForTests(storage);
+    const fake = connectFakeClient();
+    fake.on("thread/read", () => readResponse(ref));
+    await threadsStore.getState().ensureThread(ref);
+    const record = await storage.enqueueIntent({
+      targetRef: ref,
+      method: "turn/queue",
+      payload: { ref, expectedInstanceId: `thr_${ref}`, input: [{ type: "text", text: "uncertain input" }] },
+      attachments: [],
+      optimisticDisplay: { text: "uncertain input" },
+    });
+    await storage.markAttempted(record.clientMutationId);
+    await storage.markUnknown(record.clientMutationId, "blockedUnknown");
+    const read = deferred<ThreadReadResponse>();
+    fake.on("thread/read", () => read.promise);
+    const original = new Error("exit confirmation failed");
+    vi.spyOn(fake, "forceStop").mockRejectedValueOnce(original);
+    const refresh = vi.spyOn(threadsStore.getState(), "refreshThread");
+    await expect(threadsStore.getState().forceStop(ref)).rejects.toBe(original);
+    expect(refresh).toHaveBeenCalledWith(ref);
+    expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(true);
+    const refreshing = refresh.mock.results[0]?.value as Promise<void>;
+    if (readFails) {
+      read.reject(new Error("read unavailable"));
+      await expect(refreshing).rejects.toThrow("read unavailable");
+      expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(true);
+    } else {
+      const saved = readResponse(ref, { status: { type: "notLoaded" } });
+      saved.thread.evener.resumeRequired = true;
+      saved.thread.evener.mutationStateAuthoritative = false;
+      saved.thread.evener.capabilities = {} as ThreadCapabilities;
+      read.resolve(saved);
+      await refreshing;
+      expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
+      expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(true);
+    }
+    expect((await storage.getOutbox(record.clientMutationId))?.state).toBe("blockedUnknown");
+    expect(fake.calls.filter((call) => call.method === "thread/resume" || call.method === "turn/queue")).toHaveLength(
+      0,
+    );
+  },
+);
+
+test("a healthy authoritative refresh releases the fence after refused force stop", async () => {
+  const ref = "local:healthy-owner";
+  setMutationStorageForTests(new MutationOutboxIndexedDB());
+  const fake = connectFakeClient();
+  fake.on("thread/read", () => readResponse(ref));
+  await threadsStore.getState().ensureThread(ref);
+  const read = deferred<ThreadReadResponse>();
+  fake.on("thread/read", () => read.promise);
+  vi.spyOn(fake, "forceStop").mockRejectedValueOnce(new Error("termination refused"));
+  const refresh = vi.spyOn(threadsStore.getState(), "refreshThread");
+  await expect(threadsStore.getState().forceStop(ref)).rejects.toThrow("termination refused");
+  expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(true);
+  read.resolve(readResponse(ref));
+  await refresh.mock.results[0]?.value;
+  expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(false);
+  expect(fake.calls.some((call) => call.method === "thread/resume")).toBe(false);
 });

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -190,6 +190,7 @@ export interface ThreadsStoreState {
   // views switch to the new instance together.
   clearThread(ref: string): Promise<void>;
   shutdown(ref: string): Promise<void>;
+  forceStop(ref: string): Promise<void>;
   // Forks a thread from a source turn, or - with opts.aside - forks the
   // session at its current tip into a side thread (same wire method,
   // mutually exclusive param sets - see ForkFromTurnOptions). The response
@@ -1473,7 +1474,7 @@ async function publishAndReconcileThreadHydration(
     else mutationAuthorityRefs.delete(ref);
     return { mutationAuthorityRefs };
   });
-  if (published.status.type === "restartRequired") {
+  if (published.status.type === "restartRequired" || hydration.response.thread.evener.resumeRequired === true) {
     threadsStore.setState((state) => ({
       restartBlockingObligations: new Map(state.restartBlockingObligations).set(ref, Symbol()),
     }));
@@ -1543,6 +1544,7 @@ async function publishAndReconcileThreadHydration(
           current() &&
           mutationsReconciled &&
           published.status.type !== "restartRequired" &&
+          hydration.response.thread.evener.resumeRequired !== true &&
           published.status.type !== "notLoaded" &&
           threadsStore.getState().restartBlockingObligations.get(ref) === blockingObligation
         ) {
@@ -2756,6 +2758,27 @@ export const threadsStore = createStore<ThreadsStoreState>(() => ({
     dispatchableMutationRefs.add(ref);
     await runtime.dispatcher.dispatchTargets([ref]);
     await refreshMutationPins(runtime, [ref]);
+  },
+
+  async forceStop(ref) {
+    try {
+      await requireClient().forceStop(ref);
+    } catch (error) {
+      // The signal may have succeeded despite failed exit confirmation.
+      // Retain the recovery fence until a fresh snapshot proves it can clear.
+      threadsStore.setState((state) => ({
+        restartBlockingObligations: new Map(state.restartBlockingObligations).set(ref, Symbol()),
+      }));
+      // Reconcile the hub's recovery requirement without delaying this error.
+      void threadsStore
+        .getState()
+        .refreshThread(ref)
+        .catch(() => {});
+      throw error;
+    }
+    threadsStore.setState((state) => ({
+      restartBlockingObligations: new Map(state.restartBlockingObligations).set(ref, Symbol()),
+    }));
   },
 
   async shutdown(ref) {

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -27,6 +27,9 @@ type LocalDaemonSource struct {
 	itemPagingLocks keyedMutexRegistry
 	itemSnapshots   *itemSnapshotStateCache
 
+	callsMu sync.Mutex
+	calls   map[daemonIdentity]*daemonCalls
+
 	relayMu       sync.Mutex
 	relaySessions map[string]*relaySession
 	legacyRelays  map[string]legacyRelayRead
@@ -296,8 +299,14 @@ func (s *LocalDaemonSource) ReadThread(ctx context.Context, params appwire.Threa
 	if err != nil {
 		return appwire.ThreadReadResponse{}, err
 	}
+	return s.ReadThreadAtEntry(ctx, entry, params)
+}
+
+// ReadThreadAtEntry reads an exact daemon endpoint, including before roster
+// admission, within the source's recovery cancellation scope.
+func (s *LocalDaemonSource) ReadThreadAtEntry(ctx context.Context, entry rendezvous.Entry, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
 	var out appwire.ThreadReadResponse
-	err = s.withClient(ctx, entry, func(client *appwire.Client) error {
+	err := s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.ThreadRead(ctx, params)
 		return callErr
@@ -311,7 +320,7 @@ func (s *LocalDaemonSource) ListTurns(ctx context.Context, params appwire.Thread
 		return appwire.ThreadTurnsListResponse{}, err
 	}
 	var out appwire.ThreadTurnsListResponse
-	err = s.withClient(ctx, entry, func(client *appwire.Client) error {
+	err = s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.ThreadTurnsList(ctx, params)
 		return callErr
@@ -336,8 +345,13 @@ func (s *LocalDaemonSource) StartTurn(ctx context.Context, params appwire.TurnSt
 	if err != nil {
 		return appwire.TurnStartResponse{}, err
 	}
+	return s.StartTurnAtEntry(ctx, entry, params)
+}
+
+// StartTurnAtEntry sends input to an exact daemon within shared recovery cancellation.
+func (s *LocalDaemonSource) StartTurnAtEntry(ctx context.Context, entry rendezvous.Entry, params appwire.TurnStartParams) (appwire.TurnStartResponse, error) {
 	var out appwire.TurnStartResponse
-	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
+	err := s.withMutationClient(ctx, entry, params.ClientMutationID, func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.TurnStart(ctx, params)
 		return callErr
@@ -351,7 +365,7 @@ func (s *LocalDaemonSource) SteerTurn(ctx context.Context, params appwire.TurnSt
 		return appwire.TurnSteerResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnSteerResponse
-	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
+	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(ctx context.Context, client *appwire.Client) error {
 		return client.Request(ctx, appwire.MethodTurnSteer, params, &out)
 	})
 	return out, err
@@ -362,7 +376,7 @@ func (s *LocalDaemonSource) ResolveSandboxEscalation(ctx context.Context, params
 	if err != nil {
 		return err
 	}
-	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+	return s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		return client.Request(ctx, appwire.MethodEvenerSandboxEscalationResolve, params, nil)
 	})
 }
@@ -373,7 +387,7 @@ func (s *LocalDaemonSource) InterruptTurn(ctx context.Context, params appwire.Tu
 		return appwire.TurnInterruptResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnInterruptResponse
-	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
+	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(ctx context.Context, client *appwire.Client) error {
 		return client.Request(ctx, appwire.MethodTurnInterrupt, params, &out)
 	})
 	return out, err
@@ -385,7 +399,7 @@ func (s *LocalDaemonSource) QueueTurn(ctx context.Context, params appwire.TurnQu
 		return appwire.TurnQueueResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnQueueResponse
-	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
+	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(ctx context.Context, client *appwire.Client) error {
 		return client.Request(ctx, appwire.MethodTurnQueue, params, &out)
 	})
 	return out, err
@@ -397,7 +411,7 @@ func (s *LocalDaemonSource) DrainAsSteer(ctx context.Context, params appwire.Tur
 		return appwire.TurnDrainAsSteerResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnDrainAsSteerResponse
-	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
+	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(ctx context.Context, client *appwire.Client) error {
 		return client.Request(ctx, appwire.MethodTurnDrainAsSteer, params, &out)
 	})
 	return out, err
@@ -409,7 +423,7 @@ func (s *LocalDaemonSource) PromoteQueuedAsSteer(ctx context.Context, params app
 		return appwire.TurnPromoteQueuedAsSteerResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var out appwire.TurnPromoteQueuedAsSteerResponse
-	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
+	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(ctx context.Context, client *appwire.Client) error {
 		return client.Request(ctx, appwire.MethodTurnPromoteQueuedAsSteer, params, &out)
 	})
 	return out, err
@@ -421,7 +435,7 @@ func (s *LocalDaemonSource) CancelQueued(ctx context.Context, params appwire.Tur
 		return appwire.TurnCancelQueuedResponse{}, localDaemonMutationEntryError(params.ClientMutationID, err)
 	}
 	var resp appwire.TurnCancelQueuedResponse
-	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(client *appwire.Client) error {
+	err = s.withMutationClient(ctx, entry, params.ClientMutationID, func(ctx context.Context, client *appwire.Client) error {
 		var cerr error
 		resp, cerr = client.TurnCancelQueued(ctx, params)
 		return cerr
@@ -437,7 +451,7 @@ func (s *LocalDaemonSource) CompactThread(ctx context.Context, params appwire.Th
 	if err != nil {
 		return err
 	}
-	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+	return s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		return client.ThreadCompactStart(ctx, params)
 	})
 }
@@ -447,7 +461,7 @@ func (s *LocalDaemonSource) ShutdownThread(ctx context.Context, params appwire.T
 	if err != nil {
 		return err
 	}
-	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+	return s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		return client.ThreadShutdown(ctx, params)
 	})
 }
@@ -457,7 +471,7 @@ func (s *LocalDaemonSource) SetThreadModel(ctx context.Context, params appwire.T
 	if err != nil {
 		return err
 	}
-	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+	return s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		return client.ThreadModelSet(ctx, params)
 	})
 }
@@ -467,7 +481,7 @@ func (s *LocalDaemonSource) SetThreadVisionModel(ctx context.Context, params app
 	if err != nil {
 		return err
 	}
-	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+	return s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		return client.ThreadVisionModelSet(ctx, params)
 	})
 }
@@ -477,7 +491,7 @@ func (s *LocalDaemonSource) SetThreadReasoningEffort(ctx context.Context, params
 	if err != nil {
 		return err
 	}
-	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+	return s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		return client.ThreadReasoningEffortSet(ctx, params)
 	})
 }
@@ -487,7 +501,7 @@ func (s *LocalDaemonSource) SetThreadName(ctx context.Context, params appwire.Th
 	if err != nil {
 		return err
 	}
-	return s.withClient(ctx, entry, func(client *appwire.Client) error {
+	return s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		return client.ThreadNameSet(ctx, params)
 	})
 }
@@ -498,7 +512,7 @@ func (s *LocalDaemonSource) GoalSet(ctx context.Context, params appwire.GoalSetP
 		return appwire.GoalSetResponse{}, err
 	}
 	var out appwire.GoalSetResponse
-	err = s.withClient(ctx, entry, func(client *appwire.Client) error {
+	err = s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.GoalSet(ctx, params)
 		return callErr
@@ -512,7 +526,7 @@ func (s *LocalDaemonSource) ClearThread(ctx context.Context, params appwire.Thre
 		return appwire.ThreadClearResponse{}, err
 	}
 	var out appwire.ThreadClearResponse
-	err = s.withClient(ctx, entry, func(client *appwire.Client) error {
+	err = s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.ThreadClear(ctx, params)
 		return callErr
@@ -526,7 +540,7 @@ func (s *LocalDaemonSource) ListModels(ctx context.Context, params appwire.Model
 		return appwire.ModelListResponse{}, nil
 	}
 	var out appwire.ModelListResponse
-	err := s.withClient(ctx, localDaemonRendezvousEntry(entries[0]), func(client *appwire.Client) error {
+	err := s.withClient(ctx, localDaemonRendezvousEntry(entries[0]), func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.ModelList(ctx, params)
 		return callErr
@@ -540,7 +554,7 @@ func (s *LocalDaemonSource) ListTasks(ctx context.Context, params appwire.TaskLi
 		return appwire.TaskListResponse{}, err
 	}
 	var out appwire.TaskListResponse
-	err = s.withClient(ctx, entry, func(client *appwire.Client) error {
+	err = s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.TasksList(ctx, params)
 		return callErr
@@ -554,7 +568,7 @@ func (s *LocalDaemonSource) ListJobs(ctx context.Context, params appwire.JobsLis
 		return appwire.JobsListResponse{}, err
 	}
 	var out appwire.JobsListResponse
-	err = s.withClient(ctx, entry, func(client *appwire.Client) error {
+	err = s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.JobsList(ctx, params)
 		return callErr
@@ -568,7 +582,7 @@ func (s *LocalDaemonSource) JobOutput(ctx context.Context, params appwire.JobsOu
 		return appwire.JobsOutputResponse{}, err
 	}
 	var out appwire.JobsOutputResponse
-	err = s.withClient(ctx, entry, func(client *appwire.Client) error {
+	err = s.withClient(ctx, entry, func(ctx context.Context, client *appwire.Client) error {
 		var callErr error
 		out, callErr = client.JobOutput(ctx, params)
 		return callErr
@@ -642,7 +656,7 @@ func forwardLocalDaemonNotification(ctx context.Context, out chan<- appwire.Noti
 	}
 }
 
-func (s *LocalDaemonSource) withClient(ctx context.Context, entry rendezvous.Entry, fn func(*appwire.Client) error) error {
+func (s *LocalDaemonSource) withClient(ctx context.Context, entry rendezvous.Entry, fn func(context.Context, *appwire.Client) error) error {
 	return s.withClientCallMapper(ctx, entry, fn, localDaemonCallError)
 }
 
@@ -650,7 +664,7 @@ func (s *LocalDaemonSource) withMutationClient(
 	ctx context.Context,
 	entry rendezvous.Entry,
 	clientMutationID string,
-	fn func(*appwire.Client) error,
+	fn func(context.Context, *appwire.Client) error,
 ) error {
 	return s.withClientCallMapper(ctx, entry, fn, func(err error) error {
 		return localDaemonMutationCallError(clientMutationID, err)
@@ -660,9 +674,14 @@ func (s *LocalDaemonSource) withMutationClient(
 func (s *LocalDaemonSource) withClientCallMapper(
 	ctx context.Context,
 	entry rendezvous.Entry,
-	fn func(*appwire.Client) error,
+	fn func(context.Context, *appwire.Client) error,
 	mapCallError func(error) error,
 ) error {
+	ctx, finish := s.beginDaemonCall(ctx, entry)
+	defer finish()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	transport, err := s.dial(ctx, entry.Endpoint, s.client, daemonAuthHeader(entry.HubToken))
 	if err != nil {
 		if cerr := ctx.Err(); cerr != nil {
@@ -680,7 +699,10 @@ func (s *LocalDaemonSource) withClientCallMapper(
 		}
 		return localDaemonInitializeError(err)
 	}
-	if err := fn(client); err != nil {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := fn(ctx, client); err != nil {
 		if cerr := ctx.Err(); cerr != nil {
 			return cerr
 		}

--- a/cmd/evener-hub/internal/appsource/recovery.go
+++ b/cmd/evener-hub/internal/appsource/recovery.go
@@ -1,0 +1,82 @@
+package appsource
+
+import (
+	"context"
+	"time"
+
+	"primeradiant.com/evener/rendezvous"
+)
+
+// daemonIdentity excludes session aliases: clear can change them while an RPC
+// is outstanding, but it does not change the process that recovery must stop.
+type daemonIdentity struct {
+	pid       int
+	startedAt time.Time
+	stateDir  string
+}
+
+type daemonCalls struct {
+	blocked int
+	calls   map[*context.CancelFunc]struct{}
+}
+
+func recoveryIdentity(entry rendezvous.Entry) daemonIdentity {
+	return daemonIdentity{entry.PID, entry.StartedAt.UTC(), entry.StateDir}
+}
+
+// BeginRecovery cancels outstanding direct RPCs and rejects new ones for this
+// process until the caller releases its ownership reservation. Cancellation is
+// deliberately not session-unavailable: callers must not auto-resume it.
+// Read-only relay feeds own their connection epochs separately. Observing a
+// replacement neither launches a daemon nor acknowledges hub recovery authority.
+func (s *LocalDaemonSource) BeginRecovery(entry rendezvous.Entry) func() {
+	s.callsMu.Lock()
+	key := recoveryIdentity(entry)
+	state := s.daemonCallsLocked(key)
+	state.blocked++
+	for cancel := range state.calls {
+		(*cancel)()
+	}
+	s.callsMu.Unlock()
+	return func() {
+		s.callsMu.Lock()
+		defer s.callsMu.Unlock()
+		state.blocked--
+		if state.blocked == 0 && len(state.calls) == 0 {
+			delete(s.calls, key)
+		}
+	}
+}
+
+func (s *LocalDaemonSource) daemonCallsLocked(key daemonIdentity) *daemonCalls {
+	if s.calls == nil {
+		s.calls = make(map[daemonIdentity]*daemonCalls)
+	}
+	state := s.calls[key]
+	if state == nil {
+		state = &daemonCalls{calls: make(map[*context.CancelFunc]struct{})}
+		s.calls[key] = state
+	}
+	return state
+}
+
+func (s *LocalDaemonSource) beginDaemonCall(ctx context.Context, entry rendezvous.Entry) (context.Context, func()) {
+	s.callsMu.Lock()
+	defer s.callsMu.Unlock()
+	key := recoveryIdentity(entry)
+	state := s.daemonCallsLocked(key)
+	ctx, cancel := context.WithCancel(ctx)
+	state.calls[&cancel] = struct{}{}
+	if state.blocked > 0 {
+		cancel()
+	}
+	return ctx, func() {
+		cancel()
+		s.callsMu.Lock()
+		defer s.callsMu.Unlock()
+		delete(state.calls, &cancel)
+		if state.blocked == 0 && len(state.calls) == 0 {
+			delete(s.calls, key)
+		}
+	}
+}

--- a/cmd/evener-hub/internal/appsource/recovery_test.go
+++ b/cmd/evener-hub/internal/appsource/recovery_test.go
@@ -1,0 +1,176 @@
+package appsource
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/rendezvous"
+)
+
+func TestRecoveryCancelsDaemonCallsAcrossClearAliases(t *testing.T) {
+	source := NewLocalDaemonSource("local", nil, nil)
+	entry := rendezvous.Entry{PID: 4242, StartedAt: time.Now(), StateDir: t.TempDir(), SessionID: "before", ThreadID: "stable"}
+	pending, finish := source.beginDaemonCall(t.Context(), entry)
+	defer finish()
+	other := entry
+	other.PID++
+	unaffected, finishOther := source.beginDaemonCall(t.Context(), other)
+	defer finishOther()
+	cleared := entry
+	// Rendezvous discovery has no monotonic clock component.
+	cleared.StartedAt = entry.StartedAt.UTC()
+	cleared.SessionID = "after"
+	cleared.WorkspaceRef = "local:after"
+	release := source.BeginRecovery(cleared)
+	if !errors.Is(pending.Err(), context.Canceled) {
+		t.Fatalf("in-flight old alias: %v", pending.Err())
+	}
+	if unaffected.Err() != nil {
+		t.Fatalf("another daemon canceled: %v", unaffected.Err())
+	}
+	blocked, finishBlocked := source.beginDaemonCall(t.Context(), entry)
+	defer finishBlocked()
+	if !errors.Is(blocked.Err(), context.Canceled) {
+		t.Fatalf("new old-alias call admitted: %v", blocked.Err())
+	}
+	release()
+	resumed, finishResumed := source.beginDaemonCall(t.Context(), cleared)
+	defer finishResumed()
+	if resumed.Err() != nil {
+		t.Fatalf("call blocked after recovery release: %v", resumed.Err())
+	}
+}
+
+func TestRecoveryCancelsInitializedDaemonRPC(t *testing.T) {
+	for _, tc := range []struct {
+		method     string
+		duringSend bool
+	}{
+		{appwire.MethodThreadRead, false},
+		{appwire.MethodTurnStart, false},
+		{appwire.MethodThreadRead, true},
+		{appwire.MethodTurnStart, true},
+	} {
+		boundary := "initialized"
+		if tc.duringSend {
+			boundary = "send"
+		}
+		t.Run(tc.method+"/"+boundary, func(t *testing.T) {
+			source := NewLocalDaemonSource("local", nil, nil)
+			entry := rendezvousEntry("ws://daemon")
+			accepted := 0
+			attempted := 0
+			var transport *scriptedAppwireTransport
+			transport = newScriptedAppwireTransport(func(ctx context.Context, msg appwire.Message) error {
+				if msg.Request != nil && msg.Request.Method == tc.method {
+					attempted++
+					if tc.duringSend {
+						// Cancellation while a send is pending must reach its context.
+						t.Cleanup(source.BeginRecovery(entry))
+					}
+				}
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				if !tc.duringSend && msg.Notification != nil && msg.Notification.Method == appwire.MethodInitialized {
+					// Recovery begins after the handshake write succeeds, before
+					// the caller starts its RPC. Transport teardown may lag it.
+					t.Cleanup(source.BeginRecovery(entry))
+					return nil
+				}
+				if msg.Request != nil {
+					if msg.Request.Method == appwire.MethodInitialize {
+						transport.recv <- appwire.ResponseMessage(msg.Request.ID, appwire.InitializeResponse{ProtocolVersion: appwire.ProtocolVersion})
+					} else {
+						accepted++
+						transport.recv <- appwire.ResponseMessage(msg.Request.ID, map[string]any{})
+					}
+				}
+				return nil
+			})
+			source.dial = dialTransport(transport)
+			var err error
+			if tc.method == appwire.MethodThreadRead {
+				_, err = source.ReadThreadAtEntry(t.Context(), entry, appwire.ThreadReadParams{ThreadID: "thread"})
+			} else {
+				_, err = source.StartTurnAtEntry(t.Context(), entry, appwire.TurnStartParams{ThreadID: "thread", ClientMutationID: "mutation"})
+			}
+			if !tc.duringSend && attempted != 0 {
+				t.Errorf("attempted %d RPCs after initialization was canceled", attempted)
+			}
+			if accepted != 0 {
+				t.Errorf("accepted %d RPCs after recovery canceled the daemon call", accepted)
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("RPC error = %v, want context.Canceled", err)
+			}
+		})
+	}
+}
+
+func TestRecoveryAllowsReadOnlyRelayReplacementWithoutAdmittingDaemonActions(t *testing.T) {
+	entry := relayEntry("thread")
+	entry.PID = 4242
+	entry.StartedAt = time.Now()
+	entry.StateDir = t.TempDir()
+	entries := []rendezvous.Entry{entry}
+	// This external transport accepts only initialization and subscribed reads;
+	// any attempted mutation makes connection recovery fail instead of succeeding.
+	source, daemon := newRelayTestSource(t, entries)
+	params := appwire.ThreadReadParams{Ref: "local:thread", Subscribe: true}
+	lease, err := source.acquireRelaySession(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Close()
+	deliveries, err := lease.Listen(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	initial := readRelayAsync(t.Context(), lease, params)
+	initialCall := <-daemon.reads
+	initialCall.transport.recv <- appwire.ResponseMessage(initialCall.request.ID, relaySnapshot("thread", "initial"))
+	initialResult := <-initial
+	if initialResult.err != nil {
+		t.Fatal(initialResult.err)
+	}
+	if !initialResult.result.Handoff.Commit() {
+		t.Fatal("initial feed was not committed")
+	}
+	release := source.BeginRecovery(entry)
+	defer release()
+	replacement := entry
+	replacement.PID++
+	replacement.Endpoint = "ws://replacement"
+	// An externally present replacement is observation, not a hub daemon launch.
+	entries[0] = replacement
+	if err := initialCall.transport.Close(); err != nil {
+		t.Fatal(err)
+	}
+	replacementRead := <-daemon.reads
+	replacementRead.transport.recv <- appwire.ResponseMessage(replacementRead.request.ID, relaySnapshot("thread", "replacement"))
+	resync := <-deliveries
+	if resync.Notification.Method != appwire.NotifyEvenerThreadResync {
+		t.Fatalf("replacement feed did not invalidate old state: %s", resync.Notification.Method)
+	}
+	resync.Acknowledge()
+	replacementRead.transport.recv <- appwire.Message{Notification: new(relayDelta("thread", "observed"))}
+	observed := <-deliveries
+	if got := decodeRelayDelta(t, observed.Notification); got != "observed" {
+		t.Fatalf("replacement observation=%q", got)
+	}
+	observed.Acknowledge()
+	if got := daemon.dials.Load(); got != 2 {
+		t.Fatalf("read-only connection count=%d", got)
+	}
+	_, err = source.StartTurnAtEntry(t.Context(), entry, appwire.TurnStartParams{Ref: "local:thread", ClientMutationID: "blocked"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("recovery admitted direct action: %v", err)
+	}
+	if got := daemon.dials.Load(); got != 2 {
+		t.Fatalf("blocked action opened a connection: %d", got)
+	}
+}

--- a/cmd/evener-hub/internal/appsource/transport_seams_test.go
+++ b/cmd/evener-hub/internal/appsource/transport_seams_test.go
@@ -90,7 +90,7 @@ func fuzzScenarioLocalDaemonDialSeamPreservesCallerCancellation(t *testing.T) {
 
 	local := NewLocalDaemonSource("local", nil, nil)
 	local.dial = dial
-	if err := local.withClient(ctx, rendezvousEntry("ws://daemon"), func(*appwire.Client) error { return nil }); !errors.Is(err, context.Canceled) {
+	if err := local.withClient(ctx, rendezvousEntry("ws://daemon"), func(context.Context, *appwire.Client) error { return nil }); !errors.Is(err, context.Canceled) {
 		t.Fatalf("local withClient error = %v", err)
 	}
 	entry := rendezvous.Entry{Protocol: appwire.ProtocolVersion, Endpoint: "ws://daemon", SourceID: "local", ThreadID: "thread"}
@@ -110,7 +110,7 @@ func TestWithClientPreservesCallerCancellationAfterCall(t *testing.T) {
 	local := NewLocalDaemonSource("local", nil, nil)
 	local.dial = dialTransport(transport)
 
-	err := local.withClient(ctx, rendezvousEntry("ws://daemon"), func(*appwire.Client) error {
+	err := local.withClient(ctx, rendezvousEntry("ws://daemon"), func(context.Context, *appwire.Client) error {
 		cancel()
 		return appwire.InternalError(context.Canceled.Error())
 	})
@@ -172,7 +172,7 @@ func fuzzScenarioLocalDaemonRemainingTransportBranches(t *testing.T) {
 		transport := respondingTransport(func(string) (any, error) { cancel(); return nil, errors.New("failed") })
 		s := NewLocalDaemonSource("local", nil, nil)
 		s.dial = dialTransport(transport)
-		if err := s.withClient(callCtx, entry, func(*appwire.Client) error { return nil }); !errors.Is(err, context.Canceled) {
+		if err := s.withClient(callCtx, entry, func(context.Context, *appwire.Client) error { return nil }); !errors.Is(err, context.Canceled) {
 			t.Fatalf("withClient error = %v", err)
 		}
 	})
@@ -186,7 +186,7 @@ func fuzzScenarioLocalDaemonRemainingTransportBranches(t *testing.T) {
 		if _, err := s.SubscribeThread(ctx, appwire.ThreadReadParams{Ref: "local:thread"}); err == nil {
 			t.Fatal("SubscribeThread returned nil")
 		}
-		if err := s.withClient(ctx, entry, func(*appwire.Client) error { return nil }); err == nil {
+		if err := s.withClient(ctx, entry, func(context.Context, *appwire.Client) error { return nil }); err == nil {
 			t.Fatal("withClient returned nil")
 		}
 	})

--- a/cmd/evener-hub/internal/daemonprocess/process.go
+++ b/cmd/evener-hub/internal/daemonprocess/process.go
@@ -1,0 +1,175 @@
+// Package daemonprocess binds force-stop requests to a verified OS process.
+package daemonprocess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrExited means the bound process has been confirmed absent.
+var ErrExited = errors.New("daemon process exited")
+
+// Target is the rendezvous identity and canonical session data location.
+type Target struct {
+	PID       int
+	SessionID string
+	StateDir  string
+	StartedAt time.Time
+}
+
+// Process owns a generation-bound OS handle. Close releases that handle.
+type Process interface {
+	Kill() error
+	Wait(context.Context) error
+	Close() error
+}
+
+// Controller verifies a daemon before exposing a termination handle.
+type Controller interface{ Open(Target) (Process, error) }
+
+type identity struct {
+	generation string
+	uid        int
+	startedAt  time.Time
+	argv       []string
+	ownsLog    bool
+}
+
+type processHandle interface {
+	inspect(Target) (identity, error)
+	kill() error
+	exited() (bool, error)
+	close() error
+}
+
+type controller struct {
+	bind func(int) (processHandle, error)
+}
+type process struct {
+	mu         sync.Mutex
+	handle     processHandle
+	target     Target
+	generation string
+	closed     bool
+}
+
+func (c controller) Open(t Target) (Process, error) {
+	if t.PID <= 1 || t.PID > 1<<31-1 || t.PID == os.Getpid() {
+		return nil, errors.New("refuse invalid or self daemon PID")
+	}
+	if t.SessionID == "" || t.SessionID == "." || t.SessionID == ".." || strings.ContainsAny(t.SessionID, "/\\\x00") {
+		return nil, errors.New("missing or invalid daemon session identity")
+	}
+	if !filepath.IsAbs(t.StateDir) || t.StartedAt.IsZero() {
+		return nil, errors.New("missing canonical state directory or rendezvous start time")
+	}
+	h, err := c.bind(t.PID)
+	if err != nil {
+		return nil, err
+	}
+	p := &process{handle: h, target: t}
+	if err := p.verify(); err != nil {
+		if gone, exitErr := h.exited(); exitErr == nil && gone {
+			err = ErrExited
+		}
+		_ = h.close()
+		return nil, err
+	}
+	return p, nil
+}
+
+func (p *process) verify() error {
+	if time.Now().Before(p.target.StartedAt) {
+		return errors.New("rendezvous start time is in the future")
+	}
+	// Inspect on both sides of ownership verification. The OS handle also binds
+	// signaling to this generation if a PID is reused after these checks.
+	for range 2 {
+		v, err := p.handle.inspect(p.target)
+		if err != nil {
+			return err
+		}
+		if v.generation == "" || (p.generation != "" && v.generation != p.generation) {
+			return errors.New("daemon process generation changed")
+		}
+		if v.uid != os.Geteuid() {
+			return errors.New("daemon process belongs to another user")
+		}
+		if len(v.argv) < 2 || v.argv[1] != "serve" {
+			return errors.New("daemon process is not a serve command")
+		}
+		if v.startedAt.IsZero() || v.startedAt.After(p.target.StartedAt) {
+			return errors.New("daemon process started after its rendezvous identity")
+		}
+		if !v.ownsLog {
+			return errors.New("daemon process does not own the session API log")
+		}
+		p.generation = v.generation
+	}
+	return nil
+}
+
+func (p *process) Kill() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return os.ErrClosed
+	}
+	if err := p.verify(); err != nil {
+		if errors.Is(err, ErrExited) {
+			return nil
+		}
+		if gone, exitErr := p.handle.exited(); exitErr == nil && gone {
+			return nil
+		}
+		return err
+	}
+	err := p.handle.kill()
+	if errors.Is(err, ErrExited) {
+		return nil
+	}
+	return err
+}
+
+func (p *process) Wait(ctx context.Context) error {
+	// pidfd readiness (Linux) or unique process identity (Darwin) confirms exit;
+	// signal delivery and a missing rendezvous file do not.
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return os.ErrClosed
+		}
+		gone, err := p.handle.exited()
+		p.mu.Unlock()
+		if err != nil {
+			return fmt.Errorf("confirm daemon exit: %w", err)
+		}
+		if gone {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (p *process) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+	return p.handle.close()
+}

--- a/cmd/evener-hub/internal/daemonprocess/process_darwin.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_darwin.go
@@ -1,0 +1,240 @@
+package daemonprocess
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Darwin's proc_info ABI is declared in XNU's proc_info.h and
+// proc_info_private.h. Audit-token signaling atomically checks pidversion;
+// kill(2) cannot provide that guarantee.
+const (
+	darwinProcInfo         = 336
+	darwinPIDInfo          = 2
+	darwinPIDFDInfo        = 3
+	darwinSignalAuditToken = 0x11
+	darwinListFDs          = 1
+	darwinBSDInfo          = 3
+	darwinUniqueInfo       = 17
+	darwinVnodeInfo        = 1
+)
+
+type darwinProcess struct {
+	pid     int
+	unique  uint64
+	version uint32
+}
+
+// NewController creates the native daemon identity verifier.
+func NewController() Controller { return controller{bind: openDarwinProcess} }
+func openDarwinProcess(pid int) (processHandle, error) {
+	unique, version, err := darwinGeneration(pid)
+	if err != nil {
+		return nil, err
+	}
+	return &darwinProcess{pid: pid, unique: unique, version: version}, nil
+}
+func (p *darwinProcess) close() error { return nil }
+
+func darwinProcCall(call, pid, flavor int, arg uintptr, buf []byte) (int, error) {
+	var ptr unsafe.Pointer
+	if len(buf) > 0 {
+		ptr = unsafe.Pointer(&buf[0])
+	}
+	n, _, errno := syscall.Syscall6(darwinProcInfo, uintptr(call), uintptr(pid), uintptr(flavor), arg, uintptr(ptr), uintptr(len(buf)))
+	runtime.KeepAlive(buf)
+	if errno != 0 {
+		if errno == syscall.ESRCH {
+			return 0, ErrExited
+		}
+		return 0, errno
+	}
+	return int(n), nil
+}
+func darwinReadInfo(pid, flavor, size int) ([]byte, error) {
+	data := make([]byte, size)
+	n, err := darwinProcCall(darwinPIDInfo, pid, flavor, 0, data)
+	if err != nil {
+		return nil, err
+	}
+	if n != size {
+		return nil, fmt.Errorf("darwin process info flavor %d returned %d bytes, expected %d", flavor, n, size)
+	}
+	return data, nil
+}
+func darwinGeneration(pid int) (uint64, uint32, error) {
+	data, err := darwinReadInfo(pid, darwinUniqueInfo, 56)
+	if err != nil {
+		return 0, 0, err
+	}
+	return binary.NativeEndian.Uint64(data[16:]), binary.NativeEndian.Uint32(data[32:]), nil
+}
+func (p *darwinProcess) kill() error {
+	token := make([]byte, 32)
+	binary.NativeEndian.PutUint32(token[20:], uint32(p.pid))
+	binary.NativeEndian.PutUint32(token[28:], p.version)
+	_, err := darwinProcCall(darwinSignalAuditToken, 0, int(unix.SIGKILL), 0, token)
+	return err
+}
+func (p *darwinProcess) exited() (bool, error) {
+	unique, version, err := darwinGeneration(p.pid)
+	if errors.Is(err, ErrExited) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if unique != p.unique || version != p.version {
+		return true, nil
+	}
+	info, err := darwinReadInfo(p.pid, darwinBSDInfo, 136)
+	if errors.Is(err, ErrExited) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return binary.NativeEndian.Uint32(info[4:]) == 5, nil // SZOMB
+}
+func (p *darwinProcess) inspect(t Target) (identity, error) {
+	gone, err := p.exited()
+	if err != nil {
+		return identity{}, err
+	}
+	if gone {
+		return identity{}, ErrExited
+	}
+	info, err := darwinReadInfo(p.pid, darwinBSDInfo, 136)
+	if err != nil {
+		return identity{}, err
+	}
+	args, err := unix.SysctlRaw("kern.procargs2", p.pid)
+	if err != nil {
+		return identity{}, err
+	}
+	argv, err := darwinArguments(args)
+	if err != nil {
+		return identity{}, err
+	}
+	owns, err := darwinOwnsLog(p.pid, t)
+	if err != nil {
+		return identity{}, err
+	}
+	gone, err = p.exited()
+	if err != nil {
+		return identity{}, err
+	}
+	if gone {
+		return identity{}, ErrExited
+	}
+	return identity{generation: strconv.FormatUint(p.unique, 10) + ":" + strconv.FormatUint(uint64(p.version), 10), uid: int(binary.NativeEndian.Uint32(info[20:])), startedAt: time.Unix(int64(binary.NativeEndian.Uint64(info[120:])), int64(binary.NativeEndian.Uint64(info[128:]))*1000), argv: argv, ownsLog: owns}, nil
+}
+
+func darwinArguments(data []byte) ([]string, error) {
+	if len(data) < 4 {
+		return nil, errors.New("missing Darwin process arguments")
+	}
+	count := int(binary.NativeEndian.Uint32(data))
+	data = data[4:]
+	end := bytes.IndexByte(data, 0)
+	if end < 0 {
+		return nil, errors.New("missing Darwin executable path")
+	}
+	data = data[end+1:]
+	data = bytes.TrimLeft(data, "\x00")
+	if count < 1 || count > len(data) {
+		return nil, errors.New("invalid Darwin argument count")
+	}
+	args := make([]string, 0, count)
+	for range count {
+		end = bytes.IndexByte(data, 0)
+		if end < 0 {
+			return nil, errors.New("truncated Darwin arguments")
+		}
+		args = append(args, string(data[:end]))
+		data = data[end+1:]
+	}
+	return args, nil
+}
+
+func darwinOwnsLog(pid int, t Target) (bool, error) {
+	path := filepath.Join(t.StateDir, "sessions", t.SessionID+".api.jsonl")
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = unix.Close(fd) }()
+	var expected unix.Stat_t
+	if err := unix.Fstat(fd, &expected); err != nil {
+		return false, err
+	}
+	if expected.Mode&unix.S_IFMT != unix.S_IFREG {
+		return false, nil
+	}
+	size, err := darwinProcCall(darwinPIDInfo, pid, darwinListFDs, 0, nil)
+	if err != nil {
+		return false, err
+	}
+	// A changing FD table can outgrow this snapshot; refusal is safe, and a later
+	// explicit force-stop request takes a fresh snapshot.
+	entries := make([]byte, size+32*8)
+	n, err := darwinProcCall(darwinPIDInfo, pid, darwinListFDs, 0, entries)
+	if err != nil {
+		return false, err
+	}
+	if n > len(entries) || n%8 != 0 {
+		return false, errors.New("invalid Darwin descriptor list")
+	}
+	for offset := 0; offset < n; offset += 8 {
+		if binary.NativeEndian.Uint32(entries[offset+4:]) != 1 {
+			continue
+		} // vnode
+		targetFD := binary.NativeEndian.Uint32(entries[offset:])
+		data := make([]byte, 176)
+		got, err := darwinProcCall(darwinPIDFDInfo, pid, darwinVnodeInfo, uintptr(targetFD), data)
+		if errors.Is(err, unix.EBADF) || errors.Is(err, unix.ENOENT) {
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		if got != len(data) {
+			return false, errors.New("incomplete Darwin vnode descriptor info")
+		}
+		flags := binary.NativeEndian.Uint32(data)
+		status := binary.NativeEndian.Uint32(data[4:])
+		if flags&2 == 0 || flags&0x4000 == 0 || status&2 == 0 {
+			continue
+		} // FWRITE, FWASLOCKED, PROC_FP_CLEXEC
+		if binary.NativeEndian.Uint32(data[24:]) != uint32(expected.Dev) || binary.NativeEndian.Uint64(data[32:]) != expected.Ino {
+			continue
+		}
+		// FWASLOCKED is historical, not proof of current ownership. Evener's
+		// APILogger never unlocks a retained descriptor: Close closes it, and exec
+		// closes its O_CLOEXEC descriptor. Together with live exclusive contention,
+		// a still-open matching descriptor proves ownership within that lifecycle.
+		// This does not defend against a same-user process impersonating Evener.
+		err = unix.Flock(fd, unix.LOCK_SH|unix.LOCK_NB)
+		if err == nil {
+			if err := unix.Flock(fd, unix.LOCK_UN); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
+		if errors.Is(err, unix.EWOULDBLOCK) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
+}

--- a/cmd/evener-hub/internal/daemonprocess/process_darwin_test.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_darwin_test.go
@@ -1,0 +1,31 @@
+package daemonprocess
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func fixtureRendezvousTime(*testing.T, Target) time.Time { return time.Now() }
+
+func TestDarwinAuditTokenRefusesDifferentGeneration(t *testing.T) {
+	target, _ := startNativeChild(t, "locked")
+	h, err := openDarwinProcess(target.PID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := h.(*darwinProcess)
+	p.version++
+	if err := p.kill(); !errors.Is(err, ErrExited) {
+		t.Fatalf("wrong generation signal: %v", err)
+	}
+	if err := unix.Kill(target.PID, 0); err != nil {
+		t.Fatalf("fixture child was signaled: %v", err)
+	}
+	gone, err := p.exited()
+	if err != nil || !gone {
+		t.Fatalf("old generation exit = %v, %v", gone, err)
+	}
+}

--- a/cmd/evener-hub/internal/daemonprocess/process_linux.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_linux.go
@@ -1,0 +1,228 @@
+package daemonprocess
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"math/bits"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+type linuxProcess struct{ pid, fd int }
+
+// NewController creates the native daemon identity verifier.
+func NewController() Controller { return controller{bind: openLinuxProcess} }
+func openLinuxProcess(pid int) (processHandle, error) {
+	fd, err := unix.PidfdOpen(pid, 0)
+	if errors.Is(err, unix.ESRCH) {
+		return nil, ErrExited
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open daemon pidfd: %w", err)
+	}
+	return &linuxProcess{pid: pid, fd: fd}, nil
+}
+func (p *linuxProcess) close() error { return unix.Close(p.fd) }
+func (p *linuxProcess) kill() error {
+	err := unix.PidfdSendSignal(p.fd, unix.SIGKILL, nil, 0)
+	if errors.Is(err, unix.ESRCH) {
+		return ErrExited
+	}
+	return err
+}
+func (p *linuxProcess) exited() (bool, error) {
+	fds := []unix.PollFd{{Fd: int32(p.fd), Events: unix.POLLIN}}
+	_, err := unix.Poll(fds, 0)
+	if err != nil {
+		return false, err
+	}
+	if fds[0].Revents&unix.POLLNVAL != 0 {
+		return false, os.ErrClosed
+	}
+	return fds[0].Revents&(unix.POLLIN|unix.POLLHUP) != 0, nil
+}
+
+func (p *linuxProcess) inspect(t Target) (identity, error) {
+	gone, err := p.exited()
+	if err != nil {
+		return identity{}, err
+	}
+	if gone {
+		return identity{}, ErrExited
+	}
+	root := "/proc/" + strconv.Itoa(p.pid)
+	var procStat unix.Stat_t
+	if err := unix.Stat(root, &procStat); err != nil {
+		return identity{}, p.inspectionError(err)
+	}
+	raw, err := os.ReadFile(filepath.Join(root, "stat"))
+	if err != nil {
+		return identity{}, p.inspectionError(err)
+	}
+	end := bytes.LastIndexByte(raw, ')')
+	if end < 0 {
+		return identity{}, errors.New("malformed process stat")
+	}
+	fields := strings.Fields(string(raw[end+1:]))
+	if len(fields) < 20 {
+		return identity{}, errors.New("incomplete process stat")
+	}
+	ticks, err := strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return identity{}, err
+	}
+	auxv, err := os.ReadFile("/proc/self/auxv")
+	if err != nil {
+		return identity{}, err
+	}
+	hz, err := linuxClockTicks(auxv, int(unsafe.Sizeof(uintptr(0))))
+	if err != nil {
+		return identity{}, err
+	}
+	var boot, wall unix.Timespec
+	if err := unix.ClockGettime(unix.CLOCK_BOOTTIME, &boot); err != nil {
+		return identity{}, err
+	}
+	if err := unix.ClockGettime(unix.CLOCK_REALTIME, &wall); err != nil {
+		return identity{}, err
+	}
+	// The end of the kernel's reported clock tick is a conservative upper bound
+	// on process start. Do not accept a reused PID within that tick.
+	offset, err := linuxStartOffset(ticks, hz)
+	if err != nil {
+		return identity{}, err
+	}
+	started := time.Unix(wall.Sec, wall.Nsec).Add(-time.Duration(boot.Nano())).Add(offset)
+	argv, err := os.ReadFile(filepath.Join(root, "cmdline"))
+	if err != nil {
+		return identity{}, p.inspectionError(err)
+	}
+	owns, err := linuxOwnsLog(root, t)
+	if err != nil {
+		return identity{}, p.inspectionError(err)
+	}
+	gone, err = p.exited()
+	if err != nil {
+		return identity{}, err
+	}
+	if gone {
+		return identity{}, ErrExited
+	}
+	return identity{generation: fields[19], uid: int(procStat.Uid), startedAt: started, argv: strings.Split(strings.TrimSuffix(string(argv), "\x00"), "\x00"), ownsLog: owns}, nil
+}
+func (p *linuxProcess) inspectionError(err error) error {
+	if gone, e := p.exited(); e == nil && gone {
+		return ErrExited
+	}
+	return err
+}
+
+func linuxOwnsLog(root string, t Target) (bool, error) {
+	var expected unix.Stat_t
+	path := filepath.Join(t.StateDir, "sessions", t.SessionID+".api.jsonl")
+	if err := unix.Lstat(path, &expected); err != nil {
+		return false, err
+	}
+	if expected.Mode&unix.S_IFMT != unix.S_IFREG {
+		return false, nil
+	}
+	entries, err := os.ReadDir(filepath.Join(root, "fd"))
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		var candidate unix.Stat_t
+		if err := unix.Stat(filepath.Join(root, "fd", entry.Name()), &candidate); err != nil {
+			if errors.Is(err, unix.ENOENT) {
+				continue
+			}
+			return false, err
+		}
+		if candidate.Dev != expected.Dev || candidate.Ino != expected.Ino {
+			continue
+		}
+		evidence, err := os.ReadFile(filepath.Join(root, "fdinfo", entry.Name()))
+		if err != nil {
+			return false, err
+		}
+		if linuxOwnsLock(evidence, t.PID, expected.Dev, expected.Ino) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func linuxOwnsLock(data []byte, pid int, dev, ino uint64) bool {
+	writable, locked := false, false
+	for line := range strings.SplitSeq(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "flags:" {
+			flags, err := strconv.ParseUint(fields[1], 8, 64)
+			writable = err == nil && flags&unix.O_ACCMODE != unix.O_RDONLY && flags&unix.O_CLOEXEC != 0
+		}
+		if len(fields) != 9 || fields[0] != "lock:" || fields[2] != "FLOCK" || fields[3] != "ADVISORY" || fields[4] != "WRITE" || fields[5] != strconv.Itoa(pid) || fields[7] != "0" || fields[8] != "EOF" {
+			continue
+		}
+		parts := strings.Split(fields[6], ":")
+		if len(parts) != 3 {
+			continue
+		}
+		major, e1 := strconv.ParseUint(parts[0], 16, 32)
+		minor, e2 := strconv.ParseUint(parts[1], 16, 32)
+		inode, e3 := strconv.ParseUint(parts[2], 10, 64)
+		if e1 == nil && e2 == nil && e3 == nil && unix.Mkdev(uint32(major), uint32(minor)) == dev && inode == ino {
+			locked = true
+		}
+	}
+	return writable && locked
+}
+
+func linuxClockTicks(data []byte, word int) (uint64, error) {
+	for len(data) >= word*2 {
+		var tag, value uint64
+		switch word {
+		case 8:
+			tag = binary.NativeEndian.Uint64(data)
+			value = binary.NativeEndian.Uint64(data[word:])
+		case 4:
+			tag = uint64(binary.NativeEndian.Uint32(data))
+			value = uint64(binary.NativeEndian.Uint32(data[word:]))
+		default:
+			return 0, errors.New("unsupported auxiliary vector word size")
+		}
+		if tag == 17 && value > 0 {
+			return value, nil
+		}
+		if tag == 0 {
+			break
+		}
+		data = data[word*2:]
+	}
+	return 0, errors.New("process clock frequency unavailable")
+}
+
+func linuxStartOffset(ticks, hz uint64) (time.Duration, error) {
+	if hz == 0 || ticks == math.MaxUint64 {
+		return 0, errors.New("invalid process start ticks or clock frequency")
+	}
+	// Keep the full product until division: even valid durations exceed a
+	// uint64 nanosecond intermediate on long-running hosts at ordinary HZ.
+	high, low := bits.Mul64(ticks+1, uint64(time.Second))
+	if high >= hz {
+		return 0, errors.New("process start offset exceeds duration range")
+	}
+	nanos, _ := bits.Div64(high, low, hz)
+	if nanos > math.MaxInt64 {
+		return 0, errors.New("process start offset exceeds duration range")
+	}
+	return time.Duration(nanos), nil
+}

--- a/cmd/evener-hub/internal/daemonprocess/process_linux_test.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_linux_test.go
@@ -1,0 +1,113 @@
+package daemonprocess
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestLinuxLockEvidence(t *testing.T) {
+	for _, tt := range []struct {
+		name, text string
+		want       bool
+	}{
+		{"exclusive owner", "flags:\t02100002\nlock:\t1: FLOCK  ADVISORY  WRITE  123  08:01:55 0 EOF\n", true},
+		{"foreign owner", "flags:\t02100002\nlock:\t1: FLOCK  ADVISORY  WRITE  124  08:01:55 0 EOF\n", false},
+		{"shared lock", "flags:\t02100002\nlock:\t1: FLOCK  ADVISORY  READ  123  08:01:55 0 EOF\n", false},
+		{"read only", "flags:\t02100000\nlock:\t1: FLOCK  ADVISORY  WRITE  123  08:01:55 0 EOF\n", false},
+		{"different inode", "flags:\t02100002\nlock:\t1: FLOCK  ADVISORY  WRITE  123  08:01:56 0 EOF\n", false},
+		{"no lock", "flags:\t02100002\n", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := linuxOwnsLock([]byte(tt.text), 123, unix.Mkdev(8, 1), 55); got != tt.want {
+				t.Fatalf("owns lock = %v", got)
+			}
+		})
+	}
+}
+
+func TestLinuxClockTicks(t *testing.T) {
+	buf := make([]byte, 32)
+	binary.NativeEndian.PutUint64(buf, 17)
+	binary.NativeEndian.PutUint64(buf[8:], 100)
+	if ticks, err := linuxClockTicks(buf, 8); err != nil || ticks != 100 {
+		t.Fatalf("ticks=%d err=%v", ticks, err)
+	}
+	if _, err := linuxClockTicks(buf[:8], 8); err == nil {
+		t.Fatal("truncated auxiliary vector accepted")
+	}
+}
+
+// The fixture publishes its rendezvous after the kernel start tick has ended.
+// A Go test helper can start inside that tick, unlike a fully initialized daemon.
+func fixtureRendezvousTime(t *testing.T, target Target) time.Time {
+	t.Helper()
+	h, err := openLinuxProcess(target.PID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.close()
+	facts, err := h.inspect(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delay := time.Until(facts.startedAt); delay > 0 {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		<-timer.C
+	}
+	return time.Now()
+}
+
+func TestLinuxStartOffsetLargeTicks(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ticks, hz uint64
+		want      time.Duration
+		wantError bool
+	}{
+		{name: "before multiplication overflow", ticks: 18_446_744_072, hz: 100, want: 184_467_440_730_000_000},
+		{name: "after multiplication overflow", ticks: 18_446_744_073, hz: 100, want: 184_467_440_740_000_000},
+		{name: "long lived host", ticks: 20_000_000_000, hz: 100, want: 200_000_000_010_000_000},
+		{name: "maximum duration", ticks: 1<<63 - 2, hz: 1_000_000_000, want: 1<<63 - 1},
+		{name: "duration overflow", ticks: 1<<63 - 1, hz: 1_000_000_000, wantError: true},
+		{name: "tick overflow", ticks: 1<<64 - 1, hz: 100, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := linuxStartOffset(tc.ticks, tc.hz)
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("accepted overflowing offset %d", got)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("offset=%d err=%v; want %d", got, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLinuxLargeStartTicksRefuseNewerProcess(t *testing.T) {
+	offset, err := linuxStartOffset(20_000_000_000, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The rendezvous predates the actual start by one second; a wrapped offset
+	// would instead place the same verified session owner years before it.
+	target := validTarget()
+	target.StartedAt = time.Unix(199_999_999, 0)
+	facts := validIdentity()
+	facts.startedAt = time.Unix(0, 0).Add(offset)
+	k := &kernelProcess{facts: facts}
+	p, err := testController(k).Open(target)
+	if err == nil {
+		_ = p.Close()
+		t.Fatal("accepted a process newer than its rendezvous after tick overflow")
+	}
+	if k.signals != 0 {
+		t.Fatal("signaled a newer process")
+	}
+}

--- a/cmd/evener-hub/internal/daemonprocess/process_other.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux
+
+package daemonprocess
+
+import "errors"
+
+// NewController refuses platforms without generation-bound process signaling.
+func NewController() Controller {
+	return controller{bind: func(int) (processHandle, error) {
+		return nil, errors.New("verified daemon termination is unsupported on this platform")
+	}}
+}

--- a/cmd/evener-hub/internal/daemonprocess/process_test.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_test.go
@@ -1,0 +1,208 @@
+package daemonprocess
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// The fake replaces only OS inspection and signaling, so PID reuse and foreign
+// ownership can be tested without touching any ambient process.
+type kernelProcess struct {
+	facts      identity
+	snapshots  []identity
+	signals    int
+	closed     bool
+	gone       bool
+	signalErr  error
+	inspectErr error
+}
+
+func (k *kernelProcess) inspect(Target) (identity, error) {
+	if k.inspectErr != nil {
+		return identity{}, k.inspectErr
+	}
+	if len(k.snapshots) > 0 {
+		v := k.snapshots[0]
+		k.snapshots = k.snapshots[1:]
+		return v, nil
+	}
+	return k.facts, nil
+}
+func (k *kernelProcess) kill() error           { k.signals++; return k.signalErr }
+func (k *kernelProcess) exited() (bool, error) { return k.gone, nil }
+func (k *kernelProcess) close() error          { k.closed = true; return nil }
+func validTarget() Target {
+	return Target{PID: os.Getpid() + 100, SessionID: "session", StateDir: "/private/state", StartedAt: time.Unix(200, 0)}
+}
+func validIdentity() identity {
+	return identity{generation: "generation-a", uid: os.Getuid(), startedAt: time.Unix(100, 0), argv: []string{"evener", "serve"}, ownsLog: true}
+}
+func testController(k *kernelProcess) controller {
+	return controller{bind: func(int) (processHandle, error) { return k, nil }}
+}
+
+func TestOpenRefusesUnsafeTargets(t *testing.T) {
+	tests := []struct {
+		name   string
+		change func(*Target)
+	}{
+		{"zero pid", func(v *Target) { v.PID = 0 }}, {"negative pid", func(v *Target) { v.PID = -1 }},
+		{"overflow pid", func(v *Target) { alias := int64(1) << 32; v.PID = int(alias) + os.Getpid() }}, {"self pid", func(v *Target) { v.PID = os.Getpid() }},
+		{"missing session", func(v *Target) { v.SessionID = "" }}, {"escaping session", func(v *Target) { v.SessionID = "../other" }}, {"missing state", func(v *Target) { v.StateDir = "" }}, {"relative state", func(v *Target) { v.StateDir = "relative" }}, {"missing start", func(v *Target) { v.StartedAt = time.Time{} }},
+		{"future rendezvous", func(v *Target) { v.StartedAt = time.Now().Add(time.Hour) }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := validTarget()
+			tt.change(&v)
+			k := &kernelProcess{facts: validIdentity()}
+			p, err := testController(k).Open(v)
+			if err == nil {
+				_ = p.Close()
+				t.Fatal("unsafe target accepted")
+			}
+			if k.signals != 0 {
+				t.Fatal("signaled unsafe target")
+			}
+		})
+	}
+}
+func TestOpenRefusesUnverifiedIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		change func(*identity)
+	}{
+		{"wrong owner", func(v *identity) { v.uid++ }}, {"wrong command", func(v *identity) { v.argv = []string{"evener", "hub", "serve"} }}, {"missing argv", func(v *identity) { v.argv = nil }}, {"missing log ownership", func(v *identity) { v.ownsLog = false }}, {"newer start", func(v *identity) { v.startedAt = time.Unix(201, 0) }}, {"missing generation", func(v *identity) { v.generation = "" }}, {"missing start", func(v *identity) { v.startedAt = time.Time{} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &kernelProcess{facts: validIdentity()}
+			tt.change(&k.facts)
+			p, err := testController(k).Open(validTarget())
+			if err == nil {
+				_ = p.Close()
+				t.Fatal("unverified identity accepted")
+			}
+			if !k.closed || k.signals != 0 {
+				t.Fatal("refused process leaked or signaled")
+			}
+		})
+	}
+}
+func TestOpenRefusesGenerationChange(t *testing.T) {
+	a := validIdentity()
+	b := a
+	b.generation = "generation-b"
+	k := &kernelProcess{facts: b, snapshots: []identity{a, b}}
+	p, err := testController(k).Open(validTarget())
+	if err == nil {
+		_ = p.Close()
+		t.Fatal("reused process accepted")
+	}
+	if k.signals != 0 {
+		t.Fatal("reused process signaled")
+	}
+}
+func TestKillRechecksIdentity(t *testing.T) {
+	for _, change := range []string{"generation", "owner", "lock"} {
+		t.Run(change, func(t *testing.T) {
+			k := &kernelProcess{facts: validIdentity()}
+			p, err := testController(k).Open(validTarget())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer p.Close()
+			switch change {
+			case "generation":
+				k.facts.generation = "other"
+			case "owner":
+				k.facts.uid++
+			case "lock":
+				k.facts.ownsLog = false
+			}
+			if err := p.Kill(); err == nil {
+				t.Fatal("kill accepted changed identity")
+			}
+			if k.signals != 0 {
+				t.Fatal("unsafe signal sent")
+			}
+		})
+	}
+}
+func TestKillAndConfirmedExit(t *testing.T) {
+	k := &kernelProcess{facts: validIdentity()}
+	p, err := testController(k).Open(validTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	if err := p.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if k.signals != 1 {
+		t.Fatal("verified process not signaled")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := p.Wait(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("unconfirmed exit: %v", err)
+	}
+	k.gone = true
+	if err := p.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+func TestKillExitedIsIdempotent(t *testing.T) {
+	k := &kernelProcess{facts: validIdentity()}
+	p, err := testController(k).Open(validTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	k.inspectErr = ErrExited
+	if err := p.Kill(); err != nil {
+		t.Fatal(err)
+	}
+	if k.signals != 0 {
+		t.Fatal("signaled absent process")
+	}
+}
+func TestClosedProcessRefusesUse(t *testing.T) {
+	k := &kernelProcess{facts: validIdentity()}
+	p, err := testController(k).Open(validTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Kill(); err == nil {
+		t.Fatal("closed process signaled")
+	}
+	if err := p.Wait(context.Background()); err == nil {
+		t.Fatal("closed process treated as exited")
+	}
+}
+
+func TestInspectionFailureAfterExitIsIdempotent(t *testing.T) {
+	k := &kernelProcess{facts: validIdentity()}
+	p, err := testController(k).Open(validTarget())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	k.inspectErr = errors.New("descriptor disappeared")
+	k.gone = true
+	if err := p.Kill(); err != nil {
+		t.Fatalf("confirmed exit after inspection failure: %v", err)
+	}
+	if k.signals != 0 {
+		t.Fatal("signaled an exited process")
+	}
+	if _, err := testController(k).Open(validTarget()); !errors.Is(err, ErrExited) {
+		t.Fatalf("Open did not report confirmed exit: %v", err)
+	}
+}

--- a/cmd/evener-hub/internal/daemonprocess/process_unix_test.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_unix_test.go
@@ -1,0 +1,126 @@
+//go:build darwin || linux
+
+package daemonprocess
+
+import (
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("EVENER_DAEMONPROCESS_HELPER") == "1" {
+		file, err := os.OpenFile(os.Args[2], os.O_RDWR, 0)
+		if err != nil {
+			os.Exit(2)
+		}
+		if os.Args[3] != "unlocked" {
+			if unix.Flock(int(file.Fd()), unix.LOCK_EX) != nil {
+				os.Exit(3)
+			}
+		}
+		if os.Args[3] == "released" {
+			if unix.Flock(int(file.Fd()), unix.LOCK_UN) != nil {
+				os.Exit(4)
+			}
+		}
+		_, _ = os.Stdout.Write([]byte{1})
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		_ = file.Close()
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func TestNativeControllerKillsOnlyOwnedChild(t *testing.T) {
+	for _, mode := range []string{"locked", "unlocked", "released"} {
+		t.Run(mode, func(t *testing.T) {
+			target, cmd := startNativeChild(t, mode)
+			p, err := NewController().Open(target)
+			if mode != "locked" {
+				if err == nil {
+					_ = p.Close()
+					t.Fatal("accepted child without current lock")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer p.Close()
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			if err := p.Wait(ctx); err == nil {
+				t.Fatal("live child declared exited")
+			}
+			if err := p.Kill(); err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := p.Wait(ctx); err != nil {
+				t.Fatal(err)
+			}
+			if err := p.Kill(); err != nil {
+				t.Fatal(err)
+			}
+			_ = cmd
+		})
+	}
+}
+
+func TestNativeControllerRefusesReplacedLog(t *testing.T) {
+	target, _ := startNativeChild(t, "locked")
+	path := filepath.Join(target.StateDir, "sessions", target.SessionID+".api.jsonl")
+	if err := os.Rename(path, path+".old"); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	p, err := NewController().Open(target)
+	if err == nil {
+		_ = p.Close()
+		t.Fatal("accepted a different API-log inode")
+	}
+}
+
+func startNativeChild(t *testing.T, mode string) (Target, *exec.Cmd) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sessions"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "sessions", "session.api.jsonl")
+	if err := os.WriteFile(path, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(os.Args[0], "serve", path, mode)
+	cmd.Env = append(os.Environ(), "EVENER_DAEMONPROCESS_HELPER=1")
+	in, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = in.Close(); _ = cmd.Wait() })
+	var ready [1]byte
+	if _, err := io.ReadFull(out, ready[:]); err != nil {
+		t.Fatal(err)
+	}
+	target := Target{PID: cmd.Process.Pid, SessionID: "session", StateDir: dir}
+	target.StartedAt = fixtureRendezvousTime(t, target)
+	return target, cmd
+}

--- a/cmd/evener-hub/internal/hubcore/config.go
+++ b/cmd/evener-hub/internal/hubcore/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/daemonprocess"
 	"primeradiant.com/evener/cmd/evener-hub/internal/launchconfig"
 	"primeradiant.com/evener/identifier"
 	"primeradiant.com/evener/internal/credentials"
@@ -33,20 +34,21 @@ type RelayLifecycleHooks struct {
 // WebConfig is everything the web server needs.
 type WebConfig struct {
 	HubAddr                   string
-	AuthToken                 string                  // capability token gating every non-exempt route
-	MobileBaseURL             string                  // optional external origin used for mobile pairing QR codes
-	HubStateRoot              string                  // root of hub-level machine state (auth-token, index.db, deletions/); defaults to cmdutil.DefaultStateRoot()
-	LaunchConfigRoot          string                  // root of the layered launch config (launch.toml, projects/<id>/{launch.toml,meta.toml}); user-editable, so distinct from HubStateRoot — defaults to cmdutil.DefaultConfigRoot() when empty
-	TranscriptDisplayStore    *TranscriptDisplayStore // hub-authoritative Desktop/Mobile transcript-display defaults; nil → load from HubStateRoot
-	TranscriptDisplayStoreErr error                   // diagnostic returned while loading the injected store; retained for startup diagnostics
-	KeybindingsStore          *KeybindingsStore       // hub-authoritative user keybinding overrides; nil → load from HubStateRoot
-	KeybindingsStoreErr       error                   // diagnostic returned while loading the injected store; retained for startup diagnostics
-	RunDir                    string                  // run directory where rendezvous files live
-	PastIndexPath             string                  // path to the SQLite past-index DB, for display in settings
+	AuthToken                 string                   // capability token gating every non-exempt route
+	MobileBaseURL             string                   // optional external origin used for mobile pairing QR codes
+	HubStateRoot              string                   // root of hub-level machine state (auth-token, index.db, deletions/); defaults to cmdutil.DefaultStateRoot()
+	LaunchConfigRoot          string                   // root of the layered launch config (launch.toml, projects/<id>/{launch.toml,meta.toml}); user-editable, so distinct from HubStateRoot — defaults to cmdutil.DefaultConfigRoot() when empty
+	TranscriptDisplayStore    *TranscriptDisplayStore  // hub-authoritative Desktop/Mobile transcript-display defaults; nil → load from HubStateRoot
+	TranscriptDisplayStoreErr error                    // diagnostic returned while loading the injected store; retained for startup diagnostics
+	KeybindingsStore          *KeybindingsStore        // hub-authoritative user keybinding overrides; nil → load from HubStateRoot
+	KeybindingsStoreErr       error                    // diagnostic returned while loading the injected store; retained for startup diagnostics
+	DaemonProcesses           daemonprocess.Controller // nil selects verified native process operations
+	RunDir                    string                   // run directory where rendezvous files live
+	PastIndexPath             string                   // path to the SQLite past-index DB, for display in settings
 	Roster                    *Roster
 	Past                      *PastIndex
 	Spawner                   Spawner            // optional; nil disables spawn
-	ResumeLocks               *ResumeLocks       // per-session resume serialization shared by the REST and RPC paths; nil → each path falls back to its own lock
+	ResumeLocks               *ResumeLocks       // shared session ownership and recovery authority; web construction loads from HubStateRoot when nil
 	DeletionStore             *DeletionStore     // host-authoritative deletion fences; production persists this under HubStateRoot
 	PastPerPage               int                // results per page for /past; defaults to 50 when zero
 	StateDir                  string             // root of the projects/<sha> state directory; needed for ForkSession

--- a/cmd/evener-hub/internal/hubcore/pin_section_retry_test.go
+++ b/cmd/evener-hub/internal/hubcore/pin_section_retry_test.go
@@ -160,6 +160,8 @@ func (t *lockedTx) Rollback() error {
 // can delegate to it after injecting failures.
 func setupLockedStore(t *testing.T) *PinSectionStore {
 	t.Helper()
+	resetLockedCounters()
+	t.Cleanup(resetLockedCounters)
 	initLockedDriver()
 	dbPath := filepath.Join(t.TempDir(), "index.db")
 	seed := NewPinSectionStore(dbPath)

--- a/cmd/evener-hub/internal/hubcore/recovery_store.go
+++ b/cmd/evener-hub/internal/hubcore/recovery_store.go
@@ -1,0 +1,226 @@
+package hubcore
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+type recoveryAuthority struct {
+	ExitConfirmed bool   `json:"exit_confirmed"`
+	Group         string `json:"group"`
+	SessionID     string `json:"session_id"`
+}
+
+type recoveryRecord struct {
+	Alias string `json:"alias"`
+	recoveryAuthority
+}
+
+type recoverySnapshot struct {
+	Version int              `json:"version"`
+	Records []recoveryRecord `json:"records"`
+}
+
+type recoveryStoreFaults struct {
+	BeforeRename func() error
+	AfterRename  func() error
+}
+
+// recoveryStore is serialized by ResumeLocks.persistenceMu, independently of
+// the admission mutex. Its state follows the visible file even on sync failure.
+type recoveryStore struct {
+	fs            afero.Fs
+	root          string
+	directoryBase string
+	state         map[string]recoveryAuthority
+	faults        recoveryStoreFaults
+}
+
+func openRecoveryStore(fs afero.Fs, root string) (*recoveryStore, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, errors.New("recovery state root is required")
+	}
+	root = filepath.Clean(root)
+	base, err := existingRecoveryDirectory(fs, root)
+	if err != nil {
+		return nil, err
+	}
+	store := &recoveryStore{fs: fs, root: root, directoryBase: base, state: map[string]recoveryAuthority{}}
+	data, err := afero.ReadFile(fs, filepath.Join(root, "recovery", "state.json"))
+	if os.IsNotExist(err) {
+		return store, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read recovery state: %w", err)
+	}
+	var snapshot recoverySnapshot
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&snapshot); err != nil {
+		return nil, fmt.Errorf("decode recovery state: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return nil, errors.New("decode recovery state: trailing data")
+	}
+	if snapshot.Version != 3 {
+		return nil, fmt.Errorf("unsupported recovery state version %d", snapshot.Version)
+	}
+	targets := make(map[string]recoveryAuthority)
+	for _, record := range snapshot.Records {
+		if !validRecoveryAlias(record.Alias) || strings.TrimSpace(record.Group) == "" || !validRecoveryAlias(record.SessionID) {
+			return nil, errors.New("invalid recovery alias or group")
+		}
+		if _, exists := store.state[record.Alias]; exists {
+			return nil, fmt.Errorf("duplicate recovery alias %q", record.Alias)
+		}
+		if target, ok := targets[record.Group]; ok && target != record.recoveryAuthority {
+			return nil, errors.New("recovery group has conflicting exit or session authority")
+		}
+		targets[record.Group] = record.recoveryAuthority
+		store.state[record.Alias] = record.recoveryAuthority
+	}
+	return store, nil
+}
+
+func validRecoveryAlias(alias string) bool {
+	return alias != "" && alias != "." && alias != ".." && strings.TrimSpace(alias) == alias && !strings.ContainsAny(alias, "/\\:\x00")
+}
+
+func (s *recoveryStore) commit(next map[string]recoveryAuthority) (bool, error) {
+	snapshot := recoverySnapshot{Version: 3, Records: []recoveryRecord{}}
+	for _, alias := range slices.Sorted(maps.Keys(next)) {
+		snapshot.Records = append(snapshot.Records, recoveryRecord{Alias: alias, recoveryAuthority: next[alias]})
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return false, err
+	}
+	renamed, err := s.write(data)
+	if renamed {
+		s.state = next
+	}
+	if err != nil {
+		return renamed, fmt.Errorf("persist recovery state: %w", err)
+	}
+	return renamed, nil
+}
+
+func (s *recoveryStore) write(data []byte) (renamed bool, err error) {
+	dir := filepath.Join(s.root, "recovery")
+	if err := createRecoveryDirectory(s.fs, dir, s.directoryBase); err != nil {
+		return false, err
+	}
+	temp, err := afero.TempFile(s.fs, dir, "state.json.tmp-*")
+	if err != nil {
+		return false, err
+	}
+	tempPath := temp.Name()
+	defer func() {
+		if temp != nil {
+			_ = temp.Close()
+		}
+		if !renamed {
+			_ = s.fs.Remove(tempPath)
+		}
+	}()
+	if _, err := temp.Write(data); err != nil {
+		return false, err
+	}
+	if err := temp.Sync(); err != nil {
+		return false, err
+	}
+	if err := temp.Close(); err != nil {
+		return false, err
+	}
+	temp = nil
+	if s.faults.BeforeRename != nil {
+		if err := s.faults.BeforeRename(); err != nil {
+			return false, err
+		}
+	}
+	if err := s.fs.Rename(tempPath, filepath.Join(dir, "state.json")); err != nil {
+		return false, err
+	}
+	renamed = true
+	if s.faults.AfterRename != nil {
+		if err := s.faults.AfterRename(); err != nil {
+			return true, err
+		}
+	}
+	return true, syncRecoveryDirectory(s.fs, dir)
+}
+
+// The existing hierarchy is owned by the caller. Retain its boundary across
+// retries so links created by this store are synced even after a failed sync,
+// without requiring read access to unrelated traversal-only ancestors.
+func existingRecoveryDirectory(fs afero.Fs, dir string) (string, error) {
+	for {
+		info, err := fs.Stat(dir)
+		if err == nil {
+			if !info.IsDir() {
+				return "", fmt.Errorf("recovery state parent %q is not a directory", dir)
+			}
+			return dir, nil
+		}
+		if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", err
+		}
+		dir = parent
+	}
+}
+
+// Every missing directory is linked durably in its parent before intent can
+// authorize a signal. Unsupported sync is an error, never claimed as durable.
+func createRecoveryDirectory(fs afero.Fs, dir, base string) error {
+	if dir == base {
+		return nil
+	}
+	parent := filepath.Dir(dir)
+	if parent != dir {
+		if err := createRecoveryDirectory(fs, parent, base); err != nil {
+			return err
+		}
+	}
+	info, err := fs.Stat(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := fs.Mkdir(dir, 0700); err != nil && !os.IsExist(err) {
+			return err
+		}
+	} else if !info.IsDir() {
+		return fmt.Errorf("recovery state parent %q is not a directory", dir)
+	}
+	// Repeat parent syncs even for existing directories: an earlier attempt may
+	// have created one and failed before its parent's sync completed.
+	if parent != dir {
+		return syncRecoveryDirectory(fs, parent)
+	}
+	return nil
+}
+
+func syncRecoveryDirectory(fs afero.Fs, dir string) error {
+	directory, err := fs.Open(dir)
+	if err != nil {
+		return err
+	}
+	syncErr := directory.Sync()
+	closeErr := directory.Close()
+	return errors.Join(syncErr, closeErr)
+}

--- a/cmd/evener-hub/internal/hubcore/recovery_store_test.go
+++ b/cmd/evener-hub/internal/hubcore/recovery_store_test.go
@@ -1,0 +1,509 @@
+package hubcore
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"time"
+
+	"github.com/spf13/afero"
+)
+
+func TestPersistentRecoverySurvivesRecreationAndClearsOnlyItsGroup(t *testing.T) {
+	root := t.TempDir()
+	locks, err := NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish := locks.BeginForceStop([]string{"A", "B"})
+	if err := locks.PersistForceStop([]string{"A", "B"}, "B"); err != nil {
+		t.Fatal(err)
+	}
+	finish(false) // Committed intent survives a failed signal.
+	locks, err = NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"A", "B"} {
+		if state := locks.RecoveryState(id); !state.ResumeRequired || state.Stopping != 0 || state.ResumeSessionID != "B" {
+			t.Fatalf("lost intent %s: %+v", id, state)
+		}
+	}
+	finish = locks.BeginForceStop([]string{"B", "C"})
+	if err := locks.PersistForceStop([]string{"B", "C"}, "C"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	locks, err = NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := locks.ExplicitResumeCompleted("A", locks.RecoveryState("A").Epoch); err != nil {
+		t.Fatal(err)
+	}
+	locks, err = NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if locks.RecoveryState("A").ResumeRequired || !locks.RecoveryState("B").ResumeRequired || !locks.RecoveryState("C").ResumeRequired {
+		t.Fatal("older group clear removed newer overlap")
+	}
+	if err := locks.ExplicitResumeCompleted("B", locks.RecoveryState("B").Epoch); err != nil {
+		t.Fatal(err)
+	}
+	locks, err = NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if locks.RecoveryState("B").ResumeRequired || locks.RecoveryState("C").ResumeRequired {
+		t.Fatal("explicit resume failed to durably clear aliases")
+	}
+}
+
+func TestPersistentRecoveryRejectsCorruptAuthority(t *testing.T) {
+	for _, raw := range []string{`{"version":2,"records":[]}`, `{"version":3,"records":[{"alias":"A","group":"one","session_id":"A","exit_confirmed":true},{"alias":"B","group":"one","session_id":"A","exit_confirmed":false}]}`, `{`, `{"version":1,"records":[]}`, `{"version":3,"records":[],"unknown":true}`, `{"version":3,"records":[{"alias":"A","group":"one"}]}`, `{"version":3,"records":[{"alias":"A","group":"one","session_id":"A"},{"alias":"B","group":"one","session_id":"B"}]}`, `{"version":3,"records":[]} {}`, `{"version":3,"records":[{"alias":"A","group":"","session_id":"A"}]}`, `{"version":3,"records":[{"alias":"A","group":"one","session_id":"A"},{"alias":"A","group":"two","session_id":"A"}]}`} {
+		t.Run(raw, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(root, "recovery"), 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, "recovery", "state.json"), []byte(raw), 0600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := NewPersistentResumeLocks(root); err == nil {
+				t.Fatal("corrupt authority silently reset")
+			}
+		})
+	}
+	if _, err := NewPersistentResumeLocks(""); err == nil {
+		t.Fatal("persistent constructor accepted missing root")
+	}
+}
+
+func TestPersistentRecoveryWriteFailurePolicy(t *testing.T) {
+	for _, clear := range []bool{false, true} {
+		for _, renamed := range []bool{false, true} {
+			t.Run(map[bool]string{false: "intent", true: "clear"}[clear]+map[bool]string{false: " before rename", true: " after rename"}[renamed], func(t *testing.T) {
+				root := t.TempDir()
+				locks, err := NewPersistentResumeLocks(root)
+				if err != nil {
+					t.Fatal(err)
+				}
+				finish := locks.BeginForceStop([]string{"A", "B"})
+				if clear {
+					if err := locks.PersistForceStop([]string{"A", "B"}, "B"); err != nil {
+						t.Fatal(err)
+					}
+					finish(true)
+				}
+				boom := errors.New("disk failure")
+				fail := func() error { return boom }
+				if renamed {
+					locks.store.faults.AfterRename = fail
+				} else {
+					locks.store.faults.BeforeRename = fail
+				}
+				if clear {
+					err = locks.ExplicitResumeCompleted("A", locks.RecoveryState("A").Epoch)
+				} else {
+					err = locks.PersistForceStop([]string{"A", "B"}, "B")
+					finish(false)
+				}
+				if !errors.Is(err, boom) {
+					t.Fatalf("lost write error: %v", err)
+				}
+				if state := locks.RecoveryState("A"); state.ResumeRequired && state.ResumeSessionID != "B" {
+					t.Fatalf("memory lost target after uncertain write: %+v", state)
+				}
+				if got := locks.RecoveryState("A").ResumeRequired; got != (clear || renamed) {
+					t.Fatalf("memory obligation=%v", got)
+				}
+				reopened, err := NewPersistentResumeLocks(root)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if state := reopened.RecoveryState("A"); state.ResumeRequired && state.ResumeSessionID != "B" {
+					t.Fatalf("disk lost target after uncertain write: %+v", state)
+				}
+				wantDisk := renamed != clear
+				if got := reopened.RecoveryState("A").ResumeRequired; got != wantDisk {
+					t.Fatalf("reopened obligation=%v want=%v", got, wantDisk)
+				}
+				locks.store.faults = recoveryStoreFaults{}
+				if clear {
+					if err := locks.ExplicitResumeCompleted("A", locks.RecoveryState("A").Epoch); err != nil {
+						t.Fatal(err)
+					}
+					if locks.RecoveryState("A").ResumeRequired {
+						t.Fatal("clear retry retained fence")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestRecoveryAdmissionRemainsResponsiveDuringDurableClear(t *testing.T) {
+	root := t.TempDir()
+	locks, err := NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish := locks.BeginForceStop([]string{"A", "B"})
+	if err := locks.PersistForceStop([]string{"A", "B"}, "B"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	entered, release := make(chan struct{}), make(chan struct{})
+	locks.store.faults.BeforeRename = func() error { close(entered); <-release; return nil }
+	done := make(chan error, 1)
+	go func() { done <- locks.ExplicitResumeCompleted("A", locks.RecoveryState("A").Epoch) }()
+	<-entered
+	admission := make(chan func(bool), 1)
+	go func() {
+		next := locks.BeginForceStop([]string{"B", "C"})
+		_ = locks.RecoverySequence()
+		_ = locks.RecoveryState("B")
+		admission <- next
+	}()
+	var finishNew func(bool)
+	select {
+	case finishNew = <-admission:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("disk clear blocked admission")
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if !locks.RecoveryState("B").ResumeRequired || locks.RecoveryState("B").Stopping != 1 {
+		t.Fatal("old clear removed newer memory fence")
+	}
+	locks.store.faults = recoveryStoreFaults{}
+	if err := locks.PersistForceStop([]string{"B", "C"}, "C"); err != nil {
+		t.Fatal(err)
+	}
+	finishNew(true)
+	reopened, err := NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopened.RecoveryState("A").ResumeRequired || !reopened.RecoveryState("B").ResumeRequired || !reopened.RecoveryState("C").ResumeRequired {
+		t.Fatal("new commit lost overlap after held clear")
+	}
+}
+
+// recoverySyncFS observes real directory and temp-file sync boundaries while
+// retaining ordinary file contents and atomic rename behavior.
+type recoverySyncFS struct {
+	afero.Fs
+	sync func(string) error
+}
+type recoverySyncFile struct {
+	afero.File
+	sync func(string) error
+}
+
+func (f recoverySyncFile) Sync() error {
+	if err := f.sync(f.Name()); err != nil {
+		return err
+	}
+	return f.File.Sync()
+}
+func (fs recoverySyncFS) Open(name string) (afero.File, error) {
+	file, err := fs.Fs.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return recoverySyncFile{file, fs.sync}, nil
+}
+func (fs recoverySyncFS) OpenFile(name string, flag int, mode os.FileMode) (afero.File, error) {
+	file, err := fs.Fs.OpenFile(name, flag, mode)
+	if err != nil {
+		return nil, err
+	}
+	return recoverySyncFile{file, fs.sync}, nil
+}
+
+func TestRecoveryIntentRequiresFileAndDirectoryDurability(t *testing.T) {
+	for _, stage := range []string{"new directory parent", "temporary file", "renamed directory"} {
+		t.Run(stage, func(t *testing.T) {
+			base := afero.NewMemMapFs()
+			boom := errors.New("sync unsupported")
+			fail := true
+			observed := map[string]int{}
+			fs := recoverySyncFS{Fs: base, sync: func(path string) error {
+				observed[path]++
+				matches := stage == "new directory parent" && path == "/state" || stage == "temporary file" && strings.Contains(filepath.Base(path), ".tmp-") || stage == "renamed directory" && path == "/state/recovery"
+				if fail && matches {
+					return boom
+				}
+				return nil
+			}}
+			store, err := openRecoveryStore(fs, "/state")
+			if err != nil {
+				t.Fatal(err)
+			}
+			locks := NewResumeLocks()
+			locks.store = store
+			finish := locks.BeginForceStop([]string{"A"})
+			if err := locks.PersistForceStop([]string{"A"}, "A"); !errors.Is(err, boom) {
+				t.Fatalf("sync failure did not prohibit signal: %v", err)
+			}
+			if got := locks.RecoveryState("A").ResumeRequired; got != (stage == "renamed directory") {
+				t.Fatalf("uncertain intent memory=%v", got)
+			}
+			fail = false
+			if err := locks.PersistForceStop([]string{"A"}, "A"); err != nil {
+				t.Fatal(err)
+			}
+			finish(false)
+			if observed["/"] == 0 || observed["/state"] < 2 || observed["/state/recovery"] == 0 {
+				t.Fatalf("missing first-use or retry directory syncs: %v", observed)
+			}
+			reopened, err := openRecoveryStore(base, "/state")
+			if err != nil || reopened.state["A"].Group == "" {
+				t.Fatalf("retry did not preserve intent: store=%+v err=%v", reopened, err)
+			}
+		})
+	}
+}
+
+func TestExplicitResumeDoesNotClearChangedEpoch(t *testing.T) {
+	locks, err := NewPersistentResumeLocks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish := locks.BeginForceStop([]string{"A"})
+	if err := locks.PersistForceStop([]string{"A"}, "A"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	epoch := locks.RecoveryState("A").Epoch
+	finish = locks.BeginForceStop([]string{"A"})
+	if err := locks.PersistForceStop([]string{"A"}, "A"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	if err := locks.ExplicitResumeCompleted("A", epoch); err != nil {
+		t.Fatal(err)
+	}
+	if !locks.RecoveryState("A").ResumeRequired {
+		t.Fatal("stale completion cleared newer durable intent")
+	}
+}
+
+func TestPersistentRecoveryFailsOnUnreadableState(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "recovery", "state.json"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewPersistentResumeLocks(root); err == nil {
+		t.Fatal("unreadable authority silently reset")
+	}
+}
+
+func TestRecoveryIntentNormalizesAliasesAndPreservesMemorySemantics(t *testing.T) {
+	locks := NewResumeLocks()
+	finish := locks.BeginForceStop([]string{"A", "B"})
+	if err := locks.PersistForceStop([]string{"B", "A", "B"}, "B"); err != nil {
+		t.Fatal(err)
+	}
+	finish(false)
+	if !locks.RecoveryState("A").ResumeRequired || !locks.RecoveryState("B").ResumeRequired {
+		t.Fatal("failed signal discarded committed memory intent")
+	}
+	if err := locks.ExplicitResumeCompleted("A", locks.RecoveryState("A").Epoch); err != nil {
+		t.Fatal(err)
+	}
+	if locks.RecoveryState("A").ResumeRequired || locks.RecoveryState("B").ResumeRequired {
+		t.Fatal("memory aliases failed to clear")
+	}
+	for _, aliases := range [][]string{nil, {""}, {"../A"}, {" local:A "}} {
+		if err := locks.PersistForceStop(aliases, "A"); err == nil {
+			t.Fatalf("invalid authority accepted: %v", aliases)
+		}
+	}
+}
+
+func TestRecoveryPersistenceUnderTraversalOnlyAncestor(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "hub")
+	if err := os.Mkdir(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(ancestor, 0111); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Chmod(ancestor, 0700); err != nil {
+			t.Error(err)
+		}
+	}()
+	locks, err := NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish := locks.BeginForceStop([]string{"A"})
+	defer finish(false)
+	if err := locks.PersistForceStop([]string{"A"}, "A"); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reopened.RecoveryState("A").ResumeRequired {
+		t.Fatal("persisted obligation missing")
+	}
+}
+
+func TestRecoveryTargetMustBeVerifiedAlias(t *testing.T) {
+	locks := NewResumeLocks()
+	for _, target := range []string{"", "../A", "other"} {
+		if err := locks.PersistForceStop([]string{"A", "B"}, target); err == nil {
+			t.Fatalf("accepted unverified target %q", target)
+		}
+	}
+}
+
+func TestRecoveryTargetSurvivesPartialGroupOverlap(t *testing.T) {
+	root := t.TempDir()
+	locks, err := NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finish := locks.BeginForceStop([]string{"A", "B"})
+	if err := locks.PersistForceStop([]string{"A", "B"}, "A"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	finish = locks.BeginForceStop([]string{"A", "C"})
+	if err := locks.PersistForceStop([]string{"A", "C"}, "C"); err != nil {
+		t.Fatal(err)
+	}
+	finish(true)
+	locks, err = NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state := locks.RecoveryState("B"); !state.ResumeRequired || state.ResumeSessionID != "A" {
+		t.Fatalf("partial old group lost target: %+v", state)
+	}
+	if state := locks.RecoveryState("A"); !state.ResumeRequired || state.ResumeSessionID != "C" {
+		t.Fatalf("new group lost target: %+v", state)
+	}
+	if err := locks.ExplicitResumeCompleted("B", locks.RecoveryState("B").Epoch); err != nil {
+		t.Fatal(err)
+	}
+	locks, err = NewPersistentResumeLocks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if locks.RecoveryState("B").ResumeRequired || locks.RecoveryState("A").ResumeSessionID != "C" || locks.RecoveryState("C").ResumeSessionID != "C" {
+		t.Fatal("old clear changed newer target")
+	}
+}
+
+func TestFailedOverlappingStopPreservesCommittedGroup(t *testing.T) {
+	for _, renamed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "before rename", true: "after rename"}[renamed], func(t *testing.T) {
+			locks, err := NewPersistentResumeLocks(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			finish := locks.BeginForceStop([]string{"A", "B"})
+			if err := locks.PersistForceStop([]string{"A", "B"}, "B"); err != nil {
+				t.Fatal(err)
+			}
+			finish(true)
+			oldEpoch := locks.RecoveryState("B").Epoch
+			finish = locks.BeginForceStop([]string{"B", "C"})
+			boom := errors.New("disk failure")
+			if renamed {
+				locks.store.faults.AfterRename = func() error { return boom }
+			} else {
+				locks.store.faults.BeforeRename = func() error { return boom }
+			}
+			if err := locks.PersistForceStop([]string{"B", "C"}, "C"); !errors.Is(err, boom) {
+				t.Fatalf("write error=%v", err)
+			}
+			finish(false)
+			wantTarget := "B"
+			if renamed {
+				wantTarget = "C"
+			}
+			if got := locks.RecoveryState("B").ResumeSessionID; got != wantTarget {
+				t.Fatalf("committed target=%q want=%q", got, wantTarget)
+			}
+			if got := locks.RecoveryState("C").ResumeRequired; got != renamed {
+				t.Fatalf("overlapping obligation=%v want=%v", got, renamed)
+			}
+			locks.store.faults = recoveryStoreFaults{}
+			if err := locks.ExplicitResumeCompleted("B", oldEpoch); err != nil {
+				t.Fatal(err)
+			}
+			if !locks.RecoveryState("B").ResumeRequired {
+				t.Fatal("old epoch cleared recovery")
+			}
+			if err := locks.ExplicitResumeCompleted("B", locks.RecoveryState("B").Epoch); err != nil {
+				t.Fatal(err)
+			}
+			if got := locks.RecoveryState("A").ResumeRequired; got != renamed {
+				t.Fatalf("original group obligation=%v want=%v", got, renamed)
+			}
+			if locks.RecoveryState("C").ResumeRequired {
+				t.Fatal("new group alias remained after its resume")
+			}
+		})
+	}
+}
+
+func TestConfirmedExitPersistenceFailureRetainsAdmissionFence(t *testing.T) {
+	for _, renamed := range []bool{false, true} {
+		t.Run(map[bool]string{false: "before rename", true: "after rename"}[renamed], func(t *testing.T) {
+			root := t.TempDir()
+			locks, err := NewPersistentResumeLocks(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := locks.PersistForceStop([]string{"A", "B"}, "B"); err != nil {
+				t.Fatal(err)
+			}
+			fail := func() error { return errors.New("disk failure") }
+			if renamed {
+				locks.store.faults.AfterRename = fail
+			} else {
+				locks.store.faults.BeforeRename = fail
+			}
+			if err := locks.ConfirmForceStop("B"); err == nil {
+				t.Fatal("expected confirmation persistence error")
+			}
+			for _, id := range []string{"A", "B"} {
+				if state := locks.RecoveryState(id); !state.ResumeRequired || state.ExitConfirmed {
+					t.Fatalf("failed persistence released %s: %+v", id, state)
+				}
+			}
+			locks.store.faults = recoveryStoreFaults{}
+			if err := locks.ConfirmForceStop("B"); err != nil {
+				t.Fatal(err)
+			}
+			locks, err = NewPersistentResumeLocks(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, id := range []string{"A", "B"} {
+				if state := locks.RecoveryState(id); !state.ResumeRequired || !state.ExitConfirmed {
+					t.Fatalf("confirmation lost %s: %+v", id, state)
+				}
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/internal/hubcore/resumelocks.go
+++ b/cmd/evener-hub/internal/hubcore/resumelocks.go
@@ -1,6 +1,14 @@
 package hubcore
 
-import "sync"
+import (
+	"crypto/rand"
+	"errors"
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/spf13/afero"
+)
 
 // ResumeLocks hands out one mutex per session id so concurrent resume attempts
 // for the same session serialize. Both the REST send path and the RPC
@@ -8,13 +16,147 @@ import "sync"
 // resume triggered on one transport blocks a racing resume on the other,
 // preventing two daemons from being spawned for one exited session (kata sm1a).
 type ResumeLocks struct {
-	mu    sync.Mutex
-	locks map[string]*sync.Mutex
+	persistenceMu sync.Mutex
+	store         *recoveryStore
+	mu            sync.Mutex
+	locks         map[string]*sync.Mutex
+	recovery      map[string]SessionRecoveryState
+	sequence      uint64
 }
 
 // NewResumeLocks returns an empty registry ready for use.
 func NewResumeLocks() *ResumeLocks {
 	return &ResumeLocks{locks: map[string]*sync.Mutex{}}
+}
+
+// NewPersistentResumeLocks restores explicit-resume authority before serving.
+// Call NewResumeLocks explicitly for an in-memory registry; an empty root is an error.
+func NewPersistentResumeLocks(stateRoot string) (*ResumeLocks, error) {
+	store, err := openRecoveryStore(afero.NewOsFs(), stateRoot)
+	if err != nil {
+		return nil, err
+	}
+	r := NewResumeLocks()
+	r.store = store
+	r.recovery = make(map[string]SessionRecoveryState)
+	groups := make(map[string]*sessionRecoveryGroup)
+	for alias, authority := range store.state {
+		id := authority.Group
+		group := groups[id]
+		if group == nil {
+			group = &sessionRecoveryGroup{}
+			groups[id] = group
+		}
+		group.aliases = append(group.aliases, alias)
+		r.recovery[alias] = SessionRecoveryState{ResumeRequired: true, ExitConfirmed: authority.ExitConfirmed, group: group, durableGroup: id, ResumeSessionID: authority.SessionID}
+	}
+	return r, nil
+}
+
+// PersistForceStop records verified aliases and their current transcript under
+// ownership locks before signaling. Committed intent survives signaling failure.
+func (r *ResumeLocks) PersistForceStop(aliases []string, sessionID string) error {
+	if len(aliases) == 0 {
+		return errors.New("recovery alias set is empty")
+	}
+	aliases = slices.Compact(slices.Sorted(slices.Values(aliases)))
+	for _, alias := range aliases {
+		if !validRecoveryAlias(alias) {
+			return errors.New("invalid recovery alias")
+		}
+	}
+	if !validRecoveryAlias(sessionID) || !slices.Contains(aliases, sessionID) {
+		return errors.New("recovery target must be a verified ownership alias")
+	}
+	r.persistenceMu.Lock()
+	defer r.persistenceMu.Unlock()
+	id := rand.Text()
+	committed := true
+	var err error
+	if r.store != nil {
+		next := maps.Clone(r.store.state)
+		for _, alias := range aliases {
+			next[alias] = recoveryAuthority{Group: id, SessionID: sessionID}
+		}
+		committed, err = r.store.commit(next)
+	}
+	if committed {
+		r.mu.Lock()
+		if r.recovery == nil {
+			r.recovery = make(map[string]SessionRecoveryState)
+		}
+		group := &sessionRecoveryGroup{aliases: slices.Clone(aliases)}
+		for _, alias := range aliases {
+			state := r.recovery[alias]
+			state.group = group
+			state.ResumeRequired = true
+			state.ExitConfirmed = false
+			state.durableGroup = id
+			state.ResumeSessionID = sessionID
+			r.recovery[alias] = state
+		}
+		r.mu.Unlock()
+	}
+	return err
+}
+
+// ConfirmForceStop records proven process exit without acknowledging explicit
+// Resume. Descendants may recover independently once their owner cannot run.
+func (r *ResumeLocks) ConfirmForceStop(sessionID string) error {
+	r.persistenceMu.Lock()
+	defer r.persistenceMu.Unlock()
+	r.mu.Lock()
+	state := r.recovery[sessionID]
+	eligible := make(map[string]SessionRecoveryState)
+	if state.group != nil {
+		for _, alias := range state.group.aliases {
+			current := r.recovery[alias]
+			if current.group == state.group {
+				eligible[alias] = current
+			}
+		}
+	}
+	r.mu.Unlock()
+	if len(eligible) == 0 {
+		return errors.New("session has no committed recovery authority")
+	}
+	if r.store != nil {
+		next := maps.Clone(r.store.state)
+		for alias, current := range eligible {
+			authority := next[alias]
+			if authority.Group != current.durableGroup {
+				return errors.New("session recovery authority changed")
+			}
+			authority.ExitConfirmed = true
+			next[alias] = authority
+		}
+		if _, err := r.store.commit(next); err != nil {
+			return err
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for alias, previous := range eligible {
+		current := r.recovery[alias]
+		if current.group == previous.group {
+			current.ExitConfirmed = true
+			r.recovery[alias] = current
+		}
+	}
+	return nil
+}
+
+// HasUnconfirmedRecovery keeps admission checks active on fresh connections and
+// after hub recreation while a stopped owner may still be executing delegates.
+func (r *ResumeLocks) HasUnconfirmedRecovery() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, state := range r.recovery {
+		if state.Stopping > 0 || (state.ResumeRequired && !state.ExitConfirmed) {
+			return true
+		}
+	}
+	return false
 }
 
 // For returns the mutex for sessionID, creating it on first use. Repeated calls
@@ -29,4 +171,153 @@ func (r *ResumeLocks) For(sessionID string) *sync.Mutex {
 		r.locks[sessionID] = m
 	}
 	return m
+}
+
+// SessionRecoveryState is the action admission state shared by every transport.
+// Epoch changes invalidate actions that were waiting for session ownership.
+type SessionRecoveryState struct {
+	Epoch                uint64
+	LastRecoverySequence uint64
+	Stopping             int
+	ResumeRequired       bool
+	ExitConfirmed        bool
+	ResumeSessionID      string
+	group                *sessionRecoveryGroup
+	durableGroup         string
+}
+
+type sessionRecoveryGroup struct {
+	aliases           []string
+	resolvedSessionID string
+}
+
+func (r *ResumeLocks) RecoveryState(sessionID string) SessionRecoveryState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.recovery[sessionID]
+}
+
+// RecoveryAliases returns the verified ownership group, including after explicit
+// recovery completes. The aliases reserve one daemon without choosing its target.
+func (r *ResumeLocks) RecoveryAliases(sessionID string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if group := r.recovery[sessionID].group; group != nil {
+		return slices.Clone(group.aliases)
+	}
+	return []string{sessionID}
+}
+
+// HasSeparatePendingRecovery identifies an obligation the requested alias cannot
+// acknowledge. Repeated stops of the same transcript still create a new group.
+func (r *ResumeLocks) HasSeparatePendingRecovery(sessionID, targetID string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	requested, target := r.recovery[sessionID], r.recovery[targetID]
+	return (target.ResumeRequired || target.Stopping > 0) && target.group != requested.group
+}
+
+// RecordResolvedSession retains alias routing after successful Resume without
+// recreating a recovery obligation. Fresh rendezvous evidence takes priority.
+func (r *ResumeLocks) RecordResolvedSession(sessionID, target string, epoch uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	state := r.recovery[sessionID]
+	if target != "" && state.Epoch == epoch && state.Stopping == 0 && !state.ResumeRequired && state.group != nil {
+		state.group.resolvedSessionID = target
+	}
+}
+
+func (r *ResumeLocks) ResolvedSessionID(sessionID string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if group := r.recovery[sessionID].group; group != nil {
+		return group.resolvedSessionID
+	}
+	return ""
+}
+
+// RecoverySequence is captured once when a transport is established. A
+// request read later cannot turn unread pre-recovery input into fresh intent.
+func (r *ResumeLocks) RecoverySequence() uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sequence
+}
+
+// BeginForceStop blocks new actions and invalidates existing ownership waiters.
+// Temporary fences preserve committed alias routing. PersistForceStop installs
+// a new group only once its recovery authority may have reached durable storage.
+func (r *ResumeLocks) BeginForceStop(aliases []string) func(bool) {
+	r.mu.Lock()
+	if r.recovery == nil {
+		r.recovery = make(map[string]SessionRecoveryState)
+	}
+	r.sequence++
+	for _, id := range aliases {
+		state := r.recovery[id]
+		state.Epoch++
+		state.LastRecoverySequence = r.sequence
+		state.Stopping++
+		r.recovery[id] = state
+	}
+	r.mu.Unlock()
+	return func(stopped bool) {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.sequence++
+		for _, id := range aliases {
+			state := r.recovery[id]
+			state.Stopping--
+			state.LastRecoverySequence = r.sequence
+			state.ResumeRequired = state.ResumeRequired || stopped
+			r.recovery[id] = state
+		}
+	}
+}
+
+// ExplicitResumeCompleted clears every alias only if no newer recovery began.
+func (r *ResumeLocks) ExplicitResumeCompleted(sessionID string, epoch uint64) error {
+	r.persistenceMu.Lock()
+	defer r.persistenceMu.Unlock()
+	r.mu.Lock()
+	state := r.recovery[sessionID]
+	if state.Epoch != epoch || state.Stopping != 0 || state.group == nil {
+		r.mu.Unlock()
+		return nil
+	}
+	eligible := make(map[string]SessionRecoveryState)
+	for _, id := range state.group.aliases {
+		alias := r.recovery[id]
+		if alias.group == state.group && alias.Stopping == 0 {
+			eligible[id] = alias
+		}
+	}
+	r.mu.Unlock()
+	if r.store != nil {
+		next := maps.Clone(r.store.state)
+		for id, alias := range eligible {
+			if next[id].Group == alias.durableGroup {
+				delete(next, id)
+			}
+		}
+		// Retry the write even when a previous removal was renamed before a sync
+		// error: only a fully synced replacement establishes clear completion.
+		if _, err := r.store.commit(next); err != nil {
+			return err
+		}
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for id, previous := range eligible {
+		alias := r.recovery[id]
+		if alias.group != previous.group || alias.Epoch != previous.Epoch || alias.Stopping != 0 {
+			continue
+		}
+		alias.ResumeRequired = false
+		alias.durableGroup = ""
+		alias.ResumeSessionID = ""
+		r.recovery[id] = alias
+	}
+	return nil
 }

--- a/cmd/evener-hub/internal/hubcore/resumelocks_recovery_test.go
+++ b/cmd/evener-hub/internal/hubcore/resumelocks_recovery_test.go
@@ -1,0 +1,78 @@
+package hubcore
+
+import "testing"
+
+func TestExplicitResumePreservesNewerAliasRecovery(t *testing.T) {
+	for _, complete := range []bool{false, true} {
+		t.Run(map[bool]string{false: "during exit", true: "after exit"}[complete], func(t *testing.T) {
+			locks := NewResumeLocks()
+			finishOld := locks.BeginForceStop([]string{"A", "B"})
+			if err := locks.PersistForceStop([]string{"A", "B"}, "B"); err != nil {
+				t.Fatal(err)
+			}
+			finishOld(true)
+			epochA := locks.RecoveryState("A").Epoch
+			finishNew := locks.BeginForceStop([]string{"B", "C"})
+			if err := locks.PersistForceStop([]string{"B", "C"}, "C"); err != nil {
+				t.Fatal(err)
+			}
+			if complete {
+				finishNew(true)
+			}
+			beforeB := locks.RecoveryState("B")
+			beforeC := locks.RecoveryState("C")
+			if err := locks.ExplicitResumeCompleted("A", epochA); err != nil {
+				t.Fatal(err)
+			}
+			if locks.RecoveryState("A").ResumeRequired {
+				t.Fatal("explicitly resumed alias remains fenced")
+			}
+			if after := locks.RecoveryState("B"); after.ResumeRequired != beforeB.ResumeRequired || after.Stopping != beforeB.Stopping {
+				t.Fatalf("older resume changed newer B recovery: before=%+v after=%+v", beforeB, after)
+			}
+			if after := locks.RecoveryState("C"); after.ResumeRequired != beforeC.ResumeRequired || after.Stopping != beforeC.Stopping {
+				t.Fatalf("older resume changed newer C recovery: before=%+v after=%+v", beforeC, after)
+			}
+			if !complete {
+				finishNew(true)
+			}
+		})
+	}
+}
+
+func TestResolvedSessionMappingRequiresCompletedCurrentEpoch(t *testing.T) {
+	locks := NewResumeLocks()
+	finish := locks.BeginForceStop([]string{"stable", "current"})
+	if err := locks.PersistForceStop([]string{"stable", "current"}, "current"); err != nil {
+		t.Fatal(err)
+	}
+	epoch := locks.RecoveryState("stable").Epoch
+	locks.RecordResolvedSession("stable", "wrong", epoch)
+	if locks.ResolvedSessionID("stable") != "" {
+		t.Fatal("stopping action recorded a target")
+	}
+	finish(true)
+	locks.RecordResolvedSession("stable", "wrong", epoch)
+	if locks.ResolvedSessionID("stable") != "" {
+		t.Fatal("pending recovery recorded a completed target")
+	}
+	if err := locks.ExplicitResumeCompleted("stable", epoch); err != nil {
+		t.Fatal(err)
+	}
+	locks.RecordResolvedSession("stable", "current", epoch)
+	if locks.ResolvedSessionID("current") != "current" {
+		t.Fatal("completed target was not shared across aliases")
+	}
+	newer := locks.BeginForceStop([]string{"stable", "next"})
+	if err := locks.PersistForceStop([]string{"stable", "next"}, "next"); err != nil {
+		t.Fatal(err)
+	}
+	newer(true)
+	locks.RecordResolvedSession("stable", "current", epoch)
+	if locks.ResolvedSessionID("stable") != "" {
+		t.Fatal("stale completion replaced newer ownership")
+	}
+	if !locks.RecoveryState("stable").ResumeRequired {
+		t.Fatal("target record cleared newer recovery")
+	}
+}

--- a/cmd/evener-hub/internal/hubcore/roster.go
+++ b/cmd/evener-hub/internal/hubcore/roster.go
@@ -202,6 +202,13 @@ func (r *Roster) SetFs(fs afero.Fs) *Roster {
 	return r
 }
 
+// SetProcessAlive overrides the process-liveness probe. Tests with synthetic
+// rendezvous claims must not depend on whether their PIDs exist on the host.
+func (r *Roster) SetProcessAlive(probe func(int) bool) *Roster {
+	r.procAlive = probe
+	return r
+}
+
 // NewRosterWithEntries returns a Roster pre-seeded with the given live entries,
 // bypassing the rendezvous-dir scan. Each entry is indexed by its PID (for List)
 // and, when non-empty, by its SessionID (for Find), mirroring how Refresh

--- a/cmd/evener-hub/main.go
+++ b/cmd/evener-hub/main.go
@@ -344,6 +344,11 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 	}
 	cfg.Addr = hubListener.Addr().String()
 
+	resumeLocks, err := hubcore.NewPersistentResumeLocks(hubStateRoot)
+	if err != nil {
+		_ = hubListener.Close()
+		return fmt.Errorf("load recovery state: %w", err)
+	}
 	deletionStore, err := hubcore.NewDeletionStore(hubStateRoot)
 	if err != nil {
 		_ = hubListener.Close()
@@ -384,6 +389,7 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 		PinSections:               pinSections,
 		Spawner:                   spawner,
 		DeletionStore:             deletionStore,
+		ResumeLocks:               resumeLocks,
 		PastPerPage:               cfg.PastResultsPerPage,
 		StateDir:                  stateDir,
 		CredsStore:                credsStore,

--- a/cmd/evener-hub/web.go
+++ b/cmd/evener-hub/web.go
@@ -46,6 +46,7 @@ type WebServer struct {
 	manifestFS fs.FS
 
 	frontendHash              string
+	recoveryStoreErr          error
 	deletionStoreErr          error
 	transcriptDisplayStoreErr error
 	keybindingsStoreErr       error
@@ -75,8 +76,14 @@ func newWebServer(cfg hubcore.WebConfig, appwireTrace *appserver.WebSocketTrace)
 	// One resume-lock registry backs both the REST send path (lockForSession)
 	// and the RPC auto-resume path (hubThreadResume via cfg), so a resume
 	// triggered on either transport serializes a racing resume on the other.
+	var recoveryStoreErr error
 	if cfg.ResumeLocks == nil {
-		cfg.ResumeLocks = hubcore.NewResumeLocks()
+		if cfg.HubStateRoot == "" {
+			// Embedders without a state root explicitly use process-local state.
+			cfg.ResumeLocks = hubcore.NewResumeLocks()
+		} else {
+			cfg.ResumeLocks, recoveryStoreErr = hubcore.NewPersistentResumeLocks(cfg.HubStateRoot)
+		}
 	}
 	fHash, _ := frontendDistHash(distFS())
 	web := &WebServer{
@@ -89,6 +96,7 @@ func newWebServer(cfg hubcore.WebConfig, appwireTrace *appserver.WebSocketTrace)
 		manifestFS:                assetsRoot(),
 		frontendHash:              fHash,
 		deletionStoreErr:          deletionStoreErr,
+		recoveryStoreErr:          recoveryStoreErr,
 		transcriptDisplayStoreErr: transcriptDisplayStoreErr,
 		keybindingsStoreErr:       keybindingsStoreErr,
 	}
@@ -100,7 +108,7 @@ func newWebServer(cfg hubcore.WebConfig, appwireTrace *appserver.WebSocketTrace)
 	registerArchiveHandler(web.appRPC, web.cfg, func() *NavigationService { return web.navigation })
 	registerProjectDeleteHandler(web.appRPC, web)
 	registerSessionDeleteHandler(web.appRPC, web.sessionDelete)
-	if deletionStoreErr == nil {
+	if deletionStoreErr == nil && recoveryStoreErr == nil {
 		_ = web.resumeProjectDeletions()
 	}
 	return web
@@ -135,6 +143,11 @@ func validAssetPath(next http.Handler) http.Handler {
 }
 
 func (s *WebServer) Handler() http.Handler {
+	if s.recoveryStoreErr != nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "recovery state unavailable", http.StatusServiceUnavailable)
+		})
+	}
 	mux := http.NewServeMux()
 
 	// Assets — the embedded PWA icons + manifest, auth-exempt per hubedge.

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -435,6 +435,13 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 			return fmt.Errorf("resolve project state: %w", err)
 		}
 	}
+	// Rendezvous ownership must identify the same state files regardless of the
+	// hub's working directory, including when serve accepts a relative path.
+	absoluteStateDir, stateDirErr := filepath.Abs(sd)
+	if stateDirErr != nil {
+		return fmt.Errorf("resolve absolute state directory: %w", stateDirErr)
+	}
+	sd = absoluteStateDir
 	resuming := *resume != "" || *resumeLast
 	var resumedMeta schema.SessionMeta
 	if resuming {

--- a/cmd/evener/serve_test.go
+++ b/cmd/evener/serve_test.go
@@ -512,6 +512,54 @@ func TestRunServeNonInteractiveFlagControlsPromptAddendum(t *testing.T) {
 	}
 }
 
+func TestRunServeRecordsAbsoluteStateDirectory(t *testing.T) {
+	for _, fromEnv := range []bool{false, true} {
+		t.Run(strconv.FormatBool(fromEnv), func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			stateDir := "relative-state"
+			want, err := filepath.Abs(stateDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			runDir := t.TempDir()
+			args := []string{"--model", "openai/test", "--addr", "127.0.0.1:0", "--dir", t.TempDir(), "--run-dir", runDir}
+			if fromEnv {
+				t.Setenv("EVENER_STATE_DIR", stateDir)
+			} else {
+				args = append(args, "--state-dir", stateDir)
+			}
+			deps := defaultServeDeps()
+			deps.newClient = func(string, io.Writer) (*llm.Client, func() error, error) {
+				client := llm.NewClient()
+				client.Register(serveLoggingAdapter{})
+				return client, func() error { return nil }, nil
+			}
+			done := make(chan error, 1)
+			go func() { done <- runServeWithDeps(args, deps) }()
+			entry := waitForServeTestRendezvous(t, runDir)
+			if err := shutdownServeTestDaemon(t.Context(), entry.Address, entry.SessionID); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatal(err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("serve failed to shut down")
+			}
+			if entry.StateDir != want {
+				t.Fatalf("rendezvous stateDir=%q, want %q", entry.StateDir, want)
+			}
+			for _, suffix := range []string{".transcript.jsonl", ".api.jsonl"} {
+				if _, err := os.Stat(filepath.Join(entry.StateDir, "sessions", entry.SessionID+suffix)); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func TestRunServeShutdownWaitsForInFlightInput(t *testing.T) {
 	adapter := &shutdownBlockingAdapter{
 		entered:   make(chan struct{}, 1),

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -101,6 +101,7 @@ no router (reserved).
 | `thread/reasoning-effort/set` | both | `ThreadReasoningEffortSetParams` | `EmptyResponse` | Sets reasoning effort, normalizing and validating the value. |
 | `thread/vision-model/set` | both | `ThreadVisionModelSetParams` | `EmptyResponse` | Sets the vision side-channel routing ("", "off", or a model ref). |
 | `thread/compact/start` | both | `ThreadCompactStartParams` | `EmptyResponse` | Starts a context-compaction pass on the session. |
+| `evener/thread/forceStop` | hub | `ThreadForceStopParams` | `EmptyResponse` | Explicitly terminates a verified local daemon and confirms exit; saved session data is retained. |
 | `thread/shutdown` | both | `ThreadShutdownParams` | `EmptyResponse` | Shuts the session down (the daemon runs it asynchronously). |
 | `turn/start` | both | `TurnStartParams` | `TurnStartResponse` | Starts a new user turn and reserves a turn ID. |
 | `turn/steer` | both | `TurnSteerParams` | `TurnSteerResponse` | Injects a steering message into the active turn. |
@@ -1507,6 +1508,13 @@ _(no fields)_
 
 
 ### `ThreadCompactStartParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `ref` | `string` |  |  |
+
+
+### `ThreadForceStopParams`
 
 | Field | Go type | Omitempty | Embedded |
 |-------|---------|-----------|----------|

--- a/docs/superpowers/plans/2026-09-07-session-force-stop.md
+++ b/docs/superpowers/plans/2026-09-07-session-force-stop.md
@@ -1,0 +1,159 @@
+# Session Force Stop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Jesse explicitly stop an incompatible or unresponsive local daemon without losing saved session data.
+
+**Architecture:** A hub-owned force-stop operation resolves one local root daemon under the existing session ownership lock. A platform boundary verifies the OS process generation and the daemon's ownership of the session API log, signals that generation, and confirms exit. The frontend asks for explicit confirmation and refreshes only after the operation succeeds.
+
+**Tech Stack:** Go, AppWire, React/TypeScript, Linux pidfds, Darwin proc_info/audit-token signaling. No cgo or new dependencies.
+
+**Spec:** GitHub issue https://github.com/prime-radiant-inc/evener/issues/934 and Jesse's approved design in this task.
+
+## Global Constraints
+
+- Keep this PR separate from #936; initially stack it on codex/running-session-regressions.
+- No old-protocol compatibility and no automatic force-stop or restart.
+- Refuse stale or ambiguous identity. Never signal by an unverified numeric PID.
+- Preserve transcripts and API logs. Do not remove rendezvous or session files as a substitute for process exit.
+- Explicitly warn that active turns and jobs may be interrupted.
+- Tests use fake OS boundaries or fixture-owned processes and files; never target ambient agent processes.
+- Resume and deletion must remain serialized with force-stop.
+
+## Task 1: Verified process termination
+
+**Files:** Create `cmd/evener-hub/internal/daemonprocess/process.go`, `process_darwin.go`, `process_linux.go`, `process_other.go`, and direct behavioral tests.
+
+**Interfaces:** The hub supplies the rendezvous identity and canonical session data location. The package exposes:
+
+```go
+type Target struct {
+    PID int
+    SessionID string
+    StateDir string
+    StartedAt time.Time
+}
+type Process interface {
+    Kill() error
+    Wait(context.Context) error
+    Close() error
+}
+type Controller interface { Open(Target) (Process, error) }
+```
+
+- [ ] Write tests for refusal of invalid/self PID, missing session identity, reused process generation, wrong owner, and missing API-log ownership; verify no signal occurs.
+- [ ] Verify each test fails before implementation.
+- [ ] Implement the platform boundary. Linux opens a pidfd before inspection and signals through that fd. Darwin reads the unique process identifier and pid version, then signals with an audit token carrying that pid version. Compare identity before and after inspecting ownership. Refuse unsupported inspection/signaling APIs.
+- [ ] Verify the current user owns a `serve` process and that its writable, locked API-log descriptor identifies `StateDir/sessions/SessionID.api.jsonl`. Compare device/inode, not only a path string. Recheck ownership before signaling. Reject OS process starts after the rendezvous timestamp.
+- [ ] Confirm exit using the bound process identity. An already-exited process is idempotent success; a timeout remains an error. A reused PID is never waited on or signaled as the old process.
+- [ ] Run direct package tests and cross-compile the supported platform implementations; commit with the identity and failure contracts documented.
+
+## Task 2: Hub force-stop operation
+
+**Files:** Create `cmd/evener-hub/app_force_stop.go` and `app_force_stop_test.go`; modify `appwire/types.go`, the AppWire registration/generation inputs, `cmd/evener-hub/app_rpc.go`, and `cmd/evener-hub/internal/hubcore/config.go`.
+
+**Interfaces:** Add a hub-only `evener/thread/forceStop` request with a local root session ref. Inject Task 1's controller through WebConfig for deterministic OS-boundary tests.
+
+```go
+type ThreadForceStopParams struct { Ref string `json:"ref"` }
+// The response is EmptyResponse only after confirmed process exit.
+```
+
+- [ ] Add real hub RPC tests using real rendezvous files and a fake process controller. Cover incompatible and unresponsive roots, responsive normal shutdown remaining unchanged, already-exited targets, ambiguous/multiple owners, wrong-source refs, stale identity, signal errors, timeout, and saved transcript retention.
+- [ ] Add a lock-order test: hold force-stop's exit confirmation and prove resume/deletion cannot replace/remove that session until it completes.
+- [ ] Run the new tests and establish failures.
+- [ ] Resolve only direct local root claims from strict rendezvous discovery. Do not infer a descendant force-stop as permission to kill its ancestor. Hold the same per-session lock used by resume/deletion across discovery, validation, signaling, and exit confirmation. Call `Open`, `Kill`, then `Wait`; always `Close` the handle. Return errors without changing ownership or saved data.
+- [ ] Refresh roster/navigation after confirmed exit. Preserve a successful stop result if ancillary UI refresh fails; retain stale-discovery diagnostics.
+- [ ] Register the typed method as hub-only, update required protocol contracts, run `make generate`, and verify focused RPC tests before committing.
+
+## Task 3: Explicit user action and end-to-end verification
+
+**Files:** Modify the session actions UI and its tests, session store method, and generated frontend protocol files.
+
+**Interfaces:** The confirmed action calls `evener/thread/forceStop` and refreshes the session only after success. Ordinary shutdown remains separate.
+
+- [ ] Add frontend behavior tests: no RPC before confirmation, cancel sends nothing, confirm sends one force-stop request, pending confirmation remains disabled, failures retain an actionable error, and successful exit enables explicit resume after refresh.
+- [ ] Add a Force stop action for local root sessions, including restart-required sessions whose daemon capabilities are unavailable. Use the existing dialog/button conventions with the warning that active turns and jobs may be interrupted and saved transcripts retained.
+- [ ] Run the tests red, implement the action, then run focused tests green.
+- [ ] Run Biome on touched src files, `make test-web`, all five browser guards, and `make merge-approval-gate`. Review the whole branch against its stack base and commit verified changes.
+- [ ] Create a separate PR closing #934, state the #936 dependency, request RoboRev, and address actionable findings without merging.
+
+## Verification boundaries
+
+Darwin does not expose a PID-specific current flock owner. The verifier combines the bound process generation, user, command and start time with a writable matching API-log inode, CLOEXEC, historical lock evidence, and current exclusive contention. This depends on Evener's API logger closing its descriptor when releasing ownership; it never unlocks and retains that descriptor. The historical flag alone does not establish ownership. Deliberate same-user process impersonation is outside this recovery contract.
+
+Linux binds signaling and exit confirmation through a pidfd. Its process start timestamp is rounded conservatively to the end of the reported clock tick, so a rendezvous published inside that first tick can be refused. Checked arithmetic preserves that bound on long-running hosts. Both platforms refuse unavailable verification rather than fall back to numeric-PID signaling. Historical wall-clock changes can make timestamp ordering ambiguous; generation and inode/lock checks remain required independently.
+
+Recovery must remain reachable when both navigation and initial thread hydration fail. A local session loading surface therefore offers the same confirmation as the session menus; the hub remains the authority for whether the ref has a direct daemon owner.
+
+Serialization tests combine ownership of the actual stable/current mutexes with real resume/delete outcomes and acquisition call-site review. They do not infer scheduler timing from sleeps or runtime stack text; Go synctest does not consider mutex waits durably blocked.
+
+Recovery first opens a verified process handle, then fences and cancels that daemon's direct RPCs before acquiring the ownership locks. An independent bounded recovery slot can admit the request while the normal WebSocket worker is stalled; ordinary mutations retain FIFO order. Cancellation remains distinct from session-unavailable so it cannot trigger automatic resume. Exact-entry reads during spawn confirmation use the persistent source's cancellation scope too. The process key excludes mutable session aliases and normalizes timestamps to UTC.
+
+Retained rendezvous evidence is excluded from ambiguity only after verified process exit. A direct exited claim remains available for idempotent retry when every overlapping claim is verified dead; any live or unresolved competitor still prevents termination. Signaling and exit confirmation remain under the existing ownership locks, with discovery and native identity rechecked before the signal.
+
+The hub retains an explicit-resume requirement after verified force stop. Saved and live thread reads expose that requirement without claiming protocol incompatibility; successful fresh explicit resume acknowledges it across the same recovery alias group. Session mutations carry the recovery generation captured by a pure, in-memory request-admission callback before the WebSocket FIFO queue. The queue retains the derived connection context through execution and retries, so recovery cannot turn previously queued resume or mutation requests into fresh intent. Target extraction follows each handler's supported parameters and precedence; unrelated sessions are unaffected, malformed targets retain native validation, and direct handler calls capture their generation at execution. Admission failures retain the connection's existing error/panic containment.
+
+Force stop uses one bounded, short-lived browser recovery connection owned by the primary client. It reuses the endpoint, authentication and strict handshake, sends the stop once, and closes on completion, failure, timeout or owner teardown. This is necessary when the primary connection's normal 64-entry FIFO is full and its receive loop is applying backpressure; the independent server recovery slot alone cannot admit an unread frame. Ordinary queue semantics remain unchanged. Once verified signaling succeeds, the hub retains the explicit-resume requirement even if the connection drops or exit confirmation times out. That requirement records the user's termination intent; the RPC still reports unconfirmed exit as failure.
+
+The WebSocket connection captures a recovery sequence before its HTTP upgrade, before any request frame is accepted. Each affected alias records the latest sequence at both recovery start and completion, invalidating unread socket backlog and connections created during exit confirmation. Action handlers compare that immutable connection sequence as well as request admission epochs; neither another initialize nor explicit resume on an old connection can advance it. This restriction is per affected alias: reads and unrelated-session actions remain available. A stale connection's readable snapshot continues to advertise Resume even after another client acknowledged recovery. Pressing the existing Resume button replaces the primary transport through normal reconnect lifecycle, rejects its old pending calls without replay, and only then sends explicit resume. New connections still cannot automatically clear the hub's explicit-resume requirement. The live hub AppWire endpoint is WebSocket-only; direct handler calls retain their execution-time admission checks.
+
+## Durable recovery authority
+
+Jesse approved extending the explicit-Resume requirement across hub restarts.
+Store a versioned recovery snapshot under the same HubStateRoot as hub.lock.
+Persist verified alias-group obligations before signaling or reporting an
+already-exited stop successful. Restore them before request admission; corrupt
+or unsupported authority prevents production startup. An embedded server with
+an explicit empty state root remains process-local.
+
+Persist recovery obligations, overlap-safe group identity, and the verified
+current session ID needed to resume after rendezvous cleanup. Keep request
+epochs, connection sequences, active stop counts and ownership locks in memory.
+Serialize atomic snapshot writes separately from admission reads. A completed
+explicit Resume clears only the applicable generation, and persistence failure
+must remain visible. After committed intent, interrupted or failed signaling
+conservatively retains the requirement rather than guessing whether stop took
+place. No old-protocol compatibility, automatic Resume or input replay is added.
+
+Validate real hub recreation, automatic-action rejection, explicit Resume and a
+second recreation after clearing; signal/write ordering; already-exited and
+failed-confirmation paths; malformed authority; before/after-rename failures;
+overlapping alias groups and admission responsiveness during held writes.
+
+
+## Recovery identity through marker cleanup
+
+The durable snapshot must identify the current transcript as well as its alias
+group. Dead rendezvous markers can expire during ordinary roster refresh, so
+marker restoration cannot be a prerequisite for normal explicit Resume. Use a
+new strict snapshot version with the verified current session ID committed
+before signaling. Unsupported older snapshots fail startup; no compatibility
+path is introduced.
+
+Resolve alias ownership under the same sorted reservations used by force stop.
+Distinguish verified dead markers from live or unresolved claims, and use the
+durable target when stopped markers no longer exist. Never derive a current
+session by sorting aliases. Fresh explicit Resume must also attach the pane to
+the returned current thread identity. Preserve uncertain messages under their
+original identity without replaying them to a replacement session.
+
+Acceptance includes expired-marker force stop, recreated hub recovery, retained
+dead A alongside live cleared B, concurrent stable/current Resume, and the real
+client/store/pane transition to the resumed transcript and follow-up send target.
+
+
+## Descendant admission after an uncertain stop
+
+Commit unconfirmed exit state with the owner recovery authority before signaling.
+Only a verified exit followed by a successful durable confirmation write permits
+fresh descendant actions. Check journal-verified ancestry even on fresh
+connections while any owner remains stopping or unconfirmed. This also covers
+delegates committed after a failed wait and restored recovery after hub restart.
+Keep descendants out of the owner's alias group: confirmed termination permits
+independent descendant Resume, while the owner still requires its own explicit
+Resume. The strict recovery snapshot version is 3; unsupported versions fail
+startup without a compatibility path.
+
+Regression coverage includes signal failure, failed exit confirmation, late
+children, hub recreation, confirmation-write failures, and confirmed retry.

--- a/internal/appserver/request_admission_test.go
+++ b/internal/appserver/request_admission_test.go
@@ -1,0 +1,176 @@
+package appserver
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+)
+
+type requestAdmissionTestKey struct{}
+
+func TestRequestAdmissionContextSurvivesSerialQueue(t *testing.T) {
+	var epoch atomic.Int32
+	epoch.Store(1)
+	admitted := make(chan struct{})
+	observed := make(chan context.Context, 1)
+	server := NewServer(ServerConfig{RequestAdmissionContext: func(ctx context.Context, message appwire.Message) context.Context {
+		if message.Request.Method != appwire.MethodThreadModelSet {
+			return ctx
+		}
+		ctx = context.WithValue(ctx, requestAdmissionTestKey{}, epoch.Load())
+		close(admitted)
+		return ctx
+	}})
+	serialStarted, release := parkThreadList(t, server)
+	HandleTyped(server.Router(), appwire.MethodThreadModelSet, func(ctx context.Context, _ appwire.ThreadModelSetParams) (appwire.EmptyResponse, error) {
+		observed <- ctx
+		return appwire.EmptyResponse{}, nil
+	})
+	client := dialAppWireClient(t, serveWebSocketHTTP(t, server))
+	go func() { _, _ = client.ThreadList(t.Context(), appwire.ThreadListParams{}) }()
+	waitFor(t, "serial handler", serialStarted)
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Request(t.Context(), appwire.MethodThreadModelSet, appwire.ThreadModelSetParams{Ref: "local:A", Model: "test", ModelProvider: "test"}, nil)
+	}()
+	waitFor(t, "request admission", admitted)
+	epoch.Store(2)
+	release()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	ctx := <-observed
+	if ctx.Value(requestAdmissionTestKey{}) != int32(1) {
+		t.Fatalf("queued request recaptured metadata: %v", ctx.Value(requestAdmissionTestKey{}))
+	}
+	if err := client.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("admitted context lost connection cancellation")
+	}
+}
+
+func TestRequestAdmissionFailureKeepsConnectionUsable(t *testing.T) {
+	for _, mode := range []string{"panic", "nil context"} {
+		t.Run(mode, func(t *testing.T) {
+			server := NewServer(ServerConfig{RequestAdmissionContext: func(ctx context.Context, message appwire.Message) context.Context {
+				if message.Request.Method != appwire.MethodThreadModelSet {
+					return ctx
+				}
+				if mode == "panic" {
+					panic("fixture admission failure")
+				}
+				return nil
+			}})
+			client := dialAppWireClient(t, serveWebSocketHTTP(t, server))
+			err := client.Request(t.Context(), appwire.MethodThreadModelSet, appwire.ThreadModelSetParams{Ref: "local:A", Model: "test", ModelProvider: "test"}, nil)
+			if err == nil {
+				t.Fatal("failed admission accepted")
+			}
+			if err := client.Request(t.Context(), appwire.MethodPing, appwire.EmptyParams{}, nil); err != nil {
+				t.Fatalf("admission failure broke connection: %v", err)
+			}
+		})
+	}
+}
+
+func TestRecoveryConnectionReachesHandlerWhilePrimaryQueueIsFull(t *testing.T) {
+	server := NewServer(ServerConfig{})
+	blocked := make(chan struct{}, 1)
+	server.blockedEnqueue = func() { blocked <- struct{}{} }
+	started, release := parkThreadList(t, server)
+	enteredRecovery := make(chan struct{})
+	HandleTyped(server.Router(), appwire.MethodEvenerThreadForceStop, func(context.Context, appwire.ThreadForceStopParams) (appwire.EmptyResponse, error) {
+		close(enteredRecovery)
+		return appwire.EmptyResponse{}, nil
+	})
+	hub := serveWebSocketHTTP(t, server)
+	primary := dialRawAppWire(t, hub)
+	initializeRaw(t, primary)
+	for id := int64(2); id < 68; id++ {
+		sendRaw(t, primary, rawRequest(t, id, appwire.MethodThreadList, appwire.ThreadListParams{}))
+	}
+	waitFor(t, "stalled primary worker", started)
+	waitFor(t, "full 64-entry queue blocking primary receive loop", blocked)
+	recovery := dialAppWireClient(t, hub)
+	if err := recovery.Request(t.Context(), appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: "local:owner"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, "independent recovery handler", enteredRecovery)
+	release()
+}
+
+func TestConnectionAdmissionPrecedesUnreadBacklog(t *testing.T) {
+	var generation atomic.Uint64
+	server := NewServer(ServerConfig{ConnectionAdmissionContext: func(ctx context.Context) context.Context {
+		return context.WithValue(ctx, requestAdmissionTestKey{}, generation.Load())
+	}})
+	blocked := make(chan struct{}, 1)
+	server.blockedEnqueue = func() { blocked <- struct{}{} }
+	started, release := parkThreadList(t, server)
+	var resumed, mutated atomic.Int32
+	check := func(ctx context.Context) error {
+		if ctx.Value(requestAdmissionTestKey{}).(uint64) != generation.Load() {
+			return appwire.Unavailable("session requires explicit Resume on a fresh connection")
+		}
+		return nil
+	}
+	HandleTyped(server.Router(), appwire.MethodThreadResume, func(ctx context.Context, _ appwire.ThreadResumeParams) (appwire.ThreadResumeResponse, error) {
+		if err := check(ctx); err != nil {
+			return appwire.ThreadResumeResponse{}, err
+		}
+		resumed.Add(1)
+		return appwire.ThreadResumeResponse{}, nil
+	})
+	HandleTyped(server.Router(), appwire.MethodThreadReasoningEffortSet, func(ctx context.Context, _ appwire.ThreadReasoningEffortSetParams) (appwire.EmptyResponse, error) {
+		if err := check(ctx); err != nil {
+			return appwire.EmptyResponse{}, err
+		}
+		mutated.Add(1)
+		return appwire.EmptyResponse{}, nil
+	})
+	HandleTyped(server.Router(), appwire.MethodEvenerThreadForceStop, func(context.Context, appwire.ThreadForceStopParams) (appwire.EmptyResponse, error) {
+		generation.Add(1)
+		return appwire.EmptyResponse{}, nil
+	})
+	hub := serveWebSocketHTTP(t, server)
+	primary := dialRawAppWire(t, hub)
+	initializeRaw(t, primary)
+	for id := int64(2); id < 68; id++ {
+		sendRaw(t, primary, rawRequest(t, id, appwire.MethodThreadList, appwire.ThreadListParams{}))
+	}
+	waitFor(t, "stalled worker", started)
+	waitFor(t, "full queue", blocked)
+	sendRaw(t, primary, rawRequest(t, 68, appwire.MethodThreadResume, appwire.ThreadResumeParams{Ref: "local:owner"}))
+	sendRaw(t, primary, rawRequest(t, 69, appwire.MethodThreadReasoningEffortSet, appwire.ThreadReasoningEffortSetParams{Ref: "local:owner", ReasoningEffort: "high"}))
+	recovery := dialAppWireClient(t, hub)
+	if err := recovery.Request(t.Context(), appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: "local:owner"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	release()
+	for id := int64(2); id <= 69; id++ {
+		message, err := primary.Recv(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if id >= 68 && message.Error == nil {
+			t.Fatalf("unread request %d admitted after recovery: %+v", id, message)
+		}
+	}
+	if resumed.Load() != 0 || mutated.Load() != 0 {
+		t.Fatal("unread actions replayed")
+	}
+	fresh := dialAppWireClient(t, hub)
+	if err := fresh.Request(t.Context(), appwire.MethodThreadResume, appwire.ThreadResumeParams{Ref: "local:owner"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if resumed.Load() != 1 {
+		t.Fatal("fresh explicit resume failed")
+	}
+}

--- a/internal/appserver/server.go
+++ b/internal/appserver/server.go
@@ -43,6 +43,13 @@ type ServerConfig struct {
 	// SubscriptionAdmissionResolverV2 distinguishes invalid target requests from
 	// unresolved subscribing reads, so native handlers retain validation errors.
 	SubscriptionAdmissionResolverV2 func(appwire.Message) SubscriptionAdmissionResolution
+	// RequestAdmissionContext captures immutable request metadata before queueing.
+	// It must be pure, synchronous, and derive its result from the supplied
+	// connection context so cancellation remains inherited.
+	RequestAdmissionContext func(context.Context, appwire.Message) context.Context
+	// ConnectionAdmissionContext captures immutable metadata before accepting
+	// any WebSocket frames. It must preserve the supplied context cancellation.
+	ConnectionAdmissionContext func(context.Context) context.Context
 }
 
 type SubscriptionAdmissionIntent uint8
@@ -246,7 +253,7 @@ func (s *Server) NewConnection(id string) *Connection {
 		id:                id,
 		server:            s,
 		send:              make(chan appwire.Message, appwire.NotificationBufferCap),
-		requests:          make(chan appwire.Message, s.requestQueueCapacity),
+		requests:          make(chan admittedRequest, s.requestQueueCapacity),
 		slowReadSlots:     make(chan struct{}, slowReadDispatchCap),
 		slowReadInflight:  map[string]int{},
 		workerExited:      make(chan struct{}),
@@ -500,6 +507,11 @@ func navigationCapability(capability *appwire.NavigationCapability) *appwire.Nav
 	return &clone
 }
 
+type admittedRequest struct {
+	ctx     context.Context
+	message appwire.Message
+}
+
 type Connection struct {
 	id         string
 	server     *Server
@@ -512,7 +524,7 @@ type Connection struct {
 	// consumer teardown is context cancellation — and ServeWebSocket purges
 	// its buffered frames at teardown so an orphaned handler retains at most
 	// the one frame it is executing.
-	requests chan appwire.Message
+	requests chan admittedRequest
 	// queueSaturationAdvised makes the queue-saturation advisory one-shot per
 	// connection. Only the receive-loop goroutine touches it.
 	queueSaturationAdvised bool
@@ -538,6 +550,7 @@ type Connection struct {
 	pendingAdmissions map[*subscriptionAdmission]struct{}
 	mu                sync.RWMutex
 	initialized       bool
+	recoveryRunning   bool
 	cancel            context.CancelFunc
 	responseMu        sync.Mutex
 	hydrationMu       sync.Mutex
@@ -1243,8 +1256,8 @@ func concurrentDispatchMethod(method string) bool {
 // concerns: a ping request is answered inline through the shared
 // handleAndEnqueue barrier, bypassing the request queue — one ping
 // implementation, one panic barrier, no hand-built response beside the real
-// path that could drift from it — and every other frame is enqueued for the
-// serial worker. False means the connection died while blocked on a full
+// path that could drift from it. Initialized force-stop requests have one
+// independent recovery slot; every other frame is enqueued for the serial worker. False means the connection died while blocked on a full
 // queue and the loop should return. A second transport inherits the whole
 // policy by driving this same entry point.
 //
@@ -1253,8 +1266,35 @@ func concurrentDispatchMethod(method string) bool {
 // cascade cancels the connection: ping liveness is guaranteed against
 // handler behavior, not against a peer that stopped draining its own socket.
 func (c *Connection) receiveInbound(ctx context.Context, msg appwire.Message) bool {
+	if msg.Request != nil && c.server.cfg.RequestAdmissionContext != nil {
+		admitted, ok := c.admitRequestContext(ctx, msg)
+		if !ok {
+			c.enqueueDispatched(ctx, appwire.ErrorMessage(msg.Request.ID, appwire.InternalError("internal error admitting request")))
+			return true
+		}
+		ctx = admitted
+	}
 	if msg.Request != nil && msg.Request.Method == appwire.MethodPing {
 		c.handleAndEnqueue(ctx, msg)
+		return true
+	}
+	if msg.Request != nil && msg.Request.Method == appwire.MethodEvenerThreadForceStop && c.isInitialized() {
+		c.mu.Lock()
+		busy := c.recoveryRunning
+		if !busy {
+			c.recoveryRunning = true
+		}
+		c.mu.Unlock()
+		if busy {
+			c.enqueueDispatched(ctx, appwire.ErrorMessage(msg.Request.ID, appwire.Unavailable("force stop is already running")))
+			return true
+		}
+		// Recovery must reach ownership cancellation even when the serial worker
+		// is awaiting an unresponsive daemon. Other mutations retain FIFO order.
+		go func() {
+			defer func() { c.mu.Lock(); c.recoveryRunning = false; c.mu.Unlock() }()
+			c.handleAndEnqueue(ctx, msg)
+		}()
 		return true
 	}
 	return c.enqueueRequest(ctx, msg)
@@ -1271,8 +1311,9 @@ func (c *Connection) receiveInbound(ctx context.Context, msg appwire.Message) bo
 // exactly the ordering it asked for, applied at the transport instead of in
 // server memory.
 func (c *Connection) enqueueRequest(ctx context.Context, msg appwire.Message) bool {
+	request := admittedRequest{ctx: ctx, message: msg}
 	select {
-	case c.requests <- msg:
+	case c.requests <- request:
 		return true
 	default:
 	}
@@ -1289,7 +1330,7 @@ func (c *Connection) enqueueRequest(ctx context.Context, msg appwire.Message) bo
 		c.server.blockedEnqueue()
 	}
 	select {
-	case c.requests <- msg:
+	case c.requests <- request:
 		return true
 	case <-ctx.Done():
 		return false
@@ -1323,7 +1364,8 @@ func (c *Connection) runWorker(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case msg := <-c.requests:
+		case request := <-c.requests:
+			msg := request.message
 			if c.server.afterWorkerDequeue != nil {
 				c.server.afterWorkerDequeue(msg)
 			}
@@ -1334,7 +1376,7 @@ func (c *Connection) runWorker(ctx context.Context) {
 			if ctx.Err() != nil {
 				return
 			}
-			c.executeOrdered(ctx, msg)
+			c.executeOrdered(request.ctx, msg)
 		}
 	}
 }
@@ -1361,7 +1403,8 @@ func (c *Connection) purgeRequestQueue() {
 drain:
 	for {
 		select {
-		case msg := <-c.requests:
+		case request := <-c.requests:
+			msg := request.message
 			discarded++
 			// Tally only cataloged names verbatim: the method field is
 			// client-controlled and the transport read limit admits very
@@ -1634,4 +1677,15 @@ func (c *Connection) enqueueDispatched(ctx context.Context, resp appwire.Message
 	if err := c.enqueueResponse(ctx, resp); err != nil {
 		c.cancelContext()
 	}
+}
+
+func (c *Connection) admitRequestContext(ctx context.Context, msg appwire.Message) (admitted context.Context, ok bool) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			c.server.panicLogf("appserver: panic admitting %s: %v\n%s", methodOf(msg), recovered, debug.Stack())
+			admitted, ok = nil, false
+		}
+	}()
+	admitted = c.server.cfg.RequestAdmissionContext(ctx, msg)
+	return admitted, admitted != nil
 }

--- a/internal/appserver/websocket.go
+++ b/internal/appserver/websocket.go
@@ -125,6 +125,10 @@ func (s *Server) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 	defer s.endWebSocket()
 
+	parent := r.Context()
+	if s.cfg.ConnectionAdmissionContext != nil {
+		parent = s.cfg.ConnectionAdmissionContext(parent)
+	}
 	ws, err := websocket.Accept(w, r, nil)
 	if err != nil {
 		return
@@ -142,7 +146,7 @@ func (s *Server) ServeWebSocket(w http.ResponseWriter, r *http.Request) {
 	if s.wrapWebSocketTransport != nil {
 		transport = s.wrapWebSocketTransport(transport)
 	}
-	ctx, cancel := context.WithCancel(r.Context())
+	ctx, cancel := context.WithCancel(parent)
 	conn := s.NewConnection(connectionID)
 	conn.setCancel(cancel)
 	s.registerConnection(conn)

--- a/internal/appserver/websocket_recovery_test.go
+++ b/internal/appserver/websocket_recovery_test.go
@@ -1,0 +1,41 @@
+package appserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+)
+
+func TestServeWebSocketRecoveryBypassesSerialWorkerAndRefusesOverlap(t *testing.T) {
+	server, httpServer, serialStarted, releaseSerial := dispatchSlowSerialServer(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	defer close(release)
+	HandleTyped(server.Router(), appwire.MethodEvenerThreadForceStop, func(ctx context.Context, _ appwire.ThreadForceStopParams) (appwire.EmptyResponse, error) {
+		close(started)
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		return appwire.EmptyResponse{}, nil
+	})
+	client := dialAppWireClient(t, httpServer)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	go func() { _, _ = client.ThreadList(ctx, appwire.ThreadListParams{}) }()
+	waitFor(t, "serial handler", serialStarted)
+	first := make(chan error, 1)
+	go func() {
+		first <- client.Request(ctx, appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: "local:owner"}, nil)
+	}()
+	waitFor(t, "recovery handler", started)
+	if err := client.Request(ctx, appwire.MethodEvenerThreadForceStop, appwire.ThreadForceStopParams{Ref: "local:owner"}, nil); err == nil || ctx.Err() != nil {
+		t.Fatalf("overlapping recovery error=%v context=%v", err, ctx.Err())
+	}
+	if err := client.Request(ctx, appwire.MethodPing, appwire.EmptyParams{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	releaseSerial()
+}


### PR DESCRIPTION
A local daemon that cannot complete AppWire initialization can still reserve its session, leaving normal shutdown unavailable. Add a confirmed **Force stop** action that verifies the exact daemon, requests termination, and confirms exit. The dialog warns that active turns and jobs may be interrupted; saved transcripts remain intact.

Linux uses pidfds and Darwin uses process-generation audit tokens. Both verify user, command, start time, and API-log inode/lock evidence before signaling. Ambiguous ownership and unsupported verification fail closed. Stable/current aliases stay reserved against resume and deletion until exit confirmation ends.

Recovery uses one short-lived connection so a saturated primary queue cannot block it. Connection and request generations prevent old queued actions from restarting the session. Explicit Resume refreshes the primary connection and submits once without replaying pending requests. A successful signal retains the explicit-resume requirement even when exit confirmation fails; the RPC still reports that failure.

Recovery obligations are persisted as atomic alias-group snapshots before signaling or reporting an already-exited stop successful. Startup restores them before admission. Only successful explicit Resume can clear them, and a failed clear reports an error while retaining recovery state. Disk I/O is separated from request admission locking. Descendants retain independent identities, but journal-verified ancestry blocks fresh actions while an owner’s exit is unconfirmed. Confirmed exit is persisted separately from explicit Resume, so this restriction survives hub recreation and releases only after confirmation or successful owner recovery.

Validation at `534cd8b1e`: `make merge-approval-gate` passed (lint, build, all Go modules, and frontend). The repaired concurrent-alias fixture passed ten runs under race; expanded recovery tests cover failed signaling, unconfirmed exit, late descendants, hub recreation, and confirmation-write failures. All five browser guards passed on the unchanged frontend runtime. All checks in GitHub CI run34298741948 passed on this head. Local explicit branch review222 and hosted member6653 found no issues. Combined review6654’s sole Darwin UID-offset finding was disproved against Apple’s SDK layout, a compiled live-kernel probe, and native race tests; it is documented and closed ([evidence](https://github.com/prime-radiant-inc/evener/pull/977#issuecomment-5594587243)). No actionable findings remain.

Based on main after #936 merged. No old-protocol compatibility or automatic restart is added.

Limits: snapshot version3 includes current-session identity and verified exit confirmation; unsupported older authority prevents startup, with no compatibility migration. Unresolved process ownership or genuinely competing identities still refuse Resume. Durable recovery authority applies to the same HubStateRoot and its single-hub lock. Interrupted termination conservatively retains an explicit-Resume requirement; unreadable recovery authority prevents startup. Changing/removing that root or running an older binary that ignores it is outside this guarantee. Linux conservatively refuses rendezvous timestamps inside the process start tick. Darwin combines kernel descriptor evidence with Evener's close-on-release API-log lifecycle; it does not claim protection against deliberate same-user process impersonation.

Closes #934.

The PR contains two logical commits: backend behavior and regression tests, followed by frontend behavior and regression tests.
