### PR TITLE
Personal AGENTS.md: loaded into every session, editable in settings

### DIFF
--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -1765,6 +1765,8 @@ func (runtime delegateRuntime) restoreIdle(started delegateStartCommit) (*subage
 		LLMSleep:                s.cfg.LLMSleep,
 		clock:                   s.clock,
 		testOnly:                s.cfg.testOnly,
+		// The personal doc belongs to whoever runs the tree now, not to the run that froze this delegate.
+		AgentsDocPath:           s.cfg.AgentsDocPath,
 		TurnEndsProcess:         s.cfg.TurnEndsProcess,
 		ForceRealIO:             s.cfg.ForceRealIO,
 		artifactStore:           s.artifactStore,

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -20,6 +20,7 @@ type ProjectDoc struct {
 const (
 	projectDocByteBudget = 32 * 1024
 	projectDocTruncMark  = "[Project instructions truncated at 32KB]"
+	userDocTruncMark     = "[Personal instructions truncated at 32KB]"
 )
 
 // UserDocFile is the personal instructions file evener loads from the user
@@ -34,23 +35,22 @@ func LoadProjectDocs(env execenv.ExecutionEnvironment, filenames ...string) ([]P
 }
 
 // LoadInstructionDocs is a session's whole instruction set: the personal doc
-// at userDocPath first, then the repo's project docs, sharing one byte
-// budget. The personal doc is loaded first because it is the user's own
-// standing instructions for every session; the repo docs get whatever budget
-// remains, truncated exactly as LoadProjectDocs truncates them.
+// at userDocPath first, then the repo's project docs. The two byte budgets are
+// separate, each the size of projectDocByteBudget, so a long personal doc can
+// never silence a repo's instructions and a long repo doc can never silence
+// the user's own; each side truncates with its own marker.
 func LoadInstructionDocs(env execenv.ExecutionEnvironment, userDocPath string, filenames ...string) ([]ProjectDoc, bool) {
 	out := []ProjectDoc{}
-	used := 0
+	userTruncated := false
 	if user, ok := LoadUserDoc(userDocPath); ok {
 		if len(user.Content) > projectDocByteBudget {
-			user.Content = truncateDoc(user.Content, projectDocByteBudget)
-			return append(out, user), true
+			user.Content = truncateDoc(user.Content, projectDocByteBudget, userDocTruncMark)
+			userTruncated = true
 		}
-		used = len(user.Content)
 		out = append(out, user)
 	}
-	project, truncated := loadProjectDocs(env, used, filenames...)
-	return append(out, project...), truncated
+	project, truncated := loadProjectDocs(env, 0, filenames...)
+	return append(out, project...), truncated || userTruncated
 }
 
 // LoadUserDoc reads the personal instructions file at path. ok is false when
@@ -83,15 +83,16 @@ func tildeCollapse(path string) string {
 	return "~/" + filepath.ToSlash(rel)
 }
 
-// truncateDoc cuts content to remain bytes and appends the truncation marker.
-func truncateDoc(content string, remain int) string {
+// truncateDoc cuts content to remain bytes and appends mark, the truncation
+// marker naming the kind of doc that was cut.
+func truncateDoc(content string, remain int, mark string) string {
 	if remain < len(content) {
 		content = content[:remain]
 	}
 	if !strings.HasSuffix(content, "\n") {
 		content += "\n"
 	}
-	return content + projectDocTruncMark + "\n"
+	return content + mark + "\n"
 }
 
 // loadProjectDocs is LoadProjectDocs with `used` bytes of the budget already
@@ -140,7 +141,7 @@ func loadProjectDocs(env execenv.ExecutionEnvironment, used int, filenames ...st
 
 			content := string(b)
 			if used+len(content) > projectDocByteBudget {
-				out = append(out, ProjectDoc{Path: key, Content: truncateDoc(content, projectDocByteBudget-used)})
+				out = append(out, ProjectDoc{Path: key, Content: truncateDoc(content, projectDocByteBudget-used, projectDocTruncMark)})
 				return out, true
 			}
 			used += len(content)

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -39,7 +39,10 @@ const UserDocFile = "AGENTS.md"
 // an absolute path, and LoadUserDoc already reports an empty path as an absent
 // doc.
 func personalDocPath(configured string) string {
-	path := configured
+	// Trimmed to match RestoreSessionFromMetaWithConfig, which trims the
+	// override it stores, and LoadUserDoc, which trims the path it reads: a
+	// hub's concrete root with stray whitespace still names the same file.
+	path := strings.TrimSpace(configured)
 	if path == "" {
 		path = userdirs.Subdir(userdirs.DefaultConfigRoot(), UserDocFile)
 	}

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -31,7 +31,58 @@ const UserDocFile = "AGENTS.md"
 // in a git repo) down to the current working directory. Files are loaded in depth order (root first; deeper
 // files have higher precedence) and filtered by the active provider profile (caller-provided list).
 func LoadProjectDocs(env execenv.ExecutionEnvironment, filenames ...string) ([]ProjectDoc, bool) {
-	return loadProjectDocs(env, 0, filenames...)
+	if env == nil {
+		return nil, false
+	}
+
+	cwd := strings.TrimSpace(env.WorkingDirectory())
+	if cwd == "" {
+		return nil, false
+	}
+	// Resolve symlinks so cwd and git root use consistent paths (macOS /var -> /private/var).
+	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
+		cwd = resolved
+	}
+
+	root := cwd
+	if gr := execenv.GitRootOrEmpty(env, cwd); gr != "" {
+		root = gr
+	}
+
+	dirs := execenv.DirsFromRootToCwd(root, cwd)
+	used := 0
+	out := []ProjectDoc{}
+	for _, dir := range dirs {
+		relDir := "."
+		if r, err := filepath.Rel(root, dir); err == nil {
+			relDir = r
+		}
+		for _, name := range filenames {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			b, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+
+			key := name
+			if relDir != "." && relDir != "" {
+				key = filepath.Join(relDir, name)
+			}
+
+			content := string(b)
+			if used+len(content) > projectDocByteBudget {
+				out = append(out, ProjectDoc{Path: key, Content: truncateDoc(content, projectDocByteBudget-used, projectDocTruncMark)})
+				return out, true
+			}
+			used += len(content)
+			out = append(out, ProjectDoc{Path: key, Content: content})
+		}
+	}
+	return out, false
 }
 
 // LoadInstructionDocs is a session's whole instruction set: the personal doc
@@ -49,7 +100,7 @@ func LoadInstructionDocs(env execenv.ExecutionEnvironment, userDocPath string, f
 		}
 		out = append(out, user)
 	}
-	project, truncated := loadProjectDocs(env, 0, filenames...)
+	project, truncated := LoadProjectDocs(env, filenames...)
 	return append(out, project...), truncated || userTruncated
 }
 
@@ -93,60 +144,4 @@ func truncateDoc(content string, remain int, mark string) string {
 		content += "\n"
 	}
 	return content + mark + "\n"
-}
-
-// loadProjectDocs is LoadProjectDocs with `used` bytes of the budget already
-// spent by a doc loaded before the repo's own.
-func loadProjectDocs(env execenv.ExecutionEnvironment, used int, filenames ...string) ([]ProjectDoc, bool) {
-	if env == nil {
-		return nil, false
-	}
-
-	cwd := strings.TrimSpace(env.WorkingDirectory())
-	if cwd == "" {
-		return nil, false
-	}
-	// Resolve symlinks so cwd and git root use consistent paths (macOS /var -> /private/var).
-	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
-		cwd = resolved
-	}
-
-	root := cwd
-	if gr := execenv.GitRootOrEmpty(env, cwd); gr != "" {
-		root = gr
-	}
-
-	dirs := execenv.DirsFromRootToCwd(root, cwd)
-	out := []ProjectDoc{}
-	for _, dir := range dirs {
-		relDir := "."
-		if r, err := filepath.Rel(root, dir); err == nil {
-			relDir = r
-		}
-		for _, name := range filenames {
-			name = strings.TrimSpace(name)
-			if name == "" {
-				continue
-			}
-			path := filepath.Join(dir, name)
-			b, err := os.ReadFile(path)
-			if err != nil {
-				continue
-			}
-
-			key := name
-			if relDir != "." && relDir != "" {
-				key = filepath.Join(relDir, name)
-			}
-
-			content := string(b)
-			if used+len(content) > projectDocByteBudget {
-				out = append(out, ProjectDoc{Path: key, Content: truncateDoc(content, projectDocByteBudget-used, projectDocTruncMark)})
-				return out, true
-			}
-			used += len(content)
-			out = append(out, ProjectDoc{Path: key, Content: content})
-		}
-	}
-	return out, false
 }

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -34,14 +34,14 @@ func LoadProjectDocs(env execenv.ExecutionEnvironment, filenames ...string) ([]P
 }
 
 // LoadInstructionDocs is a session's whole instruction set: the personal doc
-// under configRoot first, then the repo's project docs, sharing one byte
+// at userDocPath first, then the repo's project docs, sharing one byte
 // budget. The personal doc is loaded first because it is the user's own
 // standing instructions for every session; the repo docs get whatever budget
 // remains, truncated exactly as LoadProjectDocs truncates them.
-func LoadInstructionDocs(env execenv.ExecutionEnvironment, configRoot string, filenames ...string) ([]ProjectDoc, bool) {
+func LoadInstructionDocs(env execenv.ExecutionEnvironment, userDocPath string, filenames ...string) ([]ProjectDoc, bool) {
 	out := []ProjectDoc{}
 	used := 0
-	if user, ok := LoadUserDoc(configRoot); ok {
+	if user, ok := LoadUserDoc(userDocPath); ok {
 		if len(user.Content) > projectDocByteBudget {
 			user.Content = truncateDoc(user.Content, projectDocByteBudget)
 			return append(out, user), true
@@ -53,17 +53,16 @@ func LoadInstructionDocs(env execenv.ExecutionEnvironment, configRoot string, fi
 	return append(out, project...), truncated
 }
 
-// LoadUserDoc reads <configRoot>/AGENTS.md. ok is false when the config root
-// is empty or the file is missing or blank. Path is the display path the
-// prompt labels the block with: the home directory collapsed to "~", so the
-// model sees "~/.config/evener/AGENTS.md" rather than a machine-specific
+// LoadUserDoc reads the personal instructions file at path. ok is false when
+// the path is empty or the file is missing or blank. Path is the display path
+// the prompt labels the block with: the home directory collapsed to "~", so
+// the model sees "~/.config/evener/AGENTS.md" rather than a machine-specific
 // absolute path.
-func LoadUserDoc(configRoot string) (ProjectDoc, bool) {
-	configRoot = strings.TrimSpace(configRoot)
-	if configRoot == "" {
+func LoadUserDoc(path string) (ProjectDoc, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
 		return ProjectDoc{}, false
 	}
-	path := filepath.Join(configRoot, UserDocFile)
 	b, err := os.ReadFile(path)
 	if err != nil || strings.TrimSpace(string(b)) == "" {
 		return ProjectDoc{}, false

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/envvars/userdirs"
 )
 
 // ProjectDoc holds a single loaded project instruction file: its identifier path and raw content.
@@ -26,6 +27,19 @@ const (
 // UserDocFile is the personal instructions file evener loads from the user
 // config root ahead of every repo's own project docs.
 const UserDocFile = "AGENTS.md"
+
+// personalDocPath is the personal instructions file a session reads: the path
+// its launcher configured, or the default under the user config root. A root
+// that cannot be resolved stays empty rather than joining into the relative
+// "AGENTS.md" — a daemon would otherwise read whatever file happens to sit in
+// its working directory as the user's own instructions, and LoadUserDoc
+// already reports an empty path as an absent doc.
+func personalDocPath(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	return userdirs.Subdir(userdirs.DefaultConfigRoot(), UserDocFile)
+}
 
 // LoadProjectDocs discovers and loads project instruction files from git root (or working directory when not
 // in a git repo) down to the current working directory. Files are loaded in depth order (root first; deeper

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -21,10 +21,82 @@ const (
 	projectDocTruncMark  = "[Project instructions truncated at 32KB]"
 )
 
+// UserDocFile is the personal instructions file evener loads from the user
+// config root ahead of every repo's own project docs.
+const UserDocFile = "AGENTS.md"
+
 // LoadProjectDocs discovers and loads project instruction files from git root (or working directory when not
 // in a git repo) down to the current working directory. Files are loaded in depth order (root first; deeper
 // files have higher precedence) and filtered by the active provider profile (caller-provided list).
 func LoadProjectDocs(env execenv.ExecutionEnvironment, filenames ...string) ([]ProjectDoc, bool) {
+	return loadProjectDocs(env, 0, filenames...)
+}
+
+// LoadInstructionDocs is a session's whole instruction set: the personal doc
+// under configRoot first, then the repo's project docs, sharing one byte
+// budget. The personal doc is loaded first because it is the user's own
+// standing instructions for every session; the repo docs get whatever budget
+// remains, truncated exactly as LoadProjectDocs truncates them.
+func LoadInstructionDocs(env execenv.ExecutionEnvironment, configRoot string, filenames ...string) ([]ProjectDoc, bool) {
+	out := []ProjectDoc{}
+	used := 0
+	if user, ok := LoadUserDoc(configRoot); ok {
+		if len(user.Content) > projectDocByteBudget {
+			user.Content = truncateDoc(user.Content, projectDocByteBudget)
+			return append(out, user), true
+		}
+		used = len(user.Content)
+		out = append(out, user)
+	}
+	project, truncated := loadProjectDocs(env, used, filenames...)
+	return append(out, project...), truncated
+}
+
+// LoadUserDoc reads <configRoot>/AGENTS.md. ok is false when the config root
+// is empty or the file is missing or blank. Path is the display path the
+// prompt labels the block with: the home directory collapsed to "~", so the
+// model sees "~/.config/evener/AGENTS.md" rather than a machine-specific
+// absolute path.
+func LoadUserDoc(configRoot string) (ProjectDoc, bool) {
+	configRoot = strings.TrimSpace(configRoot)
+	if configRoot == "" {
+		return ProjectDoc{}, false
+	}
+	path := filepath.Join(configRoot, UserDocFile)
+	b, err := os.ReadFile(path)
+	if err != nil || strings.TrimSpace(string(b)) == "" {
+		return ProjectDoc{}, false
+	}
+	return ProjectDoc{Path: tildeCollapse(path), Content: string(b)}, true
+}
+
+// tildeCollapse rewrites a path under the home directory as "~/...".
+func tildeCollapse(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	rel, err := filepath.Rel(home, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return "~/" + filepath.ToSlash(rel)
+}
+
+// truncateDoc cuts content to remain bytes and appends the truncation marker.
+func truncateDoc(content string, remain int) string {
+	if remain < len(content) {
+		content = content[:remain]
+	}
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	return content + projectDocTruncMark + "\n"
+}
+
+// loadProjectDocs is LoadProjectDocs with `used` bytes of the budget already
+// spent by a doc loaded before the repo's own.
+func loadProjectDocs(env execenv.ExecutionEnvironment, used int, filenames ...string) ([]ProjectDoc, bool) {
 	if env == nil {
 		return nil, false
 	}
@@ -45,7 +117,6 @@ func LoadProjectDocs(env execenv.ExecutionEnvironment, filenames ...string) ([]P
 
 	dirs := execenv.DirsFromRootToCwd(root, cwd)
 	out := []ProjectDoc{}
-	used := 0
 	for _, dir := range dirs {
 		relDir := "."
 		if r, err := filepath.Rel(root, dir); err == nil {
@@ -69,15 +140,7 @@ func LoadProjectDocs(env execenv.ExecutionEnvironment, filenames ...string) ([]P
 
 			content := string(b)
 			if used+len(content) > projectDocByteBudget {
-				remain := projectDocByteBudget - used
-				if remain < len(content) {
-					content = content[:remain]
-				}
-				if !strings.HasSuffix(content, "\n") {
-					content += "\n"
-				}
-				content += projectDocTruncMark + "\n"
-				out = append(out, ProjectDoc{Path: key, Content: content})
+				out = append(out, ProjectDoc{Path: key, Content: truncateDoc(content, projectDocByteBudget-used)})
 				return out, true
 			}
 			used += len(content)
@@ -86,6 +149,3 @@ func LoadProjectDocs(env execenv.ExecutionEnvironment, filenames ...string) ([]P
 	}
 	return out, false
 }
-
-// (gitRootOrEmpty and dirsFromRootToCwd moved to agent/execenv as
-// GitRootOrEmpty / DirsFromRootToCwd — see agent/execenv/gitpath.go.)

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -29,16 +29,23 @@ const (
 const UserDocFile = "AGENTS.md"
 
 // personalDocPath is the personal instructions file a session reads: the path
-// its launcher configured, or the default under the user config root. A root
-// that cannot be resolved stays empty rather than joining into the relative
-// "AGENTS.md" — a daemon would otherwise read whatever file happens to sit in
-// its working directory as the user's own instructions, and LoadUserDoc
-// already reports an empty path as an absent doc.
+// its launcher configured, or the default under the user config root. A
+// relative path is never trusted, whichever way it was named. A daemon would
+// resolve it against its own working directory and read whatever file the
+// repository put there as the user's standing instructions, so a root that
+// cannot be resolved (empty), a relative root (XDG_CONFIG_HOME=conf), and an
+// operator's `--agents-doc ./x` are all refused alike. The hub only ever hands
+// an absolute path, and LoadUserDoc already reports an empty path as an absent
+// doc.
 func personalDocPath(configured string) string {
-	if configured != "" {
-		return configured
+	path := configured
+	if path == "" {
+		path = userdirs.Subdir(userdirs.DefaultConfigRoot(), UserDocFile)
 	}
-	return userdirs.Subdir(userdirs.DefaultConfigRoot(), UserDocFile)
+	if !filepath.IsAbs(path) {
+		return ""
+	}
+	return path
 }
 
 // LoadProjectDocs discovers and loads project instruction files from git root (or working directory when not

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -11,6 +11,7 @@ import (
 // ProjectDoc holds a single loaded project instruction file: its identifier path and raw content.
 type ProjectDoc struct {
 	// Path is a stable, human-friendly identifier for the instruction file (relative to git root when available).
+	// The personal doc is the exception: a display path outside the repo, with the home directory collapsed to "~".
 	Path string
 	// Content is the raw file content (may be truncated when total budget is exceeded).
 	Content string

--- a/agent/project_docs.go
+++ b/agent/project_docs.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/envvars/userdirs"
@@ -159,6 +160,11 @@ func tildeCollapse(path string) string {
 // marker naming the kind of doc that was cut.
 func truncateDoc(content string, remain int, mark string) string {
 	if remain < len(content) {
+		// The budget is bytes but the prompt must stay valid UTF-8, so the cut
+		// lands on the last whole rune that fits.
+		for remain > 0 && !utf8.RuneStart(content[remain]) {
+			remain--
+		}
 		content = content[:remain]
 	}
 	if !strings.HasSuffix(content, "\n") {

--- a/agent/project_docs_test.go
+++ b/agent/project_docs_test.go
@@ -359,6 +359,44 @@ func TestPersonalDocPath_RefusesARelativeConfiguredPath(t *testing.T) {
 	}
 }
 
+// A hub hands over its own concrete config root, and stray whitespace around
+// it must not switch the personal doc off: RestoreSessionFromMetaWithConfig
+// trims the override it stores and LoadUserDoc trims the path it reads, so
+// the resolver trims too.
+func TestPersonalDocPath_TrimsSurroundingWhitespace(t *testing.T) {
+	t.Parallel()
+	if got := personalDocPath("  /hub/AGENTS.md  "); got != "/hub/AGENTS.md" {
+		t.Fatalf("personalDocPath = %q, want the trimmed absolute path", got)
+	}
+}
+
+// The default newSession fixture must read no ambient personal doc: with no
+// explicit cfg it points AgentsDocPath at an isolated path that does not
+// exist, so a <config root>/AGENTS.md in the test environment can never leak
+// into the session's cached instruction docs.
+func TestNewSession_DefaultIsolatesThePersonalDoc(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	if err := os.MkdirAll(filepath.Join(configHome, "evener"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configHome, "evener", UserDocFile), []byte("AMBIENT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sess := newSession(t)
+	if got := personalDocPath(sess.cfg.AgentsDocPath); got == "" {
+		t.Fatal("default AgentsDocPath resolves to no path, want an isolated path")
+	}
+	if _, ok := LoadUserDoc(personalDocPath(sess.cfg.AgentsDocPath)); ok {
+		t.Fatalf("default AgentsDocPath %q loads a personal doc, want an absent one", sess.cfg.AgentsDocPath)
+	}
+	for _, doc := range sess.projectDocs {
+		if doc.Content == "AMBIENT\n" {
+			t.Fatalf("cached project docs contain the ambient personal doc: %+v", sess.projectDocs)
+		}
+	}
+}
+
 // The budget is counted in bytes, so it can land inside a multi-byte rune: a
 // doc of two-byte runes cut at an odd byte would put half a rune into the
 // system prompt. The cut keeps whole runes and never invalid UTF-8.

--- a/agent/project_docs_test.go
+++ b/agent/project_docs_test.go
@@ -220,12 +220,12 @@ func TestLoadInstructionDocs_MissingPersonalDocChangesNothing(t *testing.T) {
 	}
 }
 
-func TestLoadInstructionDocs_PersonalDocCountsAgainstTheSharedBudget(t *testing.T) {
+func TestLoadInstructionDocs_PersonalDocHasItsOwnBudget(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	markGitRoot(t, root)
-	half := strings.Repeat("r", projectDocByteBudget/2+1024)
-	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(half), 0o644); err != nil {
+	repo := strings.Repeat("r", projectDocByteBudget/2+1024)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(repo), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	configRoot := t.TempDir()
@@ -236,20 +236,17 @@ func TestLoadInstructionDocs_PersonalDocCountsAgainstTheSharedBudget(t *testing.
 
 	env := execenv.NewLocalExecutionEnvironment(root)
 	docs, truncated := LoadInstructionDocs(env, filepath.Join(configRoot, "AGENTS.md"), "AGENTS.md")
-	if !truncated {
-		t.Fatal("expected the repo doc to be truncated")
+	if truncated {
+		t.Fatal("neither doc exceeds its own budget; expected no truncation")
 	}
 	if len(docs) != 2 {
 		t.Fatalf("docs: got %d want 2", len(docs))
 	}
 	if docs[0].Content != personal {
-		t.Fatal("the personal doc must land intact; it is loaded first")
+		t.Fatal("the personal doc must land intact")
 	}
-	if !strings.Contains(docs[1].Content, projectDocTruncMark) {
-		t.Fatalf("the repo doc must carry the truncation marker, got:\n%s", docs[1].Content[len(docs[1].Content)-80:])
-	}
-	if len(docs[0].Content)+len(docs[1].Content) > projectDocByteBudget+len(projectDocTruncMark)+2 {
-		t.Fatalf("the two docs exceed the shared budget: %d", len(docs[0].Content)+len(docs[1].Content))
+	if docs[1].Content != repo {
+		t.Fatal("the repo doc must land intact; the personal doc does not spend the repo's budget")
 	}
 }
 
@@ -267,10 +264,47 @@ func TestLoadInstructionDocs_OversizedPersonalDocIsTruncatedAlone(t *testing.T) 
 	}
 	env := execenv.NewLocalExecutionEnvironment(root)
 	docs, truncated := LoadInstructionDocs(env, filepath.Join(configRoot, "AGENTS.md"), "AGENTS.md")
-	if !truncated || len(docs) != 1 {
-		t.Fatalf("docs = %d truncated = %v; an oversized personal doc consumes the whole budget", len(docs), truncated)
+	if !truncated {
+		t.Fatal("expected the personal doc to be truncated")
 	}
-	if !strings.Contains(docs[0].Content, projectDocTruncMark) {
-		t.Fatal("expected the truncation marker on the personal doc")
+	if len(docs) != 2 {
+		t.Fatalf("docs: got %d want 2; the repo doc survives an oversized personal doc", len(docs))
+	}
+	if !strings.Contains(docs[0].Content, userDocTruncMark) {
+		t.Fatal("expected the personal truncation marker on the personal doc")
+	}
+	if len(docs[0].Content) > projectDocByteBudget+len(userDocTruncMark)+2 {
+		t.Fatalf("the personal doc exceeds its own budget: %d bytes", len(docs[0].Content))
+	}
+	if docs[1].Content != "ROOT\n" {
+		t.Fatalf("doc1 = %q, want the repo doc whole", docs[1].Content)
+	}
+}
+
+func TestLoadInstructionDocs_OversizedRepoDocLeavesThePersonalDocIntact(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	huge := strings.Repeat("r", projectDocByteBudget+4096)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(huge), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	configRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("PERSONAL\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, truncated := LoadInstructionDocs(env, filepath.Join(configRoot, "AGENTS.md"), "AGENTS.md")
+	if !truncated {
+		t.Fatal("expected the repo doc to be truncated")
+	}
+	if len(docs) != 2 {
+		t.Fatalf("docs: got %d want 2", len(docs))
+	}
+	if docs[0].Content != "PERSONAL\n" {
+		t.Fatalf("doc0 = %q, want the personal doc whole", docs[0].Content)
+	}
+	if !strings.Contains(docs[1].Content, projectDocTruncMark) {
+		t.Fatal("expected the project truncation marker on the repo doc")
 	}
 }

--- a/agent/project_docs_test.go
+++ b/agent/project_docs_test.go
@@ -336,3 +336,24 @@ func TestPersonalDocPath_DefaultsUnderTheConfigRoot(t *testing.T) {
 		t.Fatalf("personalDocPath = %q, want %q", got, want)
 	}
 }
+
+// A relative config root — XDG_CONFIG_HOME set to a relative value — derives a
+// relative personal-doc path, which a daemon would resolve against its own
+// working directory: the repository's conf/evener/AGENTS.md would become the
+// user's standing instructions.
+func TestPersonalDocPath_RefusesARelativeRoot(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "conf")
+	if got := personalDocPath(""); got != "" {
+		t.Fatalf("personalDocPath = %q, want no path when the config root is relative", got)
+	}
+}
+
+// The same rule holds for a path an operator named outright: `--agents-doc
+// ./AGENTS.md` resolves against the daemon's working directory exactly as a
+// derived relative path does, so it is refused for the same reason.
+func TestPersonalDocPath_RefusesARelativeConfiguredPath(t *testing.T) {
+	t.Parallel()
+	if got := personalDocPath("./AGENTS.md"); got != "" {
+		t.Fatalf("personalDocPath = %q, want no path when the configured path is relative", got)
+	}
+}

--- a/agent/project_docs_test.go
+++ b/agent/project_docs_test.go
@@ -308,3 +308,31 @@ func TestLoadInstructionDocs_OversizedRepoDocLeavesThePersonalDocIntact(t *testi
 		t.Fatal("expected the project truncation marker on the repo doc")
 	}
 }
+
+func TestPersonalDocPath_ConfiguredWins(t *testing.T) {
+	t.Parallel()
+	if got := personalDocPath("/hub/AGENTS.md"); got != "/hub/AGENTS.md" {
+		t.Fatalf("personalDocPath = %q, want the configured path untouched", got)
+	}
+}
+
+// A daemon whose config root cannot be resolved must read no personal doc at
+// all: joining an empty root would leave the relative "AGENTS.md", and the
+// daemon would take whatever file sits in its working directory as the user's
+// own instructions.
+func TestPersonalDocPath_EmptyRootIsEmpty(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	if got := personalDocPath(""); got != "" {
+		t.Fatalf("personalDocPath = %q, want no path when the config root is unresolvable", got)
+	}
+}
+
+func TestPersonalDocPath_DefaultsUnderTheConfigRoot(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	want := filepath.Join(configHome, "evener", UserDocFile)
+	if got := personalDocPath(""); got != want {
+		t.Fatalf("personalDocPath = %q, want %q", got, want)
+	}
+}

--- a/agent/project_docs_test.go
+++ b/agent/project_docs_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/envvars/userdirs"
@@ -355,5 +356,23 @@ func TestPersonalDocPath_RefusesARelativeConfiguredPath(t *testing.T) {
 	t.Parallel()
 	if got := personalDocPath("./AGENTS.md"); got != "" {
 		t.Fatalf("personalDocPath = %q, want no path when the configured path is relative", got)
+	}
+}
+
+// The budget is counted in bytes, so it can land inside a multi-byte rune: a
+// doc of two-byte runes cut at an odd byte would put half a rune into the
+// system prompt. The cut keeps whole runes and never invalid UTF-8.
+func TestTruncateDocKeepsRuneBoundaries(t *testing.T) {
+	t.Parallel()
+	content := strings.Repeat("é", 8)
+	for _, remain := range []int{7, 6} {
+		got := truncateDoc(content, remain, userDocTruncMark)
+		if !utf8.ValidString(got) {
+			t.Fatalf("truncateDoc(remain=%d) = %q, want valid UTF-8", remain, got)
+		}
+		want := content[:6] + "\n" + userDocTruncMark + "\n"
+		if got != want {
+			t.Fatalf("truncateDoc(remain=%d) = %q, want %q (three whole runes plus the marker)", remain, got, want)
+		}
 	}
 }

--- a/agent/project_docs_test.go
+++ b/agent/project_docs_test.go
@@ -94,3 +94,154 @@ func initGitRepo(t *testing.T, dir string) {
 	run("add", "README.md")
 	run("commit", "-m", "init")
 }
+
+func TestLoadUserDoc_ReadsTheConfigRootFile(t *testing.T) {
+	t.Parallel()
+	configRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("PERSONAL\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	doc, ok := LoadUserDoc(configRoot)
+	if !ok {
+		t.Fatal("expected the personal doc to load")
+	}
+	if doc.Path != filepath.Join(configRoot, "AGENTS.md") {
+		t.Fatalf("path: %q", doc.Path)
+	}
+	if doc.Content != "PERSONAL\n" {
+		t.Fatalf("content: %q", doc.Content)
+	}
+}
+
+func TestLoadUserDoc_MissingOrBlankFileIsAbsent(t *testing.T) {
+	t.Parallel()
+	if _, ok := LoadUserDoc(t.TempDir()); ok {
+		t.Fatal("a missing file must not load")
+	}
+	blank := t.TempDir()
+	if err := os.WriteFile(filepath.Join(blank, "AGENTS.md"), []byte("  \n\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, ok := LoadUserDoc(blank); ok {
+		t.Fatal("a blank file must not load")
+	}
+	if _, ok := LoadUserDoc(""); ok {
+		t.Fatal("an empty config root must not load")
+	}
+}
+
+func TestLoadUserDoc_CollapsesTheHomeDirectoryToTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configRoot := filepath.Join(home, ".config", "evener")
+	if err := os.MkdirAll(configRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	doc, ok := LoadUserDoc(configRoot)
+	if !ok {
+		t.Fatal("expected the personal doc to load")
+	}
+	if doc.Path != "~/.config/evener/AGENTS.md" {
+		t.Fatalf("path: %q, want the tilde-collapsed display path", doc.Path)
+	}
+}
+
+func TestLoadInstructionDocs_PersonalDocComesFirst(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("ROOT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	configRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("PERSONAL\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	if truncated {
+		t.Fatal("did not expect truncation")
+	}
+	if len(docs) != 2 {
+		t.Fatalf("docs: got %d want 2 (%v)", len(docs), docs)
+	}
+	if docs[0].Path != filepath.Join(configRoot, "AGENTS.md") || docs[0].Content != "PERSONAL\n" {
+		t.Fatalf("doc0 = %+v, want the personal doc first", docs[0])
+	}
+	if docs[1].Path != "AGENTS.md" || docs[1].Content != "ROOT\n" {
+		t.Fatalf("doc1 = %+v, want the repo doc second", docs[1])
+	}
+}
+
+func TestLoadInstructionDocs_MissingPersonalDocChangesNothing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("ROOT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, _ := LoadInstructionDocs(env, t.TempDir(), "AGENTS.md")
+	if len(docs) != 1 || docs[0].Path != "AGENTS.md" {
+		t.Fatalf("docs = %+v, want only the repo doc", docs)
+	}
+}
+
+func TestLoadInstructionDocs_PersonalDocCountsAgainstTheSharedBudget(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	half := strings.Repeat("r", projectDocByteBudget/2+1024)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(half), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	configRoot := t.TempDir()
+	personal := strings.Repeat("p", projectDocByteBudget/2)
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte(personal), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	if !truncated {
+		t.Fatal("expected the repo doc to be truncated")
+	}
+	if len(docs) != 2 {
+		t.Fatalf("docs: got %d want 2", len(docs))
+	}
+	if docs[0].Content != personal {
+		t.Fatal("the personal doc must land intact; it is loaded first")
+	}
+	if !strings.Contains(docs[1].Content, projectDocTruncMark) {
+		t.Fatalf("the repo doc must carry the truncation marker, got:\n%s", docs[1].Content[len(docs[1].Content)-80:])
+	}
+	if len(docs[0].Content)+len(docs[1].Content) > projectDocByteBudget+len(projectDocTruncMark)+2 {
+		t.Fatalf("the two docs exceed the shared budget: %d", len(docs[0].Content)+len(docs[1].Content))
+	}
+}
+
+func TestLoadInstructionDocs_OversizedPersonalDocIsTruncatedAlone(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("ROOT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	configRoot := t.TempDir()
+	huge := strings.Repeat("p", projectDocByteBudget+4096)
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte(huge), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	if !truncated || len(docs) != 1 {
+		t.Fatalf("docs = %d truncated = %v; an oversized personal doc consumes the whole budget", len(docs), truncated)
+	}
+	if !strings.Contains(docs[0].Content, projectDocTruncMark) {
+		t.Fatal("expected the truncation marker on the personal doc")
+	}
+}

--- a/agent/project_docs_test.go
+++ b/agent/project_docs_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/envvars/userdirs"
 )
 
 func TestLoadProjectDocs_WalksFromGitRootToWorkingDir_InDepthOrder(t *testing.T) {
@@ -101,7 +102,7 @@ func TestLoadUserDoc_ReadsTheConfigRootFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("PERSONAL\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	doc, ok := LoadUserDoc(configRoot)
+	doc, ok := LoadUserDoc(filepath.Join(configRoot, "AGENTS.md"))
 	if !ok {
 		t.Fatal("expected the personal doc to load")
 	}
@@ -115,18 +116,18 @@ func TestLoadUserDoc_ReadsTheConfigRootFile(t *testing.T) {
 
 func TestLoadUserDoc_MissingOrBlankFileIsAbsent(t *testing.T) {
 	t.Parallel()
-	if _, ok := LoadUserDoc(t.TempDir()); ok {
+	if _, ok := LoadUserDoc(filepath.Join(t.TempDir(), "AGENTS.md")); ok {
 		t.Fatal("a missing file must not load")
 	}
 	blank := t.TempDir()
 	if err := os.WriteFile(filepath.Join(blank, "AGENTS.md"), []byte("  \n\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if _, ok := LoadUserDoc(blank); ok {
+	if _, ok := LoadUserDoc(filepath.Join(blank, "AGENTS.md")); ok {
 		t.Fatal("a blank file must not load")
 	}
 	if _, ok := LoadUserDoc(""); ok {
-		t.Fatal("an empty config root must not load")
+		t.Fatal("an empty path must not load")
 	}
 }
 
@@ -140,12 +141,40 @@ func TestLoadUserDoc_CollapsesTheHomeDirectoryToTilde(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("x\n"), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	doc, ok := LoadUserDoc(configRoot)
+	doc, ok := LoadUserDoc(filepath.Join(configRoot, "AGENTS.md"))
 	if !ok {
 		t.Fatal("expected the personal doc to load")
 	}
 	if doc.Path != "~/.config/evener/AGENTS.md" {
 		t.Fatalf("path: %q, want the tilde-collapsed display path", doc.Path)
+	}
+}
+
+// The path the loader is handed is the file it reads, whatever the process
+// environment would resolve on its own: a hub whose launch config overrides
+// XDG_CONFIG_HOME per launch hands its own concrete path to the session, and
+// Settings and that session have to agree on the file.
+func TestLoadUserDoc_ReadsTheGivenPathNotTheEnvironment(t *testing.T) {
+	decoyConfigHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", decoyConfigHome)
+	decoyRoot := userdirs.DefaultConfigRoot()
+	if err := os.MkdirAll(decoyRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(decoyRoot, UserDocFile), []byte("DECOY\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	wanted := filepath.Join(t.TempDir(), UserDocFile)
+	if err := os.WriteFile(wanted, []byte("EXPLICIT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	doc, ok := LoadUserDoc(wanted)
+	if !ok {
+		t.Fatal("expected the explicitly named file to load")
+	}
+	if doc.Content != "EXPLICIT\n" {
+		t.Fatalf("content = %q, want the file at the given path", doc.Content)
 	}
 }
 
@@ -162,7 +191,7 @@ func TestLoadInstructionDocs_PersonalDocComesFirst(t *testing.T) {
 	}
 
 	env := execenv.NewLocalExecutionEnvironment(root)
-	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	docs, truncated := LoadInstructionDocs(env, filepath.Join(configRoot, "AGENTS.md"), "AGENTS.md")
 	if truncated {
 		t.Fatal("did not expect truncation")
 	}
@@ -185,7 +214,7 @@ func TestLoadInstructionDocs_MissingPersonalDocChangesNothing(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	env := execenv.NewLocalExecutionEnvironment(root)
-	docs, _ := LoadInstructionDocs(env, t.TempDir(), "AGENTS.md")
+	docs, _ := LoadInstructionDocs(env, filepath.Join(t.TempDir(), "AGENTS.md"), "AGENTS.md")
 	if len(docs) != 1 || docs[0].Path != "AGENTS.md" {
 		t.Fatalf("docs = %+v, want only the repo doc", docs)
 	}
@@ -206,7 +235,7 @@ func TestLoadInstructionDocs_PersonalDocCountsAgainstTheSharedBudget(t *testing.
 	}
 
 	env := execenv.NewLocalExecutionEnvironment(root)
-	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	docs, truncated := LoadInstructionDocs(env, filepath.Join(configRoot, "AGENTS.md"), "AGENTS.md")
 	if !truncated {
 		t.Fatal("expected the repo doc to be truncated")
 	}
@@ -237,7 +266,7 @@ func TestLoadInstructionDocs_OversizedPersonalDocIsTruncatedAlone(t *testing.T) 
 		t.Fatalf("WriteFile: %v", err)
 	}
 	env := execenv.NewLocalExecutionEnvironment(root)
-	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	docs, truncated := LoadInstructionDocs(env, filepath.Join(configRoot, "AGENTS.md"), "AGENTS.md")
 	if !truncated || len(docs) != 1 {
 		t.Fatalf("docs = %d truncated = %v; an oversized personal doc consumes the whole budget", len(docs), truncated)
 	}

--- a/agent/schema/config_snapshot.go
+++ b/agent/schema/config_snapshot.go
@@ -29,6 +29,7 @@ type ConfigSnapshot struct {
 	SystemPromptFile            string                     `json:"system_prompt_file,omitempty"`            // replacement base instruction prelude
 	SystemPromptAppend          []string                   `json:"system_prompt_append,omitempty"`          // file paths appended to the system prompt
 	NoProjectPrompts            bool                       `json:"no_project_prompts,omitempty"`            // suppress loading .evener/prompts/
+	AgentsDocPath               string                     `json:"agents_doc_path,omitempty"`               // personal AGENTS.md loaded ahead of project docs; empty resolves the process environment's config root
 	NonInteractive              bool                       `json:"non_interactive,omitempty"`               // no human available for questions/confirmation
 	TurnEndsProcess             bool                       `json:"turn_ends_process,omitempty"`             // the process exits with the turn (one-shot run), so nothing reports later
 	ContextStrategy             string                     `json:"context_strategy,omitempty"`              // context-management strategy

--- a/agent/session_config.go
+++ b/agent/session_config.go
@@ -122,6 +122,13 @@ type SessionConfig struct {
 	// Useful for A/B testing to match Docker container behavior (no project prompts).
 	NoProjectPrompts bool `json:"no_project_prompts,omitempty"`
 
+	// AgentsDocPath is the personal AGENTS.md loaded ahead of the project's own
+	// instruction docs. Empty resolves <userdirs.DefaultConfigRoot()>/AGENTS.md
+	// from the process environment; a hub passes its own concrete path so
+	// Settings and the sessions it spawns agree on the file even when a launch
+	// overrides XDG_CONFIG_HOME.
+	AgentsDocPath string `json:"agents_doc_path,omitempty"`
+
 	// NonInteractive indicates no human is available for questions or confirmation.
 	// The task prompt is the complete specification; the agent must make all decisions
 	// autonomously. Appends guidance to the system prompt adapting skill behavior.
@@ -752,6 +759,7 @@ func (c SessionConfig) toSnapshot() schema.ConfigSnapshot {
 		SystemPromptFile:            c.SystemPromptFile,
 		SystemPromptAppend:          c.SystemPromptAppend,
 		NoProjectPrompts:            c.NoProjectPrompts,
+		AgentsDocPath:               c.AgentsDocPath,
 		NonInteractive:              c.NonInteractive,
 		TurnEndsProcess:             c.TurnEndsProcess,
 		ContextStrategy:             c.ContextStrategy,
@@ -794,6 +802,7 @@ func configFromSnapshot(s schema.ConfigSnapshot) SessionConfig {
 		SystemPromptFile:            s.SystemPromptFile,
 		SystemPromptAppend:          s.SystemPromptAppend,
 		NoProjectPrompts:            s.NoProjectPrompts,
+		AgentsDocPath:               s.AgentsDocPath,
 		NonInteractive:              s.NonInteractive,
 		TurnEndsProcess:             s.TurnEndsProcess,
 		ContextStrategy:             s.ContextStrategy,

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -616,6 +616,15 @@ type RestoreSessionConfig struct {
 	// from the parent's own toSnapshot), which is a different question.
 	TurnEndsProcess bool
 
+	// AgentsDocPath carries through to the restored Session's SessionConfig,
+	// REPLACING the persisted value rather than merging with it, exactly like
+	// TurnEndsProcess above. Which personal AGENTS.md a session reads belongs
+	// to whoever is restoring it — a hub hands over its own concrete config
+	// root, the same one Settings edits — not to the session on disk, whose
+	// snapshot predates the flag or names a root the hub has since left. Empty
+	// keeps the persisted path.
+	AgentsDocPath string
+
 	// ForceRealIO carries through to the restored Session's SessionConfig.
 	// See SessionConfig.ForceRealIO's own comment (session_config.go) - the
 	// same exported escape valve for a black-box/live test in another
@@ -714,6 +723,9 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	}
 	if _, err := ParseProviderIdleTimeout(cfg.ProviderIdleTimeout); err != nil {
 		return nil, err
+	}
+	if v := strings.TrimSpace(restoreCfg.AgentsDocPath); v != "" {
+		cfg.AgentsDocPath = v
 	}
 	if strings.TrimSpace(restoreCfg.OpenAIResponsesContinuation) != "" {
 		cfg.OpenAIResponsesContinuation = strings.TrimSpace(restoreCfg.OpenAIResponsesContinuation)

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1439,8 +1439,12 @@ func (s *Session) initSessionState(sessionStartKind plugin.SessionStartKind, run
 		s.reg.RestrictKeepingResultTool(ceiling, s.resultToolName())
 	}
 
+	agentsDocPath := s.cfg.AgentsDocPath
+	if agentsDocPath == "" {
+		agentsDocPath = filepath.Join(userdirs.DefaultConfigRoot(), UserDocFile)
+	}
 	// Cache instruction docs once; reused every round for system prompt rebuilds.
-	s.projectDocs, s.projectDocsTruncated = LoadInstructionDocs(s.currentEnv(), userdirs.DefaultConfigRoot(), s.profile.ProjectDocFiles()...)
+	s.projectDocs, s.projectDocsTruncated = LoadInstructionDocs(s.currentEnv(), agentsDocPath, s.profile.ProjectDocFiles()...)
 
 	// Cache tool definitions and the rendered prompt. A render failure here is a
 	// construction-time diagnostic, so it BUFFERS rather than emitting: nothing

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -622,7 +622,12 @@ type RestoreSessionConfig struct {
 	// to whoever is restoring it — a hub hands over its own concrete config
 	// root, the same one Settings edits — not to the session on disk, whose
 	// snapshot predates the flag or names a root the hub has since left. Empty
-	// keeps the persisted path.
+	// is the restorer's own answer as much as a path is, and means the one thing
+	// it means everywhere: no personal doc resolves in this environment. A hub
+	// whose config root is unresolvable and a plain `evener serve --resume` both
+	// read the file their own environment names and never one a departed hub
+	// persisted. The persisted field exists so a CHILD built from its parent's
+	// snapshot inherits the parent's answer; it does not outlive the run.
 	AgentsDocPath string
 
 	// ForceRealIO carries through to the restored Session's SessionConfig.
@@ -724,9 +729,7 @@ func RestoreSessionFromMetaWithConfig(client *llm.Client, profile *provider.Prof
 	if _, err := ParseProviderIdleTimeout(cfg.ProviderIdleTimeout); err != nil {
 		return nil, err
 	}
-	if v := strings.TrimSpace(restoreCfg.AgentsDocPath); v != "" {
-		cfg.AgentsDocPath = v
-	}
+	cfg.AgentsDocPath = strings.TrimSpace(restoreCfg.AgentsDocPath)
 	if strings.TrimSpace(restoreCfg.OpenAIResponsesContinuation) != "" {
 		cfg.OpenAIResponsesContinuation = strings.TrimSpace(restoreCfg.OpenAIResponsesContinuation)
 	}

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1440,7 +1440,7 @@ func (s *Session) initSessionState(sessionStartKind plugin.SessionStartKind, run
 	}
 
 	// Cache project docs once; reused every round for system prompt rebuilds.
-	s.projectDocs, s.projectDocsTruncated = LoadProjectDocs(s.currentEnv(), s.profile.ProjectDocFiles()...)
+	s.projectDocs, s.projectDocsTruncated = LoadInstructionDocs(s.currentEnv(), userdirs.DefaultConfigRoot(), s.profile.ProjectDocFiles()...)
 
 	// Cache tool definitions and the rendered prompt. A render failure here is a
 	// construction-time diagnostic, so it BUFFERS rather than emitting: nothing

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1451,12 +1451,8 @@ func (s *Session) initSessionState(sessionStartKind plugin.SessionStartKind, run
 		s.reg.RestrictKeepingResultTool(ceiling, s.resultToolName())
 	}
 
-	agentsDocPath := s.cfg.AgentsDocPath
-	if agentsDocPath == "" {
-		agentsDocPath = filepath.Join(userdirs.DefaultConfigRoot(), UserDocFile)
-	}
 	// Cache instruction docs once; reused every round for system prompt rebuilds.
-	s.projectDocs, s.projectDocsTruncated = LoadInstructionDocs(s.currentEnv(), agentsDocPath, s.profile.ProjectDocFiles()...)
+	s.projectDocs, s.projectDocsTruncated = LoadInstructionDocs(s.currentEnv(), personalDocPath(s.cfg.AgentsDocPath), s.profile.ProjectDocFiles()...)
 
 	// Cache tool definitions and the rendered prompt. A render failure here is a
 	// construction-time diagnostic, so it BUFFERS rather than emitting: nothing

--- a/agent/session_init.go
+++ b/agent/session_init.go
@@ -1439,7 +1439,7 @@ func (s *Session) initSessionState(sessionStartKind plugin.SessionStartKind, run
 		s.reg.RestrictKeepingResultTool(ceiling, s.resultToolName())
 	}
 
-	// Cache project docs once; reused every round for system prompt rebuilds.
+	// Cache instruction docs once; reused every round for system prompt rebuilds.
 	s.projectDocs, s.projectDocsTruncated = LoadInstructionDocs(s.currentEnv(), userdirs.DefaultConfigRoot(), s.profile.ProjectDocFiles()...)
 
 	// Cache tool definitions and the rendered prompt. A render failure here is a

--- a/agent/session_perf_test.go
+++ b/agent/session_perf_test.go
@@ -698,6 +698,8 @@ func TestSession_ProjectDocsLoadedOnceAtInit(t *testing.T) {
 
 	sess, err := NewSession(c, withTestSessionNamer(c, NewOpenAIProfile("gpt-5.2")), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
 		MaxToolRoundsPerInput: 200,
+		// The count below is of repo docs only, so the personal doc is pointed at nothing regardless of the environment.
+		AgentsDocPath: filepath.Join(dir, "no-personal-AGENTS.md"),
 	})
 	if err != nil {
 		t.Fatalf("NewSession: %v", err)

--- a/agent/session_perf_test.go
+++ b/agent/session_perf_test.go
@@ -705,8 +705,8 @@ func TestSession_ProjectDocsLoadedOnceAtInit(t *testing.T) {
 	defer sess.Close()
 
 	// Session should have cached project docs.
-	if sess.projectDocs == nil {
-		t.Fatal("expected projectDocs to be cached after NewSession")
+	if len(sess.projectDocs) != 1 {
+		t.Fatalf("projectDocs = %d, want the one doc written into the working directory: %+v", len(sess.projectDocs), sess.projectDocs)
 	}
 }
 
@@ -754,6 +754,60 @@ func TestSession_CachedProjectDocsUsedInSystemPrompt(t *testing.T) {
 	sys := reqs[0].Messages[0].Text()
 	if !strings.Contains(sys, "cached-doc-content") {
 		t.Fatalf("system prompt should contain cached project doc content, got: %s", sys[:min(200, len(sys))])
+	}
+}
+
+func TestSession_PersonalDocUsedInSystemPrompt(t *testing.T) {
+	// t.Setenv rules out t.Parallel, and the config root has to be a temp dir so
+	// the run never picks up the developer's own personal doc.
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	configRoot := filepath.Join(configHome, "evener")
+	if err := os.MkdirAll(configRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configRoot, UserDocFile), []byte("personal-doc-content"), 0o644); err != nil {
+		t.Fatalf("write personal %s: %v", UserDocFile, err)
+	}
+
+	// The working directory holds no instruction file at all: the personal doc
+	// reaches the prompt only through the session's config-root wiring.
+	dir := t.TempDir()
+
+	c := llm.NewClient()
+	adapter := &snapshotFakeAdapter{name: "openai"}
+	c.Register(adapter)
+
+	sess, err := NewSession(c, withTestSessionNamer(c, NewOpenAIProfile("gpt-5.2")), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{
+		MaxToolRoundsPerInput: 200,
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	go func() {
+		for range sess.Events() {
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TRIPWIRE: scripted in-process adapter, no real I/O; only fires on a genuine hang.
+	defer cancel()
+
+	if _, err := sess.ProcessInput(ctx, "hello", nil); err != nil {
+		t.Fatalf("ProcessInput: %v", err)
+	}
+	sess.Close()
+
+	reqs := adapter.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("expected at least 1 LLM request")
+	}
+	// System prompt is the first message (role=system).
+	if len(reqs[0].Messages) == 0 {
+		t.Fatal("expected at least 1 message in request")
+	}
+	sys := reqs[0].Messages[0].Text()
+	if !strings.Contains(sys, "personal-doc-content") {
+		t.Fatalf("system prompt should contain the personal doc content, got: %s", sys[:min(200, len(sys))])
 	}
 }
 

--- a/agent/session_restore_agents_doc_test.go
+++ b/agent/session_restore_agents_doc_test.go
@@ -14,14 +14,16 @@ import (
 // it: a hub passes its own concrete config root on resume exactly as it does
 // on spawn, while the snapshot carries whatever was true when the session was
 // created — nothing at all for a pre-feature session, a stale root for one
-// whose hub moved. An empty override leaves the persisted path alone, so a
-// plain `evener serve --resume` still reads the file it always did.
+// whose hub moved. An empty override is the restorer's own answer too, not a
+// request to keep the snapshot's: a hub with no resolvable config root reads no
+// personal doc on resume, matching what Settings reports and what its fresh
+// sessions do, and never a path a departed hub left behind.
 func TestRestoreSessionAppliesTheAgentsDocOverride(t *testing.T) {
 	c := llm.NewClient()
 	c.Register(&fakeAdapter{name: "openai"})
 	persisted := SessionConfig{AgentsDocPath: "/old/AGENTS.md"}.toSnapshot()
 	for _, tc := range []struct{ override, want string }{
-		{override: "", want: "/old/AGENTS.md"},
+		{override: "", want: ""},
 		{override: "/new/AGENTS.md", want: "/new/AGENTS.md"},
 	} {
 		meta := schema.SessionMeta{ID: "agents-doc-resume", ProfileID: "openai", Model: "gpt-5.2", Config: persisted}

--- a/agent/session_restore_agents_doc_test.go
+++ b/agent/session_restore_agents_doc_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/llm"
+)
+
+// The personal AGENTS.md a resumed session reads belongs to whoever restores
+// it: a hub passes its own concrete config root on resume exactly as it does
+// on spawn, while the snapshot carries whatever was true when the session was
+// created — nothing at all for a pre-feature session, a stale root for one
+// whose hub moved. An empty override leaves the persisted path alone, so a
+// plain `evener serve --resume` still reads the file it always did.
+func TestRestoreSessionAppliesTheAgentsDocOverride(t *testing.T) {
+	c := llm.NewClient()
+	c.Register(&fakeAdapter{name: "openai"})
+	persisted := SessionConfig{AgentsDocPath: "/old/AGENTS.md"}.toSnapshot()
+	for _, tc := range []struct{ override, want string }{
+		{override: "", want: "/old/AGENTS.md"},
+		{override: "/new/AGENTS.md", want: "/new/AGENTS.md"},
+	} {
+		meta := schema.SessionMeta{ID: "agents-doc-resume", ProfileID: "openai", Model: "gpt-5.2", Config: persisted}
+		restored, err := RestoreSessionFromMetaWithConfig(c, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(t.TempDir()), meta, RestoreSessionConfig{AgentsDocPath: tc.override, testOnly: testConfig{skipGitSnapshot: true, minimalSystemPrompt: true, noSyncJobStore: true}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := restored.cfg.AgentsDocPath; got != tc.want {
+			t.Errorf("restored AgentsDocPath for override %q = %q, want %q", tc.override, got, tc.want)
+		}
+		restored.Close()
+	}
+}

--- a/agent/session_restore_agents_doc_test.go
+++ b/agent/session_restore_agents_doc_test.go
@@ -33,3 +33,15 @@ func TestRestoreSessionAppliesTheAgentsDocOverride(t *testing.T) {
 		restored.Close()
 	}
 }
+
+// A stable delegate restarted from its frozen descriptor reads the personal
+// doc of whoever is running the tree now, not the one named when it was
+// frozen: after a resume through a hub whose config root moved, a root session
+// and its delegates would otherwise load different personal instructions.
+func TestFrozenDescriptorTakesTheAgentsDocPathFromTheLiveParent(t *testing.T) {
+	frozen := SessionConfig{AgentsDocPath: "/old/AGENTS.md", NoProjectPrompts: true}.toSnapshot()
+	got := subagentConfigFromFrozenDescriptor(frozen, SessionConfig{AgentsDocPath: "/hub/AGENTS.md"})
+	if got.AgentsDocPath != "/hub/AGENTS.md" {
+		t.Fatalf("frozen-descriptor AgentsDocPath = %q, want the live parent's %q (frozen was %q)", got.AgentsDocPath, "/hub/AGENTS.md", "/old/AGENTS.md")
+	}
+}

--- a/agent/session_restore_agents_doc_test.go
+++ b/agent/session_restore_agents_doc_test.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"errors"
 	"testing"
 
 	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/internal/delegatestore"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/llm"
 )
@@ -43,5 +45,43 @@ func TestFrozenDescriptorTakesTheAgentsDocPathFromTheLiveParent(t *testing.T) {
 	got := subagentConfigFromFrozenDescriptor(frozen, SessionConfig{AgentsDocPath: "/hub/AGENTS.md"})
 	if got.AgentsDocPath != "/hub/AGENTS.md" {
 		t.Fatalf("frozen-descriptor AgentsDocPath = %q, want the live parent's %q (frozen was %q)", got.AgentsDocPath, "/hub/AGENTS.md", "/old/AGENTS.md")
+	}
+}
+
+// The third path into a child's config, and the one the two rules above do not
+// cover: a stable delegate restarted from its committed descriptor, whose
+// snapshot names the path that was true when the delegate was frozen. A hub
+// whose config root moved between runs would otherwise leave a resumed root
+// session and the delegates it restores on different personal instructions.
+func TestRestoredStableDelegateTakesTheAgentsDocPathFromTheLiveParent(t *testing.T) {
+	fixture := newColdStableDelegateFixtureConfigured(t, "", func(descriptor *delegatestore.Descriptor) {
+		descriptor.Config.AgentsDocPath = "/old/AGENTS.md"
+	})
+	root, err := restoreDelegateResourceBootstrapSession(fixture.client, fixture.profile, fixture.workspace, fixture.meta, fixture.stateDir)
+	if err != nil {
+		t.Fatalf("restore root: %v", err)
+	}
+	defer root.Close()
+	root.cfg.AgentsDocPath = "/hub/AGENTS.md"
+
+	reservation, err := root.delegateController.ReserveStart(rootDelegateActor(root.id), fixture.delegateID)
+	if err != nil {
+		t.Fatalf("ReserveStart: %v", err)
+	}
+	started, err := root.delegateController.CommitStart(reservation)
+	if err != nil {
+		t.Fatalf("CommitStart: %v", err)
+	}
+	defer func() {
+		_, _ = root.delegateController.FailCommittedRestart(started.lease, delegatePermanentStartFailure(errors.New("test complete"), "construction_failed"))
+	}()
+
+	sub, _, err := (delegateRuntime{owner: root}).restoreIdle(started)
+	if err != nil {
+		t.Fatalf("restoreIdle: %v", err)
+	}
+	defer sub.sess.discardRestoredCandidate()
+	if got := sub.sess.cfg.AgentsDocPath; got != "/hub/AGENTS.md" {
+		t.Fatalf("restored delegate AgentsDocPath = %q, want the live parent's %q (the descriptor froze %q)", got, "/hub/AGENTS.md", "/old/AGENTS.md")
 	}
 }

--- a/agent/subagents.go
+++ b/agent/subagents.go
@@ -774,6 +774,9 @@ func subagentConfigFromFrozenDescriptor(frozenConfig schema.ConfigSnapshot, pare
 	subCfg.ExportATIFPath = parentCfg.ExportATIFPath
 	subCfg.ExportATIFProviderHandles = parentCfg.ExportATIFProviderHandles
 	subCfg.ResolveProfile = parentCfg.ResolveProfile
+	// The personal doc belongs to whoever is running the tree now — the hub's
+	// root — so a delegate reads the same file its live parent does.
+	subCfg.AgentsDocPath = parentCfg.AgentsDocPath
 	subCfg.testOnly = parentCfg.testOnly
 	subCfg.TurnEndsProcess = parentCfg.TurnEndsProcess
 	subCfg.ForceRealIO = parentCfg.ForceRealIO

--- a/agent/testkit_test.go
+++ b/agent/testkit_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 	"maps"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -106,6 +107,13 @@ func newSession(t *testing.T, opts ...sessionOpt) *Session {
 	cfg := o.cfg
 	if !o.cfgSet {
 		cfg = SessionConfig{MaxSubagentDepth: 1}
+		// No ambient personal doc: the default fixture points AgentsDocPath
+		// at an isolated path that does not exist, so a <config
+		// root>/AGENTS.md in the test environment can never leak into the
+		// session's cached instruction docs. LoadUserDoc treats a missing
+		// file as absent, so the path itself never needs creating. An
+		// explicit cfg is the caller's own answer and is left untouched.
+		cfg.AgentsDocPath = filepath.Join(t.TempDir(), "no-personal-AGENTS.md")
 	}
 	if o.skipGitSnapshot {
 		cfg.testOnly.skipGitSnapshot = true

--- a/appwire/agents_doc.go
+++ b/appwire/agents_doc.go
@@ -1,0 +1,26 @@
+package appwire
+
+// The personal AGENTS.md: a plain file at <config root>/AGENTS.md that every
+// session loads ahead of the repo's own project docs
+// (agent.LoadInstructionDocs). The hub reads and rewrites it whole; there is
+// deliberately no revision or precondition (spec 2026-09-07 §1): the file is
+// also hand-edited in editors, and the last write wins.
+const (
+	MethodEvenerSettingsAgentsDocGet     = "evener/settings/agentsDoc/get"
+	MethodEvenerSettingsAgentsDocSet     = "evener/settings/agentsDoc/set"
+	NotifyEvenerSettingsAgentsDocChanged = "evener/settings/agentsDoc/changed"
+)
+
+// AgentsDocResponse is the file as the hub sees it: the get result, the set
+// result, and the changed broadcast all carry this shape. A missing file is
+// Exists=false with empty Content, never an error.
+type AgentsDocResponse struct {
+	Path    string `json:"path"`
+	Exists  bool   `json:"exists"`
+	Content string `json:"content"`
+}
+
+// AgentsDocSetParams replaces the whole file with Content, byte for byte.
+type AgentsDocSetParams struct {
+	Content string `json:"content"`
+}

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -200,6 +200,8 @@ var Methods = []MethodSpec{
 	{MethodEvenerSettingsTranscriptDisplayPatch, TranscriptDisplayDefaultsPatchParams{}, TranscriptDisplayPatchResponse{}, ScopeHub, "Updates one transcript-display default using an expected revision and returns the canonical value."},
 	{MethodEvenerSettingsKeybindingsGet, EmptyParams{}, KeybindingsOverrides{}, ScopeHub, "Reads the canonical user keybinding overrides (version, revision, rules)."},
 	{MethodEvenerSettingsKeybindingsPatch, KeybindingsPatchParams{}, KeybindingsOverrides{}, ScopeHub, "Replaces the user keybinding overrides using an expected revision and returns the canonical value."},
+	{MethodEvenerSettingsAgentsDocGet, EmptyParams{}, AgentsDocResponse{}, ScopeHub, "Reads the personal AGENTS.md under the user config root: its path, whether it exists, and its content."},
+	{MethodEvenerSettingsAgentsDocSet, AgentsDocSetParams{}, AgentsDocResponse{}, ScopeHub, "Replaces the personal AGENTS.md whole (no precondition); broadcasts evener/settings/agentsDoc/changed."},
 	{MethodEvenerSandboxEscalationResolve, SandboxEscalationResolveParams{}, EmptyResponse{}, ScopeBoth, "Delivers a human's approve/deny decision for a pending sandbox-exemption escalation (M7); the daemon unblocks the waiting tool-exec goroutine, the hub relays."},
 }
 
@@ -293,4 +295,5 @@ var Notifications = []NotificationSpec{
 	{NotifyEvenerSandboxEscalationResolved, SandboxEscalationResolved{}, "A previously-raised sandbox escalation left the pending set — resolved, turn-interrupted, or cleared by session close (M7); every OTHER subscribed client clears its now-stale copy of the card."},
 	{NotifyEvenerSettingsTranscriptDisplayChanged, TranscriptDisplayChangedParams{}, "Broadcast after a transcript-display default changes; carries the layout, revision, and canonical configuration."},
 	{NotifyEvenerSettingsKeybindingsChanged, KeybindingsOverrides{}, "Broadcast after the user keybinding overrides change; carries the revision and canonical rules."},
+	{NotifyEvenerSettingsAgentsDocChanged, AgentsDocResponse{}, "Broadcast after the personal AGENTS.md is written; carries the new path, existence, and content."},
 }

--- a/appwire/protocol_test.go
+++ b/appwire/protocol_test.go
@@ -278,6 +278,44 @@ func TestKeybindingsCatalog(t *testing.T) {
 	}
 }
 
+func TestAgentsDocCatalog(t *testing.T) {
+	methods := map[string]MethodSpec{}
+	for _, method := range Methods {
+		methods[method.Name] = method
+	}
+	for _, name := range []string{
+		MethodEvenerSettingsAgentsDocGet,
+		MethodEvenerSettingsAgentsDocSet,
+	} {
+		method, ok := methods[name]
+		if !ok {
+			t.Fatalf("method catalog missing %s", name)
+		}
+		if method.Scope != ScopeHub {
+			t.Errorf("method %s scope = %q, want %q", name, method.Scope, ScopeHub)
+		}
+		if reflect.TypeOf(method.Result) != reflect.TypeFor[AgentsDocResponse]() {
+			t.Errorf("method %s result type = %T, want %T", name, method.Result, AgentsDocResponse{})
+		}
+	}
+	if reflect.TypeOf(methods[MethodEvenerSettingsAgentsDocSet].Params) != reflect.TypeFor[AgentsDocSetParams]() {
+		t.Errorf("set params type = %T, want %T", methods[MethodEvenerSettingsAgentsDocSet].Params, AgentsDocSetParams{})
+	}
+	var changed *NotificationSpec
+	for i := range Notifications {
+		if Notifications[i].Name == NotifyEvenerSettingsAgentsDocChanged {
+			changed = &Notifications[i]
+			break
+		}
+	}
+	if changed == nil {
+		t.Fatalf("notification catalog missing %s", NotifyEvenerSettingsAgentsDocChanged)
+	}
+	if reflect.TypeOf(changed.Payload) != reflect.TypeFor[AgentsDocResponse]() {
+		t.Fatalf("changed payload type = %T, want %T", changed.Payload, AgentsDocResponse{})
+	}
+}
+
 func TestFeatureSetKeybindingsJSONField(t *testing.T) {
 	encoded, err := json.Marshal(FeatureSet{})
 	if err != nil {
@@ -455,6 +493,7 @@ func TestThreadNotificationsRequireAuthoritativeRoutingIdentity(t *testing.T) {
 		NotifyEvenerNavigationInvalidated:            true,
 		NotifyEvenerSettingsTranscriptDisplayChanged: true,
 		NotifyEvenerSettingsKeybindingsChanged:       true,
+		NotifyEvenerSettingsAgentsDocChanged:         true,
 	}
 	for _, notification := range Notifications {
 		if global[notification.Name] {

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -342,7 +342,7 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 	registerPluginAutoUpgradeHandlers(server, plugins.NewManager(cfg.PluginRoot))
 	registerTranscriptDisplayHandlers(server, cfg.TranscriptDisplayStore)
 	registerKeybindingsHandlers(server, cfg.KeybindingsStore)
-	registerAgentsDocHandlers(server, hubLaunchConfigRoot(cfg))
+	registerAgentsDocHandlers(server, hubAgentsDocPath(cfg))
 	return server
 }
 

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -342,6 +342,7 @@ func newHubAppServerWithNavigationAndTrace(cfg hubcore.WebConfig, sources *appso
 	registerPluginAutoUpgradeHandlers(server, plugins.NewManager(cfg.PluginRoot))
 	registerTranscriptDisplayHandlers(server, cfg.TranscriptDisplayStore)
 	registerKeybindingsHandlers(server, cfg.KeybindingsStore)
+	registerAgentsDocHandlers(server, hubLaunchConfigRoot(cfg))
 	return server
 }
 

--- a/cmd/evener-hub/app_rpc_agents_doc.go
+++ b/cmd/evener-hub/app_rpc_agents_doc.go
@@ -40,7 +40,11 @@ func readAgentsDoc(path string) (appwire.AgentsDocResponse, error) {
 // (Jesse's ruling, 2026-09-07; providers.toml follows in its own PR).
 // Content is written byte for byte: this is the user's own prose, and
 // trimming or appending a newline would make the editor disagree with the
-// file it just saved.
+// file it just saved. The temp file is created exclusively, under a name
+// nothing else holds, and chmodded outright: a stale temp file - a symlink
+// into someone else's file, or a leftover whose own mode a plain write would
+// have kept - then has no say in where the save goes or what it lands as,
+// and neither does the umask the hub happens to run under.
 func writeAgentsDoc(path, content string) error {
 	// EvalSymlinks fails on a file that is not there yet, leaving target at
 	// path: a first save creates the file where the config root says it is.
@@ -48,29 +52,53 @@ func writeAgentsDoc(path, content string) error {
 	if resolved, err := filepath.EvalSymlinks(path); err == nil {
 		target = resolved
 	}
-	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("AGENTS.md: mkdir: %w", err)
 	}
-	tmp := target + ".tmp"
-	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
-		// A write that dies partway (ENOSPC, EIO) has already created the
-		// temp file, so clear it too: the real file is untouched either way,
-		// and a half-written AGENTS.md.tmp has no business outliving the
-		// failure in the user's config root.
-		_ = os.Remove(tmp)
+	tmp, err := os.CreateTemp(dir, ".AGENTS.md-*.tmp")
+	if err != nil {
 		return fmt.Errorf("AGENTS.md: write: %w", err)
 	}
-	if err := os.Rename(tmp, target); err != nil {
-		_ = os.Remove(tmp)
+	// A save that dies partway (ENOSPC, EIO) has already created the temp
+	// file, so clear it too: the real file is untouched either way, and a
+	// half-written temp file has no business outliving the failure in the
+	// user's config root. The rename takes the name with it, so this is a
+	// no-op once the save has landed.
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := writeTempAgentsDoc(tmp, content); err != nil {
+		return fmt.Errorf("AGENTS.md: write: %w", err)
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
 		return fmt.Errorf("AGENTS.md: rename: %w", err)
 	}
 	return nil
 }
 
+// writeTempAgentsDoc lands the content in the open temp file and closes it,
+// whichever step fails.
+func writeTempAgentsDoc(tmp *os.File, content string) (err error) {
+	defer func() {
+		if closeErr := tmp.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+	if err := tmp.Chmod(0o644); err != nil {
+		return err
+	}
+	if _, err := tmp.WriteString(content); err != nil {
+		return err
+	}
+	return tmp.Sync()
+}
+
 // registerAgentsDocHandlers serves evener/settings/agentsDoc/{get,set}. Writes
-// serialize on one mutex so two clients saving at once cannot interleave on
-// the shared temp path; there is no revision check by design (spec
-// 2026-09-07 §1) - the last write wins, and every client hears about it.
+// serialize on one mutex so a save's rename, read back and broadcast land as
+// one unit: two clients saving at once could otherwise rename in one order
+// and broadcast in the other, leaving every client on content the file does
+// not hold. There is no revision check by design (spec 2026-09-07 §1) - the
+// last write wins, and every client hears about it.
 func registerAgentsDocHandlers(server *appserver.Server, configRoot string) {
 	path := agentsDocPath(configRoot)
 	var mu sync.Mutex

--- a/cmd/evener-hub/app_rpc_agents_doc.go
+++ b/cmd/evener-hub/app_rpc_agents_doc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -75,11 +76,19 @@ func readAgentsDoc(path string) (appwire.AgentsDocResponse, error) {
 // have kept - then has no say in where the save goes or what it lands as,
 // and neither does the umask the hub happens to run under.
 func writeAgentsDoc(path, content string) error {
-	// EvalSymlinks fails on a file that is not there yet, leaving target at
-	// path: a first save creates the file where the config root says it is.
+	// Only a path with nothing at the end of it - no file yet, or a link whose
+	// target is gone - falls back to path itself, so a first save creates the
+	// file where the config root says it is and a broken link is replaced. A
+	// link that is there but unresolvable (a loop, a directory along the way the
+	// hub cannot search) is a real target the save cannot reach: renaming over
+	// it would sever the dotfiles link this writer follows in order to keep.
 	target := path
-	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+	resolved, err := filepath.EvalSymlinks(path)
+	switch {
+	case err == nil:
 		target = resolved
+	case !errors.Is(err, fs.ErrNotExist):
+		return fmt.Errorf("AGENTS.md: resolve: %w", err)
 	}
 	dir := filepath.Dir(target)
 	if err := os.MkdirAll(dir, 0o700); err != nil {

--- a/cmd/evener-hub/app_rpc_agents_doc.go
+++ b/cmd/evener-hub/app_rpc_agents_doc.go
@@ -44,6 +44,11 @@ func writeAgentsDoc(path, content string) error {
 	}
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		// A write that dies partway (ENOSPC, EIO) has already created the
+		// temp file, so clear it too: the real file is untouched either way,
+		// and a half-written AGENTS.md.tmp has no business outliving the
+		// failure in the user's config root.
+		_ = os.Remove(tmp)
 		return fmt.Errorf("AGENTS.md: write: %w", err)
 	}
 	if err := os.Rename(tmp, path); err != nil {
@@ -75,7 +80,13 @@ func registerAgentsDocHandlers(server *appserver.Server, configRoot string) {
 			}
 			resp, err := readAgentsDoc(path)
 			if err != nil {
-				return appwire.AgentsDocResponse{}, err
+				// The rename landed, so the save APPLIED. Surfacing the
+				// re-read failure would tell the requester its write was
+				// rejected and leave every other client on the old content,
+				// so describe what was just put on disk instead - the write
+				// is byte for byte, so this is the file (same reasoning as
+				// the post-rename path in registerKeybindingsHandlers).
+				resp = appwire.AgentsDocResponse{Path: path, Exists: true, Content: params.Content}
 			}
 			server.BroadcastAll(appwire.NotifyEvenerSettingsAgentsDocChanged, resp)
 			return resp, nil

--- a/cmd/evener-hub/app_rpc_agents_doc.go
+++ b/cmd/evener-hub/app_rpc_agents_doc.go
@@ -85,7 +85,10 @@ func registerAgentsDocHandlers(server *appserver.Server, configRoot string) {
 				// rejected and leave every other client on the old content,
 				// so describe what was just put on disk instead - the write
 				// is byte for byte, so this is the file (same reasoning as
-				// the post-rename path in registerKeybindingsHandlers).
+				// the post-rename path in registerKeybindingsHandlers). The
+				// response says nothing went wrong, so the log is the only
+				// place the failure is visible at all.
+				server.Logf("AGENTS.md read back after write failed: %v", err)
 				resp = appwire.AgentsDocResponse{Path: path, Exists: true, Content: params.Content}
 			}
 			server.BroadcastAll(appwire.NotifyEvenerSettingsAgentsDocChanged, resp)

--- a/cmd/evener-hub/app_rpc_agents_doc.go
+++ b/cmd/evener-hub/app_rpc_agents_doc.go
@@ -35,14 +35,23 @@ func readAgentsDoc(path string) (appwire.AgentsDocResponse, error) {
 
 // writeAgentsDoc replaces the file atomically (temp + rename, mode 0644,
 // parent created), the same way registry.WriteConfigFile lands
-// providers.toml beside it. Content is written byte for byte: this is the
-// user's own prose, and trimming or appending a newline would make the
-// editor disagree with the file it just saved.
+// providers.toml beside it, except that this writer follows a symlinked
+// AGENTS.md first so a dotfiles-managed copy keeps being the source of truth
+// (Jesse's ruling, 2026-09-07; providers.toml follows in its own PR).
+// Content is written byte for byte: this is the user's own prose, and
+// trimming or appending a newline would make the editor disagree with the
+// file it just saved.
 func writeAgentsDoc(path, content string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	// EvalSymlinks fails on a file that is not there yet, leaving target at
+	// path: a first save creates the file where the config root says it is.
+	target := path
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		target = resolved
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
 		return fmt.Errorf("AGENTS.md: mkdir: %w", err)
 	}
-	tmp := path + ".tmp"
+	tmp := target + ".tmp"
 	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
 		// A write that dies partway (ENOSPC, EIO) has already created the
 		// temp file, so clear it too: the real file is untouched either way,
@@ -51,7 +60,7 @@ func writeAgentsDoc(path, content string) error {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("AGENTS.md: write: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := os.Rename(tmp, target); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("AGENTS.md: rename: %w", err)
 	}

--- a/cmd/evener-hub/app_rpc_agents_doc.go
+++ b/cmd/evener-hub/app_rpc_agents_doc.go
@@ -10,6 +10,8 @@ import (
 
 	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/envvars/userdirs"
 	"primeradiant.com/evener/internal/appserver"
 )
 
@@ -18,6 +20,33 @@ import (
 func agentsDocPath(configRoot string) string {
 	return filepath.Join(configRoot, agent.UserDocFile)
 }
+
+// hubAgentsDocPath is the personal AGENTS.md this hub edits and hands to the
+// sessions it spawns, or "" when there is none to point at. The root has to be
+// absolute: a relative one - what cmdutil.DefaultConfigRoot() substitutes when
+// neither XDG_CONFIG_HOME nor a home directory resolves - would resolve against
+// whatever directory the process happens to sit in, and a repository's own
+// .config/evener/AGENTS.md must never become the user's standing instructions.
+// An empty result means "no personal doc": the spawn and resume builders then
+// omit --agents-doc and the settings handlers refuse, which is the rule
+// agent.personalDocPath already applies on the daemon side.
+func hubAgentsDocPath(cfg hubcore.WebConfig) string {
+	root := cfg.LaunchConfigRoot
+	if root == "" {
+		// userdirs, not cmdutil: this one reports an unresolvable root as
+		// empty instead of substituting a relative path.
+		root = userdirs.DefaultConfigRoot()
+	}
+	if root == "" || !filepath.IsAbs(root) {
+		return ""
+	}
+	return agentsDocPath(root)
+}
+
+// errNoAgentsDocPath is what the settings handlers answer when no user config
+// root resolves. Reading or writing a relative AGENTS.md instead would put the
+// process working directory in charge of the user's personal instructions.
+var errNoAgentsDocPath = errors.New("personal AGENTS.md is unavailable: no user config root could be resolved")
 
 // readAgentsDoc reports the file as it is on disk. A missing file is the
 // empty document, not an error: the settings section shows an empty editor
@@ -98,18 +127,24 @@ func writeTempAgentsDoc(tmp *os.File, content string) (err error) {
 // one unit: two clients saving at once could otherwise rename in one order
 // and broadcast in the other, leaving every client on content the file does
 // not hold. There is no revision check by design (spec 2026-09-07 §1) - the
-// last write wins, and every client hears about it.
-func registerAgentsDocHandlers(server *appserver.Server, configRoot string) {
-	path := agentsDocPath(configRoot)
+// last write wins, and every client hears about it. An empty path is a hub
+// with no user config root to edit under, and both methods refuse.
+func registerAgentsDocHandlers(server *appserver.Server, path string) {
 	var mu sync.Mutex
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsAgentsDocGet,
 		func(context.Context, appwire.EmptyParams) (appwire.AgentsDocResponse, error) {
+			if path == "" {
+				return appwire.AgentsDocResponse{}, errNoAgentsDocPath
+			}
 			mu.Lock()
 			defer mu.Unlock()
 			return readAgentsDoc(path)
 		})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsAgentsDocSet,
 		func(_ context.Context, params appwire.AgentsDocSetParams) (appwire.AgentsDocResponse, error) {
+			if path == "" {
+				return appwire.AgentsDocResponse{}, errNoAgentsDocPath
+			}
 			mu.Lock()
 			defer mu.Unlock()
 			if err := writeAgentsDoc(path, params.Content); err != nil {

--- a/cmd/evener-hub/app_rpc_agents_doc.go
+++ b/cmd/evener-hub/app_rpc_agents_doc.go
@@ -1,0 +1,83 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/appserver"
+)
+
+// agentsDocPath is the personal AGENTS.md under the user config root - the
+// same file agent.LoadInstructionDocs reads at session init.
+func agentsDocPath(configRoot string) string {
+	return filepath.Join(configRoot, agent.UserDocFile)
+}
+
+// readAgentsDoc reports the file as it is on disk. A missing file is the
+// empty document, not an error: the settings section shows an empty editor
+// and the first save creates it.
+func readAgentsDoc(path string) (appwire.AgentsDocResponse, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return appwire.AgentsDocResponse{Path: path}, nil
+	}
+	if err != nil {
+		return appwire.AgentsDocResponse{}, fmt.Errorf("AGENTS.md: read: %w", err)
+	}
+	return appwire.AgentsDocResponse{Path: path, Exists: true, Content: string(b)}, nil
+}
+
+// writeAgentsDoc replaces the file atomically (temp + rename, mode 0644,
+// parent created), the same way registry.WriteConfigFile lands
+// providers.toml beside it. Content is written byte for byte: this is the
+// user's own prose, and trimming or appending a newline would make the
+// editor disagree with the file it just saved.
+func writeAgentsDoc(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("AGENTS.md: mkdir: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("AGENTS.md: write: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("AGENTS.md: rename: %w", err)
+	}
+	return nil
+}
+
+// registerAgentsDocHandlers serves evener/settings/agentsDoc/{get,set}. Writes
+// serialize on one mutex so two clients saving at once cannot interleave on
+// the shared temp path; there is no revision check by design (spec
+// 2026-09-07 §1) - the last write wins, and every client hears about it.
+func registerAgentsDocHandlers(server *appserver.Server, configRoot string) {
+	path := agentsDocPath(configRoot)
+	var mu sync.Mutex
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsAgentsDocGet,
+		func(context.Context, appwire.EmptyParams) (appwire.AgentsDocResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return readAgentsDoc(path)
+		})
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsAgentsDocSet,
+		func(_ context.Context, params appwire.AgentsDocSetParams) (appwire.AgentsDocResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if err := writeAgentsDoc(path, params.Content); err != nil {
+				return appwire.AgentsDocResponse{}, err
+			}
+			resp, err := readAgentsDoc(path)
+			if err != nil {
+				return appwire.AgentsDocResponse{}, err
+			}
+			server.BroadcastAll(appwire.NotifyEvenerSettingsAgentsDocChanged, resp)
+			return resp, nil
+		})
+}

--- a/cmd/evener-hub/app_rpc_agents_doc_test.go
+++ b/cmd/evener-hub/app_rpc_agents_doc_test.go
@@ -287,6 +287,92 @@ func TestWriteAgentsDocFailureRemovesTheTempFile(t *testing.T) {
 	}
 }
 
+// A dotfiles-managed ~/.config keeps AGENTS.md as a symlink into the dotfiles
+// repo. Renaming over the link would replace it with a regular file and take
+// the dotfiles copy out of the loop without saying so, so the save follows it.
+func TestWriteAgentsDocFollowsASymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is privileged on Windows")
+	}
+	base := t.TempDir()
+	realDir := filepath.Join(base, "real")
+	root := filepath.Join(base, "root")
+	for _, dir := range []string{realDir, root} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	realFile := filepath.Join(realDir, "AGENTS.md")
+	if err := os.WriteFile(realFile, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := agentsDocPath(root)
+	if err := os.Symlink(realFile, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeAgentsDoc(link, "new"); err != nil {
+		t.Fatalf("writeAgentsDoc: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("mode = %v, want the symlink itself to survive the save", info.Mode())
+	}
+	onDisk, err := os.ReadFile(realFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != "new" {
+		t.Fatalf("linked file = %q, want the saved content", onDisk)
+	}
+	for _, tmp := range []string{link + ".tmp", realFile + ".tmp"} {
+		if _, statErr := os.Lstat(tmp); !os.IsNotExist(statErr) {
+			t.Fatalf("%s survived the rename: stat = %v", tmp, statErr)
+		}
+	}
+}
+
+// A link with no target has nothing to follow: EvalSymlinks fails and the
+// ordinary temp-and-rename applies, so the save lands as a regular file where
+// the broken link was.
+func TestWriteAgentsDocDanglingSymlinkIsReplaced(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is privileged on Windows")
+	}
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := agentsDocPath(root)
+	if err := os.Symlink(filepath.Join(base, "gone", "AGENTS.md"), link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeAgentsDoc(link, "new"); err != nil {
+		t.Fatalf("writeAgentsDoc: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("mode = %v, want a regular file where the broken link was", info.Mode())
+	}
+	onDisk, err := os.ReadFile(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != "new" {
+		t.Fatalf("on disk = %q, want the saved content", onDisk)
+	}
+}
+
 func receiveAgentsDocChanged(t *testing.T, client *appwire.Client) appwire.AgentsDocResponse {
 	t.Helper()
 	select {

--- a/cmd/evener-hub/app_rpc_agents_doc_test.go
+++ b/cmd/evener-hub/app_rpc_agents_doc_test.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -126,9 +127,7 @@ func TestHubRPCAgentsDocSetWritesVerbatimAndBroadcasts(t *testing.T) {
 			t.Fatalf("mode = %o, want 0644", info.Mode().Perm())
 		}
 	}
-	if _, err := os.Stat(filepath.Join(root, "AGENTS.md.tmp")); !os.IsNotExist(err) {
-		t.Fatal("the temp file survived the rename")
-	}
+	requireNoAgentsDocTempFiles(t, root)
 
 	for _, client := range []*appwire.Client{clientA, clientB} {
 		notification := receiveAgentsDocChanged(t, client)
@@ -167,18 +166,28 @@ func TestHubRPCAgentsDocSetReplacesThePreviousContent(t *testing.T) {
 // save. The rename already landed, so telling the requester its write failed
 // would show an error over content that is on disk and leave every other
 // client stale; the byte-for-byte contract means the content just written is
-// what the file holds. A leftover write-only AGENTS.md.tmp makes that happen
-// for real: os.WriteFile keeps the mode of a file it did not create, so the
-// write and the rename both succeed and the file that lands cannot be read.
+// what the file holds. A long symlink chain makes that happen for real: the
+// save resolves the chain through filepath.EvalSymlinks and lands on the file
+// at the end of it, and the read back walks the same chain through the kernel,
+// which gives up long before EvalSymlinks does (see linkChainBeyondTheKernel).
 func TestHubRPCAgentsDocSetReportsTheSaveWhenTheReadBackFails(t *testing.T) {
-	if runtime.GOOS == "windows" || os.Getuid() == 0 {
-		t.Skip("relies on a file the process cannot read")
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is privileged on Windows")
 	}
-	root := t.TempDir()
-	path := agentsDocPath(root)
-	if err := os.WriteFile(path+".tmp", nil, 0o200); err != nil {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	realDir := filepath.Join(base, "real")
+	for _, dir := range []string{root, realDir} {
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	realFile := filepath.Join(realDir, "AGENTS.md")
+	if err := os.WriteFile(realFile, []byte("old\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	path := agentsDocPath(root)
+	linkChainBeyondTheKernel(t, path, realFile)
 	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
 	defer hub.Close()
 	clientA := dialHubRPC(t, hub)
@@ -207,23 +216,36 @@ func TestHubRPCAgentsDocSetReportsTheSaveWhenTheReadBackFails(t *testing.T) {
 	}
 
 	// Guards the premise: both branches return the same response, so unless
-	// the file that landed is genuinely unreadable this test proves nothing.
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
+	// the read back is genuinely denied this test proves nothing.
+	if _, err := os.ReadFile(path); err == nil {
+		t.Fatal("the read back was never actually denied")
 	}
-	if info.Mode().Perm() != 0o200 {
-		t.Fatalf("mode = %o, want 0200 - the read back was never actually denied", info.Mode().Perm())
-	}
-	if err := os.Chmod(path, 0o644); err != nil {
-		t.Fatal(err)
-	}
-	onDisk, err := os.ReadFile(path)
+	onDisk, err := os.ReadFile(realFile)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(onDisk) != content {
 		t.Fatalf("on disk = %q, want the content the save reported", onDisk)
+	}
+}
+
+// linkChainBeyondTheKernel points head at target through more symlinks than
+// the kernel will follow - Linux stops at 40 hops and macOS at 32, while
+// filepath.EvalSymlinks walks up to 255 of them in userspace. A path built
+// this way is one writeAgentsDoc can resolve and os.ReadFile cannot.
+func linkChainBeyondTheKernel(t *testing.T, head, target string) {
+	t.Helper()
+	hops := t.TempDir()
+	next := target
+	for i := range 44 {
+		hop := filepath.Join(hops, fmt.Sprintf("hop%02d", i))
+		if err := os.Symlink(next, hop); err != nil {
+			t.Fatal(err)
+		}
+		next = hop
+	}
+	if err := os.Symlink(next, head); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -253,37 +275,87 @@ func TestWriteAgentsDocFailureLeavesThePreviousFile(t *testing.T) {
 	}
 }
 
-// A write that dies partway must not leave AGENTS.md.tmp sitting in the user's
-// config root. A directory at the temp path is the portable way to fail the
-// write itself - the open cannot succeed, and whatever is at that path is what
-// the cleanup has to clear.
+// A save that dies partway must not leave a temp file sitting in the user's
+// config root. Nothing can occupy the temp path itself any more, so the
+// portable way to fail after the temp file exists is a directory where
+// AGENTS.md goes: the content lands, the rename cannot.
 func TestWriteAgentsDocFailureRemovesTheTempFile(t *testing.T) {
 	root := t.TempDir()
 	path := agentsDocPath(root)
-	if err := os.WriteFile(path, []byte("keep me\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	tmp := path + ".tmp"
-	if err := os.Mkdir(tmp, 0o755); err != nil {
+	if err := os.Mkdir(path, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
 	err := writeAgentsDoc(path, "new")
 	if err == nil {
-		t.Fatal("expected the write to fail with a directory at the temp path")
+		t.Fatal("expected the save to fail with a directory where AGENTS.md goes")
 	}
-	if !strings.Contains(err.Error(), "AGENTS.md: write:") {
-		t.Fatalf("err = %v, want the failure to come from the write step", err)
+	if !strings.Contains(err.Error(), "AGENTS.md: rename:") {
+		t.Fatalf("err = %v, want the failure to come from the rename step", err)
 	}
-	if _, statErr := os.Stat(tmp); !os.IsNotExist(statErr) {
-		t.Fatalf("the temp path survived a failed write: stat = %v", statErr)
+	requireNoAgentsDocTempFiles(t, root)
+}
+
+// A stale AGENTS.md.tmp - an older evener's leftover, or a symlink planted
+// where one used to sit - is no longer part of a save at all: the temp file
+// is created exclusively under a name of its own, so the link is neither
+// written through nor renamed into place.
+func TestWriteAgentsDocIgnoresAStaleTempSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is privileged on Windows")
 	}
-	onDisk, readErr := os.ReadFile(path)
-	if readErr != nil {
-		t.Fatal(readErr)
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
 	}
-	if string(onDisk) != "keep me\n" {
-		t.Fatalf("a failed write changed the file: %q", onDisk)
+	elsewhere := filepath.Join(base, "elsewhere")
+	if err := os.WriteFile(elsewhere, []byte("not yours\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := agentsDocPath(root)
+	stale := path + ".tmp"
+	if err := os.Symlink(elsewhere, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeAgentsDoc(path, "mine\n"); err != nil {
+		t.Fatalf("writeAgentsDoc: %v", err)
+	}
+
+	untouched, err := os.ReadFile(elsewhere)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(untouched) != "not yours\n" {
+		t.Fatalf("the save wrote through the stale link: %q", untouched)
+	}
+	info, err := os.Lstat(stale)
+	if err != nil {
+		t.Fatalf("the stale link did not survive the save: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("mode = %v, want the stale link left as it was", info.Mode())
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != "mine\n" {
+		t.Fatalf("on disk = %q, want the saved content", onDisk)
+	}
+}
+
+// requireNoAgentsDocTempFiles asserts that no temp file writeAgentsDoc could
+// have created survives in dir.
+func requireNoAgentsDocTempFiles(t *testing.T, dir string) {
+	t.Helper()
+	leftovers, err := filepath.Glob(filepath.Join(dir, ".AGENTS.md-*.tmp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("temp files survived: %v", leftovers)
 	}
 }
 
@@ -329,11 +401,8 @@ func TestWriteAgentsDocFollowsASymlink(t *testing.T) {
 	if string(onDisk) != "new" {
 		t.Fatalf("linked file = %q, want the saved content", onDisk)
 	}
-	for _, tmp := range []string{link + ".tmp", realFile + ".tmp"} {
-		if _, statErr := os.Lstat(tmp); !os.IsNotExist(statErr) {
-			t.Fatalf("%s survived the rename: stat = %v", tmp, statErr)
-		}
-	}
+	requireNoAgentsDocTempFiles(t, root)
+	requireNoAgentsDocTempFiles(t, realDir)
 }
 
 // A link with no target has nothing to follow: EvalSymlinks fails and the

--- a/cmd/evener-hub/app_rpc_agents_doc_test.go
+++ b/cmd/evener-hub/app_rpc_agents_doc_test.go
@@ -443,6 +443,41 @@ func TestWriteAgentsDocDanglingSymlinkIsReplaced(t *testing.T) {
 	}
 }
 
+// A link that exists but cannot be resolved - a loop here, a permission error
+// on an intermediate directory in the field - is not a missing file, and
+// renaming over it would sever exactly the dotfiles link the symlink rule
+// exists to keep. The save refuses and leaves the link alone.
+func TestWriteAgentsDocRefusesAnUnresolvableSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is privileged on Windows")
+	}
+	root := t.TempDir()
+	path := agentsDocPath(root)
+	other := path + ".other"
+	if err := os.Symlink(other, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(path, other); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeAgentsDoc(path, "new")
+	if err == nil {
+		t.Fatal("expected the save to fail on a symlink it cannot resolve")
+	}
+	if !strings.Contains(err.Error(), "AGENTS.md: resolve:") {
+		t.Fatalf("err = %v, want the failure to come from the resolve step", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("the link did not survive the refused save: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("mode = %v, want the symlink itself left as it was", info.Mode())
+	}
+	requireNoAgentsDocTempFiles(t, root)
+}
+
 func receiveAgentsDocChanged(t *testing.T, client *appwire.Client) appwire.AgentsDocResponse {
 	t.Helper()
 	select {

--- a/cmd/evener-hub/app_rpc_agents_doc_test.go
+++ b/cmd/evener-hub/app_rpc_agents_doc_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -496,5 +497,84 @@ func TestThreadStartHandsSpawnedSessionsThePathSettingsEdits(t *testing.T) {
 	args := buildSpawnArgs(spawns[0])
 	if !slicesContainOrderedFlag(args, "--agents-doc", settings.Path) {
 		t.Fatalf("spawn args = %v, want --agents-doc %q", args, settings.Path)
+	}
+}
+
+// The hub's own path derivation has to be as strict as the daemon's
+// (agent.personalDocPath): a root that resolves to nothing, or to a relative
+// directory, yields no path at all.
+func TestHubAgentsDocPath_RefusesARelativeOrUnresolvableRoot(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	if got := hubAgentsDocPath(hubcore.WebConfig{}); got != "" {
+		t.Fatalf("hubAgentsDocPath = %q, want no path when no user config root resolves", got)
+	}
+	relative := filepath.Join(".", ".config", "evener")
+	if got := hubAgentsDocPath(hubcore.WebConfig{LaunchConfigRoot: relative}); got != "" {
+		t.Fatalf("hubAgentsDocPath = %q, want no path for the relative root %q", got, relative)
+	}
+	root := t.TempDir()
+	want := filepath.Join(root, "AGENTS.md")
+	if got := hubAgentsDocPath(hubcore.WebConfig{LaunchConfigRoot: root}); got != want {
+		t.Fatalf("hubAgentsDocPath = %q, want %q", got, want)
+	}
+}
+
+// Without a path there is no file to serve, and the handlers must say so
+// rather than fall back to a repository-relative AGENTS.md.
+func TestHubRPCAgentsDocRefusesWithoutAConfigRoot(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{HubStateRoot: t.TempDir(), PluginRoot: t.TempDir()})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	var got appwire.AgentsDocResponse
+	err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocGet, appwire.EmptyParams{}, &got)
+	if err == nil || !strings.Contains(err.Error(), "no user config root") {
+		t.Fatalf("get error = %v, want one naming the unresolved user config root", err)
+	}
+	err = client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocSet, appwire.AgentsDocSetParams{Content: "# mine\n"}, &got)
+	if err == nil || !strings.Contains(err.Error(), "no user config root") {
+		t.Fatalf("set error = %v, want one naming the unresolved user config root", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".config", "evener", "AGENTS.md")); !os.IsNotExist(err) {
+		t.Fatalf("stat of a working-directory AGENTS.md = %v, want it never created", err)
+	}
+}
+
+// A spawn with nothing to point at hands the child no --agents-doc rather
+// than a relative one; the daemon then resolves (or refuses) on its own.
+func TestThreadStartOmitsTheAgentsDocFlagWithoutAConfigRoot(t *testing.T) {
+	t.Setenv("HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	spawner := &recordingSpawner{}
+	cfg := hubcore.WebConfig{PluginRoot: t.TempDir(), Spawner: spawner}
+
+	if _, err := hubThreadStart(context.Background(), cfg, appsource.NewRegistry(), appwire.ThreadStartParams{
+		CWD:   t.TempDir(),
+		Model: "openai/gpt-5",
+	}); err != nil {
+		t.Fatalf("ThreadStart: %v", err)
+	}
+	spawns := spawner.Spawns()
+	if len(spawns) != 1 {
+		t.Fatalf("spawn calls = %d, want 1", len(spawns))
+	}
+	if spawns[0].AgentsDocPath != "" {
+		t.Fatalf("spawn AgentsDocPath = %q, want none when no user config root resolves", spawns[0].AgentsDocPath)
+	}
+	if args := buildSpawnArgs(spawns[0]); slices.Contains(args, "--agents-doc") {
+		t.Fatalf("spawn args = %v, want no --agents-doc", args)
 	}
 }

--- a/cmd/evener-hub/app_rpc_agents_doc_test.go
+++ b/cmd/evener-hub/app_rpc_agents_doc_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 )
 
@@ -301,5 +302,44 @@ func receiveAgentsDocChanged(t *testing.T, client *appwire.Client) appwire.Agent
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for the agentsDoc notification")
 		return appwire.AgentsDocResponse{}
+	}
+}
+
+// Settings edits the hub's AGENTS.md and the sessions the hub spawns have to
+// read that same file. Both come from one expression over the hub's config
+// root; this pins them together so neither can move on its own.
+func TestThreadStartHandsSpawnedSessionsThePathSettingsEdits(t *testing.T) {
+	spawner := &recordingSpawner{}
+	cfg := hubcore.WebConfig{LaunchConfigRoot: t.TempDir(), PluginRoot: t.TempDir(), Spawner: spawner}
+
+	if _, err := hubThreadStart(context.Background(), cfg, appsource.NewRegistry(), appwire.ThreadStartParams{
+		CWD:   t.TempDir(),
+		Model: "openai/gpt-5",
+	}); err != nil {
+		t.Fatalf("ThreadStart: %v", err)
+	}
+	spawns := spawner.Spawns()
+	if len(spawns) != 1 {
+		t.Fatalf("spawn calls = %d, want 1", len(spawns))
+	}
+
+	hub := newHubRPCTestServer(t, cfg)
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	var settings appwire.AgentsDocResponse
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocGet, appwire.EmptyParams{}, &settings); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	if spawns[0].AgentsDocPath != settings.Path {
+		t.Fatalf("spawn AgentsDocPath = %q, want the file Settings edits %q", spawns[0].AgentsDocPath, settings.Path)
+	}
+	args := buildSpawnArgs(spawns[0])
+	if !slicesContainOrderedFlag(args, "--agents-doc", settings.Path) {
+		t.Fatalf("spawn args = %v, want --agents-doc %q", args, settings.Path)
 	}
 }

--- a/cmd/evener-hub/app_rpc_agents_doc_test.go
+++ b/cmd/evener-hub/app_rpc_agents_doc_test.go
@@ -1,0 +1,206 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestHubRPCAgentsDocGetReportsAMissingFile(t *testing.T) {
+	root := t.TempDir()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	var got appwire.AgentsDocResponse
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	want := appwire.AgentsDocResponse{Path: filepath.Join(root, "AGENTS.md")}
+	if got != want {
+		t.Fatalf("get = %+v, want %+v", got, want)
+	}
+}
+
+func TestHubRPCAgentsDocGetReadsAnExistingFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	var got appwire.AgentsDocResponse
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	want := appwire.AgentsDocResponse{Path: filepath.Join(root, "AGENTS.md"), Exists: true, Content: "# mine\n"}
+	if got != want {
+		t.Fatalf("get = %+v, want %+v", got, want)
+	}
+}
+
+// A blank file is Exists=true with its actual content. agent.LoadUserDoc
+// treats a whitespace-only AGENTS.md as absent, but that is a judgement about
+// what is worth putting in a prompt: the editor edits the file on disk, and
+// telling it the file is missing would make "clear the box and save" look
+// like it never happened.
+func TestHubRPCAgentsDocGetReportsABlankFileAsExisting(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("  \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	var got appwire.AgentsDocResponse
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	want := appwire.AgentsDocResponse{Path: filepath.Join(root, "AGENTS.md"), Exists: true, Content: "  \n"}
+	if got != want {
+		t.Fatalf("get = %+v, want %+v", got, want)
+	}
+}
+
+func TestHubRPCAgentsDocSetWritesVerbatimAndBroadcasts(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "evener") // the config root itself may not exist yet
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const content = "  leading space, no trailing newline"
+	var result appwire.AgentsDocResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocSet, appwire.AgentsDocSetParams{Content: content}, &result); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	want := appwire.AgentsDocResponse{Path: filepath.Join(root, "AGENTS.md"), Exists: true, Content: content}
+	if result != want {
+		t.Fatalf("set = %+v, want %+v", result, want)
+	}
+
+	onDisk, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(onDisk) != content {
+		t.Fatalf("on disk = %q, want the content byte for byte", onDisk)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(root, "AGENTS.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o644 {
+			t.Fatalf("mode = %o, want 0644", info.Mode().Perm())
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "AGENTS.md.tmp")); !os.IsNotExist(err) {
+		t.Fatal("the temp file survived the rename")
+	}
+
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		notification := receiveAgentsDocChanged(t, client)
+		if notification != want {
+			t.Fatalf("notification = %+v, want %+v", notification, want)
+		}
+	}
+}
+
+func TestHubRPCAgentsDocSetReplacesThePreviousContent(t *testing.T) {
+	root := t.TempDir()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []string{"first\n", "second\n", ""} {
+		var result appwire.AgentsDocResponse
+		if err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocSet, appwire.AgentsDocSetParams{Content: content}, &result); err != nil {
+			t.Fatalf("set %q: %v", content, err)
+		}
+		onDisk, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(onDisk) != content {
+			t.Fatalf("on disk = %q after set %q", onDisk, content)
+		}
+		receiveAgentsDocChanged(t, client)
+	}
+}
+
+func TestWriteAgentsDocFailureLeavesThePreviousFile(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Getuid() == 0 {
+		t.Skip("relies on a directory the process cannot write")
+	}
+	root := t.TempDir()
+	path := agentsDocPath(root)
+	if err := os.WriteFile(path, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(root, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(root, 0o755) })
+
+	if err := writeAgentsDoc(path, "new"); err == nil {
+		t.Fatal("expected the write to fail in a read-only directory")
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != "keep me\n" {
+		t.Fatalf("a failed write changed the file: %q", onDisk)
+	}
+}
+
+func receiveAgentsDocChanged(t *testing.T, client *appwire.Client) appwire.AgentsDocResponse {
+	t.Helper()
+	select {
+	case notification := <-client.Notifications():
+		if notification.Method != appwire.NotifyEvenerSettingsAgentsDocChanged {
+			t.Fatalf("notification method = %q, want %q", notification.Method, appwire.NotifyEvenerSettingsAgentsDocChanged)
+		}
+		var params appwire.AgentsDocResponse
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode notification: %v", err)
+		}
+		return params
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the agentsDoc notification")
+		return appwire.AgentsDocResponse{}
+	}
+}

--- a/cmd/evener-hub/app_rpc_agents_doc_test.go
+++ b/cmd/evener-hub/app_rpc_agents_doc_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -161,6 +162,70 @@ func TestHubRPCAgentsDocSetReplacesThePreviousContent(t *testing.T) {
 	}
 }
 
+// A re-read that fails after the rename must not be reported as a rejected
+// save. The rename already landed, so telling the requester its write failed
+// would show an error over content that is on disk and leave every other
+// client stale; the byte-for-byte contract means the content just written is
+// what the file holds. A leftover write-only AGENTS.md.tmp makes that happen
+// for real: os.WriteFile keeps the mode of a file it did not create, so the
+// write and the rename both succeed and the file that lands cannot be read.
+func TestHubRPCAgentsDocSetReportsTheSaveWhenTheReadBackFails(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Getuid() == 0 {
+		t.Skip("relies on a file the process cannot read")
+	}
+	root := t.TempDir()
+	path := agentsDocPath(root)
+	if err := os.WriteFile(path+".tmp", nil, 0o200); err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const content = "saved even though the read back cannot see it\n"
+	var result appwire.AgentsDocResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocSet, appwire.AgentsDocSetParams{Content: content}, &result); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	want := appwire.AgentsDocResponse{Path: path, Exists: true, Content: content}
+	if result != want {
+		t.Fatalf("set = %+v, want %+v", result, want)
+	}
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if notification := receiveAgentsDocChanged(t, client); notification != want {
+			t.Fatalf("notification = %+v, want %+v", notification, want)
+		}
+	}
+
+	// Guards the premise: both branches return the same response, so unless
+	// the file that landed is genuinely unreadable this test proves nothing.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o200 {
+		t.Fatalf("mode = %o, want 0200 - the read back was never actually denied", info.Mode().Perm())
+	}
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != content {
+		t.Fatalf("on disk = %q, want the content the save reported", onDisk)
+	}
+}
+
 func TestWriteAgentsDocFailureLeavesThePreviousFile(t *testing.T) {
 	if runtime.GOOS == "windows" || os.Getuid() == 0 {
 		t.Skip("relies on a directory the process cannot write")
@@ -181,6 +246,40 @@ func TestWriteAgentsDocFailureLeavesThePreviousFile(t *testing.T) {
 	onDisk, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if string(onDisk) != "keep me\n" {
+		t.Fatalf("a failed write changed the file: %q", onDisk)
+	}
+}
+
+// A write that dies partway must not leave AGENTS.md.tmp sitting in the user's
+// config root. A directory at the temp path is the portable way to fail the
+// write itself - the open cannot succeed, and whatever is at that path is what
+// the cleanup has to clear.
+func TestWriteAgentsDocFailureRemovesTheTempFile(t *testing.T) {
+	root := t.TempDir()
+	path := agentsDocPath(root)
+	if err := os.WriteFile(path, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tmp := path + ".tmp"
+	if err := os.Mkdir(tmp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeAgentsDoc(path, "new")
+	if err == nil {
+		t.Fatal("expected the write to fail with a directory at the temp path")
+	}
+	if !strings.Contains(err.Error(), "AGENTS.md: write:") {
+		t.Fatalf("err = %v, want the failure to come from the write step", err)
+	}
+	if _, statErr := os.Stat(tmp); !os.IsNotExist(statErr) {
+		t.Fatalf("the temp path survived a failed write: stat = %v", statErr)
+	}
+	onDisk, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
 	}
 	if string(onDisk) != "keep me\n" {
 		t.Fatalf("a failed write changed the file: %q", onDisk)

--- a/cmd/evener-hub/app_rpc_agents_doc_umask_unix_test.go
+++ b/cmd/evener-hub/app_rpc_agents_doc_umask_unix_test.go
@@ -1,0 +1,32 @@
+//go:build unix
+
+package hub
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// writeAgentsDoc says the file it lands is mode 0644, and that has to hold
+// whatever umask the hub was started under - a mode argument alone is masked,
+// so the same save would produce 0644 for one user and 0600 for another.
+// Umask is process-wide, so this test must never run in parallel.
+func TestWriteAgentsDocModeIsExplicitUnderARestrictiveUmask(t *testing.T) {
+	previous := syscall.Umask(0o077)
+	t.Cleanup(func() { syscall.Umask(previous) })
+
+	root := t.TempDir()
+	path := agentsDocPath(root)
+	if err := writeAgentsDoc(path, "mine\n"); err != nil {
+		t.Fatalf("writeAgentsDoc: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("mode = %o, want 0644", info.Mode().Perm())
+	}
+}

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11167,6 +11167,8 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodEvenerSettingsTranscriptDisplayPatch,
 		appwire.MethodEvenerSettingsKeybindingsGet,
 		appwire.MethodEvenerSettingsKeybindingsPatch,
+		appwire.MethodEvenerSettingsAgentsDocGet,
+		appwire.MethodEvenerSettingsAgentsDocSet,
 		appwire.MethodEvenerMarketplaceList,
 		appwire.MethodEvenerMarketplaceAdd,
 		appwire.MethodEvenerMarketplaceRemove,

--- a/cmd/evener-hub/app_threadlifecycle.go
+++ b/cmd/evener-hub/app_threadlifecycle.go
@@ -153,11 +153,12 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 	ctx, cancelDetached := context.WithTimeout(context.WithoutCancel(ctx), threadStartDetachedTimeout)
 	defer cancelDetached()
 	entry, err := cfg.Spawner.Spawn(ctx, hubcore.SpawnRequest{
-		Project:    spawnResolved.Project,
-		Resolved:   spawnResolved,
-		WorkingDir: workingDir,
-		PluginRoot: cfg.PluginRoot,
-		Provider:   modelRef.Provider,
+		Project:       spawnResolved.Project,
+		Resolved:      spawnResolved,
+		WorkingDir:    workingDir,
+		PluginRoot:    cfg.PluginRoot,
+		AgentsDocPath: agentsDocPath(hubLaunchConfigRoot(cfg)),
+		Provider:      modelRef.Provider,
 	})
 	if err != nil {
 		return appwire.ThreadStartResponse{}, appwire.HubLaunchError(err.Error())
@@ -398,7 +399,7 @@ func hubResumedThreadResponse(ctx context.Context, sources *appsource.Registry, 
 }
 
 func resumeRequestForConfig(cfg hubcore.WebConfig, id string) (hubcore.ResumeRequest, error) {
-	req := hubcore.ResumeRequest{SessionID: id}
+	req := hubcore.ResumeRequest{SessionID: id, AgentsDocPath: agentsDocPath(hubLaunchConfigRoot(cfg))}
 	if cfg.Past != nil {
 		if pe, ok := cfg.Past.Find(id); ok {
 			// Restore root, not the live working dir: a session actively

--- a/cmd/evener-hub/app_threadlifecycle.go
+++ b/cmd/evener-hub/app_threadlifecycle.go
@@ -157,7 +157,7 @@ func hubThreadStart(ctx context.Context, cfg hubcore.WebConfig, sources *appsour
 		Resolved:      spawnResolved,
 		WorkingDir:    workingDir,
 		PluginRoot:    cfg.PluginRoot,
-		AgentsDocPath: agentsDocPath(hubLaunchConfigRoot(cfg)),
+		AgentsDocPath: hubAgentsDocPath(cfg),
 		Provider:      modelRef.Provider,
 	})
 	if err != nil {
@@ -399,7 +399,7 @@ func hubResumedThreadResponse(ctx context.Context, sources *appsource.Registry, 
 }
 
 func resumeRequestForConfig(cfg hubcore.WebConfig, id string) (hubcore.ResumeRequest, error) {
-	req := hubcore.ResumeRequest{SessionID: id, AgentsDocPath: agentsDocPath(hubLaunchConfigRoot(cfg))}
+	req := hubcore.ResumeRequest{SessionID: id, AgentsDocPath: hubAgentsDocPath(cfg)}
 	if cfg.Past != nil {
 		if pe, ok := cfg.Past.Find(id); ok {
 			// Restore root, not the live working dir: a session actively

--- a/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/Settings.tsx
@@ -18,6 +18,7 @@ import { SettingsNav } from "./SettingsNav";
 import { DEFAULT_SECTION_ID, isKnownSettingsSection, settingsSectionLabel } from "./sections";
 import { AboutSection } from "./sections/about";
 import { AgentsSection } from "./sections/agents";
+import { AgentsDocSection } from "./sections/agentsDoc";
 import { CredentialsSection } from "./sections/credentials/CredentialsSection";
 import { DisplaySection } from "./sections/display";
 import { GeneralSection } from "./sections/general";
@@ -69,6 +70,7 @@ const CLASS = {
 const SECTION_COMPONENTS: Record<string, ComponentType<{ sectionId: string }>> = {
   credentials: CredentialsSection,
   agents: AgentsSection,
+  "agents-md": AgentsDocSection,
   "launch-evener": LaunchServerSection,
   inrepo: InRepoSection,
   project: ProjectSection,

--- a/cmd/evener-hub/frontend/src/panes/settings/sections.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections.test.ts
@@ -11,11 +11,11 @@ import {
 // Section inventory verified against templates/partials/settings.html:13-31
 // (15 exact after Codex launch controls were removed) - see the wave-7
 // floor doc's own citation of that range - plus
-// three sections with no legacy counterpart, "keybindings", "about", and "mobile" (see
-// sections.ts's own doc comment).
+// four sections with no legacy counterpart, "keybindings", "about", "mobile", and
+// "agents-md" (see sections.ts's own doc comment).
 
-test("has exactly 18 sections", () => {
-  expect(SETTINGS_SECTIONS).toHaveLength(18);
+test("has exactly 19 sections", () => {
+  expect(SETTINGS_SECTIONS).toHaveLength(19);
 });
 
 test("every section id is unique", () => {
@@ -36,22 +36,28 @@ test("the 6 ungrouped sections are General/Theme/Transcript display/Display/Noti
   expect(SETTINGS_SECTIONS.slice(0, 6)).toEqual(ungrouped);
 });
 
-test('the "Agent setup" cluster has exactly these 4 sections, in order, right after the ungrouped ones', () => {
+test('the "Agent setup" cluster has exactly these 5 sections, in order, right after the ungrouped ones', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "agents-models");
-  expect(cluster.map((s) => s.label)).toEqual(["Providers & credentials", "Agents", "Evener launch", "In-repo config"]);
-  expect(SETTINGS_SECTIONS.slice(6, 10)).toEqual(cluster);
+  expect(cluster.map((s) => s.label)).toEqual([
+    "Providers & credentials",
+    "Agents",
+    "AGENTS.md",
+    "Evener launch",
+    "In-repo config",
+  ]);
+  expect(SETTINGS_SECTIONS.slice(6, 11)).toEqual(cluster);
 });
 
 test('the "Extensions" cluster has exactly these 4 sections, in order, right after "Agent setup"', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "extensions");
   expect(cluster.map((s) => s.label)).toEqual(["Marketplaces & Plugins", "Plugins", "Skills", "MCP servers"]);
-  expect(SETTINGS_SECTIONS.slice(10, 14)).toEqual(cluster);
+  expect(SETTINGS_SECTIONS.slice(11, 15)).toEqual(cluster);
 });
 
 test('the "Daemon" cluster has exactly these 4 sections, in order, last', () => {
   const cluster = SETTINGS_SECTIONS.filter((s) => s.cluster === "daemon");
   expect(cluster.map((s) => s.label)).toEqual(["Hub", "Mobile app", "Storage", "About"]);
-  expect(SETTINGS_SECTIONS.slice(14, 18)).toEqual(cluster);
+  expect(SETTINGS_SECTIONS.slice(15, 19)).toEqual(cluster);
 });
 
 test('"About" is the very last section overall', () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections.ts
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections.ts
@@ -2,7 +2,7 @@
 // SettingsNav's link list/grouping, the pane's own title() (paneRegistry),
 // and (via DEFAULT_SECTION_ID) what a bare /settings resolves to. Verified
 // against the original settings inventory after Codex launch controls were
-// removed, plus keybindings, about, and mobile. The original
+// removed, plus keybindings, about, mobile, and agents-md. The original
 // legacy-parity sections are 5 ungrouped top links (General/Theme/
 // Transcript display/Display/Notifications) plus 3 labeled clusters ("Agents &
 // models"/"Extensions"/"Daemon"), in this fixed order. The per-project
@@ -43,6 +43,7 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
   // --- Agents & models -----------------------------------------------
   { id: "credentials", label: "Providers & credentials", cluster: "agents-models" },
   { id: "agents", label: "Agents", cluster: "agents-models" },
+  { id: "agents-md", label: "AGENTS.md", cluster: "agents-models" },
   { id: "launch-evener", label: "Evener launch", cluster: "agents-models" },
   { id: "inrepo", label: "In-repo config", cluster: "agents-models" },
   // --- Extensions ------------------------------------------------------

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.module.css
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.module.css
@@ -1,0 +1,41 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-width: 720px;
+}
+
+.help {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+}
+
+.error {
+  margin: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+}
+
+/* The file is Markdown the user hand-edits elsewhere too, so it reads in
+ * mono here as it does in their editor. The shared Textarea has no font
+ * prop; scoping the face to this section's own control is the narrowest
+ * override. */
+.editor textarea {
+  width: 100%;
+  font-family: var(--font-mono);
+}
+
+.note {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -233,17 +233,19 @@ test("a changed broadcast echoing this client's own save leaves later keystrokes
   expect(screen.queryByRole("status")).toBeNull();
 });
 
-// A dropped socket is replaced by a whole new client (ConnectionBanner's
-// retry), and the editor heard no `changed` broadcast while it was down. A
-// one-shot mount fetch would leave it holding pre-drop content, and the next
-// Save would push that over whatever the reconnected hub now has.
-test("a reconnect on a fresh client refetches the file", async () => {
-  connectFakeClient();
+// An automatic reconnect keeps the same client - only a banner retry brings
+// a fresh one - and the editor heard no `changed` broadcast while the socket
+// was down. A one-shot mount fetch would leave it holding pre-drop content,
+// and the next Save would push that over whatever the reconnected hub has.
+test("a reconnect refetches the file", async () => {
+  const fake = connectFakeClient();
   renderSection();
   await waitFor(() => expect(editor().value).toBe("# hi\n"));
 
   act(() => {
-    connectFakeClient({ ...DOC, content: "# while we were away\n" });
+    fake.on("evener/settings/agentsDoc/get", () => ({ ...DOC, content: "# while we were away\n" }));
+    fake.emitStateChange("reconnecting");
+    fake.emitReady();
   });
   await waitFor(() => expect(editor().value).toBe("# while we were away\n"));
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -72,14 +72,17 @@ test("a missing file renders an empty editor, not an error", async () => {
   expect(screen.queryByText(/Failed to load/)).toBeNull();
 });
 
-test("a failed load shows the error", async () => {
+// The hub's own text is the whole point for a file editor - "permission
+// denied" and "is a directory" are what tell the user what to fix - and it
+// has to be announced, not just drawn.
+test("a failed load shows the hub's own reason and announces it", async () => {
   const fake = new FakeClient("ready");
   fake.on("evener/settings/agentsDoc/get", () => {
     throw new Error("disk on fire");
   });
   connectionStore.getState().connect(fake);
   renderSection();
-  await waitFor(() => expect(screen.getByText(/Failed to load/)).toBeTruthy());
+  await waitFor(() => expect(screen.getByRole("alert").textContent).toBe("Failed to load: disk on fire"));
 });
 
 test("Save and Revert are disabled until the draft differs from the loaded file", async () => {
@@ -228,4 +231,36 @@ test("a changed broadcast echoing this client's own save leaves later keystrokes
 
   expect(editor().value).toBe("# hi\nmore again");
   expect(screen.queryByRole("status")).toBeNull();
+});
+
+// A dropped socket is replaced by a whole new client (ConnectionBanner's
+// retry), and the editor heard no `changed` broadcast while it was down. A
+// one-shot mount fetch would leave it holding pre-drop content, and the next
+// Save would push that over whatever the reconnected hub now has.
+test("a reconnect on a fresh client refetches the file", async () => {
+  connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+
+  act(() => {
+    connectFakeClient({ ...DOC, content: "# while we were away\n" });
+  });
+  await waitFor(() => expect(editor().value).toBe("# while we were away\n"));
+});
+
+test("a reconnect while the draft is dirty keeps the draft and offers Load current", async () => {
+  connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+
+  act(() => {
+    connectFakeClient({ ...DOC, content: "# while we were away\n" });
+  });
+  await waitFor(() => expect(screen.getByRole("status").textContent).toContain("changed on disk"));
+  expect(editor().value).toBe("# hi\nmore");
+
+  await user.click(screen.getByRole("button", { name: "Load current" }));
+  expect(editor().value).toBe("# while we were away\n");
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -250,6 +250,31 @@ test("a reconnect refetches the file", async () => {
   await waitFor(() => expect(editor().value).toBe("# while we were away\n"));
 });
 
+// A refetch that fails leaves `doc` where it was, so the editor goes on
+// showing a copy it can no longer confirm - and a Save from there would push
+// that over whatever is on disk now. Save stays enabled anyway: a reload that
+// failed because the hub is unreachable fails a save the same way, and
+// disabling it would only trap the draft.
+test("a failed reload after a successful load shows a reload notice and keeps the editor", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const saveDisabledBefore = saveButton().disabled;
+
+  act(() => {
+    fake.on("evener/settings/agentsDoc/get", () => {
+      throw new WireError("hub unreachable", -1);
+    });
+    fake.emitStateChange("reconnecting");
+    fake.emitReady();
+  });
+
+  await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("Couldn't reload AGENTS.md"));
+  expect(screen.getByRole("alert").textContent).toContain("hub unreachable");
+  expect(editor().value).toBe("# hi\n");
+  expect(saveButton().disabled).toBe(saveDisabledBefore);
+});
+
 test("a reconnect while the draft is dirty keeps the draft and offers Load current", async () => {
   connectFakeClient();
   renderSection();

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -1,0 +1,164 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { WireError } from "../../../protocol/errors";
+import { FakeClient } from "../../../protocol/testing/fakeClient";
+import type { AgentsDocResponse, AnyNotification } from "../../../protocol/types.gen";
+import { resetAgentsDocStoreForTests } from "../../../stores/agentsDoc";
+import { connectionStore } from "../../../stores/connection";
+import { Toast } from "../../../widgets";
+import { getToasts, resetToastStoreForTests } from "../../../widgets/toast/store";
+import { AgentsDocSection } from "./agentsDoc";
+
+const DOC: AgentsDocResponse = { path: "/home/u/.config/evener/AGENTS.md", exists: true, content: "# hi\n" };
+
+function connectFakeClient(doc: AgentsDocResponse = DOC): FakeClient {
+  const fake = new FakeClient("ready");
+  fake.on("evener/settings/agentsDoc/get", () => doc);
+  fake.on("evener/settings/agentsDoc/set", (params) => ({ ...doc, exists: true, content: params.content }));
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+function renderSection() {
+  return render(
+    <>
+      <Toast />
+      <AgentsDocSection sectionId="agents-md" />
+    </>,
+  );
+}
+
+function editor(): HTMLTextAreaElement {
+  return screen.getByRole("textbox", { name: "AGENTS.md contents" }) as HTMLTextAreaElement;
+}
+
+function saveButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetAgentsDocStoreForTests();
+  resetToastStoreForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+test("loads the file on mount and shows its path and content", async () => {
+  connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  expect(screen.getByText("/home/u/.config/evener/AGENTS.md")).toBeTruthy();
+});
+
+test("a missing file renders an empty editor, not an error", async () => {
+  connectFakeClient({ path: "/home/u/.config/evener/AGENTS.md", exists: false, content: "" });
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe(""));
+  expect(screen.queryByText(/Failed to load/)).toBeNull();
+});
+
+test("a failed load shows the error", async () => {
+  const fake = new FakeClient("ready");
+  fake.on("evener/settings/agentsDoc/get", () => {
+    throw new Error("disk on fire");
+  });
+  connectionStore.getState().connect(fake);
+  renderSection();
+  await waitFor(() => expect(screen.getByText(/Failed to load/)).toBeTruthy());
+});
+
+test("Save and Revert are disabled until the draft differs from the loaded file", async () => {
+  connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  expect(saveButton().disabled).toBe(true);
+  expect((screen.getByRole("button", { name: "Revert" }) as HTMLButtonElement).disabled).toBe(true);
+
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  expect(saveButton().disabled).toBe(false);
+  expect((screen.getByRole("button", { name: "Revert" }) as HTMLButtonElement).disabled).toBe(false);
+});
+
+test("Revert restores the loaded content", async () => {
+  connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(screen.getByRole("button", { name: "Revert" }));
+  expect(editor().value).toBe("# hi\n");
+  expect(saveButton().disabled).toBe(true);
+});
+
+test("Save sends the draft, toasts, and the editor is clean afterwards", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(saveButton());
+  await waitFor(() => expect(getToasts().some((t) => t.text === "Saved AGENTS.md")).toBe(true));
+  const set = fake.calls.find((c) => c.method === "evener/settings/agentsDoc/set");
+  expect(set?.params).toEqual({ content: "# hi\nmore" });
+  expect(saveButton().disabled).toBe(true);
+  expect(editor().value).toBe("# hi\nmore");
+});
+
+test("a failed save shows the hub's error inline and keeps the draft", async () => {
+  const fake = connectFakeClient();
+  // A WireError, as the hub really sends: friendlyErrorMessage passes a
+  // wire message through but replaces a plain Error with a generic line
+  // (mcp.test.tsx pins that), so a plain Error here would never reach the DOM.
+  fake.on("evener/settings/agentsDoc/set", () => {
+    throw new WireError("read-only file system", -1);
+  });
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(saveButton());
+  await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("read-only file system"));
+  expect(editor().value).toBe("# hi\nmore");
+  expect(saveButton().disabled).toBe(false);
+});
+
+test("a changed broadcast while the draft is clean replaces the editor", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  act(() => {
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "# from the TUI\n" },
+    } as AnyNotification);
+  });
+  await waitFor(() => expect(editor().value).toBe("# from the TUI\n"));
+  expect(screen.queryByText(/changed on disk/)).toBeNull();
+});
+
+test("a changed broadcast while the draft is dirty keeps the draft and offers Load current", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  act(() => {
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "# from the TUI\n" },
+    } as AnyNotification);
+  });
+  await waitFor(() => expect(screen.getByText(/changed on disk/)).toBeTruthy());
+  expect(editor().value).toBe("# hi\nmore");
+
+  await user.click(screen.getByRole("button", { name: "Load current" }));
+  expect(editor().value).toBe("# from the TUI\n");
+  expect(screen.queryByText(/changed on disk/)).toBeNull();
+  expect(saveButton().disabled).toBe(true);
+});

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -254,12 +254,12 @@ test("a reconnect refetches the file", async () => {
 // showing a copy it can no longer confirm - and a Save from there would push
 // that over whatever is on disk now. Save stays enabled anyway: a reload that
 // failed because the hub is unreachable fails a save the same way, and
-// disabling it would only trap the draft.
+// disabling it would only trap the draft. When that save lands, the notice
+// has to go with it - the editor is no longer showing an unconfirmed copy.
 test("a failed reload after a successful load shows a reload notice and keeps the editor", async () => {
   const fake = connectFakeClient();
   renderSection();
   await waitFor(() => expect(editor().value).toBe("# hi\n"));
-  const saveDisabledBefore = saveButton().disabled;
 
   act(() => {
     fake.on("evener/settings/agentsDoc/get", () => {
@@ -272,7 +272,14 @@ test("a failed reload after a successful load shows a reload notice and keeps th
   await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("Couldn't reload AGENTS.md"));
   expect(screen.getByRole("alert").textContent).toContain("hub unreachable");
   expect(editor().value).toBe("# hi\n");
-  expect(saveButton().disabled).toBe(saveDisabledBefore);
+
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  expect(saveButton().disabled).toBe(false);
+
+  await user.click(saveButton());
+  await waitFor(() => expect(getToasts().some((t) => t.text === "Saved AGENTS.md")).toBe(true));
+  expect(screen.queryByRole("alert")).toBeNull();
 });
 
 test("a reconnect while the draft is dirty keeps the draft and offers Load current", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -322,6 +322,47 @@ test("a read landing after a superseded save re-syncs a draft that matches disk"
   expect(editor().value).toBe("# hi\nmore");
 });
 
+// A save whose client was replaced mid-flight resolves with its own raw
+// response, because the store refuses to land anything for a socket that is
+// gone - and the replacement's reconnect refetch may already have put a newer
+// document there. So the resolved value is not evidence about the file any
+// more; the document the store holds is, and that is what the save is judged
+// against.
+test("a save resolving on a replaced client defers to the document the replacement fetched", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+
+  let finishWriting!: (doc: AgentsDocResponse) => void;
+  fake.on(
+    "evener/settings/agentsDoc/set",
+    () =>
+      new Promise<AgentsDocResponse>((resolve) => {
+        finishWriting = resolve;
+      }),
+  );
+  await user.click(saveButton());
+
+  // A fresh client - a banner retry - whose reconnect refetch lands first.
+  act(() => {
+    connectFakeClient({ ...DOC, content: "# theirs\n" });
+  });
+  await waitFor(() => expect(screen.getByRole("status").textContent).toContain("changed on disk"));
+
+  await act(async () => {
+    finishWriting({ ...DOC, content: "# hi\nmore" });
+  });
+
+  await waitFor(() =>
+    expect(getToasts().some((t) => t.kind === "warning" && t.text.startsWith("Saved AGENTS.md, but"))).toBe(true),
+  );
+  expect(getToasts().some((t) => t.text === "Saved AGENTS.md")).toBe(false);
+  expect(screen.getByRole("status").textContent).toContain("changed on disk");
+  expect(editor().value).toBe("# hi\nmore");
+});
+
 // An automatic reconnect keeps the same client - only a banner retry brings
 // a fresh one - and the editor heard no `changed` broadcast while the socket
 // was down. A one-shot mount fetch would leave it holding pre-drop content,

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, expect, test } from "vitest";
 import { WireError } from "../../../protocol/errors";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import type { AgentsDocResponse, AnyNotification } from "../../../protocol/types.gen";
-import { resetAgentsDocStoreForTests } from "../../../stores/agentsDoc";
+import { agentsDocStore, resetAgentsDocStoreForTests } from "../../../stores/agentsDoc";
 import { connectionStore } from "../../../stores/connection";
 import { Toast } from "../../../widgets";
 import { getToasts, resetToastStoreForTests } from "../../../widgets/toast/store";
@@ -270,6 +270,55 @@ test("a save superseded by a broadcast keeps the changed-on-disk note", async ()
   expect(getToasts().some((t) => t.text === "Saved AGENTS.md")).toBe(false);
   expect(screen.getByRole("status").textContent).toContain("changed on disk");
   expect(screen.getByRole("button", { name: "Load current" })).toBeTruthy();
+  expect(editor().value).toBe("# hi\nmore");
+});
+
+// The read that superseded the save then lands - holding exactly what the
+// editor has, because the save it fenced out is what put it there. The file
+// on disk IS the draft, so there is nothing to warn about and nothing to save.
+test("a read landing after a superseded save re-syncs a draft that matches disk", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+
+  let finishWriting!: (doc: AgentsDocResponse) => void;
+  fake.on(
+    "evener/settings/agentsDoc/set",
+    () =>
+      new Promise<AgentsDocResponse>((resolve) => {
+        finishWriting = resolve;
+      }),
+  );
+  await user.click(saveButton());
+
+  // A read started behind the write fences it out: the store resolves the
+  // save with the document it still holds, which is the pre-save file.
+  let finishReading!: (doc: AgentsDocResponse) => void;
+  fake.on(
+    "evener/settings/agentsDoc/get",
+    () =>
+      new Promise<AgentsDocResponse>((resolve) => {
+        finishReading = resolve;
+      }),
+  );
+  act(() => {
+    void agentsDocStore.getState().fetch();
+  });
+
+  const sent: AgentsDocResponse = { ...DOC, content: "# hi\nmore" };
+  await act(async () => {
+    finishWriting(sent);
+  });
+  await waitFor(() => expect(screen.getByRole("status").textContent).toContain("changed on disk"));
+  expect(saveButton().disabled).toBe(false);
+
+  await act(async () => {
+    finishReading(sent);
+  });
+  await waitFor(() => expect(screen.queryByRole("status")).toBeNull());
+  expect(saveButton().disabled).toBe(true);
   expect(editor().value).toBe("# hi\nmore");
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -282,6 +282,30 @@ test("a failed reload after a successful load shows a reload notice and keeps th
   expect(screen.queryByRole("alert")).toBeNull();
 });
 
+// The notice is the only sign the copy on screen is unconfirmed, so it carries
+// the way out of that state: a reload that failed because the hub blinked
+// succeeds on the next try, and the user should not have to reach a refetch
+// through a reconnect to get one.
+test("Reload in the reload notice re-reads the file", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+
+  act(() => {
+    fake.on("evener/settings/agentsDoc/get", () => {
+      throw new WireError("hub unreachable", -1);
+    });
+    fake.emitStateChange("reconnecting");
+    fake.emitReady();
+  });
+  await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("Couldn't reload AGENTS.md"));
+
+  fake.on("evener/settings/agentsDoc/get", () => ({ ...DOC, content: "# back\n" }));
+  await userEvent.setup().click(screen.getByRole("button", { name: "Reload" }));
+  await waitFor(() => expect(editor().value).toBe("# back\n"));
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
 test("a reconnect while the draft is dirty keeps the draft and offers Load current", async () => {
   connectFakeClient();
   renderSection();

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -233,6 +233,46 @@ test("a changed broadcast echoing this client's own save leaves later keystrokes
   expect(screen.queryByRole("status")).toBeNull();
 });
 
+// The hub takes last write wins, so a save a broadcast superseded did land -
+// and someone else's write went over it a moment later. The store resolves
+// such a save with that newer document, which is the section's only sign that
+// what it just wrote is already gone.
+test("a save superseded by a broadcast keeps the changed-on-disk note", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+
+  let finishWriting!: (doc: AgentsDocResponse) => void;
+  fake.on(
+    "evener/settings/agentsDoc/set",
+    () =>
+      new Promise<AgentsDocResponse>((resolve) => {
+        finishWriting = resolve;
+      }),
+  );
+  await user.click(saveButton());
+
+  act(() => {
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "# theirs\n" },
+    } as AnyNotification);
+  });
+  await act(async () => {
+    finishWriting({ ...DOC, content: "# hi\nmore" });
+  });
+
+  await waitFor(() =>
+    expect(getToasts().some((t) => t.kind === "warning" && t.text.startsWith("Saved AGENTS.md, but"))).toBe(true),
+  );
+  expect(getToasts().some((t) => t.text === "Saved AGENTS.md")).toBe(false);
+  expect(screen.getByRole("status").textContent).toContain("changed on disk");
+  expect(screen.getByRole("button", { name: "Load current" })).toBeTruthy();
+  expect(editor().value).toBe("# hi\nmore");
+});
+
 // An automatic reconnect keeps the same client - only a banner retry brings
 // a fresh one - and the editor heard no `changed` broadcast while the socket
 // was down. A one-shot mount fetch would leave it holding pre-drop content,

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test } from "vitest";
 import { WireError } from "../../../protocol/errors";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import type { AgentsDocResponse, AnyNotification } from "../../../protocol/types.gen";
@@ -17,6 +17,17 @@ function connectFakeClient(doc: AgentsDocResponse = DOC): FakeClient {
   fake.on("evener/settings/agentsDoc/get", () => doc);
   fake.on("evener/settings/agentsDoc/set", (params) => ({ ...doc, exists: true, content: params.content }));
   connectionStore.getState().connect(fake);
+  return fake;
+}
+
+// A WireError, as the hub really sends: friendlyErrorMessage passes a wire
+// message through but replaces a plain Error with a generic line
+// (mcp.test.tsx pins that), so a plain Error here would never reach the DOM.
+function failingSaveClient(): FakeClient {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/agentsDoc/set", () => {
+    throw new WireError("read-only file system", -1);
+  });
   return fake;
 }
 
@@ -45,7 +56,6 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  vi.restoreAllMocks();
 });
 
 test("loads the file on mount and shows its path and content", async () => {
@@ -111,13 +121,7 @@ test("Save sends the draft, toasts, and the editor is clean afterwards", async (
 });
 
 test("a failed save shows the hub's error inline and keeps the draft", async () => {
-  const fake = connectFakeClient();
-  // A WireError, as the hub really sends: friendlyErrorMessage passes a
-  // wire message through but replaces a plain Error with a generic line
-  // (mcp.test.tsx pins that), so a plain Error here would never reach the DOM.
-  fake.on("evener/settings/agentsDoc/set", () => {
-    throw new WireError("read-only file system", -1);
-  });
+  failingSaveClient();
   renderSection();
   await waitFor(() => expect(editor().value).toBe("# hi\n"));
   const user = userEvent.setup();
@@ -126,6 +130,38 @@ test("a failed save shows the hub's error inline and keeps the draft", async () 
   await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("read-only file system"));
   expect(editor().value).toBe("# hi\nmore");
   expect(saveButton().disabled).toBe(false);
+});
+
+test("Revert clears a failed save's error", async () => {
+  failingSaveClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(saveButton());
+  await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("read-only file system"));
+
+  await user.click(screen.getByRole("button", { name: "Revert" }));
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+test("Load current clears a failed save's error", async () => {
+  const fake = failingSaveClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(saveButton());
+  await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("read-only file system"));
+
+  act(() => {
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "# from the TUI\n" },
+    } as AnyNotification);
+  });
+  await user.click(screen.getByRole("button", { name: "Load current" }));
+  expect(screen.queryByRole("alert")).toBeNull();
 });
 
 test("a changed broadcast while the draft is clean replaces the editor", async () => {
@@ -139,7 +175,7 @@ test("a changed broadcast while the draft is clean replaces the editor", async (
     } as AnyNotification);
   });
   await waitFor(() => expect(editor().value).toBe("# from the TUI\n"));
-  expect(screen.queryByText(/changed on disk/)).toBeNull();
+  expect(screen.queryByRole("status")).toBeNull();
 });
 
 test("a changed broadcast while the draft is dirty keeps the draft and offers Load current", async () => {
@@ -154,11 +190,42 @@ test("a changed broadcast while the draft is dirty keeps the draft and offers Lo
       params: { ...DOC, content: "# from the TUI\n" },
     } as AnyNotification);
   });
-  await waitFor(() => expect(screen.getByText(/changed on disk/)).toBeTruthy());
+  await waitFor(() => expect(screen.getByRole("status").textContent).toContain("changed on disk"));
   expect(editor().value).toBe("# hi\nmore");
 
   await user.click(screen.getByRole("button", { name: "Load current" }));
   expect(editor().value).toBe("# from the TUI\n");
-  expect(screen.queryByText(/changed on disk/)).toBeNull();
+  expect(screen.queryByRole("status")).toBeNull();
   expect(saveButton().disabled).toBe(true);
+});
+
+// The hub broadcasts every write, this client's own save included, and
+// Task 4's store deliberately does not suppress that self-echo: the section's
+// content-keyed stale test is what makes the echo inert. An echo arriving
+// after the user has typed again is where a dirtiness-keyed test would go
+// wrong, so that is the shape this pins.
+test("a changed broadcast echoing this client's own save leaves later keystrokes alone", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(saveButton());
+  // The whole round-trip has settled: the toast landed and the editor is
+  // editable again (it is disabled only while saving).
+  await waitFor(() => {
+    expect(getToasts().some((t) => t.text === "Saved AGENTS.md")).toBe(true);
+    expect(editor().disabled).toBe(false);
+  });
+  await user.type(editor(), " again");
+
+  act(() => {
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "# hi\nmore" },
+    } as AnyNotification);
+  });
+
+  expect(editor().value).toBe("# hi\nmore again");
+  expect(screen.queryByRole("status")).toBeNull();
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -131,6 +131,16 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
           </Button>
         </p>
       )}
+      {/* A refetch that failed leaves `doc` where it was, so the editor is
+          showing a copy it can no longer confirm. Save stays enabled: a
+          reload that failed because the hub is unreachable fails a save the
+          same way, and disabling it would only trap the draft. */}
+      {error !== null && (
+        <p className={CLASS.error} role="alert">
+          Couldn't reload AGENTS.md: {error}. The editor shows the last copy it loaded; saving would overwrite anything
+          changed on disk since.
+        </p>
+      )}
       {saveError !== null && (
         <p className={CLASS.error} role="alert">
           Save failed: {saveError}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -82,9 +82,13 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
       // The store resolves a save with whatever document is newer than the
       // write when one landed behind it, so a save that comes back holding
       // something other than what it sent was overwritten on its way in -
-      // the file moved under the user and the notice has to stay up.
-      setBaseline(saved.content);
-      if (saved.content === sent) {
+      // the file moved under the user and the notice has to stay up. The
+      // reference is the store's own document rather than the resolved value:
+      // a response from a client the store has since replaced never lands
+      // there, so it can be older than what the replacement already fetched.
+      const authoritative = agentsDocStore.getState().doc?.content ?? saved.content;
+      setBaseline(authoritative);
+      if (authoritative === sent) {
         setStale(false);
         toast.push("success", "Saved AGENTS.md");
       } else {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -66,13 +66,26 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
   const dirty = baseline !== null && draft !== baseline;
 
   async function handleSave(): Promise<void> {
+    const sent = draft;
     setSaving(true);
     setSaveError(null);
     try {
-      const saved = await agentsDocStore.getState().save(draft);
+      const saved = await agentsDocStore.getState().save(sent);
+      // The store resolves a save with whatever document is newer than the
+      // write when one landed behind it, so a save that comes back holding
+      // something other than what it sent was overwritten on its way in -
+      // the file moved under the user and the notice has to stay up.
       setBaseline(saved.content);
-      setStale(false);
-      toast.push("success", "Saved AGENTS.md");
+      if (saved.content === sent) {
+        setStale(false);
+        toast.push("success", "Saved AGENTS.md");
+      } else {
+        setStale(true);
+        toast.push(
+          "warning",
+          "Saved AGENTS.md, but it changed on disk since. Review the current copy before saving again.",
+        );
+      }
     } catch (err) {
       setSaveError(friendlyErrorMessage(err));
     } finally {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -141,7 +141,18 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
         <p className={CLASS.error} role="alert">
           Couldn't reload AGENTS.md: {error}. The editor shows the last copy it loaded; saving would overwrite anything
           changed on disk since.
-          <Button size="sm" variant="quiet" onClick={() => void agentsDocStore.getState().fetch()}>
+          {/* The store lands its own failure in `error` above; the rejection is
+              caught only so it never surfaces as an unhandled one. */}
+          <Button
+            size="sm"
+            variant="quiet"
+            onClick={() =>
+              void agentsDocStore
+                .getState()
+                .fetch()
+                .catch(() => {})
+            }
+          >
             Reload
           </Button>
         </p>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -14,6 +14,7 @@
 import { useEffect, useState } from "react";
 import { friendlyErrorMessage } from "../../../protocol/errors";
 import { agentsDocStore, useAgentsDocStore } from "../../../stores/agentsDoc";
+import { useConnectionStore } from "../../../stores/connection";
 import { Button, Skeleton, Textarea, useToasts } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import styles from "./agentsDoc.module.css";
@@ -44,9 +45,15 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
   const [stale, setStale] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const client = useConnectionStore((s) => s.client);
   const toast = useToasts();
 
-  useConnectedEffect(() => agentsDocStore.getState().fetch(), []);
+  // `client` is a trigger-only dependency, never read here: a drop replaces
+  // the wired client outright (shell/ConnectionBanner.tsx's retry), and the
+  // broadcasts that landed while the socket was down are gone, so the fresh
+  // client has to re-read the file. The content-keyed effect below is what
+  // keeps that refetch from taking a dirty draft with it.
+  useConnectedEffect(() => agentsDocStore.getState().fetch(), [client]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: doc is the only trigger; draft and baseline are read at that moment, not watched
   useEffect(() => {
@@ -91,7 +98,15 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
   }
 
   if (doc === null && loading) return <Skeleton />;
-  if (doc === null && error) return <p className={CLASS.error}>Failed to load: {friendlyErrorMessage(error)}</p>;
+  // The store has already flattened the rejection to text, and for a file
+  // editor that text IS the fix - "permission denied", "is a directory" -
+  // so it goes to the user as it stands (inrepo.tsx does the same).
+  if (doc === null && error)
+    return (
+      <p className={CLASS.error} role="alert">
+        Failed to load: {error}
+      </p>
+    );
   if (doc === null) return null; // not yet fetched: the connected effect hasn't run
 
   return (

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -14,7 +14,6 @@
 import { useEffect, useState } from "react";
 import { friendlyErrorMessage } from "../../../protocol/errors";
 import { agentsDocStore, useAgentsDocStore } from "../../../stores/agentsDoc";
-import { useConnectionStore } from "../../../stores/connection";
 import { Button, Skeleton, Textarea, useToasts } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import styles from "./agentsDoc.module.css";
@@ -45,15 +44,12 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
   const [stale, setStale] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const client = useConnectionStore((s) => s.client);
   const toast = useToasts();
 
-  // `client` is a trigger-only dependency, never read here: a drop replaces
-  // the wired client outright (shell/ConnectionBanner.tsx's retry), and the
-  // broadcasts that landed while the socket was down are gone, so the fresh
-  // client has to re-read the file. The content-keyed effect below is what
-  // keeps that refetch from taking a dirty draft with it.
-  useConnectedEffect(() => agentsDocStore.getState().fetch(), [client]);
+  // Reconnects are the store's business (stores/agentsDoc.ts refetches on
+  // every one); this is the mount read. The content-keyed effect below is
+  // what keeps either of them from taking a dirty draft with it.
+  useConnectedEffect(() => agentsDocStore.getState().fetch(), []);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: doc is the only trigger; draft and baseline are read at that moment, not watched
   useEffect(() => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -11,7 +11,7 @@
 // nor the draft while dirty is someone else's write, and flips `stale` -
 // this client's own save lands with content equal to the draft, so it never
 // reads as stale.
-import { useEffect, useId, useState } from "react";
+import { useEffect, useState } from "react";
 import { friendlyErrorMessage } from "../../../protocol/errors";
 import { agentsDocStore, useAgentsDocStore } from "../../../stores/agentsDoc";
 import { Button, Skeleton, Textarea, useToasts } from "../../../widgets";
@@ -45,7 +45,6 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const toast = useToasts();
-  const fieldId = useId();
 
   useConnectedEffect(() => agentsDocStore.getState().fetch(), []);
 
@@ -80,6 +79,7 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
 
   function handleRevert(): void {
     if (baseline !== null) setDraft(baseline);
+    setSaveError(null);
   }
 
   function handleLoadCurrent(): void {
@@ -87,6 +87,7 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
     setDraft(doc.content);
     setBaseline(doc.content);
     setStale(false);
+    setSaveError(null);
   }
 
   if (doc === null && loading) return <Skeleton />;
@@ -102,7 +103,6 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
       </p>
       <div className={CLASS.editor}>
         <Textarea
-          id={fieldId}
           aria-label="AGENTS.md contents"
           value={draft}
           onChange={(event) => setDraft(event.target.value)}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -7,7 +7,8 @@
 //
 // `baseline` is the content the draft was last synced to; `dirty` is
 // draft !== baseline. A hub push (the `doc` subscription) syncs the draft
-// only while it is clean. A push whose content matches neither the baseline
+// while it is clean, and adopts a document that already equals the draft as
+// the new baseline. A push whose content matches neither the baseline
 // nor the draft while dirty is someone else's write, and flips `stale` -
 // this client's own save lands with content equal to the draft, so it never
 // reads as stale.
@@ -56,6 +57,13 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
     if (doc === null) return;
     if (baseline === null || draft === baseline) {
       setDraft(doc.content);
+      setBaseline(doc.content);
+      setStale(false);
+      return;
+    }
+    // A document that equals the draft is what the editor already holds, so
+    // there is nothing to warn about and nothing left to save.
+    if (doc.content === draft) {
       setBaseline(doc.content);
       setStale(false);
       return;

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -1,0 +1,138 @@
+// Settings -> AGENTS.md: the personal instructions file every session loads
+// ahead of the repo's own project docs (spec 2026-09-07 §1). A whole-file
+// editor over stores/agentsDoc.ts: Save is dirty-gated, Revert restores the
+// last loaded content, and there is no conflict precondition by design (last
+// write wins) - what the section does instead is tell the user when the file
+// changed under a dirty draft and let them load the current version.
+//
+// `baseline` is the content the draft was last synced to; `dirty` is
+// draft !== baseline. A hub push (the `doc` subscription) syncs the draft
+// only while it is clean. A push whose content matches neither the baseline
+// nor the draft while dirty is someone else's write, and flips `stale` -
+// this client's own save lands with content equal to the draft, so it never
+// reads as stale.
+import { useEffect, useId, useState } from "react";
+import { friendlyErrorMessage } from "../../../protocol/errors";
+import { agentsDocStore, useAgentsDocStore } from "../../../stores/agentsDoc";
+import { Button, Skeleton, Textarea, useToasts } from "../../../widgets";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import styles from "./agentsDoc.module.css";
+import { Code } from "./settingsField";
+import { useConnectedEffect } from "./useConnectedEffect";
+
+const CLASS = {
+  root: requireClass(styles.root, "agentsDoc.module.css", "root"),
+  help: requireClass(styles.help, "agentsDoc.module.css", "help"),
+  error: requireClass(styles.error, "agentsDoc.module.css", "error"),
+  editor: requireClass(styles.editor, "agentsDoc.module.css", "editor"),
+  note: requireClass(styles.note, "agentsDoc.module.css", "note"),
+  actions: requireClass(styles.actions, "agentsDoc.module.css", "actions"),
+};
+
+export interface AgentsDocSectionProps {
+  /** Unused - kept so this component's signature matches every other
+   * dispatched settings section (see Settings.tsx's SECTION_COMPONENTS map). */
+  sectionId: string;
+}
+
+export function AgentsDocSection(_props: AgentsDocSectionProps) {
+  const doc = useAgentsDocStore((s) => s.doc);
+  const loading = useAgentsDocStore((s) => s.loading);
+  const error = useAgentsDocStore((s) => s.error);
+  const [draft, setDraft] = useState("");
+  const [baseline, setBaseline] = useState<string | null>(null);
+  const [stale, setStale] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const toast = useToasts();
+  const fieldId = useId();
+
+  useConnectedEffect(() => agentsDocStore.getState().fetch(), []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: doc is the only trigger; draft and baseline are read at that moment, not watched
+  useEffect(() => {
+    if (doc === null) return;
+    if (baseline === null || draft === baseline) {
+      setDraft(doc.content);
+      setBaseline(doc.content);
+      setStale(false);
+      return;
+    }
+    if (doc.content !== baseline && doc.content !== draft) setStale(true);
+  }, [doc]);
+
+  const dirty = baseline !== null && draft !== baseline;
+
+  async function handleSave(): Promise<void> {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const saved = await agentsDocStore.getState().save(draft);
+      setBaseline(saved.content);
+      setStale(false);
+      toast.push("success", "Saved AGENTS.md");
+    } catch (err) {
+      setSaveError(friendlyErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleRevert(): void {
+    if (baseline !== null) setDraft(baseline);
+  }
+
+  function handleLoadCurrent(): void {
+    if (doc === null) return;
+    setDraft(doc.content);
+    setBaseline(doc.content);
+    setStale(false);
+  }
+
+  if (doc === null && loading) return <Skeleton />;
+  if (doc === null && error) return <p className={CLASS.error}>Failed to load: {friendlyErrorMessage(error)}</p>;
+  if (doc === null) return null; // not yet fetched: the connected effect hasn't run
+
+  return (
+    <div className={CLASS.root}>
+      <h2>AGENTS.md</h2>
+      <p className={CLASS.help}>
+        Personal instructions loaded into every session, ahead of the repo's own AGENTS.md. Stored at{" "}
+        <Code>{doc.path}</Code>.
+      </p>
+      <div className={CLASS.editor}>
+        <Textarea
+          id={fieldId}
+          aria-label="AGENTS.md contents"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          minLines={16}
+          autoGrow
+          disabled={saving}
+          placeholder="# Instructions for every session"
+        />
+      </div>
+      {stale && (
+        <p className={CLASS.note} role="status">
+          AGENTS.md changed on disk while you were editing.
+          <Button size="sm" variant="quiet" onClick={handleLoadCurrent}>
+            Load current
+          </Button>
+        </p>
+      )}
+      {saveError !== null && (
+        <p className={CLASS.error} role="alert">
+          Save failed: {saveError}
+        </p>
+      )}
+      <div className={CLASS.actions}>
+        <Button onClick={() => void handleSave()} disabled={!dirty || saving}>
+          Save
+        </Button>
+        <Button variant="quiet" onClick={handleRevert} disabled={!dirty || saving}>
+          Revert
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx
@@ -134,11 +134,16 @@ export function AgentsDocSection(_props: AgentsDocSectionProps) {
       {/* A refetch that failed leaves `doc` where it was, so the editor is
           showing a copy it can no longer confirm. Save stays enabled: a
           reload that failed because the hub is unreachable fails a save the
-          same way, and disabling it would only trap the draft. */}
+          same way, and disabling it would only trap the draft. The way out
+          rides the notice, as "Load current" does above: the next read often
+          succeeds, and waiting for a reconnect to fire one is not a fix. */}
       {error !== null && (
         <p className={CLASS.error} role="alert">
           Couldn't reload AGENTS.md: {error}. The editor shows the last copy it loaded; saving would overwrite anything
           changed on disk since.
+          <Button size="sm" variant="quiet" onClick={() => void agentsDocStore.getState().fetch()}>
+            Reload
+          </Button>
         </p>
       )}
       {saveError !== null && (

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -15,6 +15,16 @@ export interface AgentMessageResetParams {
   itemId: string;
 }
 
+export interface AgentsDocResponse {
+  path: string;
+  exists: boolean;
+  content: string;
+}
+
+export interface AgentsDocSetParams {
+  content: string;
+}
+
 export interface ArchiveParams {
   kind: string;
   id: string;
@@ -2193,6 +2203,8 @@ export const METHOD_NAMES = [
   "evener/settings/transcriptDisplay/patch",
   "evener/settings/keybindings/get",
   "evener/settings/keybindings/patch",
+  "evener/settings/agentsDoc/get",
+  "evener/settings/agentsDoc/set",
   "evener/sandbox/escalation/resolve",
 ] as const;
 
@@ -2235,6 +2247,7 @@ export const NOTIFICATION_NAMES = [
   "evener/sandbox/escalation/resolved",
   "evener/settings/transcriptDisplay/changed",
   "evener/settings/keybindings/changed",
+  "evener/settings/agentsDoc/changed",
 ] as const;
 
 export type NotificationName = (typeof NOTIFICATION_NAMES)[number];
@@ -2374,6 +2387,8 @@ export interface MethodTypes {
   "evener/settings/transcriptDisplay/patch": { params: TranscriptDisplayDefaultsPatchParams; result: TranscriptDisplayPatchResponse };
   "evener/settings/keybindings/get": { params: EmptyParams; result: KeybindingsOverrides };
   "evener/settings/keybindings/patch": { params: KeybindingsPatchParams; result: KeybindingsOverrides };
+  "evener/settings/agentsDoc/get": { params: EmptyParams; result: AgentsDocResponse };
+  "evener/settings/agentsDoc/set": { params: AgentsDocSetParams; result: AgentsDocResponse };
   "evener/sandbox/escalation/resolve": { params: SandboxEscalationResolveParams; result: EmptyResponse };
 }
 
@@ -2414,6 +2429,7 @@ export interface NotificationTypes {
   "evener/sandbox/escalation/resolved": SandboxEscalationResolved;
   "evener/settings/transcriptDisplay/changed": TranscriptDisplayChangedParams;
   "evener/settings/keybindings/changed": KeybindingsOverrides;
+  "evener/settings/agentsDoc/changed": AgentsDocResponse;
 }
 
 export type AnyNotification = { [K in NotificationName]: { method: K; params: NotificationTypes[K] } }[NotificationName];

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { FakeClient } from "../protocol/testing/fakeClient";
+import type { AgentsDocResponse, AnyNotification } from "../protocol/types.gen";
+import { agentsDocStore, resetAgentsDocStoreForTests } from "./agentsDoc";
+import { connectionStore } from "./connection";
+
+const DOC: AgentsDocResponse = { path: "/home/u/.config/evener/AGENTS.md", exists: true, content: "# hi\n" };
+
+function connectFakeClient(): FakeClient {
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetAgentsDocStoreForTests();
+});
+
+describe("fetch", () => {
+  test("loads the document from evener/settings/agentsDoc/get", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+    expect(agentsDocStore.getState().loading).toBe(false);
+    expect(agentsDocStore.getState().error).toBeNull();
+  });
+
+  test("records a failed fetch as error text and keeps doc null", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => {
+      throw new Error("disk on fire");
+    });
+    await agentsDocStore.getState().fetch();
+    expect(agentsDocStore.getState().doc).toBeNull();
+    expect(agentsDocStore.getState().error).toContain("disk on fire");
+    expect(agentsDocStore.getState().loading).toBe(false);
+  });
+
+  test("throws when no client is connected", async () => {
+    await expect(agentsDocStore.getState().fetch()).rejects.toThrow(/no client connected/);
+  });
+});
+
+describe("save", () => {
+  test("sends the content to evener/settings/agentsDoc/set and adopts the response", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/set", (params) => ({ ...DOC, content: params.content }));
+    const saved = await agentsDocStore.getState().save("# new\n");
+    expect(saved.content).toBe("# new\n");
+    expect(agentsDocStore.getState().doc?.content).toBe("# new\n");
+    expect(fake.calls.map((c) => c.method)).toEqual(["evener/settings/agentsDoc/set"]);
+    expect(fake.calls[0]?.params).toEqual({ content: "# new\n" });
+  });
+
+  test("a rejected save propagates and leaves doc untouched", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+    fake.on("evener/settings/agentsDoc/set", () => {
+      throw new Error("read-only");
+    });
+    await expect(agentsDocStore.getState().save("x")).rejects.toThrow("read-only");
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+  });
+});
+
+describe("changed notification", () => {
+  test("replaces doc with the broadcast payload", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+    const pushed: AgentsDocResponse = { ...DOC, content: "# elsewhere\n" };
+    fake.emitNotification({ method: "evener/settings/agentsDoc/changed", params: pushed } as AnyNotification);
+    expect(agentsDocStore.getState().doc).toEqual(pushed);
+  });
+
+  test("a replaced client is re-wired: the old client's notifications stop landing", async () => {
+    const first = connectFakeClient();
+    const second = connectFakeClient();
+    second.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+    first.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "stale" },
+    } as AnyNotification);
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+    second.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "live" },
+    } as AnyNotification);
+    expect(agentsDocStore.getState().doc?.content).toBe("live");
+  });
+});

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -62,6 +62,94 @@ describe("fetch", () => {
   test("throws when no client is connected", async () => {
     await expect(agentsDocStore.getState().fetch()).rejects.toThrow(/no client connected/);
   });
+
+  // Only the most recently started read may land, exactly as
+  // stores/credentials.ts fences its own: an overlapping older response
+  // carries a view of the file that is already out of date, and the section
+  // syncs its draft off whatever `doc` holds.
+  test("an older fetch that resolves last does not overwrite the newer one", async () => {
+    const fake = connectFakeClient();
+    let finishOlder!: (doc: AgentsDocResponse) => void;
+    fake.on(
+      "evener/settings/agentsDoc/get",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          finishOlder = resolve;
+        }),
+    );
+    const older = agentsDocStore.getState().fetch();
+    await Promise.resolve();
+
+    fake.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+
+    finishOlder({ ...DOC, content: "# older\n" });
+    await older;
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+  });
+
+  test("a late response from a replaced client is dropped", async () => {
+    const first = connectFakeClient();
+    let finishFirst!: (doc: AgentsDocResponse) => void;
+    first.on(
+      "evener/settings/agentsDoc/get",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          finishFirst = resolve;
+        }),
+    );
+    const interrupted = agentsDocStore.getState().fetch();
+    await Promise.resolve();
+
+    // Scripted before connecting: the replacement's own reconnect refetch
+    // fires the moment it becomes the store's client.
+    const second = new FakeClient("ready");
+    second.on("evener/settings/agentsDoc/get", () => DOC);
+    connectionStore.getState().connect(second);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+
+    finishFirst({ ...DOC, content: "# from the dead socket\n" });
+    await interrupted;
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+  });
+});
+
+// An automatic reconnect reuses the same AppwireClient, so a socket drop and
+// recovery is a state transition and nothing else. The broadcasts that landed
+// while it was down are gone, so the store has to re-read the file itself.
+describe("reconnect", () => {
+  test("a reconnect on the same client refetches", async () => {
+    const fake = connectFakeClient();
+    const away: AgentsDocResponse = { ...DOC, content: "# while we were away\n" };
+    let calls = 0;
+    fake.on("evener/settings/agentsDoc/get", () => {
+      calls += 1;
+      return calls === 1 ? DOC : away;
+    });
+    await agentsDocStore.getState().fetch();
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+
+    fake.emitStateChange("reconnecting");
+    fake.emitReady();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(calls).toBe(2);
+    expect(agentsDocStore.getState().doc).toEqual(away);
+  });
+
+  test("a reconnect before anything was requested fetches nothing", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => DOC);
+
+    fake.emitStateChange("reconnecting");
+    fake.emitReady();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fake.calls).toEqual([]);
+    expect(agentsDocStore.getState().doc).toBeNull();
+  });
 });
 
 describe("save", () => {

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -60,6 +60,32 @@ describe("fetch", () => {
     expect(agentsDocStore.getState().loading).toBe(false);
   });
 
+  // A fetch that lands has the hub's fresh document, so whatever error was
+  // recorded before it landed is moot - exactly as save() and the changed
+  // broadcast already clear it. The stale error is seeded after the retry
+  // starts (a plain failed-then-retried sequence would clear at the retry's
+  // own start instead), so only the success branch itself can take it away.
+  test("a successful retry clears a stale fetch error", async () => {
+    const fake = connectFakeClient();
+    let land!: (doc: AgentsDocResponse) => void;
+    fake.on(
+      "evener/settings/agentsDoc/get",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          land = resolve;
+        }),
+    );
+    const retry = agentsDocStore.getState().fetch();
+    await Promise.resolve();
+    expect(agentsDocStore.getState().loading).toBe(true);
+
+    agentsDocStore.setState({ error: "hub unreachable" });
+    land(DOC);
+    await retry;
+    expect(agentsDocStore.getState().error).toBeNull();
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+  });
+
   test("throws when no client is connected", async () => {
     await expect(agentsDocStore.getState().fetch()).rejects.toThrow(/no client connected/);
   });

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -217,6 +217,63 @@ describe("save", () => {
     expect(agentsDocStore.getState().error).toBeNull();
     expect(agentsDocStore.getState().doc?.content).toBe("x");
   });
+
+  // A reconnect refetch that started before a save can only land after it
+  // holding the pre-save file, so a save fences older reads out the way a
+  // newer read does. A fetch started AFTER the save is fresher and still wins.
+  test("a save invalidates an older in-flight fetch", async () => {
+    const fake = connectFakeClient();
+    let finishReading!: (doc: AgentsDocResponse) => void;
+    fake.on(
+      "evener/settings/agentsDoc/get",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          finishReading = resolve;
+        }),
+    );
+    const reading = agentsDocStore.getState().fetch();
+    await Promise.resolve();
+
+    fake.on("evener/settings/agentsDoc/set", (params) => ({ ...DOC, content: params.content }));
+    await agentsDocStore.getState().save("# new\n");
+    expect(agentsDocStore.getState().doc?.content).toBe("# new\n");
+
+    finishReading({ ...DOC, content: "# old\n" });
+    await reading;
+    expect(agentsDocStore.getState().doc?.content).toBe("# new\n");
+  });
+
+  // The write did reach the hub, so the caller still gets its result - what
+  // it may not do is speak for a socket the store has already replaced.
+  test("a save response from a replaced client is not committed", async () => {
+    const first = connectFakeClient();
+    first.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+
+    const written: AgentsDocResponse = { ...DOC, content: "# from the dead socket\n" };
+    let finishWriting!: (doc: AgentsDocResponse) => void;
+    first.on(
+      "evener/settings/agentsDoc/set",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          finishWriting = resolve;
+        }),
+    );
+    const writing = agentsDocStore.getState().save(written.content);
+    await Promise.resolve();
+
+    // Scripted before connecting: the replacement's own reconnect refetch
+    // fires the moment it becomes the store's client.
+    const second = new FakeClient("ready");
+    second.on("evener/settings/agentsDoc/get", () => DOC);
+    connectionStore.getState().connect(second);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    finishWriting(written);
+    await expect(writing).resolves.toEqual(written);
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+  });
 });
 
 describe("changed notification", () => {

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -219,9 +219,9 @@ describe("save", () => {
   });
 
   // A reconnect refetch that started before a save can only land after it
-  // holding the pre-save file, so a save fences older reads out the way a
-  // newer read does. A read started after it may land, but the save's own
-  // response - the hub's view of the file after the write - lands over it.
+  // holding the pre-save file, so the save's own bump fences it out the way a
+  // newer read does. A read that bumps the version after the save runs the
+  // other way round: it fences the save's own response out instead.
   test("a save invalidates an older in-flight fetch", async () => {
     const fake = connectFakeClient();
     let finishReading!: (doc: AgentsDocResponse) => void;

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -301,6 +301,34 @@ describe("save", () => {
     await expect(writing).resolves.toEqual(written);
     expect(agentsDocStore.getState().doc).toEqual(DOC);
   });
+
+  // A broadcast that lands mid-save carries a write that reached the file
+  // after this one, so the save's own response is stale by the time it
+  // arrives: committing it would put the older content back under the editor,
+  // and the next Save would then push it over what is actually on disk.
+  test("a save response older than a broadcast is not committed and the broadcast's document is returned", async () => {
+    const fake = connectFakeClient();
+    let finishWriting!: (doc: AgentsDocResponse) => void;
+    fake.on(
+      "evener/settings/agentsDoc/set",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          finishWriting = resolve;
+        }),
+    );
+    const writing = agentsDocStore.getState().save("mine");
+    await Promise.resolve();
+
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "newer" },
+    } as AnyNotification);
+
+    finishWriting({ ...DOC, content: "mine" });
+    const resolved = await writing;
+    expect(resolved.content).toBe("newer");
+    expect(agentsDocStore.getState().doc?.content).toBe("newer");
+  });
 });
 
 describe("changed notification", () => {
@@ -332,6 +360,9 @@ describe("changed notification", () => {
       method: "evener/settings/agentsDoc/changed",
       params: { ...DOC, content: "pushed" },
     } as AnyNotification);
+    // The bump just dropped the read, so nothing is left to turn `loading`
+    // off - the handler does it, as the save and the connection subscriber do.
+    expect(agentsDocStore.getState().loading).toBe(false);
 
     finishReading({ ...DOC, content: "old" });
     await reading;

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test } from "vitest";
+import { WireError } from "../protocol/errors";
 import { FakeClient } from "../protocol/testing/fakeClient";
 import type { AgentsDocResponse, AnyNotification } from "../protocol/types.gen";
 import { agentsDocStore, resetAgentsDocStoreForTests } from "./agentsDoc";
@@ -198,6 +199,23 @@ describe("save", () => {
     });
     await expect(agentsDocStore.getState().save("x")).rejects.toThrow("read-only");
     expect(agentsDocStore.getState().doc).toEqual(DOC);
+  });
+
+  // A reload can fail while the socket stays up, and the section's notice for
+  // that ("saving would overwrite anything changed on disk since") is false
+  // the moment a write lands, so a save has to take the error with it.
+  test("a successful save clears a stale fetch error", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => {
+      throw new WireError("hub unreachable", -1);
+    });
+    await agentsDocStore.getState().fetch();
+    expect(agentsDocStore.getState().error).toContain("hub unreachable");
+
+    fake.on("evener/settings/agentsDoc/set", (params) => ({ ...DOC, content: params.content }));
+    await agentsDocStore.getState().save("x");
+    expect(agentsDocStore.getState().error).toBeNull();
+    expect(agentsDocStore.getState().doc?.content).toBe("x");
   });
 });
 

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -220,7 +220,8 @@ describe("save", () => {
 
   // A reconnect refetch that started before a save can only land after it
   // holding the pre-save file, so a save fences older reads out the way a
-  // newer read does. A fetch started AFTER the save is fresher and still wins.
+  // newer read does. A read started after it may land, but the save's own
+  // response - the hub's view of the file after the write - lands over it.
   test("a save invalidates an older in-flight fetch", async () => {
     const fake = connectFakeClient();
     let finishReading!: (doc: AgentsDocResponse) => void;
@@ -241,6 +242,32 @@ describe("save", () => {
     finishReading({ ...DOC, content: "# old\n" });
     await reading;
     expect(agentsDocStore.getState().doc?.content).toBe("# new\n");
+  });
+
+  // The bump that fences a read out leaves nothing to turn `loading` off, so
+  // the save has to clear it itself - otherwise the section keeps drawing a
+  // load it will never see land.
+  test("a save clears the loading left behind by the fetch it fenced out", async () => {
+    const fake = connectFakeClient();
+    let finishReading!: (doc: AgentsDocResponse) => void;
+    fake.on(
+      "evener/settings/agentsDoc/get",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          finishReading = resolve;
+        }),
+    );
+    const reading = agentsDocStore.getState().fetch();
+    await Promise.resolve();
+    expect(agentsDocStore.getState().loading).toBe(true);
+
+    fake.on("evener/settings/agentsDoc/set", (params) => ({ ...DOC, content: params.content }));
+    await agentsDocStore.getState().save("x");
+    expect(agentsDocStore.getState().loading).toBe(false);
+
+    finishReading({ ...DOC, content: "# old\n" });
+    await reading;
+    expect(agentsDocStore.getState().doc?.content).toBe("x");
   });
 
   // The write did reach the hub, so the caller still gets its result - what
@@ -283,6 +310,48 @@ describe("changed notification", () => {
     await agentsDocStore.getState().fetch();
     const pushed: AgentsDocResponse = { ...DOC, content: "# elsewhere\n" };
     fake.emitNotification({ method: "evener/settings/agentsDoc/changed", params: pushed } as AnyNotification);
+    expect(agentsDocStore.getState().doc).toEqual(pushed);
+  });
+
+  // A broadcast is the hub's own view of the file, so a read that started
+  // before it can only land holding an older one.
+  test("a changed broadcast invalidates an older in-flight fetch", async () => {
+    const fake = connectFakeClient();
+    let finishReading!: (doc: AgentsDocResponse) => void;
+    fake.on(
+      "evener/settings/agentsDoc/get",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          finishReading = resolve;
+        }),
+    );
+    const reading = agentsDocStore.getState().fetch();
+    await Promise.resolve();
+
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "pushed" },
+    } as AnyNotification);
+
+    finishReading({ ...DOC, content: "old" });
+    await reading;
+    expect(agentsDocStore.getState().doc?.content).toBe("pushed");
+  });
+
+  // The section's reload notice ("saving would overwrite anything changed on
+  // disk since") is false the moment the hub pushes the current file, exactly
+  // as it is when a save lands.
+  test("a changed broadcast clears a stale fetch error", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => {
+      throw new WireError("hub unreachable", -1);
+    });
+    await agentsDocStore.getState().fetch();
+    expect(agentsDocStore.getState().error).toContain("hub unreachable");
+
+    const pushed: AgentsDocResponse = { ...DOC, content: "# elsewhere\n" };
+    fake.emitNotification({ method: "evener/settings/agentsDoc/changed", params: pushed } as AnyNotification);
+    expect(agentsDocStore.getState().error).toBeNull();
     expect(agentsDocStore.getState().doc).toEqual(pushed);
   });
 

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -139,6 +139,32 @@ describe("reconnect", () => {
     expect(agentsDocStore.getState().doc).toEqual(away);
   });
 
+  // A drop the fence catches mid-fetch drops that response, so nothing is
+  // left to turn `loading` off - and a drop that never recovers would leave
+  // the section drawing its Skeleton over a document it will never get.
+  test("a drop mid-fetch clears loading", async () => {
+    const fake = connectFakeClient();
+    let land!: (doc: AgentsDocResponse) => void;
+    fake.on(
+      "evener/settings/agentsDoc/get",
+      () =>
+        new Promise<AgentsDocResponse>((resolve) => {
+          land = resolve;
+        }),
+    );
+    const interrupted = agentsDocStore.getState().fetch();
+    await Promise.resolve(); // the fake defers its handler by a microtask
+    expect(agentsDocStore.getState().loading).toBe(true);
+
+    fake.emitStateChange("reconnecting");
+    expect(agentsDocStore.getState().loading).toBe(false);
+
+    land(DOC);
+    await interrupted;
+    expect(agentsDocStore.getState().doc).toBeNull();
+    expect(agentsDocStore.getState().loading).toBe(false);
+  });
+
   test("a reconnect before anything was requested fetches nothing", async () => {
     const fake = connectFakeClient();
     fake.on("evener/settings/agentsDoc/get", () => DOC);

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts
@@ -27,6 +27,27 @@ describe("fetch", () => {
     expect(agentsDocStore.getState().error).toBeNull();
   });
 
+  // `loading` is what the section draws its Skeleton from, and it is only
+  // observable while a request is outstanding - a handler that never resolves
+  // is the only way to stand in that window.
+  test("loading is true while the request is in flight", async () => {
+    const fake = connectFakeClient();
+    let land: ((doc: AgentsDocResponse) => void) | undefined;
+    const pending = new Promise<AgentsDocResponse>((resolve) => {
+      land = resolve;
+    });
+    fake.on("evener/settings/agentsDoc/get", () => pending);
+
+    const inFlight = agentsDocStore.getState().fetch();
+    expect(agentsDocStore.getState().loading).toBe(true);
+    expect(agentsDocStore.getState().doc).toBeNull();
+
+    land?.(DOC);
+    await inFlight;
+    expect(agentsDocStore.getState().loading).toBe(false);
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+  });
+
   test("records a failed fetch as error text and keeps doc null", async () => {
     const fake = connectFakeClient();
     fake.on("evener/settings/agentsDoc/get", () => {

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -1,0 +1,101 @@
+// The personal AGENTS.md store: the hub-authoritative file behind
+// Settings -> AGENTS.md (spec 2026-09-07 §1). One document, read whole and
+// written whole; no revision or conflict handling by design - the file is
+// also hand-edited, and the hub's own rule is last write wins. What the
+// store DOES keep current is `doc`: every evener/settings/agentsDoc/changed
+// broadcast (this client's own save included) replaces it, so a second tab
+// or a save from the TUI lands here without a refetch.
+//
+// requireClient() throws outside any try/catch, matching stores/credentials.ts:
+// "no client connected" is a programmer error, not a state to degrade into.
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+import { errorText } from "../protocol/errors";
+import type { AppwireClientLike } from "../protocol/testing/fakeClient";
+import type { AgentsDocResponse, AnyNotification } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+
+function requireClient(): AppwireClientLike {
+  const client = connectionStore.getState().client;
+  if (!client) {
+    throw new Error("agentsDoc store: no client connected; call useConnectionStore.getState().connect(client) first");
+  }
+  return client;
+}
+
+export interface AgentsDocStoreState {
+  /** The last document the hub confirmed - null until the first fetch lands. */
+  doc: AgentsDocResponse | null;
+  loading: boolean;
+  error: string | null;
+  fetch(): Promise<void>;
+  /** Replaces the file whole. Resolves with the hub's view of the saved file,
+   * which is also what `doc` becomes. Rejections propagate: the section
+   * owns the inline error and the toast. */
+  save(content: string): Promise<AgentsDocResponse>;
+}
+
+export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
+  doc: null,
+  loading: false,
+  error: null,
+
+  async fetch() {
+    const client = requireClient();
+    set({ loading: true, error: null });
+    try {
+      const doc = await client.request("evener/settings/agentsDoc/get", {});
+      set({ doc, loading: false });
+    } catch (err) {
+      set({ loading: false, error: errorText(err) });
+    }
+  },
+
+  async save(content) {
+    const client = requireClient();
+    const doc = await client.request("evener/settings/agentsDoc/set", { content });
+    set({ doc });
+    return doc;
+  },
+}));
+
+export function useAgentsDocStore(): AgentsDocStoreState;
+export function useAgentsDocStore<T>(selector: (state: AgentsDocStoreState) => T): T;
+export function useAgentsDocStore<T>(selector?: (state: AgentsDocStoreState) => T): T | AgentsDocStoreState {
+  // Not a real conditional hook call - see stores/connection.ts's own
+  // useConnectionStore for the full explanation.
+  // biome-ignore lint/correctness/useHookAtTopLevel: same hook both arms, JS default param not a real conditional - see stores/connection.ts
+  return selector ? useStore(agentsDocStore, selector) : useStore(agentsDocStore);
+}
+
+// --- notification wiring ----------------------------------------------------
+
+let wiredClient: AppwireClientLike | null = null;
+let unsubscribeNotifications: (() => void) | undefined;
+
+function handleNotification(n: AnyNotification): void {
+  if (n.method === "evener/settings/agentsDoc/changed") agentsDocStore.setState({ doc: n.params });
+}
+
+function attachNotifications(client: AppwireClientLike | null): void {
+  if (client === wiredClient) return; // already wired to this exact client
+  unsubscribeNotifications?.();
+  wiredClient = client;
+  unsubscribeNotifications = client?.onNotification(handleNotification);
+}
+
+// React to the connection store rather than reading it once: this module can
+// be evaluated before AppShell's connect() effect runs (stores/extensions.ts
+// documents the mount-order race in full).
+connectionStore.subscribe((state) => attachNotifications(state.client));
+const initialClient = connectionStore.getState().client;
+if (initialClient) attachNotifications(initialClient);
+
+// resetAgentsDocStoreForTests resets the singleton between tests, including
+// the module-private wiring above. No production code should ever call this.
+export function resetAgentsDocStoreForTests(): void {
+  unsubscribeNotifications?.();
+  unsubscribeNotifications = undefined;
+  wiredClient = null;
+  agentsDocStore.setState({ doc: null, loading: false, error: null });
+}

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -35,8 +35,8 @@ export interface AgentsDocStoreState {
   error: string | null;
   fetch(): Promise<void>;
   /** Replaces the file whole. Resolves with the hub's view of the saved file,
-   * which is also what `doc` becomes. Rejections propagate: the section
-   * owns the inline error and the toast. */
+   * which is also what `doc` becomes while this client is still the store's.
+   * Rejections propagate: the section owns the inline error and the toast. */
   save(content: string): Promise<AgentsDocResponse>;
 }
 
@@ -70,11 +70,18 @@ export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
 
   async save(content) {
     const client = requireClient();
+    // Bumped before the request, not after it: a read already in flight can
+    // only land holding the pre-save file, so the write fences it out the way
+    // a newer read does. A read started after this keeps a higher version and
+    // still wins, which is right - it is the fresher view.
+    ++requestVersion;
     const doc = await client.request("evener/settings/agentsDoc/set", { content });
     // A write that landed is the freshest view of the file there is, so an
     // earlier read's error is moot - and the section's notice for one
     // ("saving would overwrite anything changed on disk since") is now false.
-    set({ doc, error: null });
+    // A response from a client the store has since replaced speaks for a
+    // socket that is gone, so it goes back to the caller without landing.
+    if (connectionStore.getState().client === client) set({ doc, error: null });
     return doc;
   },
 }));

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -72,9 +72,13 @@ export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
     const client = requireClient();
     // Bumped before the request, not after it: a read already in flight can
     // only land holding the pre-save file, so the write fences it out the way
-    // a newer read does. A read started after this keeps a higher version and
-    // still wins, which is right - it is the fresher view.
+    // a newer read does. A read started after this one may land first, and the
+    // commit below then lands over it - which is right: the write's response
+    // is the hub's own view of the file after the write, never staler than a
+    // read that raced it. The bump leaves nothing to turn `loading` off, so
+    // the save does it, as the connection subscriber does for its own bump.
     ++requestVersion;
+    set({ loading: false });
     const doc = await client.request("evener/settings/agentsDoc/set", { content });
     // A write that landed is the freshest view of the file there is, so an
     // earlier read's error is moot - and the section's notice for one
@@ -101,7 +105,12 @@ let wiredClient: AppwireClientLike | null = null;
 let unsubscribeNotifications: (() => void) | undefined;
 
 function handleNotification(n: AnyNotification): void {
-  if (n.method === "evener/settings/agentsDoc/changed") agentsDocStore.setState({ doc: n.params });
+  if (n.method !== "evener/settings/agentsDoc/changed") return;
+  // A broadcast is the hub's own authoritative view of the file, so a read
+  // that started before it is stale by definition and any earlier reload
+  // failure is moot.
+  ++requestVersion;
+  agentsDocStore.setState({ doc: n.params, error: null });
 }
 
 function attachNotifications(client: AppwireClientLike | null): void {

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -83,14 +83,14 @@ export const agentsDocStore = createStore<AgentsDocStoreState>((set, get) => ({
     // A response from a client the store has since replaced speaks for a
     // socket that is gone, so it goes back to the caller without landing.
     if (connectionStore.getState().client !== client) return doc;
-    // Anything that bumped the version behind this write speaks for the file
-    // later than this response does: a `changed` broadcast carrying someone
-    // else's write, or a read started after this one. Committing the response
-    // would put the older content back under the editor and the next Save
-    // would push it over what is on disk, so the newer document stands and
-    // goes back to the caller, whose content-keyed sync then shows it against
-    // the draft. The `??` is honesty about the type: a bump the store did not
-    // give a document to cannot happen behind a landed write.
+    // Something bumped the version behind this write - a `changed` broadcast
+    // carrying someone else's write, or a read started after this one - so
+    // this branch commits nothing and defers to whatever that newer read or
+    // broadcast lands, which is what keeps the store only ever moving
+    // forward. The caller gets the newest document the store has, whose
+    // content its content-keyed sync then shows against the draft, and this
+    // response itself when the store has none: the `??` is honesty about the
+    // type, since a bump that landed no document cannot follow a landed write.
     if (version !== requestVersion) return get().doc ?? doc;
     // A write that landed is the freshest view of the file there is, so an
     // earlier read's error is moot - and the section's notice for one

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -40,6 +40,14 @@ export interface AgentsDocStoreState {
   save(content: string): Promise<AgentsDocResponse>;
 }
 
+// Only the most recently started read may land: a response from an
+// overlapping older fetch, or from a client the store has since replaced,
+// carries a view of the file that is already out of date. requestedDoc is
+// what tells the reconnect subscriber below that a view has asked for this
+// file at all.
+let requestVersion = 0;
+let requestedDoc = false;
+
 export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
   doc: null,
   loading: false,
@@ -47,11 +55,15 @@ export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
 
   async fetch() {
     const client = requireClient();
+    requestedDoc = true;
+    const version = ++requestVersion;
     set({ loading: true, error: null });
     try {
       const doc = await client.request("evener/settings/agentsDoc/get", {});
+      if (version !== requestVersion || connectionStore.getState().client !== client) return;
       set({ doc, loading: false });
     } catch (err) {
+      if (version !== requestVersion || connectionStore.getState().client !== client) return;
       set({ loading: false, error: errorText(err) });
     }
   },
@@ -92,13 +104,36 @@ function attachNotifications(client: AppwireClientLike | null): void {
 // React to the connection store rather than reading it once: this module can
 // be evaluated before AppShell's connect() effect runs (stores/extensions.ts
 // documents the mount-order race in full).
-connectionStore.subscribe((state) => attachNotifications(state.client));
+connectionStore.subscribe((state, previous) => {
+  if (state.client !== previous.client || state.state !== previous.state) {
+    requestVersion += 1;
+  }
+  attachNotifications(state.client);
+  // Once a view has read the file, every reconnect has to re-read it - an
+  // automatic one reuses this same client, so a drop and recovery is a state
+  // transition and nothing else. The `changed` broadcasts that landed while
+  // the socket was down are gone, and the next Save would push pre-drop
+  // content over whatever the hub now has.
+  if (
+    requestedDoc &&
+    state.client &&
+    state.state === "ready" &&
+    (state.client !== previous.client || previous.state !== "ready")
+  ) {
+    void agentsDocStore
+      .getState()
+      .fetch()
+      .catch(() => {});
+  }
+});
 const initialClient = connectionStore.getState().client;
 if (initialClient) attachNotifications(initialClient);
 
 // resetAgentsDocStoreForTests resets the singleton between tests, including
 // the module-private wiring above. No production code should ever call this.
 export function resetAgentsDocStoreForTests(): void {
+  requestVersion += 1;
+  requestedDoc = false;
   unsubscribeNotifications?.();
   unsubscribeNotifications = undefined;
   wiredClient = null;

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -35,7 +35,10 @@ export interface AgentsDocStoreState {
   error: string | null;
   fetch(): Promise<void>;
   /** Replaces the file whole. Resolves with the hub's view of the saved file,
-   * which is also what `doc` becomes while this client is still the store's.
+   * which is also what `doc` becomes while this client is still the store's
+   * and no newer view of the file landed behind the write. When one did - a
+   * `changed` broadcast, or a read started after the write - that newer
+   * document stands and is resolved in this response's place.
    * Rejections propagate: the section owns the inline error and the toast. */
   save(content: string): Promise<AgentsDocResponse>;
 }
@@ -48,7 +51,7 @@ export interface AgentsDocStoreState {
 let requestVersion = 0;
 let requestedDoc = false;
 
-export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
+export const agentsDocStore = createStore<AgentsDocStoreState>((set, get) => ({
   doc: null,
   loading: false,
   error: null,
@@ -72,20 +75,27 @@ export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
     const client = requireClient();
     // Bumped before the request, not after it: a read already in flight can
     // only land holding the pre-save file, so the write fences it out the way
-    // a newer read does. A read started after this one may land first, and the
-    // commit below then lands over it - which is right: the write's response
-    // is the hub's own view of the file after the write, never staler than a
-    // read that raced it. The bump leaves nothing to turn `loading` off, so
+    // a newer read does. The bump leaves nothing to turn `loading` off, so
     // the save does it, as the connection subscriber does for its own bump.
-    ++requestVersion;
+    const version = ++requestVersion;
     set({ loading: false });
     const doc = await client.request("evener/settings/agentsDoc/set", { content });
+    // A response from a client the store has since replaced speaks for a
+    // socket that is gone, so it goes back to the caller without landing.
+    if (connectionStore.getState().client !== client) return doc;
+    // Anything that bumped the version behind this write speaks for the file
+    // later than this response does: a `changed` broadcast carrying someone
+    // else's write, or a read started after this one. Committing the response
+    // would put the older content back under the editor and the next Save
+    // would push it over what is on disk, so the newer document stands and
+    // goes back to the caller, whose content-keyed sync then shows it against
+    // the draft. The `??` is honesty about the type: a bump the store did not
+    // give a document to cannot happen behind a landed write.
+    if (version !== requestVersion) return get().doc ?? doc;
     // A write that landed is the freshest view of the file there is, so an
     // earlier read's error is moot - and the section's notice for one
     // ("saving would overwrite anything changed on disk since") is now false.
-    // A response from a client the store has since replaced speaks for a
-    // socket that is gone, so it goes back to the caller without landing.
-    if (connectionStore.getState().client === client) set({ doc, error: null });
+    set({ doc, error: null });
     return doc;
   },
 }));
@@ -108,9 +118,10 @@ function handleNotification(n: AnyNotification): void {
   if (n.method !== "evener/settings/agentsDoc/changed") return;
   // A broadcast is the hub's own authoritative view of the file, so a read
   // that started before it is stale by definition and any earlier reload
-  // failure is moot.
+  // failure is moot. The bump leaves nothing to turn `loading` off, so the
+  // broadcast does it, as the save and the connection subscriber do for theirs.
   ++requestVersion;
-  agentsDocStore.setState({ doc: n.params, error: null });
+  agentsDocStore.setState({ doc: n.params, error: null, loading: false });
 }
 
 function attachNotifications(client: AppwireClientLike | null): void {

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -6,6 +6,11 @@
 // broadcast (this client's own save included) replaces it, so a second tab
 // or a save from the TUI lands here without a refetch.
 //
+// An editor must key off `doc.content`, never `doc` itself: one save yields
+// two referentially-distinct `doc` objects carrying the same content - the
+// save's own result, then the hub's broadcast echo behind it - so an
+// identity-keyed effect would wipe anything typed during the round-trip.
+//
 // requireClient() throws outside any try/catch, matching stores/credentials.ts:
 // "no client connected" is a programmer error, not a state to degrade into.
 import { useStore } from "zustand";

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -107,6 +107,10 @@ function attachNotifications(client: AppwireClientLike | null): void {
 connectionStore.subscribe((state, previous) => {
   if (state.client !== previous.client || state.state !== previous.state) {
     requestVersion += 1;
+    // The bump just dropped whatever read was in flight, so nothing is left
+    // to turn `loading` off - and a drop that never recovers would leave the
+    // section on its Skeleton forever (stores/credentials.ts does the same).
+    agentsDocStore.setState({ loading: false });
   }
   attachNotifications(state.client);
   // Once a view has read the file, every reconnect has to re-read it - an

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -64,7 +64,10 @@ export const agentsDocStore = createStore<AgentsDocStoreState>((set, get) => ({
     try {
       const doc = await client.request("evener/settings/agentsDoc/get", {});
       if (version !== requestVersion || connectionStore.getState().client !== client) return;
-      set({ doc, loading: false });
+      // A fetch that lands has the hub's fresh document, so an earlier
+      // reload's error is moot - as when a save lands and when a `changed`
+      // broadcast arrives.
+      set({ doc, loading: false, error: null });
     } catch (err) {
       if (version !== requestVersion || connectionStore.getState().client !== client) return;
       set({ loading: false, error: errorText(err) });

--- a/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
+++ b/cmd/evener-hub/frontend/src/stores/agentsDoc.ts
@@ -71,7 +71,10 @@ export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
   async save(content) {
     const client = requireClient();
     const doc = await client.request("evener/settings/agentsDoc/set", { content });
-    set({ doc });
+    // A write that landed is the freshest view of the file there is, so an
+    // earlier read's error is moot - and the section's notice for one
+    // ("saving would overwrite anything changed on disk since") is now false.
+    set({ doc, error: null });
     return doc;
   },
 }));

--- a/cmd/evener-hub/internal/hubcore/config.go
+++ b/cmd/evener-hub/internal/hubcore/config.go
@@ -104,6 +104,7 @@ type SpawnRequest struct {
 	StateDir      string
 	RunDir        string
 	PluginRoot    string // internal/plugins.Manager root handed to the child serve process; "" keeps the child's default root resolution
+	AgentsDocPath string // personal AGENTS.md handed to the child serve process; "" lets the child resolve it from its own environment
 	AppReplaySize int
 	Env           []string // populated by ToEnv during Spawn
 	Provider      string   // instance the launch selected; gated against the registry before spawning
@@ -117,6 +118,7 @@ type ResumeRequest struct {
 	StateDir      string
 	Resolved      launchconfig.Resolved
 	RunDir        string
+	AgentsDocPath string // personal AGENTS.md handed to the child serve process; "" lets the child resolve it from its own environment
 	AppReplaySize int
 	Env           []string // populated by ToEnv during Resume
 	Provider      string   // instance the launch selected; gated against the registry before spawning

--- a/cmd/evener-hub/spawn.go
+++ b/cmd/evener-hub/spawn.go
@@ -299,6 +299,9 @@ func buildSpawnArgs(req hubcore.SpawnRequest) []string {
 	if req.PluginRoot != "" {
 		args = append(args, "--plugin-root", req.PluginRoot)
 	}
+	if req.AgentsDocPath != "" {
+		args = append(args, "--agents-doc", req.AgentsDocPath)
+	}
 	if req.AppReplaySize > 0 {
 		args = append(args, "--app-replay-size", strconv.Itoa(req.AppReplaySize))
 	}
@@ -316,6 +319,9 @@ func buildResumeArgs(req hubcore.ResumeRequest) []string {
 	}
 	if req.RunDir != "" {
 		args = append(args, "--run-dir", req.RunDir)
+	}
+	if req.AgentsDocPath != "" {
+		args = append(args, "--agents-doc", req.AgentsDocPath)
 	}
 	if req.AppReplaySize > 0 {
 		args = append(args, "--app-replay-size", strconv.Itoa(req.AppReplaySize))

--- a/cmd/evener-hub/spawn_test.go
+++ b/cmd/evener-hub/spawn_test.go
@@ -54,9 +54,10 @@ func TestBuildSpawnArgs(t *testing.T) {
 			ReasoningEffort: "medium",
 			AppReplaySize:   &ssering,
 		}},
-		WorkingDir: "/Users/jesse/git/foo",
-		StateDir:   "/Users/jesse/.local/state/evener/projects/foo",
-		RunDir:     "/Users/jesse/.cache/evener/run",
+		WorkingDir:    "/Users/jesse/git/foo",
+		StateDir:      "/Users/jesse/.local/state/evener/projects/foo",
+		RunDir:        "/Users/jesse/.cache/evener/run",
+		AgentsDocPath: "/Users/jesse/.config/evener/AGENTS.md",
 	}
 	args := buildSpawnArgs(req)
 	want := map[string]string{
@@ -68,6 +69,7 @@ func TestBuildSpawnArgs(t *testing.T) {
 		"--dir":              "/Users/jesse/git/foo",
 		"--state-dir":        "/Users/jesse/.local/state/evener/projects/foo",
 		"--run-dir":          "/Users/jesse/.cache/evener/run",
+		"--agents-doc":       "/Users/jesse/.config/evener/AGENTS.md",
 		"--addr":             "127.0.0.1:0",
 	}
 	got := pairsToMap(args)
@@ -118,10 +120,11 @@ func TestBuildSpawnArgs_FromResolved(t *testing.T) {
 func TestBuildResumeArgsOmitAmbientModelKnobs(t *testing.T) {
 	maxRounds := 50
 	req := hubcore.ResumeRequest{
-		SessionID:  "01JRESUME",
-		WorkingDir: "/wd",
-		StateDir:   "/st",
-		RunDir:     "/rn",
+		SessionID:     "01JRESUME",
+		WorkingDir:    "/wd",
+		StateDir:      "/st",
+		RunDir:        "/rn",
+		AgentsDocPath: "/Users/jesse/.config/evener/AGENTS.md",
 		Resolved: launchconfig.Resolved{Effective: launchconfig.Layer{
 			Model:           "openai/gpt-env",
 			FastCheapModel:  "openai/gpt-4.1-nano",
@@ -137,7 +140,7 @@ func TestBuildResumeArgsOmitAmbientModelKnobs(t *testing.T) {
 			t.Fatalf("resume args must not include ambient %s: %v", forbidden, args)
 		}
 	}
-	for _, required := range []string{"serve", "--resume", "01JRESUME", "--agent", "default", "--reasoning-effort", "medium", "--max-rounds", "50"} {
+	for _, required := range []string{"serve", "--resume", "01JRESUME", "--agent", "default", "--reasoning-effort", "medium", "--max-rounds", "50", "--agents-doc", "/Users/jesse/.config/evener/AGENTS.md"} {
 		if !hasArg(args, required) {
 			t.Fatalf("resume args missing %q: %v", required, args)
 		}

--- a/cmd/evener-tui/hub_notification_coverage_test.go
+++ b/cmd/evener-tui/hub_notification_coverage_test.go
@@ -36,6 +36,10 @@ var notifyMethodsDeliberatelyIgnored = []string{
 	// Keybinding overrides configure the Web UI's dispatcher. The TUI has its
 	// own input handling and no remappable-binding surface.
 	appwire.NotifyEvenerSettingsKeybindingsChanged,
+	// The personal AGENTS.md is edited in the Web UI's settings section. The
+	// TUI has no editor for it, and a session reads its instruction docs once
+	// at session init, so a rewrite changes nothing the TUI is showing.
+	appwire.NotifyEvenerSettingsAgentsDocChanged,
 }
 
 // kata e79v: evener/thread/modelRetry was added to the catalog and the TUI ignored

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -316,6 +316,7 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 	var pluginDirs cmdutil.StringSliceFlag
 	fs.Var(&pluginDirs, "plugin-dir", "plugin directory (repeatable)")
 	pluginRoot := fs.String("plugin-root", "", "internal plugin registry root override")
+	agentsDoc := fs.String("agents-doc", "", "personal AGENTS.md loaded ahead of project docs (default: <user config root>/AGENTS.md)")
 	var enabledPlugins pluginSelectionFlag
 	fs.Var(&enabledPlugins, "enabled-plugins", "comma-separated plugin names to enable (empty selects none)")
 	var modelFallbacks cmdutil.StringSliceFlag
@@ -514,6 +515,7 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 		SystemPromptFile:            *systemPrompt,
 		SystemPromptAppend:          []string(systemPromptAppend),
 		NoProjectPrompts:            *noProjectPrompts,
+		AgentsDocPath:               *agentsDoc,
 		AgentName:                   *agentName,
 		SkillsDirs:                  []string(skillsDirs),
 		MCPConfigFiles:              []string(mcpConfigs),

--- a/cmd/evener/serve.go
+++ b/cmd/evener/serve.go
@@ -578,6 +578,7 @@ func runServeWithDeps(args []string, deps serveDeps) error {
 			ModelFallbacks:              sessionCfg.ModelFallbacks,
 			OpenAIResponsesContinuation: resolvedOpenAIResponsesContinuation,
 			ProviderIdleTimeout:         *providerIdleTimeout,
+			AgentsDocPath:               *agentsDoc,
 		})
 		if err != nil {
 			// A resume provisions this environment's sandbox from the

--- a/cmd/evener/serve_test.go
+++ b/cmd/evener/serve_test.go
@@ -1353,3 +1353,30 @@ func TestServeDisposesTheSandboxScratchWhenRestoreFails(t *testing.T) {
 		t.Fatalf("serve error = %v, want the restore failure", err)
 	}
 }
+
+// A hub hands every session it spawns the hub's own concrete AGENTS.md path,
+// the way it hands over the plugin root, so a per-launch XDG_CONFIG_HOME
+// override cannot make Settings and the session read different files.
+func TestServeAgentsDocFlagReachesTheSessionConfig(t *testing.T) {
+	installServeScriptedProvider(t, &scriptedProvider{name: "openai"})
+	deps := defaultServeDeps()
+	deps.ensureConfigDirs = func() error { return nil }
+	deps.seedMarketplaces = func(context.Context) error { return nil }
+	wantPath := filepath.Join(t.TempDir(), "AGENTS.md")
+	got := ""
+	deps.newSession = func(_ *llm.Client, _ *provider.Profile, _ execenv.ExecutionEnvironment, cfg agent.SessionConfig) (*agent.Session, error) {
+		got = cfg.AgentsDocPath
+		return nil, errors.New("no session today")
+	}
+
+	err := runServeWithDeps([]string{
+		"--model", "openai/gpt-test", "--dir", t.TempDir(), "--state-dir", t.TempDir(),
+		"--agents-doc", wantPath,
+	}, deps)
+	if err == nil || !strings.Contains(err.Error(), "session creation") {
+		t.Fatalf("serve error = %v, want the session-creation failure", err)
+	}
+	if got != wantPath {
+		t.Fatalf("SessionConfig.AgentsDocPath = %q, want %q", got, wantPath)
+	}
+}

--- a/cmd/evener/serve_test.go
+++ b/cmd/evener/serve_test.go
@@ -1380,3 +1380,39 @@ func TestServeAgentsDocFlagReachesTheSessionConfig(t *testing.T) {
 		t.Fatalf("SessionConfig.AgentsDocPath = %q, want %q", got, wantPath)
 	}
 }
+
+// A resume takes the flag too: the hub passes --agents-doc on every resume it
+// spawns (buildResumeArgs), and the restore has to prefer it over the path
+// frozen in the snapshot, which a pre-feature session never had and a moved
+// hub no longer uses.
+func TestServeAgentsDocFlagReachesTheRestoredSessionConfig(t *testing.T) {
+	installServeScriptedProvider(t, &scriptedProvider{name: "openai"})
+	stateDir := t.TempDir()
+	const sessionID = "02wMz5Txv1C3Hut0M8GCeB"
+	if err := schema.SaveSessionMeta(stateDir, schema.SessionMeta{
+		ID: sessionID, ProfileID: "openai", Model: "gpt-test",
+		CreatedAt: time.Unix(1, 0).UTC(), UpdatedAt: time.Unix(2, 0).UTC(),
+	}); err != nil {
+		t.Fatalf("SaveSessionMeta: %v", err)
+	}
+	deps := defaultServeDeps()
+	deps.ensureConfigDirs = func() error { return nil }
+	deps.seedMarketplaces = func(context.Context) error { return nil }
+	wantPath := filepath.Join(t.TempDir(), "AGENTS.md")
+	got := ""
+	deps.restoreSession = func(_ *llm.Client, _ *provider.Profile, _ execenv.ExecutionEnvironment, _ schema.SessionMeta, restoreCfg agent.RestoreSessionConfig) (*agent.Session, error) {
+		got = restoreCfg.AgentsDocPath
+		return nil, errors.New("no session today")
+	}
+
+	err := runServeWithDeps([]string{
+		"--resume", sessionID, "--dir", stateDir, "--state-dir", stateDir, "--run-dir", t.TempDir(),
+		"--agents-doc", wantPath,
+	}, deps)
+	if err == nil || !strings.Contains(err.Error(), "restore session") {
+		t.Fatalf("serve error = %v, want the restore failure", err)
+	}
+	if got != wantPath {
+		t.Fatalf("RestoreSessionConfig.AgentsDocPath = %q, want %q", got, wantPath)
+	}
+}

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -175,6 +175,8 @@ no router (reserved).
 | `evener/settings/transcriptDisplay/patch` | hub | `TranscriptDisplayDefaultsPatchParams` | `TranscriptDisplayPatchResponse` | Updates one transcript-display default using an expected revision and returns the canonical value. |
 | `evener/settings/keybindings/get` | hub | `EmptyParams` | `KeybindingsOverrides` | Reads the canonical user keybinding overrides (version, revision, rules). |
 | `evener/settings/keybindings/patch` | hub | `KeybindingsPatchParams` | `KeybindingsOverrides` | Replaces the user keybinding overrides using an expected revision and returns the canonical value. |
+| `evener/settings/agentsDoc/get` | hub | `EmptyParams` | `AgentsDocResponse` | Reads the personal AGENTS.md under the user config root: its path, whether it exists, and its content. |
+| `evener/settings/agentsDoc/set` | hub | `AgentsDocSetParams` | `AgentsDocResponse` | Replaces the personal AGENTS.md whole (no precondition); broadcasts evener/settings/agentsDoc/changed. |
 | `evener/sandbox/escalation/resolve` | both | `SandboxEscalationResolveParams` | `EmptyResponse` | Delivers a human's approve/deny decision for a pending sandbox-exemption escalation (M7); the daemon unblocks the waiting tool-exec goroutine, the hub relays. |
 
 ## Notifications (server → client)
@@ -220,6 +222,7 @@ Pushed to subscribed connections; no `id`. The web client maps these in
 | `evener/sandbox/escalation/resolved` | `SandboxEscalationResolved` | A previously-raised sandbox escalation left the pending set — resolved, turn-interrupted, or cleared by session close (M7); every OTHER subscribed client clears its now-stale copy of the card. |
 | `evener/settings/transcriptDisplay/changed` | `TranscriptDisplayChangedParams` | Broadcast after a transcript-display default changes; carries the layout, revision, and canonical configuration. |
 | `evener/settings/keybindings/changed` | `KeybindingsOverrides` | Broadcast after the user keybinding overrides change; carries the revision and canonical rules. |
+| `evener/settings/agentsDoc/changed` | `AgentsDocResponse` | Broadcast after the personal AGENTS.md is written; carries the new path, existence, and content. |
 
 ## Type reference
 
@@ -246,6 +249,22 @@ An embedded type contributes its own fields inline.
 | `ref` | `string` |  |  |
 | `turnId` | `string` |  |  |
 | `itemId` | `string` |  |  |
+
+
+### `AgentsDocResponse`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `path` | `string` |  |  |
+| `exists` | `bool` |  |  |
+| `content` | `string` |  |  |
+
+
+### `AgentsDocSetParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `content` | `string` |  |  |
 
 
 ### `ArchiveParams`

--- a/docs/evener-hub.md
+++ b/docs/evener-hub.md
@@ -83,7 +83,9 @@ unset, the corresponding defaults are under `$HOME/.local/state` and
   standing instructions file. Every session loads it ahead of the repo's own
   instruction docs — AGENTS.md plus whichever sibling the model's surface reads
   (CLAUDE.md, GEMINI.md) — and Settings → AGENTS.md in the web UI edits it in
-  place.
+  place. Hub-spawned sessions receive the hub's own path (`--agents-doc`) the
+  way they receive the plugin root, so a per-launch `XDG_CONFIG_HOME` override
+  cannot make Settings and sessions disagree about the file.
 
 Those extension roots are not active just because they exist. Add standalone
 skill paths to `skills_dirs` and plugin roots to `plugin_dirs` in the layered

--- a/docs/evener-hub.md
+++ b/docs/evener-hub.md
@@ -81,7 +81,9 @@ unset, the corresponding defaults are under `$HOME/.local/state` and
   created by Evener startup.
 - `${XDG_CONFIG_HOME:-$HOME/.config}/evener/AGENTS.md` is your personal
   standing instructions file. Every session loads it ahead of the repo's own
-  AGENTS.md, and Settings → AGENTS.md in the web UI edits it in place.
+  instruction docs — AGENTS.md plus whichever sibling the model's surface reads
+  (CLAUDE.md, GEMINI.md) — and Settings → AGENTS.md in the web UI edits it in
+  place.
 
 Those extension roots are not active just because they exist. Add standalone
 skill paths to `skills_dirs` and plugin roots to `plugin_dirs` in the layered

--- a/docs/evener-hub.md
+++ b/docs/evener-hub.md
@@ -79,6 +79,9 @@ unset, the corresponding defaults are under `$HOME/.local/state` and
 - `${XDG_CONFIG_HOME:-$HOME/.config}/evener/skills` and
   `${XDG_CONFIG_HOME:-$HOME/.config}/evener/plugins` are user extension roots
   created by Evener startup.
+- `${XDG_CONFIG_HOME:-$HOME/.config}/evener/AGENTS.md` is your personal
+  standing instructions file. Every session loads it ahead of the repo's own
+  AGENTS.md, and Settings → AGENTS.md in the web UI edits it in place.
 
 Those extension roots are not active just because they exist. Add standalone
 skill paths to `skills_dirs` and plugin roots to `plugin_dirs` in the layered

--- a/docs/superpowers/plans/2026-09-07-agents-doc.md
+++ b/docs/superpowers/plans/2026-09-07-agents-doc.md
@@ -1088,6 +1088,7 @@ Create `cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx`:
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { WireError } from "../../../protocol/errors";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import type { AgentsDocResponse, AnyNotification } from "../../../protocol/types.gen";
 import { resetAgentsDocStoreForTests } from "../../../stores/agentsDoc";
@@ -1196,10 +1197,13 @@ test("Save sends the draft, toasts, and the editor is clean afterwards", async (
   expect(editor().value).toBe("# hi\nmore");
 });
 
-test("a failed save shows the error inline and keeps the draft", async () => {
+test("a failed save shows the hub's error inline and keeps the draft", async () => {
   const fake = connectFakeClient();
+  // A WireError, as the hub really sends: friendlyErrorMessage passes a
+  // wire message through but replaces a plain Error with a generic line
+  // (mcp.test.tsx pins that), so a plain Error here would never reach the DOM.
   fake.on("evener/settings/agentsDoc/set", () => {
-    throw new Error("read-only file system");
+    throw new WireError("read-only file system", -1);
   });
   renderSection();
   await waitFor(() => expect(editor().value).toBe("# hi\n"));
@@ -1479,17 +1483,18 @@ git commit -m "feat(web): AGENTS.md settings section"
 ### Task 6: Docs, gates, and the pull request
 
 **Files:**
-- Modify: `docs/evener-hub.md` (the paragraph around line 230 that names `providers.toml` under the config root; add one sentence that `AGENTS.md` beside it holds personal instructions loaded ahead of every repo's project docs, editable under Settings → AGENTS.md)
-- Modify: `docs/llm-providers.md` is NOT touched; `docs/appwire-protocol.md` was regenerated in Task 2.
+- Modify: `docs/evener-hub.md` (the "Runtime directories" bullet list, lines 61-81, whose last bullet names the skills and plugins roots under `${XDG_CONFIG_HOME:-$HOME/.config}/evener`)
+- Modify: `docs/superpowers/plans/2026-09-07-agents-doc.md` is committed alongside (it carries pre-flight corrections made while this plan ran; see the workspace's `preflight-verification.md`).
+- `docs/llm-providers.md` is NOT touched; `docs/appwire-protocol.md` was regenerated in Task 2.
 
 - [ ] **Step 1: Document the file**
 
-In `docs/evener-hub.md`, find the sentence that describes the config root contents (grep `providers.toml` around line 230) and add, in the same paragraph:
+In `docs/evener-hub.md`, in the "Runtime directories" bullet list, add one bullet directly after the skills/plugins bullet (the list's last), using the file's own `${XDG_CONFIG_HOME:-$HOME/.config}` path convention:
 
 ```
-`AGENTS.md` beside it holds your personal standing instructions; every
-session loads it ahead of the repo's own AGENTS.md, and Settings → AGENTS.md
-edits it in place.
+- `${XDG_CONFIG_HOME:-$HOME/.config}/evener/AGENTS.md` is your personal
+  standing instructions file. Every session loads it ahead of the repo's own
+  AGENTS.md, and Settings → AGENTS.md in the web UI edits it in place.
 ```
 
 - [ ] **Step 2: Run every gate**
@@ -1506,12 +1511,12 @@ Expected: all green. `make lint` includes the generated-output freshness check, 
 
 - [ ] **Step 3: Live check against a throwaway hub**
 
-Follow the WebUI screenshot recipe in memory (`webui-screenshot-recipe.md`): start a throwaway hub with `XDG_CONFIG_HOME` pointed at a temp dir, open Settings → AGENTS.md in the browser pane, type a line, Save, and confirm with `cat "$XDG_CONFIG_HOME/evener/AGENTS.md"` that the file holds exactly what was typed. Then start a session in a temp repo and confirm the transcript's system-prompt view (or `evener` debug prompt dump, if the recipe records one) shows a `----- BEGIN ~/.config/evener/AGENTS.md -----` block before the repo's block. Attach a desktop and a phone-width screenshot of the section to the PR.
+Follow the WebUI screenshot recipe in memory (`webui-screenshot-recipe.md`): start a throwaway hub with `XDG_CONFIG_HOME` pointed at a temp dir, open Settings → AGENTS.md in the browser pane, type a line, Save, and confirm with `cat "$XDG_CONFIG_HOME/evener/AGENTS.md"` that the file holds exactly what was typed. Then start a session in a temp repo and confirm the transcript's system-prompt view (or `evener` debug prompt dump, if the recipe records one) shows a `----- BEGIN <XDG_CONFIG_HOME>/evener/AGENTS.md -----` block before the repo's `----- BEGIN AGENTS.md -----` block. The path is absolute here: the display path collapses to `~/.config/evener/AGENTS.md` only when the config root sits under the real `$HOME`, and a temp `XDG_CONFIG_HOME` does not. Attach a desktop and a phone-width screenshot of the section to the PR.
 
 - [ ] **Step 4: Commit and open the PR**
 
 ```bash
-git add docs/evener-hub.md
+git add docs/evener-hub.md docs/superpowers/plans/2026-09-07-agents-doc.md
 git commit -m "docs(hub): describe the personal AGENTS.md"
 git push -u origin HEAD
 gh pr create --repo prime-radiant-inc/evener --base main --title "Personal AGENTS.md: loaded into every session, editable in settings" --body-file - <<'EOF'

--- a/docs/superpowers/plans/2026-09-07-agents-doc.md
+++ b/docs/superpowers/plans/2026-09-07-agents-doc.md
@@ -1,0 +1,1528 @@
+# Personal AGENTS.md Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every session loads `~/.config/evener/AGENTS.md` ahead of the repo's own project docs, and the web UI's settings pane can read and write that file.
+
+**Architecture:** The daemon gains a user-doc loader that shares the existing 32KB project-doc budget and renders through the existing project-docs prompt section. The hub gains two additive `evener-appwire-v4` methods plus a change notification, wired like the keybindings settings handlers. The frontend gains a small zustand store and a new "AGENTS.md" settings section with a monospace textarea, Save and Revert.
+
+**Tech Stack:** Go (agent, appwire, cmd/evener-hub), TypeScript + React + zustand + vitest (cmd/evener-hub/frontend), `make generate` for wire types.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md` §1 (plus §5 testing, §6 delivery). This plan is slice 1 of 3.
+
+## Global Constraints
+
+- Repo root for every command below: the git worktree you were started in (`git rev-parse --show-toplevel`). Frontend commands run from `cmd/evener-hub/frontend`.
+- Protocol version stays `evener-appwire-v4`; every wire change is additive.
+- The personal file lives at `<config root>/AGENTS.md`, where the config root is `envvars/userdirs.DefaultConfigRoot()` (`$XDG_CONFIG_HOME/evener`, default `~/.config/evener`).
+- `set` writes content byte-for-byte (no trimming, no forced newline), temp-file-and-rename, mode 0o644, no precondition (last write wins).
+- No `git add -A`. Commit after every task with the exact message given.
+- Frontend: run `npx biome check --write <touched files under src/>` before every commit that touches frontend files; the gate is `make test-web` from the repo root.
+- Go: `gofmt` is enforced by `make lint`; keep files gofmt-clean.
+- Tests must be deterministic and never read the developer's real config root: every test that touches a config root uses `t.TempDir()`.
+- Follow the file's existing comment style: explain why, never narrate what changed.
+
+---
+
+### Task 1: Daemon loads the personal doc ahead of project docs
+
+**Files:**
+- Modify: `agent/project_docs.go`
+- Modify: `agent/session_init.go:1443`
+- Test: `agent/project_docs_test.go`
+
+**Interfaces:**
+- Produces: `agent.UserDocFile` (const `"AGENTS.md"`), `agent.LoadUserDoc(configRoot string) (ProjectDoc, bool)`, `agent.LoadInstructionDocs(env execenv.ExecutionEnvironment, configRoot string, filenames ...string) ([]ProjectDoc, bool)`. `LoadProjectDocs` keeps its signature and behavior.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `agent/project_docs_test.go`:
+
+```go
+func TestLoadUserDoc_ReadsTheConfigRootFile(t *testing.T) {
+	t.Parallel()
+	configRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("PERSONAL\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	doc, ok := LoadUserDoc(configRoot)
+	if !ok {
+		t.Fatal("expected the personal doc to load")
+	}
+	if doc.Path != filepath.Join(configRoot, "AGENTS.md") {
+		t.Fatalf("path: %q", doc.Path)
+	}
+	if doc.Content != "PERSONAL\n" {
+		t.Fatalf("content: %q", doc.Content)
+	}
+}
+
+func TestLoadUserDoc_MissingOrBlankFileIsAbsent(t *testing.T) {
+	t.Parallel()
+	if _, ok := LoadUserDoc(t.TempDir()); ok {
+		t.Fatal("a missing file must not load")
+	}
+	blank := t.TempDir()
+	if err := os.WriteFile(filepath.Join(blank, "AGENTS.md"), []byte("  \n\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, ok := LoadUserDoc(blank); ok {
+		t.Fatal("a blank file must not load")
+	}
+	if _, ok := LoadUserDoc(""); ok {
+		t.Fatal("an empty config root must not load")
+	}
+}
+
+func TestLoadUserDoc_CollapsesTheHomeDirectoryToTilde(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configRoot := filepath.Join(home, ".config", "evener")
+	if err := os.MkdirAll(configRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	doc, ok := LoadUserDoc(configRoot)
+	if !ok {
+		t.Fatal("expected the personal doc to load")
+	}
+	if doc.Path != "~/.config/evener/AGENTS.md" {
+		t.Fatalf("path: %q, want the tilde-collapsed display path", doc.Path)
+	}
+}
+
+func TestLoadInstructionDocs_PersonalDocComesFirst(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("ROOT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	configRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte("PERSONAL\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	if truncated {
+		t.Fatal("did not expect truncation")
+	}
+	if len(docs) != 2 {
+		t.Fatalf("docs: got %d want 2 (%v)", len(docs), docs)
+	}
+	if docs[0].Path != filepath.Join(configRoot, "AGENTS.md") || docs[0].Content != "PERSONAL\n" {
+		t.Fatalf("doc0 = %+v, want the personal doc first", docs[0])
+	}
+	if docs[1].Path != "AGENTS.md" || docs[1].Content != "ROOT\n" {
+		t.Fatalf("doc1 = %+v, want the repo doc second", docs[1])
+	}
+}
+
+func TestLoadInstructionDocs_MissingPersonalDocChangesNothing(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("ROOT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, _ := LoadInstructionDocs(env, t.TempDir(), "AGENTS.md")
+	if len(docs) != 1 || docs[0].Path != "AGENTS.md" {
+		t.Fatalf("docs = %+v, want only the repo doc", docs)
+	}
+}
+
+func TestLoadInstructionDocs_PersonalDocCountsAgainstTheSharedBudget(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	half := strings.Repeat("r", projectDocByteBudget/2+1024)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte(half), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	configRoot := t.TempDir()
+	personal := strings.Repeat("p", projectDocByteBudget/2)
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte(personal), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	if !truncated {
+		t.Fatal("expected the repo doc to be truncated")
+	}
+	if len(docs) != 2 {
+		t.Fatalf("docs: got %d want 2", len(docs))
+	}
+	if docs[0].Content != personal {
+		t.Fatal("the personal doc must land intact; it is loaded first")
+	}
+	if !strings.Contains(docs[1].Content, projectDocTruncMark) {
+		t.Fatalf("the repo doc must carry the truncation marker, got:\n%s", docs[1].Content[len(docs[1].Content)-80:])
+	}
+	if len(docs[0].Content)+len(docs[1].Content) > projectDocByteBudget+len(projectDocTruncMark)+2 {
+		t.Fatalf("the two docs exceed the shared budget: %d", len(docs[0].Content)+len(docs[1].Content))
+	}
+}
+
+func TestLoadInstructionDocs_OversizedPersonalDocIsTruncatedAlone(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	markGitRoot(t, root)
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("ROOT\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	configRoot := t.TempDir()
+	huge := strings.Repeat("p", projectDocByteBudget+4096)
+	if err := os.WriteFile(filepath.Join(configRoot, "AGENTS.md"), []byte(huge), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	env := execenv.NewLocalExecutionEnvironment(root)
+	docs, truncated := LoadInstructionDocs(env, configRoot, "AGENTS.md")
+	if !truncated || len(docs) != 1 {
+		t.Fatalf("docs = %d truncated = %v; an oversized personal doc consumes the whole budget", len(docs), truncated)
+	}
+	if !strings.Contains(docs[0].Content, projectDocTruncMark) {
+		t.Fatal("expected the truncation marker on the personal doc")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./agent -run 'TestLoadUserDoc|TestLoadInstructionDocs' 2>&1 | head -20`
+Expected: compile error, `undefined: LoadUserDoc` / `undefined: LoadInstructionDocs`.
+
+- [ ] **Step 3: Implement the loader**
+
+Replace `agent/project_docs.go` from the `LoadProjectDocs` doc comment to the end of the file with:
+
+```go
+// UserDocFile is the personal instructions file evener loads from the user
+// config root ahead of every repo's own project docs.
+const UserDocFile = "AGENTS.md"
+
+// LoadProjectDocs discovers and loads project instruction files from git root (or working directory when not
+// in a git repo) down to the current working directory. Files are loaded in depth order (root first; deeper
+// files have higher precedence) and filtered by the active provider profile (caller-provided list).
+func LoadProjectDocs(env execenv.ExecutionEnvironment, filenames ...string) ([]ProjectDoc, bool) {
+	return loadProjectDocs(env, 0, filenames...)
+}
+
+// LoadInstructionDocs is a session's whole instruction set: the personal doc
+// under configRoot first, then the repo's project docs, sharing one byte
+// budget. The personal doc is loaded first because it is the user's own
+// standing instructions for every session; the repo docs get whatever budget
+// remains, truncated exactly as LoadProjectDocs truncates them.
+func LoadInstructionDocs(env execenv.ExecutionEnvironment, configRoot string, filenames ...string) ([]ProjectDoc, bool) {
+	out := []ProjectDoc{}
+	used := 0
+	if user, ok := LoadUserDoc(configRoot); ok {
+		if len(user.Content) > projectDocByteBudget {
+			user.Content = truncateDoc(user.Content, projectDocByteBudget)
+			return append(out, user), true
+		}
+		used = len(user.Content)
+		out = append(out, user)
+	}
+	project, truncated := loadProjectDocs(env, used, filenames...)
+	return append(out, project...), truncated
+}
+
+// LoadUserDoc reads <configRoot>/AGENTS.md. ok is false when the config root
+// is empty or the file is missing or blank. Path is the display path the
+// prompt labels the block with: the home directory collapsed to "~", so the
+// model sees "~/.config/evener/AGENTS.md" rather than a machine-specific
+// absolute path.
+func LoadUserDoc(configRoot string) (ProjectDoc, bool) {
+	configRoot = strings.TrimSpace(configRoot)
+	if configRoot == "" {
+		return ProjectDoc{}, false
+	}
+	path := filepath.Join(configRoot, UserDocFile)
+	b, err := os.ReadFile(path)
+	if err != nil || strings.TrimSpace(string(b)) == "" {
+		return ProjectDoc{}, false
+	}
+	return ProjectDoc{Path: tildeCollapse(path), Content: string(b)}, true
+}
+
+// tildeCollapse rewrites a path under the home directory as "~/...".
+func tildeCollapse(path string) string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+	rel, err := filepath.Rel(home, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return "~/" + filepath.ToSlash(rel)
+}
+
+// truncateDoc cuts content to remain bytes and appends the truncation marker.
+func truncateDoc(content string, remain int) string {
+	if remain < len(content) {
+		content = content[:remain]
+	}
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	return content + projectDocTruncMark + "\n"
+}
+
+// loadProjectDocs is LoadProjectDocs with `used` bytes of the budget already
+// spent by a doc loaded before the repo's own.
+func loadProjectDocs(env execenv.ExecutionEnvironment, used int, filenames ...string) ([]ProjectDoc, bool) {
+	if env == nil {
+		return nil, false
+	}
+
+	cwd := strings.TrimSpace(env.WorkingDirectory())
+	if cwd == "" {
+		return nil, false
+	}
+	// Resolve symlinks so cwd and git root use consistent paths (macOS /var -> /private/var).
+	if resolved, err := filepath.EvalSymlinks(cwd); err == nil {
+		cwd = resolved
+	}
+
+	root := cwd
+	if gr := execenv.GitRootOrEmpty(env, cwd); gr != "" {
+		root = gr
+	}
+
+	dirs := execenv.DirsFromRootToCwd(root, cwd)
+	out := []ProjectDoc{}
+	for _, dir := range dirs {
+		relDir := "."
+		if r, err := filepath.Rel(root, dir); err == nil {
+			relDir = r
+		}
+		for _, name := range filenames {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			b, err := os.ReadFile(path)
+			if err != nil {
+				continue
+			}
+
+			key := name
+			if relDir != "." && relDir != "" {
+				key = filepath.Join(relDir, name)
+			}
+
+			content := string(b)
+			if used+len(content) > projectDocByteBudget {
+				out = append(out, ProjectDoc{Path: key, Content: truncateDoc(content, projectDocByteBudget-used)})
+				return out, true
+			}
+			used += len(content)
+			out = append(out, ProjectDoc{Path: key, Content: content})
+		}
+	}
+	return out, false
+}
+```
+
+Keep the `ProjectDoc` type, the two constants, and the imports at the top of the file exactly as they are.
+
+- [ ] **Step 4: Run the loader tests**
+
+Run: `go test ./agent -run 'TestLoadUserDoc|TestLoadProjectDocs|TestLoadInstructionDocs' -v 2>&1 | tail -20`
+Expected: all PASS, including the two pre-existing `TestLoadProjectDocs_*` tests.
+
+- [ ] **Step 5: Wire the session to the new loader**
+
+In `agent/session_init.go`, change line 1443 from
+
+```go
+	s.projectDocs, s.projectDocsTruncated = LoadProjectDocs(s.currentEnv(), s.profile.ProjectDocFiles()...)
+```
+
+to
+
+```go
+	s.projectDocs, s.projectDocsTruncated = LoadInstructionDocs(s.currentEnv(), userdirs.DefaultConfigRoot(), s.profile.ProjectDocFiles()...)
+```
+
+`userdirs` is already imported in that file (it is used for the user skills dir at line 1345).
+
+- [ ] **Step 6: Run the agent package tests and vet**
+
+Run: `go build ./... && go vet ./agent && go test ./agent 2>&1 | tail -5`
+Expected: build OK, vet clean, `ok  primeradiant.com/evener/agent`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/project_docs.go agent/project_docs_test.go agent/session_init.go
+git commit -m "feat(agent): load the personal AGENTS.md ahead of project docs"
+```
+
+---
+
+### Task 2: Wire types and catalog for the agentsDoc methods
+
+**Files:**
+- Create: `appwire/agents_doc.go`
+- Modify: `appwire/protocol.go` (the `Methods` list after the keybindings entries at lines 201-202; the `Notifications` list after the keybindings entry at line 295)
+- Test: `appwire/protocol_test.go`
+- Regenerate: `cmd/evener-hub/frontend/src/protocol/types.gen.ts`, `docs/appwire-protocol.md`
+
+**Interfaces:**
+- Produces: `appwire.MethodEvenerSettingsAgentsDocGet = "evener/settings/agentsDoc/get"`, `appwire.MethodEvenerSettingsAgentsDocSet = "evener/settings/agentsDoc/set"`, `appwire.NotifyEvenerSettingsAgentsDocChanged = "evener/settings/agentsDoc/changed"`, `appwire.AgentsDocResponse{Path string; Exists bool; Content string}`, `appwire.AgentsDocSetParams{Content string}`. The generated TS gains `AgentsDocResponse`, `AgentsDocSetParams`, and the three names in `METHOD_NAMES` / `NOTIFICATION_NAMES`.
+
+- [ ] **Step 1: Write the failing catalog test**
+
+Append to `appwire/protocol_test.go` (next to `TestKeybindingsCatalog`):
+
+```go
+func TestAgentsDocCatalog(t *testing.T) {
+	methods := map[string]MethodSpec{}
+	for _, method := range Methods {
+		methods[method.Name] = method
+	}
+	for _, name := range []string{
+		MethodEvenerSettingsAgentsDocGet,
+		MethodEvenerSettingsAgentsDocSet,
+	} {
+		method, ok := methods[name]
+		if !ok {
+			t.Fatalf("method catalog missing %s", name)
+		}
+		if method.Scope != ScopeHub {
+			t.Errorf("method %s scope = %q, want %q", name, method.Scope, ScopeHub)
+		}
+		if reflect.TypeOf(method.Result) != reflect.TypeFor[AgentsDocResponse]() {
+			t.Errorf("method %s result type = %T, want %T", name, method.Result, AgentsDocResponse{})
+		}
+	}
+	if reflect.TypeOf(methods[MethodEvenerSettingsAgentsDocSet].Params) != reflect.TypeFor[AgentsDocSetParams]() {
+		t.Errorf("set params type = %T, want %T", methods[MethodEvenerSettingsAgentsDocSet].Params, AgentsDocSetParams{})
+	}
+	var changed *NotificationSpec
+	for i := range Notifications {
+		if Notifications[i].Name == NotifyEvenerSettingsAgentsDocChanged {
+			changed = &Notifications[i]
+			break
+		}
+	}
+	if changed == nil {
+		t.Fatalf("notification catalog missing %s", NotifyEvenerSettingsAgentsDocChanged)
+	}
+	if reflect.TypeOf(changed.Payload) != reflect.TypeFor[AgentsDocResponse]() {
+		t.Fatalf("changed payload type = %T, want %T", changed.Payload, AgentsDocResponse{})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./appwire -run TestAgentsDocCatalog 2>&1 | head -5`
+Expected: compile error, `undefined: MethodEvenerSettingsAgentsDocGet`.
+
+- [ ] **Step 3: Add the types**
+
+Create `appwire/agents_doc.go`:
+
+```go
+package appwire
+
+// The personal AGENTS.md: a plain file at <config root>/AGENTS.md that every
+// session loads ahead of the repo's own project docs
+// (agent.LoadInstructionDocs). The hub reads and rewrites it whole; there is
+// deliberately no revision or precondition (spec 2026-09-07 §1): the file is
+// also hand-edited in editors, and the last write wins.
+const (
+	MethodEvenerSettingsAgentsDocGet     = "evener/settings/agentsDoc/get"
+	MethodEvenerSettingsAgentsDocSet     = "evener/settings/agentsDoc/set"
+	NotifyEvenerSettingsAgentsDocChanged = "evener/settings/agentsDoc/changed"
+)
+
+// AgentsDocResponse is the file as the hub sees it: the get result, the set
+// result, and the changed broadcast all carry this shape. A missing file is
+// Exists=false with empty Content, never an error.
+type AgentsDocResponse struct {
+	Path    string `json:"path"`
+	Exists  bool   `json:"exists"`
+	Content string `json:"content"`
+}
+
+// AgentsDocSetParams replaces the whole file with Content, byte for byte.
+type AgentsDocSetParams struct {
+	Content string `json:"content"`
+}
+```
+
+- [ ] **Step 4: Catalog the methods and the notification**
+
+In `appwire/protocol.go`, after the `MethodEvenerSettingsKeybindingsPatch` line in `Methods`, add:
+
+```go
+	{MethodEvenerSettingsAgentsDocGet, EmptyParams{}, AgentsDocResponse{}, ScopeHub, "Reads the personal AGENTS.md under the user config root: its path, whether it exists, and its content."},
+	{MethodEvenerSettingsAgentsDocSet, AgentsDocSetParams{}, AgentsDocResponse{}, ScopeHub, "Replaces the personal AGENTS.md whole (no precondition); broadcasts evener/settings/agentsDoc/changed."},
+```
+
+After the `NotifyEvenerSettingsKeybindingsChanged` line in `Notifications`, add:
+
+```go
+	{NotifyEvenerSettingsAgentsDocChanged, AgentsDocResponse{}, "Broadcast after the personal AGENTS.md is written; carries the new path, existence, and content."},
+```
+
+- [ ] **Step 5: Run the appwire tests**
+
+Run: `go test ./appwire 2>&1 | tail -5`
+Expected: `ok`. `TestMethodCatalogWellFormed` and `TestNotificationCatalogWellFormed` cover the new entries; a catalog-to-router parity test in `cmd/evener-hub` will fail until Task 3 registers the handlers, which is expected at this point.
+
+- [ ] **Step 6: Regenerate the wire outputs**
+
+Run: `make generate && git status --short`
+Expected: `cmd/evener-hub/frontend/src/protocol/types.gen.ts` and `docs/appwire-protocol.md` are modified. Confirm with `grep -n "agentsDoc" cmd/evener-hub/frontend/src/protocol/types.gen.ts | head` that `AgentsDocResponse`, `AgentsDocSetParams`, the two method entries, and the notification entry are present.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add appwire/agents_doc.go appwire/protocol.go appwire/protocol_test.go cmd/evener-hub/frontend/src/protocol/types.gen.ts docs/appwire-protocol.md
+git commit -m "feat(appwire): catalogue the personal AGENTS.md get/set methods"
+```
+
+---
+
+### Task 3: Hub handlers for get and set
+
+**Files:**
+- Create: `cmd/evener-hub/app_rpc_agents_doc.go`
+- Modify: `cmd/evener-hub/app_rpc.go:344` (register after `registerKeybindingsHandlers`)
+- Test: `cmd/evener-hub/app_rpc_agents_doc_test.go`
+
+**Interfaces:**
+- Consumes: Task 2's constants and types; `hubLaunchConfigRoot(cfg)` (already in `app_rpc.go`); test helpers `newHubRPCTestServer`, `dialHubRPC` (in `app_rpc_test.go`).
+- Produces: `registerAgentsDocHandlers(server *appserver.Server, configRoot string)`, `agentsDocPath(configRoot string) string`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cmd/evener-hub/app_rpc_agents_doc_test.go`:
+
+```go
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestHubRPCAgentsDocGetReportsAMissingFile(t *testing.T) {
+	root := t.TempDir()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	var got appwire.AgentsDocResponse
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	want := appwire.AgentsDocResponse{Path: filepath.Join(root, "AGENTS.md")}
+	if got != want {
+		t.Fatalf("get = %+v, want %+v", got, want)
+	}
+}
+
+func TestHubRPCAgentsDocGetReadsAnExistingFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("# mine\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	var got appwire.AgentsDocResponse
+	if err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocGet, appwire.EmptyParams{}, &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	want := appwire.AgentsDocResponse{Path: filepath.Join(root, "AGENTS.md"), Exists: true, Content: "# mine\n"}
+	if got != want {
+		t.Fatalf("get = %+v, want %+v", got, want)
+	}
+}
+
+func TestHubRPCAgentsDocSetWritesVerbatimAndBroadcasts(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "evener") // the config root itself may not exist yet
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	clientA := dialHubRPC(t, hub)
+	defer clientA.Close()
+	clientB := dialHubRPC(t, hub)
+	defer clientB.Close()
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const content = "  leading space, no trailing newline"
+	var result appwire.AgentsDocResponse
+	if err := clientA.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocSet, appwire.AgentsDocSetParams{Content: content}, &result); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	want := appwire.AgentsDocResponse{Path: filepath.Join(root, "AGENTS.md"), Exists: true, Content: content}
+	if result != want {
+		t.Fatalf("set = %+v, want %+v", result, want)
+	}
+
+	onDisk, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(onDisk) != content {
+		t.Fatalf("on disk = %q, want the content byte for byte", onDisk)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(root, "AGENTS.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o644 {
+			t.Fatalf("mode = %o, want 0644", info.Mode().Perm())
+		}
+	}
+	if _, err := os.Stat(filepath.Join(root, "AGENTS.md.tmp")); !os.IsNotExist(err) {
+		t.Fatal("the temp file survived the rename")
+	}
+
+	for _, client := range []*appwire.Client{clientA, clientB} {
+		notification := receiveAgentsDocChanged(t, client)
+		if notification != want {
+			t.Fatalf("notification = %+v, want %+v", notification, want)
+		}
+	}
+}
+
+func TestHubRPCAgentsDocSetReplacesThePreviousContent(t *testing.T) {
+	root := t.TempDir()
+	hub := newHubRPCTestServer(t, hubcore.WebConfig{LaunchConfigRoot: root})
+	defer hub.Close()
+	client := dialHubRPC(t, hub)
+	defer client.Close()
+	if _, err := client.Initialize(context.Background(), appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}); err != nil {
+		t.Fatal(err)
+	}
+	for _, content := range []string{"first\n", "second\n", ""} {
+		var result appwire.AgentsDocResponse
+		if err := client.Request(context.Background(), appwire.MethodEvenerSettingsAgentsDocSet, appwire.AgentsDocSetParams{Content: content}, &result); err != nil {
+			t.Fatalf("set %q: %v", content, err)
+		}
+		onDisk, err := os.ReadFile(filepath.Join(root, "AGENTS.md"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(onDisk) != content {
+			t.Fatalf("on disk = %q after set %q", onDisk, content)
+		}
+		receiveAgentsDocChanged(t, client)
+	}
+}
+
+func TestWriteAgentsDocFailureLeavesThePreviousFile(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Getuid() == 0 {
+		t.Skip("relies on a directory the process cannot write")
+	}
+	root := t.TempDir()
+	path := agentsDocPath(root)
+	if err := os.WriteFile(path, []byte("keep me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(root, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(root, 0o755) })
+
+	if err := writeAgentsDoc(path, "new"); err == nil {
+		t.Fatal("expected the write to fail in a read-only directory")
+	}
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(onDisk) != "keep me\n" {
+		t.Fatalf("a failed write changed the file: %q", onDisk)
+	}
+}
+
+func receiveAgentsDocChanged(t *testing.T, client *appwire.Client) appwire.AgentsDocResponse {
+	t.Helper()
+	select {
+	case notification := <-client.Notifications():
+		if notification.Method != appwire.NotifyEvenerSettingsAgentsDocChanged {
+			t.Fatalf("notification method = %q, want %q", notification.Method, appwire.NotifyEvenerSettingsAgentsDocChanged)
+		}
+		var params appwire.AgentsDocResponse
+		if err := json.Unmarshal(notification.Params, &params); err != nil {
+			t.Fatalf("decode notification: %v", err)
+		}
+		return params
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the agentsDoc notification")
+		return appwire.AgentsDocResponse{}
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./cmd/evener-hub -run 'AgentsDoc' 2>&1 | head -10`
+Expected: compile error, `undefined: agentsDocPath` / `undefined: writeAgentsDoc`.
+
+- [ ] **Step 3: Implement the handlers**
+
+Create `cmd/evener-hub/app_rpc_agents_doc.go`:
+
+```go
+package hub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/appserver"
+)
+
+// agentsDocPath is the personal AGENTS.md under the user config root - the
+// same file agent.LoadInstructionDocs reads at session init.
+func agentsDocPath(configRoot string) string {
+	return filepath.Join(configRoot, agent.UserDocFile)
+}
+
+// readAgentsDoc reports the file as it is on disk. A missing file is the
+// empty document, not an error: the settings section shows an empty editor
+// and the first save creates it.
+func readAgentsDoc(path string) (appwire.AgentsDocResponse, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return appwire.AgentsDocResponse{Path: path}, nil
+	}
+	if err != nil {
+		return appwire.AgentsDocResponse{}, fmt.Errorf("AGENTS.md: read: %w", err)
+	}
+	return appwire.AgentsDocResponse{Path: path, Exists: true, Content: string(b)}, nil
+}
+
+// writeAgentsDoc replaces the file atomically (temp + rename, mode 0644,
+// parent created), the same way registry.WriteConfigFile lands
+// providers.toml beside it. Content is written byte for byte: this is the
+// user's own prose, and trimming or appending a newline would make the
+// editor disagree with the file it just saved.
+func writeAgentsDoc(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("AGENTS.md: mkdir: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("AGENTS.md: write: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("AGENTS.md: rename: %w", err)
+	}
+	return nil
+}
+
+// registerAgentsDocHandlers serves evener/settings/agentsDoc/{get,set}. Writes
+// serialize on one mutex so two clients saving at once cannot interleave on
+// the shared temp path; there is no revision check by design (spec
+// 2026-09-07 §1) - the last write wins, and every client hears about it.
+func registerAgentsDocHandlers(server *appserver.Server, configRoot string) {
+	path := agentsDocPath(configRoot)
+	var mu sync.Mutex
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsAgentsDocGet,
+		func(context.Context, appwire.EmptyParams) (appwire.AgentsDocResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return readAgentsDoc(path)
+		})
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsAgentsDocSet,
+		func(_ context.Context, params appwire.AgentsDocSetParams) (appwire.AgentsDocResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if err := writeAgentsDoc(path, params.Content); err != nil {
+				return appwire.AgentsDocResponse{}, err
+			}
+			resp, err := readAgentsDoc(path)
+			if err != nil {
+				return appwire.AgentsDocResponse{}, err
+			}
+			server.BroadcastAll(appwire.NotifyEvenerSettingsAgentsDocChanged, resp)
+			return resp, nil
+		})
+}
+```
+
+In `cmd/evener-hub/app_rpc.go`, directly after the line `registerKeybindingsHandlers(server, cfg.KeybindingsStore)` add:
+
+```go
+	registerAgentsDocHandlers(server, hubLaunchConfigRoot(cfg))
+```
+
+- [ ] **Step 4: Run the hub tests**
+
+Run: `go test ./cmd/evener-hub -run 'AgentsDoc|Catalog|Parity' 2>&1 | tail -8`
+Expected: PASS. Then the whole package: `go test ./cmd/evener-hub 2>&1 | tail -3` → `ok`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/app_rpc_agents_doc.go cmd/evener-hub/app_rpc_agents_doc_test.go cmd/evener-hub/app_rpc.go
+git commit -m "feat(hub): serve the personal AGENTS.md over appwire"
+```
+
+---
+
+### Task 4: Frontend store for the personal doc
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/stores/agentsDoc.ts`
+- Test: `cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts`
+
+**Interfaces:**
+- Consumes: generated `AgentsDocResponse`, `AgentsDocSetParams`, method names from `protocol/types.gen.ts` (Task 2); `connectionStore` from `stores/connection.ts`; `FakeClient` (`emitNotification`, `on`, `calls`) from `protocol/testing/fakeClient.ts`.
+- Produces: `agentsDocStore`, `useAgentsDocStore`, `resetAgentsDocStoreForTests`, `AgentsDocStoreState { doc: AgentsDocResponse | null; loading: boolean; error: string | null; fetch(): Promise<void>; save(content: string): Promise<AgentsDocResponse> }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cmd/evener-hub/frontend/src/stores/agentsDoc.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, test } from "vitest";
+import { FakeClient } from "../protocol/testing/fakeClient";
+import type { AgentsDocResponse, AnyNotification } from "../protocol/types.gen";
+import { agentsDocStore, resetAgentsDocStoreForTests } from "./agentsDoc";
+import { connectionStore } from "./connection";
+
+const DOC: AgentsDocResponse = { path: "/home/u/.config/evener/AGENTS.md", exists: true, content: "# hi\n" };
+
+function connectFakeClient(): FakeClient {
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetAgentsDocStoreForTests();
+});
+
+describe("fetch", () => {
+  test("loads the document from evener/settings/agentsDoc/get", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+    expect(agentsDocStore.getState().loading).toBe(false);
+    expect(agentsDocStore.getState().error).toBeNull();
+  });
+
+  test("records a failed fetch as error text and keeps doc null", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => {
+      throw new Error("disk on fire");
+    });
+    await agentsDocStore.getState().fetch();
+    expect(agentsDocStore.getState().doc).toBeNull();
+    expect(agentsDocStore.getState().error).toContain("disk on fire");
+    expect(agentsDocStore.getState().loading).toBe(false);
+  });
+
+  test("throws when no client is connected", async () => {
+    await expect(agentsDocStore.getState().fetch()).rejects.toThrow(/no client connected/);
+  });
+});
+
+describe("save", () => {
+  test("sends the content to evener/settings/agentsDoc/set and adopts the response", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/set", (params) => ({ ...DOC, content: params.content }));
+    const saved = await agentsDocStore.getState().save("# new\n");
+    expect(saved.content).toBe("# new\n");
+    expect(agentsDocStore.getState().doc?.content).toBe("# new\n");
+    expect(fake.calls.map((c) => c.method)).toEqual(["evener/settings/agentsDoc/set"]);
+    expect(fake.calls[0]?.params).toEqual({ content: "# new\n" });
+  });
+
+  test("a rejected save propagates and leaves doc untouched", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+    fake.on("evener/settings/agentsDoc/set", () => {
+      throw new Error("read-only");
+    });
+    await expect(agentsDocStore.getState().save("x")).rejects.toThrow("read-only");
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+  });
+});
+
+describe("changed notification", () => {
+  test("replaces doc with the broadcast payload", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+    const pushed: AgentsDocResponse = { ...DOC, content: "# elsewhere\n" };
+    fake.emitNotification({ method: "evener/settings/agentsDoc/changed", params: pushed } as AnyNotification);
+    expect(agentsDocStore.getState().doc).toEqual(pushed);
+  });
+
+  test("a replaced client is re-wired: the old client's notifications stop landing", async () => {
+    const first = connectFakeClient();
+    const second = connectFakeClient();
+    second.on("evener/settings/agentsDoc/get", () => DOC);
+    await agentsDocStore.getState().fetch();
+    first.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "stale" },
+    } as AnyNotification);
+    expect(agentsDocStore.getState().doc).toEqual(DOC);
+    second.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "live" },
+    } as AnyNotification);
+    expect(agentsDocStore.getState().doc?.content).toBe("live");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `cmd/evener-hub/frontend`): `npx vitest run src/stores/agentsDoc.test.ts 2>&1 | tail -15`
+Expected: FAIL, cannot resolve `./agentsDoc`.
+
+- [ ] **Step 3: Implement the store**
+
+Create `cmd/evener-hub/frontend/src/stores/agentsDoc.ts`:
+
+```ts
+// The personal AGENTS.md store: the hub-authoritative file behind
+// Settings -> AGENTS.md (spec 2026-09-07 §1). One document, read whole and
+// written whole; no revision or conflict handling by design - the file is
+// also hand-edited, and the hub's own rule is last write wins. What the
+// store DOES keep current is `doc`: every evener/settings/agentsDoc/changed
+// broadcast (this client's own save included) replaces it, so a second tab
+// or a save from the TUI lands here without a refetch.
+//
+// requireClient() throws outside any try/catch, matching stores/credentials.ts:
+// "no client connected" is a programmer error, not a state to degrade into.
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+import { errorText } from "../protocol/errors";
+import type { AppwireClientLike } from "../protocol/testing/fakeClient";
+import type { AgentsDocResponse, AnyNotification } from "../protocol/types.gen";
+import { connectionStore } from "./connection";
+
+function requireClient(): AppwireClientLike {
+  const client = connectionStore.getState().client;
+  if (!client) {
+    throw new Error("agentsDoc store: no client connected; call useConnectionStore.getState().connect(client) first");
+  }
+  return client;
+}
+
+export interface AgentsDocStoreState {
+  /** The last document the hub confirmed - null until the first fetch lands. */
+  doc: AgentsDocResponse | null;
+  loading: boolean;
+  error: string | null;
+  fetch(): Promise<void>;
+  /** Replaces the file whole. Resolves with the hub's view of the saved file,
+   * which is also what `doc` becomes. Rejections propagate: the section
+   * owns the inline error and the toast. */
+  save(content: string): Promise<AgentsDocResponse>;
+}
+
+export const agentsDocStore = createStore<AgentsDocStoreState>((set) => ({
+  doc: null,
+  loading: false,
+  error: null,
+
+  async fetch() {
+    const client = requireClient();
+    set({ loading: true, error: null });
+    try {
+      const doc = await client.request("evener/settings/agentsDoc/get", {});
+      set({ doc, loading: false });
+    } catch (err) {
+      set({ loading: false, error: errorText(err) });
+    }
+  },
+
+  async save(content) {
+    const client = requireClient();
+    const doc = await client.request("evener/settings/agentsDoc/set", { content });
+    set({ doc });
+    return doc;
+  },
+}));
+
+export function useAgentsDocStore(): AgentsDocStoreState;
+export function useAgentsDocStore<T>(selector: (state: AgentsDocStoreState) => T): T;
+export function useAgentsDocStore<T>(selector?: (state: AgentsDocStoreState) => T): T | AgentsDocStoreState {
+  // Not a real conditional hook call - see stores/connection.ts's own
+  // useConnectionStore for the full explanation.
+  // biome-ignore lint/correctness/useHookAtTopLevel: same hook both arms, JS default param not a real conditional - see stores/connection.ts
+  return selector ? useStore(agentsDocStore, selector) : useStore(agentsDocStore);
+}
+
+// --- notification wiring ----------------------------------------------------
+
+let wiredClient: AppwireClientLike | null = null;
+let unsubscribeNotifications: (() => void) | undefined;
+
+function handleNotification(n: AnyNotification): void {
+  if (n.method === "evener/settings/agentsDoc/changed") agentsDocStore.setState({ doc: n.params });
+}
+
+function attachNotifications(client: AppwireClientLike | null): void {
+  if (client === wiredClient) return; // already wired to this exact client
+  unsubscribeNotifications?.();
+  wiredClient = client;
+  unsubscribeNotifications = client?.onNotification(handleNotification);
+}
+
+// React to the connection store rather than reading it once: this module can
+// be evaluated before AppShell's connect() effect runs (stores/extensions.ts
+// documents the mount-order race in full).
+connectionStore.subscribe((state) => attachNotifications(state.client));
+const initialClient = connectionStore.getState().client;
+if (initialClient) attachNotifications(initialClient);
+
+// resetAgentsDocStoreForTests resets the singleton between tests, including
+// the module-private wiring above. No production code should ever call this.
+export function resetAgentsDocStoreForTests(): void {
+  unsubscribeNotifications?.();
+  unsubscribeNotifications = undefined;
+  wiredClient = null;
+  agentsDocStore.setState({ doc: null, loading: false, error: null });
+}
+```
+
+- [ ] **Step 4: Run the store tests**
+
+Run: `npx biome check --write src/stores/agentsDoc.ts src/stores/agentsDoc.test.ts && npx vitest run src/stores/agentsDoc.test.ts 2>&1 | tail -8`
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/stores/agentsDoc.ts src/stores/agentsDoc.test.ts
+git commit -m "feat(web): personal AGENTS.md store"
+```
+
+---
+
+### Task 5: The AGENTS.md settings section
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx`
+- Create: `cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.module.css`
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/sections.ts` (the `SETTINGS_SECTIONS` list)
+- Modify: `cmd/evener-hub/frontend/src/panes/settings/Settings.tsx` (import + `SECTION_COMPONENTS`)
+- Test: `cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx`
+- Test (update): `cmd/evener-hub/frontend/src/panes/settings/sections.test.ts`
+
+**Interfaces:**
+- Consumes: Task 4's store; widgets `Button`, `Skeleton`, `Textarea`, `Toast`, `useToasts`; `Code` from `./settingsField`; `useConnectedEffect` from `./useConnectedEffect`; `friendlyErrorMessage` from `protocol/errors`.
+- Produces: `AgentsDocSection({ sectionId }: { sectionId: string })`; nav id `agents-md`, label `AGENTS.md`, cluster `agents-models`, placed right after `agents`.
+
+- [ ] **Step 1: Update the nav inventory test**
+
+In `cmd/evener-hub/frontend/src/panes/settings/sections.test.ts`:
+- `test("has exactly 18 sections"` → `19`, `toHaveLength(19)`.
+- The Agent setup test: title becomes `'the "Agent setup" cluster has exactly these 5 sections, in order, right after the ungrouped ones'`; expected labels `["Providers & credentials", "Agents", "AGENTS.md", "Evener launch", "In-repo config"]`; slice `slice(6, 11)`.
+- Extensions test: `slice(11, 15)`.
+- Daemon test: `slice(15, 19)`.
+
+Run: `npx vitest run src/panes/settings/sections.test.ts 2>&1 | tail -8`
+Expected: 4 failures (count, three slices).
+
+- [ ] **Step 2: Add the nav entry**
+
+In `sections.ts`, after `{ id: "agents", label: "Agents", cluster: "agents-models" },` add:
+
+```ts
+  { id: "agents-md", label: "AGENTS.md", cluster: "agents-models" },
+```
+
+Run the same test file: all pass.
+
+- [ ] **Step 3: Write the failing section tests**
+
+Create `cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.test.tsx`:
+
+```tsx
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { FakeClient } from "../../../protocol/testing/fakeClient";
+import type { AgentsDocResponse, AnyNotification } from "../../../protocol/types.gen";
+import { resetAgentsDocStoreForTests } from "../../../stores/agentsDoc";
+import { connectionStore } from "../../../stores/connection";
+import { Toast } from "../../../widgets";
+import { getToasts, resetToastStoreForTests } from "../../../widgets/toast/store";
+import { AgentsDocSection } from "./agentsDoc";
+
+const DOC: AgentsDocResponse = { path: "/home/u/.config/evener/AGENTS.md", exists: true, content: "# hi\n" };
+
+function connectFakeClient(doc: AgentsDocResponse = DOC): FakeClient {
+  const fake = new FakeClient("ready");
+  fake.on("evener/settings/agentsDoc/get", () => doc);
+  fake.on("evener/settings/agentsDoc/set", (params) => ({ ...doc, exists: true, content: params.content }));
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+function renderSection() {
+  return render(
+    <>
+      <Toast />
+      <AgentsDocSection sectionId="agents-md" />
+    </>,
+  );
+}
+
+function editor(): HTMLTextAreaElement {
+  return screen.getByRole("textbox", { name: "AGENTS.md contents" }) as HTMLTextAreaElement;
+}
+
+function saveButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetAgentsDocStoreForTests();
+  resetToastStoreForTests();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+test("loads the file on mount and shows its path and content", async () => {
+  connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  expect(screen.getByText("/home/u/.config/evener/AGENTS.md")).toBeTruthy();
+});
+
+test("a missing file renders an empty editor, not an error", async () => {
+  connectFakeClient({ path: "/home/u/.config/evener/AGENTS.md", exists: false, content: "" });
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe(""));
+  expect(screen.queryByText(/Failed to load/)).toBeNull();
+});
+
+test("a failed load shows the error", async () => {
+  const fake = new FakeClient("ready");
+  fake.on("evener/settings/agentsDoc/get", () => {
+    throw new Error("disk on fire");
+  });
+  connectionStore.getState().connect(fake);
+  renderSection();
+  await waitFor(() => expect(screen.getByText(/Failed to load/)).toBeTruthy());
+});
+
+test("Save and Revert are disabled until the draft differs from the loaded file", async () => {
+  connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  expect(saveButton().disabled).toBe(true);
+  expect((screen.getByRole("button", { name: "Revert" }) as HTMLButtonElement).disabled).toBe(true);
+
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  expect(saveButton().disabled).toBe(false);
+  expect((screen.getByRole("button", { name: "Revert" }) as HTMLButtonElement).disabled).toBe(false);
+});
+
+test("Revert restores the loaded content", async () => {
+  connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(screen.getByRole("button", { name: "Revert" }));
+  expect(editor().value).toBe("# hi\n");
+  expect(saveButton().disabled).toBe(true);
+});
+
+test("Save sends the draft, toasts, and the editor is clean afterwards", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(saveButton());
+  await waitFor(() => expect(getToasts().some((t) => t.text === "Saved AGENTS.md")).toBe(true));
+  const set = fake.calls.find((c) => c.method === "evener/settings/agentsDoc/set");
+  expect(set?.params).toEqual({ content: "# hi\nmore" });
+  expect(saveButton().disabled).toBe(true);
+  expect(editor().value).toBe("# hi\nmore");
+});
+
+test("a failed save shows the error inline and keeps the draft", async () => {
+  const fake = connectFakeClient();
+  fake.on("evener/settings/agentsDoc/set", () => {
+    throw new Error("read-only file system");
+  });
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  await user.click(saveButton());
+  await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("read-only file system"));
+  expect(editor().value).toBe("# hi\nmore");
+  expect(saveButton().disabled).toBe(false);
+});
+
+test("a changed broadcast while the draft is clean replaces the editor", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  act(() => {
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "# from the TUI\n" },
+    } as AnyNotification);
+  });
+  await waitFor(() => expect(editor().value).toBe("# from the TUI\n"));
+  expect(screen.queryByText(/changed on disk/)).toBeNull();
+});
+
+test("a changed broadcast while the draft is dirty keeps the draft and offers Load current", async () => {
+  const fake = connectFakeClient();
+  renderSection();
+  await waitFor(() => expect(editor().value).toBe("# hi\n"));
+  const user = userEvent.setup();
+  await user.type(editor(), "more");
+  act(() => {
+    fake.emitNotification({
+      method: "evener/settings/agentsDoc/changed",
+      params: { ...DOC, content: "# from the TUI\n" },
+    } as AnyNotification);
+  });
+  await waitFor(() => expect(screen.getByText(/changed on disk/)).toBeTruthy());
+  expect(editor().value).toBe("# hi\nmore");
+
+  await user.click(screen.getByRole("button", { name: "Load current" }));
+  expect(editor().value).toBe("# from the TUI\n");
+  expect(screen.queryByText(/changed on disk/)).toBeNull();
+  expect(saveButton().disabled).toBe(true);
+});
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `npx vitest run src/panes/settings/sections/agentsDoc.test.tsx 2>&1 | tail -8`
+Expected: FAIL, cannot resolve `./agentsDoc`.
+
+- [ ] **Step 5: Implement the section and its stylesheet**
+
+Create `cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.module.css`:
+
+```css
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-width: 720px;
+}
+
+.help {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+}
+
+.error {
+  margin: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-ui);
+}
+
+/* The file is Markdown the user hand-edits elsewhere too, so it reads in
+ * mono here as it does in their editor. The shared Textarea has no font
+ * prop; scoping the face to this section's own control is the narrowest
+ * override. */
+.editor textarea {
+  width: 100%;
+  font-family: var(--font-mono);
+}
+
+.note {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-ui);
+}
+
+.actions {
+  display: flex;
+  gap: var(--space-2);
+}
+```
+
+Create `cmd/evener-hub/frontend/src/panes/settings/sections/agentsDoc.tsx`:
+
+```tsx
+// Settings -> AGENTS.md: the personal instructions file every session loads
+// ahead of the repo's own project docs (spec 2026-09-07 §1). A whole-file
+// editor over stores/agentsDoc.ts: Save is dirty-gated, Revert restores the
+// last loaded content, and there is no conflict precondition by design (last
+// write wins) - what the section does instead is tell the user when the file
+// changed under a dirty draft and let them load the current version.
+//
+// `baseline` is the content the draft was last synced to; `dirty` is
+// draft !== baseline. A hub push (the `doc` subscription) syncs the draft
+// only while it is clean. A push whose content matches neither the baseline
+// nor the draft while dirty is someone else's write, and flips `stale` -
+// this client's own save lands with content equal to the draft, so it never
+// reads as stale.
+import { useEffect, useId, useState } from "react";
+import { friendlyErrorMessage } from "../../../protocol/errors";
+import { agentsDocStore, useAgentsDocStore } from "../../../stores/agentsDoc";
+import { Button, Skeleton, Textarea, useToasts } from "../../../widgets";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import styles from "./agentsDoc.module.css";
+import { Code } from "./settingsField";
+import { useConnectedEffect } from "./useConnectedEffect";
+
+const CLASS = {
+  root: requireClass(styles.root, "agentsDoc.module.css", "root"),
+  help: requireClass(styles.help, "agentsDoc.module.css", "help"),
+  error: requireClass(styles.error, "agentsDoc.module.css", "error"),
+  editor: requireClass(styles.editor, "agentsDoc.module.css", "editor"),
+  note: requireClass(styles.note, "agentsDoc.module.css", "note"),
+  actions: requireClass(styles.actions, "agentsDoc.module.css", "actions"),
+};
+
+export interface AgentsDocSectionProps {
+  /** Unused - kept so this component's signature matches every other
+   * dispatched settings section (see Settings.tsx's SECTION_COMPONENTS map). */
+  sectionId: string;
+}
+
+export function AgentsDocSection(_props: AgentsDocSectionProps) {
+  const doc = useAgentsDocStore((s) => s.doc);
+  const loading = useAgentsDocStore((s) => s.loading);
+  const error = useAgentsDocStore((s) => s.error);
+  const [draft, setDraft] = useState("");
+  const [baseline, setBaseline] = useState<string | null>(null);
+  const [stale, setStale] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const toast = useToasts();
+  const fieldId = useId();
+
+  useConnectedEffect(() => agentsDocStore.getState().fetch(), []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: doc is the only trigger; draft and baseline are read at that moment, not watched
+  useEffect(() => {
+    if (doc === null) return;
+    if (baseline === null || draft === baseline) {
+      setDraft(doc.content);
+      setBaseline(doc.content);
+      setStale(false);
+      return;
+    }
+    if (doc.content !== baseline && doc.content !== draft) setStale(true);
+  }, [doc]);
+
+  const dirty = baseline !== null && draft !== baseline;
+
+  async function handleSave(): Promise<void> {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const saved = await agentsDocStore.getState().save(draft);
+      setBaseline(saved.content);
+      setStale(false);
+      toast.push("success", "Saved AGENTS.md");
+    } catch (err) {
+      setSaveError(friendlyErrorMessage(err));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleRevert(): void {
+    if (baseline !== null) setDraft(baseline);
+  }
+
+  function handleLoadCurrent(): void {
+    if (doc === null) return;
+    setDraft(doc.content);
+    setBaseline(doc.content);
+    setStale(false);
+  }
+
+  if (doc === null && loading) return <Skeleton />;
+  if (doc === null && error) return <p className={CLASS.error}>Failed to load: {friendlyErrorMessage(error)}</p>;
+  if (doc === null) return null; // not yet fetched: the connected effect hasn't run
+
+  return (
+    <div className={CLASS.root}>
+      <h2>AGENTS.md</h2>
+      <p className={CLASS.help}>
+        Personal instructions loaded into every session, ahead of the repo's own AGENTS.md. Stored at{" "}
+        <Code>{doc.path}</Code>.
+      </p>
+      <div className={CLASS.editor}>
+        <Textarea
+          id={fieldId}
+          aria-label="AGENTS.md contents"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          minLines={16}
+          autoGrow
+          disabled={saving}
+          placeholder="# Instructions for every session"
+        />
+      </div>
+      {stale && (
+        <p className={CLASS.note} role="status">
+          AGENTS.md changed on disk while you were editing.
+          <Button size="sm" variant="quiet" onClick={handleLoadCurrent}>
+            Load current
+          </Button>
+        </p>
+      )}
+      {saveError !== null && (
+        <p className={CLASS.error} role="alert">
+          Save failed: {saveError}
+        </p>
+      )}
+      <div className={CLASS.actions}>
+        <Button onClick={() => void handleSave()} disabled={!dirty || saving}>
+          Save
+        </Button>
+        <Button variant="quiet" onClick={handleRevert} disabled={!dirty || saving}>
+          Revert
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+If `Button` does not accept `size="sm"` with `variant="quiet"` together (check `widgets/button/index.tsx`'s `ButtonProps`), drop `size` rather than invent a prop.
+
+- [ ] **Step 6: Dispatch the section**
+
+In `cmd/evener-hub/frontend/src/panes/settings/Settings.tsx`, add the import beside `AgentsSection`:
+
+```ts
+import { AgentsDocSection } from "./sections/agentsDoc";
+```
+
+and in `SECTION_COMPONENTS` after `agents: AgentsSection,` add:
+
+```ts
+  "agents-md": AgentsDocSection,
+```
+
+- [ ] **Step 7: Run the section tests, then the full frontend gate**
+
+Run: `npx biome check --write src/panes/settings/sections/agentsDoc.tsx src/panes/settings/sections/agentsDoc.module.css src/panes/settings/sections/agentsDoc.test.tsx src/panes/settings/sections.ts src/panes/settings/sections.test.ts src/panes/settings/Settings.tsx && npx vitest run src/panes/settings 2>&1 | tail -8`
+Expected: all settings tests pass.
+
+Then from the repo root: `make test-web 2>&1 | tail -15`
+Expected: typecheck, unit tests, and Biome all green. Read the output for `FAIL` rather than trusting the exit code of a piped command.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/panes/settings/sections/agentsDoc.tsx src/panes/settings/sections/agentsDoc.module.css src/panes/settings/sections/agentsDoc.test.tsx src/panes/settings/sections.ts src/panes/settings/sections.test.ts src/panes/settings/Settings.tsx
+git commit -m "feat(web): AGENTS.md settings section"
+```
+
+---
+
+### Task 6: Docs, gates, and the pull request
+
+**Files:**
+- Modify: `docs/evener-hub.md` (the paragraph around line 230 that names `providers.toml` under the config root; add one sentence that `AGENTS.md` beside it holds personal instructions loaded ahead of every repo's project docs, editable under Settings → AGENTS.md)
+- Modify: `docs/llm-providers.md` is NOT touched; `docs/appwire-protocol.md` was regenerated in Task 2.
+
+- [ ] **Step 1: Document the file**
+
+In `docs/evener-hub.md`, find the sentence that describes the config root contents (grep `providers.toml` around line 230) and add, in the same paragraph:
+
+```
+`AGENTS.md` beside it holds your personal standing instructions; every
+session loads it ahead of the repo's own AGENTS.md, and Settings → AGENTS.md
+edits it in place.
+```
+
+- [ ] **Step 2: Run every gate**
+
+From the repo root, one at a time, and read each output for failures:
+
+```bash
+make lint 2>&1 | tail -20
+make vet 2>&1 | tail -5
+make test 2>&1 | tail -20
+```
+
+Expected: all green. `make lint` includes the generated-output freshness check, which passes because Task 2 committed the regenerated files. If `make test` reports one of the known flaky tests from the memory file (drain-abandon cleanup race, execenv, procgroup, drain-continue), re-run that package once and report which it was.
+
+- [ ] **Step 3: Live check against a throwaway hub**
+
+Follow the WebUI screenshot recipe in memory (`webui-screenshot-recipe.md`): start a throwaway hub with `XDG_CONFIG_HOME` pointed at a temp dir, open Settings → AGENTS.md in the browser pane, type a line, Save, and confirm with `cat "$XDG_CONFIG_HOME/evener/AGENTS.md"` that the file holds exactly what was typed. Then start a session in a temp repo and confirm the transcript's system-prompt view (or `evener` debug prompt dump, if the recipe records one) shows a `----- BEGIN ~/.config/evener/AGENTS.md -----` block before the repo's block. Attach a desktop and a phone-width screenshot of the section to the PR.
+
+- [ ] **Step 4: Commit and open the PR**
+
+```bash
+git add docs/evener-hub.md
+git commit -m "docs(hub): describe the personal AGENTS.md"
+git push -u origin HEAD
+gh pr create --repo prime-radiant-inc/evener --base main --title "Personal AGENTS.md: loaded into every session, editable in settings" --body-file - <<'EOF'
+Slice 1 of docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md.
+
+- The daemon prepends `~/.config/evener/AGENTS.md` to every session's project docs, sharing the existing 32KB budget.
+- New `evener/settings/agentsDoc/{get,set}` methods and a `changed` broadcast (additive, v4).
+- New Settings → AGENTS.md section: monospace editor, dirty-gated Save, Revert, and a "changed on disk" notice with Load current.
+
+Gates: make lint, make vet, make test, make test-web. Screenshots attached.
+EOF
+```
+
+Then watch the PR's CI and roborev comments; a finding that recurs on every push has to be fixed in code, not declined (memory: roborev findings block merge).

--- a/docs/superpowers/plans/2026-09-07-marketplace-sheet-editor.md
+++ b/docs/superpowers/plans/2026-09-07-marketplace-sheet-editor.md
@@ -1,0 +1,1720 @@
+# Marketplace Sheet Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Marketplace rows open a sheet that edits the marketplace in place (rename, change source) and carries Refresh and Remove, backed by a new `evener/marketplace/edit` method that renames and re-sources a registered marketplace safely.
+
+**Architecture:** `internal/plugins.Manager.EditMarketplace` does the on-disk work under the store lock in a fetch-first order with directory-rename rollback: fetch a changed source into staging, rename the clone and cache directories and re-key `installed_plugins.json`, swap the staged clone in, then save the registry and the marketplaces file. The hub exposes it as one additive v4 method and maps the manager's sentinels to wire error classes. On the frontend, `MarketplacesSection` rows become single tappable buttons, a new `MarketplaceSheet` holds the form plus Refresh and Remove, and `marketplacesPlugins/index.tsx` owns the selection the same way it owns the plugin sheet's.
+
+**Tech Stack:** Go (internal/plugins, appwire, cmd/evener-hub), TypeScript + React + zustand + vitest, `make generate`.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md` §3 (plus §5, §6). This plan is slice 3 of 3; it does not depend on slices 1 or 2, but it follows the design-system rule slice 2 rewrote (a detail sheet is the item's editor).
+
+## Global Constraints
+
+- Repo root for every command: the git worktree you were started in. Frontend commands run from `cmd/evener-hub/frontend`.
+- Protocol version stays `evener-appwire-v4`; the new method is additive. Empty `newName` and absent `source` mean unchanged.
+- A marketplace name must pass `validNameComponent` (a single non-traversing path component). A taken name is `plugins.ErrMarketplaceExists` → `appwire.Conflict`; an unknown name is `plugins.ErrMarketplaceNotFound` → `appwire.InvalidParams`.
+- The manager's order is fixed: fetch new source → rename directories and re-key the registry → swap the clone in → save the registry, then the marketplaces file. Any failure after a directory rename renames back before returning.
+- The source picker offers the same three kinds the Add form offers: Git URL (`url`), owner/repo (`github`), Local path (`directory`). A `git-subdir` entry renders its URL under Git URL and is saved back unchanged unless edited.
+- No `git add -A`. Commit after every task with the exact message given.
+- Frontend: `npx biome check --write <touched files under src/>` before every commit that touches frontend files; gate is `make test-web` from the repo root.
+- Go plugin tests that need git call `gitAvailable()` and skip otherwise, like their neighbours; tests that stub a package-level seam (`marketplaceRename`) restore it in `t.Cleanup` and must not call `t.Parallel()`.
+- Follow each file's comment style: explain why, never narrate what changed.
+
+---
+
+### Task 1: The manager edits a marketplace
+
+**Files:**
+- Modify: `internal/plugins/errors.go` (add `ErrMarketplaceExists`)
+- Modify: `internal/plugins/marketplaces.go` (add `EditMarketplace`, `rekeyRegistry`; add `"strings"` to the imports)
+- Test: `internal/plugins/marketplaces_test.go`
+
+**Interfaces:**
+- Consumes: existing `acquireStoreLock`, `loadMarketplaces`/`saveMarketplaces`, `loadRegistry`/`saveRegistry`, `fetchMarketplaceContainer`, `ParseCatalog`, `swapInClone`, `marketplaceDir`, `cacheDir`, `marketplaceStat`, `marketplaceRename`, `marketplaceRemoveAll`, `registryKey`, `splitKey`, `validNameComponent`, `m.now()`.
+- Produces: `plugins.ErrMarketplaceExists`; `(*Manager).EditMarketplace(ctx context.Context, name, newName string, src *Source) (MarketplaceRef, error)`; `rekeyRegistry(reg Registry, oldName, newName, oldCache, newCache string) Registry`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/plugins/marketplaces_test.go`:
+
+```go
+// makeMarketplaceRepoWithPlugin builds a git repo whose marketplace.json is
+// named name and lists one installable plugin at ./plugins/<plugin>.
+func makeMarketplaceRepoWithPlugin(t *testing.T, name, plugin string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "mkt-"+name+"-"+plugin)
+	mj := `{"name":"` + name + `","owner":{"name":"o"},"plugins":[{"name":"` + plugin + `","source":"./plugins/` + plugin + `"}]}`
+	if err := os.MkdirAll(filepath.Join(dir, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".claude-plugin", "marketplace.json"), []byte(mj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writePlugin(t, filepath.Join(dir, "plugins", plugin), plugin, nil)
+	makeGitRepo(t, dir, "README.md", "mkt")
+	return dir
+}
+
+// makeDirectoryMarketplace builds a directory-source marketplace (no git)
+// named name with one installable plugin.
+func makeDirectoryMarketplace(t *testing.T, name, plugin string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "dir-"+name)
+	mj := `{"name":"` + name + `","owner":{"name":"o"},"plugins":[{"name":"` + plugin + `","source":"./plugins/` + plugin + `"}]}`
+	if err := os.MkdirAll(filepath.Join(dir, ".claude-plugin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".claude-plugin", "marketplace.json"), []byte(mj), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writePlugin(t, filepath.Join(dir, "plugins", plugin), plugin, nil)
+	return dir
+}
+
+func TestEditMarketplace_RenameMovesCloneCacheAndRegistry(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not available")
+	}
+	mktRepo, name := makeInstallableMarketplace(t)
+	m := NewManager(t.TempDir())
+	ctx := context.Background()
+	if _, err := m.AddMarketplace(ctx, "", Source{Kind: SourceURL, URL: mktRepo}); err != nil {
+		t.Fatalf("AddMarketplace: %v", err)
+	}
+	if _, err := m.Install(ctx, "widget", name); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	ref, err := m.EditMarketplace(ctx, name, "acme2", nil)
+	if err != nil {
+		t.Fatalf("EditMarketplace: %v", err)
+	}
+	if ref.InstallLocation != m.marketplaceDir("acme2") {
+		t.Fatalf("InstallLocation = %q, want %q", ref.InstallLocation, m.marketplaceDir("acme2"))
+	}
+	if _, err := os.Stat(m.marketplaceDir("acme2")); err != nil {
+		t.Fatalf("renamed clone missing: %v", err)
+	}
+	if _, err := os.Stat(m.marketplaceDir(name)); !os.IsNotExist(err) {
+		t.Fatal("old clone directory survived the rename")
+	}
+	list, err := m.ListMarketplaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := list["acme2"]; !ok {
+		t.Fatalf("acme2 not registered: %v", list)
+	}
+	if _, ok := list[name]; ok {
+		t.Fatal("the old name is still registered")
+	}
+	reg, err := m.loadRegistry()
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, ok := reg.Plugins[registryKey("widget", "acme2")]
+	if !ok || len(entries) != 1 {
+		t.Fatalf("registry not re-keyed: %v", reg.Plugins)
+	}
+	if _, still := reg.Plugins[registryKey("widget", name)]; still {
+		t.Fatal("the old registry key survived")
+	}
+	wantPrefix := filepath.Join(m.cacheDir(), "acme2") + string(filepath.Separator)
+	if !strings.HasPrefix(entries[0].InstallPath, wantPrefix) {
+		t.Fatalf("InstallPath = %q, want it under %q", entries[0].InstallPath, wantPrefix)
+	}
+	if _, err := os.Stat(entries[0].InstallPath); err != nil {
+		t.Fatalf("the re-keyed install path does not exist: %v", err)
+	}
+	items, err := m.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Plugin != "widget" || items[0].Marketplace != "acme2" {
+		t.Fatalf("List = %+v", items)
+	}
+	cat, err := m.Browse(ctx, "acme2")
+	if err != nil || len(cat.Plugins) != 1 {
+		t.Fatalf("Browse acme2 = %+v, %v", cat, err)
+	}
+}
+
+func TestEditMarketplace_DirectorySourceRenameKeepsThePath(t *testing.T) {
+	dir := makeDirectoryMarketplace(t, "acme", "widget")
+	m := NewManager(t.TempDir())
+	ctx := context.Background()
+	if _, err := m.AddMarketplace(ctx, "", Source{Kind: SourceDirectory, Path: dir}); err != nil {
+		t.Fatalf("AddMarketplace: %v", err)
+	}
+	if _, err := m.Install(ctx, "widget", "acme"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	ref, err := m.EditMarketplace(ctx, "acme", "beta", nil)
+	if err != nil {
+		t.Fatalf("EditMarketplace: %v", err)
+	}
+	if ref.InstallLocation != dir {
+		t.Fatalf("a directory source is referenced in place; InstallLocation = %q", ref.InstallLocation)
+	}
+	reg, _ := m.loadRegistry()
+	entries, ok := reg.Plugins[registryKey("widget", "beta")]
+	if !ok || len(entries) != 1 {
+		t.Fatalf("registry not re-keyed: %v", reg.Plugins)
+	}
+	if _, err := os.Stat(entries[0].InstallPath); err != nil {
+		t.Fatalf("install path after rename: %v", err)
+	}
+}
+
+func TestEditMarketplace_ResourceSwapsTheClone(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not available")
+	}
+	repoA := makeMarketplaceRepoWithPlugin(t, "acme", "widget")
+	repoB := makeMarketplaceRepoWithPlugin(t, "acme", "gadget")
+	m := NewManager(t.TempDir())
+	ctx := context.Background()
+	if _, err := m.AddMarketplace(ctx, "", Source{Kind: SourceURL, URL: repoA}); err != nil {
+		t.Fatalf("AddMarketplace: %v", err)
+	}
+	ref, err := m.EditMarketplace(ctx, "acme", "", &Source{Kind: SourceURL, URL: repoB})
+	if err != nil {
+		t.Fatalf("EditMarketplace: %v", err)
+	}
+	if ref.Source.URL != repoB {
+		t.Fatalf("Source = %+v, want repoB", ref.Source)
+	}
+	cat, err := m.Browse(ctx, "acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cat.Plugins) != 1 || cat.Plugins[0].Name != "gadget" {
+		t.Fatalf("catalog after re-source = %+v, want gadget", cat.Plugins)
+	}
+	if _, err := os.Stat(m.marketplaceDir(".staging")); !os.IsNotExist(err) {
+		t.Fatal("staging directory survived")
+	}
+}
+
+func TestEditMarketplace_RenameAndResourceTogether(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not available")
+	}
+	repoA := makeMarketplaceRepoWithPlugin(t, "acme", "widget")
+	repoB := makeMarketplaceRepoWithPlugin(t, "acme", "gadget")
+	m := NewManager(t.TempDir())
+	ctx := context.Background()
+	if _, err := m.AddMarketplace(ctx, "", Source{Kind: SourceURL, URL: repoA}); err != nil {
+		t.Fatalf("AddMarketplace: %v", err)
+	}
+	if _, err := m.Install(ctx, "widget", "acme"); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	ref, err := m.EditMarketplace(ctx, "acme", "beta", &Source{Kind: SourceURL, URL: repoB})
+	if err != nil {
+		t.Fatalf("EditMarketplace: %v", err)
+	}
+	if ref.InstallLocation != m.marketplaceDir("beta") || ref.Source.URL != repoB {
+		t.Fatalf("ref = %+v", ref)
+	}
+	list, _ := m.ListMarketplaces()
+	if _, ok := list["beta"]; !ok || len(list) != 1 {
+		t.Fatalf("list = %v", list)
+	}
+	cat, err := m.Browse(ctx, "beta")
+	if err != nil || len(cat.Plugins) != 1 || cat.Plugins[0].Name != "gadget" {
+		t.Fatalf("Browse beta = %+v, %v", cat, err)
+	}
+	reg, _ := m.loadRegistry()
+	entries, ok := reg.Plugins[registryKey("widget", "beta")]
+	if !ok || len(entries) != 1 {
+		t.Fatalf("registry = %v", reg.Plugins)
+	}
+	if _, err := os.Stat(entries[0].InstallPath); err != nil {
+		t.Fatalf("the installed plugin is unaffected by a re-source, but its path is gone: %v", err)
+	}
+}
+
+func TestEditMarketplace_FetchFailureChangesNothing(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not available")
+	}
+	mktRepo, name := makeInstallableMarketplace(t)
+	m := NewManager(t.TempDir())
+	ctx := context.Background()
+	if _, err := m.AddMarketplace(ctx, "", Source{Kind: SourceURL, URL: mktRepo}); err != nil {
+		t.Fatalf("AddMarketplace: %v", err)
+	}
+	if _, err := m.Install(ctx, "widget", name); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	bad := &Source{Kind: SourceURL, URL: filepath.Join(t.TempDir(), "does-not-exist")}
+	if _, err := m.EditMarketplace(ctx, name, "beta", bad); err == nil {
+		t.Fatal("expected the fetch to fail")
+	}
+	list, _ := m.ListMarketplaces()
+	if _, ok := list[name]; !ok || len(list) != 1 {
+		t.Fatalf("list changed after a failed fetch: %v", list)
+	}
+	if _, err := os.Stat(m.marketplaceDir(name)); err != nil {
+		t.Fatalf("the clone moved after a failed fetch: %v", err)
+	}
+	if _, err := os.Stat(m.marketplaceDir("beta")); !os.IsNotExist(err) {
+		t.Fatal("a beta directory appeared")
+	}
+	reg, _ := m.loadRegistry()
+	if _, ok := reg.Plugins[registryKey("widget", name)]; !ok {
+		t.Fatalf("registry changed after a failed fetch: %v", reg.Plugins)
+	}
+	if _, err := os.Stat(m.marketplaceDir(".staging")); !os.IsNotExist(err) {
+		t.Fatal("staging directory survived")
+	}
+}
+
+func TestEditMarketplace_RestoresDirectoriesWhenARenameStepFails(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not available")
+	}
+	mktRepo, name := makeInstallableMarketplace(t)
+	m := NewManager(t.TempDir())
+	ctx := context.Background()
+	if _, err := m.AddMarketplace(ctx, "", Source{Kind: SourceURL, URL: mktRepo}); err != nil {
+		t.Fatalf("AddMarketplace: %v", err)
+	}
+	if _, err := m.Install(ctx, "widget", name); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// The clone directory renames; the cache directory refuses. The undo
+	// then runs through the same seam, so only the second call fails.
+	orig := marketplaceRename
+	calls := 0
+	marketplaceRename = func(from, to string) error {
+		calls++
+		if calls == 2 {
+			return errors.New("boom")
+		}
+		return orig(from, to)
+	}
+	t.Cleanup(func() { marketplaceRename = orig })
+
+	if _, err := m.EditMarketplace(ctx, name, "beta", nil); err == nil {
+		t.Fatal("expected the rename to fail")
+	}
+	if _, err := os.Stat(m.marketplaceDir(name)); err != nil {
+		t.Fatalf("the clone was not restored: %v", err)
+	}
+	if _, err := os.Stat(m.marketplaceDir("beta")); !os.IsNotExist(err) {
+		t.Fatal("a beta clone remained")
+	}
+	list, _ := m.ListMarketplaces()
+	if _, ok := list[name]; !ok || len(list) != 1 {
+		t.Fatalf("list changed after a failed rename: %v", list)
+	}
+	reg, _ := m.loadRegistry()
+	if _, ok := reg.Plugins[registryKey("widget", name)]; !ok {
+		t.Fatalf("registry changed after a failed rename: %v", reg.Plugins)
+	}
+}
+
+func TestEditMarketplace_Refusals(t *testing.T) {
+	m := NewManager(t.TempDir())
+	ctx := context.Background()
+	for _, name := range []string{"acme", "beta"} {
+		dir := makeDirectoryMarketplace(t, name, "widget")
+		if _, err := m.AddMarketplace(ctx, "", Source{Kind: SourceDirectory, Path: dir}); err != nil {
+			t.Fatalf("AddMarketplace %s: %v", name, err)
+		}
+	}
+	if _, err := m.EditMarketplace(ctx, "acme", "beta", nil); !errors.Is(err, ErrMarketplaceExists) {
+		t.Fatalf("rename onto a taken name = %v, want ErrMarketplaceExists", err)
+	}
+	if _, err := m.EditMarketplace(ctx, "nope", "x", nil); !errors.Is(err, ErrMarketplaceNotFound) {
+		t.Fatalf("unknown marketplace = %v, want ErrMarketplaceNotFound", err)
+	}
+	if _, err := m.EditMarketplace(ctx, "acme", "../escape", nil); err == nil {
+		t.Fatal("a traversing name must be refused")
+	}
+}
+
+func TestEditMarketplace_NoOpReturnsTheCurrentRef(t *testing.T) {
+	dir := makeDirectoryMarketplace(t, "acme", "widget")
+	m := NewManager(t.TempDir())
+	ctx := context.Background()
+	before, err := m.AddMarketplace(ctx, "", Source{Kind: SourceDirectory, Path: dir})
+	if err != nil {
+		t.Fatalf("AddMarketplace: %v", err)
+	}
+	same := Source{Kind: SourceDirectory, Path: dir}
+	after, err := m.EditMarketplace(ctx, "acme", "acme", &same)
+	if err != nil {
+		t.Fatalf("EditMarketplace: %v", err)
+	}
+	if after != before {
+		t.Fatalf("a no-op edit changed the ref: %+v → %+v", before, after)
+	}
+}
+
+func TestRekeyRegistry(t *testing.T) {
+	oldCache, newCache := filepath.Join("cache", "acme"), filepath.Join("cache", "beta")
+	reg := Registry{Version: 2, Plugins: map[string][]InstallEntry{
+		registryKey("widget", "acme"): {{InstallPath: filepath.Join(oldCache, "widget", "abc")}},
+		registryKey("other", "zeta"):  {{InstallPath: filepath.Join("cache", "zeta", "other", "def")}},
+		registryKey("elsewhere", "acme"): {{InstallPath: filepath.Join("somewhere", "else")}},
+	}}
+	got := rekeyRegistry(reg, "acme", "beta", oldCache, newCache)
+	if _, still := got.Plugins[registryKey("widget", "acme")]; still {
+		t.Fatal("old key survived")
+	}
+	if p := got.Plugins[registryKey("widget", "beta")][0].InstallPath; p != filepath.Join(newCache, "widget", "abc") {
+		t.Fatalf("InstallPath = %q", p)
+	}
+	if p := got.Plugins[registryKey("other", "zeta")][0].InstallPath; p != filepath.Join("cache", "zeta", "other", "def") {
+		t.Fatalf("an unrelated entry changed: %q", p)
+	}
+	if p := got.Plugins[registryKey("elsewhere", "beta")][0].InstallPath; p != filepath.Join("somewhere", "else") {
+		t.Fatalf("a path outside the cache changed: %q", p)
+	}
+	if got.Version != 2 {
+		t.Fatalf("Version = %d", got.Version)
+	}
+}
+```
+
+`strings` and `errors` are already imported by this test file.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/plugins -run 'TestEditMarketplace|TestRekeyRegistry' 2>&1 | head -8`
+Expected: compile errors, `undefined: ErrMarketplaceExists`, `m.EditMarketplace undefined`, `undefined: rekeyRegistry`.
+
+- [ ] **Step 3: Implement**
+
+In `internal/plugins/errors.go`, add to the `var (...)` block:
+
+```go
+	ErrMarketplaceExists   = errors.New("marketplace already registered")
+```
+
+In `internal/plugins/marketplaces.go`, add `"strings"` to the import block, and after `RemoveMarketplace` add:
+
+```go
+// EditMarketplace renames a registered marketplace and/or replaces its
+// source (spec 2026-09-07 §3). The order is chosen so the one step that can
+// take a long time or fail for reasons outside the store - fetching the new
+// source - happens before anything on disk moves, and every directory rename
+// is undone if a later step fails before the files are saved:
+//
+//  1. fetch a changed source into staging and parse its catalog (Add's own
+//     staging discipline: a bad source never half-registers);
+//  2. rename the clone directory and the plugin cache directory, and re-key
+//     every <plugin>@old registry entry (its install path lives under the
+//     renamed cache);
+//  3. swap the staged clone into the (possibly renamed) install location, or
+//     point a directory source at its path;
+//  4. save the installed registry, then the marketplaces file.
+//
+// A same-name, same-source call is a no-op that returns the current ref.
+// Installed plugins are materialized under the cache, so a re-source never
+// touches them beyond the re-key a rename implies.
+func (m *Manager) EditMarketplace(ctx context.Context, name, newName string, src *Source) (MarketplaceRef, error) {
+	release, err := m.acquireStoreLock(ctx, marketplaceAcquireLock, m.lockPath(), 30*time.Second)
+	if err != nil {
+		return MarketplaceRef{}, err
+	}
+	defer release()
+
+	mk, err := m.loadMarketplaces()
+	if err != nil {
+		return MarketplaceRef{}, err
+	}
+	ref, ok := mk[name]
+	if !ok {
+		return MarketplaceRef{}, fmt.Errorf("marketplace %q: %w", name, ErrMarketplaceNotFound)
+	}
+	renaming := newName != "" && newName != name
+	resourcing := src != nil && *src != ref.Source
+	if !renaming && !resourcing {
+		return ref, nil
+	}
+	if renaming {
+		if err := validNameComponent("marketplace", newName); err != nil {
+			return MarketplaceRef{}, err
+		}
+		if _, taken := mk[newName]; taken {
+			return MarketplaceRef{}, fmt.Errorf("marketplace %q: %w", newName, ErrMarketplaceExists)
+		}
+	}
+	reg, err := m.loadRegistry()
+	if err != nil {
+		return MarketplaceRef{}, err
+	}
+
+	// 1. The network step, before anything on disk moves.
+	staging := m.marketplaceDir(".staging")
+	if resourcing {
+		_ = marketplaceRemoveAll(staging)
+		root, err := m.fetchMarketplaceContainer(ctx, *src, staging)
+		if err != nil {
+			_ = marketplaceRemoveAll(staging)
+			return MarketplaceRef{}, err
+		}
+		if _, err := ParseCatalog(root); err != nil {
+			_ = marketplaceRemoveAll(staging)
+			return MarketplaceRef{}, fmt.Errorf("reading marketplace.json: %w", err)
+		}
+	}
+	// From here until the files are saved, a failure runs undo in reverse
+	// and sweeps staging.
+	var undo []func()
+	fail := func(err error) (MarketplaceRef, error) {
+		for i := len(undo) - 1; i >= 0; i-- {
+			undo[i]()
+		}
+		_ = marketplaceRemoveAll(staging)
+		return MarketplaceRef{}, err
+	}
+
+	// 2. Rename on disk and in the registry.
+	target := name
+	if renaming {
+		target = newName
+		if ref.Source.Kind != SourceDirectory && ref.InstallLocation != "" {
+			oldDir, newDir := m.marketplaceDir(name), m.marketplaceDir(newName)
+			if _, err := marketplaceStat(oldDir); err == nil {
+				if err := marketplaceRename(oldDir, newDir); err != nil {
+					return fail(fmt.Errorf("renaming marketplace clone: %w", err))
+				}
+				undo = append(undo, func() { _ = marketplaceRename(newDir, oldDir) })
+			}
+			ref.InstallLocation = newDir
+		}
+		oldCache, newCache := filepath.Join(m.cacheDir(), name), filepath.Join(m.cacheDir(), newName)
+		if _, err := marketplaceStat(oldCache); err == nil {
+			if err := marketplaceRename(oldCache, newCache); err != nil {
+				return fail(fmt.Errorf("renaming plugin cache: %w", err))
+			}
+			undo = append(undo, func() { _ = marketplaceRename(newCache, oldCache) })
+		}
+		reg = rekeyRegistry(reg, name, newName, oldCache, newCache)
+	}
+
+	// 3. Apply the new source into the install location. An old clone that a
+	// directory source makes redundant goes only after the files say so.
+	var afterSave []func()
+	if resourcing {
+		if src.Kind == SourceDirectory {
+			if ref.Source.Kind != SourceDirectory {
+				clone := m.marketplaceDir(target)
+				afterSave = append(afterSave, func() { _ = marketplaceRemoveAll(clone) })
+			}
+			_ = marketplaceRemoveAll(staging)
+			ref.InstallLocation = src.Path
+		} else {
+			dest := m.marketplaceDir(target)
+			if err := m.swapInClone(staging, dest); err != nil {
+				return fail(err)
+			}
+			ref.InstallLocation = dest
+		}
+		ref.Source = *src
+	}
+	ref.LastUpdated = m.now().UTC()
+
+	// 4. The registry first: a marketplaces file naming a marketplace whose
+	// plugins are still keyed under the old name is the worse of the two
+	// half-states, and evener-doctor reports the other one.
+	if renaming {
+		if err := m.saveRegistry(reg); err != nil {
+			return fail(err)
+		}
+		delete(mk, name)
+	}
+	mk[target] = ref
+	if err := m.saveMarketplaces(mk); err != nil {
+		if renaming {
+			return MarketplaceRef{}, fmt.Errorf("marketplace %q renamed in %s but not in %s: %w", name, registryFileName, marketplacesFileName, err)
+		}
+		return MarketplaceRef{}, err
+	}
+	for _, fn := range afterSave {
+		fn()
+	}
+	return ref, nil
+}
+
+// rekeyRegistry moves every <plugin>@oldName entry to <plugin>@newName and
+// rewrites the install paths that lived under the renamed cache directory;
+// entries for other marketplaces, and paths outside the cache, are untouched.
+func rekeyRegistry(reg Registry, oldName, newName, oldCache, newCache string) Registry {
+	out := Registry{Version: reg.Version, Plugins: make(map[string][]InstallEntry, len(reg.Plugins))}
+	for key, entries := range reg.Plugins {
+		plugin, marketplace := splitKey(key)
+		if marketplace != oldName {
+			out.Plugins[key] = entries
+			continue
+		}
+		moved := make([]InstallEntry, 0, len(entries))
+		for _, e := range entries {
+			rel, err := filepath.Rel(oldCache, e.InstallPath)
+			if err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				e.InstallPath = filepath.Join(newCache, rel)
+			}
+			moved = append(moved, e)
+		}
+		out.Plugins[registryKey(plugin, newName)] = moved
+	}
+	return out
+}
+```
+
+If `marketplaceStat` is not a package-level var in this file (check `grep -n marketplaceStat internal/plugins/marketplaces.go`), use `os.Stat` in its place.
+
+- [ ] **Step 4: Run the plugin tests**
+
+Run: `go test ./internal/plugins 2>&1 | tail -4`
+Expected: ok, including the fuzz-coverage tests that also stub `marketplaceRename`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/plugins/errors.go internal/plugins/marketplaces.go internal/plugins/marketplaces_test.go
+git commit -m "feat(plugins): rename and re-source a registered marketplace"
+```
+
+---
+
+### Task 2: Wire method, hub controller, and handler
+
+**Files:**
+- Modify: `appwire/types.go` (constant beside `MethodEvenerMarketplaceRefresh`; `MarketplaceEditParams` after `MarketplaceAddParams`)
+- Modify: `appwire/protocol.go` (catalog entry after the Refresh entry; the two notification doc strings)
+- Modify: `cmd/evener-hub/app_plugins.go` (`EditMarketplace`)
+- Modify: `cmd/evener-hub/app_rpc.go` (handler after the Refresh handler)
+- Test: `cmd/evener-hub/app_plugins_test.go`, `appwire/protocol_test.go`
+- Regenerate: `cmd/evener-hub/frontend/src/protocol/types.gen.ts`, `docs/appwire-protocol.md`
+
+**Interfaces:**
+- Produces: `appwire.MethodEvenerMarketplaceEdit = "evener/marketplace/edit"`; `appwire.MarketplaceEditParams{ Name string; NewName string omitempty; Source *MarketplaceSourceInput omitempty }`; `(*hubPluginsController).EditMarketplace(ctx, params) (appwire.MarketplaceListResponse, error)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `appwire/protocol_test.go`:
+
+```go
+func TestMarketplaceEditCatalog(t *testing.T) {
+	for _, method := range Methods {
+		if method.Name != MethodEvenerMarketplaceEdit {
+			continue
+		}
+		if method.Scope != ScopeHub {
+			t.Errorf("scope = %q, want %q", method.Scope, ScopeHub)
+		}
+		if reflect.TypeOf(method.Params) != reflect.TypeFor[MarketplaceEditParams]() {
+			t.Errorf("params type = %T", method.Params)
+		}
+		if reflect.TypeOf(method.Result) != reflect.TypeFor[MarketplaceListResponse]() {
+			t.Errorf("result type = %T", method.Result)
+		}
+		return
+	}
+	t.Fatalf("method catalog missing %s", MethodEvenerMarketplaceEdit)
+}
+```
+
+Append to `cmd/evener-hub/app_plugins_test.go`:
+
+```go
+func TestPlugins_Marketplace_EditRenamesAndReturnsTheList(t *testing.T) {
+	ctl := newTestPluginsController(t)
+	dir := t.TempDir()
+	writeTestMarketplace(t, dir)
+	addTestMarketplace(t, ctl, dir)
+
+	resp, err := ctl.EditMarketplace(context.Background(), appwire.MarketplaceEditParams{Name: "acme", NewName: "acme2"})
+	if err != nil {
+		t.Fatalf("EditMarketplace: %v", err)
+	}
+	if len(resp.Marketplaces) != 1 || resp.Marketplaces[0].Name != "acme2" {
+		t.Fatalf("EditMarketplace response = %+v, want one entry named acme2", resp.Marketplaces)
+	}
+	if resp.Marketplaces[0].Source.Kind != "directory" || resp.Marketplaces[0].Source.Path != dir {
+		t.Fatalf("Source = %+v", resp.Marketplaces[0].Source)
+	}
+}
+
+func TestPlugins_Marketplace_EditRefusalsAreWireErrors(t *testing.T) {
+	ctl := newTestPluginsController(t)
+	dir := t.TempDir()
+	writeTestMarketplace(t, dir)
+	addTestMarketplace(t, ctl, dir)
+	other := t.TempDir()
+	writeTestMarketplaceManifest(t, other, "beta", "[]")
+	if _, err := ctl.AddMarketplace(context.Background(), appwire.MarketplaceAddParams{
+		Source: appwire.MarketplaceSourceInput{Kind: "directory", Path: other},
+	}); err != nil {
+		t.Fatalf("AddMarketplace beta: %v", err)
+	}
+
+	_, err := ctl.EditMarketplace(context.Background(), appwire.MarketplaceEditParams{Name: "acme", NewName: "beta"})
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeConflict {
+		t.Fatalf("rename onto a taken name = %v, want a Conflict wire error", err)
+	}
+	_, err = ctl.EditMarketplace(context.Background(), appwire.MarketplaceEditParams{Name: "nope", NewName: "x"})
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("unknown marketplace = %v, want an InvalidParams wire error", err)
+	}
+}
+```
+
+Add `"errors"` to that test file's imports if it is not there.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./appwire -run TestMarketplaceEditCatalog 2>&1 | head -4; go test ./cmd/evener-hub -run 'TestPlugins_Marketplace_Edit' 2>&1 | head -4`
+Expected: compile errors on the undefined constant, type, and method.
+
+- [ ] **Step 3: Implement the wire shape and catalog**
+
+In `appwire/types.go`, after `MethodEvenerMarketplaceRefresh`, add:
+
+```go
+	MethodEvenerMarketplaceEdit       = "evener/marketplace/edit"
+```
+
+After `MarketplaceAddParams`, add:
+
+```go
+// MarketplaceEditParams is the params for evener/marketplace/edit (spec
+// 2026-09-07 §3). NewName renames the registered marketplace (empty means
+// unchanged); Source replaces its source and re-fetches it (absent means
+// unchanged). Installed plugins are unaffected beyond being re-keyed under
+// the new name.
+type MarketplaceEditParams struct {
+	Name    string                  `json:"name"`
+	NewName string                  `json:"newName,omitempty"`
+	Source  *MarketplaceSourceInput `json:"source,omitempty"`
+}
+```
+
+In `appwire/protocol.go`, after the `MethodEvenerMarketplaceRefresh` catalog line, add:
+
+```go
+	{MethodEvenerMarketplaceEdit, MarketplaceEditParams{}, MarketplaceListResponse{}, ScopeHub, "Renames a registered marketplace and/or replaces its source, re-fetching it; returns the updated list and broadcasts evener/marketplace/updated and evener/plugin/updated."},
+```
+
+Change the two notification doc strings `(add/remove/refresh)` → `(add/edit/remove/refresh)` and `(install/upgrade/remove/enable/disable/setAutoUpgrade)` → `(install/upgrade/remove/enable/disable/setAutoUpgrade, or a marketplace rename re-keying installs)`.
+
+If `go test ./appwire` then reports that every hub method needs a `*Client` wrapper, add beside `MarketplaceAdd` in `appwire/client.go`:
+
+```go
+// MarketplaceEdit renames a marketplace and/or replaces its source.
+func (c *Client) MarketplaceEdit(ctx context.Context, params MarketplaceEditParams) (MarketplaceListResponse, error) {
+	var out MarketplaceListResponse
+	err := c.Request(ctx, MethodEvenerMarketplaceEdit, params, &out)
+	return out, err
+}
+```
+
+(Match `MarketplaceAdd`'s exact body shape if it differs.)
+
+- [ ] **Step 4: Implement the controller and handler**
+
+In `cmd/evener-hub/app_plugins.go`, after `RefreshMarketplace`, add:
+
+```go
+// EditMarketplace renames a marketplace and/or replaces its source and
+// returns the updated list. The manager's sentinels become the wire's own
+// refusal classes - a taken name is the caller's Conflict, an unknown name
+// their InvalidParams - while a fetch failure or a rename the filesystem
+// refused stays the hub's plain error.
+func (c *hubPluginsController) EditMarketplace(ctx context.Context, params appwire.MarketplaceEditParams) (appwire.MarketplaceListResponse, error) {
+	var src *plugins.Source
+	if params.Source != nil {
+		converted := marketplaceSourceFromWire(*params.Source)
+		src = &converted
+	}
+	if _, err := c.mgr.EditMarketplace(ctx, params.Name, params.NewName, src); err != nil {
+		switch {
+		case errors.Is(err, plugins.ErrMarketplaceExists):
+			return appwire.MarketplaceListResponse{}, appwire.Conflict(err.Error())
+		case errors.Is(err, plugins.ErrMarketplaceNotFound):
+			return appwire.MarketplaceListResponse{}, appwire.InvalidParams(err.Error())
+		}
+		return appwire.MarketplaceListResponse{}, err
+	}
+	return c.listMarketplaces()
+}
+```
+
+In `cmd/evener-hub/app_rpc.go`, after the `MethodEvenerMarketplaceRefresh` handler, add:
+
+```go
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerMarketplaceEdit, func(ctx context.Context, params appwire.MarketplaceEditParams) (appwire.MarketplaceListResponse, error) {
+		resp, err := pluginsController.EditMarketplace(ctx, params)
+		if err == nil {
+			// A rename re-keys installed plugins, so both lists refresh.
+			notifyMarketplaceUpdated(server)
+			notifyPluginUpdated(server)
+		}
+		return resp, err
+	})
+```
+
+- [ ] **Step 5: Regenerate and run the tests**
+
+Run: `make generate && go test ./appwire ./internal/appwirets ./cmd/evener-hub 2>&1 | tail -6`
+Expected: ok for all three (the hub's catalog-to-router parity test sees the new handler). `git status --short` shows `types.gen.ts` and `docs/appwire-protocol.md` modified; confirm `grep -n "marketplace/edit" cmd/evener-hub/frontend/src/protocol/types.gen.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add appwire/types.go appwire/protocol.go appwire/protocol_test.go cmd/evener-hub/app_plugins.go cmd/evener-hub/app_plugins_test.go cmd/evener-hub/app_rpc.go cmd/evener-hub/frontend/src/protocol/types.gen.ts docs/appwire-protocol.md
+git commit -m "feat(hub): serve evener/marketplace/edit"
+```
+
+(Add `appwire/client.go` if the wrapper was needed.)
+
+---
+
+### Task 3: Store mutation and the form model
+
+**Files:**
+- Modify: `cmd/evener-hub/frontend/src/stores/extensions.ts`
+- Create: `cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/marketplaceEdit.ts`
+- Test: `cmd/evener-hub/frontend/src/stores/extensions.test.ts`, `.../marketplacesPlugins/marketplaceEdit.test.ts`
+
+**Interfaces:**
+- Produces: `extensionsStore.editMarketplace(params: MarketplaceEditParams): Promise<void>`; `MarketplaceDraft { name: string; kind: "url" | "github" | "directory"; url: string; repo: string; path: string }`; `marketplaceDraftFor(entry: MarketplaceEntry): MarketplaceDraft`; `marketplaceEditParams(entry, draft): MarketplaceEditParams | null`; `MARKETPLACE_SOURCE_OPTIONS`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/stores/extensions.test.ts`, after the `refreshMarketplace` describe:
+
+```ts
+describe("editMarketplace", () => {
+  test("calls evener/marketplace/edit, applies the response, and drops the browse cache for both names", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/marketplace/browse", () => ({ name: "acme-plugins", description: "", plugins: [] }));
+    await extensionsStore.getState().browseMarketplace("acme-plugins");
+    expect(extensionsStore.getState().browseCatalogs.has("acme-plugins")).toBe(true);
+
+    fake.on("evener/marketplace/edit", (params) => {
+      expect(params).toEqual({ name: "acme-plugins", newName: "acme2", source: { kind: "url", url: "https://x/y.git" } });
+      return { marketplaces: [{ ...MARKETPLACE_A, name: "acme2", source: { kind: "url", url: "https://x/y.git" } }] };
+    });
+    await extensionsStore.getState().editMarketplace({
+      name: "acme-plugins",
+      newName: "acme2",
+      source: { kind: "url", url: "https://x/y.git" },
+    });
+    expect(extensionsStore.getState().marketplaces?.map((m) => m.name)).toEqual(["acme2"]);
+    expect(extensionsStore.getState().browseCatalogs.has("acme-plugins")).toBe(false);
+    expect(extensionsStore.getState().browseCatalogs.has("acme2")).toBe(false);
+  });
+
+  test("a rejection propagates", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/marketplace/edit", () => {
+      throw new Error("edit failed");
+    });
+    await expect(extensionsStore.getState().editMarketplace({ name: "acme-plugins", newName: "x" })).rejects.toThrow(
+      "edit failed",
+    );
+  });
+});
+```
+
+Create `marketplaceEdit.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, expect, test } from "vitest";
+import type { MarketplaceEntry } from "../../../../protocol/types.gen";
+import { MARKETPLACE_SOURCE_OPTIONS, marketplaceDraftFor, marketplaceEditParams } from "./marketplaceEdit";
+
+const GITHUB: MarketplaceEntry = { name: "acme", source: { kind: "github", repo: "acme/plugins" }, lastUpdated: 1 };
+const URL: MarketplaceEntry = { name: "acme", source: { kind: "url", url: "https://x/y.git" }, lastUpdated: 1 };
+const DIR: MarketplaceEntry = { name: "acme", source: { kind: "directory", path: "/srv/mkt" }, lastUpdated: 1 };
+const SUBDIR: MarketplaceEntry = {
+  name: "acme",
+  source: { kind: "git-subdir", url: "https://x/mono.git", path: "mkt" },
+  lastUpdated: 1,
+};
+
+describe("marketplaceDraftFor", () => {
+  test("seeds the kind and the matching field, blanking the others", () => {
+    expect(marketplaceDraftFor(GITHUB)).toEqual({ name: "acme", kind: "github", url: "", repo: "acme/plugins", path: "" });
+    expect(marketplaceDraftFor(URL)).toEqual({ name: "acme", kind: "url", url: "https://x/y.git", repo: "", path: "" });
+    expect(marketplaceDraftFor(DIR)).toEqual({ name: "acme", kind: "directory", url: "", repo: "", path: "/srv/mkt" });
+  });
+
+  test("a git-subdir source shows its URL under Git URL", () => {
+    expect(marketplaceDraftFor(SUBDIR)).toEqual({ name: "acme", kind: "url", url: "https://x/mono.git", repo: "", path: "" });
+  });
+});
+
+describe("marketplaceEditParams", () => {
+  test("null when nothing changed, whitespace included", () => {
+    expect(marketplaceEditParams(GITHUB, marketplaceDraftFor(GITHUB))).toBeNull();
+    expect(marketplaceEditParams(GITHUB, { ...marketplaceDraftFor(GITHUB), name: " acme ", repo: "acme/plugins " })).toBeNull();
+  });
+
+  test("a changed name is a rename", () => {
+    expect(marketplaceEditParams(GITHUB, { ...marketplaceDraftFor(GITHUB), name: "beta" })).toEqual({ name: "acme", newName: "beta" });
+  });
+
+  test("a changed field or kind sends the whole new source", () => {
+    expect(marketplaceEditParams(GITHUB, { ...marketplaceDraftFor(GITHUB), repo: "acme/other" })).toEqual({
+      name: "acme",
+      source: { kind: "github", repo: "acme/other" },
+    });
+    expect(marketplaceEditParams(GITHUB, { ...marketplaceDraftFor(GITHUB), kind: "directory", path: "/srv/x" })).toEqual({
+      name: "acme",
+      source: { kind: "directory", path: "/srv/x" },
+    });
+  });
+
+  test("an untouched git-subdir source is not re-sent; an edited URL becomes a plain url source", () => {
+    expect(marketplaceEditParams(SUBDIR, marketplaceDraftFor(SUBDIR))).toBeNull();
+    expect(marketplaceEditParams(SUBDIR, { ...marketplaceDraftFor(SUBDIR), url: "https://x/other.git" })).toEqual({
+      name: "acme",
+      source: { kind: "url", url: "https://x/other.git" },
+    });
+  });
+
+  test("rename and re-source ride one request", () => {
+    expect(marketplaceEditParams(URL, { ...marketplaceDraftFor(URL), name: "beta", url: "https://x/z.git" })).toEqual({
+      name: "acme",
+      newName: "beta",
+      source: { kind: "url", url: "https://x/z.git" },
+    });
+  });
+});
+
+test("the source options are the add form's three kinds", () => {
+  expect(MARKETPLACE_SOURCE_OPTIONS.map((o) => o.value)).toEqual(["url", "github", "directory"]);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/stores/extensions.test.ts src/panes/settings/sections/marketplacesPlugins/marketplaceEdit.test.ts 2>&1 | tail -8`
+Expected: the store tests fail (`editMarketplace is not a function`); the model file cannot be resolved.
+
+- [ ] **Step 3: Implement the store mutation**
+
+In `src/stores/extensions.ts`:
+- Add `MarketplaceEditParams` to the `import type { ... } from "../protocol/types.gen"` list.
+- In `ExtensionsStoreState`, after `refreshMarketplace(name: string): Promise<void>;`, add:
+
+```ts
+  /** Rename and/or re-source a marketplace (spec 2026-09-07 §3). The browse
+   * cache for the old AND new names is dropped: a re-source changes the
+   * catalog, and a renamed entry's catalog is keyed by its new name. */
+  editMarketplace(params: MarketplaceEditParams): Promise<void>;
+```
+
+- After the `refreshMarketplace` implementation, add:
+
+```ts
+  async editMarketplace(params) {
+    const client = requireClient();
+    const resp = await client.request("evener/marketplace/edit", params);
+    set((s) => {
+      const nextCatalogs = new Map(s.browseCatalogs);
+      nextCatalogs.delete(params.name);
+      if (params.newName) nextCatalogs.delete(params.newName);
+      return { marketplaces: resp.marketplaces, browseCatalogs: nextCatalogs };
+    });
+  },
+```
+
+- [ ] **Step 4: Implement the form model**
+
+Create `marketplaceEdit.ts`:
+
+```ts
+// marketplaceEdit.ts: the marketplace sheet's form model - the draft, how it
+// is seeded from a MarketplaceEntry, and how a dirty draft becomes the
+// smallest evener/marketplace/edit request. Pure, so the rules (the kind's
+// own field is the only one that counts, a git-subdir entry is left alone
+// unless its URL is edited) are pinned without rendering anything.
+import type { MarketplaceEditParams, MarketplaceEntry, MarketplaceSourceInput } from "../../../../protocol/types.gen";
+
+export type MarketplaceSourceKind = "url" | "github" | "directory";
+
+/** The same three kinds, in the same order, the add form offers. git-subdir
+ * is not offered: the picker would need a second field, and the add form
+ * never had one. */
+export const MARKETPLACE_SOURCE_OPTIONS: { value: MarketplaceSourceKind; label: string }[] = [
+  { value: "url", label: "Git URL" },
+  { value: "github", label: "owner/repo" },
+  { value: "directory", label: "Local path" },
+];
+
+export interface MarketplaceDraft {
+  name: string;
+  kind: MarketplaceSourceKind;
+  url: string;
+  repo: string;
+  path: string;
+}
+
+export function marketplaceDraftFor(entry: MarketplaceEntry): MarketplaceDraft {
+  const { source } = entry;
+  const kind: MarketplaceSourceKind =
+    source.kind === "github" ? "github" : source.kind === "directory" ? "directory" : "url";
+  return {
+    name: entry.name,
+    kind,
+    url: kind === "url" ? (source.url ?? "") : "",
+    repo: kind === "github" ? (source.repo ?? "") : "",
+    path: kind === "directory" ? (source.path ?? "") : "",
+  };
+}
+
+function sourceFromDraft(draft: MarketplaceDraft): MarketplaceSourceInput {
+  if (draft.kind === "github") return { kind: "github", repo: draft.repo.trim() };
+  if (draft.kind === "directory") return { kind: "directory", path: draft.path.trim() };
+  return { kind: "url", url: draft.url.trim() };
+}
+
+/** Whether the draft still describes the entry's own source. A git-subdir
+ * entry renders as its URL under the url kind, so it is unchanged exactly
+ * when that URL is untouched. */
+function sourceUnchanged(entry: MarketplaceEntry, draft: MarketplaceDraft): boolean {
+  const { source } = entry;
+  if (source.kind === "git-subdir") return draft.kind === "url" && draft.url.trim() === (source.url ?? "");
+  const next = sourceFromDraft(draft);
+  if (next.kind !== source.kind) return false;
+  if (next.kind === "github") return next.repo === (source.repo ?? "");
+  if (next.kind === "directory") return next.path === (source.path ?? "");
+  return next.url === (source.url ?? "");
+}
+
+/** The request carrying exactly what changed, or null when nothing did. */
+export function marketplaceEditParams(entry: MarketplaceEntry, draft: MarketplaceDraft): MarketplaceEditParams | null {
+  const params: MarketplaceEditParams = { name: entry.name };
+  let changed = false;
+  const name = draft.name.trim();
+  if (name !== entry.name) {
+    params.newName = name;
+    changed = true;
+  }
+  if (!sourceUnchanged(entry, draft)) {
+    params.source = sourceFromDraft(draft);
+    changed = true;
+  }
+  return changed ? params : null;
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx biome check --write src/stores/extensions.ts src/stores/extensions.test.ts src/panes/settings/sections/marketplacesPlugins/marketplaceEdit.ts src/panes/settings/sections/marketplacesPlugins/marketplaceEdit.test.ts && npx vitest run src/stores/extensions.test.ts src/panes/settings/sections/marketplacesPlugins/marketplaceEdit.test.ts 2>&1 | tail -6`
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/stores/extensions.ts src/stores/extensions.test.ts src/panes/settings/sections/marketplacesPlugins/marketplaceEdit.ts src/panes/settings/sections/marketplacesPlugins/marketplaceEdit.test.ts
+git commit -m "feat(web): marketplace edit mutation and form model"
+```
+
+---
+
+### Task 4: MarketplaceSheet, tappable rows, and the page's selection
+
+**Files:**
+- Create: `marketplacesPlugins/MarketplaceSheet.tsx`
+- Modify: `marketplacesPlugins/MarketplacesSection.tsx` (rows become buttons; Refresh/Remove and their state move out; new `onSelect` prop)
+- Modify: `marketplacesPlugins/index.tsx` (`selectedMarketplace`; renders the sheet)
+- Modify: `marketplacesPlugins/marketplacesPlugins.module.css` (add `.sheetForm`, `.sheetNote`, `.sheetActions`, `.sheetDivider`)
+- Test: `marketplacesPlugins/MarketplaceSheet.test.tsx` (new), `marketplacesPlugins/MarketplacesSection.test.tsx` (rows + moved tests), `marketplacesPlugins/index.test.tsx` (segment switch closes the sheet)
+
+**Interfaces:**
+- Consumes: Task 3's model and store mutation; widgets `Button`, `ConfirmDialog`, `FormRow`, `Input`, `PathField`, `RadioGroup`, `Sheet`, `useToasts`; `directoryActions`, `extensionsStore`, `useExtensionsStore`; `sourceLabel`; `useIsMobile`.
+- Produces: `MarketplaceSheet({ name: string | null; onClose(); onRenamed(newName: string); expandedMarketplaces: Set<string> })`; `MarketplacesSection({ onSelect(name: string) })` (the `expandedMarketplaces` prop moves to the sheet).
+
+- [ ] **Step 1: Write the failing sheet tests**
+
+Create `MarketplaceSheet.test.tsx`:
+
+```tsx
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { FakeClient } from "../../../../protocol/testing/fakeClient";
+import type { MarketplaceEntry } from "../../../../protocol/types.gen";
+import { connectionStore } from "../../../../stores/connection";
+import { extensionsStore, resetExtensionsStoreForTests } from "../../../../stores/extensions";
+import { Toast } from "../../../../widgets";
+import { getToasts, resetToastStoreForTests } from "../../../../widgets/toast/store";
+import { MarketplaceSheet } from "./MarketplaceSheet";
+
+const ACME: MarketplaceEntry = {
+  name: "acme",
+  source: { kind: "github", repo: "acme/plugins" },
+  installLocation: "/home/u/.config/evener/plugins/marketplaces/acme",
+  lastUpdated: 1_700_000_000,
+};
+
+function connectFakeClient(): FakeClient {
+  const fake = new FakeClient("ready");
+  connectionStore.getState().connect(fake);
+  return fake;
+}
+
+function renderSheet(entry: MarketplaceEntry | null, expanded: Set<string> = new Set()) {
+  const onClose = vi.fn();
+  const onRenamed = vi.fn();
+  extensionsStore.setState({ marketplaces: entry === null ? [] : [entry] });
+  render(
+    <>
+      <Toast />
+      <MarketplaceSheet name={entry?.name ?? null} onClose={onClose} onRenamed={onRenamed} expandedMarketplaces={expanded} />
+    </>,
+  );
+  return { onClose, onRenamed };
+}
+
+function field(label: string): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement;
+}
+function saveButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
+  resetExtensionsStoreForTests();
+  resetToastStoreForTests();
+  connectFakeClient();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+test("renders nothing when name is null", () => {
+  renderSheet(null);
+  expect(screen.queryByRole("dialog")).toBeNull();
+});
+
+test("prefills the name, the source kind, and its field; shows install location and last updated", () => {
+  renderSheet(ACME);
+  expect(screen.getByRole("dialog", { name: "acme" })).toBeTruthy();
+  expect(field("Name").value).toBe("acme");
+  expect((screen.getByRole("radio", { name: "owner/repo" }) as HTMLInputElement).checked).toBe(true);
+  // The kind's input shares its label text with the radio, so query it by
+  // placeholder - the same idiom MarketplacesSection.test.tsx uses.
+  expect((screen.getByPlaceholderText("owner/repo") as HTMLInputElement).value).toBe("acme/plugins");
+  expect(screen.queryByPlaceholderText("https://github.com/owner/repo.git")).toBeNull();
+  expect(screen.getByText("/home/u/.config/evener/plugins/marketplaces/acme")).toBeTruthy();
+  expect(screen.getByText("Last updated")).toBeTruthy();
+});
+
+test("Save is disabled until something changes", async () => {
+  renderSheet(ACME);
+  expect(saveButton().disabled).toBe(true);
+  const user = userEvent.setup();
+  await user.type(field("Name"), "2");
+  expect(saveButton().disabled).toBe(false);
+});
+
+test("switching the kind shows only that kind's field and the re-fetch note", async () => {
+  renderSheet(ACME);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("radio", { name: "Git URL" }));
+  expect(screen.getByPlaceholderText("https://github.com/owner/repo.git")).toBeTruthy();
+  expect(screen.queryByPlaceholderText("owner/repo")).toBeNull();
+  expect(screen.getByText(/Saving re-fetches the marketplace/)).toBeTruthy();
+});
+
+test("Save sends a rename and the section re-selects the new name without the sheet closing", async () => {
+  const fake = connectionStore.getState().client as FakeClient;
+  fake.on("evener/marketplace/edit", (params) => {
+    expect(params).toEqual({ name: "acme", newName: "acme2" });
+    return { marketplaces: [{ ...ACME, name: "acme2" }] };
+  });
+  const { onClose, onRenamed } = renderSheet(ACME);
+  const user = userEvent.setup();
+  await user.type(field("Name"), "2");
+  await user.click(saveButton());
+  await waitFor(() => expect(onRenamed).toHaveBeenCalledWith("acme2"));
+  expect(getToasts().some((t) => t.text === "Saved acme2")).toBe(true);
+  expect(onClose).not.toHaveBeenCalled();
+});
+
+test("Save sends a changed source and reseeds the form from the refreshed entry", async () => {
+  const fake = connectionStore.getState().client as FakeClient;
+  fake.on("evener/marketplace/edit", (params) => {
+    expect(params).toEqual({ name: "acme", source: { kind: "url", url: "https://x/y.git" } });
+    return { marketplaces: [{ ...ACME, source: { kind: "url", url: "https://x/y.git" } }] };
+  });
+  renderSheet(ACME);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("radio", { name: "Git URL" }));
+  await user.type(screen.getByPlaceholderText("https://github.com/owner/repo.git"), "https://x/y.git");
+  await user.click(saveButton());
+  await waitFor(() => expect(getToasts().some((t) => t.text === "Saved acme")).toBe(true));
+  expect(saveButton().disabled).toBe(true);
+  expect((screen.getByPlaceholderText("https://github.com/owner/repo.git") as HTMLInputElement).value).toBe(
+    "https://x/y.git",
+  );
+});
+
+test("a failed save shows the error inline and toasts", async () => {
+  const fake = connectionStore.getState().client as FakeClient;
+  fake.on("evener/marketplace/edit", () => {
+    throw new Error("clone failed");
+  });
+  renderSheet(ACME);
+  const user = userEvent.setup();
+  await user.type(field("Name"), "2");
+  await user.click(saveButton());
+  await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("clone failed"));
+  expect(getToasts().some((t) => t.text.startsWith("Save failed"))).toBe(true);
+  expect(field("Name").value).toBe("acme2");
+});
+
+test("Refresh calls refreshMarketplace, is busy in flight, toasts, and re-browses an expanded marketplace", async () => {
+  const fake = connectionStore.getState().client as FakeClient;
+  let release: (() => void) | undefined;
+  fake.on(
+    "evener/marketplace/refresh",
+    () =>
+      new Promise((resolve) => {
+        release = () => resolve({ marketplaces: [ACME] });
+      }),
+  );
+  fake.on("evener/marketplace/browse", () => ({ name: "acme", description: "", plugins: [] }));
+  renderSheet(ACME, new Set(["acme"]));
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Refresh" }));
+  expect((screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement).disabled).toBe(true);
+  act(() => release?.());
+  await waitFor(() => expect(getToasts().some((t) => t.text === "Refreshed acme")).toBe(true));
+  expect((screen.getByRole("button", { name: "Refresh" }) as HTMLButtonElement).disabled).toBe(false);
+  expect(fake.calls.some((c) => c.method === "evener/marketplace/browse")).toBe(true);
+});
+
+test("Remove opens a confirm; confirming removes, toasts, and the sheet closes when the entry vanishes", async () => {
+  const fake = connectionStore.getState().client as FakeClient;
+  fake.on("evener/marketplace/remove", () => ({ marketplaces: [] }));
+  const { onClose } = renderSheet(ACME);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Remove" }));
+  const confirm = screen.getByRole("dialog", { name: "Remove marketplace" });
+  expect(within(confirm).getByText(/Installed plugins from it are unaffected/)).toBeTruthy();
+  await user.click(within(confirm).getByRole("button", { name: "Remove" }));
+  await waitFor(() => expect(getToasts().some((t) => t.text === "Removed marketplace acme")).toBe(true));
+  await waitFor(() => expect(onClose).toHaveBeenCalled());
+});
+
+test("cancelling the remove confirm calls nothing", async () => {
+  const fake = connectionStore.getState().client as FakeClient;
+  renderSheet(ACME);
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Remove" }));
+  await user.click(within(screen.getByRole("dialog", { name: "Remove marketplace" })).getByRole("button", { name: "Cancel" }));
+  expect(fake.calls.some((c) => c.method === "evener/marketplace/remove")).toBe(false);
+});
+
+test("closes itself when the entry disappears from the store", async () => {
+  const { onClose } = renderSheet(ACME);
+  act(() => extensionsStore.setState({ marketplaces: [] }));
+  await waitFor(() => expect(onClose).toHaveBeenCalled());
+});
+```
+
+- [ ] **Step 2: Update the section and page tests**
+
+In `MarketplacesSection.test.tsx`:
+- Change the first test to:
+
+```tsx
+test("renders each marketplace as one tappable row carrying name, kind, and source; tapping selects it", async () => {
+  connectFakeClient();
+  extensionsStore.setState({ marketplaces: [MARKETPLACE_A] });
+  const onSelect = vi.fn();
+  render(<MarketplacesSection onSelect={onSelect} />);
+  const row = screen.getByRole("button", { name: /acme-plugins/ });
+  expect(within(row).getByText("github")).toBeTruthy();
+  expect(within(row).getByText("github: acme/plugins")).toBeTruthy();
+  expect(screen.queryByRole("button", { name: "Refresh" })).toBeNull();
+  expect(screen.queryByRole("button", { name: "Remove" })).toBeNull();
+  await userEvent.setup().click(row);
+  expect(onSelect).toHaveBeenCalledWith("acme-plugins");
+});
+```
+
+- Every remaining render of `<MarketplacesSection expandedMarketplaces={...} />` becomes `<MarketplacesSection onSelect={vi.fn()} />`.
+- Delete the tests from `"Refresh calls refreshMarketplace and toasts success"` through `"the confirm dialog's buttons disable while removal is in flight, and it stays open until it resolves"` (they now live in `MarketplaceSheet.test.tsx`).
+
+In `index.test.tsx`, append:
+
+```tsx
+test("switching segments while the marketplace sheet is open closes it", async () => {
+  connectSeededClient();
+  render(<MarketplacesPluginsSection />);
+  const user = userEvent.setup();
+  await user.click(await screen.findByRole("radio", { name: "Marketplaces (1)" }));
+  await user.click(await screen.findByRole("button", { name: /acme-plugins/ }));
+  expect(screen.getByRole("dialog", { name: "acme-plugins" })).toBeTruthy();
+  await user.click(screen.getByRole("radio", { name: "Browse" }));
+  expect(screen.queryByRole("dialog", { name: "acme-plugins" })).toBeNull();
+});
+```
+
+(`connectSeededClient` and the segment radio names are the file's own; the existing "switching segments while the detail sheet is open closes it" test is the model.)
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run src/panes/settings/sections/marketplacesPlugins 2>&1 | tail -10`
+Expected: the sheet test file cannot resolve `./MarketplaceSheet`; the section tests fail on the new prop and missing row button.
+
+- [ ] **Step 4: Add the stylesheet rules**
+
+Append to `marketplacesPlugins.module.css`:
+
+```css
+/* MarketplaceSheet body (the sheet is the editor, spec 2026-09-07 §3): the
+ * form above the meta table, then Refresh, then the danger zone under a
+ * divider - the same shape as the provider sheet. */
+.sheetForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.sheetNote {
+  margin: 0;
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
+.sheetError {
+  margin: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-caption);
+}
+
+.sheetActions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.sheetActions > button {
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.sheetDivider {
+  margin: var(--space-3) 0;
+  border: none;
+  border-top: 1px solid var(--edge);
+}
+```
+
+- [ ] **Step 5: Implement the sheet**
+
+Create `MarketplaceSheet.tsx`:
+
+```tsx
+// MarketplaceSheet: the marketplace's editor (spec 2026-09-07 §3). Opens
+// from a MarketplacesSection row tap and IS the edit surface: Name and the
+// source (the add form's own three-way picker) are prefilled form fields,
+// Save in the footer lights up when either differs, and a changed source
+// says it will re-fetch. Refresh and Remove - the two actions the row used
+// to carry inline - sit below the meta table, Remove behind its
+// ConfirmDialog. A wide right Sheet on desktop, a bottom Sheet on mobile.
+//
+// The entry is read from the store by name so cross-client changes land
+// live; the draft reseeds when a different marketplace opens or this
+// sheet's own save lands, never on an unrelated refresh. The sheet closes
+// itself when its entry vanishes - except across its own rename, where the
+// page re-selects the new name (onRenamed).
+import { useEffect, useId, useRef, useState } from "react";
+import { errorText } from "../../../../protocol/errors";
+import type { MarketplaceEntry } from "../../../../protocol/types.gen";
+import { useIsMobile } from "../../../../shell/useIsMobile";
+import { directoryActions, extensionsStore, useExtensionsStore } from "../../../../stores/extensions";
+import { Button, ConfirmDialog, FormRow, Input, PathField, RadioGroup, Sheet, useToasts } from "../../../../widgets";
+import { requireClass } from "../../../../widgets/internal/requireClass";
+import {
+  MARKETPLACE_SOURCE_OPTIONS,
+  type MarketplaceDraft,
+  type MarketplaceSourceKind,
+  marketplaceDraftFor,
+  marketplaceEditParams,
+} from "./marketplaceEdit";
+import styles from "./marketplacesPlugins.module.css";
+
+const CLASS = {
+  sheetForm: requireClass(styles.sheetForm, "marketplacesPlugins.module.css", "sheetForm"),
+  sheetNote: requireClass(styles.sheetNote, "marketplacesPlugins.module.css", "sheetNote"),
+  sheetError: requireClass(styles.sheetError, "marketplacesPlugins.module.css", "sheetError"),
+  sheetActions: requireClass(styles.sheetActions, "marketplacesPlugins.module.css", "sheetActions"),
+  sheetDivider: requireClass(styles.sheetDivider, "marketplacesPlugins.module.css", "sheetDivider"),
+  metaList: requireClass(styles.metaList, "marketplacesPlugins.module.css", "metaList"),
+  metaRow: requireClass(styles.metaRow, "marketplacesPlugins.module.css", "metaRow"),
+  metaLabel: requireClass(styles.metaLabel, "marketplacesPlugins.module.css", "metaLabel"),
+  metaValue: requireClass(styles.metaValue, "marketplacesPlugins.module.css", "metaValue"),
+  rowMeta: requireClass(styles.rowMeta, "marketplacesPlugins.module.css", "rowMeta"),
+};
+
+export interface MarketplaceSheetProps {
+  name: string | null;
+  onClose: () => void;
+  /** After a successful rename, with the new name: the page re-selects it
+   * so the sheet stays open on the same marketplace. */
+  onRenamed: (newName: string) => void;
+  /** Read-only: a Refresh on a marketplace BrowseSection currently has
+   * expanded re-browses it at once, so the tree never shows a catalog the
+   * refresh just invalidated (see index.tsx's own comment on lifting it). */
+  expandedMarketplaces: Set<string>;
+}
+
+function lastUpdatedText(seconds: number): string {
+  return seconds > 0 ? new Date(seconds * 1000).toLocaleString() : "never";
+}
+
+export function MarketplaceSheet({ name, onClose, onRenamed, expandedMarketplaces }: MarketplaceSheetProps) {
+  const marketplaces = useExtensionsStore((s) => s.marketplaces);
+  const isMobile = useIsMobile();
+  const toasts = useToasts();
+  const ids = useId();
+
+  const entry = name === null || marketplaces === null ? undefined : marketplaces.find((m) => m.name === name);
+
+  const [draft, setDraft] = useState<MarketplaceDraft | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [pendingRemove, setPendingRemove] = useState(false);
+  const [removeBusy, setRemoveBusy] = useState(false);
+  // Set for the span of a rename request: the old name vanishes from the
+  // store when the response lands, and that vanish must not close the sheet.
+  const pendingRename = useRef<string | null>(null);
+
+  function seed(current: MarketplaceEntry): void {
+    setDraft(marketplaceDraftFor(current));
+    setFormError(null);
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reseed only when a different marketplace opens; a refresh of the same one must not clobber in-progress edits
+  useEffect(() => {
+    if (entry === undefined) {
+      setDraft(null);
+      setFormError(null);
+      setPendingRemove(false);
+      return;
+    }
+    seed(entry);
+  }, [entry?.name]);
+
+  useEffect(() => {
+    if (name !== null && marketplaces !== null && entry === undefined && pendingRename.current === null) onClose();
+  }, [name, marketplaces, entry, onClose]);
+  useEffect(() => {
+    pendingRename.current = null;
+  }, [name]);
+
+  const open = name !== null && entry !== undefined;
+  const params = entry !== undefined && draft !== null ? marketplaceEditParams(entry, draft) : null;
+  const dirty = params !== null;
+  const sourceDirty = params?.source !== undefined;
+
+  function update(patch: Partial<MarketplaceDraft>): void {
+    setDraft((current) => (current === null ? current : { ...current, ...patch }));
+  }
+
+  async function handleSave(): Promise<void> {
+    if (entry === undefined || params === null) return;
+    setFormError(null);
+    setSaving(true);
+    if (params.newName !== undefined) pendingRename.current = params.newName;
+    try {
+      await extensionsStore.getState().editMarketplace(params);
+      toasts.push("success", `Saved ${params.newName ?? entry.name}`);
+      if (params.newName !== undefined) {
+        onRenamed(params.newName);
+      } else {
+        const refreshed = extensionsStore.getState().marketplaces?.find((m) => m.name === entry.name);
+        if (refreshed !== undefined) seed(refreshed);
+      }
+    } catch (err) {
+      pendingRename.current = null;
+      const message = errorText(err);
+      setFormError(message);
+      toasts.push("error", `Save failed: ${message}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRefresh(): Promise<void> {
+    if (entry === undefined) return;
+    setRefreshing(true);
+    try {
+      await extensionsStore.getState().refreshMarketplace(entry.name);
+      if (expandedMarketplaces.has(entry.name)) void extensionsStore.getState().browseMarketplace(entry.name);
+      toasts.push("success", `Refreshed ${entry.name}`);
+    } catch (err) {
+      toasts.push("error", `Refresh failed: ${errorText(err)}`);
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  async function handleConfirmRemove(): Promise<void> {
+    if (entry === undefined) return;
+    setRemoveBusy(true);
+    try {
+      await extensionsStore.getState().removeMarketplace(entry.name);
+      toasts.push("success", `Removed marketplace ${entry.name}`);
+      setPendingRemove(false);
+      // onClose fires via the entry-vanished effect once the store's updated
+      // list lands - no explicit close here.
+    } catch (err) {
+      toasts.push("error", `Remove marketplace failed: ${errorText(err)}`);
+    } finally {
+      setRemoveBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <Sheet
+        open={open}
+        onClose={onClose}
+        title={entry?.name ?? ""}
+        side={isMobile ? "bottom" : "right"}
+        size="wide"
+        footer={
+          entry !== undefined && (
+            <Button onClick={() => void handleSave()} disabled={!dirty || saving}>
+              Save
+            </Button>
+          )
+        }
+      >
+        {entry !== undefined && draft !== null && (
+          <>
+            <form
+              className={CLASS.sheetForm}
+              aria-label={`Edit ${entry.name}`}
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleSave();
+              }}
+            >
+              <FormRow label="Name" htmlFor={`${ids}-name`}>
+                <Input
+                  id={`${ids}-name`}
+                  value={draft.name}
+                  onChange={(event) => update({ name: event.target.value })}
+                  disabled={saving}
+                />
+              </FormRow>
+              <RadioGroup
+                label="Source"
+                value={draft.kind}
+                onChange={(value) => update({ kind: value as MarketplaceSourceKind })}
+                options={MARKETPLACE_SOURCE_OPTIONS}
+                disabled={saving}
+              />
+              {draft.kind === "url" && (
+                <FormRow label="Git URL" htmlFor={`${ids}-url`}>
+                  <Input
+                    id={`${ids}-url`}
+                    value={draft.url}
+                    onChange={(event) => update({ url: event.target.value })}
+                    placeholder="https://github.com/owner/repo.git"
+                    disabled={saving}
+                  />
+                </FormRow>
+              )}
+              {draft.kind === "github" && (
+                <FormRow label="owner/repo" htmlFor={`${ids}-repo`}>
+                  <Input
+                    id={`${ids}-repo`}
+                    value={draft.repo}
+                    onChange={(event) => update({ repo: event.target.value })}
+                    placeholder="owner/repo"
+                    disabled={saving}
+                  />
+                </FormRow>
+              )}
+              {draft.kind === "directory" && (
+                <FormRow label="Local path" htmlFor={`${ids}-path`}>
+                  <PathField
+                    ariaLabel="Local path"
+                    directory={directoryActions}
+                    id={`${ids}-path`}
+                    value={draft.path}
+                    onChange={(value) => update({ path: value })}
+                    kind="dir"
+                    complete={(prefix, includeFiles) => extensionsStore.getState().completePaths(prefix, includeFiles)}
+                    placeholder="/absolute/path"
+                  />
+                </FormRow>
+              )}
+              {sourceDirty && (
+                <p className={CLASS.sheetNote} role="status">
+                  Saving re-fetches the marketplace. Installed plugins are unaffected.
+                </p>
+              )}
+              {formError !== null && (
+                <p className={CLASS.sheetError} role="alert">
+                  {formError}
+                </p>
+              )}
+            </form>
+            <div className={CLASS.metaList}>
+              <div className={CLASS.metaRow}>
+                <span className={CLASS.metaLabel}>Install location</span>
+                <span className={`${CLASS.metaValue} ${CLASS.rowMeta}`}>{entry.installLocation || "not fetched yet"}</span>
+              </div>
+              <div className={CLASS.metaRow}>
+                <span className={CLASS.metaLabel}>Last updated</span>
+                <span className={`${CLASS.metaValue} ${CLASS.rowMeta}`}>{lastUpdatedText(entry.lastUpdated)}</span>
+              </div>
+            </div>
+            <div className={CLASS.sheetActions}>
+              <Button variant="quiet" onClick={() => void handleRefresh()} disabled={refreshing}>
+                Refresh
+              </Button>
+            </div>
+            <hr className={CLASS.sheetDivider} />
+            <div className={CLASS.sheetActions}>
+              <Button variant="danger" onClick={() => setPendingRemove(true)}>
+                Remove
+              </Button>
+            </div>
+          </>
+        )}
+      </Sheet>
+      <ConfirmDialog
+        open={pendingRemove && entry !== undefined}
+        title="Remove marketplace"
+        confirmLabel="Remove"
+        busy={removeBusy}
+        onConfirm={() => void handleConfirmRemove()}
+        onCancel={() => setPendingRemove(false)}
+      >
+        {entry !== undefined ? `Remove marketplace "${entry.name}"? Installed plugins from it are unaffected.` : ""}
+      </ConfirmDialog>
+    </>
+  );
+}
+```
+
+If `PathField`'s `onChange` fires on commit rather than every keystroke (read its doc comment), the "Local path" field still works: the draft updates on commit. If `RadioGroup`'s `options` type requires `{ value: string; label: string }` exactly, cast `MARKETPLACE_SOURCE_OPTIONS` at the call site rather than widening the constant.
+
+- [ ] **Step 6: Make the rows tappable and lift the selection**
+
+Rewrite `MarketplacesSection.tsx`'s list and props:
+- Props become `export interface MarketplacesSectionProps { onSelect: (name: string) => void; }`.
+- Delete `pendingRemove`, `removeBusy`, `refreshBusy`, `handleRefresh`, `handleConfirmRemove`, the `ConfirmDialog`, and the `rowActions` markup; drop `ConfirmDialog` from the widgets import and remove `rowActions` from `CLASS`; add `rowButton` and `rowChevron` to `CLASS` (both already exist in the stylesheet) and import `Chevron` from widgets.
+- Each list item renders:
+
+```tsx
+            <li key={m.name}>
+              <button type="button" className={CLASS.rowButton} onClick={() => onSelect(m.name)}>
+                <div className={CLASS.rowMain}>
+                  <div className={CLASS.rowText}>
+                    {m.name} <span className={CLASS.rowKind}>{m.source.kind}</span>
+                  </div>
+                  <div className={CLASS.rowMeta}>{sourceLabel(m.source)}</div>
+                </div>
+                <span className={CLASS.rowChevron} aria-hidden="true">
+                  <Chevron direction="right" />
+                </span>
+              </button>
+            </li>
+```
+
+- Update the header comment: the section is the list plus the add form; every per-marketplace action lives in `MarketplaceSheet`, which is why `expandedMarketplaces` now flows to the sheet instead of here.
+
+In `index.tsx`:
+- Add `const [selectedMarketplace, setSelectedMarketplace] = useState<string | null>(null);`.
+- In `handleSegmentChange` also `setSelectedMarketplace(null);` and extend its comment: both sheets belong to their segments.
+- Render `<MarketplacesSection onSelect={setSelectedMarketplace} />` and, beside `PluginDetailSheet`:
+
+```tsx
+      <MarketplaceSheet
+        name={selectedMarketplace}
+        onClose={() => setSelectedMarketplace(null)}
+        onRenamed={setSelectedMarketplace}
+        expandedMarketplaces={expandedMarketplaces}
+      />
+```
+
+with `import { MarketplaceSheet } from "./MarketplaceSheet";`.
+
+- [ ] **Step 7: Run the marketplaces tests and the whole settings suite**
+
+Run: `npx biome check --write src/panes/settings/sections/marketplacesPlugins/MarketplaceSheet.tsx src/panes/settings/sections/marketplacesPlugins/MarketplaceSheet.test.tsx src/panes/settings/sections/marketplacesPlugins/MarketplacesSection.tsx src/panes/settings/sections/marketplacesPlugins/MarketplacesSection.test.tsx src/panes/settings/sections/marketplacesPlugins/index.tsx src/panes/settings/sections/marketplacesPlugins/index.test.tsx src/panes/settings/sections/marketplacesPlugins/marketplacesPlugins.module.css && npx vitest run src/panes/settings 2>&1 | tail -10`
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/panes/settings/sections/marketplacesPlugins/MarketplaceSheet.tsx src/panes/settings/sections/marketplacesPlugins/MarketplaceSheet.test.tsx src/panes/settings/sections/marketplacesPlugins/MarketplacesSection.tsx src/panes/settings/sections/marketplacesPlugins/MarketplacesSection.test.tsx src/panes/settings/sections/marketplacesPlugins/index.tsx src/panes/settings/sections/marketplacesPlugins/index.test.tsx src/panes/settings/sections/marketplacesPlugins/marketplacesPlugins.module.css
+git commit -m "feat(web): marketplace rows open an editor sheet"
+```
+
+---
+
+### Task 5: Docs, gates, browser pass, and the pull request
+
+**Files:**
+- Modify: `docs/web-ui/design-system.md` (§10: the sentence naming the reference implementations gains `MarketplaceSheet.tsx` beside `InstanceSheet.tsx`; if slice 2 has not merged yet, add the equivalent sentence to the existing paragraph without rewriting it)
+
+- [ ] **Step 1: Name the second reference implementation**
+
+In `docs/web-ui/design-system.md` §10, where the sheet-as-editor reference implementation is named, add `and Settings → Marketplaces & Plugins → Marketplaces (`marketplacesPlugins/MarketplaceSheet.tsx`)`.
+
+- [ ] **Step 2: Run every gate from the repo root, reading each for failures**
+
+```bash
+make test-web 2>&1 | tail -15
+make test-web-browser 2>&1 | tail -10
+make lint 2>&1 | tail -20
+make vet 2>&1 | tail -5
+make test 2>&1 | tail -20
+```
+
+Expected: all green. If `make test` reports one of the known flaky tests (drain-abandon cleanup race, execenv, procgroup, drain-continue), re-run that package once and say which it was.
+
+- [ ] **Step 3: Live check against a throwaway hub**
+
+Follow the WebUI screenshot recipe in memory with `XDG_CONFIG_HOME` pointed at a temp dir. Create a local directory marketplace (a dir with `.claude-plugin/marketplace.json` naming one plugin at `./plugins/widget` with its own `.claude-plugin/plugin.json`), add it from Settings → Marketplaces & Plugins → Marketplaces as a Local path, install the plugin from Browse, then open the marketplace row: rename it, Save, and confirm the sheet stays open under the new name, `known_marketplaces.json` and `installed_plugins.json` under `$XDG_CONFIG_HOME/evener/plugins` carry the new name, and the Installed segment still lists the plugin under it. Take a desktop and a phone-width screenshot of the sheet for the PR.
+
+- [ ] **Step 4: Commit, push, open the PR**
+
+```bash
+git add docs/web-ui/design-system.md
+git commit -m "docs(web-ui): name the marketplace sheet as a reference editor"
+git push -u origin HEAD
+gh pr create --repo prime-radiant-inc/evener --base main --title "Marketplace rows open an editor sheet; marketplace/edit renames and re-sources" --body-file - <<'EOF'
+Slice 3 of docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md.
+
+- `internal/plugins.Manager.EditMarketplace`: fetch-first, directory-rename rollback, re-keys installed_plugins.json and install paths on rename, swaps the staged clone on re-source.
+- New additive `evener/marketplace/edit` (v4); taken name → Conflict, unknown → InvalidParams; broadcasts marketplace-updated and plugin-updated.
+- Marketplace rows are single tappable targets; the new `MarketplaceSheet` edits name and source in place with a dirty-gated Save and carries Refresh and the confirm-gated Remove.
+
+Gates: make lint, make vet, make test, make test-web, make test-web-browser. Screenshots attached.
+EOF
+```
+
+Then watch CI and roborev; findings that recur on every push get fixed in code.

--- a/docs/superpowers/plans/2026-09-07-provider-sheet-editor.md
+++ b/docs/superpowers/plans/2026-09-07-provider-sheet-editor.md
@@ -1,0 +1,1941 @@
+# Provider Sheet Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The provider instance sheet becomes the instance's editor: name, base URL, protocol, surface, provider variables, API key env var and credential header edit in place with a dirty-gated Save, and the backend can rename an instance and set or clear every one of those fields.
+
+**Architecture:** Additive `evener-appwire-v4` fields on `InstanceEditParams` (rename, api-key-env and credential-header set/clear, protocol/surface clear, var deletion) and two authored fields on `InstanceEntry` so the form can prefill. The hub's `Edit` applies the new pairs and, for a rename, re-keys providers.toml, repoints the default, and moves the stored key and OAuth record. On the frontend `InstanceDetailSheet` becomes `InstanceSheet` with a form above the existing credential actions; `EditInstanceDialog` is deleted; the Add form gains the same protocol and surface selects. The design-system rule is rewritten to say a detail sheet is the editor.
+
+**Tech Stack:** Go (appwire, cmd/evener-hub, llm/registry), TypeScript + React + zustand + vitest, `make generate`.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md` §2 and §4 (plus §5, §6). This plan is slice 2 of 3; it does not depend on slice 1.
+
+## Global Constraints
+
+- Repo root for every command: the git worktree you were started in. Frontend commands run from `cmd/evener-hub/frontend`.
+- Protocol version stays `evener-appwire-v4`; every wire change is additive and keeps "empty means unchanged" for string fields.
+- Protocol values: `openai-chat`, `openai-responses`, `anthropic`, `google`. Surface values: `openai`, `anthropic`, `google`, `generic`. The registry rejects anything else on write (`llm/registry/schema.go`).
+- A credential header on the wire is `NAME=VALUE`; the value must reference a `$VAR` (`registry.CheckCredentialHeaderValue`); never a literal secret. The client refuses a value without `$` before any RPC, as the Add form already does.
+- Rename is refused for implicit instances (`InvalidParams`), for an invalid name (`InvalidParams`, `registry.ValidInstanceName`), and for a name any instance already has (`Conflict`).
+- No `git add -A`. Commit after every task with the exact message given.
+- Frontend: `npx biome check --write <touched files under src/>` before every commit that touches frontend files; gate is `make test-web` from the repo root.
+- Tests never read the developer's config root; every Go instances test uses `newInstancesFixture` (isolated temp dirs).
+- Follow each file's comment style: explain why, never narrate what changed.
+
+---
+
+### Task 1: Wire types
+
+**Files:**
+- Modify: `appwire/types.go` (the `InstanceEditParams` doc comment and struct near line 2762; the `InstanceEntry` struct near line 2671)
+- Regenerate: `cmd/evener-hub/frontend/src/protocol/types.gen.ts`, `docs/appwire-protocol.md`
+
+**Interfaces:**
+- Produces on `InstanceEditParams`: `NewName string json:"newName,omitempty"`, `ClearProtocol bool json:"clearProtocol,omitempty"`, `ClearSurface bool json:"clearSurface,omitempty"`, `APIKeyEnv string json:"apiKeyEnv,omitempty"`, `ClearAPIKeyEnv bool json:"clearApiKeyEnv,omitempty"`, `CredentialHeader string json:"credentialHeader,omitempty"`, `ClearCredentialHeader bool json:"clearCredentialHeader,omitempty"`.
+- Produces on `InstanceEntry`: `APIKeyEnv string json:"apiKeyEnv,omitempty"`, `CredentialHeader string json:"credentialHeader,omitempty"`.
+
+- [ ] **Step 1: Replace the InstanceEditParams doc comment and struct**
+
+In `appwire/types.go`, replace the paragraph that begins `// Protocol and Surface have no clear operation yet` (three lines, through `// treatment as BaseURL is ledgered for whenever a form needs to clear one.`) with:
+
+```go
+// The 2026-09-07 sheet-editor additions keep the same rule. NewName renames
+// the instance (empty means unchanged). APIKeyEnv/ClearAPIKeyEnv and
+// CredentialHeader/ClearCredentialHeader set or drop the authored
+// api_key_env and credential_headers; CredentialHeader is NAME=VALUE with a
+// $VAR value, exactly as InstanceCreateParams takes it. ClearProtocol and
+// ClearSurface are the clears the paragraph above ledgered. A Vars entry
+// whose value is empty DELETES that variable: a blank var never meant
+// anything, so the empty value is free to mean "remove". Each set/clear
+// pair follows BaseURL/ClearBaseURL: never both meaningful in one request.
+```
+
+Then replace the struct with:
+
+```go
+type InstanceEditParams struct {
+	Name                  string            `json:"name"`
+	NewName               string            `json:"newName,omitempty"`
+	BaseURL               string            `json:"baseUrl,omitempty"`
+	ClearBaseURL          bool              `json:"clearBaseUrl,omitempty"`
+	Protocol              string            `json:"protocol,omitempty"`
+	ClearProtocol         bool              `json:"clearProtocol,omitempty"`
+	Surface               string            `json:"surface,omitempty"`
+	ClearSurface          bool              `json:"clearSurface,omitempty"`
+	Vars                  map[string]string `json:"vars,omitempty"`
+	APIKeyEnv             string            `json:"apiKeyEnv,omitempty"`
+	ClearAPIKeyEnv        bool              `json:"clearApiKeyEnv,omitempty"`
+	CredentialHeader      string            `json:"credentialHeader,omitempty"`
+	ClearCredentialHeader bool              `json:"clearCredentialHeader,omitempty"`
+}
+```
+
+- [ ] **Step 2: Add the authored fields to InstanceEntry**
+
+In the `InstanceEntry` struct, after the `Vars` field, add:
+
+```go
+	// APIKeyEnv and CredentialHeader are the AUTHORED api_key_env (its first
+	// entry) and credential header (as NAME=VALUE) from providers.toml, so
+	// the sheet's form can prefill them. Never the registry's own defaults
+	// for an implicit instance, and never a secret: a credential header
+	// value is a $VAR template by construction
+	// (registry.CheckCredentialHeaderValue refuses a literal).
+	APIKeyEnv        string `json:"apiKeyEnv,omitempty"`
+	CredentialHeader string `json:"credentialHeader,omitempty"`
+```
+
+- [ ] **Step 3: Build, regenerate, verify**
+
+Run: `go build ./... && make generate && git status --short`
+Expected: build OK; `types.gen.ts` and `docs/appwire-protocol.md` modified. Confirm: `grep -n "clearProtocol\|newName\|credentialHeader" cmd/evener-hub/frontend/src/protocol/types.gen.ts | head`.
+
+Run: `go test ./appwire ./internal/appwirets 2>&1 | tail -4`
+Expected: ok.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add appwire/types.go cmd/evener-hub/frontend/src/protocol/types.gen.ts docs/appwire-protocol.md
+git commit -m "feat(appwire): rename, credential-field, and clear additions to instance/edit"
+```
+
+---
+
+### Task 2: The list reports the authored API key env and credential header
+
+**Files:**
+- Modify: `cmd/evener-hub/app_instances.go` (`List` at line 43, `entryFor` at line 87)
+- Test: `cmd/evener-hub/app_instances_test.go`
+
+**Interfaces:**
+- Produces: `entryFor(inst registry.Instance, authored *registry.Provider) appwire.InstanceEntry`; `credentialHeaderField(headers map[string]string) string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `cmd/evener-hub/app_instances_test.go`:
+
+```go
+// TestInstances_ListReportsAuthoredCredentialFields: the sheet's form
+// prefills api_key_env and the credential header from what the user
+// authored, and only that - an implicit instance inherits both from the
+// registry and shows neither.
+func TestInstances_ListReportsAuthoredCredentialFields(t *testing.T) {
+	f := newInstancesFixture(t, map[string]string{"GROQ_API_KEY": "gk", "PORTKEY_KEY": "pk"})
+	if err := f.ctl.Create(appwire.InstanceCreateParams{
+		Name: "work", Base: "openai", APIKeyEnv: "PORTKEY_KEY", CredentialHeader: "Authorization=Bearer $PORTKEY_KEY",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	work := entry(t, f.ctl.List(), "work")
+	if work.APIKeyEnv != "PORTKEY_KEY" {
+		t.Fatalf("APIKeyEnv = %q, want PORTKEY_KEY", work.APIKeyEnv)
+	}
+	if work.CredentialHeader != "Authorization=Bearer $PORTKEY_KEY" {
+		t.Fatalf("CredentialHeader = %q", work.CredentialHeader)
+	}
+	groq := entry(t, f.ctl.List(), "groq")
+	if groq.APIKeyEnv != "" || groq.CredentialHeader != "" {
+		t.Fatalf("an implicit instance has nothing authored, got apiKeyEnv=%q credentialHeader=%q", groq.APIKeyEnv, groq.CredentialHeader)
+	}
+}
+
+func TestCredentialHeaderField_RendersTheFirstHeaderInSortedOrder(t *testing.T) {
+	if got := credentialHeaderField(nil); got != "" {
+		t.Fatalf("nil = %q", got)
+	}
+	got := credentialHeaderField(map[string]string{"X-Key": "$B", "Authorization": "Bearer $A"})
+	if got != "Authorization=Bearer $A" {
+		t.Fatalf("got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./cmd/evener-hub -run 'TestInstances_ListReportsAuthoredCredentialFields|TestCredentialHeaderField' 2>&1 | head -8`
+Expected: compile error `undefined: credentialHeaderField`.
+
+- [ ] **Step 3: Implement**
+
+In `cmd/evener-hub/app_instances.go`, change `List` so the instance loop reads the authored layer once:
+
+```go
+	r := c.reg.Get()
+	if r != nil {
+		// The authored layer is what the sheet's form edits, so the entry
+		// carries the authored credential fields alongside the registry's
+		// resolved view. A file that cannot be read right now simply
+		// prefills nothing; the refusal itself is already in Diagnostics.
+		var layer *registry.Layer
+		if l, exists, err := c.read(); err == nil && exists {
+			layer = l
+		}
+		for _, inst := range r.Instances() {
+			var authored *registry.Provider
+			if layer != nil {
+				if p, ok := layer.Providers[inst.Name]; ok {
+					authored = &p
+				}
+			}
+			entries = append(entries, c.entryFor(inst, authored))
+		}
+```
+
+Change `entryFor`'s signature to `func (c *hubInstancesController) entryFor(inst registry.Instance, authored *registry.Provider) appwire.InstanceEntry`, build the entry into a local `entry := appwire.InstanceEntry{...}` (same literal as today), and before returning it add:
+
+```go
+	if authored != nil {
+		if len(authored.APIKeyEnv) > 0 {
+			entry.APIKeyEnv = authored.APIKeyEnv[0]
+		}
+		entry.CredentialHeader = credentialHeaderField(authored.CredentialHeaders)
+	}
+	return entry
+```
+
+Add below `entryFor`:
+
+```go
+// credentialHeaderField renders the authored credential_headers map as the
+// single NAME=VALUE field the forms use; credentialHeaderFrom is its
+// inverse. Several headers are possible by hand-editing the file, never
+// through the pane; the first in sorted order is the one the form edits.
+func credentialHeaderField(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	names := slices.Sorted(maps.Keys(headers))
+	return names[0] + "=" + headers[names[0]]
+}
+```
+
+`slices` and `maps` are already imported by this file. Then run `grep -n "entryFor(" cmd/evener-hub/*.go` and pass `nil` as the second argument at every other call site (there may be none besides `List`).
+
+- [ ] **Step 4: Run the instances tests and the wire-fixture corpus test**
+
+Run: `go test ./cmd/evener-hub -run 'TestInstances_|TestCredentialHeaderField|TestAuthWireFixtures' 2>&1 | tail -8`
+Expected: PASS. If `TestAuthWireFixturesMatchTheHubHandler` fails because a scenario now carries `apiKeyEnv` or `credentialHeader`, regenerate the corpus exactly as its failure message says (`go test ./cmd/evener-hub -run TestAuthWireFixtures -update-authwire`), then run `go test ./cmd/evener-tui/... 2>&1 | tail -3` and, from `cmd/evener-hub/frontend`, `npx vitest run src/panes/settings/sections/credentials 2>&1 | tail -5`, and include `cmd/evener-hub/testdata/authwire/responses.json` in the commit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/app_instances.go cmd/evener-hub/app_instances_test.go
+git commit -m "feat(hub): report an instance's authored api_key_env and credential header"
+```
+
+(Add `cmd/evener-hub/testdata/authwire/responses.json` to the `git add` if it was regenerated.)
+
+---
+
+### Task 3: Edit applies the new field pairs, the clears, and var deletion
+
+**Files:**
+- Modify: `cmd/evener-hub/app_instances.go` (`Edit`, lines 280-360)
+- Test: `cmd/evener-hub/app_instances_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's fields; the existing `credentialHeaderFrom(field string) (map[string]string, error)` and `validVarNames`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cmd/evener-hub/app_instances_test.go`:
+
+```go
+func TestInstances_EditSetsAndClearsAPIKeyEnvAndCredentialHeader(t *testing.T) {
+	f := newInstancesFixture(t, map[string]string{"GROQ_API_KEY": "gk", "PORTKEY_KEY": "pk"})
+	if err := f.ctl.Create(appwire.InstanceCreateParams{Name: "work", Base: "openai"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := f.ctl.Edit(appwire.InstanceEditParams{
+		Name: "work", APIKeyEnv: "PORTKEY_KEY", CredentialHeader: "Authorization=Bearer $PORTKEY_KEY",
+	}); err != nil {
+		t.Fatalf("Edit(set): %v", err)
+	}
+	p := authoredEntry(t, f.tomlPath, "work")
+	if !slices.Equal(p.APIKeyEnv, []string{"PORTKEY_KEY"}) {
+		t.Fatalf("authored api_key_env = %v", p.APIKeyEnv)
+	}
+	if p.CredentialHeaders["Authorization"] != "Bearer $PORTKEY_KEY" {
+		t.Fatalf("authored credential_headers = %v", p.CredentialHeaders)
+	}
+	if e := entry(t, f.ctl.List(), "work"); e.APIKeyEnv != "PORTKEY_KEY" || e.CredentialHeader != "Authorization=Bearer $PORTKEY_KEY" {
+		t.Fatalf("List = apiKeyEnv %q credentialHeader %q", e.APIKeyEnv, e.CredentialHeader)
+	}
+
+	if err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", ClearAPIKeyEnv: true, ClearCredentialHeader: true}); err != nil {
+		t.Fatalf("Edit(clear): %v", err)
+	}
+	p = authoredEntry(t, f.tomlPath, "work")
+	if len(p.APIKeyEnv) != 0 || len(p.CredentialHeaders) != 0 {
+		t.Fatalf("after clearing: api_key_env %v credential_headers %v", p.APIKeyEnv, p.CredentialHeaders)
+	}
+	if e := entry(t, f.ctl.List(), "work"); e.APIKeyEnv != "" || e.CredentialHeader != "" {
+		t.Fatalf("List after clearing = apiKeyEnv %q credentialHeader %q", e.APIKeyEnv, e.CredentialHeader)
+	}
+}
+
+func TestInstances_EditRefusesALiteralCredentialHeader(t *testing.T) {
+	f := newInstancesFixture(t, map[string]string{"GROQ_API_KEY": "gk"})
+	if err := f.ctl.Create(appwire.InstanceCreateParams{Name: "work", Base: "openai"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", CredentialHeader: "Authorization=Bearer sk-literal"})
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("Edit = %v, want an InvalidParams wire error", err)
+	}
+	if p := authoredEntry(t, f.tomlPath, "work"); len(p.CredentialHeaders) != 0 {
+		t.Fatalf("a refused header was written: %v", p.CredentialHeaders)
+	}
+}
+
+func TestInstances_EditClearsProtocolAndSurface(t *testing.T) {
+	f := newInstancesFixture(t, map[string]string{"GROQ_API_KEY": "gk"})
+	if err := f.ctl.Create(appwire.InstanceCreateParams{
+		Name: "work", Base: "openai", Protocol: "openai-responses", Surface: "generic",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if p := authoredEntry(t, f.tomlPath, "work"); p.Protocol != "openai-responses" || p.Surface != "generic" {
+		t.Fatalf("authored = protocol %q surface %q", p.Protocol, p.Surface)
+	}
+	if err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", ClearProtocol: true, ClearSurface: true}); err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+	if p := authoredEntry(t, f.tomlPath, "work"); p.Protocol != "" || p.Surface != "" {
+		t.Fatalf("after clearing: protocol %q surface %q", p.Protocol, p.Surface)
+	}
+	if e := entry(t, f.ctl.List(), "work"); e.Protocol == "" {
+		t.Fatal("the resolved protocol must fall back to the base's, not vanish")
+	}
+}
+
+func TestInstances_EditDeletesAVarGivenAnEmptyValue(t *testing.T) {
+	f := newInstancesFixture(t, map[string]string{"GROQ_API_KEY": "gk"})
+	if err := f.ctl.Create(appwire.InstanceCreateParams{
+		Name: "work", Base: "openai", Vars: map[string]string{"REGION": "us-east-1", "ZONE": "a"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", Vars: map[string]string{"REGION": ""}}); err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+	got := readConfigProviders(t, f.tomlPath)["work"].Transport.Vars
+	if _, still := got["REGION"]; still {
+		t.Fatalf("REGION survived an empty-value edit: %v", got)
+	}
+	if got["ZONE"] != "a" {
+		t.Fatalf("an untouched var changed: %v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./cmd/evener-hub -run 'TestInstances_EditSetsAndClears|TestInstances_EditRefusesALiteral|TestInstances_EditClearsProtocol|TestInstances_EditDeletesAVar' 2>&1 | tail -12`
+Expected: the four tests FAIL (fields silently ignored, no refusal, var kept).
+
+- [ ] **Step 3: Implement**
+
+In `Edit`, directly after the `validVarNames` check at the top, add the header validation before any lock is taken:
+
+```go
+	credentialHeaders, err := credentialHeaderFrom(params.CredentialHeader)
+	if err != nil {
+		return err
+	}
+```
+
+(`credentialHeaderFrom` returns `nil, nil` for an empty field and an `InvalidParams` wire error for a malformed one.) Note that `err` is then reused by the existing `before, _, err := c.read()` line: change that line to `before, _, err := c.read()` → `before, _, readErr := c.read(); if readErr != nil { return readErr }` only if the compiler complains about redeclaration; otherwise leave it.
+
+Replace the field-apply block (from `if params.ClearBaseURL {` through the `if len(params.Vars) > 0 { ... }` block) with:
+
+```go
+	if params.ClearBaseURL {
+		// Drops the authored override and goes back to the registry
+		// default, restoring spec §10's credential inheritance from the
+		// base provider (#711). Additive over BaseURL's existing "empty
+		// means unchanged" (v3): the two are never both meaningful in the
+		// same request (appwire.InstanceEditParams doc comment).
+		p.Transport.BaseURL = ""
+	} else if v := strings.TrimSpace(params.BaseURL); v != "" {
+		p.Transport.BaseURL = v
+	}
+	if params.ClearProtocol {
+		p.Protocol = ""
+	} else if v := strings.TrimSpace(params.Protocol); v != "" {
+		p.Protocol = v
+	}
+	if params.ClearSurface {
+		p.Surface = ""
+	} else if v := strings.TrimSpace(params.Surface); v != "" {
+		p.Surface = v
+	}
+	if params.ClearAPIKeyEnv {
+		p.APIKeyEnv = nil
+	} else if v := strings.TrimSpace(params.APIKeyEnv); v != "" {
+		p.APIKeyEnv = []string{v}
+	}
+	if params.ClearCredentialHeader {
+		p.CredentialHeaders = nil
+	} else if credentialHeaders != nil {
+		p.CredentialHeaders = credentialHeaders
+	}
+	// An empty value deletes the variable (appwire.InstanceEditParams);
+	// anything else is set as sent, over whatever was authored before.
+	for key, value := range params.Vars {
+		if strings.TrimSpace(value) == "" {
+			delete(p.Transport.Vars, key)
+			continue
+		}
+		if p.Transport.Vars == nil {
+			p.Transport.Vars = map[string]string{}
+		}
+		p.Transport.Vars[key] = value
+	}
+```
+
+If `maps` is now unused in this file after removing `maps.Copy`, it is still used by `List` and `credentialHeaderField`, so the import stays.
+
+- [ ] **Step 4: Run the instances tests**
+
+Run: `go test ./cmd/evener-hub -run 'TestInstances_' 2>&1 | tail -6`
+Expected: all PASS, including the pre-existing edit tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/app_instances.go cmd/evener-hub/app_instances_test.go
+git commit -m "feat(hub): edit an instance's api_key_env, credential header, and clears"
+```
+
+---
+
+### Task 4: Edit renames an instance
+
+**Files:**
+- Modify: `cmd/evener-hub/app_instances.go` (`Edit`; new `moveCredentials`)
+- Test: `cmd/evener-hub/app_instances_test.go`
+
+**Interfaces:**
+- Consumes: `hubAuthController` fields `creds`, `stateDir`, `setCredential`, `clearCredential`, `loadAuth`, `saveAuth`, `deleteAuth` (all exist in `app_auth.go`); `authopenai.ErrAuthNotFound`; `registry.ValidInstanceName`; `appwire.Conflict`.
+- Produces: `(*hubInstancesController).moveCredentials(oldName, newName string) error`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cmd/evener-hub/app_instances_test.go`:
+
+```go
+func TestInstances_EditRenamesEntryDefaultStoredKeyAndOAuthRecord(t *testing.T) {
+	f := newInstancesFixture(t, nil)
+	if err := f.ctl.Create(appwire.InstanceCreateParams{Name: "work", Base: "openai-codex"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := f.store.Set("work", "sk-stored"); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := authopenai.SaveAuth(f.stateDir, "work", authopenai.AuthRecord{Version: 1, Provider: "openai", Source: authopenai.AuthSourceOAuth}); err != nil {
+		t.Fatalf("SaveAuth: %v", err)
+	}
+	if err := f.ctl.SetDefault(appwire.InstanceSetDefaultParams{Name: "work"}); err != nil {
+		t.Fatalf("SetDefault: %v", err)
+	}
+
+	if err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", NewName: "personal"}); err != nil {
+		t.Fatalf("Edit(rename): %v", err)
+	}
+
+	l, _, err := registry.ReadConfigFile(f.tomlPath)
+	if err != nil {
+		t.Fatalf("ReadConfigFile: %v", err)
+	}
+	if _, still := l.Providers["work"]; still {
+		t.Fatal("[providers.work] survived the rename")
+	}
+	if _, ok := l.Providers["personal"]; !ok {
+		t.Fatalf("[providers.personal] missing; got %v", l.Providers)
+	}
+	if l.Default != "personal" {
+		t.Fatalf("default = %q, want the renamed instance", l.Default)
+	}
+	if v, _ := f.store.Get("personal"); v != "sk-stored" {
+		t.Fatalf("stored key did not move: personal = %q", v)
+	}
+	if v, _ := f.store.Get("work"); v != "" {
+		t.Fatalf("the old stored key was left behind: %q", v)
+	}
+	if _, err := authopenai.LoadAuth(f.stateDir, "personal"); err != nil {
+		t.Fatalf("OAuth record did not move: %v", err)
+	}
+	if _, err := authopenai.LoadAuth(f.stateDir, "work"); !errors.Is(err, authopenai.ErrAuthNotFound) {
+		t.Fatalf("the old OAuth record was left behind (err = %v)", err)
+	}
+	resp := f.ctl.List()
+	e := entry(t, resp, "personal")
+	if !e.IsDefault || !e.HasStoredFile || !e.HasStoredOAuth {
+		t.Fatalf("personal = %+v, want default with the stored key and OAuth record", e)
+	}
+	for _, e := range resp.Instances {
+		if e.Name == "work" {
+			t.Fatal("List still shows the old name")
+		}
+	}
+}
+
+func TestInstances_EditRenameRefusesAnImplicitInstance(t *testing.T) {
+	f := newInstancesFixture(t, map[string]string{"GROQ_API_KEY": "gk"})
+	err := f.ctl.Edit(appwire.InstanceEditParams{Name: "groq", NewName: "g2"})
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("Edit = %v, want an InvalidParams wire error", err)
+	}
+	if l, exists, _ := registry.ReadConfigFile(f.tomlPath); exists {
+		if _, authored := l.Providers["g2"]; authored {
+			t.Fatal("a refused rename authored [providers.g2]")
+		}
+		if _, authored := l.Providers["groq"]; authored {
+			t.Fatal("a refused rename authored a shadow for groq")
+		}
+	}
+}
+
+func TestInstances_EditRenameRefusesATakenName(t *testing.T) {
+	f := newInstancesFixture(t, map[string]string{"GROQ_API_KEY": "gk"})
+	for _, name := range []string{"work", "other"} {
+		if err := f.ctl.Create(appwire.InstanceCreateParams{Name: name, Base: "openai"}); err != nil {
+			t.Fatalf("Create %s: %v", name, err)
+		}
+	}
+	for _, taken := range []string{"other", "groq"} {
+		err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", NewName: taken})
+		var wire appwire.WireError
+		if !errors.As(err, &wire) || wire.Code != appwire.CodeConflict {
+			t.Fatalf("rename to %q = %v, want a Conflict wire error", taken, err)
+		}
+	}
+	authoredEntry(t, f.tomlPath, "work")
+	authoredEntry(t, f.tomlPath, "other")
+}
+
+func TestInstances_EditRenameRejectsAnInvalidName(t *testing.T) {
+	f := newInstancesFixture(t, nil)
+	if err := f.ctl.Create(appwire.InstanceCreateParams{Name: "work", Base: "openai"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", NewName: "Bad/Name"})
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("Edit = %v, want an InvalidParams wire error", err)
+	}
+	authoredEntry(t, f.tomlPath, "work")
+}
+
+func TestInstances_EditRenameAppliesTheOtherFieldsToo(t *testing.T) {
+	f := newInstancesFixture(t, nil)
+	if err := f.ctl.Create(appwire.InstanceCreateParams{Name: "work", Base: "openai"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", NewName: "work2", BaseURL: "https://gw.example.test/v1"}); err != nil {
+		t.Fatalf("Edit: %v", err)
+	}
+	if p := authoredEntry(t, f.tomlPath, "work2"); p.Transport.BaseURL != "https://gw.example.test/v1" {
+		t.Fatalf("work2 base_url = %q", p.Transport.BaseURL)
+	}
+}
+
+func TestInstances_EditSameNameIsNotARename(t *testing.T) {
+	f := newInstancesFixture(t, nil)
+	if err := f.ctl.Create(appwire.InstanceCreateParams{Name: "work", Base: "openai"}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := f.ctl.Edit(appwire.InstanceEditParams{Name: "work", NewName: "work"}); err != nil {
+		t.Fatalf("Edit with NewName == Name must be a plain no-op edit: %v", err)
+	}
+	authoredEntry(t, f.tomlPath, "work")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./cmd/evener-hub -run 'TestInstances_EditRename|TestInstances_EditSameName' 2>&1 | tail -12`
+Expected: rename tests FAIL (the name is silently ignored today).
+
+- [ ] **Step 3: Implement**
+
+In `Edit`, right after the block that resolves `p, authored := l.Providers[name]` (including its `if !authored { ... }`), add:
+
+```go
+	newName := strings.TrimSpace(params.NewName)
+	renaming := newName != "" && newName != name
+	if renaming {
+		if !authored {
+			return appwire.InvalidParams(fmt.Sprintf("instance %q comes from the environment and cannot be renamed", name))
+		}
+		if !registry.ValidInstanceName(newName) {
+			return appwire.InvalidParams(fmt.Sprintf("invalid instance name %q (lowercase, no slash)", params.NewName))
+		}
+		if _, taken := l.Providers[newName]; taken {
+			return appwire.Conflict(fmt.Sprintf("instance %q already exists", newName))
+		}
+		if _, taken := c.reg.Get().Instance(newName); taken {
+			return appwire.Conflict(fmt.Sprintf("instance %q already exists", newName))
+		}
+	}
+```
+
+Replace the single line `l.Providers[name] = p` (just before `writeLoadable`) with:
+
+```go
+	if renaming {
+		// The map key is the instance name providers.toml is written under;
+		// the default pointer follows so the file still loads.
+		delete(l.Providers, name)
+		p.ID = newName
+		if l.Default == name {
+			l.Default = newName
+		}
+		l.Providers[newName] = p
+	} else {
+		l.Providers[name] = p
+	}
+```
+
+Replace the final `return nil` of `Edit` (after the reload-and-restore block) with:
+
+```go
+	if renaming {
+		return c.moveCredentials(name, newName)
+	}
+	return nil
+```
+
+Add after `Edit`:
+
+```go
+// moveCredentials carries an instance's stored key and OAuth record to its
+// new name after a rename. It runs once providers.toml is written and
+// reloaded: the config is already renamed, so a failure here is reported as
+// what was left behind rather than undone - the list stays consistent with
+// the file, and a leftover stays reachable under the old name through
+// evener/auth/apiKey/clear or the state directory.
+func (c *hubInstancesController) moveCredentials(oldName, newName string) error {
+	var problems []string
+	if value, ok := c.auth.creds.Get(oldName); ok {
+		if err := c.auth.setCredential(newName, value); err != nil {
+			problems = append(problems, fmt.Sprintf("stored key not copied: %v", err))
+		} else if err := c.auth.clearCredential(oldName); err != nil {
+			problems = append(problems, fmt.Sprintf("stored key for %q left behind: %v", oldName, err))
+		}
+	}
+	record, err := c.auth.loadAuth(c.auth.stateDir, oldName)
+	switch {
+	case errors.Is(err, authopenai.ErrAuthNotFound):
+	case err != nil:
+		problems = append(problems, fmt.Sprintf("OAuth record not read: %v", err))
+	default:
+		if err := c.auth.saveAuth(c.auth.stateDir, newName, record); err != nil {
+			problems = append(problems, fmt.Sprintf("OAuth record not copied: %v", err))
+		} else if _, err := c.auth.deleteAuth(c.auth.stateDir, oldName); err != nil {
+			problems = append(problems, fmt.Sprintf("OAuth record for %q left behind: %v", oldName, err))
+		}
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("renamed %q to %q, but: %s", oldName, newName, strings.Join(problems, "; "))
+	}
+	return nil
+}
+```
+
+Update `Edit`'s doc comment: after the first paragraph add `A NewName re-keys the entry, follows the default pointer, and then moves the stored key and OAuth record (moveCredentials); it is refused for an implicit instance, an invalid name, or a name any instance already has.`
+
+- [ ] **Step 4: Run the hub tests**
+
+Run: `go test ./cmd/evener-hub 2>&1 | tail -4`
+Expected: ok.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/evener-hub/app_instances.go cmd/evener-hub/app_instances_test.go
+git commit -m "feat(hub): rename a provider instance, moving its stored credentials"
+```
+
+---
+
+### Task 5: The form model and its diff rules
+
+**Files:**
+- Create: `cmd/evener-hub/frontend/src/panes/settings/sections/credentials/instanceEdit.ts`
+- Test: `cmd/evener-hub/frontend/src/panes/settings/sections/credentials/instanceEdit.test.ts`
+
+**Interfaces:**
+- Consumes: generated `InstanceEditParams`, `InstanceEntry`, `ProviderDescriptor`; `SelectOption` from `widgets`.
+- Produces: `PROTOCOL_OPTIONS`, `SURFACE_OPTIONS: SelectOption[]`; `InstanceDraft { name; baseUrl; protocol; surface; vars: Record<string,string>; apiKeyEnv; credentialHeader }`; `draftFor(instance, template): InstanceDraft`; `varRows(draft, template): { key: string; label: string }[]`; `instanceEditParams(initial, draft): InstanceEditParams | null`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `instanceEdit.test.ts`:
+
+```ts
+// @vitest-environment node
+import { describe, expect, test } from "vitest";
+import type { InstanceEntry, ProviderDescriptor } from "../../../../protocol/types.gen";
+import { draftFor, instanceEditParams, PROTOCOL_OPTIONS, SURFACE_OPTIONS, varRows } from "./instanceEdit";
+
+function instance(overrides: Partial<InstanceEntry> & Pick<InstanceEntry, "name" | "providerId">): InstanceEntry {
+  return {
+    protocol: "openai-chat",
+    auth: "bearer",
+    implicit: false,
+    isDefault: false,
+    activeSource: "none",
+    hasStoredOAuth: false,
+    credentialRequired: true,
+    ...overrides,
+  };
+}
+
+const VERTEX: ProviderDescriptor = {
+  id: "google-vertex-anthropic",
+  protocol: "anthropic",
+  auth: "gcp-adc",
+  implicit: true,
+  vars: { GOOGLE_VERTEX_PROJECT: "GOOGLE_VERTEX_PROJECT", GOOGLE_VERTEX_LOCATION: "GOOGLE_VERTEX_LOCATION" },
+};
+
+describe("draftFor", () => {
+  test("seeds every field from the entry, blanking what is unset", () => {
+    const draft = draftFor(instance({ name: "a", providerId: "openai", baseUrl: "https://x", surface: "generic" }), undefined);
+    expect(draft).toEqual({
+      name: "a",
+      baseUrl: "https://x",
+      protocol: "openai-chat",
+      surface: "generic",
+      vars: {},
+      apiKeyEnv: "",
+      credentialHeader: "",
+    });
+  });
+
+  test("seeds a row for every template var, prefilled from the entry's vars", () => {
+    const draft = draftFor(
+      instance({ name: "v", providerId: "google-vertex-anthropic", vars: { GOOGLE_VERTEX_PROJECT: "p1", EXTRA: "e" } }),
+      VERTEX,
+    );
+    expect(draft.vars).toEqual({ GOOGLE_VERTEX_PROJECT: "p1", GOOGLE_VERTEX_LOCATION: "", EXTRA: "e" });
+  });
+
+  test("carries the authored apiKeyEnv and credentialHeader", () => {
+    const draft = draftFor(
+      instance({ name: "a", providerId: "openai", apiKeyEnv: "PORTKEY_KEY", credentialHeader: "Authorization=Bearer $PORTKEY_KEY" }),
+      undefined,
+    );
+    expect(draft.apiKeyEnv).toBe("PORTKEY_KEY");
+    expect(draft.credentialHeader).toBe("Authorization=Bearer $PORTKEY_KEY");
+  });
+});
+
+describe("varRows", () => {
+  test("template vars first, labelled by env var name and sorted, then authored extras labelled by key", () => {
+    const draft = draftFor(instance({ name: "v", providerId: "google-vertex-anthropic", vars: { EXTRA: "e" } }), VERTEX);
+    expect(varRows(draft, VERTEX)).toEqual([
+      { key: "GOOGLE_VERTEX_LOCATION", label: "GOOGLE_VERTEX_LOCATION" },
+      { key: "GOOGLE_VERTEX_PROJECT", label: "GOOGLE_VERTEX_PROJECT" },
+      { key: "EXTRA", label: "EXTRA" },
+    ]);
+  });
+});
+
+describe("instanceEditParams", () => {
+  const base = draftFor(
+    instance({ name: "a", providerId: "openai", baseUrl: "https://x", surface: "openai", apiKeyEnv: "K", credentialHeader: "H=$K", vars: { R: "1" } }),
+    undefined,
+  );
+
+  test("returns null when nothing changed", () => {
+    expect(instanceEditParams(base, { ...base })).toBeNull();
+    expect(instanceEditParams(base, { ...base, name: " a ", baseUrl: "https://x " })).toBeNull();
+  });
+
+  test("a changed name is a rename", () => {
+    expect(instanceEditParams(base, { ...base, name: "b" })).toEqual({ name: "a", newName: "b" });
+  });
+
+  test("a changed base URL is sent; an emptied one is a clear", () => {
+    expect(instanceEditParams(base, { ...base, baseUrl: "https://y" })).toEqual({ name: "a", baseUrl: "https://y" });
+    expect(instanceEditParams(base, { ...base, baseUrl: "" })).toEqual({ name: "a", clearBaseUrl: true });
+  });
+
+  test("protocol and surface: a value is sent, inherit is a clear", () => {
+    expect(instanceEditParams(base, { ...base, protocol: "openai-responses" })).toEqual({ name: "a", protocol: "openai-responses" });
+    expect(instanceEditParams(base, { ...base, protocol: "" })).toEqual({ name: "a", clearProtocol: true });
+    expect(instanceEditParams(base, { ...base, surface: "generic" })).toEqual({ name: "a", surface: "generic" });
+    expect(instanceEditParams(base, { ...base, surface: "" })).toEqual({ name: "a", clearSurface: true });
+  });
+
+  test("only changed vars are sent, trimmed; an emptied var is sent empty so the hub deletes it", () => {
+    expect(instanceEditParams(base, { ...base, vars: { R: "1", Z: " 2 " } })).toEqual({ name: "a", vars: { Z: "2" } });
+    expect(instanceEditParams(base, { ...base, vars: { R: "" } })).toEqual({ name: "a", vars: { R: "" } });
+  });
+
+  test("api key env and credential header: a value is sent, an emptied one is a clear", () => {
+    expect(instanceEditParams(base, { ...base, apiKeyEnv: "K2" })).toEqual({ name: "a", apiKeyEnv: "K2" });
+    expect(instanceEditParams(base, { ...base, apiKeyEnv: "" })).toEqual({ name: "a", clearApiKeyEnv: true });
+    expect(instanceEditParams(base, { ...base, credentialHeader: "X=$K" })).toEqual({ name: "a", credentialHeader: "X=$K" });
+    expect(instanceEditParams(base, { ...base, credentialHeader: "" })).toEqual({ name: "a", clearCredentialHeader: true });
+  });
+
+  test("several changes ride one request", () => {
+    expect(instanceEditParams(base, { ...base, name: "b", baseUrl: "", protocol: "google" })).toEqual({
+      name: "a",
+      newName: "b",
+      clearBaseUrl: true,
+      protocol: "google",
+    });
+  });
+});
+
+test("the option lists lead with inherit and carry exactly the registry's vocabularies", () => {
+  expect(PROTOCOL_OPTIONS.map((o) => o.value)).toEqual(["", "openai-chat", "openai-responses", "anthropic", "google"]);
+  expect(SURFACE_OPTIONS.map((o) => o.value)).toEqual(["", "openai", "anthropic", "google", "generic"]);
+  expect(PROTOCOL_OPTIONS[0]?.label).toBe("inherit from base");
+  expect(SURFACE_OPTIONS[0]?.label).toBe("inherit from base");
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run (from `cmd/evener-hub/frontend`): `npx vitest run src/panes/settings/sections/credentials/instanceEdit.test.ts 2>&1 | tail -6`
+Expected: FAIL, cannot resolve `./instanceEdit`.
+
+- [ ] **Step 3: Implement**
+
+Create `instanceEdit.ts`:
+
+```ts
+// instanceEdit.ts: the provider sheet's form model - the draft the sheet
+// edits, how it is seeded from an InstanceEntry, and how a dirty draft
+// becomes the smallest evener/instance/edit request. Pure, so the diff rules
+// (empty means unchanged on the wire, a clear flag for an emptied field,
+// only the vars that changed) are pinned without rendering anything.
+//
+// protocol and baseUrl on the wire are the RESOLVED values - InstanceEntry
+// carries no authored/inherited distinction for them - so the selects show
+// what is in effect and "inherit from base" is the way back to the base's
+// value (a clear the hub treats as a no-op when nothing was authored).
+import type { InstanceEditParams, InstanceEntry, ProviderDescriptor } from "../../../../protocol/types.gen";
+import type { SelectOption } from "../../../../widgets";
+
+export const PROTOCOL_OPTIONS: SelectOption[] = [
+  { value: "", label: "inherit from base" },
+  { value: "openai-chat", label: "openai-chat" },
+  { value: "openai-responses", label: "openai-responses" },
+  { value: "anthropic", label: "anthropic" },
+  { value: "google", label: "google" },
+];
+
+export const SURFACE_OPTIONS: SelectOption[] = [
+  { value: "", label: "inherit from base" },
+  { value: "openai", label: "openai" },
+  { value: "anthropic", label: "anthropic" },
+  { value: "google", label: "google" },
+  { value: "generic", label: "generic" },
+];
+
+export interface InstanceDraft {
+  name: string;
+  baseUrl: string;
+  protocol: string;
+  surface: string;
+  vars: Record<string, string>;
+  apiKeyEnv: string;
+  credentialHeader: string;
+}
+
+/** The form's initial values for an instance. Every template variable of the
+ * base provider gets a row (blank unless authored), keyed by template name
+ * exactly as the Add form keys its inputs. */
+export function draftFor(instance: InstanceEntry, template: ProviderDescriptor | undefined): InstanceDraft {
+  const vars: Record<string, string> = {};
+  for (const key of Object.keys(template?.vars ?? {})) vars[key] = "";
+  for (const [key, value] of Object.entries(instance.vars ?? {})) vars[key] = value;
+  return {
+    name: instance.name,
+    baseUrl: instance.baseUrl ?? "",
+    protocol: instance.protocol,
+    surface: instance.surface ?? "",
+    vars,
+    apiKeyEnv: instance.apiKeyEnv ?? "",
+    credentialHeader: instance.credentialHeader ?? "",
+  };
+}
+
+/** The variable rows to render: the template's, labelled by the env var
+ * name the docs tell users to set (the Add form's own labelling), then any
+ * authored var the template does not name, labelled by its key. */
+export function varRows(draft: InstanceDraft, template: ProviderDescriptor | undefined): { key: string; label: string }[] {
+  const templateVars = template?.vars ?? {};
+  const rows = Object.entries(templateVars)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, env]) => ({ key, label: env }));
+  for (const key of Object.keys(draft.vars).sort()) {
+    if (!(key in templateVars)) rows.push({ key, label: key });
+  }
+  return rows;
+}
+
+/** The request that carries exactly the fields whose trimmed value differs
+ * from `initial`, or null when none does. */
+export function instanceEditParams(initial: InstanceDraft, draft: InstanceDraft): InstanceEditParams | null {
+  const params: InstanceEditParams = { name: initial.name };
+  let changed = false;
+
+  const name = draft.name.trim();
+  if (name !== initial.name) {
+    params.newName = name;
+    changed = true;
+  }
+  const baseUrl = draft.baseUrl.trim();
+  if (baseUrl !== initial.baseUrl) {
+    if (baseUrl === "") params.clearBaseUrl = true;
+    else params.baseUrl = baseUrl;
+    changed = true;
+  }
+  if (draft.protocol !== initial.protocol) {
+    if (draft.protocol === "") params.clearProtocol = true;
+    else params.protocol = draft.protocol;
+    changed = true;
+  }
+  if (draft.surface !== initial.surface) {
+    if (draft.surface === "") params.clearSurface = true;
+    else params.surface = draft.surface;
+    changed = true;
+  }
+  const vars: Record<string, string> = {};
+  for (const [key, value] of Object.entries(draft.vars)) {
+    const trimmed = value.trim();
+    if (trimmed !== (initial.vars[key] ?? "")) vars[key] = trimmed;
+  }
+  if (Object.keys(vars).length > 0) {
+    params.vars = vars;
+    changed = true;
+  }
+  const apiKeyEnv = draft.apiKeyEnv.trim();
+  if (apiKeyEnv !== initial.apiKeyEnv) {
+    if (apiKeyEnv === "") params.clearApiKeyEnv = true;
+    else params.apiKeyEnv = apiKeyEnv;
+    changed = true;
+  }
+  const credentialHeader = draft.credentialHeader.trim();
+  if (credentialHeader !== initial.credentialHeader) {
+    if (credentialHeader === "") params.clearCredentialHeader = true;
+    else params.credentialHeader = credentialHeader;
+    changed = true;
+  }
+  return changed ? params : null;
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx biome check --write src/panes/settings/sections/credentials/instanceEdit.ts src/panes/settings/sections/credentials/instanceEdit.test.ts && npx vitest run src/panes/settings/sections/credentials/instanceEdit.test.ts 2>&1 | tail -6`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/panes/settings/sections/credentials/instanceEdit.ts src/panes/settings/sections/credentials/instanceEdit.test.ts
+git commit -m "feat(web): provider instance form model and edit-request diff"
+```
+
+---
+
+### Task 6: InstanceSheet: the sheet is the editor
+
+**Files:**
+- Rename: `credentials/InstanceDetailSheet.tsx` → `credentials/InstanceSheet.tsx`; `credentials/InstanceDetailSheet.module.css` → `credentials/InstanceSheet.module.css`; `credentials/InstanceDetailSheet.test.tsx` → `credentials/InstanceSheet.test.tsx`; `credentials/InstanceDetailSheet.wire.test.tsx` → `credentials/InstanceSheet.wire.test.tsx` (all with `git mv`).
+- Test: `credentials/InstanceSheet.test.tsx`, `credentials/InstanceSheet.wire.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 5's module; `credentialsStore.edit(params)`; widgets `FormRow`, `Input`, `Select`, `Sheet` (`size="wide"`), `useToasts`; `errorText`.
+- Produces: `InstanceSheet(props: InstanceSheetProps)` where `InstanceSheetProps` = the old `InstanceDetailSheetProps` minus `onEdit` plus `onRenamed: (newName: string) => void`.
+
+- [ ] **Step 1: Rename the four files**
+
+```bash
+git mv src/panes/settings/sections/credentials/InstanceDetailSheet.tsx src/panes/settings/sections/credentials/InstanceSheet.tsx
+git mv src/panes/settings/sections/credentials/InstanceDetailSheet.module.css src/panes/settings/sections/credentials/InstanceSheet.module.css
+git mv src/panes/settings/sections/credentials/InstanceDetailSheet.test.tsx src/panes/settings/sections/credentials/InstanceSheet.test.tsx
+git mv src/panes/settings/sections/credentials/InstanceDetailSheet.wire.test.tsx src/panes/settings/sections/credentials/InstanceSheet.wire.test.tsx
+```
+
+- [ ] **Step 2: Rewrite the sheet tests**
+
+In `InstanceSheet.test.tsx`:
+- Change the import to `import { InstanceSheet } from "./InstanceSheet";` and add `import { Toast } from "../../../../widgets";`, `import { getToasts, resetToastStoreForTests } from "../../../../widgets/toast/store";`, `import type { InstanceEntry, ProviderDescriptor } from "../../../../protocol/types.gen";`.
+- In `noopHandlers()` remove `onEdit: vi.fn(),` and add `onRenamed: vi.fn(),`.
+- In `renderSheet`, render `<><Toast /><InstanceSheet name={inst?.name ?? null} onClose={onClose} {...handlers} {...extra} /></>` and add a third parameter `providers: ProviderDescriptor[] = []` that is set into the store alongside the instance: `credentialsStore.setState({ instances: inst === null ? [] : [inst], availableProviders: providers });`.
+- In `beforeEach` add `resetToastStoreForTests();`.
+- Delete the whole `describe("the meta table", ...)` block (the form replaces it).
+- In `describe("actions are conditionally rendered")`, replace the two Edit tests with:
+
+```tsx
+  test("Remove is offered for a non-implicit instance", () => {
+    renderSheet(instance({ name: "a", providerId: "x" }));
+    expect(screen.getByRole("button", { name: "Remove" })).toBeTruthy();
+  });
+
+  // Removing an implicit instance is refused server-side (spec §11.3), so
+  // the sheet must not even offer the button; the form stays, since editing
+  // an implicit instance writes a shadow rather than changing it.
+  test("an implicit instance offers the form but no Remove", () => {
+    renderSheet(instance({ name: "groq", providerId: "groq", implicit: true }));
+    expect(screen.getByLabelText("Base URL")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Remove" })).toBeNull();
+  });
+```
+
+- Append a new block:
+
+```tsx
+describe("the form", () => {
+  const OPENAI: ProviderDescriptor = { id: "openai", protocol: "openai-chat", auth: "bearer", implicit: true };
+  const VERTEX: ProviderDescriptor = {
+    id: "google-vertex-anthropic",
+    protocol: "anthropic",
+    auth: "gcp-adc",
+    implicit: true,
+    vars: { GOOGLE_VERTEX_PROJECT: "GOOGLE_VERTEX_PROJECT", GOOGLE_VERTEX_LOCATION: "GOOGLE_VERTEX_LOCATION" },
+  };
+  const WORK = instance({
+    name: "work",
+    providerId: "openai",
+    protocol: "openai-responses",
+    surface: "generic",
+    baseUrl: "https://gw.example.test/v1",
+    apiKeyEnv: "PORTKEY_KEY",
+    credentialHeader: "Authorization=Bearer $PORTKEY_KEY",
+    hasStoredFile: true,
+    activeSource: "store",
+  });
+
+  function field(label: string): HTMLInputElement {
+    return screen.getByLabelText(label) as HTMLInputElement;
+  }
+  function select(label: string): HTMLSelectElement {
+    return screen.getByLabelText(label) as HTMLSelectElement;
+  }
+  function saveButton(): HTMLButtonElement {
+    return screen.getByRole("button", { name: "Save" }) as HTMLButtonElement;
+  }
+
+  test("prefills every field from the instance and shows the base provider as a fact", () => {
+    renderSheet(WORK, {}, [OPENAI]);
+    expect(field("Name").value).toBe("work");
+    expect(field("Base URL").value).toBe("https://gw.example.test/v1");
+    expect(select("Protocol").value).toBe("openai-responses");
+    expect(select("Surface").value).toBe("generic");
+    expect(field("API key environment variable").value).toBe("PORTKEY_KEY");
+    expect(field("Credential header").value).toBe("Authorization=Bearer $PORTKEY_KEY");
+    // "openai" is also a Surface option's text, so read the meta row's value cell.
+    expect(screen.getByText("Base provider").nextElementSibling?.textContent).toBe("openai");
+  });
+
+  test("renders one input per base-provider variable, labelled by env var name, plus authored extras", () => {
+    renderSheet(
+      instance({ name: "v", providerId: "google-vertex-anthropic", vars: { GOOGLE_VERTEX_PROJECT: "p1", EXTRA: "e" } }),
+      {},
+      [VERTEX],
+    );
+    expect(field("GOOGLE_VERTEX_PROJECT").value).toBe("p1");
+    expect(field("GOOGLE_VERTEX_LOCATION").value).toBe("");
+    expect(field("EXTRA").value).toBe("e");
+  });
+
+  test("Save is disabled until a field changes, and while writesRefused", async () => {
+    renderSheet(WORK, {}, [OPENAI]);
+    expect(saveButton().disabled).toBe(true);
+    const user = userEvent.setup();
+    await user.type(field("Base URL"), "/x");
+    expect(saveButton().disabled).toBe(false);
+
+    cleanup();
+    renderSheet(WORK, { writesRefused: true }, [OPENAI]);
+    await user.type(field("Base URL"), "/x");
+    expect(saveButton().disabled).toBe(true);
+  });
+
+  test("an implicit instance's Name is disabled with the environment note", () => {
+    renderSheet(instance({ name: "groq", providerId: "groq", implicit: true }));
+    expect(field("Name").disabled).toBe(true);
+    expect(screen.getByText(/comes from the environment/)).toBeTruthy();
+  });
+
+  test("changing the name shows the rename note", async () => {
+    renderSheet(WORK, {}, [OPENAI]);
+    const user = userEvent.setup();
+    await user.type(field("Name"), "2");
+    expect(screen.getByText(/reference "work" keep the old name/)).toBeTruthy();
+  });
+
+  test("Save sends only the changed fields", async () => {
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/edit", (params) => {
+      expect(params).toEqual({ name: "work", baseUrl: "https://gw.example.test/v1/x" });
+      return { instances: [{ ...WORK, baseUrl: "https://gw.example.test/v1/x" }], availableProviders: [OPENAI] };
+    });
+    connectionStore.getState().connect(fake);
+    renderSheet(WORK, {}, [OPENAI]);
+    const user = userEvent.setup();
+    await user.type(field("Base URL"), "/x");
+    await user.click(saveButton());
+    await waitFor(() => expect(getToasts().some((t) => t.text === "Saved work")).toBe(true));
+    expect(fake.calls.filter((c) => c.method === "evener/instance/edit")).toHaveLength(1);
+    // Reseeded from the refreshed instance: clean again.
+    expect(saveButton().disabled).toBe(true);
+    expect(field("Base URL").value).toBe("https://gw.example.test/v1/x");
+  });
+
+  test("emptying Base URL shows the reset note and sends clearBaseUrl", async () => {
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/edit", (params) => {
+      expect(params).toEqual({ name: "work", clearBaseUrl: true });
+      return { instances: [WORK], availableProviders: [OPENAI] };
+    });
+    connectionStore.getState().connect(fake);
+    renderSheet(WORK, {}, [OPENAI]);
+    const user = userEvent.setup();
+    await user.clear(field("Base URL"));
+    expect(screen.getByText("Resets the endpoint to the provider's default.")).toBeTruthy();
+    await user.click(saveButton());
+    await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/instance/edit")).toBe(true));
+  });
+
+  test("choosing inherit from base sends clearProtocol", async () => {
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/edit", (params) => {
+      expect(params).toEqual({ name: "work", clearProtocol: true });
+      return { instances: [WORK], availableProviders: [OPENAI] };
+    });
+    connectionStore.getState().connect(fake);
+    renderSheet(WORK, {}, [OPENAI]);
+    const user = userEvent.setup();
+    await user.selectOptions(select("Protocol"), "");
+    await user.click(saveButton());
+    await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/instance/edit")).toBe(true));
+  });
+
+  test("emptying a var sends it empty so the hub deletes it", async () => {
+    const V = instance({ name: "v", providerId: "google-vertex-anthropic", vars: { GOOGLE_VERTEX_PROJECT: "p1" } });
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/edit", (params) => {
+      expect(params).toEqual({ name: "v", vars: { GOOGLE_VERTEX_PROJECT: "" } });
+      return { instances: [V], availableProviders: [VERTEX] };
+    });
+    connectionStore.getState().connect(fake);
+    renderSheet(V, {}, [VERTEX]);
+    const user = userEvent.setup();
+    await user.clear(field("GOOGLE_VERTEX_PROJECT"));
+    await user.click(saveButton());
+    await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/instance/edit")).toBe(true));
+  });
+
+  test("a credential header without $ is refused inline, with no RPC", async () => {
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/edit", () => {
+      throw new Error("must not be called");
+    });
+    connectionStore.getState().connect(fake);
+    renderSheet(WORK, {}, [OPENAI]);
+    const user = userEvent.setup();
+    await user.clear(field("Credential header"));
+    await user.type(field("Credential header"), "Authorization=Bearer sk-literal");
+    await user.click(saveButton());
+    expect(screen.getByRole("alert").textContent).toContain("$VARIABLE");
+    expect(fake.calls.filter((c) => c.method === "evener/instance/edit")).toHaveLength(0);
+  });
+
+  test("a failed save shows the error inline and toasts Save failed", async () => {
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/edit", () => {
+      throw new Error("providers.toml: write: read-only");
+    });
+    connectionStore.getState().connect(fake);
+    renderSheet(WORK, {}, [OPENAI]);
+    const user = userEvent.setup();
+    await user.type(field("Base URL"), "/x");
+    await user.click(saveButton());
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("read-only"));
+    expect(getToasts().some((t) => t.text.startsWith("Save failed"))).toBe(true);
+    expect(field("Base URL").value).toBe("https://gw.example.test/v1/x");
+  });
+
+  test("a rename toasts the new name, calls onRenamed, and does not close the sheet", async () => {
+    const fake = new FakeClient("ready");
+    fake.on("evener/instance/edit", (params) => {
+      expect(params).toEqual({ name: "work", newName: "work2" });
+      return { instances: [{ ...WORK, name: "work2" }], availableProviders: [OPENAI] };
+    });
+    connectionStore.getState().connect(fake);
+    const { handlers, onClose } = renderSheet(WORK, {}, [OPENAI]);
+    const user = userEvent.setup();
+    await user.type(field("Name"), "2");
+    await user.click(saveButton());
+    await waitFor(() => expect(handlers.onRenamed).toHaveBeenCalledWith("work2"));
+    expect(getToasts().some((t) => t.text === "Saved work2")).toBe(true);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+```
+
+In `InstanceSheet.wire.test.tsx`, change the import to `InstanceSheet`, the rendered component to `<InstanceSheet ...>`, remove the `onEdit={vi.fn()}` prop and add `onRenamed={vi.fn()}`. Update the file's top comment to name `InstanceSheet.test.tsx`.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `npx vitest run src/panes/settings/sections/credentials/InstanceSheet 2>&1 | tail -10`
+Expected: FAIL (`InstanceSheet` is not exported; the old file still exports `InstanceDetailSheet`).
+
+- [ ] **Step 4: Rewrite the stylesheet**
+
+In `InstanceSheet.module.css`, change the header comment's first line to `/* InstanceSheet body layout (the sheet is the editor, spec 2026-09-07 §2).` and add after `.headingRow`:
+
+```css
+/* The authored fields, as a form: FormRow's own label/control/help rhythm,
+ * one column, sitting above the credential actions the inspector already
+ * had. The base provider row reuses the meta-table vocabulary since it is
+ * a fact, not a field. */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.formError {
+  margin: 0;
+  color: var(--ink-hi);
+  font-size: var(--font-size-caption);
+}
+```
+
+- [ ] **Step 5: Rewrite the component**
+
+Replace the whole of `InstanceSheet.tsx` with:
+
+```tsx
+// InstanceSheet: the provider instance's editor (spec 2026-09-07 §2). Opens
+// from an InstanceRow tap and IS the edit surface: the authored fields are
+// form inputs prefilled from the instance, Save in the sheet footer lights
+// up when any differs, and renaming is editing the Name field. Below the
+// form sit the layered credential display and the actions the inspector
+// this replaced already had (test, set/replace key or credential JSON,
+// sign in/refresh OAuth, make default) and the danger zone; the secret
+// entry and OAuth flows stay dialogs because they carry write-only values
+// or several steps. A wide right Sheet on desktop, a bottom Sheet on mobile
+// (useIsMobile, the shell's own source).
+//
+// The instance is read from the store by name so cross-client changes land
+// live. The draft is seeded when a different instance opens and again
+// after this sheet's own save lands, never on an unrelated refresh, so
+// in-progress edits survive another client's change. The sheet closes
+// itself when its instance disappears - except across its own rename,
+// where the section re-selects the new name (onRenamed) and the vanish is
+// the rename landing, not a removal.
+//
+// Owns the one mutation it edits (evener/instance/edit); the section still
+// owns what every other action DOES (opening an editor, a confirm, or
+// calling the store), the same division of labor as before.
+import { useEffect, useId, useRef, useState } from "react";
+import { errorText } from "../../../../protocol/errors";
+import type { AuthTestResponse, InstanceEntry } from "../../../../protocol/types.gen";
+import { useIsMobile } from "../../../../shell/useIsMobile";
+import { credentialsStore, useCredentialsStore } from "../../../../stores/credentials";
+import { Button, Chip, FormRow, Input, Select, Sheet, StatusDot, useToasts } from "../../../../widgets";
+import { requireClass } from "../../../../widgets/internal/requireClass";
+import {
+  credentialLayers,
+  keylessByDesign,
+  safeCredentialTestMessage,
+  safeCredentialTestResult,
+  unconfiguredLabel,
+} from "./credentialLabels";
+import { draftFor, type InstanceDraft, instanceEditParams, PROTOCOL_OPTIONS, SURFACE_OPTIONS, varRows } from "./instanceEdit";
+import styles from "./InstanceSheet.module.css";
+
+const CLASS = {
+  headingRow: requireClass(styles.headingRow, "InstanceSheet.module.css", "headingRow"),
+  form: requireClass(styles.form, "InstanceSheet.module.css", "form"),
+  formError: requireClass(styles.formError, "InstanceSheet.module.css", "formError"),
+  layers: requireClass(styles.layers, "InstanceSheet.module.css", "layers"),
+  layer: requireClass(styles.layer, "InstanceSheet.module.css", "layer"),
+  unconfigured: requireClass(styles.unconfigured, "InstanceSheet.module.css", "unconfigured"),
+  metaRow: requireClass(styles.metaRow, "InstanceSheet.module.css", "metaRow"),
+  metaLabel: requireClass(styles.metaLabel, "InstanceSheet.module.css", "metaLabel"),
+  metaValue: requireClass(styles.metaValue, "InstanceSheet.module.css", "metaValue"),
+  actionRows: requireClass(styles.actionRows, "InstanceSheet.module.css", "actionRows"),
+  fullRow: requireClass(styles.fullRow, "InstanceSheet.module.css", "fullRow"),
+  divider: requireClass(styles.divider, "InstanceSheet.module.css", "divider"),
+  testResult: requireClass(styles.testResult, "InstanceSheet.module.css", "testResult"),
+};
+
+const LITERAL_HEADER_ERROR = "Credential header must reference a $VARIABLE, never a literal secret.";
+
+export interface InstanceSheetProps {
+  name: string | null;
+  onClose: () => void;
+  /** After a successful rename, with the new name: the section re-selects
+   * it so the sheet stays open on the same instance. */
+  onRenamed: (newName: string) => void;
+  onSetApiKey: () => void;
+  onSetCredentialJson: () => void;
+  onOAuthStart: () => void;
+  onClear: () => void;
+  onClearStoredKey: () => void;
+  onRemove: () => void;
+  onSetDefault: () => void;
+  onTestCredentials: () => void;
+  testCredentialsPending?: boolean;
+  testCredentialsResult?: AuthTestResponse;
+  /** Disables Save/Remove/make default while providers.toml cannot be
+   * written (InstanceListResponse.writesRefused, spec §11.3) - Set key/Sign
+   * in/Clear/Clear stored key/Test credentials are unaffected: they write
+   * the credentials store or an OAuth record, never providers.toml. */
+  writesRefused?: boolean;
+}
+
+export function InstanceSheet({
+  name,
+  onClose,
+  onRenamed,
+  onSetApiKey,
+  onSetCredentialJson,
+  onOAuthStart,
+  onClear,
+  onClearStoredKey,
+  onRemove,
+  onSetDefault,
+  onTestCredentials,
+  testCredentialsPending = false,
+  testCredentialsResult,
+  writesRefused = false,
+}: InstanceSheetProps) {
+  const instances = useCredentialsStore((s) => s.instances);
+  const availableProviders = useCredentialsStore((s) => s.availableProviders);
+  const isMobile = useIsMobile();
+  const toast = useToasts();
+  const ids = useId();
+
+  const instance = name === null ? undefined : instances.find((i) => i.name === name);
+  const template = instance === undefined ? undefined : availableProviders.find((p) => p.id === instance.providerId);
+
+  const [initial, setInitial] = useState<InstanceDraft | null>(null);
+  const [draft, setDraft] = useState<InstanceDraft | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  // Set for the span of a rename request: the old name vanishes from the
+  // store when the response lands, and that vanish must not close the sheet.
+  const pendingRename = useRef<string | null>(null);
+
+  function seed(inst: InstanceEntry): void {
+    const seeded = draftFor(
+      inst,
+      credentialsStore.getState().availableProviders.find((p) => p.id === inst.providerId),
+    );
+    setInitial(seeded);
+    setDraft(seeded);
+    setFormError(null);
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reseed only when a different instance opens; a refresh of the same instance must not clobber in-progress edits
+  useEffect(() => {
+    if (instance === undefined) {
+      setInitial(null);
+      setDraft(null);
+      setFormError(null);
+      return;
+    }
+    seed(instance);
+  }, [instance?.name]);
+
+  // An inspector is only as alive as its subject: the instance can vanish
+  // under an open sheet (its own Remove completing, or another client's
+  // change), and an editor for a thing that no longer exists closes itself
+  // rather than offering actions on a ghost. Its own rename is the one
+  // vanish that is not a removal.
+  useEffect(() => {
+    if (name !== null && instance === undefined && pendingRename.current === null) onClose();
+  }, [name, instance, onClose]);
+  // The section moved the selection to the new name: the guard is spent.
+  useEffect(() => {
+    pendingRename.current = null;
+  }, [name]);
+
+  const open = name !== null && instance !== undefined;
+
+  const params = initial !== null && draft !== null ? instanceEditParams(initial, draft) : null;
+  const dirty = params !== null;
+
+  function update(patch: Partial<InstanceDraft>): void {
+    setDraft((current) => (current === null ? current : { ...current, ...patch }));
+  }
+  function updateVar(key: string, value: string): void {
+    setDraft((current) => (current === null ? current : { ...current, vars: { ...current.vars, [key]: value } }));
+  }
+
+  async function handleSave(): Promise<void> {
+    if (instance === undefined || params === null) return;
+    if (params.credentialHeader !== undefined && !params.credentialHeader.includes("$")) {
+      setFormError(LITERAL_HEADER_ERROR);
+      return;
+    }
+    setFormError(null);
+    setBusy(true);
+    if (params.newName !== undefined) pendingRename.current = params.newName;
+    try {
+      await credentialsStore.getState().edit(params);
+      toast.push("success", `Saved ${params.newName ?? instance.name}`);
+      if (params.newName !== undefined) {
+        onRenamed(params.newName);
+      } else {
+        const refreshed = credentialsStore.getState().instances.find((i) => i.name === instance.name);
+        if (refreshed !== undefined) seed(refreshed);
+      }
+    } catch (err) {
+      pendingRename.current = null;
+      const message = errorText(err);
+      setFormError(message);
+      toast.push("error", `Save failed: ${message}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const supportsApiKey = instance !== undefined && (instance.authModes ?? []).includes("apiKey");
+  const supportsCredentialJson = instance !== undefined && (instance.authModes ?? []).includes("credentialJson");
+  const supportsOAuth = instance !== undefined && (instance.authModes ?? []).includes("oauth");
+  const showClear = instance !== undefined && (instance.activeSource === "store" || instance.activeSource === "oauth");
+  // showClearStoredKey: a stray stored key sits shadowed behind whatever IS
+  // active (the same condition credentialLayers uses to render that second,
+  // non-effective layer above) - true for an oauth/adc login with a leftover
+  // credentials.toml entry, and just as much for a signed-out Codex row a
+  // previous Clear left stranded (Clear's Codex branch removes the OAuth
+  // record, not the file, when one is active; issue #713). This action
+  // always targets the store layer only, so it is safe to offer regardless
+  // of what is effective.
+  const showClearStoredKey = instance?.hasStoredFile && instance.activeSource !== "store";
+  // The danger zone is Clear + Clear stored key + Remove under a divider; an
+  // implicit instance with nothing stored offers none of them, and a divider
+  // over nothing reads as a rendering bug.
+  const showDangerZone = instance !== undefined && (showClear || showClearStoredKey || !instance.implicit);
+  const layers = instance === undefined ? [] : credentialLayers(instance);
+  const unconfigured = instance === undefined ? null : unconfiguredLabel(instance);
+  const safeTestResult = testCredentialsResult
+    ? safeCredentialTestResult(name ?? "", testCredentialsResult)
+    : undefined;
+  const clearingBaseUrl =
+    instance !== undefined && draft !== null && Boolean(instance.baseUrl) && draft.baseUrl.trim() === "";
+  const renaming = initial !== null && draft !== null && draft.name.trim() !== initial.name;
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      title={instance?.name ?? ""}
+      side={isMobile ? "bottom" : "right"}
+      size="wide"
+      footer={
+        instance !== undefined && (
+          <Button onClick={() => void handleSave()} disabled={!dirty || busy || writesRefused}>
+            Save
+          </Button>
+        )
+      }
+    >
+      {instance !== undefined && (
+        <>
+          <div className={CLASS.headingRow}>
+            <StatusDot state={layers.length > 0 || keylessByDesign(instance) ? "idle" : "ended"} />
+            {instance.isDefault && <Chip>★ default</Chip>}
+            {instance.implicit && <Chip>from environment</Chip>}
+          </div>
+          {draft !== null && (
+            <form
+              className={CLASS.form}
+              aria-label={`Edit ${instance.name}`}
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleSave();
+              }}
+            >
+              <FormRow
+                label="Name"
+                htmlFor={`${ids}-name`}
+                help={
+                  instance.implicit
+                    ? "This instance comes from the environment and cannot be renamed."
+                    : renaming
+                      ? `Launch config and past sessions that reference "${instance.name}" keep the old name.`
+                      : undefined
+                }
+              >
+                <Input
+                  id={`${ids}-name`}
+                  value={draft.name}
+                  onChange={(event) => update({ name: event.target.value })}
+                  disabled={busy || instance.implicit}
+                />
+              </FormRow>
+              <div className={CLASS.metaRow}>
+                <span className={CLASS.metaLabel}>Base provider</span>
+                <span className={CLASS.metaValue}>{instance.providerId}</span>
+              </div>
+              <FormRow
+                label="Base URL"
+                htmlFor={`${ids}-baseurl`}
+                help={clearingBaseUrl ? "Resets the endpoint to the provider's default." : undefined}
+              >
+                <Input
+                  id={`${ids}-baseurl`}
+                  value={draft.baseUrl}
+                  onChange={(event) => update({ baseUrl: event.target.value })}
+                  placeholder="https://…"
+                  disabled={busy}
+                />
+              </FormRow>
+              <FormRow label="Protocol" htmlFor={`${ids}-protocol`}>
+                <Select
+                  id={`${ids}-protocol`}
+                  value={draft.protocol}
+                  onChange={(event) => update({ protocol: event.target.value })}
+                  options={PROTOCOL_OPTIONS}
+                  disabled={busy}
+                />
+              </FormRow>
+              <FormRow label="Surface" htmlFor={`${ids}-surface`}>
+                <Select
+                  id={`${ids}-surface`}
+                  value={draft.surface}
+                  onChange={(event) => update({ surface: event.target.value })}
+                  options={SURFACE_OPTIONS}
+                  disabled={busy}
+                />
+              </FormRow>
+              {varRows(draft, template).map(({ key, label }) => (
+                <FormRow key={key} label={label} htmlFor={`${ids}-var-${key}`}>
+                  <Input
+                    id={`${ids}-var-${key}`}
+                    value={draft.vars[key] ?? ""}
+                    onChange={(event) => updateVar(key, event.target.value)}
+                    disabled={busy}
+                  />
+                </FormRow>
+              ))}
+              <FormRow label="API key environment variable" htmlFor={`${ids}-apikeyenv`}>
+                <Input
+                  id={`${ids}-apikeyenv`}
+                  value={draft.apiKeyEnv}
+                  onChange={(event) => update({ apiKeyEnv: event.target.value })}
+                  placeholder="e.g. PORTKEY_KEY"
+                  disabled={busy}
+                />
+              </FormRow>
+              <FormRow
+                label="Credential header"
+                htmlFor={`${ids}-credentialheader`}
+                help="NAME=VALUE; the value must reference a $VARIABLE, never a literal secret."
+              >
+                <Input
+                  id={`${ids}-credentialheader`}
+                  value={draft.credentialHeader}
+                  onChange={(event) => update({ credentialHeader: event.target.value })}
+                  placeholder="Authorization=Bearer $VAR"
+                  disabled={busy}
+                />
+              </FormRow>
+              {formError !== null && (
+                <p className={CLASS.formError} role="alert">
+                  {formError}
+                </p>
+              )}
+            </form>
+          )}
+          {unconfigured !== null ? (
+            <p className={CLASS.unconfigured}>{unconfigured}</p>
+          ) : (
+            <div className={CLASS.layers}>
+              {layers.map((layer) => (
+                <div key={layer.source} className={CLASS.layer}>
+                  <span>↳ {layer.label}</span>
+                  <Chip tone={layer.effective ? "alive" : "neutral"}>{layer.effective ? "effective" : "shadowed"}</Chip>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className={CLASS.actionRows}>
+            <div className={CLASS.fullRow}>
+              <Button variant="quiet" onClick={onTestCredentials} disabled={testCredentialsPending}>
+                {testCredentialsPending ? "Testing credentials…" : "Test credentials"}
+              </Button>
+            </div>
+            {safeTestResult && (
+              <p className={CLASS.testResult} role="status">
+                {safeTestResult.status}: {safeCredentialTestMessage(safeTestResult.status)}
+              </p>
+            )}
+            {supportsApiKey && (
+              <div className={CLASS.fullRow}>
+                <Button variant="quiet" onClick={onSetApiKey}>
+                  {instance.hasStoredFile ? "Replace key" : "Set key"}
+                </Button>
+              </div>
+            )}
+            {supportsCredentialJson && (
+              <div className={CLASS.fullRow}>
+                <Button variant="quiet" onClick={onSetCredentialJson}>
+                  {instance.hasStoredFile ? "Replace credential JSON" : "Set credential JSON"}
+                </Button>
+              </div>
+            )}
+            {supportsOAuth && (
+              <div className={CLASS.fullRow}>
+                <Button variant="quiet" onClick={onOAuthStart}>
+                  {instance.hasStoredOAuth ? "Refresh OAuth" : "Sign in…"}
+                </Button>
+              </div>
+            )}
+            {!instance.isDefault && (
+              <div className={CLASS.fullRow}>
+                <Button variant="quiet" onClick={onSetDefault} disabled={writesRefused}>
+                  ★ make default
+                </Button>
+              </div>
+            )}
+          </div>
+          {showDangerZone && (
+            <>
+              <hr className={CLASS.divider} />
+              <div className={CLASS.actionRows}>
+                {showClearStoredKey && (
+                  <div className={CLASS.fullRow}>
+                    <Button variant="dangerQuiet" onClick={onClearStoredKey}>
+                      {supportsCredentialJson ? "Clear stored credential JSON" : "Clear stored key"}
+                    </Button>
+                  </div>
+                )}
+                {showClear && (
+                  <div className={CLASS.fullRow}>
+                    <Button variant="dangerQuiet" onClick={onClear}>
+                      Clear
+                    </Button>
+                  </div>
+                )}
+                {!instance.implicit && (
+                  <div className={CLASS.fullRow}>
+                    <Button variant="danger" onClick={onRemove} disabled={writesRefused}>
+                      Remove
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </Sheet>
+  );
+}
+```
+
+Delete the now-unused `.metaList` and `.metaMono` rules from the stylesheet only if `requireClass` no longer references them (it does not in the code above); keep `.metaRow`, `.metaLabel`, `.metaValue`.
+
+- [ ] **Step 6: Run the sheet tests**
+
+Run: `npx biome check --write src/panes/settings/sections/credentials/InstanceSheet.tsx src/panes/settings/sections/credentials/InstanceSheet.module.css src/panes/settings/sections/credentials/InstanceSheet.test.tsx src/panes/settings/sections/credentials/InstanceSheet.wire.test.tsx && npx vitest run src/panes/settings/sections/credentials/InstanceSheet 2>&1 | tail -12`
+Expected: every test in both files passes. `CredentialsSection` tests will fail until Task 7 rewires the section; that is expected here.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/panes/settings/sections/credentials/InstanceSheet.tsx src/panes/settings/sections/credentials/InstanceSheet.module.css src/panes/settings/sections/credentials/InstanceSheet.test.tsx src/panes/settings/sections/credentials/InstanceSheet.wire.test.tsx
+git commit -m "feat(web): the provider instance sheet is the editor"
+```
+
+---
+
+### Task 7: Wire the section, delete the edit dialog
+
+**Files:**
+- Modify: `credentials/CredentialsSection.tsx`
+- Modify: `credentials/instanceDialogs.tsx` (delete `EditInstanceDialogProps` and `EditInstanceDialog`)
+- Test: `credentials/CredentialsSection.test.tsx`, `credentials/CredentialsSection.edge.test.tsx`, `credentials/instanceDialogs.test.tsx`
+
+- [ ] **Step 1: Update the section tests first**
+
+In `CredentialsSection.test.tsx`:
+- In the `describe("single-open-editor invariant")` test, rename it to `"opening the Add form, then Replace key from a row's sheet, replaces it (only one editor open at a time)"` and change the clicked button from `"Edit"` to `"Replace key"`, and the final expectation from `screen.getByRole("dialog", { name: "Edit work" })` to `screen.getByRole("dialog", { name: "Set API key for work" })`.
+- In the `writesRefused` test, rename it to `"writesRefused disables Add and each sheet's Save/Remove/make default, but not Test credentials/Set key/Clear"` and change the `"Edit"` assertion to `{ name: "Save" }`.
+- At the other `"Edit"` assertion (around line 234, inside the diagnostics tests), change it to `{ name: "Remove" }`.
+- Append to the file:
+
+```tsx
+describe("rename from the sheet", () => {
+  test("re-selects the instance under its new name so the sheet stays open", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/instance/list", () => LIST);
+    fake.on("evener/instance/edit", (params) => ({
+      instances: [{ ...WORK, name: params.newName ?? WORK.name }, PERSONAL],
+      availableProviders: [],
+    }));
+    render(
+      <>
+        <Toast />
+        <CredentialsSection sectionId="credentials" />
+      </>,
+    );
+    await screen.findByText("work");
+    const user = userEvent.setup();
+    const inspector = await openSheet(user, "work");
+    await user.type(within(inspector).getByLabelText("Name"), "2");
+    await user.click(within(inspector).getByRole("button", { name: "Save" }));
+    await screen.findByRole("dialog", { name: "work2" });
+    expect(screen.queryByRole("dialog", { name: "work" })).toBeNull();
+    expect(screen.getByRole("button", { name: /work2/ })).toBeTruthy();
+  });
+});
+```
+
+In `CredentialsSection.edge.test.tsx`, delete the test `"an edit dialog closes when a refreshed list removes its instance"` and its leading comment.
+
+In `instanceDialogs.test.tsx`, delete the whole `describe("EditInstanceDialog", ...)` block and remove `EditInstanceDialog` from the import line.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/panes/settings/sections/credentials 2>&1 | tail -12`
+Expected: `CredentialsSection*` fail to compile (`InstanceDetailSheet` no longer exists); `instanceDialogs.test.tsx` passes.
+
+- [ ] **Step 3: Rewire the section**
+
+In `CredentialsSection.tsx`:
+- Replace the import `import { InstanceDetailSheet } from "./InstanceDetailSheet";` with `import { InstanceSheet } from "./InstanceSheet";`.
+- Change `import { AddInstanceDialog, ApiKeyDialog, CredentialJsonDialog, EditInstanceDialog } from "./instanceDialogs";` to drop `EditInstanceDialog`.
+- In `type OpenEditor`, delete the `| { kind: "edit"; name: string }` member.
+- Delete the `{openEditor?.kind === "edit" && (() => { ... })()}` render block.
+- Replace `<InstanceDetailSheet` with `<InstanceSheet`, delete the `onEdit={...}` prop, and add `onRenamed={setSelectedInstance}`.
+- In the header comment, replace `every per-instance action (test, set key, sign in, edit, make default, clear, clear stored key, remove) lives in that sheet` with `the sheet is the instance's editor (name, base URL, protocol, surface, vars, api-key env, credential header; spec 2026-09-07 §2) and every other per-instance action (test, set key, sign in, make default, clear, clear stored key, remove) lives in it too`, and `The editors (add/apiKey/edit/OAuth flows) stay dialogs` with `The secret-entry and multi-step flows (add/apiKey/credential JSON/OAuth) stay dialogs`.
+
+In `instanceDialogs.tsx`, delete `EditInstanceDialogProps` and `EditInstanceDialog` (the interface, the doc comment, and the function), and drop `InstanceEntry` from the type import only if nothing else in the file uses it (ApiKeyDialogProps does, so keep it). Update the file's top comment: `the 3 instance-CRUD editors ... Add, Edit, and Set/Replace API key` → `the instance-CRUD editors that stay dialogs (spec 2026-09-07 §2): Add, plus Set/Replace API key and credential JSON. Editing an existing instance lives in InstanceSheet.`
+
+- [ ] **Step 4: Run the credentials tests and the whole settings suite**
+
+Run: `npx biome check --write src/panes/settings/sections/credentials/CredentialsSection.tsx src/panes/settings/sections/credentials/instanceDialogs.tsx src/panes/settings/sections/credentials/CredentialsSection.test.tsx src/panes/settings/sections/credentials/CredentialsSection.edge.test.tsx src/panes/settings/sections/credentials/instanceDialogs.test.tsx && npx vitest run src/panes/settings 2>&1 | tail -10`
+Expected: all pass. Then `grep -rn "InstanceDetailSheet\|EditInstanceDialog" src` must print nothing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/panes/settings/sections/credentials/CredentialsSection.tsx src/panes/settings/sections/credentials/instanceDialogs.tsx src/panes/settings/sections/credentials/CredentialsSection.test.tsx src/panes/settings/sections/credentials/CredentialsSection.edge.test.tsx src/panes/settings/sections/credentials/instanceDialogs.test.tsx
+git commit -m "refactor(web): route instance editing through the sheet; drop the edit dialog"
+```
+
+---
+
+### Task 8: Protocol and surface on the Add form
+
+**Files:**
+- Modify: `credentials/instanceDialogs.tsx` (`AddInstanceDialog`)
+- Test: `credentials/instanceDialogs.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Inside `describe("AddInstanceDialog", ...)` in `instanceDialogs.test.tsx`, append:
+
+```tsx
+  test("Protocol and Surface default to inherit and are sent only when chosen", async () => {
+    const fake = connectFakeClient();
+    fake.on("evener/instance/create", (params) => {
+      expect(params).toEqual({ name: "work", base: "anthropic", baseUrl: "", protocol: "openai-responses", surface: "generic" });
+      return { instances: [], availableProviders: [] };
+    });
+    const onSuccess = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <>
+        <AddInstanceDialog availableProviders={[ANTHROPIC]} onCancel={() => {}} onSuccess={onSuccess} />
+        <Toast />
+      </>,
+    );
+    expect((screen.getByLabelText("Protocol") as HTMLSelectElement).value).toBe("");
+    expect((screen.getByLabelText("Surface") as HTMLSelectElement).value).toBe("");
+    await user.selectOptions(screen.getByLabelText("Base provider"), "anthropic");
+    await user.type(screen.getByLabelText("Name"), "work");
+    await user.selectOptions(screen.getByLabelText("Protocol"), "openai-responses");
+    await user.selectOptions(screen.getByLabelText("Surface"), "generic");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    await vi.waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/panes/settings/sections/credentials/instanceDialogs.test.tsx -t "Protocol and Surface" 2>&1 | tail -8`
+Expected: FAIL, no element labelled "Protocol".
+
+- [ ] **Step 3: Implement**
+
+In `AddInstanceDialog`:
+- Add `import { PROTOCOL_OPTIONS, SURFACE_OPTIONS } from "./instanceEdit";`.
+- Add state after `baseUrl`: `const [protocol, setProtocol] = useState("");` and `const [surface, setSurface] = useState("");`.
+- In the `create` call add `protocol: protocol || undefined,` and `surface: surface || undefined,` after `baseUrl`.
+- After the Base URL `FormRow`, add:
+
+```tsx
+        <FormRow
+          label="Protocol"
+          htmlFor="add-instance-protocol"
+          help="Leave on inherit unless the endpoint speaks a different wire protocol than its base."
+        >
+          <Select
+            id="add-instance-protocol"
+            value={protocol}
+            onChange={(event) => setProtocol(event.target.value)}
+            options={PROTOCOL_OPTIONS}
+            disabled={busy}
+          />
+        </FormRow>
+        <FormRow label="Surface" htmlFor="add-instance-surface">
+          <Select
+            id="add-instance-surface"
+            value={surface}
+            onChange={(event) => setSurface(event.target.value)}
+            options={SURFACE_OPTIONS}
+            disabled={busy}
+          />
+        </FormRow>
+```
+
+Update the file's top comment sentence `the openai-only API-style radio is gone (Protocol is no longer openai-specific data the form special-cases)` to `Protocol and Surface are plain selects over the registry's vocabularies (instanceEdit.ts), defaulting to inherit`.
+
+- [ ] **Step 4: Run the dialog tests**
+
+Run: `npx biome check --write src/panes/settings/sections/credentials/instanceDialogs.tsx src/panes/settings/sections/credentials/instanceDialogs.test.tsx && npx vitest run src/panes/settings/sections/credentials/instanceDialogs.test.tsx 2>&1 | tail -6`
+Expected: all pass (the existing "submit calls instanceCreate" test still matches because `toEqual` ignores `undefined` properties).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/panes/settings/sections/credentials/instanceDialogs.tsx src/panes/settings/sections/credentials/instanceDialogs.test.tsx
+git commit -m "feat(web): protocol and surface selects on the add-instance form"
+```
+
+---
+
+### Task 9: The design-system rule and the decisions entry
+
+**Files:**
+- Modify: `docs/web-ui/design-system.md` (§10, the paragraph beginning `**Rows are single tappable targets; actions live in a detail sheet.**`)
+- Modify: `docs/web-ui/decisions.md` (append)
+
+- [ ] **Step 1: Rewrite the §10 paragraph**
+
+Replace that paragraph (through `...closing the pane out from under an open overlay.`) with:
+
+```markdown
+**Rows are single tappable targets; the detail sheet is the item's editor.** A collection row
+carries identity and status only — `StatusDot`, name, state chips, one mono meta line
+(`@ marketplace · v1.2.0`) — and a trailing chevron; it is one full-width `<button>`, so the
+whole row is the target on desktop and touch alike. A row NEVER grows a trailing cluster of
+small action buttons (the pre-redesign installed row had four): everything about the item lives
+in its **detail sheet**, a `Sheet` with `side="right"` on desktop and `side="bottom"` at the
+mobile breakpoint (chosen via `useIsMobile`, the same source the shell uses), `size="wide"`
+when it carries a form. The sheet is the item's editor, not an inspector (2026-09-07): every
+authored, editable fact renders as a prefilled form field in place — `FormRow` over `Input` /
+`Select`, one column — with a dirty-gated **Save** as the footer's primary `Button`, and
+renaming is editing the name field. Read-only facts keep the meta-table idiom below. A
+separate `Dialog` is reserved for write-only secret entry (an API key, a credential JSON) and
+multi-step flows (OAuth); it never exists to edit a field the sheet could show. Binary state
+(Enabled, Auto-upgrade) is a `Switch` row that applies immediately, disabled while its RPC is
+in flight; the destructive action keeps its `ConfirmDialog` even though that nests a second
+modal over the sheet — `OverlayPanel` instances stack in DOM order, each traps and restores
+focus down the stack, and its `preventDefault` on Escape is what keeps the settings pane's own
+document-level Escape handler from closing the pane out from under an open overlay. Closing a
+sheet with unsaved edits discards them silently; the sheet reseeds only when a different item
+opens or its own save lands, so another client's refresh never clobbers a draft.
+```
+
+Also update the sentence in the section's first paragraph `It is now the reference implementation for the two idioms below` to `Settings → Providers & credentials (`panes/settings/sections/credentials/InstanceSheet.tsx`) is the reference implementation of the sheet-as-editor form; Marketplaces & Plugins remains the reference for segments`.
+
+- [ ] **Step 2: Append the decisions entry**
+
+Append to `docs/web-ui/decisions.md`:
+
+```markdown
+## 2026-09-07 detail sheets are editors
+
+The provider instance sheet shipped as an inspector: a stack of quiet
+buttons whose "Edit" opened a one-field dialog (Base URL), and nothing could
+rename an instance or change its api_key_env or credential header after
+creation. Jesse called the whole pattern out. The rule in design-system.md
+§10 now reads: a detail sheet is the item's editor. Editable facts are
+prefilled form fields in place with a dirty-gated Save in the footer;
+rename is editing the name field; dialogs are reserved for write-only
+secret entry and multi-step flows. `InstanceSheet` is the reference
+implementation (spec
+`docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md`);
+the marketplaces list follows in its own slice, and the installed-plugin
+sheet already edited its two switches in place and is unchanged.
+
+Two consequences ride along. Protocol and surface are exposed on both the
+sheet and the Add form as selects over the registry's four-value
+vocabularies, with an "inherit from base" empty option that sends the new
+clear flags. And the wire's instance entry now carries the authored
+api_key_env and credential header (never a secret: the header value is a
+`$VAR` template by construction) so the form can prefill them.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/web-ui/design-system.md docs/web-ui/decisions.md
+git commit -m "docs(web-ui): a detail sheet is the item's editor"
+```
+
+---
+
+### Task 10: Gates, browser pass, and the pull request
+
+- [ ] **Step 1: Run every gate from the repo root, reading each for failures**
+
+```bash
+make test-web 2>&1 | tail -15
+make test-web-browser 2>&1 | tail -10
+make lint 2>&1 | tail -20
+make vet 2>&1 | tail -5
+make test 2>&1 | tail -20
+```
+
+Expected: all green. `make lint`'s generated-output freshness check passes because Task 1 committed the regenerated files. If `make test` reports one of the known flaky tests (drain-abandon cleanup race, execenv, procgroup, drain-continue), re-run that package once and say which it was.
+
+- [ ] **Step 2: Live check against a throwaway hub**
+
+Follow the WebUI screenshot recipe in memory (`webui-screenshot-recipe.md`) with `XDG_CONFIG_HOME` pointed at a temp dir. In Settings → Providers & credentials: add an instance `work` on base `openai` with base URL `https://gw.example.test/v1`; open its row; confirm the form prefills; change the name to `work2`, the protocol to `openai-responses`, and the API key env to `PORTKEY_KEY`; Save; confirm the sheet stays open titled `work2`, and `cat "$XDG_CONFIG_HOME/evener/providers.toml"` shows `[providers.work2]` with `protocol = "openai-responses"` and `api_key_env = ["PORTKEY_KEY"]` and no `[providers.work]`. Set a key first and confirm it moved (`[work2]` in credentials.toml). Take a desktop and a phone-width screenshot of the sheet for the PR.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --repo prime-radiant-inc/evener --base main --title "Provider sheet is the editor: rename, credential fields, protocol and surface" --body-file - <<'EOF'
+Slice 2 of docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md.
+
+- `evener/instance/edit` gains `newName`, `apiKeyEnv`/`clearApiKeyEnv`, `credentialHeader`/`clearCredentialHeader`, `clearProtocol`, `clearSurface`; an empty var value deletes the var. All additive within v4.
+- The instance entry carries the authored `apiKeyEnv` and `credentialHeader` so the form can prefill.
+- A rename re-keys providers.toml, follows the default pointer, and moves the stored key and OAuth record; refused for implicit instances, invalid names, and taken names.
+- `InstanceDetailSheet` → `InstanceSheet`: a prefilled form with a dirty-gated Save; `EditInstanceDialog` is gone. The Add form gains Protocol and Surface selects.
+- design-system.md §10 now says a detail sheet is the item's editor; decisions.md records why.
+
+Gates: make lint, make vet, make test, make test-web, make test-web-browser. Screenshots attached.
+EOF
+```
+
+Then watch CI and roborev; findings that recur on every push get fixed in code.

--- a/docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md
+++ b/docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md
@@ -29,16 +29,24 @@ skills directories.
 
 ### Daemon: load it
 
-`agent.LoadUserDoc(configRoot string) (ProjectDoc, bool)` reads
-`<configRoot>/AGENTS.md`. Session init calls it with
-`userdirs.DefaultConfigRoot()` (hub-spawned daemons resolve the same root
-from their environment; nothing new is plumbed) and prepends the result to
-`s.projectDocs`, so it renders first inside the existing
+`agent.LoadUserDoc(path string) (ProjectDoc, bool)` reads the file at the
+given path, and `agent.LoadInstructionDocs(env, userDocPath, filenames...)`
+returns a session's whole instruction set: the personal doc first, then the
+repo's own project docs. Session init takes the path from
+`SessionConfig.AgentsDocPath`, falling back to
+`<userdirs.DefaultConfigRoot()>/AGENTS.md`, and stores the result in
+`s.projectDocs`, so the personal doc renders first inside the existing
 `prompts/sections/project-docs.md.tmpl` block, ahead of the repo's own docs.
-Its `Path` is the tilde-collapsed display path `~/.config/evener/AGENTS.md`.
-It applies to every provider profile. It shares `projectDocByteBudget` and
-counts first: the repo docs get whatever is left, and truncation behaves
-exactly as today. A missing or empty file changes nothing.
+The hub hands its own path to every spawned and resumed daemon as
+`--agents-doc`, the way it passes `--plugin-root`, so a per-launch
+`XDG_CONFIG_HOME` override cannot make Settings and sessions disagree
+(roborev finding on PR #979, Jesse's ruling 2026-09-07). Its `Path` is the
+tilde-collapsed display path `~/.config/evener/AGENTS.md`. It applies to
+every provider profile. It has its own byte budget, equal to the project
+docs' 32KB, so a long personal doc can never starve a repo's instructions and
+vice versa (Jesse's ruling, 2026-09-07, revising the shared-budget design);
+each side truncates with its own marker. A missing or empty file changes
+nothing.
 
 ### Hub: read and write it
 

--- a/docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md
+++ b/docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md
@@ -1,0 +1,363 @@
+# Settings: sheet editors and the personal AGENTS.md
+
+Jesse asked for three things in the web UI's settings pane (2026-09-07): a way
+to edit the user's personal AGENTS.md; a rethink of the provider "sidebar
+edit" sheet, which could not rename an instance or edit much of anything;
+and the same fix wherever that pattern is used. Brainstorm decisions, in
+order: the personal file lives at `~/.config/evener/AGENTS.md` and is loaded
+into every session; "plugin sources" means the Marketplaces list, and
+marketplace editing covers rename and re-source; the edit UI keeps
+row-tap-opens-sheet but the sheet becomes the editor; the AGENTS.md write has
+no conflict precondition; protocol and surface are exposed on the provider
+form; a marketplace's git ref stays unexposed.
+
+Paths are relative to the repo root; frontend paths under
+`cmd/evener-hub/frontend/src/`.
+
+## 1. Personal AGENTS.md
+
+### What exists today
+
+Nothing loads a user-level instruction file. `agent.LoadProjectDocs`
+(`agent/project_docs.go`) walks from the git root down to the working
+directory only, picking up the profile's doc filenames
+(`agent/provider/profile.go`: AGENTS.md plus CLAUDE.md, GEMINI.md, or
+`.codex/instructions.md`). Its single caller is `agent/session_init.go`. The
+config root `~/.config/evener` (`envvars/userdirs.ConfigRoot`) already holds
+providers.toml, hub.toml, mcp.json, and the prompts, commands, plugins and
+skills directories.
+
+### Daemon: load it
+
+`agent.LoadUserDoc(configRoot string) (ProjectDoc, bool)` reads
+`<configRoot>/AGENTS.md`. Session init calls it with
+`userdirs.DefaultConfigRoot()` (hub-spawned daemons resolve the same root
+from their environment; nothing new is plumbed) and prepends the result to
+`s.projectDocs`, so it renders first inside the existing
+`prompts/sections/project-docs.md.tmpl` block, ahead of the repo's own docs.
+Its `Path` is the tilde-collapsed display path `~/.config/evener/AGENTS.md`.
+It applies to every provider profile. It shares `projectDocByteBudget` and
+counts first: the repo docs get whatever is left, and truncation behaves
+exactly as today. A missing or empty file changes nothing.
+
+### Hub: read and write it
+
+Two additive methods and one notification (protocol version stays
+`evener-appwire-v4`; catalog entries in `appwire/protocol.go`, generated
+outputs refreshed by `make generate`):
+
+- `evener/settings/agentsDoc/get` — params `EmptyParams`; result
+  `AgentsDocResponse{ path string; exists bool; content string }`. `path` is
+  the absolute file path. A missing file is `exists=false, content=""`, not an
+  error.
+- `evener/settings/agentsDoc/set` — params `AgentsDocSetParams{ content
+  string }`; result `AgentsDocResponse`. Writes `content` as-is (no trimming,
+  no forced trailing newline) with temp-file-and-rename at mode 0o644, the
+  same way `registry.WriteConfigFile` writes providers.toml, creating the
+  config root if needed. No precondition: the last write wins (Jesse's call).
+- `evener/settings/agentsDoc/changed` — broadcast after a successful set,
+  carrying `AgentsDocResponse`, so other clients refresh.
+
+The file path is `filepath.Join(cfg.LaunchConfigRoot, "AGENTS.md")`
+(`hubcore.WebConfig.LaunchConfigRoot` is already the config root). Handlers
+live in a new `cmd/evener-hub/app_rpc_agents_doc.go` beside the keybindings
+and transcript-display handlers.
+
+### Frontend: edit it
+
+- A new settings section in the Agent setup cluster, after "Agents":
+  `{ id: "agents-md", label: "AGENTS.md", cluster: "agents-models" }` in
+  `panes/settings/sections.ts`, dispatched from `Settings.tsx`.
+- `stores/agentsDoc.ts` follows the keybindings store shape: `fetch()`,
+  `save(content)`, `loaded`/`loading`/`error`, and a subscription to the
+  `changed` notification that replaces the loaded content.
+- `panes/settings/sections/agentsDoc.tsx`: a one-line help sentence with the
+  path in `<Code>`, a monospace `Textarea` (`minLines` 16, `autoGrow`), and
+  a footer row with Save (primary, enabled only when the draft differs from
+  the loaded content) and Revert. Save success toasts "Saved AGENTS.md"; a
+  failure shows the error inline. An incoming `changed` notification while
+  the draft is clean replaces the draft; while dirty it leaves the draft and
+  shows a one-line note that the file changed elsewhere, with a "Load
+  current" button.
+
+## 2. Provider instances: the sheet is the editor
+
+### What exists today
+
+`panes/settings/sections/credentials/InstanceDetailSheet.tsx` is an
+inspector: a button stack whose "Edit" opens `EditInstanceDialog`
+(`instanceDialogs.tsx`), which edits Base URL only. `appwire.InstanceEditParams`
+accepts base URL (with `clearBaseUrl`), protocol, surface and vars, with
+"empty means unchanged". It cannot rename, and cannot change `api_key_env`
+or `credential_headers`, both of which only `InstanceCreateParams` accepts.
+`InstanceEntry` does not carry the authored `api_key_env` or
+`credential_headers`.
+
+### Wire changes (additive, `evener-appwire-v4`)
+
+`InstanceEditParams` gains:
+
+| field | meaning |
+|---|---|
+| `newName` | rename; empty means unchanged |
+| `apiKeyEnv` / `clearApiKeyEnv` | set or drop the single authored `api_key_env` entry |
+| `credentialHeader` / `clearCredentialHeader` | set (as `NAME=VALUE`, parsed by the existing `credentialHeaderFrom`) or drop `credential_headers` |
+| `clearProtocol` / `clearSurface` | drop the authored override so the base's value applies again (the clear the existing doc comment ledgers) |
+| `vars` with an empty value | deletes that authored variable (today `Edit` copies the empty string in; a blank var never meant anything, so the change is unambiguous) |
+
+Each set/clear pair follows `baseUrl`/`clearBaseUrl`: never both meaningful
+in one request. `InstanceEntry` gains `apiKeyEnv?: string` (the first
+authored `api_key_env` entry) and `credentialHeader?: string` (the single
+authored header rendered as `NAME=VALUE`). Both are variable names and
+`$VAR` templates by construction (`registry.CheckCredentialHeaderValue`
+refuses a literal), never secret values. They come from the authored layer
+(`c.read()`), which `entryFor` does not read today; `List` reads the layer
+once per call and passes the authored `registry.Provider` alongside each
+instance.
+
+### Hub: Edit
+
+`hubInstancesController.Edit` extends its existing field-by-field apply with
+the new pairs, then handles rename last, all under `c.mu`:
+
+1. Refuse when `params.NewName` is set on an implicit instance
+   (`InvalidParams`: "instance %q comes from the environment and cannot be
+   renamed").
+2. Validate with `registry.ValidInstanceName`; refuse `Conflict` when
+   `c.reg.Get().Instance(newName)` exists (authored or implicit) or
+   `l.Providers[newName]` exists.
+3. Re-key `l.Providers[old]` to `newName`, set `p.ID = newName`, and set
+   `l.Default = newName` when it named the old instance.
+4. `writeLoadable`, then `c.reg.Reload()`; on reload failure restore the
+   pre-edit file and return `InvalidParams` exactly as the current Edit does.
+5. Move the stored key: `Get(old)`, `Set(new)`, `Clear(old)` on
+   `c.auth.creds`. Move the OAuth record: `authopenai.LoadAuth(stateDir,
+   old)`, `SaveAuth(stateDir, new)`, `DeleteAuth(stateDir, old)` when a
+   record exists. Both are best-effort after the config write: a failure
+   here is returned as a plain error naming what was left behind (the
+   config is already renamed, so the instance list stays consistent with
+   the file).
+
+The existing `evener/auth/updated` broadcast follows a rename so other
+clients drop their cached credential state for the old name.
+
+### Frontend
+
+`InstanceDetailSheet` becomes `InstanceSheet` (same file, renamed), a
+`Sheet` with `size="wide"` on desktop and `side="bottom"` on mobile.
+`EditInstanceDialog` and its tests are deleted. `ApiKeyDialog`,
+`CredentialJsonDialog`, `ConnectProviderDialog`, and the OAuth dialogs are
+unchanged. Body, top to bottom:
+
+1. Header row as today: `StatusDot`, "★ default" and "from environment"
+   chips.
+2. The form, prefilled from the `InstanceEntry`:
+   - Name (`Input`). Read-only with a "from environment" note on implicit
+     instances. When dirty, an inline note under the field: "Launch config
+     and past sessions that reference `<old>` keep the old name." No
+     confirm dialog.
+   - Base provider: a read-only meta row (`providerId`); re-basing is not
+     supported by the edit RPC and is not added.
+   - Base URL (`Input`). Emptying a field that had a value sends
+     `clearBaseUrl`, with the existing "Resets the endpoint to the
+     provider's default." note.
+   - Protocol and Surface (`Select` each): options are the registry's four
+     protocols (`openai-chat`, `openai-responses`, `anthropic`, `google`) and
+     four surfaces (`openai`, `anthropic`, `google`, `generic`), plus an
+     empty first option labelled "inherit from base". Choosing "inherit" on a
+     field that had an authored value sends the matching clear flag.
+   - Provider variables: one `Input` per entry of the base provider's `vars`
+     (labelled by env var name, keyed by template name, exactly as the Add
+     form does), prefilled from `instance.vars`; any authored var not in the
+     template renders after them the same way.
+   - API key environment variable (`Input`); emptying a set value sends
+     `clearApiKeyEnv`.
+   - Credential header (`Input`, placeholder `Authorization=Bearer $VAR`);
+     emptying a set value sends `clearCredentialHeader`. The client refuses
+     a value without `$` before any RPC, as the Add form does.
+3. Sheet footer: Save (primary), enabled only when some field differs from
+   the loaded instance and `writesRefused` is false. Save sends only the
+   changed fields (existing "empty means unchanged" rule) and, on a rename,
+   the section re-selects the instance under its new name so the sheet stays
+   open on it. Success toasts "Saved <name>"; failure renders inline with a
+   "Save failed" toast. Closing the sheet with unsaved edits discards them
+   silently, matching the old editors.
+4. Below the form, unchanged from today: the credential layers block, Test
+   credentials, Set/Replace key, Set/Replace credential JSON, Sign in… /
+   Refresh OAuth, ★ make default.
+5. Danger zone, unchanged: Clear stored key, Clear, Remove, all
+   ConfirmDialog-gated.
+
+`AddInstanceDialog` gains the same Protocol and Surface selects
+(`InstanceCreateParams` already accepts both), placed after Base URL.
+
+## 3. Marketplaces: the sheet is the editor
+
+### What exists today
+
+`marketplacesPlugins/MarketplacesSection.tsx` renders rows with inline
+Refresh and Remove buttons and an inline add form. There is no edit RPC.
+`internal/plugins` keys `known_marketplaces.json` by name; a git-backed
+marketplace is cloned to `<store>/marketplaces/<name>` (its
+`InstallLocation`); `installed_plugins.json` is keyed `<plugin>@<marketplace>`
+and each entry's `InstallPath` sits under `<store>/cache/<marketplace>/<plugin>/<sha>`.
+Launch config names plugins by bare plugin name, so a marketplace rename
+does not orphan it.
+
+### Wire (additive)
+
+`evener/marketplace/edit` — params `MarketplaceEditParams{ name string;
+newName?: string; source?: MarketplaceSourceInput }`; result
+`MarketplaceListResponse`. Empty `newName` and absent `source` mean
+unchanged. Catalogued in `appwire/protocol.go`; the handler in `app_rpc.go`
+mirrors `MarketplaceAdd` and, on success, broadcasts both
+`evener/marketplace/updated` and `evener/plugin/updated` (installed plugin
+keys can change).
+
+### Manager: `EditMarketplace`
+
+`(*plugins.Manager).EditMarketplace(ctx, name, newName string, src *Source)
+(MarketplaceRef, error)`, under the store lock, in this order so the network
+step precedes anything that moves on disk:
+
+1. Load marketplaces; unknown `name` is `ErrMarketplaceNotFound`. A no-op
+   call (same name, nil or equal source) returns the current ref.
+2. If `src` is set and differs: fetch it into the shared staging dir with
+   `fetchMarketplaceContainer` and `ParseCatalog` it, exactly as
+   `AddMarketplace` does. Any failure here removes staging and returns
+   before anything else changes.
+3. If renaming: `validNameComponent`; a new `plugins.ErrMarketplaceExists`
+   sentinel when `newName` is already registered, which the hub controller
+   maps to `appwire.Conflict` (and `ErrMarketplaceNotFound` to
+   `appwire.InvalidParams`). Rename `<marketplaces>/<old>` to
+   `<marketplaces>/<new>` when the current source is not a directory; rename
+   `<cache>/<old>` to `<cache>/<new>` when it exists. In the installed
+   registry, re-key every `<plugin>@<old>` to `<plugin>@<new>` and rewrite
+   each entry's `InstallPath` prefix from `<cache>/<old>/` to
+   `<cache>/<new>/`.
+4. Apply the source: a git-backed source swaps the staged clone into the
+   (possibly renamed) install location with `swapInClone`; a directory
+   source sets `InstallLocation` to the path and removes any old clone
+   directory. Update `ref.Source` and `ref.LastUpdated`.
+5. Save the installed registry, then the marketplaces file, both through
+   `atomicWriteFile`.
+
+A failure after step 3 renames the directories back before returning, and
+never saves either file. A failure in step 5 after the registry saved but
+before the marketplaces file saved is reported as an error naming the
+inconsistency; `evener-doctor`'s plugin check already reports registry
+entries that name no marketplace.
+
+The frontend `extensionsStore` gains `editMarketplace(params)` and drops
+the browse cache entry for the old name after a rename.
+
+### Frontend
+
+Marketplace rows become single tappable targets in the collection-page
+idiom: name, a kind chip, the source meta line, a trailing chevron, one
+full-width button. The add form is unchanged. A new
+`marketplacesPlugins/MarketplaceSheet.tsx` (`size="wide"` desktop, bottom
+sheet mobile; `marketplacesPlugins/index.tsx` owns `selectedMarketplace` the
+same way it owns `selectedPlugin`, and switching segments clears both):
+
+1. The form, prefilled from the `MarketplaceEntry`: Name (`Input`); Source
+   kind (the same `RadioGroup` and three options the add form uses: Git URL,
+   owner/repo, Local path; a `git-subdir` entry renders its URL under Git
+   URL and is saved back unchanged unless the user edits it); the matching
+   field for the kind (`Input` for URL and repo, `PathField` with the
+   directory picker for a local path).
+2. Meta table: install location and last updated, in mono.
+3. Footer: Save, enabled only when dirty. When the source is dirty an
+   inline note reads "Saving re-fetches the marketplace. Installed plugins
+   are unaffected." Success toasts "Saved <name>"; on rename the page
+   re-selects the new name so the sheet stays open.
+4. Actions: Refresh (quiet), disabled while its RPC is in flight, keeping
+   the existing expanded-node re-browse behavior.
+5. Danger zone: Remove, ConfirmDialog-gated with the existing copy.
+
+The sheet reads its entry from the store and closes when it vanishes.
+
+## 4. Installed plugins and the design-system rule
+
+`PluginDetailSheet` already edits its two binary states in place and opens
+no editor dialog. It gets no functional change.
+
+`docs/web-ui/design-system.md` §10's "Rows are single tappable targets;
+actions live in a detail sheet" paragraph is rewritten: a detail sheet is the
+item's **editor**, not an inspector. Editable facts render as form fields in
+place, prefilled, with a dirty-gated Save in the sheet footer; renaming is
+editing the name field. A separate dialog is reserved for write-only secret
+entry (API key, credential JSON) and multi-step flows (OAuth). Binary state
+stays a `Switch` row that applies immediately; the destructive action stays
+ConfirmDialog-gated. `docs/web-ui/decisions.md` gets a 2026-09-07 entry
+recording this and the reason (the provider sheet's "Edit" bounced to a
+one-field dialog and could not rename).
+
+## 5. Testing and gates
+
+Test-driven throughout: each behavior below gets its failing test first.
+
+Go:
+
+- `agent/project_docs_test.go`: user doc prepended before repo docs; missing
+  file is a no-op; the shared budget truncates the repo doc, not the user
+  doc, when the user doc fits.
+- `cmd/evener-hub/app_rpc_agents_doc_test.go`: get on a missing file; set
+  creates the file (and the config root) at 0o644 and returns the new
+  state; set broadcasts `changed`; a write failure returns an error and
+  leaves the previous file intact.
+- `cmd/evener-hub/app_instances_test.go`: rename re-keys providers.toml,
+  repoints the default, moves the stored key and the OAuth record; rename
+  of an implicit instance is refused; rename onto a taken name is
+  `Conflict`; `apiKeyEnv`/`credentialHeader` set and clear; `clearProtocol`
+  and `clearSurface`; the entry carries the authored `apiKeyEnv` and
+  `credentialHeader`; a credential header without `$` is refused.
+- `internal/plugins/marketplaces_test.go`: edit rename moves both
+  directories and re-keys the registry and install paths; re-source swaps
+  the staged clone and leaves installed plugins untouched; rename plus
+  re-source; a fetch failure changes nothing on disk; a failure after the
+  directory rename restores it; conflict; not found; no-op returns the
+  current ref.
+- `appwire`'s catalog test and `make generate` freshness
+  (`types.gen.ts`, `docs/appwire-protocol.md`).
+
+Frontend (vitest at the AppWire boundary with `FakeClient`):
+
+- `stores/agentsDoc.test.ts` and `sections/agentsDoc.test.tsx`: load, edit,
+  Save enabled only when dirty, Save sends the draft, Revert, `changed`
+  while clean replaces, `changed` while dirty shows the note and Load
+  current.
+- `credentials/InstanceSheet.test.tsx`: prefill of every field; Save
+  disabled until dirty and while `writesRefused`; the request carries only
+  changed fields; each clear flag; the rename note; read-only name on an
+  implicit instance; inline error on a failed save; re-select after rename;
+  every existing sheet behavior test moves here.
+- `credentials/instanceDialogs.test.tsx`: Add form protocol and surface.
+- `marketplacesPlugins/MarketplaceSheet.test.tsx` and
+  `MarketplacesSection.test.tsx`: rows are buttons that select; prefill;
+  kind switch; Save payload for rename, re-source, and both; the re-fetch
+  note; Refresh; Remove confirm; close-on-vanish; segment switch closes it.
+- `docs/web-ui` claims about the sheet rule are covered by reading, not
+  tests.
+
+Gates before the PR: `npx biome check --write` on touched files, `make
+test-web`, `make test-web-browser` on this Mac, `make lint`, `make vet`,
+`make test`, plus a browser pass over the three sheets at desktop and
+phone widths against a throwaway hub (the WebUI screenshot recipe), with
+screenshots attached to the PR.
+
+## 6. Delivery
+
+Three independently mergeable slices, each its own PR against `main`
+(stacked PRs get no CI here), in this order: the personal AGENTS.md (§1);
+the provider sheet with its wire changes, the design-system rewrite and the
+decisions entry (§2, §4); the marketplace sheet and edit RPC (§3). Each
+slice carries its own tests and gate run.
+
+## 7. Out of scope
+
+Re-basing an instance onto a different provider; exposing a marketplace's
+git ref or sha; a `git-subdir` option in the source picker; conflict
+detection on AGENTS.md saves; any change to the installed-plugin sheet;
+backward compatibility shims (the wire changes are additive within v4, so
+none are needed).

--- a/docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md
+++ b/docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md
@@ -64,7 +64,8 @@ outputs refreshed by `make generate`):
   same way `registry.WriteConfigFile` writes providers.toml, except that a
   symlinked AGENTS.md is followed so a dotfiles-managed copy stays the source
   of truth (providers.toml gets the same fix in its own PR), creating the
-  config root if needed. No precondition: the last write wins (Jesse's call).
+  target's directory if needed. No precondition: the last write wins
+  (Jesse's call).
 - `evener/settings/agentsDoc/changed` — broadcast after a successful set,
   carrying `AgentsDocResponse`, so other clients refresh.
 

--- a/docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md
+++ b/docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md
@@ -53,7 +53,9 @@ outputs refreshed by `make generate`):
 - `evener/settings/agentsDoc/set` — params `AgentsDocSetParams{ content
   string }`; result `AgentsDocResponse`. Writes `content` as-is (no trimming,
   no forced trailing newline) with temp-file-and-rename at mode 0o644, the
-  same way `registry.WriteConfigFile` writes providers.toml, creating the
+  same way `registry.WriteConfigFile` writes providers.toml, except that a
+  symlinked AGENTS.md is followed so a dotfiles-managed copy stays the source
+  of truth (providers.toml gets the same fix in its own PR), creating the
   config root if needed. No precondition: the last write wins (Jesse's call).
 - `evener/settings/agentsDoc/changed` — broadcast after a successful set,
   carrying `AgentsDocResponse`, so other clients refresh.


### PR DESCRIPTION
Slice 1 of docs/superpowers/specs/2026-09-07-settings-sheet-editors-and-agents-doc-design.md.

- The daemon loads a personal `AGENTS.md` ahead of every session's project docs. The hub hands each spawned and resumed daemon its own concrete path (`--agents-doc`, mirroring `--plugin-root`), stable delegates inherit the parent's path, and an unresolvable config root loads nothing rather than a relative file. The personal doc has its own 32KB budget, separate from the repo docs', so neither can starve the other.
- New `evener/settings/agentsDoc/{get,set}` methods and a `changed` broadcast (additive, v4). `set` writes through a symlinked `AGENTS.md` (a dotfiles-managed copy stays the source of truth), via an exclusive temp file with an explicit 0644 mode.
- New Settings → AGENTS.md section: monospace editor, dirty-gated Save, Revert, a "changed on disk" notice with Load current, and a reload-failure alert with a Reload button. The store refetches on every reconnect and fences fetches, saves, and broadcasts by request and client generation, so a stale response can never overwrite a newer document; a save superseded by another client's write says so instead of claiming a clean save.

## Review history

The three items the first review parked were ruled on by Jesse and landed here: the hub-to-session path plumbing (roborev), symlink-following saves (final review), and separate doc budgets (final review). Every subsequent roborev finding through head `0a1fa95` is fixed in code on this branch; each fix wave had its own scoped re-review.

Known, deliberately left: in the narrow case of a socket drop and recovery inside one save round-trip, the editor shows a conservative "changed on disk" note although nothing else wrote; one click on Load current clears it. Follow-ups queued as separate PRs: the same symlink and temp-file hardening for providers.toml and the other config-root writers, and surfacing the loader's unread truncation flag.

## CI note

`web`, `lint-golangci`, and the aggregate `static` lane fail on this PR because they fail on `main` itself since the `perf(w2-*)` batch (unsorted imports in five frontend files; camelCase JSON tags in `cmd/evener-tui/hub_notifications.go`). This branch is clean on both locally; a separate PR fixes main.

## Gates

`make lint`, `make vet`, `make test` (which runs `make test-web`), `make test-web-browser` — green on the branch at each wave's head.

## Live check (first head)

Against a throwaway hub with `XDG_CONFIG_HOME` in a temp dir and fake429 as the only provider: Settings → AGENTS.md rendered the config-root path, accepted typed text, and Save toasted; the file on disk matched the typed bytes exactly (same sha256), mode 0644, no leftover temp file. Reloading re-read the saved content. Desktop (1280x800) and phone (375x812) both render the section as a single column. A dormant session in a temp repo with its own `AGENTS.md` composed the two instruction blocks in order, personal first:

```
----- BEGIN <temp XDG_CONFIG_HOME>/evener/AGENTS.md -----
...
----- END <temp XDG_CONFIG_HOME>/evener/AGENTS.md -----

----- BEGIN AGENTS.md -----
...
----- END AGENTS.md -----
```

No screenshot images are attached (`gh` cannot upload an image into a PR body). Cosmetic: the config-root path renders in a non-wrapping `<Code>` element, so a pathologically long path gives the page a horizontal scrollbar at phone width; a real `~/.config/evener/AGENTS.md` does not.
