### PR TITLE
test(hub): pin that the hub's default roots stay inside the test env

### DIFF
--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11054,9 +11054,12 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 	// the dispatch loop further down calls every expected method with empty
 	// params, including the credential-mutating evener/auth/* handlers
 	// (apiKey/set, logout, apiKey/clear). A nil CredsStore makes
-	// newHubAuthControllerWithStore fall back to the real on-disk default
-	// (~/.config/evener/credentials.toml via the ambient HOME/XDG env) -
-	// this test must never read or write a developer's actual store.
+	// newHubAuthControllerWithStore fall back to the on-disk default under
+	// the ambient HOME/XDG env. TestMain redirects that env into a throwaway
+	// root and TestHubDefaultRootsStayInsideTheTestEnvironment pins the
+	// redirect, so an unset root cannot reach a developer's actual store;
+	// per-test temp dirs keep this test's writes out of the root the whole
+	// package shares as well.
 	credsStore, loadErr := credentials.LoadStore(filepath.Join(t.TempDir(), "credentials.toml"))
 	if loadErr != nil {
 		t.Fatalf("LoadStore: %v", loadErr)

--- a/cmd/evener-hub/testmain_test.go
+++ b/cmd/evener-hub/testmain_test.go
@@ -176,19 +176,19 @@ func TestGoSubprocessesCacheOutsideTheTestRoot(t *testing.T) {
 	}
 }
 
-// defaultRootsOutsideTestEnv lists every filesystem root the hub falls back to
-// when a WebConfig field is left unset (the launch config root, the hub state
-// root, the plugin store root, the MCP config path), every path runMain opens
-// when a flag is unset (the config file, the state glob, the past-index DB,
-// the rendezvous run dir), plus the HOME and XDG bases they derive from, that
-// resolves outside testEnvRoot. Empty means the throwaway env contains them
-// all.
-func defaultRootsOutsideTestEnv() []string {
+type namedPath struct{ name, path string }
+
+// hubDefaultRoots lists every filesystem root the hub falls back to when a
+// WebConfig field is left unset (the launch config root, the hub state root,
+// the plugin store root, the MCP config path), every path runMain opens when a
+// flag is unset (the config file, the state glob, the past-index DB, the
+// rendezvous run dir), plus the HOME and XDG bases they derive from.
+func hubDefaultRoots() []namedPath {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "(unresolved: " + err.Error() + ")"
 	}
-	roots := []struct{ name, path string }{
+	return []namedPath{
 		{"os.UserHomeDir", home},
 		{envvars.XDGConfigHome.Name, envvars.XDGConfigHome.Getenv()},
 		{envvars.XDGStateHome.Name, envvars.XDGStateHome.Getenv()},
@@ -203,13 +203,33 @@ func defaultRootsOutsideTestEnv() []string {
 		{"DefaultPastIndexDBPath", DefaultPastIndexDBPath()},
 		{"rendezvous.DefaultDir", rendezvous.DefaultDir()},
 	}
+}
+
+// rootsOutside reports every entry of roots that does not lie inside root. An
+// entry that is a glob is judged on its own path and on each current match,
+// so a symlinked project directory under the state root cannot point outside.
+func rootsOutside(root string, roots []namedPath) []string {
 	var escaped []string
-	for _, root := range roots {
-		if !containedIn(testEnvRoot, root.path) {
-			escaped = append(escaped, fmt.Sprintf("%s = %q", root.name, root.path))
+	for _, r := range roots {
+		paths := []string{r.path}
+		if strings.ContainsAny(r.path, "*?[") {
+			if matches, err := filepath.Glob(r.path); err == nil {
+				paths = append(paths, matches...)
+			}
+		}
+		for _, path := range paths {
+			if !containedIn(root, path) {
+				escaped = append(escaped, fmt.Sprintf("%s = %q", r.name, path))
+			}
 		}
 	}
 	return escaped
+}
+
+// defaultRootsOutsideTestEnv is rootsOutside over the hub's defaults and the
+// throwaway root TestMain built. Empty means the env contains them all.
+func defaultRootsOutsideTestEnv() []string {
+	return rootsOutside(testEnvRoot, hubDefaultRoots())
 }
 
 // canonicalizeExisting resolves symlinks through the deepest ancestor of path
@@ -324,6 +344,34 @@ func TestContainedInResolvesSymlinksAndTraversal(t *testing.T) {
 		if got := containedIn(tc.root, tc.path); got != tc.want {
 			t.Errorf("%s: containedIn(%q, %q) = %v, want %v", tc.name, tc.root, tc.path, got, tc.want)
 		}
+	}
+}
+
+// TestRootsOutsideExpandsGlobs pins that a glob among the default roots is
+// judged by what it matches, not by its literal prefix: a symlinked project
+// directory planted under the state root and pointing outside it is reported,
+// and a pattern with no matches is judged on its own path.
+func TestRootsOutsideExpandsGlobs(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	projects := filepath.Join(root, "state", "evener", "projects")
+	if err := os.MkdirAll(projects, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	escape := filepath.Join(projects, "escape")
+	if err := os.Symlink(outside, escape); err != nil {
+		t.Fatal(err)
+	}
+	roots := []namedPath{{"state glob", filepath.Join(projects, "*")}}
+	got := rootsOutside(root, roots)
+	if len(got) != 1 || !strings.Contains(got[0], escape) {
+		t.Fatalf("rootsOutside with an escaping match = %q, want exactly that match reported", got)
+	}
+	if err := os.Remove(escape); err != nil {
+		t.Fatal(err)
+	}
+	if got := rootsOutside(root, roots); len(got) != 0 {
+		t.Fatalf("rootsOutside with no matches = %q, want none", got)
 	}
 }
 

--- a/cmd/evener-hub/testmain_test.go
+++ b/cmd/evener-hub/testmain_test.go
@@ -10,7 +10,9 @@ import (
 
 	"primeradiant.com/evener/cmd/evener-hub/internal/fspaths"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/cmdutil"
 	"primeradiant.com/evener/envvars"
+	"primeradiant.com/evener/internal/plugins"
 	"primeradiant.com/evener/rendezvous"
 )
 
@@ -157,6 +159,44 @@ func TestGoSubprocessesCacheOutsideTheTestRoot(t *testing.T) {
 		}
 		if strings.HasPrefix(got, testEnvRoot) {
 			t.Fatalf("go env %s = %q, inside the throwaway test root %q; the cache it writes there outlives the run", key, got, testEnvRoot)
+		}
+	}
+}
+
+// TestHubDefaultRootsStayInsideTheTestEnvironment pins the other half of
+// TestMain's isolation: every filesystem root the hub falls back to when a
+// WebConfig field is left unset (the launch config root, the hub state root,
+// the plugin store root, the MCP config path) and the HOME and XDG bases they
+// derive from resolve inside the throwaway root, never in the developer's own
+// home.
+//
+// TestHubRPCRegistersExpectedHandlerSet is why this has to be pinned. It
+// dispatches every registered method with empty params, and for a handler
+// where an empty request is a valid write (evener/launch/setLayer today; any
+// "set this file's content" handler tomorrow) the write happens for real,
+// against whichever root the fixture left unset. The HOME/XDG redirect above
+// is what keeps that write out of ~/.config/evener; this is the test that
+// notices if the redirect stops covering a root, or a resolver stops deriving
+// from it.
+func TestHubDefaultRootsStayInsideTheTestEnvironment(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir: %v", err)
+	}
+	roots := []struct{ name, path string }{
+		{"os.UserHomeDir", home},
+		{envvars.XDGConfigHome.Name, envvars.XDGConfigHome.Getenv()},
+		{envvars.XDGStateHome.Name, envvars.XDGStateHome.Getenv()},
+		{envvars.XDGCacheHome.Name, envvars.XDGCacheHome.Getenv()},
+		{"hubLaunchConfigRoot with LaunchConfigRoot unset", hubLaunchConfigRoot(hubcore.WebConfig{})},
+		{"cmdutil.DefaultStateRoot", cmdutil.DefaultStateRoot()},
+		{"plugins.DefaultRoot", plugins.DefaultRoot()},
+		{"defaultMCPConfigPath", defaultMCPConfigPath()},
+	}
+	inside := testEnvRoot + string(os.PathSeparator)
+	for _, root := range roots {
+		if !strings.HasPrefix(root.path, inside) {
+			t.Errorf("%s = %q, outside the throwaway test root %q; a handler dispatched with empty params would read or write there for real", root.name, root.path, testEnvRoot)
 		}
 	}
 }

--- a/cmd/evener-hub/testmain_test.go
+++ b/cmd/evener-hub/testmain_test.go
@@ -207,17 +207,22 @@ func defaultRootsOutsideTestEnv() []string {
 
 // canonicalizeExisting resolves symlinks through the deepest ancestor of path
 // that exists and rejoins the rest, so a default nothing has created yet still
-// compares against the real location of the tree it would land in.
-func canonicalizeExisting(path string) string {
+// compares against the real location of the tree it would land in. It fails
+// closed on a symlink it cannot resolve: a dangling link is where a write
+// would create its target, and that target may be anywhere.
+func canonicalizeExisting(path string) (string, bool) {
 	path = filepath.Clean(path)
 	var rest []string
 	for {
 		if resolved, err := filepath.EvalSymlinks(path); err == nil {
-			return filepath.Join(append([]string{resolved}, rest...)...)
+			return filepath.Join(append([]string{resolved}, rest...)...), true
+		}
+		if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return "", false
 		}
 		parent := filepath.Dir(path)
 		if parent == path {
-			return filepath.Join(append([]string{path}, rest...)...)
+			return filepath.Join(append([]string{path}, rest...)...), true
 		}
 		rest = append([]string{filepath.Base(path)}, rest...)
 		path = parent
@@ -227,12 +232,20 @@ func canonicalizeExisting(path string) string {
 // containedIn reports whether path lies strictly inside root once both are
 // resolved through canonicalizeExisting: a temp root reached through a symlink
 // (macOS /var is /private/var) compares equal to itself, and a link planted
-// under the root cannot point a default outside it.
+// under the root, dangling or not, cannot point a default outside it.
 func containedIn(root, path string) bool {
 	if !filepath.IsAbs(path) {
 		return false
 	}
-	rel, err := filepath.Rel(canonicalizeExisting(root), canonicalizeExisting(path))
+	realRoot, ok := canonicalizeExisting(root)
+	if !ok {
+		return false
+	}
+	realPath, ok := canonicalizeExisting(path)
+	if !ok {
+		return false
+	}
+	rel, err := filepath.Rel(realRoot, realPath)
 	if err != nil {
 		return false
 	}
@@ -280,6 +293,10 @@ func TestContainedInResolvesSymlinksAndTraversal(t *testing.T) {
 	if err := os.Symlink(outside, escape); err != nil {
 		t.Fatal(err)
 	}
+	dangling := filepath.Join(realRoot, "dangling")
+	if err := os.Symlink(filepath.Join(outside, "not-yet-created"), dangling); err != nil {
+		t.Fatal(err)
+	}
 	sep := string(os.PathSeparator)
 	cases := []struct {
 		name, root, path string
@@ -289,6 +306,7 @@ func TestContainedInResolvesSymlinksAndTraversal(t *testing.T) {
 		{"root reached through a symlink", link, filepath.Join(realRoot, "home"), true},
 		{"path reached through a symlink", realRoot, filepath.Join(link, "home"), true},
 		{"symlink planted under the root", realRoot, filepath.Join(escape, "AGENTS.md"), false},
+		{"dangling symlink planted under the root", realRoot, filepath.Join(dangling, "AGENTS.md"), false},
 		{"dot-dot traversal", realRoot, realRoot + sep + ".." + sep + "outside" + sep + "x", false},
 		{"the root itself", realRoot, realRoot, false},
 		{"sibling sharing the root as a prefix", realRoot, realRoot + "-sibling", false},

--- a/cmd/evener-hub/testmain_test.go
+++ b/cmd/evener-hub/testmain_test.go
@@ -178,9 +178,11 @@ func TestGoSubprocessesCacheOutsideTheTestRoot(t *testing.T) {
 
 // defaultRootsOutsideTestEnv lists every filesystem root the hub falls back to
 // when a WebConfig field is left unset (the launch config root, the hub state
-// root, the plugin store root, the MCP config path), plus the HOME and XDG
-// bases they derive from, that resolves outside testEnvRoot. Empty means the
-// throwaway env contains them all.
+// root, the plugin store root, the MCP config path), every path runMain opens
+// when a flag is unset (the config file, the state glob, the past-index DB,
+// the rendezvous run dir), plus the HOME and XDG bases they derive from, that
+// resolves outside testEnvRoot. Empty means the throwaway env contains them
+// all.
 func defaultRootsOutsideTestEnv() []string {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -195,6 +197,11 @@ func defaultRootsOutsideTestEnv() []string {
 		{"cmdutil.DefaultStateRoot", cmdutil.DefaultStateRoot()},
 		{"plugins.DefaultRoot", plugins.DefaultRoot()},
 		{"defaultMCPConfigPath", defaultMCPConfigPath()},
+		{"DefaultHubStateRoot", DefaultHubStateRoot()},
+		{"DefaultConfigPath", DefaultConfigPath()},
+		{"DefaultStateGlob", DefaultStateGlob()},
+		{"DefaultPastIndexDBPath", DefaultPastIndexDBPath()},
+		{"rendezvous.DefaultDir", rendezvous.DefaultDir()},
 	}
 	var escaped []string
 	for _, root := range roots {

--- a/cmd/evener-hub/testmain_test.go
+++ b/cmd/evener-hub/testmain_test.go
@@ -104,6 +104,7 @@ func TestMain(m *testing.M) {
 	}
 
 	_ = os.Setenv("HOME", filepath.Join(root, "home"))
+	_ = os.Setenv("USERPROFILE", filepath.Join(root, "home")) // what os.UserHomeDir reads on Windows
 	_ = os.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
 	_ = os.Setenv("XDG_STATE_HOME", filepath.Join(root, "state"))
 	_ = os.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
@@ -119,6 +120,18 @@ func TestMain(m *testing.M) {
 	// TestHostEvenerEnvNeverReachesTheTestEnvironment is the guard.
 	for _, v := range productEvenerEnvVars() {
 		_ = os.Unsetenv(v.Name)
+	}
+	// Refuse to start when a default root still resolves outside the throwaway
+	// env: every test from here on would otherwise read and write the
+	// developer's own ~/.config/evener and ~/.local/state/evener, and a failing
+	// guard test cannot stop the tests that run beside it.
+	// TestHubDefaultRootsStayInsideTheTestEnvironment re-checks this mid-run.
+	if escaped := defaultRootsOutsideTestEnv(); len(escaped) > 0 {
+		fmt.Fprintf(os.Stderr, "evener-hub test env: default roots resolve outside %s:\n  %s\n", root, strings.Join(escaped, "\n  "))
+		if !inherited {
+			_ = os.RemoveAll(root)
+		}
+		os.Exit(1)
 	}
 
 	code := m.Run()
@@ -163,25 +176,15 @@ func TestGoSubprocessesCacheOutsideTheTestRoot(t *testing.T) {
 	}
 }
 
-// TestHubDefaultRootsStayInsideTheTestEnvironment pins the other half of
-// TestMain's isolation: every filesystem root the hub falls back to when a
-// WebConfig field is left unset (the launch config root, the hub state root,
-// the plugin store root, the MCP config path) and the HOME and XDG bases they
-// derive from resolve inside the throwaway root, never in the developer's own
-// home.
-//
-// TestHubRPCRegistersExpectedHandlerSet is why this has to be pinned. It
-// dispatches every registered method with empty params, and for a handler
-// where an empty request is a valid write (evener/launch/setLayer today; any
-// "set this file's content" handler tomorrow) the write happens for real,
-// against whichever root the fixture left unset. The HOME/XDG redirect above
-// is what keeps that write out of ~/.config/evener; this is the test that
-// notices if the redirect stops covering a root, or a resolver stops deriving
-// from it.
-func TestHubDefaultRootsStayInsideTheTestEnvironment(t *testing.T) {
+// defaultRootsOutsideTestEnv lists every filesystem root the hub falls back to
+// when a WebConfig field is left unset (the launch config root, the hub state
+// root, the plugin store root, the MCP config path), plus the HOME and XDG
+// bases they derive from, that resolves outside testEnvRoot. Empty means the
+// throwaway env contains them all.
+func defaultRootsOutsideTestEnv() []string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		t.Fatalf("os.UserHomeDir: %v", err)
+		home = "(unresolved: " + err.Error() + ")"
 	}
 	roots := []struct{ name, path string }{
 		{"os.UserHomeDir", home},
@@ -194,10 +197,31 @@ func TestHubDefaultRootsStayInsideTheTestEnvironment(t *testing.T) {
 		{"defaultMCPConfigPath", defaultMCPConfigPath()},
 	}
 	inside := testEnvRoot + string(os.PathSeparator)
+	var escaped []string
 	for _, root := range roots {
 		if !strings.HasPrefix(root.path, inside) {
-			t.Errorf("%s = %q, outside the throwaway test root %q; a handler dispatched with empty params would read or write there for real", root.name, root.path, testEnvRoot)
+			escaped = append(escaped, fmt.Sprintf("%s = %q", root.name, root.path))
 		}
+	}
+	return escaped
+}
+
+// TestHubDefaultRootsStayInsideTheTestEnvironment pins the other half of
+// TestMain's isolation: the hub's default roots resolve inside the throwaway
+// root, never in the developer's own home, for the whole run and not only at
+// startup. TestMain refuses to start when defaultRootsOutsideTestEnv reports
+// an escape; this catches one that opens mid-run, such as a test that swaps
+// configUserHomeDir or the XDG env without restoring it.
+//
+// TestHubRPCRegistersExpectedHandlerSet is why this has to be pinned. It
+// dispatches every registered method with empty params, and for a handler
+// where an empty request is a valid write (evener/launch/setLayer today; any
+// "set this file's content" handler tomorrow) the write happens for real,
+// against whichever root the fixture left unset. The HOME/XDG redirect in
+// TestMain is what keeps that write out of ~/.config/evener.
+func TestHubDefaultRootsStayInsideTheTestEnvironment(t *testing.T) {
+	if escaped := defaultRootsOutsideTestEnv(); len(escaped) > 0 {
+		t.Fatalf("default roots resolve outside the throwaway test root %q; a handler dispatched with empty params would read or write there for real:\n  %s", testEnvRoot, strings.Join(escaped, "\n  "))
 	}
 }
 

--- a/cmd/evener-hub/testmain_test.go
+++ b/cmd/evener-hub/testmain_test.go
@@ -196,14 +196,47 @@ func defaultRootsOutsideTestEnv() []string {
 		{"plugins.DefaultRoot", plugins.DefaultRoot()},
 		{"defaultMCPConfigPath", defaultMCPConfigPath()},
 	}
-	inside := testEnvRoot + string(os.PathSeparator)
 	var escaped []string
 	for _, root := range roots {
-		if !strings.HasPrefix(root.path, inside) {
+		if !containedIn(testEnvRoot, root.path) {
 			escaped = append(escaped, fmt.Sprintf("%s = %q", root.name, root.path))
 		}
 	}
 	return escaped
+}
+
+// canonicalizeExisting resolves symlinks through the deepest ancestor of path
+// that exists and rejoins the rest, so a default nothing has created yet still
+// compares against the real location of the tree it would land in.
+func canonicalizeExisting(path string) string {
+	path = filepath.Clean(path)
+	var rest []string
+	for {
+		if resolved, err := filepath.EvalSymlinks(path); err == nil {
+			return filepath.Join(append([]string{resolved}, rest...)...)
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return filepath.Join(append([]string{path}, rest...)...)
+		}
+		rest = append([]string{filepath.Base(path)}, rest...)
+		path = parent
+	}
+}
+
+// containedIn reports whether path lies strictly inside root once both are
+// resolved through canonicalizeExisting: a temp root reached through a symlink
+// (macOS /var is /private/var) compares equal to itself, and a link planted
+// under the root cannot point a default outside it.
+func containedIn(root, path string) bool {
+	if !filepath.IsAbs(path) {
+		return false
+	}
+	rel, err := filepath.Rel(canonicalizeExisting(root), canonicalizeExisting(path))
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
 }
 
 // TestHubDefaultRootsStayInsideTheTestEnvironment pins the other half of
@@ -222,6 +255,50 @@ func defaultRootsOutsideTestEnv() []string {
 func TestHubDefaultRootsStayInsideTheTestEnvironment(t *testing.T) {
 	if escaped := defaultRootsOutsideTestEnv(); len(escaped) > 0 {
 		t.Fatalf("default roots resolve outside the throwaway test root %q; a handler dispatched with empty params would read or write there for real:\n  %s", testEnvRoot, strings.Join(escaped, "\n  "))
+	}
+}
+
+// TestContainedInResolvesSymlinksAndTraversal pins the containment test the
+// guards above rely on: it must see through a symlinked root (a macOS temp
+// root lives under /var, which is /private/var), refuse a link planted under
+// the root that points outside it, refuse dot-dot traversal, and still accept
+// a default nothing has created yet.
+func TestContainedInResolvesSymlinksAndTraversal(t *testing.T) {
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	outside := filepath.Join(base, "outside")
+	for _, dir := range []string{realRoot, outside} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := filepath.Join(base, "link")
+	if err := os.Symlink(realRoot, link); err != nil {
+		t.Fatal(err)
+	}
+	escape := filepath.Join(realRoot, "escape")
+	if err := os.Symlink(outside, escape); err != nil {
+		t.Fatal(err)
+	}
+	sep := string(os.PathSeparator)
+	cases := []struct {
+		name, root, path string
+		want             bool
+	}{
+		{"descendant nothing has created yet", realRoot, filepath.Join(realRoot, "config", "evener", "AGENTS.md"), true},
+		{"root reached through a symlink", link, filepath.Join(realRoot, "home"), true},
+		{"path reached through a symlink", realRoot, filepath.Join(link, "home"), true},
+		{"symlink planted under the root", realRoot, filepath.Join(escape, "AGENTS.md"), false},
+		{"dot-dot traversal", realRoot, realRoot + sep + ".." + sep + "outside" + sep + "x", false},
+		{"the root itself", realRoot, realRoot, false},
+		{"sibling sharing the root as a prefix", realRoot, realRoot + "-sibling", false},
+		{"relative path", realRoot, "config" + sep + "evener", false},
+		{"empty path", realRoot, "", false},
+	}
+	for _, tc := range cases {
+		if got := containedIn(tc.root, tc.path); got != tc.want {
+			t.Errorf("%s: containedIn(%q, %q) = %v, want %v", tc.name, tc.root, tc.path, got, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Mechanism

`TestHubRPCRegistersExpectedHandlerSet` dispatches every registered method with empty params. For a handler where an empty request is a valid write (`evener/launch/setLayer` today; the `evener/settings/agentsDoc/set` handler in #979 tomorrow) the write happens for real, against whichever root the fixture left unset. This package's `TestMain` redirects HOME and the XDG roots into a throwaway directory, which is what keeps those writes out of `~/.config/evener`, but nothing asserted the redirect covered the roots the hub actually falls back to. Remove the redirect and every hub test silently starts writing to the developer's home again.

Investigation note: the premise in #979's commit 8531e715f, that the empty `agentsDoc/set` dispatch would truncate the developer's real AGENTS.md, does not hold. With `LaunchConfigRoot` unset the root resolves to `<tmp>/evener-hub-test-env-*/config/evener` under this package's `TestMain` (verified by probe; the redirect is present at that branch's merge-base and head). Non-test code has no `os/user` use, so nothing resolves home outside HOME/XDG.

## Change

- `TestHubDefaultRootsStayInsideTheTestEnvironment`, beside the two existing `TestMain` guards: asserts `os.UserHomeDir`, the three XDG bases, `hubLaunchConfigRoot` with the field unset, `cmdutil.DefaultStateRoot`, `plugins.DefaultRoot`, `defaultMCPConfigPath`, and the paths `runMain` opens when a flag is unset (`DefaultHubStateRoot`, `DefaultConfigPath`, `DefaultStateGlob`, `DefaultPastIndexDBPath`, `rendezvous.DefaultDir`) all resolve under `testEnvRoot`.
- Corrects the credentials-store comment in the handler-set test, which claimed an unset root reaches the developer's real `credentials.toml`.
- `TestMain` refuses to start the package when any of those roots resolves outside the throwaway env, exiting with the offending paths before `m.Run`. A failing guard test cannot stop the tests beside it; this can. The guard test shares the root list and keeps the check live mid-run.
- `USERPROFILE` is redirected beside `HOME`, so what `os.UserHomeDir` reads is contained on Windows too.
- Containment resolves symlinks through the deepest existing ancestor of both sides and compares with `filepath.Rel`, so a link planted under the root cannot escape, a dangling link fails closed, and a symlinked temp root (macOS `/var`) compares equal to itself. `TestContainedInResolvesSymlinksAndTraversal` covers it. Globs among the defaults (the state glob) are judged on each current match too; `TestRootsOutsideExpandsGlobs` covers that.

## Test failed first

With the four `os.Setenv` redirect lines in `TestMain` commented out:

```
--- FAIL: TestHubDefaultRootsStayInsideTheTestEnvironment (0.00s)
    testmain_test.go:199: os.UserHomeDir = "/Users/jesse", outside the throwaway test root "/var/folders/.../evener-hub-test-env-1624484007"; a handler dispatched with empty params would read or write there for real
    testmain_test.go:199: hubLaunchConfigRoot with LaunchConfigRoot unset = "/Users/jesse/.config/evener", outside the throwaway test root ...
    (plus XDG_CONFIG_HOME/XDG_STATE_HOME/XDG_CACHE_HOME = "", cmdutil.DefaultStateRoot, plugins.DefaultRoot, defaultMCPConfigPath)
```

Redirect restored: PASS.

## Gates

- `go test ./cmd/evener-hub`: `ok` in 71s, 0 FAIL lines
- `make lint`: every stage PASS (naming, gofmt, evenerfuzz, eval, internal, golangci, generated, fuzz-registry, secret-scan)

## Follow-ups

- https://github.com/prime-radiant-inc/evener/issues/982
- https://github.com/prime-radiant-inc/evener/issues/983
- https://github.com/prime-radiant-inc/evener/issues/984
