### PR TITLE
fix(hub): classify instance Remove/SetDefault not-found as InvalidParams

### DIFF
--- a/cmd/evener-hub/app_instances.go
+++ b/cmd/evener-hub/app_instances.go
@@ -354,7 +354,9 @@ func (c *hubInstancesController) Edit(params appwire.InstanceEditParams) error {
 
 // Remove deletes an authored instance, its stored key and its OAuth record.
 // An instance that exists from the environment has no entry to delete, so the
-// refusal says what to unset instead (spec §5.1).
+// refusal says what to unset instead (spec §5.1). A name that resolves to no
+// instance follows Create and Edit's convention (#717/#748): the caller sent
+// it, so it comes back as appwire.InvalidParams.
 func (c *hubInstancesController) Remove(params appwire.InstanceRemoveParams) error {
 	if err := c.refuseWhenBroken(); err != nil {
 		return err
@@ -368,7 +370,7 @@ func (c *hubInstancesController) Remove(params appwire.InstanceRemoveParams) err
 	}
 	inst, ok := c.reg.Get().Instance(name)
 	if !ok {
-		return fmt.Errorf("instance %q not found", name)
+		return appwire.InvalidParams(fmt.Sprintf("instance %q not found", name))
 	}
 	if inst.Implicit {
 		return fmt.Errorf("%s exists from the environment (%s); unset it or remove the OAuth record instead of deleting the instance", name, describeImplicit(inst))
@@ -416,14 +418,16 @@ func describeImplicit(inst registry.Instance) string {
 	}
 }
 
-// SetDefault records which instance a bare model reference resolves on.
+// SetDefault records which instance a bare model reference resolves on. A
+// name that resolves to no instance follows Create and Edit's convention
+// (#717/#748): the caller sent it, so it comes back as appwire.InvalidParams.
 func (c *hubInstancesController) SetDefault(params appwire.InstanceSetDefaultParams) error {
 	if err := c.refuseWhenBroken(); err != nil {
 		return err
 	}
 	name := strings.TrimSpace(params.Name)
 	if _, ok := c.reg.Get().Instance(name); !ok {
-		return fmt.Errorf("instance %q not found", name)
+		return appwire.InvalidParams(fmt.Sprintf("instance %q not found", name))
 	}
 
 	c.mu.Lock()

--- a/cmd/evener-hub/app_instances_test.go
+++ b/cmd/evener-hub/app_instances_test.go
@@ -560,6 +560,21 @@ func TestInstances_RemoveRefusesImplicitInstance(t *testing.T) {
 	}
 }
 
+// TestInstances_RemoveRejectsUnknownInstance: a name that resolves to no
+// instance is the caller's to fix, the same class Edit's unknown-instance
+// refusal carries (#717/#748) — InvalidParams, not an internal fault.
+func TestInstances_RemoveRejectsUnknownInstance(t *testing.T) {
+	f := newInstancesFixture(t, nil)
+	err := f.ctl.Remove(appwire.InstanceRemoveParams{Name: "nowhere"})
+	if err == nil || !strings.Contains(err.Error(), "nowhere") {
+		t.Fatalf("Remove = %v, want an unknown-instance error", err)
+	}
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("Remove = %v, want an InvalidParams wire error", err)
+	}
+}
+
 func TestInstances_RemoveDeletesEntryStoreKeyAndOAuthRecord(t *testing.T) {
 	f := newInstancesFixture(t, nil)
 	if err := f.ctl.Create(appwire.InstanceCreateParams{Name: "work", Base: "openai-codex"}); err != nil {
@@ -617,8 +632,15 @@ func TestInstances_SetDefaultWritesDefault(t *testing.T) {
 	if !entry(t, f.ctl.List(), "groq").IsDefault {
 		t.Fatal("the reloaded list does not mark groq default")
 	}
-	if err := f.ctl.SetDefault(appwire.InstanceSetDefaultParams{Name: "nowhere"}); err == nil {
+	err = f.ctl.SetDefault(appwire.InstanceSetDefaultParams{Name: "nowhere"})
+	if err == nil {
 		t.Fatal("SetDefault accepted a name that is not an instance")
+	}
+	// Same class as Edit's unknown-instance refusal (#717/#748): the name the
+	// caller sent is theirs to fix, not a fault of the hub's own state.
+	var wire appwire.WireError
+	if !errors.As(err, &wire) || wire.Code != appwire.CodeInvalidParams {
+		t.Fatalf("SetDefault = %v, want an InvalidParams wire error", err)
 	}
 }
 


### PR DESCRIPTION
**Mechanism.** `hubInstancesController` classifies its refusals so the instances pane knows whether to send the user back to a field or report a hub fault. `Create` and `Edit` already return the unknown-name refusal as `appwire.InvalidParams` (#717/#748). `Remove` and `SetDefault` returned the identical `instance %q not found` message as a raw `fmt.Errorf`, so it reached the RPC layer with no class and looked like an internal fault.

**Change.** Both call sites in `cmd/evener-hub/app_instances.go` now wrap that message in `appwire.InvalidParams`, and the doc comments say so. The message text is unchanged, and the invalid-name and implicit-instance refusals in `Remove` are untouched.

**Failing first.** Wrote the assertions before the fix:

- `TestInstances_RemoveRejectsUnknownInstance` (new, mirroring `TestInstances_EditRejectsUnknownInstance`) failed with `Remove = instance "nowhere" not found, want an InvalidParams wire error`
- `TestInstances_SetDefaultWritesDefault`'s extended bad-input assertion failed with `SetDefault = instance "nowhere" not found, want an InvalidParams wire error`

**Smoke gates.** `gofmt -l` on both changed files printed nothing; `go vet ./cmd/evener-hub` and `go vet -tags evenerfuzz ./cmd/evener-hub` clean; `GOMAXPROCS=4 go test -count=1 -run` over the touched instance tests plus their neighbours passed; `go build ./...` clean.

Closes #788