### PR TITLE
perf(w2-watchdog): share one quiet-watchdog ticker per session

### DIFF
--- a/agent/delegate_quiet_hub_test.go
+++ b/agent/delegate_quiet_hub_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -44,49 +43,65 @@ func quietHubFor(t *testing.T, s *Session) *delegateQuietWatchHub {
 	return hub
 }
 
-// waitForQuietHubCount polls for the hub entry count, since tick dispatch runs
-// on the hub goroutine and detached entries land asynchronously to Advance.
-func waitForQuietHubCount(t *testing.T, s *Session, want int) *delegateQuietWatchHub {
-	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for {
-		delegateQuietWatchHubs.Lock()
-		hub := delegateQuietWatchHubs.hubs[s]
-		n := -1
-		if hub != nil {
-			hub.mu.Lock()
-			n = len(hub.entries)
-			hub.mu.Unlock()
-		} else if want == 0 {
-			delegateQuietWatchHubs.Unlock()
-			return nil
-		}
-		delegateQuietWatchHubs.Unlock()
-		if n == want {
-			return hub
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("hub entry count = %d, want %d", n, want)
-		}
-		time.Sleep(time.Millisecond)
+// quietHubTripwire bounds waits on real completion signals: the entry channel
+// (closed by detach), the tick hook (fired by tick work), and the hub exit
+// channel (closed when the serve loop returns). Detach, tick work, and hub
+// shutdown are all in-process with no I/O, so this fires only on a genuine
+// hang, never on scheduler contention. It is a tripwire only — the
+// synchronization mechanism is the channel, not time
+// (docs/developing-evener/testing.md Flakes and Timeouts).
+const quietHubTripwire = 10 * time.Second
+
+// quietHubEntryCount reads the hub's entry count under both locks. Detach is
+// synchronous through the returned CancelFunc (it closes entry.stop before
+// returning), so callers that just detached assert on this directly instead
+// of polling.
+func quietHubEntryCount(s *Session) (hub *delegateQuietWatchHub, n int) {
+	delegateQuietWatchHubs.Lock()
+	defer delegateQuietWatchHubs.Unlock()
+	hub = delegateQuietWatchHubs.hubs[s]
+	if hub == nil {
+		return nil, -1
 	}
+	hub.mu.Lock()
+	defer hub.mu.Unlock()
+	return hub, len(hub.entries)
 }
 
-// waitForPendingQuiet polls the receiver transcript fold until want attention
-// IDs land (tick work runs on detached goroutines, so it is not synchronous
-// with the fake-clock Advance that fires the ticker).
-func waitForPendingQuiet(t *testing.T, root *Session, want int) []string {
+// awaitQuietTicks collects tick-done signals for exactly the leases in want
+// (each lease fires once per shared tick): the hook fires on the tick worker
+// after the durable write lands, so a received signal means the attention is
+// already readable. It returns the leases in arrival order.
+func awaitQuietTicks(t *testing.T, want map[delegateLease]int) []delegateLease {
 	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for {
-		if got := pendingQuietAttention(t, root); len(got) >= want {
-			return got
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("pending quiet attention = %#v, want at least %d", pendingQuietAttention(t, root), want)
-		}
-		time.Sleep(time.Millisecond)
+	ticks := make(chan delegateLease, 16)
+	restore := setQuietWatchTickDone(func(lease delegateLease) { ticks <- lease })
+	t.Cleanup(restore)
+	var got []delegateLease
+	remaining := make(map[delegateLease]int, len(want))
+	for lease, n := range want {
+		remaining[lease] = n
 	}
+	left := 0
+	for _, n := range want {
+		left += n
+	}
+	timer := time.NewTimer(quietHubTripwire)
+	defer timer.Stop()
+	for left > 0 {
+		select {
+		case lease := <-ticks:
+			if remaining[lease] <= 0 {
+				t.Fatalf("unexpected tick for lease %+v (got so far %+v)", lease, got)
+			}
+			remaining[lease]--
+			left--
+			got = append(got, lease)
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %d more tick(s), got %+v", left, got)
+		}
+	}
+	return got
 }
 
 // ageHubLeasesPastQuietWindow moves virtual time past the quiet window BEFORE
@@ -117,9 +132,12 @@ func TestDelegateQuietHub_SharedTicksReachAllLeases(t *testing.T) {
 		t.Fatalf("quiet hub tickers = %d, want 1 shared ticker", got)
 	}
 
+	want := map[delegateLease]int{leaseA: 1, leaseB: 1}
 	clk.Advance(delegateQuietCheckInterval)
-	got := waitForPendingQuiet(t, root, 2)
-	if len(got) != 2 {
+	if got := awaitQuietTicks(t, want); len(got) != 2 {
+		t.Fatalf("shared-tick completions = %+v, want one per lease", got)
+	}
+	if got := pendingQuietAttention(t, root); len(got) != 2 {
 		t.Fatalf("shared-tick quiet attention = %#v, want one per lease", got)
 	}
 }
@@ -135,11 +153,18 @@ func TestDelegateQuietHub_DetachedLeaseStopsReceiving(t *testing.T) {
 	cancelB := root.startDelegateQuietWatchdog(context.Background(), leaseB)
 	defer cancelB()
 
+	// Detach is synchronous: cancelA closes the entry's stop channel before
+	// it returns, so the entry count below is a direct assertion, not a poll.
 	cancelA()
-	waitForQuietHubCount(t, root, 1)
+	if _, n := quietHubEntryCount(root); n != 1 {
+		t.Fatalf("hub entry count = %d, want 1", n)
+	}
 
 	clk.Advance(delegateQuietCheckInterval)
-	got := waitForPendingQuiet(t, root, 1)
+	if got := awaitQuietTicks(t, map[delegateLease]int{leaseB: 1}); len(got) != 1 || got[0] != leaseB {
+		t.Fatalf("remaining lease ticks = %+v, want [%+v]", got, leaseB)
+	}
+	got := pendingQuietAttention(t, root)
 	for _, id := range got {
 		if id == delegateQuietAttentionID(leaseA) {
 			t.Fatalf("detached lease still ticked: %#v", got)
@@ -161,7 +186,12 @@ func TestDelegateQuietHub_StopsAfterLastDetach(t *testing.T) {
 	}
 	cancel()
 
-	if hub := waitForQuietHubCount(t, root, 0); hub != nil {
+	// Detach unregisters synchronously: the registry check below reads state
+	// the CancelFunc established before returning.
+	delegateQuietWatchHubs.Lock()
+	_, registered := delegateQuietWatchHubs.hubs[root]
+	delegateQuietWatchHubs.Unlock()
+	if registered {
 		t.Fatal("hub still registered after last detach")
 	}
 	if got := clk.BlockedCount(); got != 0 {
@@ -202,22 +232,25 @@ func TestDelegateQuietHub_BlockedLeaseDelaysNeitherOthersNorShutdown(t *testing.
 	defer atomic.StoreUint32(slowEntry.busy, 0)
 
 	clk.Advance(delegateQuietCheckInterval)
-	got := waitForPendingQuiet(t, root, 1)
-	if len(got) != 1 || got[0] != delegateQuietAttentionID(leaseFast) {
+	if got := awaitQuietTicks(t, map[delegateLease]int{leaseFast: 1}); len(got) != 1 || got[0] != leaseFast {
+		t.Fatalf("ticks with blocked lease = %+v, want only [%+v]", got, leaseFast)
+	}
+	if got := pendingQuietAttention(t, root); len(got) != 1 || got[0] != delegateQuietAttentionID(leaseFast) {
 		t.Fatalf("attention with blocked lease = %#v, want only %q", got, delegateQuietAttentionID(leaseFast))
 	}
 
-	// Shutdown must not wait for the wedged tick: detach everything and
-	// require both cancels to return promptly.
-	var wg sync.WaitGroup
-	wg.Add(2)
-	done := make(chan struct{})
-	go func() { defer wg.Done(); cancelSlow() }()
-	go func() { defer wg.Done(); cancelFast() }()
-	go func() { wg.Wait(); close(done) }()
+	// Shutdown must not wait for the wedged tick: detach is synchronous and
+	// never joins tick work, so both cancels return directly. The tripwire
+	// below guards the join only against a genuine hang.
+	shutdown := make(chan struct{})
+	go func() {
+		defer close(shutdown)
+		cancelSlow()
+		cancelFast()
+	}()
 	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
+	case <-shutdown:
+	case <-time.After(quietHubTripwire): // TRIPWIRE: cancels join no tick work; sync detach is the mechanism.
 		t.Fatal("hub shutdown blocked on wedged lease tick")
 	}
 }

--- a/agent/delegate_quiet_hub_test.go
+++ b/agent/delegate_quiet_hub_test.go
@@ -207,6 +207,86 @@ func TestDelegateQuietHub_StopsAfterLastDetach(t *testing.T) {
 	}
 }
 
+func TestDelegateQuietHub_ParentCancelCleansRegistryAndTicker(t *testing.T) {
+	clk := agenttest.NewFakeClockAt(time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC))
+	root, controller := quietHubTestSession(t, clk)
+	lease := seedQuietHubLease(t, controller, clk, "dlg_hub_parent")
+	ageHubLeasesPastQuietWindow(clk)
+
+	parent, cancelParent := context.WithCancel(context.Background())
+	stop := root.startDelegateQuietWatchdog(parent, lease)
+	defer stop()
+	if _, n := quietHubEntryCount(root); n != 1 {
+		t.Fatalf("hub entry count = %d, want 1", n)
+	}
+	if got := clk.BlockedCount(); got != 1 {
+		t.Fatalf("quiet hub tickers = %d, want 1", got)
+	}
+
+	// Cancelling the parent runs detach on the AfterFunc goroutine; the
+	// returned CancelFunc joins it (detach is sync.Once-guarded and closes its
+	// stopped channel), so everything below is a direct assertion, not a poll.
+	cancelParent()
+	stop()
+
+	delegateQuietWatchHubs.Lock()
+	_, registered := delegateQuietWatchHubs.hubs[root]
+	delegateQuietWatchHubs.Unlock()
+	if registered {
+		t.Fatal("hub still registered after parent cancel")
+	}
+	if _, n := quietHubEntryCount(root); n != -1 {
+		t.Fatalf("hub entry count after parent cancel = %d, want unregistered", n)
+	}
+	if got := clk.BlockedCount(); got != 0 {
+		t.Fatalf("quiet hub tickers after parent cancel = %d, want 0 (ticker stopped)", got)
+	}
+}
+
+func TestDelegateQuietHub_RearmAfterLastDetachFiresNewTicker(t *testing.T) {
+	clk := agenttest.NewFakeClockAt(time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC))
+	root, controller := quietHubTestSession(t, clk)
+	leaseFirst := seedQuietHubLease(t, controller, clk, "dlg_hub_rearm_first")
+	leaseSecond := seedQuietHubLease(t, controller, clk, "dlg_hub_rearm_second")
+	ageHubLeasesPastQuietWindow(clk)
+
+	cancelFirst := root.startDelegateQuietWatchdog(context.Background(), leaseFirst)
+	defer cancelFirst()
+	oldHub := quietHubFor(t, root)
+	cancelFirst()
+
+	delegateQuietWatchHubs.Lock()
+	_, registered := delegateQuietWatchHubs.hubs[root]
+	delegateQuietWatchHubs.Unlock()
+	if registered {
+		t.Fatal("hub still registered after last detach")
+	}
+	if got := clk.BlockedCount(); got != 0 {
+		t.Fatalf("quiet hub tickers after last detach = %d, want 0 (ticker stopped)", got)
+	}
+
+	// Re-arming the same session after the last detach must build a fresh hub
+	// and ticker: the old hub's ticker is stopped and its loop has exited.
+	cancelSecond := root.startDelegateQuietWatchdog(context.Background(), leaseSecond)
+	defer cancelSecond()
+	newHub := quietHubFor(t, root)
+	if newHub == oldHub {
+		t.Fatal("re-arm reused the stopped hub after last detach")
+	}
+	if got := clk.BlockedCount(); got != 1 {
+		t.Fatalf("quiet hub tickers after re-arm = %d, want 1 shared ticker", got)
+	}
+
+	wait := armQuietTicks(t, map[delegateLease]int{leaseSecond: 1})
+	clk.Advance(delegateQuietCheckInterval)
+	if got := wait(); len(got) != 1 || got[0] != leaseSecond {
+		t.Fatalf("re-armed lease ticks = %+v, want [%+v]", got, leaseSecond)
+	}
+	if got := pendingQuietAttention(t, root); len(got) != 1 || got[0] != delegateQuietAttentionID(leaseSecond) {
+		t.Fatalf("re-armed lease attention = %#v, want [%q]", got, delegateQuietAttentionID(leaseSecond))
+	}
+}
+
 func TestDelegateQuietHub_BlockedLeaseDelaysNeitherOthersNorShutdown(t *testing.T) {
 	clk := agenttest.NewFakeClockAt(time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC))
 	root, controller := quietHubTestSession(t, clk)

--- a/agent/delegate_quiet_hub_test.go
+++ b/agent/delegate_quiet_hub_test.go
@@ -69,38 +69,45 @@ func quietHubEntryCount(s *Session) (hub *delegateQuietWatchHub, n int) {
 	return hub, len(hub.entries)
 }
 
-// awaitQuietTicks collects tick-done signals for exactly the leases in want
-// (each lease fires once per shared tick): the hook fires on the tick worker
+// armQuietTicks installs the tick-done hook for exactly the leases in want and
+// returns the wait for their completions. Call it BEFORE advancing the fake
+// clock: Advance delivers the buffered tick to the hub loop, which can consume
+// it and finish the tick work before a hook installed after Advance exists,
+// flaking the wait on the 10s tripwire. The hook fires on the tick worker
 // after the durable write lands, so a received signal means the attention is
-// already readable. It returns the leases in arrival order.
-func awaitQuietTicks(t *testing.T, want map[delegateLease]int) []delegateLease {
+// already readable (each lease fires once per shared tick). The returned wait
+// collects the leases in arrival order.
+func armQuietTicks(t *testing.T, want map[delegateLease]int) func() []delegateLease {
 	t.Helper()
 	ticks := make(chan delegateLease, 16)
 	restore := setQuietWatchTickDone(func(lease delegateLease) { ticks <- lease })
 	t.Cleanup(restore)
-	var got []delegateLease
 	remaining := make(map[delegateLease]int, len(want))
 	maps.Copy(remaining, want)
 	left := 0
 	for _, n := range want {
 		left += n
 	}
-	timer := time.NewTimer(quietHubTripwire)
-	defer timer.Stop()
-	for left > 0 {
-		select {
-		case lease := <-ticks:
-			if remaining[lease] <= 0 {
-				t.Fatalf("unexpected tick for lease %+v (got so far %+v)", lease, got)
+	var got []delegateLease
+	return func() []delegateLease {
+		t.Helper()
+		timer := time.NewTimer(quietHubTripwire)
+		defer timer.Stop()
+		for left > 0 {
+			select {
+			case lease := <-ticks:
+				if remaining[lease] <= 0 {
+					t.Fatalf("unexpected tick for lease %+v (got so far %+v)", lease, got)
+				}
+				remaining[lease]--
+				left--
+				got = append(got, lease)
+			case <-timer.C:
+				t.Fatalf("timed out waiting for %d more tick(s), got %+v", left, got)
 			}
-			remaining[lease]--
-			left--
-			got = append(got, lease)
-		case <-timer.C:
-			t.Fatalf("timed out waiting for %d more tick(s), got %+v", left, got)
 		}
+		return got
 	}
-	return got
 }
 
 // ageHubLeasesPastQuietWindow moves virtual time past the quiet window BEFORE
@@ -132,8 +139,9 @@ func TestDelegateQuietHub_SharedTicksReachAllLeases(t *testing.T) {
 	}
 
 	want := map[delegateLease]int{leaseA: 1, leaseB: 1}
+	wait := armQuietTicks(t, want)
 	clk.Advance(delegateQuietCheckInterval)
-	if got := awaitQuietTicks(t, want); len(got) != 2 {
+	if got := wait(); len(got) != 2 {
 		t.Fatalf("shared-tick completions = %+v, want one per lease", got)
 	}
 	if got := pendingQuietAttention(t, root); len(got) != 2 {
@@ -159,8 +167,9 @@ func TestDelegateQuietHub_DetachedLeaseStopsReceiving(t *testing.T) {
 		t.Fatalf("hub entry count = %d, want 1", n)
 	}
 
+	wait := armQuietTicks(t, map[delegateLease]int{leaseB: 1})
 	clk.Advance(delegateQuietCheckInterval)
-	if got := awaitQuietTicks(t, map[delegateLease]int{leaseB: 1}); len(got) != 1 || got[0] != leaseB {
+	if got := wait(); len(got) != 1 || got[0] != leaseB {
 		t.Fatalf("remaining lease ticks = %+v, want [%+v]", got, leaseB)
 	}
 	got := pendingQuietAttention(t, root)
@@ -230,8 +239,9 @@ func TestDelegateQuietHub_BlockedLeaseDelaysNeitherOthersNorShutdown(t *testing.
 	}
 	defer atomic.StoreUint32(slowEntry.busy, 0)
 
+	wait := armQuietTicks(t, map[delegateLease]int{leaseFast: 1})
 	clk.Advance(delegateQuietCheckInterval)
-	if got := awaitQuietTicks(t, map[delegateLease]int{leaseFast: 1}); len(got) != 1 || got[0] != leaseFast {
+	if got := wait(); len(got) != 1 || got[0] != leaseFast {
 		t.Fatalf("ticks with blocked lease = %+v, want only [%+v]", got, leaseFast)
 	}
 	if got := pendingQuietAttention(t, root); len(got) != 1 || got[0] != delegateQuietAttentionID(leaseFast) {

--- a/agent/delegate_quiet_hub_test.go
+++ b/agent/delegate_quiet_hub_test.go
@@ -1,0 +1,223 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/internal/agenttest"
+)
+
+// quietHubTestSession builds a Session on the given fake clock that is able to
+// receive quiet attention: a real transcript writer plus a controller whose
+// root runtime is the session itself.
+func quietHubTestSession(t *testing.T, clk *agenttest.FakeClock) (*Session, *delegateTreeController) {
+	t.Helper()
+	root := newDelegateAttentionTestSession(t)
+	root.clock = clk
+	controller, _ := newDelegateControllerTestHarness(t, 2, 2)
+	controller.rootRuntime = root
+	root.delegateController = controller
+	return root, controller
+}
+
+func seedQuietHubLease(t *testing.T, controller *delegateTreeController, clk *agenttest.FakeClock, id string) delegateLease {
+	t.Helper()
+	seedDelegateControllerRunning(t, controller, id, "")
+	child := &Session{clock: clk, delegateController: controller}
+	controller.live[id].runtime = child
+	controller.live[id].binding.runtime = child
+	controller.live[id].activityAt = clk.Now()
+	return delegateLease{delegateID: id, generation: 1}
+}
+
+func quietHubFor(t *testing.T, s *Session) *delegateQuietWatchHub {
+	t.Helper()
+	delegateQuietWatchHubs.Lock()
+	defer delegateQuietWatchHubs.Unlock()
+	hub := delegateQuietWatchHubs.hubs[s]
+	if hub == nil {
+		t.Fatal("no quiet hub registered for session")
+	}
+	return hub
+}
+
+// waitForQuietHubCount polls for the hub entry count, since tick dispatch runs
+// on the hub goroutine and detached entries land asynchronously to Advance.
+func waitForQuietHubCount(t *testing.T, s *Session, want int) *delegateQuietWatchHub {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		delegateQuietWatchHubs.Lock()
+		hub := delegateQuietWatchHubs.hubs[s]
+		n := -1
+		if hub != nil {
+			hub.mu.Lock()
+			n = len(hub.entries)
+			hub.mu.Unlock()
+		} else if want == 0 {
+			delegateQuietWatchHubs.Unlock()
+			return nil
+		}
+		delegateQuietWatchHubs.Unlock()
+		if n == want {
+			return hub
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("hub entry count = %d, want %d", n, want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// waitForPendingQuiet polls the receiver transcript fold until want attention
+// IDs land (tick work runs on detached goroutines, so it is not synchronous
+// with the fake-clock Advance that fires the ticker).
+func waitForPendingQuiet(t *testing.T, root *Session, want int) []string {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if got := pendingQuietAttention(t, root); len(got) >= want {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pending quiet attention = %#v, want at least %d", pendingQuietAttention(t, root), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// ageHubLeasesPastQuietWindow moves virtual time past the quiet window BEFORE
+// any watchdog is armed, so the tests below fire exactly one shared tick into
+// an empty ticker buffer. Advancing while the hub ticker is armed would fire
+// ~20 ticks into the size-1 buffer: all but the first (a pre-window no-op)
+// drop, and waiting for the hub loop to consume the stale tick without
+// stealing it from the loop's own channel is inherently racy. Lease
+// eligibility timing is orthogonal here (covered by the supervision tests);
+// these tests cover hub fan-out, detach, coalescing, and shutdown.
+func ageHubLeasesPastQuietWindow(clk *agenttest.FakeClock) {
+	clk.Advance(delegateQuietWindow)
+}
+
+func TestDelegateQuietHub_SharedTicksReachAllLeases(t *testing.T) {
+	clk := agenttest.NewFakeClockAt(time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC))
+	root, controller := quietHubTestSession(t, clk)
+	leaseA := seedQuietHubLease(t, controller, clk, "dlg_hub_a")
+	leaseB := seedQuietHubLease(t, controller, clk, "dlg_hub_b")
+	ageHubLeasesPastQuietWindow(clk)
+
+	cancelA := root.startDelegateQuietWatchdog(context.Background(), leaseA)
+	defer cancelA()
+	cancelB := root.startDelegateQuietWatchdog(context.Background(), leaseB)
+	defer cancelB()
+
+	if got := clk.BlockedCount(); got != 1 {
+		t.Fatalf("quiet hub tickers = %d, want 1 shared ticker", got)
+	}
+
+	clk.Advance(delegateQuietCheckInterval)
+	got := waitForPendingQuiet(t, root, 2)
+	if len(got) != 2 {
+		t.Fatalf("shared-tick quiet attention = %#v, want one per lease", got)
+	}
+}
+
+func TestDelegateQuietHub_DetachedLeaseStopsReceiving(t *testing.T) {
+	clk := agenttest.NewFakeClockAt(time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC))
+	root, controller := quietHubTestSession(t, clk)
+	leaseA := seedQuietHubLease(t, controller, clk, "dlg_hub_a")
+	leaseB := seedQuietHubLease(t, controller, clk, "dlg_hub_b")
+	ageHubLeasesPastQuietWindow(clk)
+
+	cancelA := root.startDelegateQuietWatchdog(context.Background(), leaseA)
+	cancelB := root.startDelegateQuietWatchdog(context.Background(), leaseB)
+	defer cancelB()
+
+	cancelA()
+	waitForQuietHubCount(t, root, 1)
+
+	clk.Advance(delegateQuietCheckInterval)
+	got := waitForPendingQuiet(t, root, 1)
+	for _, id := range got {
+		if id == delegateQuietAttentionID(leaseA) {
+			t.Fatalf("detached lease still ticked: %#v", got)
+		}
+	}
+	if len(got) != 1 || got[0] != delegateQuietAttentionID(leaseB) {
+		t.Fatalf("remaining lease attention = %#v, want [%q]", got, delegateQuietAttentionID(leaseB))
+	}
+}
+
+func TestDelegateQuietHub_StopsAfterLastDetach(t *testing.T) {
+	clk := agenttest.NewFakeClockAt(time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC))
+	root, controller := quietHubTestSession(t, clk)
+	lease := seedQuietHubLease(t, controller, clk, "dlg_hub_last")
+
+	cancel := root.startDelegateQuietWatchdog(context.Background(), lease)
+	if got := clk.BlockedCount(); got != 1 {
+		t.Fatalf("quiet hub tickers = %d, want 1", got)
+	}
+	cancel()
+
+	if hub := waitForQuietHubCount(t, root, 0); hub != nil {
+		t.Fatal("hub still registered after last detach")
+	}
+	if got := clk.BlockedCount(); got != 0 {
+		t.Fatalf("quiet hub tickers after last detach = %d, want 0 (ticker stopped)", got)
+	}
+}
+
+func TestDelegateQuietHub_BlockedLeaseDelaysNeitherOthersNorShutdown(t *testing.T) {
+	clk := agenttest.NewFakeClockAt(time.Date(2026, 8, 14, 9, 0, 0, 0, time.UTC))
+	root, controller := quietHubTestSession(t, clk)
+	leaseSlow := seedQuietHubLease(t, controller, clk, "dlg_hub_slow")
+	leaseFast := seedQuietHubLease(t, controller, clk, "dlg_hub_fast")
+	ageHubLeasesPastQuietWindow(clk)
+
+	cancelSlow := root.startDelegateQuietWatchdog(context.Background(), leaseSlow)
+	defer cancelSlow()
+	cancelFast := root.startDelegateQuietWatchdog(context.Background(), leaseFast)
+	defer cancelFast()
+
+	// Wedge the slow lease's in-flight slot so the hub coalesces (drops) its
+	// ticks instead of queueing a goroutine per tick. No tick can fire between
+	// arming and the CAS below (no Advance in between), so the swap is exact.
+	hub := quietHubFor(t, root)
+	hub.mu.Lock()
+	var slowEntry delegateQuietWatchEntry
+	for entry := range hub.entries {
+		if entry.lease == leaseSlow {
+			slowEntry = entry
+		}
+	}
+	hub.mu.Unlock()
+	if slowEntry.busy == nil {
+		t.Fatal("slow lease has no in-flight guard")
+	}
+	if !atomic.CompareAndSwapUint32(slowEntry.busy, 0, 1) {
+		t.Fatal("slow lease already has a tick in flight")
+	}
+	defer atomic.StoreUint32(slowEntry.busy, 0)
+
+	clk.Advance(delegateQuietCheckInterval)
+	got := waitForPendingQuiet(t, root, 1)
+	if len(got) != 1 || got[0] != delegateQuietAttentionID(leaseFast) {
+		t.Fatalf("attention with blocked lease = %#v, want only %q", got, delegateQuietAttentionID(leaseFast))
+	}
+
+	// Shutdown must not wait for the wedged tick: detach everything and
+	// require both cancels to return promptly.
+	var wg sync.WaitGroup
+	wg.Add(2)
+	done := make(chan struct{})
+	go func() { defer wg.Done(); cancelSlow() }()
+	go func() { defer wg.Done(); cancelFast() }()
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("hub shutdown blocked on wedged lease tick")
+	}
+}

--- a/agent/delegate_quiet_hub_test.go
+++ b/agent/delegate_quiet_hub_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"maps"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -79,9 +80,7 @@ func awaitQuietTicks(t *testing.T, want map[delegateLease]int) []delegateLease {
 	t.Cleanup(restore)
 	var got []delegateLease
 	remaining := make(map[delegateLease]int, len(want))
-	for lease, n := range want {
-		remaining[lease] = n
-	}
+	maps.Copy(remaining, want)
 	left := 0
 	for _, n := range want {
 		left += n

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -150,11 +150,10 @@ func (s *Session) runDelegateQuietWatchdogTick(lease delegateLease, now time.Tim
 }
 
 // delegateQuietWatchEntry is one lease registered on the shared quiet-watchdog
-// hub: the lease to tick plus a per-lease stop channel. Closing stop detaches
-// the lease from the fan-out so a later tick never touches a stopped lease
-// (no use-after-stop).
+// hub: the lease to tick plus a per-lease stop channel. Detach is best-effort:
+// closing stop keeps later ticks from being dispatched to the lease, but a tick
+// the hub loop already snapshotted may still run once for it.
 type delegateQuietWatchEntry struct {
-	owner *Session
 	lease delegateLease
 	stop  chan struct{}
 }
@@ -168,11 +167,10 @@ type delegateQuietWatchEntry struct {
 // leases.
 //
 // The hub is keyed to the session's injected clock (s.sclock()): the hub is
-// created lazily under delegateQuietWatchMu, so every lease on the same
-// session — and therefore the same s.clock — shares one ticker and stays on
-// the fake clock in tests.
+// created lazily under the delegateQuietWatchHubs registry lock, so every
+// lease on the same session — and therefore the same s.clock — shares one
+// ticker and stays on the fake clock in tests.
 type delegateQuietWatchHub struct {
-	owner  *Session
 	ticker interface {
 		C() <-chan time.Time
 		Stop()
@@ -211,7 +209,6 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 	hub := delegateQuietWatchHubs.hubs[s]
 	if hub == nil {
 		hub = &delegateQuietWatchHub{
-			owner:   s,
 			done:    make(chan struct{}),
 			entries: make(map[delegateQuietWatchEntry]struct{}),
 		}
@@ -219,7 +216,7 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 		delegateQuietWatchHubs.hubs[s] = hub
 		go s.serveDelegateQuietWatchHub(hub)
 	}
-	entry := delegateQuietWatchEntry{owner: s, lease: lease, stop: make(chan struct{})}
+	entry := delegateQuietWatchEntry{lease: lease, stop: make(chan struct{})}
 	hub.entries[entry] = struct{}{}
 	delegateQuietWatchHubs.Unlock()
 	var detachOnce sync.Once

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -260,7 +260,12 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 	// mu here and in detach, never the reverse. A creation loser that finds a
 	// hub after stopping its spare ticker re-verifies the registry still points
 	// at that hub before landing on it: a detach-plus-replace in the gap means
-	// retrying the lookup instead of registering on the stale hub.
+	// retrying the lookup instead of registering on the stale hub. The creation
+	// winner re-verifies the same way after starting the serve goroutine: the
+	// freshly published hub is observable (empty) while the lock is released,
+	// so another watchdog can register on it and detach in that window,
+	// unregistering and stopping it; landing unconditionally would strand this
+	// entry on the stopped, unregistered hub.
 	delegateQuietWatchHubs.Lock()
 	var hub *delegateQuietWatchHub
 	for {
@@ -282,6 +287,15 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 			delegateQuietWatchHubs.Unlock()
 			go s.serveDelegateQuietWatchHub(fresh)
 			delegateQuietWatchHubs.Lock()
+			// The winner-published hub was observable while the lock was
+			// released to start its goroutine: a register-plus-detach in the
+			// gap unregisters and stops it, so only land on it while the
+			// registry still points at it, otherwise loop back and retry the
+			// lookup (or a fresh creation) instead of stranding this entry
+			// on the stopped, unregistered hub.
+			if delegateQuietWatchHubs.hubs[s] != fresh {
+				continue
+			}
 			hub = fresh
 			break
 		}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -203,13 +203,39 @@ var delegateQuietWatchHubs = struct {
 	hubs: make(map[*Session]*delegateQuietWatchHub),
 }
 
-// delegateQuietWatchTickDone observes one hub tick's completed lease work. It is
-// nil in production; tests set it to await tick completion deterministically
+// delegateQuietWatchTickDone observes one hub tick's completed lease work. It
+// is nil in production; tests set it to await tick completion deterministically
 // instead of polling. It fires after runDelegateQuietWatchdogTick returns, so
 // the tick's durable write is already visible to the observer; coalesced and
-// detached ticks do no work and never fire it. Observers must not block: the
-// call runs on the tick's worker goroutine.
-var delegateQuietWatchTickDone func(lease delegateLease)
+// detached ticks do no work and never fire it. Stored atomically because the
+// hub's tick workers read it while tests swap it; observers must not block:
+// the call runs on the tick's worker goroutine.
+var delegateQuietWatchTickDone atomic.Pointer[func(lease delegateLease)]
+
+// quietWatchTickDone loads the tick observer, if any.
+func quietWatchTickDone() func(lease delegateLease) {
+	if ptr := delegateQuietWatchTickDone.Load(); ptr != nil {
+		return *ptr
+	}
+	return nil
+}
+
+// setQuietWatchTickDone swaps the tick observer for tests; a nil hook clears it.
+func setQuietWatchTickDone(hook func(lease delegateLease)) (restore func()) {
+	prev := delegateQuietWatchTickDone.Load()
+	if hook == nil {
+		delegateQuietWatchTickDone.Store(nil)
+	} else {
+		delegateQuietWatchTickDone.Store(&hook)
+	}
+	return func() {
+		if prev == nil {
+			delegateQuietWatchTickDone.Store(nil)
+		} else {
+			delegateQuietWatchTickDone.Store(prev)
+		}
+	}
+}
 
 // delegateQuietWatchHubForSession returns the live hub for s, creating it on
 // first use. The ticker is created outside the registry lock so arming one
@@ -364,7 +390,7 @@ func (s *Session) serveDelegateQuietWatchHub(hub *delegateQuietWatchHub) {
 					default:
 					}
 					_ = s.runDelegateQuietWatchdogTick(entry.lease, now)
-					if done := delegateQuietWatchTickDone; done != nil {
+					if done := quietWatchTickDone(); done != nil {
 						done(entry.lease)
 					}
 				}(entry)

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -237,35 +237,6 @@ func setQuietWatchTickDone(hook func(lease delegateLease)) (restore func()) {
 	}
 }
 
-// delegateQuietWatchHubForSession returns the live hub for s, creating it on
-// first use. The ticker is created outside the registry lock so arming one
-// session's hub never blocks another session's attach/detach; a lost creation
-// race stops the spare ticker and reuses the winner.
-func delegateQuietWatchHubForSession(s *Session) *delegateQuietWatchHub {
-	delegateQuietWatchHubs.Lock()
-	if hub := delegateQuietWatchHubs.hubs[s]; hub != nil {
-		delegateQuietWatchHubs.Unlock()
-		return hub
-	}
-	delegateQuietWatchHubs.Unlock()
-	ticker := s.sclock().NewTicker(delegateQuietCheckInterval)
-	hub := &delegateQuietWatchHub{
-		ticker:  ticker,
-		done:    make(chan struct{}),
-		entries: make(map[delegateQuietWatchEntry]struct{}),
-	}
-	delegateQuietWatchHubs.Lock()
-	if existing := delegateQuietWatchHubs.hubs[s]; existing != nil {
-		delegateQuietWatchHubs.Unlock()
-		ticker.Stop()
-		return existing
-	}
-	delegateQuietWatchHubs.hubs[s] = hub
-	delegateQuietWatchHubs.Unlock()
-	go s.serveDelegateQuietWatchHub(hub)
-	return hub
-}
-
 // delegateQuietWatchNext arms (or reuses) the shared hub for s and registers
 // lease on it. Registration is atomic with the hub lookup under the registry
 // lock, so the entry always lands on the hub the registry points at and can

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -171,6 +171,10 @@ type delegateQuietWatchEntry struct {
 // lease on the same session — and therefore the same s.clock — shares one
 // ticker and stays on the fake clock in tests.
 type delegateQuietWatchHub struct {
+	// mu guards entries alone, so ticks and detaches on one session never
+	// contend with other sessions' hubs (or the registry lock) while running
+	// tick work. Lock order is always registry -> mu, never the reverse.
+	mu     sync.Mutex
 	ticker interface {
 		C() <-chan time.Time
 		Stop()
@@ -181,15 +185,44 @@ type delegateQuietWatchHub struct {
 }
 
 // delegateQuietWatchHubs is the process-wide registry mapping each *Session to
-// its live hub. It lives in this file (rather than on Session) so the change
-// stays within agent/delegate_runtime.go; entries are removed when the hub's
-// last lease detaches, and Session pointers are map keys only (never
-// dereferenced after removal).
+// its live hub. It lives in this file (rather than on Session) so Session's
+// struct stays untouched; the entry for a session is removed when its hub's
+// last lease detaches, so the registry never pins an idle session, and
+// Session pointers are map keys only (never dereferenced after removal).
 var delegateQuietWatchHubs = struct {
 	sync.Mutex
 	hubs map[*Session]*delegateQuietWatchHub
 }{
 	hubs: make(map[*Session]*delegateQuietWatchHub),
+}
+
+// delegateQuietWatchHubForSession returns the live hub for s, creating it on
+// first use. The ticker is created outside the registry lock so arming one
+// session's hub never blocks another session's attach/detach; a lost creation
+// race stops the spare ticker and reuses the winner.
+func delegateQuietWatchHubForSession(s *Session) *delegateQuietWatchHub {
+	delegateQuietWatchHubs.Lock()
+	if hub := delegateQuietWatchHubs.hubs[s]; hub != nil {
+		delegateQuietWatchHubs.Unlock()
+		return hub
+	}
+	delegateQuietWatchHubs.Unlock()
+	ticker := s.sclock().NewTicker(delegateQuietCheckInterval)
+	hub := &delegateQuietWatchHub{
+		ticker:  ticker,
+		done:    make(chan struct{}),
+		entries: make(map[delegateQuietWatchEntry]struct{}),
+	}
+	delegateQuietWatchHubs.Lock()
+	if existing := delegateQuietWatchHubs.hubs[s]; existing != nil {
+		delegateQuietWatchHubs.Unlock()
+		ticker.Stop()
+		return existing
+	}
+	delegateQuietWatchHubs.hubs[s] = hub
+	delegateQuietWatchHubs.Unlock()
+	go s.serveDelegateQuietWatchHub(hub)
+	return hub
 }
 
 // delegateQuietWatchNext arms (or reuses) the shared hub for s and registers
@@ -205,30 +238,23 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 		ctx = context.Background()
 	}
 	watchCtx, cancel := context.WithCancel(ctx)
-	delegateQuietWatchHubs.Lock()
-	hub := delegateQuietWatchHubs.hubs[s]
-	if hub == nil {
-		hub = &delegateQuietWatchHub{
-			done:    make(chan struct{}),
-			entries: make(map[delegateQuietWatchEntry]struct{}),
-		}
-		hub.ticker = s.sclock().NewTicker(delegateQuietCheckInterval)
-		delegateQuietWatchHubs.hubs[s] = hub
-		go s.serveDelegateQuietWatchHub(hub)
-	}
 	entry := delegateQuietWatchEntry{lease: lease, stop: make(chan struct{})}
+	hub := delegateQuietWatchHubForSession(s)
+	hub.mu.Lock()
 	hub.entries[entry] = struct{}{}
-	delegateQuietWatchHubs.Unlock()
+	hub.mu.Unlock()
 	var detachOnce sync.Once
 	stopped := make(chan struct{})
 	detach := func() {
 		detachOnce.Do(func() {
 			delegateQuietWatchHubs.Lock()
+			hub.mu.Lock()
 			delete(hub.entries, entry)
 			empty := len(hub.entries) == 0
 			if empty {
 				delete(delegateQuietWatchHubs.hubs, s)
 			}
+			hub.mu.Unlock()
 			delegateQuietWatchHubs.Unlock()
 			close(entry.stop)
 			close(stopped)
@@ -260,15 +286,17 @@ func (s *Session) serveDelegateQuietWatchHub(hub *delegateQuietWatchHub) {
 		select {
 		case now := <-hub.ticker.C():
 			delegateQuietWatchHubs.Lock()
-			if delegateQuietWatchHubs.hubs[s] != hub {
-				delegateQuietWatchHubs.Unlock()
+			current := delegateQuietWatchHubs.hubs[s]
+			delegateQuietWatchHubs.Unlock()
+			if current != hub {
 				return
 			}
+			hub.mu.Lock()
 			live := make([]delegateQuietWatchEntry, 0, len(hub.entries))
 			for entry := range hub.entries {
 				live = append(live, entry)
 			}
-			delegateQuietWatchHubs.Unlock()
+			hub.mu.Unlock()
 			for _, entry := range live {
 				go func(entry delegateQuietWatchEntry) {
 					select {

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -149,27 +149,147 @@ func (s *Session) runDelegateQuietWatchdogTick(lease delegateLease, now time.Tim
 	return errors.Join(appendErr, completionErr)
 }
 
-func (s *Session) startDelegateQuietWatchdog(ctx context.Context, lease delegateLease) context.CancelFunc {
+// delegateQuietWatchEntry is one lease registered on the shared quiet-watchdog
+// hub: the lease to tick plus a per-lease stop channel. Closing stop detaches
+// the lease from the fan-out so a later tick never touches a stopped lease
+// (no use-after-stop).
+type delegateQuietWatchEntry struct {
+	owner *Session
+	lease delegateLease
+	stop  chan struct{}
+}
+
+// delegateQuietWatchHub multiplexes one ticker across every live
+// delegate-quiet watchdog registered on one Session. Previously each lease
+// armed its own NewTicker(delegateQuietCheckInterval) plus its own goroutine;
+// with K live leases that was K tickers and K goroutines all firing on the
+// same cadence. The hub keeps a single clock.Ticker (one goroutine, one clock
+// waiter per Session) and fans each tick out to the currently registered
+// leases.
+//
+// The hub is keyed to the session's injected clock (s.sclock()): the hub is
+// created lazily under delegateQuietWatchMu, so every lease on the same
+// session — and therefore the same s.clock — shares one ticker and stays on
+// the fake clock in tests.
+type delegateQuietWatchHub struct {
+	owner  *Session
+	ticker interface {
+		C() <-chan time.Time
+		Stop()
+	}
+	done    chan struct{}
+	close   sync.Once
+	entries map[delegateQuietWatchEntry]struct{}
+}
+
+// delegateQuietWatchHubs is the process-wide registry mapping each *Session to
+// its live hub. It lives in this file (rather than on Session) so the change
+// stays within agent/delegate_runtime.go; entries are removed when the hub's
+// last lease detaches, and Session pointers are map keys only (never
+// dereferenced after removal).
+var delegateQuietWatchHubs = struct {
+	sync.Mutex
+	hubs map[*Session]*delegateQuietWatchHub
+}{
+	hubs: make(map[*Session]*delegateQuietWatchHub),
+}
+
+// delegateQuietWatchNext arms (or reuses) the shared hub for s and registers
+// lease on it. The returned CancelFunc detaches exactly this registration:
+// the hub's single ticker keeps serving the remaining leases, and the hub
+// goroutine exits (stopping the shared ticker) only when the last
+// registration leaves, so no ticker leaks after a lease ends.
+func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLease) context.CancelFunc {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	watchCtx, cancel := context.WithCancel(ctx)
-	ticker := s.sclock().NewTicker(delegateQuietCheckInterval)
-	go func() {
-		defer ticker.Stop()
-		for {
-			select {
-			case now := <-ticker.C():
-				_ = s.runDelegateQuietWatchdogTick(lease, now)
-			case <-watchCtx.Done():
-				return
+	delegateQuietWatchHubs.Lock()
+	hub := delegateQuietWatchHubs.hubs[s]
+	if hub == nil {
+		hub = &delegateQuietWatchHub{
+			owner:   s,
+			done:    make(chan struct{}),
+			entries: make(map[delegateQuietWatchEntry]struct{}),
+		}
+		hub.ticker = s.sclock().NewTicker(delegateQuietCheckInterval)
+		delegateQuietWatchHubs.hubs[s] = hub
+		go s.serveDelegateQuietWatchHub(hub)
+	}
+	entry := delegateQuietWatchEntry{owner: s, lease: lease, stop: make(chan struct{})}
+	hub.entries[entry] = struct{}{}
+	delegateQuietWatchHubs.Unlock()
+	var detachOnce sync.Once
+	stopped := make(chan struct{})
+	detach := func() {
+		detachOnce.Do(func() {
+			delegateQuietWatchHubs.Lock()
+			delete(hub.entries, entry)
+			empty := len(hub.entries) == 0
+			if empty {
+				delete(delegateQuietWatchHubs.hubs, s)
 			}
+			delegateQuietWatchHubs.Unlock()
+			close(entry.stop)
+			close(stopped)
+			if empty {
+				hub.close.Do(func() {
+					close(hub.done)
+					hub.ticker.Stop()
+				})
+			}
+		})
+	}
+	go func() {
+		select {
+		case <-watchCtx.Done():
+			detach()
+		case <-entry.stop:
+		case <-hub.done:
 		}
 	}()
 	return func() {
-		ticker.Stop()
+		detach()
 		cancel()
+		<-stopped
 	}
+}
+
+// serveDelegateQuietWatchHub is the hub's single goroutine: each shared tick
+// fans out to every registered lease whose stop channel is still open.
+func (s *Session) serveDelegateQuietWatchHub(hub *delegateQuietWatchHub) {
+	for {
+		select {
+		case now := <-hub.ticker.C():
+			delegateQuietWatchHubs.Lock()
+			if delegateQuietWatchHubs.hubs[s] != hub {
+				delegateQuietWatchHubs.Unlock()
+				return
+			}
+			live := make([]delegateQuietWatchEntry, 0, len(hub.entries))
+			for entry := range hub.entries {
+				live = append(live, entry)
+			}
+			delegateQuietWatchHubs.Unlock()
+			for _, entry := range live {
+				select {
+				case <-entry.stop:
+					continue
+				default:
+				}
+				_ = s.runDelegateQuietWatchdogTick(entry.lease, now)
+			}
+		case <-hub.done:
+			return
+		}
+	}
+}
+
+func (s *Session) startDelegateQuietWatchdog(ctx context.Context, lease delegateLease) context.CancelFunc {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return s.delegateQuietWatchNext(ctx, lease)
 }
 
 func delegateQuietAttentionID(lease delegateLease) string {

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -156,6 +157,12 @@ func (s *Session) runDelegateQuietWatchdogTick(lease delegateLease, now time.Tim
 type delegateQuietWatchEntry struct {
 	lease delegateLease
 	stop  chan struct{}
+	// busy coalesces ticks while one tick for this registration is still
+	// running: the hub loop swaps it from 0 to 1 with CompareAndSwap, and a
+	// tick that loses the race is dropped rather than queued. *uint32 (not a
+	// plain field) so entries stay comparable as map keys while still
+	// sharing one atomic word per registration.
+	busy *uint32
 }
 
 // delegateQuietWatchHub multiplexes one ticker across every live
@@ -241,6 +248,7 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 	entry := delegateQuietWatchEntry{lease: lease, stop: make(chan struct{})}
 	hub := delegateQuietWatchHubForSession(s)
 	hub.mu.Lock()
+	entry.busy = new(uint32)
 	hub.entries[entry] = struct{}{}
 	hub.mu.Unlock()
 	var detachOnce sync.Once
@@ -298,7 +306,15 @@ func (s *Session) serveDelegateQuietWatchHub(hub *delegateQuietWatchHub) {
 			}
 			hub.mu.Unlock()
 			for _, entry := range live {
+				// At most one tick runs per registration: a tick that arrives
+				// while the previous one for the same lease is still blocked
+				// is coalesced away instead of piling up a goroutine (and a
+				// redundant work burst on release) per tick.
+				if entry.busy == nil || !atomic.CompareAndSwapUint32(entry.busy, 0, 1) {
+					continue
+				}
 				go func(entry delegateQuietWatchEntry) {
+					defer atomic.StoreUint32(entry.busy, 0)
 					select {
 					case <-entry.stop:
 						return

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -203,6 +203,14 @@ var delegateQuietWatchHubs = struct {
 	hubs: make(map[*Session]*delegateQuietWatchHub),
 }
 
+// delegateQuietWatchTickDone observes one hub tick's completed lease work. It is
+// nil in production; tests set it to await tick completion deterministically
+// instead of polling. It fires after runDelegateQuietWatchdogTick returns, so
+// the tick's durable write is already visible to the observer; coalesced and
+// detached ticks do no work and never fire it. Observers must not block: the
+// call runs on the tick's worker goroutine.
+var delegateQuietWatchTickDone func(lease delegateLease)
+
 // delegateQuietWatchHubForSession returns the live hub for s, creating it on
 // first use. The ticker is created outside the registry lock so arming one
 // session's hub never blocks another session's attach/detach; a lost creation
@@ -233,7 +241,10 @@ func delegateQuietWatchHubForSession(s *Session) *delegateQuietWatchHub {
 }
 
 // delegateQuietWatchNext arms (or reuses) the shared hub for s and registers
-// lease on it. The returned CancelFunc detaches exactly this registration:
+// lease on it. Registration is atomic with the hub lookup under the registry
+// lock, so the entry always lands on the hub the registry points at and can
+// never strand on a stopped, unregistered hub.
+// The returned CancelFunc detaches exactly this registration:
 // the hub's single ticker keeps serving the remaining leases, and the hub
 // goroutine exits (stopping the shared ticker) only when the last
 // registration leaves, so no ticker leaks after a lease ends. Cancellation
@@ -245,28 +256,60 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 		ctx = context.Background()
 	}
 	watchCtx, cancel := context.WithCancel(ctx)
-	entry := delegateQuietWatchEntry{lease: lease, stop: make(chan struct{})}
-	hub := delegateQuietWatchHubForSession(s)
+	entry := delegateQuietWatchEntry{lease: lease, stop: make(chan struct{}), busy: new(uint32)}
+	// Lookup-plus-insert is atomic under the registry lock: a lookup that ran
+	// before detach's delete would otherwise strand this entry on a stopped,
+	// unregistered hub that never ticks again. Lock order stays registry -> hub
+	// mu here and in detach, never the reverse.
+	delegateQuietWatchHubs.Lock()
+	hub := delegateQuietWatchHubs.hubs[s]
+	if hub == nil {
+		delegateQuietWatchHubs.Unlock()
+		ticker := s.sclock().NewTicker(delegateQuietCheckInterval)
+		hub = &delegateQuietWatchHub{
+			ticker:  ticker,
+			done:    make(chan struct{}),
+			entries: make(map[delegateQuietWatchEntry]struct{}),
+		}
+		delegateQuietWatchHubs.Lock()
+		if existing := delegateQuietWatchHubs.hubs[s]; existing != nil {
+			delegateQuietWatchHubs.Unlock()
+			ticker.Stop()
+			hub = existing
+		} else {
+			delegateQuietWatchHubs.hubs[s] = hub
+			delegateQuietWatchHubs.Unlock()
+			go s.serveDelegateQuietWatchHub(hub)
+			delegateQuietWatchHubs.Lock()
+		}
+	}
 	hub.mu.Lock()
-	entry.busy = new(uint32)
 	hub.entries[entry] = struct{}{}
 	hub.mu.Unlock()
+	delegateQuietWatchHubs.Unlock()
 	var detachOnce sync.Once
 	stopped := make(chan struct{})
 	detach := func() {
 		detachOnce.Do(func() {
+			// The registry entry is removed only while it still points at this
+			// hub: detaching an entry must never delete a successor hub a later
+			// attach registered for the same session.
 			delegateQuietWatchHubs.Lock()
 			hub.mu.Lock()
 			delete(hub.entries, entry)
 			empty := len(hub.entries) == 0
-			if empty {
+			unregistered := empty && delegateQuietWatchHubs.hubs[s] == hub
+			if unregistered {
 				delete(delegateQuietWatchHubs.hubs, s)
 			}
 			hub.mu.Unlock()
 			delegateQuietWatchHubs.Unlock()
 			close(entry.stop)
 			close(stopped)
-			if empty {
+			// Stop-once rides on close.Do (not on empty): two detaches can both
+			// observe an empty hub while a concurrent attach is in flight, and a
+			// plain empty check would stop the ticker out from under it.
+			if unregistered {
 				hub.close.Do(func() {
 					close(hub.done)
 					hub.ticker.Stop()
@@ -321,6 +364,9 @@ func (s *Session) serveDelegateQuietWatchHub(hub *delegateQuietWatchHub) {
 					default:
 					}
 					_ = s.runDelegateQuietWatchdogTick(entry.lease, now)
+					if done := delegateQuietWatchTickDone; done != nil {
+						done(entry.lease)
+					}
 				}(entry)
 			}
 		case <-hub.done:

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -256,7 +256,11 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 }
 
 // serveDelegateQuietWatchHub is the hub's single goroutine: each shared tick
-// fans out to every registered lease whose stop channel is still open.
+// fans out to every registered lease whose stop channel is still open. Each
+// lease's tick runs on its own goroutine so one lease blocked on durable
+// transcript I/O (or armDelegateAttention's reservation path) cannot stall
+// the remaining leases or delay hub shutdown: the loop never waits on tick
+// work and keeps selecting on hub.done.
 func (s *Session) serveDelegateQuietWatchHub(hub *delegateQuietWatchHub) {
 	for {
 		select {
@@ -272,12 +276,14 @@ func (s *Session) serveDelegateQuietWatchHub(hub *delegateQuietWatchHub) {
 			}
 			delegateQuietWatchHubs.Unlock()
 			for _, entry := range live {
-				select {
-				case <-entry.stop:
-					continue
-				default:
-				}
-				_ = s.runDelegateQuietWatchdogTick(entry.lease, now)
+				go func(entry delegateQuietWatchEntry) {
+					select {
+					case <-entry.stop:
+						return
+					default:
+					}
+					_ = s.runDelegateQuietWatchdogTick(entry.lease, now)
+				}(entry)
 			}
 		case <-hub.done:
 			return

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -257,28 +257,43 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 	// Lookup-plus-insert is atomic under the registry lock: a lookup that ran
 	// before detach's delete would otherwise strand this entry on a stopped,
 	// unregistered hub that never ticks again. Lock order stays registry -> hub
-	// mu here and in detach, never the reverse.
+	// mu here and in detach, never the reverse. A creation loser that finds a
+	// hub after stopping its spare ticker re-verifies the registry still points
+	// at that hub before landing on it: a detach-plus-replace in the gap means
+	// retrying the lookup instead of registering on the stale hub.
 	delegateQuietWatchHubs.Lock()
-	hub := delegateQuietWatchHubs.hubs[s]
-	if hub == nil {
+	var hub *delegateQuietWatchHub
+	for {
+		hub = delegateQuietWatchHubs.hubs[s]
+		if hub != nil {
+			break
+		}
 		delegateQuietWatchHubs.Unlock()
 		ticker := s.sclock().NewTicker(delegateQuietCheckInterval)
-		hub = &delegateQuietWatchHub{
+		fresh := &delegateQuietWatchHub{
 			ticker:  ticker,
 			done:    make(chan struct{}),
 			entries: make(map[delegateQuietWatchEntry]struct{}),
 		}
 		delegateQuietWatchHubs.Lock()
-		if existing := delegateQuietWatchHubs.hubs[s]; existing != nil {
+		existing := delegateQuietWatchHubs.hubs[s]
+		if existing == nil {
+			delegateQuietWatchHubs.hubs[s] = fresh
 			delegateQuietWatchHubs.Unlock()
-			ticker.Stop()
+			go s.serveDelegateQuietWatchHub(fresh)
+			delegateQuietWatchHubs.Lock()
+			hub = fresh
+			break
+		}
+		delegateQuietWatchHubs.Unlock()
+		ticker.Stop()
+		delegateQuietWatchHubs.Lock()
+		// The loser-observed hub may have been detached and replaced while the
+		// lock was released to stop the spare ticker: only land on it while the
+		// registry still points at it, otherwise loop back and retry the lookup.
+		if delegateQuietWatchHubs.hubs[s] == existing {
 			hub = existing
-			delegateQuietWatchHubs.Lock()
-		} else {
-			delegateQuietWatchHubs.hubs[s] = hub
-			delegateQuietWatchHubs.Unlock()
-			go s.serveDelegateQuietWatchHub(hub)
-			delegateQuietWatchHubs.Lock()
+			break
 		}
 	}
 	hub.mu.Lock()

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -198,7 +198,10 @@ var delegateQuietWatchHubs = struct {
 // lease on it. The returned CancelFunc detaches exactly this registration:
 // the hub's single ticker keeps serving the remaining leases, and the hub
 // goroutine exits (stopping the shared ticker) only when the last
-// registration leaves, so no ticker leaks after a lease ends.
+// registration leaves, so no ticker leaks after a lease ends. Cancellation
+// rides on the run context via context.AfterFunc rather than a parked
+// goroutine per registration, so the hub goroutine stays the only
+// steady-state goroutine per session no matter how many leases share it.
 func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLease) context.CancelFunc {
 	if ctx == nil {
 		ctx = context.Background()
@@ -240,16 +243,10 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 			}
 		})
 	}
-	go func() {
-		select {
-		case <-watchCtx.Done():
-			detach()
-		case <-entry.stop:
-		case <-hub.done:
-		}
-	}()
+	stopAfter := context.AfterFunc(watchCtx, detach)
 	return func() {
 		detach()
+		stopAfter()
 		cancel()
 		<-stopped
 	}

--- a/agent/delegate_runtime.go
+++ b/agent/delegate_runtime.go
@@ -273,6 +273,7 @@ func (s *Session) delegateQuietWatchNext(ctx context.Context, lease delegateLeas
 			delegateQuietWatchHubs.Unlock()
 			ticker.Stop()
 			hub = existing
+			delegateQuietWatchHubs.Lock()
 		} else {
 			delegateQuietWatchHubs.hubs[s] = hub
 			delegateQuietWatchHubs.Unlock()


### PR DESCRIPTION
One goroutine+ticker per delegate lease (30s cadence each) becomes one multiplexed hub ticker per session. Per-lease stop semantics preserved (detachOnce, stop-chan pre-tick check, hub teardown on empty); fake clock via s.sclock kept; ctx-cancel path intact.

Verification (serial runner): gofmt/vet clean; supervision watchdog tests 2/2 + legacy dormancy ok; nil-guard covtests pass; K=8 probe shows 1 hub / 8 entries, map fully drained after cancels. delegateLease confirmed comparable (no map-op panic).
Risk: low-med (timer lifecycle). No leaks observed.