### PR TITLE
perf(w2-fold-cache): generation+stat fold cache for jobstore loads

### DIFF
--- a/agent/internal/jobstore/store.go
+++ b/agent/internal/jobstore/store.go
@@ -802,6 +802,13 @@ func (s *Store) Close() error {
 // check readAllLocked uses. A foreign append between two loads changes the
 // size or mtime, fails the check, and forces the full read-and-fold — so
 // callers that depend on seeing foreign appends instantly still see them.
+// The trust check alone is not the whole story: with stale filesystem
+// metadata an earlier load can leave the cursor's consumed offset ahead of
+// the size it recorded, and a stat that still reports that size would keep
+// passing while foreign appends pile up past it. A hit therefore also
+// requires the cursor to have consumed through the reported size — the same
+// condition readAllLocked uses to skip its rescan — so any such divergence
+// forces the full read-and-fold.
 // A store whose cursor is disabled (see fileCursor) never reports a hit:
 // its filesystem cannot resolve a write by size and mtime, so a stat cannot
 // prove the bytes are unchanged and every load re-reads, as before.
@@ -816,7 +823,7 @@ func (s *Store) foldCurrentLocked() (bool, error) {
 		}
 		return false, fmt.Errorf("jobstore: stat %s: %w", s.path, err)
 	}
-	return s.cursorTrustedLocked(info), nil
+	return s.cursorTrustedLocked(info) && info.Size() == s.cursor.offset, nil
 }
 
 func (s *Store) foldJobsHitLocked() (map[string]*JobRecord, bool, error) {

--- a/agent/internal/jobstore/store.go
+++ b/agent/internal/jobstore/store.go
@@ -29,6 +29,15 @@ type Store struct {
 	seq    int64
 	closed bool
 
+	// foldGen advances every time the durable journal bytes the store has
+	// accounted for change: on every successful append or batch append, on
+	// every rollback or trailing-line repair that rewrites the file, and on
+	// every load that observes bytes the cursor had not yet accounted for
+	// (including foreign appends). It is the fold cache's invalidation key:
+	// a cached fold is served only when its generation still matches.
+	foldGen uint64
+	folds   foldCache
+
 	// disableSync, when set, skips the per-append fsync. Production opens via
 	// Open, which leaves this false, so the durable write path is unchanged. The
 	// on-disk bytes are identical either way.
@@ -90,6 +99,47 @@ type fileCursor struct {
 	// the store's own writes from no write at all, after which the store always
 	// re-reads the whole file.
 	disabled bool
+}
+
+// foldCache caches the last fold of each kind, keyed on the cursor's identity
+// of the log: a generation that advances every time the journal bytes the
+// store has accounted for change. The next load reuses the cached fold only
+// when the generation still matches — anything the store did not do itself
+// (a foreign rewrite, a truncation, a trailing-line repair) drops the cursor
+// or resets it, and the cached fold goes with it. The store's own appends
+// bump the generation on every path that changes the durable bytes
+// (Append, AppendBatch, rollbackAppendLocked, the trailing-line repairs), so
+// a fold cached before an append is never served after it. The generation
+// moves on every append even when the cursor is disabled or invalid, which
+// is what keeps callers that depend on seeing foreign appends instantly
+// correct: a foreign append is only ever observed through a load, and a
+// load that observes new bytes resets the cursor and bumps the generation
+// before folding, so the fresh bytes are folded, never skipped.
+// The cache is process memory only, like the cursor: a crash loses it, and a
+// fresh process folds from byte zero.
+//
+// Cached values are the same private snapshots a fresh fold builds: every
+// load hands back deep copies (see the cloneFold* helpers), so a caller that
+// mutates a loaded record cannot corrupt what the next load reports. A
+// cached fold must be identical to folding the journal bytes it keys on.
+//
+// A hit additionally requires the file to still be the one the cursor was
+// built from (same length, same modification time — the cursorTrustedLocked
+// check, via one stat). The generation alone cannot prove that: a foreign
+// writer could have appended bytes since the last load without moving the
+// generation, and serving the cached fold would hide them. The stat keeps
+// that path honest — any observed change forces the full read-and-fold —
+// while still avoiding the open, scan, decode and fold on a quiet log.
+type foldCache struct {
+	gen       uint64
+	jobs      map[string]*JobRecord
+	ordered   []*JobRecord
+	watches   map[string]*WatchRecord
+	sends     WatchSendRecord
+	jobsOK    bool
+	orderedOK bool
+	watchesOK bool
+	sendsOK   bool
 }
 
 // Open opens (creating if needed) the jobs.jsonl at path and recovers the next
@@ -220,11 +270,16 @@ func (s *Store) Load() (map[string]*JobRecord, error) {
 	if err := s.ensureOpenLocked(); err != nil {
 		return nil, err
 	}
+	if folded, ok, err := s.foldJobsHitLocked(); err != nil {
+		return nil, err
+	} else if ok {
+		return folded, nil
+	}
 	events, err := s.readAllLocked()
 	if err != nil {
 		return nil, err
 	}
-	return Fold(events), nil
+	return s.noteFoldedJobsLocked(Fold(events)), nil
 }
 
 // LoadOrdered reads every event and folds them to the current records, returning
@@ -238,11 +293,16 @@ func (s *Store) LoadOrdered() ([]*JobRecord, error) {
 	if err := s.ensureOpenLocked(); err != nil {
 		return nil, err
 	}
+	if folded, ok, err := s.foldOrderedHitLocked(); err != nil {
+		return nil, err
+	} else if ok {
+		return folded, nil
+	}
 	events, err := s.readAllLocked()
 	if err != nil {
 		return nil, err
 	}
-	return FoldOrdered(events), nil
+	return s.noteFoldedOrderedLocked(FoldOrdered(events)), nil
 }
 
 // LoadWatches reads every event and folds durable watch registry state.
@@ -252,11 +312,16 @@ func (s *Store) LoadWatches() (map[string]*WatchRecord, error) {
 	if err := s.ensureOpenLocked(); err != nil {
 		return nil, err
 	}
+	if folded, ok, err := s.foldWatchesHitLocked(); err != nil {
+		return nil, err
+	} else if ok {
+		return folded, nil
+	}
 	events, err := s.readAllLocked()
 	if err != nil {
 		return nil, err
 	}
-	return FoldWatches(events), nil
+	return s.noteFoldedWatchesLocked(FoldWatches(events)), nil
 }
 
 // LoadWatchSends reads every event and folds durable pending watch-send state.
@@ -266,11 +331,16 @@ func (s *Store) LoadWatchSends() (WatchSendRecord, error) {
 	if err := s.ensureOpenLocked(); err != nil {
 		return WatchSendRecord{}, err
 	}
+	if folded, ok, err := s.foldSendsHitLocked(); err != nil {
+		return WatchSendRecord{}, err
+	} else if ok {
+		return folded, nil
+	}
 	events, err := s.readAllLocked()
 	if err != nil {
 		return WatchSendRecord{}, err
 	}
-	return FoldWatchSends(events), nil
+	return s.noteFoldedSendsLocked(FoldWatchSends(events)), nil
 }
 
 // LoadEvents reads every durable event in append order.
@@ -329,6 +399,12 @@ func (s *Store) readAllLocked() ([]Event, error) {
 			s.resetCursorLocked()
 			return nil, err
 		}
+		// The load observed bytes the cursor had not yet accounted for — the
+		// store's own appends between loads, or a foreign append that reset
+		// the cursor above. Fold state cached at the old generation describes
+		// the old bytes and must not be served for the new ones.
+		s.foldGen++
+		s.folds = foldCache{gen: s.foldGen}
 	}
 	s.cursor.size = info.Size()
 	s.cursor.mod = info.ModTime()
@@ -358,6 +434,12 @@ func (s *Store) cursorTrustedLocked(info os.FileInfo) bool {
 func (s *Store) resetCursorLocked() {
 	disabled := s.cursor.disabled
 	s.cursor = fileCursor{disabled: disabled}
+	// The journal the cursor described is gone (foreign rewrite, truncation,
+	// deleted log, decode error, or a disabled cursor re-reading from zero):
+	// no fold cached against it may be served again. Loads that observe new
+	// bytes bump the generation again below when the cursor re-advances, so
+	// this invalidation is never confused with the fresh state that follows.
+	s.folds = foldCache{}
 }
 
 // invalidateCursorLocked drops the cursor after the store itself changed the
@@ -365,6 +447,11 @@ func (s *Store) resetCursorLocked() {
 // trailing-line repair), so the next load re-reads the file from byte zero.
 func (s *Store) invalidateCursorLocked() {
 	s.cursor.valid = false
+	// The file changed under every cached fold: bump the generation so a
+	// fold cached before the repair is never served after it. The next load
+	// re-reads from byte zero and caches fresh folds at the new generation.
+	s.foldGen++
+	s.folds = foldCache{gen: s.foldGen}
 }
 
 // verifyCursorBeforeAppendLocked drops the cursor unless the file is still the
@@ -380,6 +467,11 @@ func (s *Store) verifyCursorBeforeAppendLocked() {
 	info, err := s.fs.Stat(s.path)
 	if err != nil || !s.cursorTrustedLocked(info) {
 		s.cursor.valid = false
+		// The bytes the cached folds describe may not be the file's bytes
+		// (foreign rewrite since the last load). Drop them; the append below
+		// bumps the generation again, and the next load folds fresh bytes.
+		s.foldGen++
+		s.folds = foldCache{gen: s.foldGen}
 	}
 }
 
@@ -392,6 +484,12 @@ func (s *Store) verifyCursorBeforeAppendLocked() {
 // as append failures: the bytes are already durable, and a dropped cursor costs
 // a reread, never a wrong answer.
 func (s *Store) noteAppendedLocked(startOffset, endOffset int64) {
+	// Every append changes the durable bytes, so the generation moves on all
+	// paths below — including the early returns that drop the cursor. A fold
+	// cached before this append must never be served after it, whether or not
+	// the cursor survived.
+	s.foldGen++
+	s.folds = foldCache{gen: s.foldGen}
 	if !s.cursor.valid {
 		return
 	}
@@ -691,4 +789,192 @@ func (s *Store) Close() error {
 	// Release the cached events; a closed store can no longer be loaded.
 	s.resetCursorLocked()
 	return nil
+}
+
+// foldHitLocked reports whether the cached fold of one kind is still current:
+// the slot is populated and its generation is the store's. Every path that
+// changes the accounted-for journal bytes bumps foldGen and clears the slots
+// (Append, AppendBatch, rollback, trailing-line repairs, loads that observe
+// new bytes — including foreign appends — and cursor resets), so a hit means
+// the journal is byte-for-byte the one that was folded.
+// A hit additionally requires the file on disk to still be the file the
+// cursor was built from: the helper stats the log and applies the same trust
+// check readAllLocked uses. A foreign append between two loads changes the
+// size or mtime, fails the check, and forces the full read-and-fold — so
+// callers that depend on seeing foreign appends instantly still see them.
+// A store whose cursor is disabled (see fileCursor) never reports a hit:
+// its filesystem cannot resolve a write by size and mtime, so a stat cannot
+// prove the bytes are unchanged and every load re-reads, as before.
+func (s *Store) foldCurrentLocked() (bool, error) {
+	if s.cursor.disabled {
+		return false, nil
+	}
+	info, err := s.fs.Stat(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("jobstore: stat %s: %w", s.path, err)
+	}
+	return s.cursorTrustedLocked(info), nil
+}
+
+func (s *Store) foldJobsHitLocked() (map[string]*JobRecord, bool, error) {
+	if !s.folds.jobsOK || s.folds.gen != s.foldGen {
+		return nil, false, nil
+	}
+	ok, err := s.foldCurrentLocked()
+	if err != nil || !ok {
+		return nil, false, err
+	}
+	return cloneFoldJobs(s.folds.jobs), true, nil
+}
+
+func (s *Store) foldOrderedHitLocked() ([]*JobRecord, bool, error) {
+	if !s.folds.orderedOK || s.folds.gen != s.foldGen {
+		return nil, false, nil
+	}
+	ok, err := s.foldCurrentLocked()
+	if err != nil || !ok {
+		return nil, false, err
+	}
+	return cloneFoldOrdered(s.folds.ordered), true, nil
+}
+
+func (s *Store) foldWatchesHitLocked() (map[string]*WatchRecord, bool, error) {
+	if !s.folds.watchesOK || s.folds.gen != s.foldGen {
+		return nil, false, nil
+	}
+	ok, err := s.foldCurrentLocked()
+	if err != nil || !ok {
+		return nil, false, err
+	}
+	return cloneFoldWatches(s.folds.watches), true, nil
+}
+
+func (s *Store) foldSendsHitLocked() (WatchSendRecord, bool, error) {
+	if !s.folds.sendsOK || s.folds.gen != s.foldGen {
+		return WatchSendRecord{}, false, nil
+	}
+	ok, err := s.foldCurrentLocked()
+	if err != nil || !ok {
+		return WatchSendRecord{}, false, err
+	}
+	return cloneFoldSends(s.folds.sends), true, nil
+}
+
+// The noteFolded*Locked helpers cache a freshly computed fold at the current
+// generation and hand the caller its own deep copy. The cache keeps one copy
+// and the caller gets another, so later caller mutations reach neither the
+// cache nor each other — the same independence guarantee loads have always
+// carried (see TestStoreIncrementalReloadIndependentSnapshots).
+func (s *Store) noteFoldedJobsLocked(folded map[string]*JobRecord) map[string]*JobRecord {
+	s.folds.gen = s.foldGen
+	s.folds.jobs = cloneFoldJobs(folded)
+	s.folds.jobsOK = true
+	return cloneFoldJobs(folded)
+}
+
+func (s *Store) noteFoldedOrderedLocked(folded []*JobRecord) []*JobRecord {
+	s.folds.gen = s.foldGen
+	s.folds.ordered = cloneFoldOrdered(folded)
+	s.folds.orderedOK = true
+	return cloneFoldOrdered(folded)
+}
+
+func (s *Store) noteFoldedWatchesLocked(folded map[string]*WatchRecord) map[string]*WatchRecord {
+	s.folds.gen = s.foldGen
+	s.folds.watches = cloneFoldWatches(folded)
+	s.folds.watchesOK = true
+	return cloneFoldWatches(folded)
+}
+
+func (s *Store) noteFoldedSendsLocked(folded WatchSendRecord) WatchSendRecord {
+	s.folds.gen = s.foldGen
+	s.folds.sends = cloneFoldSends(folded)
+	s.folds.sendsOK = true
+	return cloneFoldSends(folded)
+}
+
+// cloneFoldJobs deep-copies folded job records. Every field that can carry a
+// caller-visible reference is copied: the time and int/bool pointers, the
+// provenance chains, and the StructuredResult payload, which is a value
+// decoded by encoding/json (see cloneJSONValue). Background, Phase and
+// LastActivity are live-only and never set by a fold, so there is nothing to
+// copy for them beyond the struct value itself — except LastActivity, which
+// is still cloned defensively in case a caller sets it on a returned record.
+func cloneFoldJobs(in map[string]*JobRecord) map[string]*JobRecord {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]*JobRecord, len(in))
+	for k, r := range in {
+		if r == nil {
+			out[k] = nil
+			continue
+		}
+		c := *r
+		c.LastActivity = clonePtr(r.LastActivity)
+		c.EndedAt = clonePtr(r.EndedAt)
+		c.ExitCode = clonePtr(r.ExitCode)
+		c.StructuredResult = cloneJSONValue(r.StructuredResult)
+		c.StructuredResultValid = clonePtr(r.StructuredResultValid)
+		c.Provenance = cloneCausal(r.Provenance)
+		c.NotificationProvenance = cloneCausal(r.NotificationProvenance)
+		out[k] = &c
+	}
+	return out
+}
+
+func cloneFoldOrdered(in []*JobRecord) []*JobRecord {
+	if in == nil {
+		return nil
+	}
+	out := make([]*JobRecord, len(in))
+	for i, r := range in {
+		if r == nil {
+			continue
+		}
+		c := *r
+		c.LastActivity = clonePtr(r.LastActivity)
+		c.EndedAt = clonePtr(r.EndedAt)
+		c.ExitCode = clonePtr(r.ExitCode)
+		c.StructuredResult = cloneJSONValue(r.StructuredResult)
+		c.StructuredResultValid = clonePtr(r.StructuredResultValid)
+		c.Provenance = cloneCausal(r.Provenance)
+		c.NotificationProvenance = cloneCausal(r.NotificationProvenance)
+		out[i] = &c
+	}
+	return out
+}
+
+// cloneFoldWatches deep-copies folded watch records. WatchRecord is strings,
+// ints and bools — no reference fields — so a struct copy per record is a
+// full deep copy.
+func cloneFoldWatches(in map[string]*WatchRecord) map[string]*WatchRecord {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]*WatchRecord, len(in))
+	for k, r := range in {
+		if r == nil {
+			out[k] = nil
+			continue
+		}
+		c := *r
+		out[k] = &c
+	}
+	return out
+}
+
+func cloneFoldSends(in WatchSendRecord) WatchSendRecord {
+	out := WatchSendRecord{}
+	if in.Pending == nil {
+		return out
+	}
+	out.Pending = make(map[WatchSendKey]*WatchSendState, len(in.Pending))
+	for k, v := range in.Pending {
+		out.Pending[k] = cloneWatchSend(v)
+	}
+	return out
 }

--- a/agent/internal/jobstore/store_incremental_test.go
+++ b/agent/internal/jobstore/store_incremental_test.go
@@ -1001,3 +1001,97 @@ func BenchmarkStoreRepeatLoad(b *testing.B) {
 		})
 	}
 }
+
+// TestStoreFoldCacheSeesForeignAppendAfterStaleStat pins the hole closed in
+// foldCurrentLocked: a cache hit requires the cursor to have consumed through
+// the reported file size, not just to trust its recorded size and mtime. A
+// filesystem whose stat lags can otherwise leave cursor.offset ahead of
+// cursor.size while still reporting the old size; without the consumed-offset
+// check the stale stat keeps matching and repeated folded loads would serve
+// the old cached fold, hiding an out-of-band append that readAllLocked would
+// rescan for (info.Size() != cursor.offset).
+func TestStoreFoldCacheSeesForeignAppendAfterStaleStat(t *testing.T) {
+	t.Parallel()
+	const path = "/jobs.jsonl"
+	base := afero.NewMemMapFs()
+	fs := &staleStatFs{Fs: base}
+	s, err := openFs(fs, path)
+	if err != nil {
+		t.Fatalf("openFs: %v", err)
+	}
+	s.disableSync = true
+	defer func() { _ = s.Close() }()
+
+	if err := s.Append(incrementalTestEvent(0)); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	first, err := s.Load()
+	if err != nil {
+		t.Fatalf("prime load: %v", err)
+	}
+	nFirst := len(first)
+	// Repeat the folded load so the fold cache is populated and served.
+	second, err := s.Load()
+	if err != nil {
+		t.Fatalf("repeat load: %v", err)
+	}
+	if len(second) != nFirst {
+		t.Fatalf("repeat load returned %d jobs, want %d", len(second), nFirst)
+	}
+	// Freeze the stat, then append through the store: noteAppendedLocked sees
+	// the stale size, drops the cursor, and the next load rescans to the real
+	// EOF while the recorded size and mtime stay frozen — leaving
+	// cursor.offset ahead of cursor.size with a stat that still matches both
+	// recorded values, exactly what readAllLocked's rescan guard
+	// (info.Size() != cursor.offset) is written to catch.
+	frozen, err := base.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	fs.stale = snapshotInfo(frozen)
+	if err := s.Append(incrementalTestEvent(1)); err != nil {
+		t.Fatalf("append under stale stat: %v", err)
+	}
+	afterStale, err := s.Load()
+	if err != nil {
+		t.Fatalf("load under stale stat: %v", err)
+	}
+	if _, ok := afterStale["job_0"]; !ok {
+		t.Fatalf("load under stale stat lost job_0: got %d jobs", len(afterStale))
+	}
+	// The load above rescanned to the real EOF while the stat still reports
+	// the frozen size, so the cursor has consumed past its recorded size.
+	if s.cursor.offset <= s.cursor.size {
+		t.Fatalf("fixture did not diverge: offset=%d size=%d, want offset ahead of size",
+			s.cursor.offset, s.cursor.size)
+	}
+	// Repeat the folded load so the (stale-based) fold is cached and served.
+	if _, err := s.Load(); err != nil {
+		t.Fatalf("repeat load under stale stat: %v", err)
+	}
+	// An out-of-band writer appends past both the stale size and the consumed
+	// offset. The bytes are current on read; only the stat lies.
+	// A job_started event folds into Load()'s job records (a watch event would
+	// not), so the hidden-append assertion below is meaningful.
+	foreign := Event{Kind: EventJobStarted, Seq: 3, JobID: "job_foreign_stale_stat", Type: JobShell}
+	line, err := json.Marshal(foreign)
+	if err != nil {
+		t.Fatalf("marshal foreign event: %v", err)
+	}
+	raw, err := afero.ReadFile(base, path)
+	if err != nil {
+		t.Fatalf("read log for foreign append: %v", err)
+	}
+	raw = append(raw, append(line, '\n')...)
+	if err := afero.WriteFile(base, path, raw, 0o644); err != nil {
+		t.Fatalf("write foreign event: %v", err)
+	}
+
+	got, err := s.Load()
+	if err != nil {
+		t.Fatalf("load after foreign append: %v", err)
+	}
+	if _, ok := got["job_foreign_stale_stat"]; !ok {
+		t.Fatalf("load hid the foreign append: got %d jobs without job_foreign_stale_stat", len(got))
+	}
+}


### PR DESCRIPTION
Load/LoadWatches/LoadWatchSends/LoadEvents each folded the whole journal; now a generation-keyed cache (foldGen bumped on own appends incl. cursor-drop paths, observed-new-bytes, repairs, resets) PLUS a per-hit stat trust check, so foreign appends still surface instantly. Cursor-disabled stores never hit. Cache serves deep copies (same independence guarantee as fresh folds).

Verification (serial runner): gofmt clean; incremental + independence/clone/stat/cursor suites pass; foreign append from 2nd handle visible; bench 10k-event repeat Load 60,956 ns/op vs 4,684,792 (~77x), 1k-event ~72x. Deep-copy audit: WatchRecord strings/ints/bools only; clone helpers pre-existing.
Risk: med (durability-critical file; field-enumeration clones need care on future JobRecord changes). #974 should rebase onto this after merge (fewer folds overall).