### PR TITLE
perf(w2-barrel): direct imports for heavy widgets

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/doc/DocPane.tsx
+++ b/cmd/evener-hub/frontend/src/panes/doc/DocPane.tsx
@@ -8,7 +8,8 @@ import {
   readDocFile,
 } from "../../protocol/docContent";
 import type { PaneProps } from "../../shell/paneRegistry";
-import { Chip, Dialog, EmptyState, Markdown, PaneScaffold, Skeleton } from "../../widgets";
+import { Chip, Dialog, EmptyState, PaneScaffold, Skeleton } from "../../widgets";
+import { Markdown } from "../../widgets/markdown";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { filenameOf, formatDocBytes, isMarkdownPath } from "./docFile";
 import styles from "./docpane.module.css";

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
@@ -15,8 +15,11 @@
 // reason.
 import { type ReactNode, useId, useState } from "react";
 import type { LaunchConfigLayer, LaunchConfigResolved, LaunchOption, MCPServerSpec } from "../../protocol/types.gen";
-import type { ModelCatalog as ModelCatalogEnvelope, PathFieldKind } from "../../widgets";
-import { Button, CollectionEditor, FormRow, Input, ModelCatalog, PathField, RadioGroup, Select } from "../../widgets";
+import { Button, CollectionEditor, FormRow, Input, RadioGroup, Select } from "../../widgets";
+import { ModelCatalog } from "../../widgets/modelCatalog";
+import type { ModelCatalog as ModelCatalogEnvelope } from "../../widgets/modelCatalog";
+import { PathField } from "../../widgets/pathfield";
+import type { PathFieldKind } from "../../widgets/pathfield";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { asEnvEntries, asMcpList, asStringList, inheritedItems } from "../settings/sections/launchShared/inherited";
 import { type PathValidation, validatePathListAdd } from "../settings/sections/launchShared/pathListAdd";

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -46,13 +46,12 @@ import {
   EmptyState,
   IconButton,
   Input,
-  Menu,
   Skeleton,
   Tooltip,
-  Tree,
-  type TreeRowInfo,
   useToasts,
 } from "../../widgets";
+import { Menu } from "../../widgets/menu";
+import { Tree, type TreeRowInfo } from "../../widgets/tree";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { useClient } from "../clientContext";
 import { closePanesForDeletedSessions } from "../deletedSessionPanes";

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.test.tsx
@@ -17,7 +17,7 @@ import {
   type ResourceKey,
   type ResourceState,
 } from "../../stores/navigation/types";
-import { Tree, type TreeRowInfo } from "../../widgets";
+import { Tree, type TreeRowInfo } from "../../widgets/tree";
 import { registerPaneForTests } from "../paneRegistry";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../workspace";
 import { activityGloss, cadenceStateFor, RailRow, type RailRowActions } from "./RailRow";

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -43,10 +43,9 @@ import {
   type CadenceState,
   Chevron,
   IconButton,
-  Menu,
-  type MenuItem,
-  type TreeRowInfo,
 } from "../../widgets";
+import { Menu, type MenuItem } from "../../widgets/menu";
+import type { TreeRowInfo } from "../../widgets/tree";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { navigate } from "../routing";
 import { type PinTarget, SessionMenu } from "../sessionMenu/SessionMenu";

--- a/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
+++ b/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
@@ -12,7 +12,8 @@
 // deliberately NOT here - the command palette owns those.
 import { type ChangeEvent, useState } from "react";
 import type { SessionPanelKind } from "../../panes/sessionPanels";
-import { Button, Dialog, Input, Menu, type MenuEntry } from "../../widgets";
+import { Button, Dialog, Input } from "../../widgets";
+import { Menu, type MenuEntry } from "../../widgets/menu";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { PinSectionPicker } from "../rail/PinSectionPicker";
 import styles from "./sessionmenu.module.css";


### PR DESCRIPTION
Heavy widgets (Markdown, ModelCatalog, PathField, Menu, Tree + types) imported via direct paths in 5 importers instead of the 120-line barrel; barrel itself untouched. No logic change; CSS-module side effects still load.

Verification (serial runner): tsc clean; 5 scoped suites 354 pass; hash-normalized vite chunk list IDENTICAL to base (38 entries, byte-identical sizes — bundler already tree-shook, so no size win materialized and no regression).
Risk: low. Honest note: this buys chunk-shape control, not bytes today.