### PR TITLE
perf(w2-sleeps): event-driven daemon hold; slower pane-size poll

### DIFF
--- a/cmd/evener-hub/internal/appsource/local_daemon_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_test.go
@@ -222,9 +222,15 @@ func fuzzScenarioLocalDaemonSourceReadThreadMapsIOTimeoutToSessionUnavailable(t 
 			}
 			// Hold the connection open without responding so the websocket
 			// handshake stalls. The caller's ctx deadline ends the dial.
+			// Event-driven hold: the dial abort closes the client side, which
+			// surfaces here as EOF/RST and releases this goroutine at the
+			// ~200ms ctx deadline instead of after a fixed sleep. The read
+			// deadline keeps the previous 2s bound so a stalled conn can
+			// never outlive it.
 			go func(c net.Conn) {
 				defer c.Close()
-				time.Sleep(2 * time.Second)
+				_ = c.SetReadDeadline(time.Now().Add(2 * time.Second))
+				_, _ = io.Copy(io.Discard, c)
 			}(conn)
 		}
 	}()

--- a/cmd/evener-tui/tmux_e2e_test.go
+++ b/cmd/evener-tui/tmux_e2e_test.go
@@ -48,6 +48,14 @@ const tuiE2EWaitTimeout = 60 * time.Second
 var tuiE2EPollInterval = 10 * time.Millisecond
 var tuiE2EDeadCheckInterval = 100 * time.Millisecond
 
+// tuiE2EPaneSizePollInterval paces waitForTmuxPaneSize only. A pane resize is
+// a slow monotonic settle (tmux applies it once and never un-applies it), so
+// 10ms granularity buys nothing there: each tick forks a display-message
+// subprocess, and 5x fewer forks during resize waits is pure CPU saved. The
+// 60s deadline is unchanged, and Resize still blocks until the size lands, so
+// no later assertion can race it.
+var tuiE2EPaneSizePollInterval = 50 * time.Millisecond
+
 // tmuxSessionCounter makes tmux session names unique even when parallel tests
 // start within the same nanosecond.
 var tmuxSessionCounter atomic.Int64
@@ -1383,7 +1391,7 @@ func waitForTmuxPaneSize(t *testing.T, socket, session string, width, height int
 				return
 			}
 		}
-		time.Sleep(tuiE2EPollInterval)
+		time.Sleep(tuiE2EPaneSizePollInterval)
 	}
 	t.Fatalf("tmux (socket %s) pane size for %s = %q, want %dx%d", socket, session, last, width, height)
 }


### PR DESCRIPTION
Two commits: (1) hung-daemon accept-loop hold becomes conn-close-driven (SetReadDeadline+io.Copy) releasing at the ~200ms ctx abort instead of a fixed 2s sleep, same 2s bound and DeadlineExceeded assertion; (2) tmux pane-size poll gets its own 50ms interval (was 10ms render-path), 60s deadline unchanged, render path byte-identical. Six render-path polls + ctrl+C debounce + cancel stimulus deliberately left alone (load-bearing, documented in commits).

Verification (serial runner): gofmt clean; FuzzAppSourceProgram ok + 20x daemon-hold repeats ok; resize E2E (AppShellPreservesLayoutAcrossWidths) pass.
Risk: med (E2E timing) — 20x repeats + resize subset green; revert-just-that-hunk guidance in commit if resize flakes appear.