### PR TITLE
perf(w2-lint-invoke): prebuilt evener-dev across lint chain

### DIFF
--- a/make/linting.mk
+++ b/make/linting.mk
@@ -23,8 +23,13 @@ secret-scan:
 ## trigger: Required CI (via make lint); local pre-merge.
 ## requires: None beyond the Go toolchain; deterministic, no provider calls.
 ## fails-when: Any TOML file has a non-snake_case key.
-lint-naming:
-	$(call run_quiet_lint,go run ./cmd/evener-dev/bin tomlcheck)
+# lint-naming, lint-internal, and lint-golangci run the prebuilt evener-dev
+# binary instead of `go run ./cmd/evener-dev/bin` so the serial LINT_TARGETS
+# chain pays one compile (via the build-dev prerequisite, which make runs
+# once per `make lint` since build-dev is .PHONY) instead of three. The
+# binary is built from the same source, so verdicts are identical.
+lint-naming: build-dev
+	$(call run_quiet_lint,./evener-dev tomlcheck)
 
 ## The compile floor for the //go:build evenerfuzz sources: host go vet and a
 ## host tagliatelle-only golangci-lint pass, plus GOOS=linux repeats of both on
@@ -87,8 +92,8 @@ lint-eval:
 ## requires: None beyond the Go toolchain.
 ## fails-when: cmd/evener-internalcheck finds an exported symbol naming an
 ##   internal type.
-lint-internal:
-	$(call run_quiet_lint,go run ./cmd/evener-dev/bin internalcheck)
+lint-internal: build-dev
+	$(call run_quiet_lint,./evener-dev internalcheck)
 
 # golangci-lint across every module (./... is per-module under go.work).
 # The runner lives in Go (cmd/evener-dev); MODULES and LINT_PARALLEL keep the
@@ -116,8 +121,8 @@ lint-internal:
 ## requires: golangci-lint. Runs against FUZZ_GO_MODULES, not GO_MODULES, so
 ##   the fuzz module's ordinary Go is covered too.
 ## fails-when: Either golangci-lint run fails for any module.
-lint-golangci:
-	$(call run_quiet_lint,MODULES="$(FUZZ_GO_MODULES)" GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" go run ./cmd/evener-dev/bin dev module-lint && GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" golangci-lint run --allow-parallel-runners --config .golangci-appwire.yml ./server/...)
+lint-golangci: build-dev
+	$(call run_quiet_lint,MODULES="$(FUZZ_GO_MODULES)" GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" ./evener-dev dev module-lint && GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" golangci-lint run --allow-parallel-runners --config .golangci-appwire.yml ./server/...)
 
 ## Remove the current worktree's golangci-lint cache without touching sibling
 ## worktrees or the user's global golangci-lint cache.

--- a/makefiletargets_audit_test.go
+++ b/makefiletargets_audit_test.go
@@ -783,11 +783,11 @@ func TestEveryGeneratedRegionIsInTheStalenessDiff(t *testing.T) {
 // you are reading this because the map and LINT_TARGETS disagree, the question
 // is which of them is wrong, not which is easier to edit.
 var lintGateCommands = map[string]string{
-	"lint-naming":        "go run ./cmd/evener-dev/bin tomlcheck",
+	"lint-naming":        "./evener-dev tomlcheck",
 	"lint-gofmt":         "/bin/gofmt\" -l",
 	"lint-evenerfuzz":    "-tags evenerfuzz",
 	"lint-eval":          "-tags eval ",
-	"lint-internal":      "go run ./cmd/evener-dev/bin internalcheck",
+	"lint-internal":      "./evener-dev internalcheck",
 	"lint-golangci":      "module-lint",
 	"lint-generated":     "docs/appwire-protocol.md",
 	"lint-fuzz-registry": "scripts/fuzz/fuzz-registry-check.sh",


### PR DESCRIPTION
Three recipes (naming/internal/golangci) invoke ./evener-dev via one build-dev prerequisite instead of three go-run compiles; audit pins moved in lockstep; module-lint matched by substring. Same source => same verdicts; no rule/config change; vet untouched.

Verification (serial runner): make -n lint shows only the intended swap; 9/9 audit tests pass; build-dev confirmed .PHONY. Cold single-gate timing shows no win (4.6s vs 3.4s — pays one build); the 3->1 win materializes across full make lint.
Risk: low. CI on this PR is the real gate.