### PR TITLE
perf(w2-fuzz-dedupe): skip FuzzXxx reseed in make fuzz steps 2-4

### DIFF
--- a/make/fuzzing.mk
+++ b/make/fuzzing.mk
@@ -68,6 +68,13 @@ fuzz-seeds:
 # (primeradiant.com/evener/invariant) are live: a tripped invariant panics and the
 # never-panic oracle catches it. The first step verifies the mechanism itself
 # fires under the tag; production builds and `make test` stay tag-free.
+# Steps 2-4 run every NON-Fuzz test, skipping the FuzzXxx corpus: the
+# FUZZ_SEED_REPLAY step below replays exactly that set (proven by
+# `go test -tags evenerfuzz --list '^Fuzz'` per module — the replay list is
+# identical to the skipped set), so running it twice would double the ~144s
+# native replay at no added coverage. The skip keeps each survivor:
+# invariant's TestFuzzBuildEnforces, the fuzz toolkit's 55 TestXxx, and the
+# fuzzcov/harvest CLIs' 40 TestXxx.
 ## Replay every native FuzzXxx target's seed corpus plus saved crashers, and
 ## every registered Rapid property surface, as ordinary deterministic tests
 ## — the CI fuzz gate.
@@ -84,9 +91,9 @@ fuzz-seeds:
 ##   nonzero.
 fuzz:
 	@GOENV=off GOFLAGS= GOWORK="$(FUZZ_GOWORK)" sh -c 'cd agent && go test -run "^$$" -tags evenerfuzz -count=1 ./...'
-	@GOENV=off GOFLAGS= GOWORK="$(FUZZ_GOWORK)" sh -c 'cd invariant && go test -tags evenerfuzz ./...'
-	@GOENV=off GOFLAGS= GOWORK="$(FUZZ_GOWORK)" sh -c 'cd fuzz && go test -tags evenerfuzz ./...'
-	@GOENV=off GOFLAGS= GOWORK="$(FUZZ_GOWORK)" sh -c 'go test ./cmd/evener-fuzzcov ./cmd/evener-fuzz-harvest'
+	@GOENV=off GOFLAGS= GOWORK="$(FUZZ_GOWORK)" sh -c 'cd invariant && go test -skip "^Fuzz" -tags evenerfuzz -count=1 ./...'
+	@GOENV=off GOFLAGS= GOWORK="$(FUZZ_GOWORK)" sh -c 'cd fuzz && go test -skip "^Fuzz" -tags evenerfuzz -count=1 ./...'
+	@GOENV=off GOFLAGS= GOWORK="$(FUZZ_GOWORK)" sh -c 'go test -skip "^Fuzz" ./cmd/evener-fuzzcov ./cmd/evener-fuzz-harvest'
 	@$(FUZZ_SEED_REPLAY)
 	@scripts/fuzz/rapid-replay.sh
 	@GOENV=off GOFLAGS= GOWORK="$(FUZZ_GOWORK)" sh -c "go test -run '^Test.*Golden\$$' ./appwire"


### PR DESCRIPTION
Steps 2-4 ran the full tagged suites AND FUZZ_SEED_REPLAY re-ran the FuzzXxx corpus (~144s native double-replay). Now steps 2-4 pass -skip '^Fuzz' (+count=1); FUZZ_SEED_REPLAY still replays the full corpus; rapid-replay untouched.

Parity (static, verified): replay set (--list '^Fuzz') identical to skipped set per module; kept-set enumerated (invariant 1 + fuzz 55 + fuzzcov/harvest 40); rapid names all Test-prefixed and disjoint; 0 TestMain/Examples/Benchmarks/tagged-files; surviving subtests Fuzz-free. Go 1.27 => -skip supported.

Verification: make -n fuzz parses; static re-proof green. Trial-merge wall-time comparison left to CI on this PR (exceeds local budget).
Risk: low-med (partition shifts if a future Fuzz-prefixed non-target appears; --list re-proof catches it).