### PR TITLE
fix(tui): nolint the camelCase appwire delta tags in hub notifications

### DIFF
--- a/cmd/evener-tui/hub_notifications.go
+++ b/cmd/evener-tui/hub_notifications.go
@@ -606,10 +606,10 @@ func streamDeltaForMethod(method string) streamDeltaKind {
 // each with no per-kind typed struct, and one reducer build + apply total.
 type streamDeltaChunk struct {
 	Ref      string `json:"ref"`
-	ThreadID string `json:"threadId"`
-	TurnID   string `json:"turnId"`
-	ItemID   string `json:"itemId"`
-	CallID   string `json:"callId"`
+	ThreadID string `json:"threadId"` //nolint:tagliatelle // mirrors the camelCase appwire delta params on the wire
+	TurnID   string `json:"turnId"`   //nolint:tagliatelle // mirrors the camelCase appwire delta params on the wire
+	ItemID   string `json:"itemId"`   //nolint:tagliatelle // mirrors the camelCase appwire delta params on the wire
+	CallID   string `json:"callId"`   //nolint:tagliatelle // mirrors the camelCase appwire delta params on the wire
 	Delta    string `json:"delta"`
 }
 

--- a/cmd/evener-tui/hub_notifications_test.go
+++ b/cmd/evener-tui/hub_notifications_test.go
@@ -250,3 +250,66 @@ func requireTUIJobRun(t testing.TB, m *hubModel, jobID string) *transcript.Subag
 	t.Fatalf("messages = %+v, want job %q", m.session.messages, jobID)
 	return nil
 }
+
+// TestStreamDeltaChunkDecodesAppWireCamelCaseParams pins the wire contract the
+// shared delta envelope decodes: the hub's producer params are camelCase, so
+// streamDeltaChunk's json tags must be camelCase too. Renaming them to this
+// repo's snake_case default would leave every routing field empty, silently
+// dropping deltas at the current-session filter instead of failing loudly.
+func TestStreamDeltaChunkDecodesAppWireCamelCaseParams(t *testing.T) {
+	agent, err := json.Marshal(appwire.AgentMessageDeltaParams{
+		ThreadID: "th_1", Ref: "local:th_1", TurnID: "turn_1", ItemID: "item_1", Delta: "hello",
+	})
+	if err != nil {
+		t.Fatalf("marshal agent params: %v", err)
+	}
+	reasoning, err := json.Marshal(appwire.ReasoningSummaryDeltaParams{
+		ThreadID: "th_1", Ref: "local:th_1", TurnID: "turn_1", ItemID: "item_2", Delta: "thinking",
+	})
+	if err != nil {
+		t.Fatalf("marshal reasoning params: %v", err)
+	}
+	toolOutput, err := json.Marshal(appwire.ToolOutputDeltaParams{
+		ThreadID: "th_1", Ref: "local:th_1", TurnID: "turn_1", ItemID: "item_3", CallID: "call_3", Delta: "one\n",
+	})
+	if err != nil {
+		t.Fatalf("marshal tool-output params: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		raw  json.RawMessage
+		want streamDeltaChunk
+	}{
+		{
+			name: "agentMessage",
+			raw:  agent,
+			want: streamDeltaChunk{Ref: "local:th_1", ThreadID: "th_1", TurnID: "turn_1", ItemID: "item_1", Delta: "hello"},
+		},
+		{
+			name: "reasoningSummary",
+			raw:  reasoning,
+			want: streamDeltaChunk{Ref: "local:th_1", ThreadID: "th_1", TurnID: "turn_1", ItemID: "item_2", Delta: "thinking"},
+		},
+		{
+			name: "toolOutput",
+			raw:  toolOutput,
+			want: streamDeltaChunk{Ref: "local:th_1", ThreadID: "th_1", TurnID: "turn_1", ItemID: "item_3", CallID: "call_3", Delta: "one\n"},
+		},
+		{
+			name: "wireKeySpelling",
+			raw:  json.RawMessage(`{"ref":"local:th_1","threadId":"th_1","turnId":"turn_1","itemId":"item_3","callId":"call_3","delta":"one\n"}`),
+			want: streamDeltaChunk{Ref: "local:th_1", ThreadID: "th_1", TurnID: "turn_1", ItemID: "item_3", CallID: "call_3", Delta: "one\n"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := decodeStreamDeltaChunk(tc.raw)
+			if !ok {
+				t.Fatalf("decode %s failed: %s", tc.name, tc.raw)
+			}
+			if got != tc.want {
+				t.Fatalf("chunk=%+v want=%+v from %s", got, tc.want, tc.raw)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Unblocks main. `lint-golangci` fails on `a1c61c0`, and every open PR inherits it:

```
cmd/evener-tui/hub_notifications.go:609:18: json(snake): got 'threadId' want 'thread_id' (tagliatelle)
cmd/evener-tui/hub_notifications.go:610:18: json(snake): got 'turnId' want 'turn_id' (tagliatelle)
cmd/evener-tui/hub_notifications.go:611:18: json(snake): got 'itemId' want 'item_id' (tagliatelle)
cmd/evener-tui/hub_notifications.go:612:18: json(snake): got 'callId' want 'call_id' (tagliatelle)
```

## Culprit

`f45c66402` perf(w2-tui-batch): single-decode streaming-delta fast path in hub notifications — it added `streamDeltaChunk` with those four fields.

## Which case this is: wire format, not wrong tags

`streamDeltaChunk` is the shared decode target for appwire's three streaming-delta params — `AgentMessageDeltaParams`, `ReasoningSummaryDeltaParams`, `ToolOutputDeltaParams` (`appwire/types.go`). Those producers spell the fields `threadId` / `turnId` / `itemId` / `callId`, and `.golangci.yml` already grants `pkg: appwire` a `json: camel` override for exactly that reason. camelCase **is** the wire format here.

Renaming the consumer tags to snake_case would not fail loudly — it would leave `ThreadID`/`TurnID`/`ItemID`/`CallID` empty on every delta frame, so `streamChunkMatchesCurrentSession` and the reducer routing would silently drop deltas. Verified, see below.

`cmd/evener-tui` is otherwise entirely snake_case (these four were its only camelCase JSON tags), so a package-wide override in `.golangci.yml` would be too broad. The established form for a camelCase wire struct inside an otherwise-snake_case package is a per-field `//nolint:tagliatelle // <reason>` — 52 sites across the repo (`appwire/types.go`, `agent/doctor/audit.go`, `internal/plugins/*`, `internal/apptranscript`, `cmd/evener/plugin_selection_flag.go`). This matches that precedent.

## Test

New `TestStreamDeltaChunkDecodesAppWireCamelCaseParams` in `cmd/evener-tui/hub_notifications_test.go` marshals each of the three real producer param structs, plus a raw camelCase wire literal, and decodes them through `decodeStreamDeltaChunk`, asserting every routing field lands. Real producer types, no mocks.

Proved it bites: with the tags renamed to snake_case (the wrong fix), all four subtests fail with the routing fields empty —

```
chunk={Ref:local:th_1 ThreadID: TurnID: ItemID: CallID: Delta:hello}
 want={Ref:local:th_1 ThreadID:th_1 TurnID:turn_1 ItemID:item_1 CallID: Delta:hello}
```

Restored to camelCase, it passes.

## Gates

- `gofmt -l` on both changed files: clean
- `go vet ./cmd/evener-tui`: exit 0
- `go vet -tags evenerfuzz ./cmd/evener-tui`: exit 0
- `GOMAXPROCS=4 go test -count=1 -run 'TestStreamDeltaChunkDecodesAppWireCamelCaseParams' ./cmd/evener-tui`: `ok`
- `make lint-golangci`: **`PASS lint-golangci (146s)`**