### PR TITLE
fix(lint): restore the tag-casing and import-order lanes on main

### DIFF
--- a/appwire/doc.go
+++ b/appwire/doc.go
@@ -11,6 +11,20 @@
 // are verified current in CI, so the catalog in code is the single source of
 // truth.
 //
+// Field names on the wire are camelCase, and the json tags here are where
+// that is decided: appwirets emits the frontend's TypeScript property names
+// from these tag strings verbatim, so a tag is simultaneously the wire name
+// every client sends and the name the web UI reads. Renaming one breaks both
+// at once, which is why the repo's snake_case tag lint is excluded for the
+// files that mirror this format rather than applied to them.
+//
+// Decode frames into the types below rather than redeclaring their shapes.
+// A local copy compiles, passes its own tests, and then drifts silently when
+// a field is added here; it also reintroduces the casing question in a
+// package that has no wire obligation, where the answer looks like a lint
+// suppression instead of a contract. If a caller needs a subset, use the
+// params type that already carries those fields.
+//
 //go:generate go run primeradiant.com/evener/internal/appwiredoc -out ../docs/appwire-protocol.md
 //go:generate go run primeradiant.com/evener/internal/appwirets -out ../cmd/evener-hub/frontend/src/protocol/types.gen.ts
 package appwire

--- a/cmd/evener-hub/frontend/src/panes/doc/DocPane.tsx
+++ b/cmd/evener-hub/frontend/src/panes/doc/DocPane.tsx
@@ -9,8 +9,8 @@ import {
 } from "../../protocol/docContent";
 import type { PaneProps } from "../../shell/paneRegistry";
 import { Chip, Dialog, EmptyState, PaneScaffold, Skeleton } from "../../widgets";
-import { Markdown } from "../../widgets/markdown";
 import { requireClass } from "../../widgets/internal/requireClass";
+import { Markdown } from "../../widgets/markdown";
 import { filenameOf, formatDocBytes, isMarkdownPath } from "./docFile";
 import styles from "./docpane.module.css";
 import type { DocParams } from "./openDoc";

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
@@ -16,11 +16,11 @@
 import { type ReactNode, useId, useState } from "react";
 import type { LaunchConfigLayer, LaunchConfigResolved, LaunchOption, MCPServerSpec } from "../../protocol/types.gen";
 import { Button, CollectionEditor, FormRow, Input, RadioGroup, Select } from "../../widgets";
-import { ModelCatalog } from "../../widgets/modelCatalog";
-import type { ModelCatalog as ModelCatalogEnvelope } from "../../widgets/modelCatalog";
-import { PathField } from "../../widgets/pathfield";
-import type { PathFieldKind } from "../../widgets/pathfield";
 import { requireClass } from "../../widgets/internal/requireClass";
+import type { ModelCatalog as ModelCatalogEnvelope } from "../../widgets/modelCatalog";
+import { ModelCatalog } from "../../widgets/modelCatalog";
+import type { PathFieldKind } from "../../widgets/pathfield";
+import { PathField } from "../../widgets/pathfield";
 import { asEnvEntries, asMcpList, asStringList, inheritedItems } from "../settings/sections/launchShared/inherited";
 import { type PathValidation, validatePathListAdd } from "../settings/sections/launchShared/pathListAdd";
 import { schemaPathKind } from "../settings/sections/launchShared/schema";

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -50,9 +50,9 @@ import {
   Tooltip,
   useToasts,
 } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
 import { Menu } from "../../widgets/menu";
 import { Tree, type TreeRowInfo } from "../../widgets/tree";
-import { requireClass } from "../../widgets/internal/requireClass";
 import { useClient } from "../clientContext";
 import { closePanesForDeletedSessions } from "../deletedSessionPanes";
 import { navigate, paneToURL } from "../routing";

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -37,16 +37,10 @@
 import { memo, type ReactNode } from "react";
 import type { SessionPanelKind } from "../../panes/sessionPanels";
 
-import {
-  Badge,
-  Cadence,
-  type CadenceState,
-  Chevron,
-  IconButton,
-} from "../../widgets";
+import { Badge, Cadence, type CadenceState, Chevron, IconButton } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
 import { Menu, type MenuItem } from "../../widgets/menu";
 import type { TreeRowInfo } from "../../widgets/tree";
-import { requireClass } from "../../widgets/internal/requireClass";
 import { navigate } from "../routing";
 import { type PinTarget, SessionMenu } from "../sessionMenu/SessionMenu";
 import { isPaneOpen, useWorkspaceStore } from "../workspace";

--- a/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
+++ b/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
@@ -13,8 +13,8 @@
 import { type ChangeEvent, useState } from "react";
 import type { SessionPanelKind } from "../../panes/sessionPanels";
 import { Button, Dialog, Input } from "../../widgets";
-import { Menu, type MenuEntry } from "../../widgets/menu";
 import { requireClass } from "../../widgets/internal/requireClass";
+import { Menu, type MenuEntry } from "../../widgets/menu";
 import { PinSectionPicker } from "../rail/PinSectionPicker";
 import styles from "./sessionmenu.module.css";
 

--- a/cmd/evener-tui/hub_notifications.go
+++ b/cmd/evener-tui/hub_notifications.go
@@ -600,26 +600,20 @@ func streamDeltaForMethod(method string) streamDeltaKind {
 	return streamDeltaNone
 }
 
-// streamDeltaChunk is the shared delta envelope: routing fields plus the one
-// text chunk the frame carries. All three delta params shapes decode into it
-// (unknown fields are ignored), so N chunks in one frame pay one unmarshal
-// each with no per-kind typed struct, and one reducer build + apply total.
-type streamDeltaChunk struct {
-	Ref      string `json:"ref"`
-	ThreadID string `json:"threadId"` //nolint:tagliatelle // AppWire frames are camelCase on the wire; renaming the tag would stop decoding them
-	TurnID   string `json:"turnId"`   //nolint:tagliatelle // AppWire frames are camelCase on the wire
-	ItemID   string `json:"itemId"`   //nolint:tagliatelle // AppWire frames are camelCase on the wire
-	CallID   string `json:"callId"`   //nolint:tagliatelle // AppWire frames are camelCase on the wire
-	Delta    string `json:"delta"`
-}
+// The three delta notifications share one params shape once the fields each
+// one omits are ignored, and appwire.ToolOutputDeltaParams is that shape: it
+// carries the routing fields plus the chunk, and its CallID is simply absent
+// from the other two. Decoding every kind into it keeps the wire contract in
+// the package that owns it, so N chunks in one frame still pay one unmarshal
+// each with no per-kind typed struct.
 
 // decodeStreamDeltaChunk extracts the shared delta envelope from raw params.
 // It reports false for malformed frames, mirroring the old per-kind behavior
 // of dropping a frame whose params fail to decode.
-func decodeStreamDeltaChunk(raw json.RawMessage) (streamDeltaChunk, bool) {
-	var chunk streamDeltaChunk
+func decodeStreamDeltaChunk(raw json.RawMessage) (appwire.ToolOutputDeltaParams, bool) {
+	var chunk appwire.ToolOutputDeltaParams
 	if len(raw) == 0 || json.Unmarshal(raw, &chunk) != nil {
-		return streamDeltaChunk{}, false
+		return appwire.ToolOutputDeltaParams{}, false
 	}
 	return chunk, true
 }
@@ -675,7 +669,7 @@ func (m *hubModel) applyHubStreamDeltaFast(notification appwire.Notification) bo
 
 // streamChunkMatchesCurrentSession is notificationMatchesCurrentSession over
 // an already-decoded delta envelope: same comparisons, no second unmarshal.
-func (m *hubModel) streamChunkMatchesCurrentSession(chunk streamDeltaChunk) bool {
+func (m *hubModel) streamChunkMatchesCurrentSession(chunk appwire.ToolOutputDeltaParams) bool {
 	detailRef := strings.TrimSpace(m.detail.Ref)
 	if chunk.Ref != "" && detailRef != "" {
 		return chunk.Ref == detailRef

--- a/cmd/evener-tui/hub_notifications.go
+++ b/cmd/evener-tui/hub_notifications.go
@@ -606,10 +606,10 @@ func streamDeltaForMethod(method string) streamDeltaKind {
 // each with no per-kind typed struct, and one reducer build + apply total.
 type streamDeltaChunk struct {
 	Ref      string `json:"ref"`
-	ThreadID string `json:"threadId"`
-	TurnID   string `json:"turnId"`
-	ItemID   string `json:"itemId"`
-	CallID   string `json:"callId"`
+	ThreadID string `json:"threadId"` //nolint:tagliatelle // AppWire frames are camelCase on the wire; renaming the tag would stop decoding them
+	TurnID   string `json:"turnId"`   //nolint:tagliatelle // AppWire frames are camelCase on the wire
+	ItemID   string `json:"itemId"`   //nolint:tagliatelle // AppWire frames are camelCase on the wire
+	CallID   string `json:"callId"`   //nolint:tagliatelle // AppWire frames are camelCase on the wire
 	Delta    string `json:"delta"`
 }
 


### PR DESCRIPTION
## What was wrong

`lint-golangci` and `web` have failed on every `main` build since two perf commits landed without their lint lanes, and `static` fails with them because it requires every static lane.

- f45c66402 added `streamDeltaChunk` in `cmd/evener-tui/hub_notifications.go` with camelCase json tags. tagliatelle enforces snake_case: `json(snake): got 'threadId' want 'thread_id'` and three more.
- 51840808f left five frontend files with imports biome rejects: `assist/source/organizeImports` on DocPane, AdvancedOptions, Rail, RailRow and SessionMenu, plus a format diff on RailRow.

## What changed

The tag complaint had a better answer than an exemption: `streamDeltaChunk` was a hand-rolled copy of appwire's wire types, and `appwire.ToolOutputDeltaParams` is exactly its shape, a superset of `AgentMessageDeltaParams` and `ReasoningSummaryDeltaParams` once the fields they omit are ignored. The local struct is deleted and the three delta kinds decode into the appwire type, so the camelCase contract stays in the package that owns it and no suppression is needed. That also removes the duplication the tags were a symptom of.

The five frontend files are fixed by their own fixer, `npm run check`.

## How it is tested

`make lint-golangci` PASS, `npm run lint` clean (1090 files, no fixes applied), and `go test ./cmd/evener-tui/` passes, which covers the delta decode and routing paths.

https://claude.ai/code/session_01VAcwdjBpgzkg3emsf9QgWT