### PR TITLE
fix(flake-goal-continuation): wait for the continuation opening event before asserting

### DIFF
--- a/agent/session_active_turn_test.go
+++ b/agent/session_active_turn_test.go
@@ -61,6 +61,10 @@ func TestGoalContinuationTurnCarriesItsNameOnTheOpeningEvent(t *testing.T) {
 
 	select {
 	case <-sawContinuation:
+	// TRIPWIRE: the event is emitted synchronously by ProcessInputKind above
+	// and delivered by the in-process drain goroutine, so it normally arrives
+	// in well under a second. 30s only fires on a genuine delivery hang, not
+	// scheduler contention under a loaded suite.
 	case <-time.After(30 * time.Second):
 		t.Fatalf("timed out waiting for the EventGoalContinuation opening event")
 	}

--- a/agent/session_active_turn_test.go
+++ b/agent/session_active_turn_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 
@@ -31,6 +32,11 @@ func TestGoalContinuationTurnCarriesItsNameOnTheOpeningEvent(t *testing.T) {
 
 	var mu sync.Mutex
 	var continuations []events.GoalContinuationData
+	// The drain ConsumeEventsLossless registers delivers on its own goroutine
+	// (session_events.go), so nothing guarantees it has run by the time
+	// ProcessInputKind returns. Wait for the event rather than asserting on a
+	// slice the consumer may not have appended to yet.
+	sawContinuation := make(chan struct{}, 1)
 	drained := make(chan struct{})
 	s.ConsumeEventsLossless(func(ev events.SessionEvent) {
 		if ev.Kind != events.EventGoalContinuation {
@@ -43,10 +49,20 @@ func TestGoalContinuationTurnCarriesItsNameOnTheOpeningEvent(t *testing.T) {
 		mu.Lock()
 		continuations = append(continuations, data)
 		mu.Unlock()
+		select {
+		case sawContinuation <- struct{}{}:
+		default:
+		}
 	}, func() { close(drained) })
 
 	if _, err := s.ProcessInputKind(context.Background(), "keep going", nil, EntryContinuation); err != nil {
 		t.Fatalf("ProcessInputKind(EntryContinuation): %v", err)
+	}
+
+	select {
+	case <-sawContinuation:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("timed out waiting for the EventGoalContinuation opening event")
 	}
 
 	mu.Lock()


### PR DESCRIPTION
## Root cause

TestGoalContinuationTurnCarriesItsNameOnTheOpeningEvent (agent/session_active_turn_test.go:29) asserted synchronously on a slice appended by the ConsumeEventsLossless drain goroutine. Chain:

- The test registers the drain via ConsumeEventsLossless (test file :35), which spawns `go func() { for ev := range s.events { consume(ev) } }` (agent/session_events.go:96-99) — the only writer of authoritativeConsumer (:93).
- ProcessInputKind(EntryContinuation) -> processOneInput mints the id synchronously (agent/session_lifecycle.go:1536-1537: `runningTurnID, _ = s.mintRunningTurnID()`) and emits EventGoalContinuation synchronously (:2072 in acceptContinuationInput).
- But emission (sendEvent, session_events.go:361 `s.events <- ev`) only hands the event to the channel; the test's append happens on the drain goroutine with no happens-before edge to ProcessInputKind's return. The test then read the slice immediately (:52-56) — a race it always loses under load/scheduling.

Why survey-only: the survey pass runs the FULL suite as one binary with `-test.parallel 6` (cmd/evener-dev/agentshards.go:270), so every parallel-capable test competes for CPU and the drain goroutine can be delayed past the assertion. A targeted local run (-run only this test) has no such contention, so it passes. CI evidence: perf/watch-batch run 34174488095 survey log shows exactly `--- FAIL: TestGoalContinuationTurnCarriesItsNameOnTheOpeningEvent (0.01s)` — a fast fail consistent with the count=0 arm, not the StableTurnID arm. Recent main runs (34177913082, 34177086388) fail only on web-lint/lint-golangci, never on this test — refutes the 'base flake on main' reading; it is a latent test race exposed by parallel scheduling.

## Fix

Signal event arrival (buffered sawContinuation channel, non-blocking send in the consumer) and wait up to 30s (the package's established event-wait convention, e.g. session_attention_test.go) before asserting count == 1 and the turn_m prefix. Test-only change; no production code touched.

## Proof

- `go test -count=1 -run 'TestGoalContinuationTurnCarriesItsNameOnTheOpeningEvent' ./agent/` green 3x (0.918s / 0.764s / 0.786s)
- Siblings green: `-run 'TestGoalContinuationTurn|TestMintRunningTurnID'` ok
- `gofmt -l` clean