### PR TITLE
fix(lint): repair main's tagliatelle and Biome import-sort findings

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/doc/DocPane.tsx
+++ b/cmd/evener-hub/frontend/src/panes/doc/DocPane.tsx
@@ -9,8 +9,8 @@ import {
 } from "../../protocol/docContent";
 import type { PaneProps } from "../../shell/paneRegistry";
 import { Chip, Dialog, EmptyState, PaneScaffold, Skeleton } from "../../widgets";
-import { Markdown } from "../../widgets/markdown";
 import { requireClass } from "../../widgets/internal/requireClass";
+import { Markdown } from "../../widgets/markdown";
 import { filenameOf, formatDocBytes, isMarkdownPath } from "./docFile";
 import styles from "./docpane.module.css";
 import type { DocParams } from "./openDoc";

--- a/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/AdvancedOptions.tsx
@@ -16,11 +16,11 @@
 import { type ReactNode, useId, useState } from "react";
 import type { LaunchConfigLayer, LaunchConfigResolved, LaunchOption, MCPServerSpec } from "../../protocol/types.gen";
 import { Button, CollectionEditor, FormRow, Input, RadioGroup, Select } from "../../widgets";
-import { ModelCatalog } from "../../widgets/modelCatalog";
-import type { ModelCatalog as ModelCatalogEnvelope } from "../../widgets/modelCatalog";
-import { PathField } from "../../widgets/pathfield";
-import type { PathFieldKind } from "../../widgets/pathfield";
 import { requireClass } from "../../widgets/internal/requireClass";
+import type { ModelCatalog as ModelCatalogEnvelope } from "../../widgets/modelCatalog";
+import { ModelCatalog } from "../../widgets/modelCatalog";
+import type { PathFieldKind } from "../../widgets/pathfield";
+import { PathField } from "../../widgets/pathfield";
 import { asEnvEntries, asMcpList, asStringList, inheritedItems } from "../settings/sections/launchShared/inherited";
 import { type PathValidation, validatePathListAdd } from "../settings/sections/launchShared/pathListAdd";
 import { schemaPathKind } from "../settings/sections/launchShared/schema";

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.tsx
@@ -50,9 +50,9 @@ import {
   Tooltip,
   useToasts,
 } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
 import { Menu } from "../../widgets/menu";
 import { Tree, type TreeRowInfo } from "../../widgets/tree";
-import { requireClass } from "../../widgets/internal/requireClass";
 import { useClient } from "../clientContext";
 import { closePanesForDeletedSessions } from "../deletedSessionPanes";
 import { navigate, paneToURL } from "../routing";

--- a/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/RailRow.tsx
@@ -37,16 +37,10 @@
 import { memo, type ReactNode } from "react";
 import type { SessionPanelKind } from "../../panes/sessionPanels";
 
-import {
-  Badge,
-  Cadence,
-  type CadenceState,
-  Chevron,
-  IconButton,
-} from "../../widgets";
+import { Badge, Cadence, type CadenceState, Chevron, IconButton } from "../../widgets";
+import { requireClass } from "../../widgets/internal/requireClass";
 import { Menu, type MenuItem } from "../../widgets/menu";
 import type { TreeRowInfo } from "../../widgets/tree";
-import { requireClass } from "../../widgets/internal/requireClass";
 import { navigate } from "../routing";
 import { type PinTarget, SessionMenu } from "../sessionMenu/SessionMenu";
 import { isPaneOpen, useWorkspaceStore } from "../workspace";

--- a/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
+++ b/cmd/evener-hub/frontend/src/shell/sessionMenu/SessionMenu.tsx
@@ -13,8 +13,8 @@
 import { type ChangeEvent, useState } from "react";
 import type { SessionPanelKind } from "../../panes/sessionPanels";
 import { Button, Dialog, Input } from "../../widgets";
-import { Menu, type MenuEntry } from "../../widgets/menu";
 import { requireClass } from "../../widgets/internal/requireClass";
+import { Menu, type MenuEntry } from "../../widgets/menu";
 import { PinSectionPicker } from "../rail/PinSectionPicker";
 import styles from "./sessionmenu.module.css";
 

--- a/cmd/evener-tui/hub_notifications.go
+++ b/cmd/evener-tui/hub_notifications.go
@@ -606,10 +606,10 @@ func streamDeltaForMethod(method string) streamDeltaKind {
 // each with no per-kind typed struct, and one reducer build + apply total.
 type streamDeltaChunk struct {
 	Ref      string `json:"ref"`
-	ThreadID string `json:"threadId"`
-	TurnID   string `json:"turnId"`
-	ItemID   string `json:"itemId"`
-	CallID   string `json:"callId"`
+	ThreadID string `json:"threadId"` //nolint:tagliatelle // mirrors the appwire delta params wire spelling (cmd/evener-hub/app_relay.go)
+	TurnID   string `json:"turnId"`   //nolint:tagliatelle // mirrors the appwire delta params wire spelling
+	ItemID   string `json:"itemId"`   //nolint:tagliatelle // mirrors the appwire delta params wire spelling
+	CallID   string `json:"callId"`   //nolint:tagliatelle // mirrors the appwire delta params wire spelling
 	Delta    string `json:"delta"`
 }
 


### PR DESCRIPTION
Repairs main-branch lint breakage from #998 (commit f45c66402) so CI lint gates pass again.

**tagliatelle (golangci):** `streamDeltaChunk` in cmd/evener-tui/hub_notifications.go (~:609-612) uses camelCase json tags (threadId/turnId/itemId/callId) mirroring the appwire delta params wire spelling (cmd/evener-hub/app_relay.go). Marked the four tags `nolint:tagliatelle` like the repo's other wire-mirroring tags (e.g. agent/doctor/audit.go, agent/plugin/hooks.go) instead of renaming the wire.

**Biome organize-imports:** import-sort repair in the five files main's w2-barrel direct-import commit left unsorted (DocPane.tsx, AdvancedOptions.tsx, Rail.tsx, RailRow.tsx, SessionMenu.tsx).

Unblocks lint/static failures on PRs that touch none of these files:
- #1010
- #1000
- #1005
- #967