### PR TITLE
fix(lint): retire tag-casing exemptions that no longer hold

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,9 +93,6 @@ linters:
           - pkg: appwire
             rules:
               json: camel
-          - pkg: cmd/evener-hub/internal/appsource
-            rules:
-              json: camel
           - pkg: internal/appserver
             rules:
               json: camel
@@ -149,16 +146,13 @@ linters:
       - path: _test\.go
         text: SA5011
 
-      # llm/providers/ speaks each upstream provider's wire format; tag
-      # casing belongs to upstream, not to this repo's snake_case default.
-      # (Paths are relative to this config file, so this matches the llm
-      # module's run from the repo root.)
-      - path: ^llm/providers/
-        linters:
-          - tagliatelle
       # server/appwire_*.go mirrors the camelCase appwire wire format inside
       # a package that is otherwise snake_case. tagliatelle's overrides are
-      # per-package, so this per-file regime is expressed as an exclusion.
+      # per-package, so this per-file regime is expressed as an exclusion here
+      # and enforced by .golangci-appwire.yml, which flips package server to
+      # camelCase and discards every finding outside these files. Exactly one
+      # of the two runs judges any given file; narrowing this pattern would
+      # make them contradict each other.
       - path: ^server/appwire_
         linters:
           - tagliatelle

--- a/cmd/evener-hub/cov_session_tree_pass3_fuzz_test.go
+++ b/cmd/evener-hub/cov_session_tree_pass3_fuzz_test.go
@@ -111,7 +111,6 @@ func FuzzSessionTreePass3(f *testing.F) {
 			p := hubcore.TreeProject{Key: "key", Current: []hubcore.TreeNode{{ID: "live", State: "active"}}, Recent: []hubcore.TreeNode{{ID: "recent", State: "ended"}}, Archived: []hubcore.TreeNode{{ID: "old", State: "closed"}}}
 			_ = p
 			_ = web.rowRenameable("live")
-			_ = hubAttentionSummaryFromCore(appwire.AttentionSummary{NeedsYou: 1})
 			_ = web.apiTreeSources()
 		case 15:
 			dir := t.TempDir()

--- a/cmd/evener-hub/navigation_service.go
+++ b/cmd/evener-hub/navigation_service.go
@@ -1351,7 +1351,7 @@ func (s webNavigationSource) Capture(ctx context.Context, generation string, now
 	favoriteView := hubcore.ClassifyFavoriteDecisions(favorites, authority).Presentation
 	pinView := classifySessionPins(assignments, authority)
 	assignments = canonicalPinAssignments(assignments, pinView)
-	inputs := navigationBuildInputsFromTreeSnapshot(generation, 0, tree, s.web.apiTreeSources(), hubAttentionSummaryFromCore(attention), snapshot.live, favoriteView, projectFavoritePresentation(favoriteView), sections, assignments)
+	inputs := navigationBuildInputsFromTreeSnapshot(generation, 0, tree, s.web.apiTreeSources(), attention, snapshot.live, favoriteView, projectFavoritePresentation(favoriteView), sections, assignments)
 	return navigationSourceSnapshot{Inputs: inputs, NextBoundary: navigationSnapshotBoundary(tree, now)}, nil
 }
 

--- a/cmd/evener-hub/web_api_tree.go
+++ b/cmd/evener-hub/web_api_tree.go
@@ -652,12 +652,6 @@ func appThreadTreeLive(thread appwire.Thread) bool {
 	}
 }
 
-// hubAttentionSummaryFromCore maps hubcore's internal attention summary to
-// hubapi's public wire type (hubapi cannot import the hub's internal package).
-func hubAttentionSummaryFromCore(sum appwire.AttentionSummary) hubapi.AttentionSummary {
-	return hubapi.AttentionSummary{NeedsYou: sum.NeedsYou, Error: sum.Error, Working: sum.Working}
-}
-
 func (s *WebServer) apiTreeSources() []hubapi.Source {
 	sources := []hubapi.Source{{
 		ID:     "local",

--- a/cmd/evener/plugin_selection_flag.go
+++ b/cmd/evener/plugin_selection_flag.go
@@ -118,11 +118,11 @@ type effectivePluginJSON struct {
 	Source       plugins.LaunchPluginSource `json:"source"`
 	Marketplace  string                     `json:"marketplace,omitempty"`
 	Path         string                     `json:"path,omitempty"`
-	SkillCount   int                        `json:"skillCount"`   //nolint:tagliatelle // stable CLI JSON uses camelCase
-	AgentCount   int                        `json:"agentCount"`   //nolint:tagliatelle // stable CLI JSON uses camelCase
-	CommandCount int                        `json:"commandCount"` //nolint:tagliatelle // stable CLI JSON uses camelCase
-	HookCount    int                        `json:"hookCount"`    //nolint:tagliatelle // stable CLI JSON uses camelCase
-	MCPCount     int                        `json:"mcpCount"`     //nolint:tagliatelle // stable CLI JSON uses camelCase
+	SkillCount   int                        `json:"skill_count"`
+	AgentCount   int                        `json:"agent_count"`
+	CommandCount int                        `json:"command_count"`
+	HookCount    int                        `json:"hook_count"`
+	MCPCount     int                        `json:"mcp_count"`
 }
 
 // fatalLaunchPluginError decides what a resolver failure means to a launch,

--- a/cmd/evener/plugincmd_test.go
+++ b/cmd/evener/plugincmd_test.go
@@ -332,7 +332,7 @@ func TestPluginListEffective_ResolverOutputAndDisabledExclusion(t *testing.T) {
 	if installed == nil || installed.Source != plugins.LaunchPluginSourceInstalled || installed.Marketplace != "task3-market" || installed.Path == "" {
 		t.Fatalf("installed candidate = %+v", installed)
 	}
-	if !strings.Contains(out.String(), `"skillCount"`) || !strings.Contains(out.String(), `"mcpCount"`) {
+	if !strings.Contains(out.String(), `"skill_count"`) || !strings.Contains(out.String(), `"mcp_count"`) {
 		t.Fatalf("effective JSON omitted count fields: %s", out.String())
 	}
 

--- a/docs/developing-evener/conventions/naming.md
+++ b/docs/developing-evener/conventions/naming.md
@@ -119,9 +119,10 @@ Two standard gates enforce the convention:
 - **Go struct tags** — golangci-lint's `tagliatelle` linter (configured in
   `.golangci.yml`) requires snake_case `json`/`toml` tags by default,
   camelCase `json` tags in the appwire-adjacent packages (per-package
-  overrides), and nothing under `llm/providers/` (excluded; upstream owns
-  the casing). A single field can opt out with a trailing
-  `//nolint:tagliatelle // <reason>` comment.
+  overrides). Every `llm/providers/` package is held to the snake_case
+  default except `providers/google`, which has a per-package camelCase
+  override because Gemini's REST wire format is camelCase. A single field
+  can opt out with a trailing `//nolint:tagliatelle // <reason>` comment.
 
   `server/appwire_*.go` is camelCase too, but it shares package `server`
   with snake_case code, and tagliatelle's overrides are per-package. That
@@ -144,10 +145,10 @@ make lint-naming     # TOML data files
 ```
 
 The Make lint targets use a worktree-scoped golangci-lint cache, so findings
-under `llm/providers/` or `server/appwire_` are evaluated against this tree's
-paths rather than a sibling checkout's. If an external invocation still uses
-the global cache, `make lint-cache-clean` clears only the Make-managed cache;
-use that invocation's own cache-clean command for its global cache.
+under `server/appwire_` are evaluated against this tree's paths rather than a
+sibling checkout's. If an external invocation still uses the global cache,
+`make lint-cache-clean` clears only the Make-managed cache; use that
+invocation's own cache-clean command for its global cache.
 
 ## Adding a new surface
 
@@ -176,15 +177,37 @@ When you add a new TOML config file, JSON payload, or CLI flag:
 
 ## Migration status
 
-The tree matches the rule end-to-end. Only two JSON tags outside the
-appwire/providers carve-outs intentionally stay camelCase:
+The tree matches the rule end-to-end. Every camelCase JSON tag outside the
+appwire/providers carve-outs carries a per-field
+`//nolint:tagliatelle // <reason>` naming the wire format that fixes it, and
+these are all of them:
 
-- `mcpServers` in `agent/mcp_config.go` and `agent/plugin.go` —
-  mirrors the Claude `.mcp.json` format. Marked
-  `// evener:naming-ignore` with a pointer back to the upstream format.
+- `mcpServers` — `agent/plugin/plugin.go`, `agent/mcpconfig/config.go`,
+  `internal/plugins/catalog.go`. The upstream `.mcp.json` key spelling.
+- The Claude plugin store's on-disk state — `internal/plugins/registry.go`
+  (`installPath`, `gitCommitSha`, `installedAt`, `lastUpdated`,
+  `autoUpgrade`), `internal/plugins/marketplaces.go` (`installLocation`,
+  `lastUpdated`), and `internal/plugins/catalog.go` (`pluginRoot`). These
+  files share `~/.claude/plugins/` state and `marketplace.json` with Claude
+  Code, so the keys are decoded as well as written —
+  `internal/plugins/registry_test.go` feeds `installPath` as fixture JSON.
+  Projections of that state that nothing decodes are snake_case, e.g.
+  `ListItem` in `internal/plugins/install.go`, which only feeds
+  `plugin list --json`.
+- The doctor Finding contract — `agent/doctor/audit.go` (`suggestedFix`,
+  `sessionRefs`, `watchIds`, …), specified in the `doctoring-evener` skill's
+  `references/finding-contract.md`, plus the narrow decoders that read it back
+  in `cmd/evener-doctor`'s tests.
+- The Claude hook wire format — `agent/plugin/hooks.go` (`asyncRewake`,
+  `statusMessage`).
+- Gemini grounding metadata — `internal/apptranscript/apptranscript.go`
+  (`webSearchQueries`, `groundingChunks`), fixed by the Gemini API.
+- The Navigation v2 wire contract — `hubapi/navigation.go`
+  (`attentionSummary`) and `hubapi/navigation_delta.go` (`entityKey`,
+  `upsertedEntities`, …), which the web client reads directly.
 
-Hub REST/SSE shapes and TUI-internal types that previously leaked
-camelCase have all migrated: REST request bodies use `turn_id`, the
-TUI now reuses the appwire-defined `ToolOutputDeltaParams` and
-`NotificationRef` types directly instead of locally redeclaring the
-wire shape with camelCase tags.
+Types that previously leaked camelCase by locally redeclaring a wire shape
+have migrated onto the type that owns it: the TUI reuses the appwire-defined
+`ToolOutputDeltaParams` and `NotificationRef` directly, and
+`hubapi.AttentionSummary` is an alias for `appwire.AttentionSummary` rather
+than a copy of it.

--- a/hubapi/types.go
+++ b/hubapi/types.go
@@ -1,6 +1,10 @@
 package hubapi
 
-import "time"
+import (
+	"time"
+
+	"primeradiant.com/evener/appwire"
+)
 
 // MobileAPIVersion is the REST contract version implemented by the dedicated
 // mobile client. Pairing requires an exact match with HealthResponse.
@@ -28,20 +32,14 @@ type HealthCapabilities struct {
 // AttentionSummary is the authoritative badge count set: how many live,
 // top-level, not-manually-archived sessions need attention, are erroring, or
 // are working — the NeedsYou tier's eligibility set (only an explicit archive
-// decision suppresses; age never decays attention). Notification clients
-// (notifications.js) drive the tab title and favicon badge from this on
-// baseline load. It mirrors
-// appwire.AttentionSummary's shape as a parallel wire type — hubapi is the
-// REST client surface and deliberately does not import appwire — including
-// its camelCase tags: this is the same "summary" object evener/attention/changed
-// pushes incrementally (appwire.AttentionChangedPayload.Summary), so the JS
-// layer applies one field-access path to either the REST baseline or the live
-// notification.
-type AttentionSummary struct {
-	NeedsYou int `json:"needsYou"` //nolint:tagliatelle // camelCase: see AttentionSummary's doc
-	Error    int `json:"error"`
-	Working  int `json:"working"`
-}
+// decision suppresses; age never decays attention). The web client drives the
+// tab title from needsYou+error (frontend/src/notifications/title.ts) and the
+// favicon badge dot from all three counts
+// (frontend/src/notifications/favicon.ts) on baseline load. It is the same
+// "summary" object evener/attention/changed pushes incrementally
+// (appwire.AttentionChangedPayload.Summary), so the JS layer applies one
+// field-access path to either the REST baseline or the live notification.
+type AttentionSummary = appwire.AttentionSummary
 
 type Source struct {
 	ID     string `json:"id"`

--- a/internal/plugins/catalog.go
+++ b/internal/plugins/catalog.go
@@ -64,7 +64,7 @@ type Catalog struct {
 	// and were therefore dropped rather than failing the whole catalog. A
 	// skipped plugin is simply absent from Plugins (and so not installable);
 	// this field exists so Browse/CLI/callers can surface a warning about it.
-	SkippedPlugins []string `json:"skippedPlugins,omitempty"` //nolint:tagliatelle // matches Claude Code plugin/marketplace JSON schema
+	SkippedPlugins []string `json:"skipped_plugins,omitempty"`
 }
 
 type catalogMetadata struct {

--- a/internal/plugins/install.go
+++ b/internal/plugins/install.go
@@ -344,12 +344,12 @@ type ListItem struct {
 	Marketplace  string    `json:"marketplace"`
 	Version      string    `json:"version"`
 	Enabled      bool      `json:"enabled"`
-	AutoUpgrade  bool      `json:"autoUpgrade"` //nolint:tagliatelle // matches Claude Code plugin/marketplace JSON schema
+	AutoUpgrade  bool      `json:"auto_upgrade"`
 	Broken       bool      `json:"broken"`
-	InstallPath  string    `json:"installPath"`  //nolint:tagliatelle // matches Claude Code plugin/marketplace JSON schema
-	GitCommitSha string    `json:"gitCommitSha"` //nolint:tagliatelle // matches Claude Code plugin/marketplace JSON schema
-	InstalledAt  time.Time `json:"installedAt"`  //nolint:tagliatelle // matches Claude Code plugin/marketplace JSON schema
-	LastUpdated  time.Time `json:"lastUpdated"`  //nolint:tagliatelle // matches Claude Code plugin/marketplace JSON schema
+	InstallPath  string    `json:"install_path"`
+	GitCommitSha string    `json:"git_commit_sha"`
+	InstalledAt  time.Time `json:"installed_at"`
+	LastUpdated  time.Time `json:"last_updated"`
 }
 
 func splitKey(key string) (plugin, marketplace string) {


### PR DESCRIPTION
An audit found `.golangci.yml`'s tagliatelle exemptions had drifted from what
they claim. Each one below is listed with the claim it made and what was
verified against the code.

## 1. `hubapi/types.go:41` — "camelCase: see AttentionSummary's doc"

**Claimed:** hubapi mirrors `appwire.AttentionSummary` as a parallel wire type
because "hubapi is the REST client surface and deliberately does not import
appwire".

**Verified false.** `hubapi/navigation.go:7` imports appwire and line 192
already declares `type NavigationMutation = appwire.NavigationMutation`. The two
structs were field-for-field and tag-for-tag identical.

**Changed:** `type AttentionSummary = appwire.AttentionSummary`, the way
`NavigationMutation` already is. That deletes the suppression and the
hand-written converter `hubAttentionSummaryFromCore`
(`cmd/evener-hub/web_api_tree.go`), whose own doc comment was also wrong — it
said hubapi "cannot import the hub's internal package" while taking an
`appwire.AttentionSummary` parameter.

**Tag names are unchanged, and proved so.** `cmd/evener-hub/frontend/src/notifications/title.ts:28`
reads `summary.needsYou + summary.error` for the tab title and
`favicon.ts:24-26` reads `.error` / `.needsYou` / `.working` for the badge dot.
`hubapi/navigation_test.go`'s `TestNavigationResourcesJSON` already asserts the
byte-exact manifest JSON including
`"attentionSummary":{"needsYou":2,"error":0,"working":0}`. It passes before and
after with the test file untouched (`git diff --stat hubapi/navigation_test.go`
is empty), which is the byte-identity proof. `lint-generated` also confirms
`types.gen.ts` is unchanged.

### Why the alias matters more than de-duplication

The duplicate was not merely redundant — it was silently shadowing appwire's type
in the generated frontend contract, and this PR closes that hazard.

`internal/appwirets/emit.go` keys its type registry on the bare type name:
`registry.types` is a `map[string]reflect.Type`, `discover` registers via
`r.addNamed(t.Name(), t)`, and `addNamed` returns early on `r.has(name)`. There is
no package comparison, so the first type to claim a name wins. `EmitCatalog`
registers `navigationRESTRoots` — which begins with `hubapi.NavigationManifest{}`
— *before* it walks `appwire.Methods` and `appwire.Notifications`. Walking the
manifest reaches `hubapi.AttentionSummary` first and claims the name
`AttentionSummary`; when `appwire.AttentionChangedPayload.Summary` is reached
later, `addNamed` sees the name taken and returns. `appwire.AttentionSummary` was
therefore never emitted, and the frontend's `AttentionSummary` interface came
from hubapi's copy.

Verified in both directions by adding a `Probe int \`json:"probeField"\`` field to
`appwire.AttentionSummary` and running the generator:

- With main's duplicate hubapi struct restored, the regenerated `types.gen.ts` is
  **byte-identical** to the committed file. The new appwire field is dropped, the
  frontend is silently mistyped, and no gate fires — `lint-generated` sees no
  diff because there is no diff.
- With this PR's alias in place, the same edit emits `probeField: number;` at
  line 45, so `lint-generated` fails until `types.gen.ts` is regenerated, and the
  byte-exact assertion in `hubapi/navigation_test.go` fails until the change is
  acknowledged deliberately.

So the alias is not tidying a duplicate; it removes a shadow that made one of the
two structs invisible to the generator and turned any future field on the
appwire side into a silent frontend type divergence.

## 2. `^llm/providers/` path exclusion — "tag casing belongs to upstream"

**Claimed:** the whole tree under `llm/providers/` needs upstream casing.

**Verified redundant.** All six camelCase tags there are in `providers/google`
(`protocol_transport.go:92-94`, `vertex_models.go:39,43,44`) and are real Google
REST names, already covered by the existing `pkg: providers/google` override.
The exclusion additionally blinded eight sibling provider packages.

**Changed:** exclusion deleted. With it gone,
`golangci-lint run --enable-only tagliatelle ./providers/...` reports `0 issues`.
The gate is now live rather than vacuous: injecting `json:"hasMore"` into
`llm/providers/anthropic/protocol_transport.go:86` is reported
(`json(snake): got 'hasMore' want 'has_more'`) where before it was not. The
mutation was reverted from a copy.

## 3. `^server/appwire_` path exclusion — kept, comment corrected

**Claim examined:** that this covers 25 files to permit three tags in one test
helper (`server/appwire_failure_push_item_test.go:17,21,28`).

**Not a defect.** `make lint-golangci` runs a *second* pass with
`.golangci-appwire.yml` over `./server/...`, which flips package `server` to
camelCase and discards every finding outside `^server/appwire_`. Those 25 files
are not unlinted — they are held to camelCase by the other half of a deliberate,
documented split (`docs/developing-evener/linting.md`, "The `server/appwire_*.go`
camelCase regime"). Narrowing this pattern, or replacing it with per-field
nolints, would make the two configs contradict each other for any future tag in
`appwire_runtime.go` / `appwire_turns.go`, and would remove the canary
`.golangci-appwire.yml` documents (if the anchored path pattern ever stops
matching, this exclusion going stale is what reds the main sweep first).

**Changed:** only the comment, which described the exclusion as if it stood
alone. It now names `.golangci-appwire.yml` and says why narrowing it is wrong.

## 4a. `internal/plugins/catalog.go:67` — "matches Claude Code plugin/marketplace JSON schema"

**Verified false.** `skippedPlugins` is this repo's own field, set only by
`ParseCatalog` when an entry's source kind is unsupported. It is not in
`marketplace.json` and is absent from `catalogHeader`, the type that actually
decodes the file. (Correcting the audit: `Catalog` *is* marshalled, by
`plugin marketplace browse --json` at `cmd/evener/plugincmd.go:190` — but nothing
anywhere decodes the key and no test asserts it.)

**Changed:** `skipped_plugins`, suppression dropped. `catalog.go:35`
(`mcpServers`) and `catalog.go:71` (`pluginRoot`) are untouched: both are decoded
from the upstream file.

## 4b. `internal/plugins/install.go:347,349-352` — same claim

**Verified false for `ListItem`.** `ListItem` is `plugin list --json` output
(`plugincmd.go:294`); nothing decodes it. The real on-disk contract is
`InstallEntry` in `internal/plugins/registry.go`, whose camelCase keys *are*
decoded — `internal/plugins/registry_test.go:51` feeds `installPath` as fixture
JSON — so those suppressions are correct and stay, as do
`marketplaces.go`'s.

**Changed:** the five `ListItem` keys to `auto_upgrade`, `install_path`,
`git_commit_sha`, `installed_at`, `last_updated`; suppressions dropped.

## 4c. `cmd/evener/plugin_selection_flag.go:121-125` — "stable CLI JSON uses camelCase"

**Verified false.** No such contract exists: nothing outside this repo's own
tests decodes `effectivePluginListJSON`, `README.md:279` documents the command
but not its keys, and every other `--json` shape in `cmd/evener` is snake_case
(`credential_source`, `pruned_fields`, `queue_held`, `operation_state`). The
type's own doc says it avoids coupling to appwire while its tags copied
`appwire.PluginLaunchCandidate` verbatim.

**Changed:** `skill_count`, `agent_count`, `command_count`, `hook_count`,
`mcp_count`; suppressions dropped. `cmd/evener/plugincmd_test.go:335` was the
only place asserting the literal key strings and now asserts the new ones.

No test was added for 4a/4b/4c on purpose: pinning these keys would manufacture
the consumer the audit proved does not exist.

## 5. `pkg: cmd/evener-hub/internal/appsource` override

**Verified stale.** That package has zero `json:` struct tags, so the override
governs nothing. Deleted. The other four overrides were checked and are live
(`internal/appserver` 26 camel tags, `internal/appprojector` 14,
`cmd/evener-hub/internal/launchconfig` 11, `appwire` 502).

## Docs

`docs/developing-evener/conventions/naming.md` said tagliatelle enforces
"nothing under `llm/providers/`". It now states what is true: the snake_case
default applies there except `providers/google`. The cache-path note dropped its
now-nonexistent `llm/providers/` path reference.

## Gates (all foreground, all green)

- `gofmt -l` over all 9 changed `.go` files: no output
- `make vet` and `GOOS=windows make vet`: exit 0
- `GOMAXPROCS=4 go test -race ./hubapi/... ./internal/plugins/... ./cmd/evener/... -count=1`: exit 0, 0 FAIL
- `GOMAXPROCS=4 go test -race ./cmd/evener-hub/... -count=1`: exit 0, 0 FAIL
- `GOMAXPROCS=4 go test -tags evenerfuzz -run Fuzz ./cmd/evener-hub/ ./cmd/evener/ ./internal/plugins/ ./hubapi/ -count=1`: exit 0, 0 FAIL
- `make lint-golangci lint-evenerfuzz lint-eval`: all PASS
- `make lint` (full set, since the lint config itself changed): lint-naming,
  lint-gofmt, lint-evenerfuzz, lint-eval, lint-internal, lint-golangci,
  lint-generated, lint-fuzz-registry, secret-scan — all PASS, 0 FAIL

## Review follow-ups (same prose this PR already rewrote)

- `hubapi/types.go` credited `notifications.js` for reading these fields. That
  file no longer exists anywhere in the tree; the comment now names
  `frontend/src/notifications/title.ts` (tab title, `needsYou+error`) and
  `frontend/src/notifications/favicon.ts` (badge dot, all three counts).
- `naming.md`'s migration-status section claimed `mcpServers` was the only
  camelCase key intentionally left outside the carve-outs, and that hub REST
  shapes had "all migrated". Both false. It now lists every family, derived
  exhaustively from the `//nolint:tagliatelle` set outside the carve-out paths
  (12 files: `agent/doctor/audit.go`, `agent/mcpconfig/config.go`,
  `agent/plugin/{hooks,plugin}.go`, `cmd/evener-doctor/{audit,study_runbooks}_test.go`,
  `hubapi/navigation{,_delta}.go`, `internal/apptranscript/apptranscript.go`,
  `internal/plugins/{catalog,marketplaces,registry}.go`) — including the plugin
  store keys this PR deliberately kept, with the reason: that state is shared
  on disk with Claude Code and is decoded, not just written
  (`internal/plugins/registry_test.go` feeds `installPath` as fixture JSON),
  whereas projections nothing decodes are now snake_case.

Rebased onto `origin/main` (`aa8dd8e1a`); the four commits it brought in touch
only `agent/internal/jobstore/` and `agent/session_active_turn_test.go`, with no
overlap with this diff. Post-rebase gates re-run: `go build ./...`, `make vet`,
`go test ./hubapi/` (the byte-identity proof), and the full `make lint` — all
PASS, 0 FAIL. The `-race` matrix and `./agent/` suite were not re-run: this diff
touches no file under `agent/`.

