### PR TITLE
fix(test): put the drain-backoff tripwire where the audit reads it

### DIFF
--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -313,11 +313,11 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 		if time.Now().After(quietDeadline) {
 			t.Fatalf("precondition: tree must read quiescent after residue clear, got outstanding=true after 30s")
 		}
-		// TRIPWIRE: not a completion-signal wait — a quiet scan above is
-		// the signal; 10ms only yields instead of busy-spinning.
 		select {
 		case <-done:
 			t.Fatalf("drain returned during quiescence poll with turns = %d, want the skipped-kick pass to run first", turns.Load())
+		// TRIPWIRE: not a completion-signal wait — the quiet scan above is
+		// the signal; 10ms only yields instead of busy-spinning.
 		case <-time.After(10 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
## What was wrong

`TestNoBareWallClockDeadlineInAgentTests` has failed on every `main` build since #967, taking the `tests` and both `race` lanes with it:

```
deadline_audit_test.go:56: bare wall-clock deadline(s) in agent test sources:
    session_jobtree_drain_backoff_test.go:321: bare wall-clock bound passed to time.After(...)
```

The audit accepts a `// TRIPWIRE:` comment on the literal's own line or the line directly above it. #967 wrote the comment above the enclosing `select`, three lines and another `case` away from the bound it explains, so the audit could not see it.

## What changed

The comment moves down to sit directly above the bound it describes. Same wording, same 10 ms yield, no behaviour change — the explanation now lives where both the audit and a reader looking at that line will find it.

## How it is tested

`go test ./agent/ -run '^TestNoBareWallClockDeadlineInAgentTests$'` passes, as do the audit's own fixture tests and the drain-backoff tests in the file being edited. Every branch cut from main inherits this failure, so this unblocks them all.
