### PR TITLE
fix(test): mark drain backoff quiescence poll tick as tripwire

### DIFF
--- a/agent/session_jobtree_drain_backoff_test.go
+++ b/agent/session_jobtree_drain_backoff_test.go
@@ -313,11 +313,11 @@ func TestDrainBackoffFinalKickDeliversUnreachableChildPending(t *testing.T) {
 		if time.Now().After(quietDeadline) {
 			t.Fatalf("precondition: tree must read quiescent after residue clear, got outstanding=true after 30s")
 		}
-		// TRIPWIRE: not a completion-signal wait — a quiet scan above is
-		// the signal; 10ms only yields instead of busy-spinning.
 		select {
 		case <-done:
 			t.Fatalf("drain returned during quiescence poll with turns = %d, want the skipped-kick pass to run first", turns.Load())
+		// TRIPWIRE: not a completion-signal wait — a quiet scan above is
+		// the signal; 10ms only yields instead of busy-spinning.
 		case <-time.After(10 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
Moves the existing TRIPWIRE marker in agent/session_jobtree_drain_backoff_test.go directly above the 10ms time.After literal so TestNoBareWallClockDeadlineInAgentTests recognizes it.

The 10ms is a poll-tick yield, not a completion-signal wait — the quiet scan above is the signal.

Unblocks: main CI plus #974, #975, #1000 (all fail the audit against main's file contents).