### PR TITLE
fix(hub): remove unused spawner state root

### DIFF
--- a/cmd/evener-hub/main.go
+++ b/cmd/evener-hub/main.go
@@ -267,7 +267,6 @@ func runMain(args []string, stderr io.Writer, deps mainDeps) error {
 		RunDir:              runDir,
 		HubToken:            hubToken,
 		Registry:            hubReg,
-		StateRoot:           hubStateRoot,
 		ProvidersConfigPath: providersConfigPath,
 		CredentialsPath:     credentialsPath,
 		NoUserLayer:         noUserLayer,

--- a/cmd/evener-hub/spawn.go
+++ b/cmd/evener-hub/spawn.go
@@ -48,7 +48,6 @@ type HubSpawner struct {
 	RunDir              string
 	HubToken            string
 	Registry            *hubcore.ProviderRegistry // live registry the credential gate reads
-	StateRoot           string                    // hub-level state root; used for resolving
 	ProvidersConfigPath string                    // providers.toml the child reads as its user layer
 	CredentialsPath     string                    // credentials.toml the child resolves keys from
 	NoUserLayer         bool                      // the tri-state from EVENER_PROVIDERS_CONFIG: present and empty means no user layer (spec §10)


### PR DESCRIPTION
## Summary
- remove the unused HubSpawner.StateRoot field
- stop passing hubStateRoot into the spawner where no child-side reader exists

Fixes #1030

## Verification
- git diff --check
- not run: go test ./cmd/evener-hub (go is not installed in this cron environment)
