### PR TITLE
feat(web-tasks): settled group first, drop task-list progress bar

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.test.tsx
@@ -156,7 +156,7 @@ test("the trigger shows the done/total counts once the aggregate has arrived", (
   expect(screen.getByRole("button", { name: "Tasks 3/7" })).toBeTruthy();
 });
 
-test("outcome aggregates show terminal progress instead of done/total", async () => {
+test("outcome aggregates show terminal counts instead of done/total", async () => {
   const fake = connectFakeClient();
   fake.on("evener/tasks/list", () => ({ data: [] }));
   const model = testModel({ tasks: { total: 7, done: 1, cancelled: 5, remaining: 1 } });
@@ -171,33 +171,25 @@ test("outcome aggregates show terminal progress instead of done/total", async ()
   expect(screen.getByRole("button", { name: "Tasks 1 done, 5 cancelled, 1 remaining (7 total)" })).toBeTruthy();
   await waitFor(() => expect(screen.getByTestId("tasks-body-head")).toBeTruthy());
   expect(screen.getByTestId("tasks-body-head").textContent).toContain("1 done, 5 cancelled, 1 remaining (7 total)");
-  expect(
-    screen
-      .getByRole("meter", { name: "Task progress: 1 done, 5 cancelled, 1 remaining (7 total)" })
-      .getAttribute("aria-valuenow"),
-  ).toBe("6");
+  expect(screen.queryByRole("meter")).toBeNull();
 });
 
-test("outcome aggregates infer an omitted zero outcome for labels and terminal meters", async () => {
+test("outcome aggregates infer an omitted zero outcome for labels", async () => {
   const fake = connectFakeClient();
   fake.on("evener/tasks/list", () => ({ data: [] }));
   const cancelledOnly = testModel({ tasks: { total: 7, done: 1, cancelled: 5 } });
   const { unmount } = render(<TasksPanelBody sessionRef="ref_cancelled" model={cancelledOnly} />);
 
   await waitFor(() => expect(screen.getByTestId("tasks-body-head")).toBeTruthy());
-  const cancelledMeter = screen.getByRole("meter", {
-    name: "Task progress: 1 done, 5 cancelled, 0 remaining (7 total)",
-  });
-  expect(cancelledMeter.getAttribute("aria-valuenow")).toBe("6");
+  expect(screen.getByTestId("tasks-body-head").textContent).toContain("1 done, 5 cancelled, 0 remaining (7 total)");
+  expect(screen.queryByRole("meter")).toBeNull();
   unmount();
 
   const remainingOnly = testModel({ tasks: { total: 7, done: 1, remaining: 5 } });
   render(<TasksPanelBody sessionRef="ref_remaining" model={remainingOnly} />);
   await waitFor(() => expect(screen.getByTestId("tasks-body-head")).toBeTruthy());
-  const remainingMeter = screen.getByRole("meter", {
-    name: "Task progress: 1 done, 0 cancelled, 5 remaining (7 total)",
-  });
-  expect(remainingMeter.getAttribute("aria-valuenow")).toBe("1");
+  expect(screen.getByTestId("tasks-body-head").textContent).toContain("1 done, 0 cancelled, 5 remaining (7 total)");
+  expect(screen.queryByRole("meter")).toBeNull();
 });
 
 // --- STATUS_TONE: pinning test (review finding) --------------------------
@@ -242,7 +234,7 @@ test("opening the panel fetches via listTasks(ref) and shows a loading state unt
   await waitFor(() => expect(screen.queryByText(/loading tasks/i)).toBeNull());
 });
 
-test("rows group by status: in progress, then open, then the collapsed settled group; wire order holds within a group", async () => {
+test("rows group by status: the collapsed settled group first, then in progress, then open; wire order holds within a group", async () => {
   const user = userEvent.setup();
   const fake = connectFakeClient();
   fake.on("evener/tasks/list", () => ({ data: TASKS_DATA }));
@@ -253,7 +245,14 @@ test("rows group by status: in progress, then open, then the collapsed settled g
   await waitFor(() => expect(screen.getAllByTestId("task-row")).toHaveLength(2));
   const liveGroups = screen.getAllByTestId("task-group-live");
   expect(liveGroups.map((group) => group.getAttribute("data-status"))).toEqual(["in_progress", "open"]);
-  expect(screen.getByTestId("task-settled-group").textContent).toContain("1");
+  const settled = screen.getByTestId("task-settled-group");
+  expect(settled.textContent).toContain("1");
+  // The folded-away settled group sits above the current work, not at the bottom.
+  const body = settled.parentElement;
+  expect(body).toBeTruthy();
+  const settledIndex = Array.from(body!.children).indexOf(settled);
+  const firstLiveIndex = Array.from(body!.children).indexOf(liveGroups[0]!);
+  expect(settledIndex).toBeLessThan(firstLiveIndex);
 
   await user.click(screen.getByTestId("task-settled-group-summary"));
   await waitFor(() => expect(screen.getAllByTestId("task-row")).toHaveLength(3));
@@ -344,7 +343,7 @@ test("the settled group defaults to collapsed and remembers being opened per ses
   expect(await screen.findByText("Implement artifact store")).toBeTruthy();
 });
 
-test("the body header shows the meter and count when the aggregate is known", async () => {
+test("the body header shows the count when the aggregate is known, with no progress bar", async () => {
   const fake = connectFakeClient();
   fake.on("evener/tasks/list", () => ({ data: [TASKS_DATA[0]] }));
 
@@ -356,7 +355,7 @@ test("the body header shows the meter and count when the aggregate is known", as
   );
   await waitFor(() => expect(screen.getByTestId("tasks-body-head")).toBeTruthy());
   expect(screen.getByTestId("tasks-body-head").textContent).toContain("16/20 done");
-  expect(screen.getByRole("meter", { name: "Task progress: 16 of 20 complete" })).toBeTruthy();
+  expect(screen.queryByRole("meter")).toBeNull();
 });
 
 test("the body header is absent while no aggregate has arrived", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/TasksPanel.tsx
@@ -73,7 +73,7 @@ import { errorText, sessionActionError, sessionActionHeadline } from "../../../p
 import type { ThreadModel } from "../../../protocol/model";
 import { EMPTY_TASKS_PANEL_ENTRY, tasksPanelStore, useTasksPanelStore } from "../../../stores/tasksPanel";
 import { threadsStore } from "../../../stores/threads";
-import { Button, Chip, type ChipTone, EmptyState, Markdown, Meter, Sheet, useToasts } from "../../../widgets";
+import { Button, Chip, type ChipTone, EmptyState, Markdown, Sheet, useToasts } from "../../../widgets";
 import { Disclosure } from "../../../widgets/disclosure";
 import { isDisclosureOpen, toggleDisclosure } from "../../../widgets/disclosure/disclosureStore";
 import { requireClass } from "../../../widgets/internal/requireClass";
@@ -178,10 +178,6 @@ export const STATUS_TONE: Record<TaskStatus, ChipTone> = {
 
 function hasTaskOutcomes(tasks: NonNullable<ThreadModel["tasks"]>): boolean {
   return tasks.cancelled !== undefined || tasks.remaining !== undefined;
-}
-
-function taskMeterValue(tasks: NonNullable<ThreadModel["tasks"]>): number {
-  return hasTaskOutcomes(tasks) ? tasks.done + (tasks.cancelled ?? 0) : tasks.done;
 }
 
 export function taskAggregateLabel(tasks: NonNullable<ThreadModel["tasks"]>): string {
@@ -424,8 +420,6 @@ function TaskListGroups({ rows, sessionRef }: { rows: TaskRow[]; sessionRef: str
   const groups = groupTasks(rows);
   return (
     <>
-      <LiveGroup label="In progress" status="in_progress" tasks={groups.inProgress} sessionRef={sessionRef} />
-      <LiveGroup label="Open" status="open" tasks={groups.open} sessionRef={sessionRef} />
       {groups.settled.length > 0 && (
         <Disclosure
           id={`${sessionRef}\0settled-group`}
@@ -443,6 +437,8 @@ function TaskListGroups({ rows, sessionRef }: { rows: TaskRow[]; sessionRef: str
           </ul>
         </Disclosure>
       )}
+      <LiveGroup label="In progress" status="in_progress" tasks={groups.inProgress} sessionRef={sessionRef} />
+      <LiveGroup label="Open" status="open" tasks={groups.open} sessionRef={sessionRef} />
     </>
   );
 }
@@ -584,16 +580,6 @@ export function TasksPanelBody({ sessionRef, model }: TasksPanelBodyProps) {
         )}
         {model.tasks && (
           <div className={CLASS.bodyHead} data-testid="tasks-body-head">
-            <Meter
-              label={
-                hasTaskOutcomes(model.tasks)
-                  ? `Task progress: ${taskAggregateLabel(model.tasks)}`
-                  : `Task progress: ${model.tasks.done} of ${model.tasks.total} complete`
-              }
-              value={taskMeterValue(model.tasks)}
-              max={model.tasks.total}
-              tone="neutral"
-            />
             <span className={CLASS.count}>
               {hasTaskOutcomes(model.tasks)
                 ? taskAggregateLabel(model.tasks)

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/taskspanel.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/taskspanel.module.css
@@ -5,7 +5,7 @@
 }
 
 /* The body header repeats the trigger's aggregate so an open panel reads as
- * a whole: the same done/total the trigger badge shows, plus the meter. */
+ * a whole: the same done/total the trigger badge shows. */
 .bodyHead {
   display: flex;
   align-items: center;

--- a/docs/superpowers/specs/2026-08-09-task-list-ui-design.md
+++ b/docs/superpowers/specs/2026-08-09-task-list-ui-design.md
@@ -41,15 +41,15 @@ A new small helper, `chrome/taskTime.ts`:
 
 ### Panel body header
 
-Above the groups, one compact summary row: the `Meter` widget (neutral tone) plus `16/20 done`, sourced from `model.tasks`. Rendered only when `model.tasks` is non-null. The trigger button already shows this aggregate; the body repeats it so an open panel reads as a whole.
+Above the groups, one compact summary row: `16/20 done`, sourced from `model.tasks`. Rendered only when `model.tasks` is non-null. The trigger button already shows this aggregate; the body repeats it so an open panel reads as a whole. (No progress bar: the count alone carries the summary.)
 
 ### Groups
 
 Rows render in three groups, in this order:
 
-1. **In progress** — tasks with `status === "in_progress"`.
-2. **Open** — tasks with `status === "open"`.
-3. **Done · settled N** — tasks with `status === "done"` or `"cancelled"`, behind a single collapsed-by-default disclosure line. "Settled" covers both because the distinction still shows per row (✓ vs ✕, struck title).
+1. **Done · settled N** — tasks with `status === "done"` or `"cancelled"`, behind a single collapsed-by-default disclosure line. "Settled" covers both because the distinction still shows per row (✓ vs ✕, struck title). The folded-away history sits above the current work, not at the bottom.
+2. **In progress** — tasks with `status === "in_progress"`.
+3. **Open** — tasks with `status === "open"`.
 
 Within each group, rows keep wire order (task id order). Empty groups render nothing — no header, no placeholder. A list that is entirely settled shows only the settled disclosure line.
 
@@ -95,7 +95,7 @@ All in `cmd/evener-hub/frontend/src/panes/session/chrome/`, styles in `taskspane
 
 ## Edge cases
 
-- **No in-progress tasks** — the In progress header is omitted; Open leads.
+- **No in-progress tasks** — the In progress header is omitted; with no settled tasks either, Open leads.
 - **All tasks settled** — only the collapsed settled line shows. The reader opens it to audit history.
 - **Empty list, unsupported source, daemon gone, failed fetch** — exactly as today; this redesign changes none of those states.
 - **`updated_at` equal to `created_at`** (never touched after append) — the timestamps line omits `updated`; the collapsed row still shows the relative creation time, since the row's time is `updatedAt` and the two are equal.
@@ -115,7 +115,7 @@ Follow `docs/testing.md` and the repo's frontend gates.
   - settled group defaults to collapsed and remembers toggles per session;
   - expanded row shows meta strip, timestamps line (fields omitted correctly), updates timeline with N notes, and "No updates yet.";
   - prompt disclosure shows the one-line markdown preview collapsed and the full markdown body open; absent prompt renders no disclosure;
-  - body header shows `Meter` + count only when `model.tasks` is non-null.
+  - body header shows the count only when `model.tasks` is non-null (no progress bar).
 - Gates: `npx biome check --write` on touched files, then `make test-web`; `make test-web-browser` on this Chrome-capable host. The token-contract test forbids new color literals and gates `--attention`/`--alive`/`--danger` to allowlisted widget stylesheets. `taskspanel.module.css` is not a widget stylesheet, so its one semantic reach (`--alive` on the latest-note dot) earns an exact-path exception in `token-contract.test.ts` following the `taskcheck.module.css` precedent (kata entry, exact path, glyph-level color only; every piece of text in the panel stays on neutral ink).
 
 ## Out of scope


### PR DESCRIPTION
Moves the folded-away Done-settled group above In progress / Open in the web task list, and drops the progress bar from the task list body (count text retained).

Changes:
- TaskListGroups renders the collapsed settled disclosure first (TasksPanel.tsx)
- Body header keeps count text, Meter + taskMeterValue helper removed
- Tests pin settled-above-live DOM order and assert no meter remains
- CSS header comment updated (no meter reference)

Verification:
- biome check --write clean on touched files
- TasksPanel.test.tsx: 47/47 pass
- make test-web: web-typecheck PASS, web-test PASS, web-lint FAIL (6 pre-existing import-sort/format errors in untouched files: DocPane, AdvancedOptions, Rail, RailRow, SessionMenu)