### PR TITLE
ci: register manual iPhone TestFlight delivery

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   NODE_VERSION: "22.13.1"
   RUBY_VERSION: "3.3.6"
-  XCODE_VERSION: "26.4"
+  XCODE_VERSION: "26.6"
   IOS_BUNDLE_IDENTIFIER: com.primeradiant.evener.native
 
 jobs:

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       build_number:
-        description: "New archive build number; recovery uses the original IPA"
+        description: "Required for a new archive; leave blank for recovery"
         required: false
         type: string
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -29,17 +29,12 @@ env:
 
 jobs:
   archive-and-upload:
-    if: inputs.recovery_run_id == ''
+    if: inputs.recovery_run_id == '' && github.ref == 'refs/heads/main'
     runs-on: macos-26
     timeout-minutes: 90
     steps:
       - name: Check out source
         uses: actions/checkout@v7
-      - name: Require main branch for TestFlight archive
-        if: github.ref != 'refs/heads/main'
-        run: |
-          echo "TestFlight archive must be dispatched from main; recovery accepts artifacts from main only." >&2
-          exit 1
       - name: Select and verify Xcode
         run: |
           sudo xcode-select --switch "/Applications/Xcode_${XCODE_VERSION}.app"
@@ -235,7 +230,7 @@ jobs:
           exit "$cleanup_status"
 
   verify-upload:
-    if: inputs.recovery_run_id != ''
+    if: inputs.recovery_run_id != '' && github.ref == 'refs/heads/main'
     runs-on: macos-26
     permissions:
       contents: read
@@ -278,9 +273,11 @@ jobs:
           bundle exec ruby -rfastlane_core/ipa_file_analyser -e '
             info = FastlaneCore::IpaFileAnalyser.fetch_info_plist_file("build/Evener.ipa")
             version = info.fetch("CFBundleShortVersionString")
+            build = info.fetch("CFBundleVersion")
+            abort "Invalid artifact build number" unless build.match?(/\A[1-9][0-9]{0,3}(?:\.[0-9]{1,2}){0,2}\z/)
             abort "IPA export encryption compliance is not false" unless info.fetch("ITSAppUsesNonExemptEncryption") == false
             abort "Invalid artifact marketing version" unless version.match?(/\A[0-9]+(?:\.[0-9]+){0,2}\z/)
-            File.open(ENV.fetch("GITHUB_ENV"), "a") { |file| file.puts("IOS_MARKETING_VERSION=#{version}") }
+            File.open(ENV.fetch("GITHUB_ENV"), "a") { |file| file.puts("IOS_MARKETING_VERSION=#{version}", "IOS_BUILD_NUMBER=#{build}") }
           '
       - name: Verify internal TestFlight availability without uploading
         working-directory: mobile-native
@@ -289,7 +286,6 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
           IOS_INTERNAL_TESTFLIGHT_GROUP: ${{ vars.IOS_INTERNAL_TESTFLIGHT_GROUP }}
-          IOS_BUILD_NUMBER: ${{ inputs.build_number }}
           IOS_RECEIPT_PATH: ${{ github.workspace }}/mobile-native/build/recovered-testflight-receipt.json
           IOS_IPA_PATH: ${{ github.workspace }}/mobile-native/build/Evener.ipa
         run: bundle exec fastlane ios verify_testflight

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,0 +1,217 @@
+name: iOS TestFlight
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: "New build number for this app version (for example 1.0.1)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-testflight
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "22.13.1"
+  RUBY_VERSION: "3.3.6"
+  XCODE_VERSION: "26.4"
+  IOS_BUNDLE_IDENTIFIER: com.primeradiant.evener.native
+
+jobs:
+  archive-and-upload:
+    runs-on: macos-26
+    timeout-minutes: 90
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+      - name: Select and verify Xcode
+        run: |
+          sudo xcode-select --switch "/Applications/Xcode_${XCODE_VERSION}.app"
+          xcodebuild -version
+          test "$(xcodebuild -version | awk '/^Xcode / { print $2 }')" = "$XCODE_VERSION"
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: mobile-native/package-lock.json
+      - name: Set up Ruby and cached gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler: "2.7.2"
+          working-directory: mobile-native
+          bundler-cache: true
+      - name: Check distribution controls
+        working-directory: mobile-native
+        run: bundle exec ruby scripts/test-ios-distribution.rb
+      - name: Install JavaScript dependencies
+        run: |
+          npm ci --prefix mobile-native
+          npm ci --prefix cmd/evener-hub/frontend/src/protocol
+      - name: Run existing native and API gates
+        run: make test-native test-api-package
+      - name: Validate Apple build number
+        env:
+          IOS_BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          set -euo pipefail
+          [[ "$IOS_BUILD_NUMBER" =~ ^[1-9][0-9]{0,3}(\.[0-9]{1,2}(\.[0-9]{1,2})?)?$ ]] || {
+            echo "build_number must be Apple-compatible: 1-4 digit major, optional 1-2 digit minor and patch components" >&2
+            exit 1
+          }
+          echo "IOS_BUILD_NUMBER=$IOS_BUILD_NUMBER" >> "$GITHUB_ENV"
+      - name: Preflight distribution credentials
+        env:
+          IOS_CERTIFICATE_P12_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64 }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_DISTRIBUTION_PROVISIONING_PROFILE_BASE64 }}
+          IOS_PROVISIONING_PROFILE_NAME: ${{ vars.IOS_DISTRIBUTION_PROVISIONING_PROFILE_NAME }}
+          IOS_INTERNAL_TESTFLIGHT_GROUP: ${{ vars.IOS_INTERNAL_TESTFLIGHT_GROUP }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          for name in IOS_CERTIFICATE_P12_BASE64 IOS_CERTIFICATE_PASSWORD IOS_PROVISIONING_PROFILE_BASE64 IOS_PROVISIONING_PROFILE_NAME IOS_INTERNAL_TESTFLIGHT_GROUP APP_STORE_CONNECT_API_KEY_ID APP_STORE_CONNECT_API_ISSUER_ID APP_STORE_CONNECT_API_KEY_CONTENT APPLE_TEAM_ID; do
+            test -n "${!name}" || { echo "Missing required distribution credential: $name" >&2; exit 1; }
+          done
+      - name: Generate iOS project and install pods
+        working-directory: mobile-native
+        run: |
+          npx expo prebuild --platform ios --no-install
+          cp Podfile.lock ios/Podfile.lock
+          bundle exec pod install --deployment --project-directory=ios
+          printf 'IOS_MARKETING_VERSION=%s\n' "$(node -p 'require("./app.json").expo.version')" >> "$GITHUB_ENV"
+      - name: Reject duplicate App Store Connect build
+        working-directory: mobile-native
+        env:
+          IOS_INTERNAL_TESTFLIGHT_GROUP: ${{ vars.IOS_INTERNAL_TESTFLIGHT_GROUP }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          IOS_BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          IOS_MARKETING_VERSION="$(node -p 'require("./app.json").expo.version')" \
+            bundle exec fastlane ios preflight
+      - name: Import distribution signing assets
+        working-directory: mobile-native
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          IOS_CERTIFICATE_P12_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_P12_BASE64 }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_DISTRIBUTION_PROVISIONING_PROFILE_BASE64 }}
+          IOS_PROVISIONING_PROFILE_NAME: ${{ vars.IOS_DISTRIBUTION_PROVISIONING_PROFILE_NAME }}
+        run: |
+          set -euo pipefail
+          umask 077
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
+          keychain="$RUNNER_TEMP/evener-signing.keychain-db"
+          cert="$RUNNER_TEMP/evener-distribution.p12"
+          profile="$RUNNER_TEMP/evener.mobileprovision"
+          security list-keychains -d user > "$RUNNER_TEMP/evener-keychains.txt"
+          security default-keychain -d user > "$RUNNER_TEMP/evener-default-keychain.txt"
+          echo "$IOS_CERTIFICATE_P12_BASE64" | base64 --decode > "$cert"
+          echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security import "$cert" -P "$IOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain"
+          security list-keychains -d user -s "$keychain"
+          security default-keychain -s "$keychain"
+          profile_plist="$RUNNER_TEMP/evener-profile.plist"
+          security cms -D -i "$profile" > "$profile_plist"
+          profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")"
+          profile_path="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles/$profile_uuid.mobileprovision"
+          if test -e "$profile_path"; then
+            cmp -s "$profile" "$profile_path" || { echo "A different profile already occupies this UUID" >&2; exit 1; }
+          else
+            echo "IOS_PROFILE_PATH=$profile_path" >> "$GITHUB_ENV"
+            mkdir -p "$(dirname "$profile_path")"
+            cp "$profile" "$profile_path"
+          fi
+          IOS_BUNDLE_IDENTIFIER="$IOS_BUNDLE_IDENTIFIER" bundle exec ruby scripts/configure-ios-distribution.rb ios/Evener.xcodeproj build/ExportOptions.plist
+      - name: Archive and export signed IPA
+        working-directory: mobile-native
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          IOS_PROVISIONING_PROFILE_NAME: ${{ vars.IOS_DISTRIBUTION_PROVISIONING_PROFILE_NAME }}
+        run: |
+          set -euo pipefail
+          mkdir -p build
+          build_number="$IOS_BUILD_NUMBER"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build_number" ios/Evener/Info.plist
+          xcodebuild -workspace ios/Evener.xcworkspace -scheme Evener -configuration Release -sdk iphoneos -destination generic/platform=iOS archive -archivePath "$PWD/build/Evener.xcarchive" | tee build/xcodebuild-archive.log
+          xcodebuild -exportArchive -archivePath "$PWD/build/Evener.xcarchive" -exportOptionsPlist build/ExportOptions.plist -exportPath build/export | tee build/xcodebuild-export.log
+          mv build/export/*.ipa build/Evener.ipa
+      - name: Record artifact identity
+        working-directory: mobile-native
+        run: |
+          git rev-parse HEAD > build/source-revision.txt
+          xcodebuild -version > build/toolchain.txt
+          shasum -a 256 build/Evener.ipa build/Evener.xcarchive/Info.plist > build/artifact-sha256.txt
+      - name: Upload to internal TestFlight and wait for processing
+        working-directory: mobile-native
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          IOS_INTERNAL_TESTFLIGHT_GROUP: ${{ vars.IOS_INTERNAL_TESTFLIGHT_GROUP }}
+          IOS_BUILD_NUMBER: ${{ inputs.build_number }}
+          IOS_BUNDLE_IDENTIFIER: ${{ env.IOS_BUNDLE_IDENTIFIER }}
+          IOS_RECEIPT_PATH: ${{ github.workspace }}/mobile-native/build/testflight-receipt.json
+          IOS_IPA_PATH: ${{ github.workspace }}/mobile-native/build/Evener.ipa
+        run: |
+          IOS_MARKETING_VERSION="$(node -p 'require("./app.json").expo.version')" \
+            bundle exec fastlane ios testflight
+      - name: Upload archive and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: evener-ios-testflight-${{ github.run_id }}
+          path: |
+            mobile-native/build/Evener.ipa
+            mobile-native/build/Evener.xcarchive
+            mobile-native/build/*.log
+            mobile-native/build/*.txt
+            mobile-native/build/testflight-receipt.json
+            mobile-native/build/ExportOptions.plist
+          if-no-files-found: warn
+      - name: Remove temporary signing assets
+        if: always()
+        env:
+          IOS_PROVISIONING_PROFILE_NAME: ${{ vars.IOS_DISTRIBUTION_PROVISIONING_PROFILE_NAME }}
+        run: |
+          set -euo pipefail
+          cleanup_status=0
+          keychain="$RUNNER_TEMP/evener-signing.keychain-db"
+          if test -e "$keychain"; then
+            security delete-keychain "$keychain" || cleanup_status=1
+          fi
+          if test -s "$RUNNER_TEMP/evener-keychains.txt"; then
+            keychains=()
+            while IFS= read -r keychain_path; do
+              keychains+=("$keychain_path")
+            done < <(ruby -e 'puts STDIN.read.scan(/"([^"]+)"/).flatten' < "$RUNNER_TEMP/evener-keychains.txt")
+            security list-keychains -d user -s "${keychains[@]}" || cleanup_status=1
+          fi
+          if test -s "$RUNNER_TEMP/evener-default-keychain.txt"; then
+            default_keychain="$(sed -n 's/^ *"\(.*\)"/\1/p' "$RUNNER_TEMP/evener-default-keychain.txt" | head -1)"
+            if test -n "$default_keychain"; then
+              security default-keychain -s "$default_keychain" || cleanup_status=1
+            else
+              cleanup_status=1
+            fi
+          fi
+          if test -n "${IOS_PROFILE_PATH:-}"; then
+            rm -f "$IOS_PROFILE_PATH" || cleanup_status=1
+          fi
+          rm -f "$RUNNER_TEMP/evener-distribution.p12" "$RUNNER_TEMP/evener.mobileprovision" "$RUNNER_TEMP/evener-profile.plist" || cleanup_status=1
+          rm -f "$RUNNER_TEMP/evener-keychains.txt" "$RUNNER_TEMP/evener-default-keychain.txt" || cleanup_status=1
+          exit "$cleanup_status"

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -116,8 +116,8 @@ jobs:
           profile="$RUNNER_TEMP/evener.mobileprovision"
           security list-keychains -d user > "$RUNNER_TEMP/evener-keychains.txt"
           security default-keychain -d user > "$RUNNER_TEMP/evener-default-keychain.txt"
-          echo "$IOS_CERTIFICATE_P12_BASE64" | base64 --decode > "$cert"
-          echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile"
+          echo "$IOS_CERTIFICATE_P12_BASE64" | base64 -D > "$cert"
+          echo "$IOS_PROVISIONING_PROFILE_BASE64" | base64 -D > "$profile"
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
@@ -149,7 +149,13 @@ jobs:
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build_number" ios/Evener/Info.plist
           xcodebuild -workspace ios/Evener.xcworkspace -scheme Evener -configuration Release -sdk iphoneos -destination generic/platform=iOS archive -archivePath "$PWD/build/Evener.xcarchive" | tee build/xcodebuild-archive.log
           xcodebuild -exportArchive -archivePath "$PWD/build/Evener.xcarchive" -exportOptionsPlist build/ExportOptions.plist -exportPath build/export | tee build/xcodebuild-export.log
-          mv build/export/*.ipa build/Evener.ipa
+          shopt -s nullglob
+          exported_ipas=(build/export/*.ipa)
+          if (( ${#exported_ipas[@]} != 1 )); then
+            echo "Expected one exported IPA; found ${#exported_ipas[@]}" >&2
+            exit 1
+          fi
+          mv "${exported_ipas[0]}" build/Evener.ipa
       - name: Record artifact identity
         working-directory: mobile-native
         run: |

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -147,6 +147,10 @@ jobs:
           profile_plist="$RUNNER_TEMP/evener-profile.plist"
           security cms -D -i "$profile" > "$profile_plist"
           profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")"
+          # Xcode 16 and later store downloaded profiles here; Xcode still
+          # reads the legacy MobileDevice location for profiles downloaded by
+          # older releases (Apple Xcode 16 release notes, issue 54347894):
+          # https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes
           profile_path="$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles/$profile_uuid.mobileprovision"
           if test -e "$profile_path"; then
             cmp -s "$profile" "$profile_path" || { echo "A different profile already occupies this UUID" >&2; exit 1; }

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       build_number:
-        description: "New build number for this app version (for example 1.0.1)"
-        required: true
+        description: "New archive build number; recovery uses the original IPA"
+        required: false
         type: string
 
       recovery_run_id:
@@ -16,6 +16,8 @@ on:
 
 permissions:
   contents: read
+  # actions/upload-artifact receives GitHub's official ACTIONS_RUNTIME_TOKEN at
+  # runtime; the recovery job separately needs actions: read to download it.
 
 concurrency:
   group: ios-testflight
@@ -28,26 +30,36 @@ env:
   IOS_BUNDLE_IDENTIFIER: com.primeradiant.evener.native
 
 jobs:
+  validate-dispatch:
+    if: github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject non-main dispatch
+        run: |
+          set -euo pipefail
+          echo "TestFlight workflow dispatches are allowed only from main (got $GITHUB_REF)" >&2
+          exit 1
+
   archive-and-upload:
     if: inputs.recovery_run_id == '' && github.ref == 'refs/heads/main'
     runs-on: macos-26
     timeout-minutes: 90
     steps:
       - name: Check out source
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Select and verify Xcode
         run: |
           sudo xcode-select --switch "/Applications/Xcode_${XCODE_VERSION}.app"
           xcodebuild -version
           test "$(xcodebuild -version | awk '/^Xcode / { print $2 }')" = "$XCODE_VERSION"
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: mobile-native/package-lock.json
       - name: Set up Ruby and cached gems
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler: "2.7.2"
@@ -185,7 +197,7 @@ jobs:
             bundle exec fastlane ios testflight
       - name: Upload archive and diagnostics
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: evener-ios-testflight-${{ github.run_id }}
           path: |
@@ -237,9 +249,9 @@ jobs:
       actions: read
     steps:
       - name: Check out verification lane
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Set up Ruby and cached gems
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
         with:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler: "2.7.2"
@@ -254,7 +266,7 @@ jobs:
           [[ "$RECOVERY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo "Recovery run ID must be numeric" >&2; exit 1; }
           gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RECOVERY_RUN_ID" > "$RUNNER_TEMP/recovery-run.json"
       - name: Download the original signed archive
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: evener-ios-testflight-${{ inputs.recovery_run_id }}
           run-id: ${{ inputs.recovery_run_id }}
@@ -291,7 +303,7 @@ jobs:
         run: bundle exec fastlane ios verify_testflight
       - name: Save recovered TestFlight receipt
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: evener-ios-testflight-verification-${{ github.run_id }}
           path: |

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -8,6 +8,12 @@ on:
         required: true
         type: string
 
+      recovery_run_id:
+        description: "Verify an uploaded build from this workflow run; leave blank to archive and upload"
+        required: false
+        default: ""
+        type: string
+
 permissions:
   contents: read
 
@@ -23,6 +29,7 @@ env:
 
 jobs:
   archive-and-upload:
+    if: inputs.recovery_run_id == ''
     runs-on: macos-26
     timeout-minutes: 90
     steps:
@@ -221,3 +228,72 @@ jobs:
           rm -f "$RUNNER_TEMP/evener-distribution.p12" "$RUNNER_TEMP/evener.mobileprovision" "$RUNNER_TEMP/evener-profile.plist" || cleanup_status=1
           rm -f "$RUNNER_TEMP/evener-keychains.txt" "$RUNNER_TEMP/evener-default-keychain.txt" || cleanup_status=1
           exit "$cleanup_status"
+
+  verify-upload:
+    if: inputs.recovery_run_id != ''
+    runs-on: macos-26
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Check out verification lane
+        uses: actions/checkout@v7
+      - name: Set up Ruby and cached gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler: "2.7.2"
+          working-directory: mobile-native
+          bundler-cache: true
+      - name: Validate recovery run
+        env:
+          RECOVERY_RUN_ID: ${{ inputs.recovery_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$RECOVERY_RUN_ID" =~ ^[1-9][0-9]*$ ]] || { echo "Recovery run ID must be numeric" >&2; exit 1; }
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RECOVERY_RUN_ID" > "$RUNNER_TEMP/recovery-run.json"
+      - name: Download the original signed archive
+        uses: actions/download-artifact@v8
+        with:
+          name: evener-ios-testflight-${{ inputs.recovery_run_id }}
+          run-id: ${{ inputs.recovery_run_id }}
+          github-token: ${{ github.token }}
+          path: mobile-native/build
+      - name: Verify original artifact provenance
+        working-directory: mobile-native
+        run: |
+          set -euo pipefail
+          ruby -rjson -e '
+            run = JSON.parse(File.read(ENV.fetch("RUNNER_TEMP") + "/recovery-run.json"))
+            abort "Recovery requires this workflow dispatched from main" unless run["path"] == ".github/workflows/ios-testflight.yml" && run["event"] == "workflow_dispatch" && run["head_branch"] == "main"
+            abort "Artifact source does not match the original run" unless File.read("build/source-revision.txt").strip == run.fetch("head_sha")
+          '
+          shasum -a 256 -c build/artifact-sha256.txt
+          bundle exec ruby -rfastlane_core -e '
+            info = FastlaneCore::IpaFileAnalyser.fetch_info_plist_file("build/Evener.ipa")
+            version = info.fetch("CFBundleShortVersionString")
+            abort "Invalid artifact marketing version" unless version.match?(/\A[0-9]+(?:\.[0-9]+){0,2}\z/)
+            File.open(ENV.fetch("GITHUB_ENV"), "a") { |file| file.puts("IOS_MARKETING_VERSION=#{version}") }
+          '
+      - name: Verify internal TestFlight availability without uploading
+        working-directory: mobile-native
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          IOS_INTERNAL_TESTFLIGHT_GROUP: ${{ vars.IOS_INTERNAL_TESTFLIGHT_GROUP }}
+          IOS_BUILD_NUMBER: ${{ inputs.build_number }}
+          IOS_RECEIPT_PATH: ${{ github.workspace }}/mobile-native/build/recovered-testflight-receipt.json
+          IOS_IPA_PATH: ${{ github.workspace }}/mobile-native/build/Evener.ipa
+        run: bundle exec fastlane ios verify_testflight
+      - name: Save recovered TestFlight receipt
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: evener-ios-testflight-verification-${{ github.run_id }}
+          path: |
+            mobile-native/build/recovered-testflight-receipt.json
+            mobile-native/build/source-revision.txt
+            mobile-native/build/artifact-sha256.txt
+          if-no-files-found: warn

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -35,6 +35,11 @@ jobs:
     steps:
       - name: Check out source
         uses: actions/checkout@v7
+      - name: Require main branch for TestFlight archive
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "TestFlight archive must be dispatched from main; recovery accepts artifacts from main only." >&2
+          exit 1
       - name: Select and verify Xcode
         run: |
           sudo xcode-select --switch "/Applications/Xcode_${XCODE_VERSION}.app"
@@ -270,9 +275,10 @@ jobs:
             abort "Artifact source does not match the original run" unless File.read("build/source-revision.txt").strip == run.fetch("head_sha")
           '
           shasum -a 256 -c build/artifact-sha256.txt
-          bundle exec ruby -rfastlane_core -e '
+          bundle exec ruby -rfastlane_core/ipa_file_analyser -e '
             info = FastlaneCore::IpaFileAnalyser.fetch_info_plist_file("build/Evener.ipa")
             version = info.fetch("CFBundleShortVersionString")
+            abort "IPA export encryption compliance is not false" unless info.fetch("ITSAppUsesNonExemptEncryption") == false
             abort "Invalid artifact marketing version" unless version.match?(/\A[0-9]+(?:\.[0-9]+){0,2}\z/)
             File.open(ENV.fetch("GITHUB_ENV"), "a") { |file| file.puts("IOS_MARKETING_VERSION=#{version}") }
           '

--- a/mobile-native/app.json
+++ b/mobile-native/app.json
@@ -15,7 +15,8 @@
         "NSAppTransportSecurity": {
           "NSAllowsArbitraryLoads": true
         },
-        "NSPhotoLibraryAddUsageDescription": "Save images from your Evener conversations to your photo library."
+        "NSPhotoLibraryAddUsageDescription": "Save images from your Evener conversations to your photo library.",
+        "ITSAppUsesNonExemptEncryption": false
       }
     },
     "android": {

--- a/mobile-native/fastlane/Fastfile
+++ b/mobile-native/fastlane/Fastfile
@@ -40,6 +40,7 @@ platform :ios do
       "CFBundleVersion" => ENV.fetch("IOS_BUILD_NUMBER"),
       "UIDeviceFamily" => [1],
       "DTPlatformName" => "iphoneos",
+      "ITSAppUsesNonExemptEncryption" => false,
     }
     UI.user_error!("IPA identity does not match the requested iPhone build") unless info && expected.all? { |key, value| info[key] == value }
   end

--- a/mobile-native/scripts/test-ios-distribution.rb
+++ b/mobile-native/scripts/test-ios-distribution.rb
@@ -35,7 +35,7 @@ def expect_failure(message)
   assert(failed, "expected failure: #{message}")
 end
 
-def write_ipa(path, identifier:, marketing_version:, build_number:, device_family: [1])
+def write_ipa(path, identifier:, marketing_version:, build_number:, device_family: [1], encryption: false)
   Dir.mktmpdir("evener-ipa") do |dir|
     app = File.join(dir, "Payload", "Evener.app")
     FileUtils.mkdir_p(app)
@@ -48,6 +48,7 @@ def write_ipa(path, identifier:, marketing_version:, build_number:, device_famil
       <key>CFBundleVersion</key><string>#{build_number}</string>
       <key>UIDeviceFamily</key><array>#{device_family.map { |value| "<integer>#{value}</integer>" }.join}</array>
       <key>DTPlatformName</key><string>iphoneos</string>
+      <key>ITSAppUsesNonExemptEncryption</key><#{encryption ? "true" : "false"}/>
       </dict></plist>
     PLIST
     Zip::File.open(path, create: true) { |zip| zip.add("Payload/Evener.app/Info.plist", File.join(app, "Info.plist")) }
@@ -62,6 +63,7 @@ def test_ipa_analyser(tmpdir)
   assert(info["CFBundleShortVersionString"] == "0.1.0", "IPA analyser lost marketing version")
   assert(info["CFBundleVersion"] == "7", "IPA analyser lost build number")
   assert(info["UIDeviceFamily"] == [1], "IPA analyser lost iPhone family")
+  assert(info["ITSAppUsesNonExemptEncryption"] == false, "IPA analyser lost export encryption compliance")
 end
 
 def test_configure_helper(tmpdir)
@@ -258,7 +260,7 @@ def test_lanes(tmpdir)
   expect_failure("external group") { lane.runner.execute(:testflight, :ios) }
   assert(DistributionStore.uploads.empty?, "uploaded before checking group type")
 
-  [[:identifier, "another.app"], [:marketing_version, "0.2.0"], [:build_number, "8"], [:device_family, [1, 2]]].each_with_index do |(key, value), index|
+  [[:identifier, "another.app"], [:marketing_version, "0.2.0"], [:build_number, "8"], [:device_family, [1, 2]], [:encryption, true]].each_with_index do |(key, value), index|
     DistributionStore.reset
     path = File.join(tmpdir, "wrong-#{index}.ipa")
     input = { identifier: "com.primeradiant.evener.native", marketing_version: "0.1.0", build_number: "7" }


### PR DESCRIPTION
Register manual TestFlight delivery for the native iPhone checkpoint. This PR is stacked on #1096; its own changes are the workflow and the iOS export-compliance declaration. Land the app first, then refresh this PR onto main before dispatching a fresh unused build number.

The job pins Xcode 26.6, Node 22.13.1 and Ruby 3.3.6, runs the native and installed API gates, prebuilds with locked pods, imports configured distribution credentials into a temporary keychain, archives and exports one signed iPhone IPA, uploads to the existing internal group, and waits for Apple processing. It saves source/toolchain/artifact identities and a TestFlight receipt, then restores keychain selection and removes temporary signing assets. The only trigger is workflow_dispatch, and archive runs explicitly require main to match recovery provenance.

The generated Info.plist declares ITSAppUsesNonExemptEncryption=false, and both exported IPA identity verification and recovery reject a missing or true flag. Networking, credential storage and cryptography use platform services; application calls to expo-crypto are UUID generation. Archive/export pipelines propagate failures, and the export step explicitly rejects missing or multiple IPAs.

A verification-only recovery dispatch accepts the original workflow run ID. It retrieves that run's signed IPA and provenance, checks the original main dispatch and exact source/hash records, derives the marketing version from the IPA, and invokes the existing availability lane without another upload. This closes the case where Apple accepted an upload but processing or internal-group verification outlasted the original job. Recovery saves its own receipt with the original artifact identity.

Validation: actionlint; real Expo prebuild with the generated declaration verified; deterministic Ruby distribution behavior checks; actual shell export behavior with zero, one and two fixture IPAs; native macOS base64 decoding. Recovery validation executes the actual workflow script against a fixture IPA: valid original provenance succeeds; a different workflow, different source revision and corrupt archive are rejected. The previous revision received a clean RoboRev review; the refreshed current head requires its own verdict. Historical builds 1–3 were uploaded through the existing lane, and authenticated preflight previously found build 4 unused; that must be checked again at dispatch. A complete hosted archive/upload/processing run from the final main revision remains required. No credential values are included.

Artifact uploads use the Actions runtime artifact token, not a repository Actions write permission. The official [artifact client](https://github.com/actions/toolkit/blob/main/packages/artifact/src/internal/shared/artifact-twirp-client.ts) authenticates with `getRuntimeToken`, whose [configuration](https://github.com/actions/toolkit/blob/main/packages/artifact/src/internal/shared/config.ts) reads `ACTIONS_RUNTIME_TOKEN`; [upload-artifact v6](https://github.com/actions/upload-artifact/blob/v6/src/shared/upload-artifact.ts) delegates to that client. Recovery uses `actions: read` for the cross-run download. The review suggestion to add `actions: write` does not match that implementation. The recovery analyzer now has an explicit require; actual execution confirmed it loads under the pinned Ruby/Fastlane toolchain.

Both workflow modes require the main ref at job admission before checkout or credential use. Recovery derives its marketing version and Apple-compatible build number from the verified original IPA. Actionlint and a real fixture IPA/provenance execution pass.

The dispatch validator now explicitly fails non-main runs, and all external workflow actions are pinned to verified upstream commit SHAs. Recovery no longer requires an ignored build-number input.

The proposed `actions: write` permission is unnecessary: `actions/upload-artifact` authenticates through `ACTIONS_RUNTIME_TOKEN`, not the repository token. This repository also demonstrates the boundary in [Build Binaries run 34464723350](https://github.com/prime-radiant-inc/evener/actions/runs/34464723350): the `build` job in [binaries.yml at 0ab47d5](https://github.com/prime-radiant-inc/evener/blob/0ab47d5f6e7f8613b675af4a75b2304f0c6fb561/.github/workflows/binaries.yml) has only `contents: read`, and its successful Upload archives step produced artifact 10147086004 (77,458,003 bytes). The v6 artifact runtime authentication sources linked above establish the same contract for the pinned TestFlight action.

The temporary provisioning profile is installed under `~/Library/Developer/Xcode/UserData/Provisioning Profiles`, which is the download location for Xcode 16 and later and therefore the correct location for the pinned Xcode 26.6 runner. Apple documents the migration and continued legacy-location compatibility in the [Xcode 16 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes), issue 54347894.

The refreshed automation at 7fe472fcf includes native checkpoint 016b118f7. Native/shared tests and strict TypeScript pass; the independently installed SDK qualification passes after installing its locked package dependencies. Distribution Ruby behavior checks pass on Ruby 3.3.6 and actionlint passes. The dispatch form now states that a build number is required for a new archive and should be blank for recovery. This stacked revision has no main-based CI run yet; retargeting and a current CI pass remain prerequisites to merge.
