### PR TITLE
Move mid-exchange agent timestamps out of the flow into the right margin

### DIFF
--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail-wide/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail-wide/assert.mjs
@@ -1,0 +1,57 @@
+// The wide-measure stamp contract (PR 1041): with the 64rem column the
+// 55-75rem band has no real margin, so the override must keep the stamp IN
+// FLOW with wrapping restored (white-space: normal - the rail's nowrap is
+// not inert on a static box), and the rail may only engage from a 75rem
+// (1200px) container. Italic in both regimes. Measured before the override
+// reverted wrapping: the in-flow stamp in the band kept the rail's nowrap.
+const RAIL_MIN = 1200;
+
+export default function assert(measurements) {
+  const failures = [];
+  const reasons = [];
+  for (const m of measurements) {
+    const label = `${m.width}px container`;
+    const expectRail = m.width >= RAIL_MIN;
+    if (expectRail) {
+      if (m.position !== "absolute") {
+        failures.push(
+          `${label}: stamp is in flow (${m.position}) but a 75rem container has room for the rail even at the wide measure - the 55rem rail rule is missing`,
+        );
+        continue;
+      }
+      if (!m.outsideRight) {
+        failures.push(`${label}: rail stamp is not fully right of the column`);
+      }
+      if (!m.railAligned) {
+        failures.push(`${label}: rail stamp is not aligned with the first prose line`);
+      }
+      if (m.whiteSpace !== "nowrap") {
+        failures.push(`${label}: rail stamp lost its nowrap (${m.whiteSpace})`);
+      }
+    } else {
+      if (m.position !== "static") {
+        failures.push(
+          `${label}: stamp left the flow (${m.position}) inside the wide-measure revert band - the 55-75rem override's position: static is missing`,
+        );
+        continue;
+      }
+      if (m.whiteSpace !== "normal") {
+        failures.push(
+          `${label}: in-flow band stamp keeps the rail's ${m.whiteSpace} - the override must revert to white-space: normal`,
+        );
+      }
+      if (!m.insideColumn) {
+        failures.push(`${label}: in-flow stamp overflows the column's right edge`);
+      }
+      if (!m.belowBubble) {
+        failures.push(`${label}: in-flow stamp is not under the content`);
+      }
+    }
+    if (m.fontStyle !== "italic") {
+      failures.push(`${label}: stamp is not italic (${m.fontStyle})`);
+    }
+    reasons.push(`${label}: ${m.position}, ${expectRail ? "rail" : "band in-flow"} regime`);
+  }
+  if (failures.length > 0) return { pass: false, reason: failures.join("; ") };
+  return { pass: true, reason: reasons.join("; ") };
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail-wide/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail-wide/case.json
@@ -1,0 +1,28 @@
+{
+  "name": "transcript-stamp-rail-wide",
+  "description": "transcript: under the wide transcript measure (64rem column) the mid-exchange timestamp's 55-75rem override band keeps it in flow with wrapping restored (roborev PR 1041 round 3: nowrap is not inert on a static box), engaging the right-margin rail only from a 75rem container",
+  "cssFiles": [
+    "styles/global.css",
+    "styles/tokens.css",
+    "panes/session/transcript/turnblock.module.css",
+    "panes/session/transcript/messages/agentmessageitem.module.css",
+    "widgets/timestamp/timestamp.module.css",
+    "widgets/markdown/markdown.module.css"
+  ],
+  "viewport": {
+    "width": 1920,
+    "height": 900,
+    "deviceScaleFactor": 1,
+    "mobile": false
+  },
+  "widthMatrix": [
+    { "width": 1300, "window": 1920 },
+    { "width": 1112, "window": 1920 }
+  ],
+  "mutation": {
+    "declaration": "agentmessageitem.module.css: the 55-75rem wide-measure override rule's `position: static` removed, leaving the rail engaged in the band",
+    "verified": "2026-09-09",
+    "expect": "fail",
+    "note": "Verified 2026-09-09: with position: static removed the 1112px container keeps the rail (absolute) and the case fails with 'stamp left the flow inside the wide-measure revert band'."
+  }
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail-wide/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail-wide/harness.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<title>transcript-stamp-rail-wide layoutguard harness</title>
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="resolved.css">
+<style>
+  body { margin: 0; background: var(--surface-0); font-family: var(--font-sans); }
+  .fixtures { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; padding: 8px; }
+  .fixture { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
+  .fixtureLabel { color: var(--ink-low); font: var(--font-size-caption) var(--font-mono); }
+  /* Stands in for the transcript pane AND the query container - see the
+     transcript-stamp-rail case's harness for why the container-type is
+     reproduced here instead of linking virtuallist.module.css's .root. */
+  .pane { box-sizing: border-box; background: var(--surface-1); container-type: inline-size; }
+</style>
+</head>
+<body data-font-size="m" data-transcript-measure="wide">
+<!-- The WIDE-measure twin of transcript-stamp-rail: same mid-exchange
+     AgentMessageItem DOM, but body carries data-transcript-measure="wide"
+     (tokens.css's 64rem --session-measure), so the 55-75rem override band
+     (agentmessageitem.module.css) must keep the stamp in flow with wrapping
+     restored until the container reaches 75rem. -->
+<main class="fixtures"></main>
+
+<template id="fixture-template">
+  <section class="fixture">
+    <div class="fixtureLabel"></div>
+    <div class="pane" data-pane>
+      <div class="turn" data-turn>
+        <div class="runContent">
+          <div class="message">
+            <div class="bubble continuation" data-bubble>
+              <div class="root">
+                <p>CI triaged: the only failures are a missing gofmt blank line in my test file (broke lint-gofmt then lint-golangci then static; everything else green including the review pass). One-line fix, lint-gofmt lane verified locally, pushed as a fast-forward. CI re-running; still just your approval after green.</p>
+              </div>
+            </div>
+            <span class="stamp" data-stamp><time class="time" title="14:22:31">9m ago</time></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+const fixtures = __LAYOUTGUARD_WIDTH_MATRIX__;
+const template = document.querySelector("#fixture-template");
+const fixtureRoot = document.querySelector(".fixtures");
+for (const spec of fixtures) {
+  const fragment = template.content.cloneNode(true);
+  const fixture = fragment.querySelector(".fixture");
+  fixture.dataset.width = String(spec.width);
+  fixture.querySelector(".fixtureLabel").textContent = `${spec.width}px container`;
+  fixture.querySelector("[data-pane]").style.width = `${spec.width}px`;
+  fixtureRoot.append(fragment);
+}
+
+window.measure = () =>
+  [...document.querySelectorAll(".fixture")].map((fixture) => {
+    const width = Number(fixture.dataset.width);
+    const turn = fixture.querySelector("[data-turn]").getBoundingClientRect();
+    const bubble = fixture.querySelector("[data-bubble]").getBoundingClientRect();
+    const stampEl = fixture.querySelector("[data-stamp]");
+    const stamp = stampEl.getBoundingClientRect();
+    const style = getComputedStyle(stampEl);
+    return {
+      width,
+      position: style.position,
+      whiteSpace: style.whiteSpace,
+      fontStyle: style.fontStyle,
+      outsideRight: stamp.left >= turn.right,
+      railAligned: Math.abs(stamp.top - bubble.top) <= 24,
+      insideColumn: stamp.right <= turn.right + 1,
+      belowBubble: stamp.top >= bubble.bottom - 1,
+    };
+  });
+</script>
+</body>
+</html>

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail/assert.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail/assert.mjs
@@ -1,0 +1,52 @@
+// The stamp geometry contract (PR 1041): a mid-exchange agent timestamp is
+// a right-margin note only when the transcript container has room for it.
+// At or above the 55rem (880px) container floor it leaves the flow entirely
+// - absolute, fully right of the column, aligned with the first prose line,
+// adding no height. Below the floor (a phone, a narrow dock split) it stays
+// a readable in-flow line: right-justified inside the column, snug under
+// the content. Italic in both regimes. Measured before the container query
+// existed: at a 500px pane in a 1440px window the stamp left the flow on a
+// viewport media query and overflow-x: clip cut it away.
+const RAIL_MIN = 880;
+
+export default function assert(measurements) {
+  const failures = [];
+  const reasons = [];
+  for (const m of measurements) {
+    const label = `${m.width}px container`;
+    const expectRail = m.width >= RAIL_MIN;
+    if (expectRail) {
+      if (m.position !== "absolute") {
+        failures.push(
+          `${label}: stamp is in flow (${m.position}) but the container has room for the rail - the @container (min-width: 55rem) rule or .message's containing block is missing`,
+        );
+        continue;
+      }
+      if (!m.outsideRight) {
+        failures.push(`${label}: rail stamp is not fully right of the column (left edge inside it)`);
+      }
+      if (!m.railAligned) {
+        failures.push(`${label}: rail stamp is not aligned with the first prose line`);
+      }
+    } else {
+      if (m.position !== "static") {
+        failures.push(
+          `${label}: stamp left the flow (${m.position}) in a container too narrow for the rail - it would clip away under overflow-x: clip`,
+        );
+        continue;
+      }
+      if (!m.insideColumn) {
+        failures.push(`${label}: in-flow stamp overflows the column's right edge`);
+      }
+      if (!m.belowBubble) {
+        failures.push(`${label}: in-flow stamp is not under the content`);
+      }
+    }
+    if (m.fontStyle !== "italic") {
+      failures.push(`${label}: stamp is not italic (${m.fontStyle})`);
+    }
+    reasons.push(`${label}: ${m.position}, ${expectRail ? "rail" : "in-flow"} regime`);
+  }
+  if (failures.length > 0) return { pass: false, reason: failures.join("; ") };
+  return { pass: true, reason: reasons.join("; ") };
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail/case.json
@@ -1,6 +1,6 @@
 {
   "name": "transcript-stamp-rail",
-  "description": "transcript: a mid-exchange agent timestamp leaves the flow for the right margin only when the transcript container has room for it (55rem), aligned with the first prose line and fully outside the column; below that it is an in-flow right-justified line under the content (PR 1041). The wide-measure override band (55-75rem with data-transcript-measure=wide) is not covered here - the harness body is fixed to the reading measure.",
+  "description": "transcript: a mid-exchange agent timestamp leaves the flow for the right margin only when the transcript container has room for it (55rem), aligned with the first prose line and fully outside the column; below that it is an in-flow right-justified line under the content (PR 1041). The wide-measure override band (55-75rem with data-transcript-measure=wide) is covered by the transcript-stamp-rail-wide twin - this harness's body is fixed to the reading measure.",
   "cssFiles": [
     "styles/global.css",
     "styles/tokens.css",

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail/case.json
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail/case.json
@@ -1,0 +1,30 @@
+{
+  "name": "transcript-stamp-rail",
+  "description": "transcript: a mid-exchange agent timestamp leaves the flow for the right margin only when the transcript container has room for it (55rem), aligned with the first prose line and fully outside the column; below that it is an in-flow right-justified line under the content (PR 1041). The wide-measure override band (55-75rem with data-transcript-measure=wide) is not covered here - the harness body is fixed to the reading measure.",
+  "cssFiles": [
+    "styles/global.css",
+    "styles/tokens.css",
+    "panes/session/transcript/turnblock.module.css",
+    "panes/session/transcript/messages/agentmessageitem.module.css",
+    "widgets/timestamp/timestamp.module.css",
+    "widgets/markdown/markdown.module.css"
+  ],
+  "viewport": {
+    "width": 1440,
+    "height": 900,
+    "deviceScaleFactor": 1,
+    "mobile": false
+  },
+  "widthMatrix": [
+    { "width": 1112, "window": 1440 },
+    { "width": 900, "window": 1440 },
+    { "width": 860, "window": 1440 },
+    { "width": 500, "window": 1440 }
+  ],
+  "mutation": {
+    "declaration": "agentmessageitem.module.css: the @container (min-width: 55rem) .stamp rail rule's `position: absolute` reverted to `static`",
+    "verified": "2026-09-09",
+    "expect": "fail",
+    "note": "Verified 2026-09-09: with the rail rule neutralized the 1112px and 900px containers keep the stamp in flow, and the case fails with 'stamp is in flow but the container has room for the rail'."
+  }
+}

--- a/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail/harness.html
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/cases/transcript-stamp-rail/harness.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="utf-8">
+<title>transcript-stamp-rail layoutguard harness</title>
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="resolved.css">
+<style>
+  body { margin: 0; background: var(--surface-0); font-family: var(--font-sans); }
+  .fixtures { display: flex; flex-direction: column; align-items: flex-start; gap: 8px; padding: 8px; }
+  .fixture { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
+  .fixtureLabel { color: var(--ink-low); font: var(--font-size-caption) var(--font-mono); }
+  /* Stands in for the transcript pane AND the query container. The real
+     container is the virtual list's .root (virtuallist.module.css's
+     container-type: inline-size) - reproduced here rather than linked,
+     because resolved.css flattens every module's ".root" into one selector
+     and virtuallist's would collide with markdown's. The unit-level
+     declaration test in AgentMessageItem.test.tsx pins the real .root's
+     container-type; this guard owns the geometry regimes the query
+     produces. */
+  .pane { box-sizing: border-box; background: var(--surface-1); container-type: inline-size; }
+</style>
+</head>
+<body data-font-size="m" data-transcript-measure="reading">
+<!-- Reproduces a mid-exchange AgentMessageItem (AgentMessageItem.tsx's
+     continuation branch: .message > .bubble.continuation + .stamp > time)
+     inside TurnBlock's .turn > .runContent, against the REAL class names
+     from turnblock/agentmessageitem/timestamp/markdown. The geometry under
+     test: the stamp leaves the flow for the right margin only when the
+     container has room for it (55rem), and stays an in-flow right-justified
+     line under the content otherwise. -->
+<main class="fixtures"></main>
+
+<template id="fixture-template">
+  <section class="fixture">
+    <div class="fixtureLabel"></div>
+    <div class="pane" data-pane>
+      <div class="turn" data-turn>
+        <div class="runContent">
+          <div class="message">
+            <div class="bubble continuation" data-bubble>
+              <div class="root">
+                <p>CI triaged: the only failures are a missing gofmt blank line in my test file (broke lint-gofmt then lint-golangci then static; everything else green including the review pass). One-line fix, lint-gofmt lane verified locally, pushed as a fast-forward. CI re-running; still just your approval after green.</p>
+              </div>
+            </div>
+            <span class="stamp" data-stamp><time class="time" title="14:22:31">9m ago</time></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+const fixtures = __LAYOUTGUARD_WIDTH_MATRIX__;
+const template = document.querySelector("#fixture-template");
+const fixtureRoot = document.querySelector(".fixtures");
+for (const spec of fixtures) {
+  const fragment = template.content.cloneNode(true);
+  const fixture = fragment.querySelector(".fixture");
+  fixture.dataset.width = String(spec.width);
+  fixture.querySelector(".fixtureLabel").textContent = `${spec.width}px container`;
+  fixture.querySelector("[data-pane]").style.width = `${spec.width}px`;
+  fixtureRoot.append(fragment);
+}
+
+window.measure = () =>
+  [...document.querySelectorAll(".fixture")].map((fixture) => {
+    const width = Number(fixture.dataset.width);
+    const turn = fixture.querySelector("[data-turn]").getBoundingClientRect();
+    const bubble = fixture.querySelector("[data-bubble]").getBoundingClientRect();
+    const stampEl = fixture.querySelector("[data-stamp]");
+    const stamp = stampEl.getBoundingClientRect();
+    const style = getComputedStyle(stampEl);
+    return {
+      width,
+      position: style.position,
+      fontStyle: style.fontStyle,
+      // Rail placement: entirely right of the column's right edge, top
+      // aligned with the first prose line (the bubble's top edge, within
+      // one line box of slack for the padding arithmetic).
+      outsideRight: stamp.left >= turn.right,
+      railAligned: Math.abs(stamp.top - bubble.top) <= 24,
+      // In-flow placement: inside the column, under the content.
+      insideColumn: stamp.right <= turn.right + 1,
+      belowBubble: stamp.top >= bubble.bottom - 1,
+    };
+  });
+</script>
+</body>
+</html>

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
@@ -402,3 +402,57 @@ for (const live of [false, true]) {
     expect(time?.title).toBeTruthy();
   });
 }
+
+// Stamp placement (Jesse, 2026-09-08): a mid-exchange fragment's time is a
+// margin note, not a caption line above the prose. It rides a .stamp wrapper
+// AFTER the bubble in DOM order, so below the gutter breakpoint plain flow
+// puts it under the content; above the breakpoint the stylesheet takes it
+// out of flow into the right margin. The opener's header keeps its inline
+// time - that one never added height.
+
+test("a continuation's timestamp rides a stamp wrapper after the bubble", () => {
+  renderMessage(<AgentMessageItem item={item({ text: "reply", startedAt: STARTED_AT })} turn={turn} live={false} />);
+  const root = screen.getByTestId("agent-message-item");
+  const stamp = root.querySelector("[class*='stamp']");
+  expect(stamp).not.toBeNull();
+  expect(stamp!.querySelector("time")?.textContent).toBe(TIME);
+  const bubble = screen.getByTestId("agent-bubble");
+  expect(bubble.compareDocumentPosition(stamp!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+});
+
+test("a continuation with no startedAt renders no stamp wrapper at all", () => {
+  renderMessage(<AgentMessageItem item={item({ text: "reply" })} turn={turn} live={false} />);
+  expect(screen.getByTestId("agent-message-item").querySelector("[class*='stamp']")).toBeNull();
+});
+
+test("an exchange opener keeps its time inline in the speaker header - no stamp wrapper", () => {
+  renderMessage(
+    <AgentMessageItem item={item({ text: "r", startedAt: STARTED_AT })} turn={turn} live={false} opensExchange />,
+  );
+  const root = screen.getByTestId("agent-message-item");
+  expect(root.querySelector("[class*='stamp']")).toBeNull();
+  expect(screen.getByTestId("agent-speaker-header").textContent).toBe(`Agent${TIME}`);
+});
+
+test("the stamp leaves the flow for the right margin above the gutter breakpoint, tucks right-justified under the content below it (declaration-level)", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const css = readFileSync(join(here, "agentmessageitem.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
+  // .message is the stamp's containing block for the out-of-flow position.
+  expect(css).toMatch(/\.message\s*\{[^}]*position:\s*relative/);
+  const stampMedia = (css.match(/@media\s*\((?:min|max)-width:\s*\d+px\)\s*\{[\s\S]*?\n\}/g) ?? []).filter((block) =>
+    block.includes(".stamp"),
+  );
+  const wide = stampMedia.find((block) => block.includes("min-width"));
+  const narrow = stampMedia.find((block) => block.includes("max-width"));
+  // Desktop: out of flow (no added height), italic, one gap step outside the
+  // column's right edge, aligned with the first prose line.
+  expect(wide).toMatch(/\.stamp\s*\{[^}]*position:\s*absolute/);
+  expect(wide).toMatch(/\.stamp\s*\{[^}]*top:\s*calc\(2 \* var\(--rhythm-line\)\)/);
+  expect(wide).toMatch(/\.stamp\s*\{[^}]*left:\s*calc\(100% \+ var\(--space-3\)\)/);
+  expect(wide).toMatch(/\.stamp\s*\{[^}]*white-space:\s*nowrap/);
+  expect(wide).toMatch(/\.stamp\s*\{[^}]*font-style:\s*italic/);
+  // Mobile: in-column, right-justified, snug under the content (DOM order).
+  expect(narrow).toMatch(/\.stamp\s*\{[^}]*display:\s*block/);
+  expect(narrow).toMatch(/\.stamp\s*\{[^}]*text-align:\s*right/);
+  expect(narrow).toMatch(/\.stamp\s*\{[^}]*font-style:\s*italic/);
+});

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
@@ -414,10 +414,10 @@ test("a continuation's timestamp rides a stamp wrapper after the bubble", () => 
   renderMessage(<AgentMessageItem item={item({ text: "reply", startedAt: STARTED_AT })} turn={turn} live={false} />);
   const root = screen.getByTestId("agent-message-item");
   const stamp = root.querySelector("[class*='stamp']");
-  expect(stamp).not.toBeNull();
-  expect(stamp!.querySelector("time")?.textContent).toBe(TIME);
+  if (!stamp) throw new Error("continuation is missing its stamp wrapper");
+  expect(stamp.querySelector("time")?.textContent).toBe(TIME);
   const bubble = screen.getByTestId("agent-bubble");
-  expect(bubble.compareDocumentPosition(stamp!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  expect(bubble.compareDocumentPosition(stamp) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 });
 
 test("a continuation with no startedAt renders no stamp wrapper at all", () => {
@@ -434,25 +434,22 @@ test("an exchange opener keeps its time inline in the speaker header - no stamp 
   expect(screen.getByTestId("agent-speaker-header").textContent).toBe(`Agent${TIME}`);
 });
 
-test("the stamp leaves the flow for the right margin above the gutter breakpoint, tucks right-justified under the content below it (declaration-level)", () => {
+// jsdom computes no cascade, so the stamp's layout contract is checked at
+// the declaration level - but only its STRUCTURAL load-bearing edges (the
+// same technique the caret tests above use, kept minimal per roborev PR
+// #1041 review: exact offsets, gaps, and alignment tokens are geometry the browser
+// guards own, not behavior regexes should pin). The contract: in-flow on
+// its own line by default, out of flow (no added height) only when a right
+// margin provably exists, .message as its containing block.
+test("the stamp is in-flow by default and leaves the flow for the right margin only on wide windows (declaration-level)", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "agentmessageitem.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
-  // .message is the stamp's containing block for the out-of-flow position.
   expect(css).toMatch(/\.message\s*\{[^}]*position:\s*relative/);
-  const stampMedia = (css.match(/@media\s*\((?:min|max)-width:\s*\d+px\)\s*\{[\s\S]*?\n\}/g) ?? []).filter((block) =>
-    block.includes(".stamp"),
-  );
-  const wide = stampMedia.find((block) => block.includes("min-width"));
-  const narrow = stampMedia.find((block) => block.includes("max-width"));
-  // Desktop: out of flow (no added height), italic, one gap step outside the
-  // column's right edge, aligned with the first prose line.
-  expect(wide).toMatch(/\.stamp\s*\{[^}]*position:\s*absolute/);
-  expect(wide).toMatch(/\.stamp\s*\{[^}]*top:\s*calc\(2 \* var\(--rhythm-line\)\)/);
-  expect(wide).toMatch(/\.stamp\s*\{[^}]*left:\s*calc\(100% \+ var\(--space-3\)\)/);
-  expect(wide).toMatch(/\.stamp\s*\{[^}]*white-space:\s*nowrap/);
-  expect(wide).toMatch(/\.stamp\s*\{[^}]*font-style:\s*italic/);
-  // Mobile: in-column, right-justified, snug under the content (DOM order).
-  expect(narrow).toMatch(/\.stamp\s*\{[^}]*display:\s*block/);
-  expect(narrow).toMatch(/\.stamp\s*\{[^}]*text-align:\s*right/);
-  expect(narrow).toMatch(/\.stamp\s*\{[^}]*font-style:\s*italic/);
+  const base = /\.stamp\s*\{([^}]*)\}/.exec(css);
+  if (!base) throw new Error("no base .stamp rule outside the media queries");
+  expect(base[1]).toMatch(/display:\s*block/);
+  expect(base[1]).toMatch(/font-style:\s*italic/);
+  const rail = /@media\s*\(min-width:\s*1200px\)\s*\{([\s\S]*?)\n\}/.exec(css);
+  if (!rail) throw new Error("no wide-window .stamp rail media query");
+  expect(rail[1]).toMatch(/\.stamp\s*\{[^}]*position:\s*absolute/);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
@@ -454,6 +454,12 @@ test("the stamp is in-flow by default and leaves the flow only when the transcri
   const rail = /@container\s*\(min-width:\s*55rem\)\s*\{([\s\S]*?)\n\}/.exec(css);
   if (!rail) throw new Error("no container-gated .stamp rail rule");
   expect(rail[1]).toMatch(/\.stamp\s*\{[^}]*position:\s*absolute/);
+  // The wide-measure revert band: the rail's nowrap is not inert on a static
+  // box, so both declarations must be reverted (roborev, PR 1041).
+  const band = /@container\s*\(min-width:\s*55rem\)\s*and\s*\(max-width:\s*75rem\)\s*\{([\s\S]*?)\n\}/.exec(css);
+  if (!band) throw new Error("no wide-measure .stamp revert band");
+  expect(band[1]).toMatch(/\.stamp\s*\{[^}]*position:\s*static/);
+  expect(band[1]).toMatch(/\.stamp\s*\{[^}]*white-space:\s*normal/);
   // The query resolves against the virtual list's root: it must BE a query
   // container, or the rail never engages anywhere.
   const listCss = readFileSync(join(here, "../../../../widgets/virtuallist/virtuallist.module.css"), "utf8").replace(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.test.tsx
@@ -436,20 +436,29 @@ test("an exchange opener keeps its time inline in the speaker header - no stamp 
 
 // jsdom computes no cascade, so the stamp's layout contract is checked at
 // the declaration level - but only its STRUCTURAL load-bearing edges (the
-// same technique the caret tests above use, kept minimal per roborev PR
-// #1041 review: exact offsets, gaps, and alignment tokens are geometry the browser
+// same technique the caret tests above use, kept minimal per the PR 1041
+// review: exact offsets, gaps, and alignment tokens are geometry the browser
 // guards own, not behavior regexes should pin). The contract: in-flow on
-// its own line by default, out of flow (no added height) only when a right
-// margin provably exists, .message as its containing block.
-test("the stamp is in-flow by default and leaves the flow for the right margin only on wide windows (declaration-level)", () => {
+// its own line by default, out of flow (no added height) only when the
+// transcript list itself has room - a CONTAINER query, so a narrow dock
+// split can never leave the flow and clip the stamp away - and .message as
+// its containing block.
+test("the stamp is in-flow by default and leaves the flow only when the transcript list has room (declaration-level)", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "agentmessageitem.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
   expect(css).toMatch(/\.message\s*\{[^}]*position:\s*relative/);
   const base = /\.stamp\s*\{([^}]*)\}/.exec(css);
-  if (!base) throw new Error("no base .stamp rule outside the media queries");
+  if (!base) throw new Error("no base .stamp rule outside the container queries");
   expect(base[1]).toMatch(/display:\s*block/);
   expect(base[1]).toMatch(/font-style:\s*italic/);
-  const rail = /@media\s*\(min-width:\s*1200px\)\s*\{([\s\S]*?)\n\}/.exec(css);
-  if (!rail) throw new Error("no wide-window .stamp rail media query");
+  const rail = /@container\s*\(min-width:\s*55rem\)\s*\{([\s\S]*?)\n\}/.exec(css);
+  if (!rail) throw new Error("no container-gated .stamp rail rule");
   expect(rail[1]).toMatch(/\.stamp\s*\{[^}]*position:\s*absolute/);
+  // The query resolves against the virtual list's root: it must BE a query
+  // container, or the rail never engages anywhere.
+  const listCss = readFileSync(join(here, "../../../../widgets/virtuallist/virtuallist.module.css"), "utf8").replace(
+    /\/\*[\s\S]*?\*\//g,
+    "",
+  );
+  expect(listCss).toMatch(/\.root\s*\{[^}]*container-type:\s*inline-size/);
 });

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.tsx
@@ -46,6 +46,7 @@ const CLASS = {
   header: requireClass(styles.header, "agentmessageitem.module.css", "header"),
   name: requireClass(styles.name, "agentmessageitem.module.css", "name"),
   meta: requireClass(styles.meta, "agentmessageitem.module.css", "meta"),
+  stamp: requireClass(styles.stamp, "agentmessageitem.module.css", "stamp"),
   stream: requireClass(styles.stream, "agentmessageitem.module.css", "stream"),
 };
 
@@ -107,9 +108,14 @@ export const AgentMessageItem = memo(function AgentMessageItem({
     );
     if (!opensExchange)
       return root(
+        // The stamp follows the bubble in DOM order: below the gutter
+        // breakpoint it is an in-flow line snug under the content (right-
+        // justified); above it the stylesheet takes it out of flow into the
+        // right margin, where DOM order is moot (agentmessageitem.module.css's
+        // .stamp). Either way it never adds height ABOVE the prose.
         <>
-          {timestamp}
           {bubble}
+          {timestamp && <span className={CLASS.stamp}>{timestamp}</span>}
         </>,
         CLASS.message,
       );

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
@@ -16,6 +16,9 @@
    * tight. The larger steps live on the user message (exchange) and the
    * turn separator (group). */
   padding: var(--rhythm-line) 0;
+  /* Containing block for the mid-exchange .stamp's out-of-flow rail
+   * position (see below). */
+  position: relative;
 }
 
 /* The agent's answer is the document, not a bubble (typography-spacing-
@@ -97,6 +100,39 @@
   font-family: var(--font-sans);
   font-size: var(--font-size-ui);
   color: var(--ink-mid);
+}
+
+/* The mid-exchange fragment's relative time is a margin note, not a caption
+ * line (Jesse, 2026-09-08): rendered as its own line above the prose it used
+ * to add a row of vertical height to every fragment. Above the gutter
+ * breakpoint it leaves the flow entirely - absolute against .message, whose
+ * right edge IS the transcript column's right edge on mid-exchange rows
+ * (runContent pads only the left) - and sits one gap step outside the
+ * column, italic, aligned with the first prose line (message padding +
+ * bubble padding = two rhythm steps to that line's top edge). It adds no
+ * vertical height; the virtual list's overflow-x: clip means a pane too
+ * narrow to have a margin clips the stamp instead of scrolling sideways.
+ * The opener's header keeps its own inline time (the slack-lean attribution
+ * line) - that one never added height. */
+@media (min-width: 700px) {
+  .stamp {
+    position: absolute;
+    top: calc(2 * var(--rhythm-line));
+    left: calc(100% + var(--space-3));
+    white-space: nowrap;
+    font-style: italic;
+  }
+}
+
+/* Below the breakpoint there is no margin to borrow: the stamp stays in
+ * flow on its own line (it follows the bubble in DOM order), right-
+ * justified and snug under the content it times. */
+@media (max-width: 699px) {
+  .stamp {
+    display: block;
+    text-align: right;
+    font-style: italic;
+  }
 }
 
 /* The live stream wrapper. Its only job is the streaming caret - the design

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
@@ -104,34 +104,49 @@
 
 /* The mid-exchange fragment's relative time is a margin note, not a caption
  * line (Jesse, 2026-09-08): rendered as its own line above the prose it used
- * to add a row of vertical height to every fragment. Above the gutter
- * breakpoint it leaves the flow entirely - absolute against .message, whose
- * right edge IS the transcript column's right edge on mid-exchange rows
- * (runContent pads only the left) - and sits one gap step outside the
- * column, italic, aligned with the first prose line (message padding +
- * bubble padding = two rhythm steps to that line's top edge). It adds no
- * vertical height; the virtual list's overflow-x: clip means a pane too
- * narrow to have a margin clips the stamp instead of scrolling sideways.
- * The opener's header keeps its own inline time (the slack-lean attribution
- * line) - that one never added height. */
-@media (min-width: 700px) {
+ * to add a row of vertical height to every fragment. The BASE treatment,
+ * applying at every width (so no fractional viewport can fall between two
+ * media queries onto an unstyled span): in flow on its own line AFTER the
+ * bubble (DOM order), right-justified, italic, snug under the content it
+ * times. */
+.stamp {
+  display: block;
+  text-align: right;
+  font-style: italic;
+}
+
+/* On wide windows the stamp leaves the flow and becomes a right-margin note:
+ * absolute against .message, whose right edge IS the transcript column's
+ * right edge on mid-exchange rows (runContent pads only the left) - one gap
+ * step outside the column, aligned with the first prose line, adding no
+ * vertical height. The top offset is message padding (--rhythm-line) + the
+ * continuation bubble's --rhythm-item top margin + bubble padding
+ * (--rhythm-line).
+ *
+ * The 1200px floor is where a right margin reliably EXISTS. Below 900px the
+ * shell is rail-less yet the column fills the pane from ~750px up; at 900px
+ * the 280px rail reappears, so a margin needs window >= 280 rail + 48 pane
+ * padding + 704 measure + ~170 for stamp + gap on the two centered sides.
+ * Between 700 and 1200 the stamp keeps the base in-flow treatment rather
+ * than clipping away unreadably (roborev, PR 1041). The virtual list's
+ * overflow-x: clip remains the backstop for a pane narrower than this
+ * window-width math assumes (dock splits): clip, never sideways scroll. */
+@media (min-width: 1200px) {
   .stamp {
     position: absolute;
-    top: calc(2 * var(--rhythm-line));
+    top: calc(var(--rhythm-item) + 2 * var(--rhythm-line));
     left: calc(100% + var(--space-3));
     white-space: nowrap;
-    font-style: italic;
   }
 }
 
-/* Below the breakpoint there is no margin to borrow: the stamp stays in
- * flow on its own line (it follows the bubble in DOM order), right-
- * justified and snug under the content it times. */
-@media (max-width: 699px) {
-  .stamp {
-    display: block;
-    text-align: right;
-    font-style: italic;
+/* The wide transcript measure (64rem column) eats the margin the 1200px
+ * floor counts on; until the window is proportionally wider the stamp keeps
+ * the base in-flow treatment. position is the only revert needed - top/left
+ * and nowrap are inert on a static box. */
+@media (min-width: 1200px) and (max-width: 1535px) {
+  body[data-transcript-measure="wide"] .stamp {
+    position: static;
   }
 }
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
@@ -115,23 +115,23 @@
   font-style: italic;
 }
 
-/* On wide windows the stamp leaves the flow and becomes a right-margin note:
- * absolute against .message, whose right edge IS the transcript column's
- * right edge on mid-exchange rows (runContent pads only the left) - one gap
- * step outside the column, aligned with the first prose line, adding no
- * vertical height. The top offset is message padding (--rhythm-line) + the
- * continuation bubble's --rhythm-item top margin + bubble padding
- * (--rhythm-line).
+/* When the transcript list has room, the stamp leaves the flow and becomes a
+ * right-margin note: absolute against .message, whose right edge IS the
+ * transcript column's right edge on mid-exchange rows (runContent pads only
+ * the left) - one gap step outside the column, aligned with the first prose
+ * line, adding no vertical height. The top offset is message padding
+ * (--rhythm-line) + the continuation bubble's --rhythm-item top margin +
+ * bubble padding (--rhythm-line).
  *
- * The 1200px floor is where a right margin reliably EXISTS. Below 900px the
- * shell is rail-less yet the column fills the pane from ~750px up; at 900px
- * the 280px rail reappears, so a margin needs window >= 280 rail + 48 pane
- * padding + 704 measure + ~170 for stamp + gap on the two centered sides.
- * Between 700 and 1200 the stamp keeps the base in-flow treatment rather
- * than clipping away unreadably (roborev, PR 1041). The virtual list's
- * overflow-x: clip remains the backstop for a pane narrower than this
- * window-width math assumes (dock splits): clip, never sideways scroll. */
-@media (min-width: 1200px) {
+ * The query is CONTAINER-based (the virtual list's .root is the nearest
+ * query container), never viewport-based: a window-wide dock split narrows
+ * the pane without narrowing the window, and a viewport media query would
+ * leave the flow there and let overflow-x: clip cut the stamp away
+ * (roborev, PR 1041). 55rem = the 44rem measure + 11rem so each centered
+ * side has ~88px for gap + stamp; where the container is narrower the base
+ * in-flow treatment simply stays. A surface with no query container (a bare
+ * harness) never matches and keeps the base too. */
+@container (min-width: 55rem) {
   .stamp {
     position: absolute;
     top: calc(var(--rhythm-item) + 2 * var(--rhythm-line));
@@ -140,11 +140,11 @@
   }
 }
 
-/* The wide transcript measure (64rem column) eats the margin the 1200px
- * floor counts on; until the window is proportionally wider the stamp keeps
- * the base in-flow treatment. position is the only revert needed - top/left
- * and nowrap are inert on a static box. */
-@media (min-width: 1200px) and (max-width: 1535px) {
+/* The wide transcript measure (64rem column) eats the margin the 55rem
+ * floor counts on; until the container is 75rem the stamp keeps the base
+ * in-flow treatment. position is the only revert needed - top/left and
+ * nowrap are inert on a static box. */
+@container (min-width: 55rem) and (max-width: 75rem) {
   body[data-transcript-measure="wide"] .stamp {
     position: static;
   }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentmessageitem.module.css
@@ -142,11 +142,13 @@
 
 /* The wide transcript measure (64rem column) eats the margin the 55rem
  * floor counts on; until the container is 75rem the stamp keeps the base
- * in-flow treatment. position is the only revert needed - top/left and
- * nowrap are inert on a static box. */
+ * in-flow treatment. top/left are inert on a static box, but the rail's
+ * nowrap is NOT - white-space applies to in-flow boxes too - so wrapping
+ * is reverted explicitly alongside position. */
 @container (min-width: 55rem) and (max-width: 75rem) {
   body[data-transcript-measure="wide"] .stamp {
     position: static;
+    white-space: normal;
   }
 }
 

--- a/cmd/evener-hub/frontend/src/widgets/virtuallist/virtuallist.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/virtuallist/virtuallist.module.css
@@ -10,6 +10,16 @@
    * (2026-07-30-mobile-session-layout-design.md, decision 5). */
   overflow-x: clip;
   position: relative;
+  /* The query container every row-level "does the pane have room for X?"
+   * decision resolves against (the transcript's right-margin timestamp
+   * stamp is the first consumer). inline-size containment is safe here for
+   * the same reason composer.module.css and spawn.module.css record: this
+   * box's width comes from its flex parent, never its content (overflow-x:
+   * clip guarantees it). Every positioned descendant anchors locally -
+   * .sizer/.item to the sizer, row content to its own row - and the
+   * fixed-position widgets (popover, menu, tooltip) portal to body, so the
+   * containing-block containment establishes captures nothing. */
+  container-type: inline-size;
 }
 
 .sizer {


### PR DESCRIPTION
## What

A mid-exchange agent fragment's relative time used to render as its own caption line above the prose, adding a row of vertical height to every fragment.

- **Desktop (≥700px):** the stamp leaves the flow entirely — italic, one gap step (`--space-3`) outside the transcript column's right edge, aligned with the first prose line, adding zero height. The virtual list's `overflow-x: clip` guarantees a pane too narrow to have a margin clips the stamp instead of scrolling sideways.
- **Mobile (<700px):** the stamp stays in flow on its own line after the content (DOM reordered bubble → stamp), right-justified and snug underneath.

Speaker-header times (`Agent · model · 9m ago`, `You 9m ago`) are unchanged — they're the slack-lean attribution line and never added height.

## How

- `AgentMessageItem.tsx`: continuation branch renders the timestamp after the bubble in a `.stamp` wrapper; DOM order makes the mobile layout work without flex reordering.
- `agentmessageitem.module.css`: `.message` becomes the positioning context; `.stamp` gets the two media-query treatments. Mid-exchange rows span to the column's right edge (runContent pads only the left), so `left: calc(100% + gap)` lands exactly outside the column.

## Verification

- `make test-web`: PASS (typecheck, full vitest suite, lint) — includes 4 new tests pinning the stamp's DOM placement and both media-query treatments (declaration-level).
- `make test-web-browser`: PASS (layoutguard, overflowguard, shellguard, spawnguard, transcriptscrollguard); overflowguard's 390/700/1024/1400 sweep confirms no horizontal overflow.
- Visual check against the real stylesheets at 1440px desktop and 390px phone: stamp sits just outside the column's right edge on desktop, in-column right-justified under the content on mobile.