### PR TITLE
fix(web): align top-level intent group with the transcript content column

### DIFF
--- a/cmd/evener-hub/frontend/scripts/overflowguard/MUTATIONS.md
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/MUTATIONS.md
@@ -67,6 +67,33 @@ incidentally during the core-scan mutation above
 real DOM it can see failing. Left as a follow-up if Jesse wants a dedicated
 mutation for the dock-split threshold itself.
 
+## Top-level intent group column (`verifyIntentColumn()` /
+`inspectIntentColumn()`, the `?intenttail=1` fixture)
+
+Asserts the reload-shaped regression: a settled transcript whose final turn
+ENDS in intent-bearing tool calls projects that trailing run as its own
+virtual-list row (TranscriptBody's `transcriptRowsForProjection`), rendered
+outside TurnBlock's `.turn` column. The horizontal-overflow scan cannot see
+the misalignment (nothing escapes a scroller), so this compares the
+top-level `details[data-testid="intent-group"]`'s box against a
+`[data-testid="turn-block"]` box directly at 1024px under the chat preset.
+
+**Mutation performed:** removed `max-width: var(--session-measure)` and
+`margin-inline: auto` from `.intentGroup` in
+`panes/session/session.module.css` (i.e. the pre-fix state — this guard was
+written red-first against exactly that CSS).
+
+**Result before restore:** FAIL -
+`intent group column ... FAIL - {"groupFound":true,"groupLeft":25,"groupRight":999,"turnLeft":160,"turnRight":864}`
+(the group spanned the full 974px pane content box; the turn column held its
+704px measure at 160-864). Every other assertion group stayed PASS, so the
+fixture mode disturbs nothing else.
+
+**Result after restore:** PASS -
+`intent group column ... PASS - top-level intent group shares the turn content column`.
+
+**Verified:** 2026-09-08. **Expect:** fail.
+
 ## Footer visibility predicate (`isElementVisible` in `src/dev/guardVisibility.ts`) — kata bsq9
 
 `footer.effortVisible` / `contextVisible` / `queueVisible` all rest on one

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -504,6 +504,28 @@ async function verifyChatFocus(cdpEndpoint, url) {
   }
 }
 
+// The reload-shaped column regression: a settled transcript whose final turn
+// ends in intent-bearing tool calls projects that trailing run as a top-level
+// virtual-list row with no .turn wrapper, so it takes the full pane width
+// while every turn above it is clamped to --session-measure and centered. The
+// horizontal-overflow scan cannot see this (nothing escapes a scroller), so
+// this compares the two boxes directly. 1024px: wide enough that the 44rem
+// measure leaves visible margins on both sides.
+async function verifyIntentColumn(cdpEndpoint, url) {
+  const page = await connectPage(cdpEndpoint);
+  const { send } = page;
+  try {
+    await applyViewport(send, { width: 1024, height: 900, mobile: false });
+    await navigateTo(page, url);
+    await evaluate(send, "window.settled");
+    await waitForFonts(send);
+    return await evaluate(send, "window.__overflowGuardIntentColumn = window.inspectIntentColumn()");
+  } finally {
+    await clearViewportOverride(send);
+    page.close();
+  }
+}
+
 function assertFieldsets(detail, label) {
   const failures = [];
   if (!detail || !Number.isFinite(detail.rootRemPx) || detail.rootRemPx <= 0) {
@@ -1024,6 +1046,23 @@ async function main() {
       console.log(`Chat focus transition ... FAIL - ${JSON.stringify(chatFocus)}`);
     } else {
       console.log("Chat focus transition ... PASS - closed action summary visibly owns focus");
+    }
+
+    const intentColumn = await verifyIntentColumn(
+      cdpEndpoint,
+      `http://127.0.0.1:${vitePort}/overflowharness.html?intenttail=1&w=1024`,
+    );
+    if (
+      !intentColumn.groupFound ||
+      intentColumn.turnLeft === null ||
+      intentColumn.turnRight === null ||
+      Math.abs(intentColumn.groupLeft - intentColumn.turnLeft) > GEOMETRY_TOLERANCE ||
+      Math.abs(intentColumn.groupRight - intentColumn.turnRight) > GEOMETRY_TOLERANCE
+    ) {
+      failed++;
+      console.log(`intent group column ... FAIL - ${JSON.stringify(intentColumn)}`);
+    } else {
+      console.log("intent group column ... PASS - top-level intent group shares the turn content column");
     }
 
     const panelCollapse = await verifyPanelCollapse(

--- a/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/overflowharness-entry.tsx
@@ -53,6 +53,7 @@ const width = Number(params.get("w") ?? "1400");
 const theme = params.get("theme");
 const settingsMode = params.get("settings") === "1";
 const pagingMode = params.get("paging") === "1";
+const intentTailMode = params.get("intenttail") === "1";
 if (theme === "light" || theme === "dark") document.documentElement.dataset.theme = theme;
 
 const REF = "overflowharness";
@@ -230,6 +231,58 @@ ${RAW_UNBROKEN_PAYLOAD}
   },
 };
 
+// ?intenttail=1: the reload-shaped fixture for the top-level intent group's
+// column alignment. A SETTLED transcript whose final turn ENDS in
+// intent-bearing tool calls projects that trailing run as its own virtual-list
+// row (TranscriptBody's transcriptRowsForProjection promotes a terminal
+// single-turn intent run), rendered OUTSIDE TurnBlock's .turn column. A live
+// stream nests the same group mid-turn inside .turn, which is why the
+// misalignment the screenshot showed only appeared after a reload. The main
+// snapshot's intent row (i3b) sits mid-turn on purpose, so it cannot see this.
+const INTENTTAIL_REF = "overflowintenttail";
+const intentTailTurn = snapshot.thread.turns?.[0];
+if (!intentTailTurn) throw new Error("overflow harness snapshot is missing turn_1");
+const intentTailSnapshot: ThreadReadResponse = {
+  thread: {
+    ...snapshot.thread,
+    id: "thr_overflow_intenttail",
+    sessionId: "sess_overflow_intenttail",
+    evener: { ...snapshot.thread.evener, ref: INTENTTAIL_REF },
+    turns: [
+      {
+        ...intentTailTurn,
+        items: [
+          ...(intentTailTurn.items ?? []),
+          {
+            type: "commandExecution",
+            id: "i8",
+            turnId: "turn_1",
+            toolName: "shell",
+            callId: "call_2",
+            status: "completed",
+            durationMs: 900,
+            description: "Creating an isolated worktree lane for the timestamp restyling work",
+            argumentsJson: JSON.stringify({ command: "git worktree add timestamp-right" }),
+            output: "Preparing worktree",
+          },
+          {
+            type: "commandExecution",
+            id: "i9",
+            turnId: "turn_1",
+            toolName: "shell",
+            callId: "call_3",
+            status: "completed",
+            durationMs: 700,
+            description: "Locating timestamp rendering in the hub frontend source",
+            argumentsJson: JSON.stringify({ command: "rg -l timestamp cmd/evener-hub/frontend/src" }),
+            output: "done",
+          },
+        ],
+      },
+    ],
+  },
+};
+
 const PAGING_REF = "overflowpaging";
 const PAGING_ITEM_IDS = Array.from({ length: 45 }, (_, index) => `paging-item-${index}`);
 PAGING_ITEM_IDS[4] = "item_tool_paging";
@@ -296,7 +349,7 @@ const pagingSnapshot: ThreadReadResponse = {
 };
 
 const fake = new FakeClient("ready");
-fake.on("thread/read", () => (pagingMode ? pagingSnapshot : snapshot));
+fake.on("thread/read", () => (pagingMode ? pagingSnapshot : intentTailMode ? intentTailSnapshot : snapshot));
 fake.on("thread/turns/list", (request: ThreadTurnsListParams): ThreadTurnsListResponse => {
   if (!pagingMode || request.ref !== PAGING_REF) return { data: [] };
   return {
@@ -315,8 +368,8 @@ fake.on("evener/tasks/list", () => ({ data: [] }));
 connectionStore.getState().connect(fake);
 // putThreadModel keeps the routing index in step with the seeded map
 // entry (the store's membership path for threads).
-const activeRef = pagingMode ? PAGING_REF : REF;
-const activeSnapshot = pagingMode ? pagingSnapshot : snapshot;
+const activeRef = pagingMode ? PAGING_REF : intentTailMode ? INTENTTAIL_REF : REF;
+const activeSnapshot = pagingMode ? pagingSnapshot : intentTailMode ? intentTailSnapshot : snapshot;
 putThreadModel(activeRef, hydrateThread(activeSnapshot, activeRef, 1000));
 const locationKey = { kind: "location", ref: REF } as const;
 const location: NavigationSessionLocation = {
@@ -1254,6 +1307,63 @@ async function inspectChatFocus(): Promise<ChatFocusMeasurement> {
   }
 }
 
+interface IntentColumnMeasurement {
+  groupFound: boolean;
+  groupLeft: number | null;
+  groupRight: number | null;
+  turnLeft: number | null;
+  turnRight: number | null;
+}
+
+// The top-level intent group (a terminal or cross-turn intent run promoted to
+// its own virtual-list row by transcriptRowsForProjection) must share the
+// content column every .turn row reads: same left edge, same right edge. It
+// renders without TurnBlock's .turn wrapper, so this measures the two boxes
+// against each other - the scan above cannot see the misalignment because
+// nothing overflows its scroller, the group is simply wider than the column.
+// Run at the ?intenttail=1 fixture under the chat preset (toolIntent on), and
+// restores the guard's own config afterwards exactly like inspectChatFocus.
+async function inspectIntentColumn(): Promise<IntentColumnMeasurement> {
+  const pane = document.getElementById("oh-pane");
+  if (!pane) throw new Error("Intent column harness pane never mounted");
+  const layout = transcriptDisplayStore.getState().viewport;
+  const original = transcriptDisplayStore.getState().local[layout];
+  const waitFor = async <T,>(read: () => T | null | undefined, label: string): Promise<T> => {
+    for (let frame = 0; frame < 180; frame += 1) {
+      const value = read();
+      if (value !== null && value !== undefined) return value;
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    }
+    throw new Error(`Intent column harness did not settle: ${label}`);
+  };
+  try {
+    transcriptDisplayStore.getState().setLocal(layout, makeTranscriptDisplayConfig({ kind: "preset", level: "chat" }));
+    const group = await waitFor(
+      () =>
+        Array.from(pane.querySelectorAll<HTMLDetailsElement>('details[data-testid="intent-group"]')).find(
+          // The nested (mid-turn) group lives INSIDE .turn and is aligned by
+          // construction; only the top-level row's geometry is in question.
+          (details) => details.closest('[data-testid="turn-block"]') === null,
+        ),
+      "top-level intent group",
+    );
+    const turn = await waitFor(() => pane.querySelector<HTMLElement>('[data-testid="turn-block"]'), "turn block");
+    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+    const groupRect = group.getBoundingClientRect();
+    const turnRect = turn.getBoundingClientRect();
+    return {
+      groupFound: true,
+      groupLeft: groupRect.left,
+      groupRight: groupRect.right,
+      turnLeft: turnRect.left,
+      turnRight: turnRect.right,
+    };
+  } finally {
+    if (original) transcriptDisplayStore.getState().setLocal(layout, original);
+    else transcriptDisplayStore.getState().clearLocal(layout);
+  }
+}
+
 function measure() {
   if (settingsMode) return measureSettings();
   const pane = document.getElementById("oh-pane");
@@ -1620,6 +1730,7 @@ declare global {
     dump: typeof dump;
     inspectDetail: typeof inspectDetail;
     inspectChatFocus: typeof inspectChatFocus;
+    inspectIntentColumn: typeof inspectIntentColumn;
     settled: Promise<true>;
     verifyItemPaging: typeof verifyItemPaging;
   }
@@ -1628,5 +1739,6 @@ window.measure = measure;
 window.dump = dump;
 window.inspectDetail = inspectDetail;
 window.inspectChatFocus = inspectChatFocus;
+window.inspectIntentColumn = inspectIntentColumn;
 window.settled = settled;
 window.verifyItemPaging = verifyItemPaging;

--- a/cmd/evener-hub/frontend/src/panes/session/session.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/session.module.css
@@ -23,6 +23,15 @@
  * every TranscriptBody surface, including read-only and preview. */
 .intentGroup {
   width: 100%;
+  /* A trailing or cross-turn intent run is promoted to its own virtual-list
+   * row (TranscriptBody's transcriptRowsForProjection) and renders WITHOUT
+   * TurnBlock's .turn wrapper, so it must read the reading measure itself or
+   * it spans the full pane while every turn above stays clamped and centered
+   * (the reload-shaped misalignment overflowguard's "intent group column"
+   * check measures). Inside .turn this is a no-op: the parent is already
+   * exactly this wide. */
+  max-width: var(--session-measure);
+  margin-inline: auto;
 }
 
 .intentGroupSummary {


### PR DESCRIPTION
## Problem

After a reload, the trailing "N actions" intent group (and its tool rows) spanned the full pane width while every turn above it stayed clamped to the centered reading measure (`--session-measure`).

Root cause: a settled transcript whose final turn **ends** in intent-bearing tool calls — exactly the shape `thread/read` rehydrates on reload — has that trailing run promoted to its own top-level virtual-list row by `transcriptRowsForProjection` (TranscriptBody.tsx). That row renders `ProjectedIntentGroup` **without** TurnBlock's `.turn` wrapper, and `.intentGroup` was `width: 100%` with no measure constraint. Live, the same group nests mid-turn inside `.turn`, which is why the misalignment only appeared after a reload.

## Fix

`.intentGroup` now declares `max-width: var(--session-measure); margin-inline: auto`. When nested inside `.turn` this is a no-op (the parent is already exactly that wide); at the top level it joins the content column.

## Regression guard

overflowguard gains an `?intenttail=1` fixture (a settled turn ending in two intent-bearing calls — the reload shape) and a `verifyIntentColumn` check comparing the top-level intent group's box against a `.turn` box in real Chrome at 1024px. The horizontal-overflow scan can't see this class of bug (nothing escapes a scroller), so it measures the two boxes directly.

- **Red before the fix:** `intent group column ... FAIL - {"groupLeft":25,"groupRight":999,"turnLeft":160,"turnRight":864}`
- **Green after:** `intent group column ... PASS - top-level intent group shares the turn content column`
- Mutation evidence recorded in `scripts/overflowguard/MUTATIONS.md` per that file's discipline.

## Gates

- `make test-web` — PASS (web-typecheck, web-test, web-lint)
- `make test-web-browser` — PASS (layoutguard, overflowguard, shellguard, spawnguard, transcriptscrollguard)

Both run after rebasing onto current `origin/main`.