### PR TITLE
Bury session force stop in the session menu

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
@@ -95,9 +95,22 @@ function stubSessionSlots(): void {
 stubSessionSlots();
 
 afterAll(() => {
+  // A test that restored a slot mid-file (and, under test.each, has no
+  // onTestFinished to re-stub it) leaves vi.mocked(...).mockRestore absent;
+  // re-stub first so handing the real components back can't fail.
+  stubSessionSlots();
   vi.mocked(ComposerModule.Composer).mockRestore();
   vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
 });
+
+// Force stop lives in the session "⋯" menu (SessionChrome) now that the inline
+// footer button is retired; this walks the same menu path a user would. Tests
+// using it must restore the real SessionChrome and render it (or the real
+// Composer, which mounts it) themselves.
+async function openForceStopDialog(user: ReturnType<typeof userEvent.setup>): Promise<void> {
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
+}
 
 const CAPABILITIES: ThreadCapabilities = {
   send: true,
@@ -2103,6 +2116,7 @@ test.each([false, true])("restart-required empty transcript suppresses first-sen
 test("explicit Resume follows the returned identity through transcript and new sends", async ({ onTestFinished }) => {
   onTestFinished(stubSessionSlots);
   vi.mocked(ComposerModule.Composer).mockRestore();
+  vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
   const stableRef = "local:stable-a";
   const currentRef = "local:current-b";
   let stopped = false;
@@ -2188,7 +2202,8 @@ test("explicit Resume follows the returned identity through transcript and new s
     await refreshPendingTurnsProjection(stableRef);
   });
   const user = userEvent.setup();
-  await user.click(screen.getByRole("button", { name: "Force stop…" }));
+  await user.click(await screen.findByRole("button", { name: /session actions/i }));
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
   await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
   await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
   expect(resumed).toBe(false);
@@ -2286,6 +2301,7 @@ test.each(["success", "refused"])(
 );
 
 test.each(["success", "refused"])("hydrated restart recovery works without navigation: %s", async (outcome) => {
+  vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
   const fake = connectFakeClient();
   const ref = "local:incompatible-root";
   let status = "restartRequired";
@@ -2301,24 +2317,28 @@ test.each(["success", "refused"])("hydrated restart recovery works without navig
   });
   render(
     <ClientProvider client={fake}>
+      <SessionChromeModule.SessionChrome ref={ref} />
       <Session params={{ ref }} paneId="p1" focused={true} />
+      <Toast />
     </ClientProvider>,
   );
   await screen.findByRole("button", { name: "Refresh session" });
   const refresh = vi.spyOn(threadsStore.getState(), "refreshThread");
   const user = userEvent.setup();
-  await user.click(screen.getByRole("button", { name: "Force stop…" }));
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
   expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
   await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
   expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
-  await user.click(screen.getByRole("button", { name: "Force stop…" }));
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
   await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
   expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
     { method: "evener/thread/forceStop", params: { ref } },
   ]);
   expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
   if (outcome === "refused") {
-    expect(await screen.findByText("no direct daemon ownership claim")).toBeTruthy();
+    expect(await screen.findByText("Couldn't force stop session: no direct daemon ownership claim")).toBeTruthy();
     expect(
       (within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }) as HTMLButtonElement).disabled,
     ).toBe(false);
@@ -2470,6 +2490,7 @@ test("keeps recovery failure visible on a compatible session until reconciliatio
 });
 
 test.each(["active", "idle"])("retained %s child preserves uncertainty until its owner releases it", async (status) => {
+  vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
   const mutationId = await seedPendingSend("local:retained-child");
   await mutationStorage.markUnknown(mutationId, "blockedUnknown");
   const fake = connectFakeClient();
@@ -2494,6 +2515,7 @@ test.each(["active", "idle"])("retained %s child preserves uncertainty until its
   });
   render(
     <ClientProvider client={fake}>
+      <SessionChromeModule.SessionChrome ref="local:retained-child" />
       <Session params={{ ref: "local:retained-child" }} paneId="p1" focused={true} />
     </ClientProvider>,
   );
@@ -2508,7 +2530,12 @@ test.each(["active", "idle"])("retained %s child preserves uncertainty until its
   await waitFor(() => expect((refresh as HTMLButtonElement).disabled).toBe(false));
   expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
   expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
-  expect(screen.queryByRole("button", { name: /Force stop/ })).toBeNull();
+  // A session retained by its owner offers no force stop anywhere in the
+  // pane: the owner directs recovery (the notice above links to it).
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  expect(screen.queryByRole("menuitem", { name: /Force stop/ })).toBeNull();
+  await user.keyboard("{Escape}");
   owned = false;
   fireEvent.click(refresh);
   const resume = await screen.findByRole("button", { name: "Resume session" });
@@ -2522,6 +2549,7 @@ test.each(["active", "idle"])("retained %s child preserves uncertainty until its
 test.each(["idle", "active"])(
   "hydrated %s session keeps recovery when subsequent reads stall without navigation",
   async (status) => {
+    vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
     const fake = connectFakeClient();
     const ref = "local:retained-unresponsive";
     let stopped = false;
@@ -2542,6 +2570,7 @@ test.each(["idle", "active"])(
     });
     render(
       <ClientProvider client={fake}>
+        <SessionChromeModule.SessionChrome ref={ref} />
         <Session params={{ ref }} paneId="p1" focused={true} />
       </ClientProvider>,
     );
@@ -2552,7 +2581,7 @@ test.each(["idle", "active"])(
     await waitFor(() => expect(reads).toBe(2));
     expect(threadsStore.getState().threads.get(ref)?.status.type).toBe(status);
     const user = userEvent.setup();
-    await user.click(screen.getByRole("button", { name: "Force stop…" }));
+    await openForceStopDialog(user);
     expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
     await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
     expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
@@ -2594,6 +2623,7 @@ test("a fresh client offers explicit Resume for a server-fenced stopped session"
 test.each(["pending", "failed"])(
   "saved session retains confirmed recovery when resumed daemon read is %s",
   async (outcome) => {
+    vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
     const fake = connectFakeClient();
     const ref = "local:saved-resume-stall";
     let daemonStarted = false;
@@ -2618,12 +2648,15 @@ test.each(["pending", "failed"])(
     try {
       render(
         <ClientProvider client={fake}>
+          <SessionChromeModule.SessionChrome ref={ref} />
           <Session params={{ ref }} paneId="p1" focused={true} />
         </ClientProvider>,
       );
       const user = userEvent.setup();
       const resume = await screen.findByRole("button", { name: "Resume session" });
-      expect(screen.getAllByRole("button", { name: "Force stop…" })).toHaveLength(1);
+      await user.click(screen.getByRole("button", { name: /session actions/i }));
+      expect(screen.getByRole("menuitem", { name: "Force stop…" })).toBeTruthy();
+      await user.keyboard("{Escape}");
       await user.click(resume);
       expect(daemonStarted).toBe(true);
       if (outcome === "failed") {
@@ -2631,7 +2664,7 @@ test.each(["pending", "failed"])(
         await screen.findByText("resumed daemon read failed");
       } else expect((resume as HTMLButtonElement).disabled).toBe(true);
       expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
-      await user.click(await screen.findByRole("button", { name: "Force stop…" }));
+      await openForceStopDialog(user);
       expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
       await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
       await waitFor(() =>
@@ -2707,6 +2740,7 @@ test("recovery rejection blocks durable dispatch and refreshes the Resume contro
 test.each(["pending", "failed"])(
   "saved Send exposes confirmed recovery when automatic resume is %s",
   async (outcome) => {
+    vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
     const fake = connectFakeClient();
     const ref = "local:saved-auto-resume";
     let daemonStarted = false;
@@ -2744,6 +2778,7 @@ test.each(["pending", "failed"])(
     try {
       render(
         <ClientProvider client={fake}>
+          <SessionChromeModule.SessionChrome ref={ref} />
           <Session params={{ ref }} paneId="p1" focused={true} />
         </ClientProvider>,
       );
@@ -2752,7 +2787,10 @@ test.each(["pending", "failed"])(
         await threadsStore.getState().refreshThread(ref);
       });
       expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(false);
-      expect(screen.getAllByRole("button", { name: "Force stop…" })).toHaveLength(1);
+      const user = userEvent.setup();
+      await user.click(screen.getByRole("button", { name: /session actions/i }));
+      expect(screen.getByRole("menuitem", { name: "Force stop…" })).toBeTruthy();
+      await user.keyboard("{Escape}");
       await act(async () => {
         await threadsStore.getState().send(ref, "continue the saved conversation");
       });
@@ -2762,8 +2800,7 @@ test.each(["pending", "failed"])(
         await waitFor(async () => expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown"));
       }
       expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
-      const user = userEvent.setup();
-      await user.click(await screen.findByRole("button", { name: "Force stop…" }));
+      await openForceStopDialog(user);
       expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
       await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
       await waitFor(() => expect(stopped).toBe(true));
@@ -2783,6 +2820,7 @@ test.each(["pending", "failed"])(
 test.each(["model", "compact"])(
   "saved %s action retains recovery while automatic resume stalls without navigation",
   async (action) => {
+    vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
     const fake = connectFakeClient();
     const ref = "local:saved-action";
     let daemonStarted = false;
@@ -2810,6 +2848,7 @@ test.each(["model", "compact"])(
     });
     render(
       <ClientProvider client={fake}>
+        <SessionChromeModule.SessionChrome ref={ref} />
         <Session params={{ ref }} paneId="p1" focused={true} />
       </ClientProvider>,
     );
@@ -2817,7 +2856,7 @@ test.each(["model", "compact"])(
     const user = userEvent.setup();
     try {
       // A saved snapshot cannot establish whether an automatic resume has launched a daemon.
-      await user.click(screen.getByRole("button", { name: "Force stop…" }));
+      await openForceStopDialog(user);
       await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
       expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
       const request =
@@ -2827,13 +2866,14 @@ test.each(["model", "compact"])(
       const settled = request.catch((error: unknown) => error);
       await waitFor(() => expect(daemonStarted).toBe(true));
       expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
-      expect(screen.getAllByRole("button", { name: "Force stop…" })).toHaveLength(1);
-      await user.click(screen.getByRole("button", { name: "Force stop…" }));
+      await openForceStopDialog(user);
       expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
       await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
       await settled;
       expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
-      expect(screen.getAllByRole("button", { name: "Force stop…" })).toHaveLength(1);
+      await user.click(screen.getByRole("button", { name: /session actions/i }));
+      expect(screen.getByRole("menuitem", { name: "Force stop…" })).toBeTruthy();
+      await user.keyboard("{Escape}");
       expect(fake.calls.filter((call) => call.method === method)).toHaveLength(1);
       expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
         { method: "evener/thread/forceStop", params: { ref } },
@@ -2850,6 +2890,7 @@ test.each(["model", "compact"])(
 test.each(["idle", "active"])(
   "independent nested fork keeps confirmed recovery during stalled %s reads",
   async (status) => {
+    vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
     const fake = connectFakeClient();
     const ref = "local:original-fork";
     setNavigationTitle(ref, "Original fork", false);
@@ -2874,6 +2915,7 @@ test.each(["idle", "active"])(
     });
     render(
       <ClientProvider client={fake}>
+        <SessionChromeModule.SessionChrome ref={ref} />
         <Session params={{ ref }} paneId="p1" focused={true} />
       </ClientProvider>,
     );
@@ -2887,10 +2929,10 @@ test.each(["idle", "active"])(
       await waitFor(() => expect(finishRead).toBeTypeOf("function"));
       expect(threadsStore.getState().threads.get(ref)?.status.type).toBe(status);
       const user = userEvent.setup();
-      await user.click(screen.getByRole("button", { name: "Force stop…" }));
+      await openForceStopDialog(user);
       await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
       expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
-      await user.click(screen.getByRole("button", { name: "Force stop…" }));
+      await openForceStopDialog(user);
       await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
       expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
       expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([

--- a/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
@@ -2948,3 +2948,56 @@ test.each(["idle", "active"])(
     }
   },
 );
+
+// Regression for the review finding on the footer-button removal: a FENCED
+// notLoaded snapshot (resumeRequired -> Send=false) renders no composer card
+// at all, which used to leave the ⋯ menu - the only force-stop surface -
+// unmounted. Session.tsx now mounts SessionChrome's menu-only placement in
+// the footer for exactly this state. This drives the REAL Session + Composer
+// tree (no slot stubs) to prove the menu is reachable there.
+test("a fenced notLoaded session keeps force stop reachable in the pane footer", async () => {
+  vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
+  vi.mocked(ComposerModule.Composer).mockRestore();
+  const fake = connectFakeClient();
+  const ref = "local:fenced-not-loaded";
+  setNavigationTitle(ref, "Fenced saved session");
+  let stopped = false;
+  fake.on("thread/read", () => {
+    const response = readResponse(ref, { status: { type: "notLoaded" } });
+    response.thread.evener.resumeRequired = !stopped;
+    response.thread.evener.mutationStateAuthoritative = false;
+    // pastThreadCapabilities advertises Send for a saved snapshot; the hub's
+    // resume fence (applyThreadResumeRequirement) takes it away - which is
+    // what kills the composer's follow-up card and its chrome mount.
+    if (!stopped) response.thread.evener.capabilities = { ...CAPABILITIES, send: false };
+    return response;
+  });
+  fake.on("evener/thread/forceStop", () => {
+    stopped = true;
+    return {};
+  });
+  render(
+    <ClientProvider client={fake}>
+      <Session params={{ ref }} paneId="p1" focused={true} />
+      <Toast />
+    </ClientProvider>,
+  );
+  // The fence kills the composer card entirely - no invitation, no chrome.
+  const menuTrigger = await screen.findByRole("button", { name: /session actions/i });
+  expect(screen.queryByTestId("composer-input-card")).toBeNull();
+  const user = userEvent.setup();
+  await user.click(menuTrigger);
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }));
+  expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+  await user.click(menuTrigger);
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+  await waitFor(() =>
+    expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toEqual([
+      { method: "evener/thread/forceStop", params: { ref } },
+    ]),
+  );
+  expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+});

--- a/cmd/evener-hub/frontend/src/panes/session/Session.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.tsx
@@ -493,9 +493,6 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
                 resumeRequired={model.status.type !== "restartRequired" && !recoveryOwnerRef}
               />
             )}
-            {ref.startsWith("local:") && !recoveryOwnerRef && model.status.type !== "closed" && (
-              <SessionForceStopRecovery sessionRef={ref} />
-            )}
             {reconciliationFailed && (
               <div role="alert">Message recovery has not completed. Sending will resume after recovery succeeds.</div>
             )}

--- a/cmd/evener-hub/frontend/src/panes/session/Session.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.tsx
@@ -35,6 +35,7 @@ import { configFingerprint, resolveEffectiveConfig } from "../../transcriptDispl
 import { projectThread } from "../../transcriptDisplay/projector";
 import { Button, Cadence, EmptyState, PaneScaffold, type VirtualListHandle } from "../../widgets";
 import { VisuallyHidden } from "../../widgets/internal/VisuallyHidden";
+import { SessionChrome } from "./chrome/SessionChrome";
 import { ColdStartSkeleton, useColdStartSkeleton } from "./coldStart";
 import { AskDock, AskDockAnnouncements, useAskDockActivationEpoch, useAskDockPending } from "./composer/askDock";
 import { Composer } from "./composer/Composer";
@@ -493,6 +494,19 @@ export default function Session({ params, paneId, focused: paneFocused }: PanePr
                 resumeRequired={model.status.type !== "restartRequired" && !recoveryOwnerRef}
               />
             )}
+            {/* A FENCED notLoaded session (resumeRequired -> Send=false)
+                renders no composer card at all, which leaves the ⋯ menu -
+                the only force-stop surface - unmounted. Force stop matters
+                most in exactly that state: a stalled or fenced snapshot may
+                still have a daemon to stop. With Send=true the composer's
+                follow-up card exists and carries the menu, so this mount is
+                scoped to send === false to never render a second one.
+                Owner-retained sessions are excluded - their notice directs
+                recovery to the owner. */}
+            {model.status.type === "notLoaded" &&
+              !recoveryOwnerRef &&
+              ref.startsWith("local:") &&
+              !model.capabilities.send && <SessionChrome ref={ref} placement="menu" />}
             {reconciliationFailed && (
               <div role="alert">Message recovery has not completed. Sending will resume after recovery succeeds.</div>
             )}

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.edge.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.edge.test.tsx
@@ -484,3 +484,43 @@ test.each(["success", "failure"])("force stop requires confirmation and waits fo
   }
   expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
 });
+
+// The original inline footer button offered force stop to nested sessions
+// too: its gate was just `local: && !recoveryOwnerRef && !closed`, with no
+// parentRef check. The hub's force-stop contract rejects a descendant with
+// "no direct daemon ownership claim" once its parent is gone, and the dialog
+// surfaces that error — that was the accepted recovery path for a nested
+// fork whose owning session is unresponsive. This pins that behavior: the
+// menu still offers the action for a nested session, and confirming surfaces
+// the hub's rejection.
+test.each(["subagent", "fork"])("a nested %s session still offers Force stop and surfaces rejection", async (kind) => {
+  const user = userEvent.setup();
+  const ref = `local:nested-${kind}`;
+  const fake = connectFakeClient();
+  fake.on("thread/read", () =>
+    readResponse(ref, {
+      status: { type: "restartRequired" },
+      evener: {
+        ref,
+        kind,
+        parentRef: "local:parent",
+        capabilities: { ...CAPABILITIES, shutdown: false },
+        queue: { revision: 0 },
+      },
+    }),
+  );
+  fake.on("evener/thread/forceStop", () => {
+    throw new Error("no direct daemon ownership claim");
+  });
+  setLocation(ref);
+  await threadsStore.getState().ensureThread(ref);
+  renderWithToast(<SessionChromeView ref={ref} />);
+  await user.click(screen.getByRole("button", { name: /session actions/i }));
+  await user.click(screen.getByRole("menuitem", { name: "Force stop…" }));
+  await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
+  const toasts = await screen.findAllByText("Couldn't force stop session: no direct daemon ownership claim");
+  expect(toasts.length).toBeGreaterThanOrEqual(1);
+  expect(
+    (within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }) as HTMLButtonElement).disabled,
+  ).toBe(false);
+});

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
@@ -82,6 +82,7 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
   const tasksOpen = useWorkspaceStore((s) => isPaneOpen(s, "sessionTasks", { ref: sessionRef }));
   const activityOpen = useWorkspaceStore((s) => isPaneOpen(s, "sessionActivity", { ref: sessionRef }));
   const activitySummary = useActivitySummaryStore((s) => s.entries.get(sessionRef));
+  const mutationStateAuthoritative = useThreadsStore((s) => s.mutationAuthorityRefs.has(sessionRef));
   // Route-demanded locations carry the authoritative owner/tier/pin metadata;
   // no project is expanded merely to decide menu eligibility.
   const navigation = useNavigationStore();
@@ -130,6 +131,20 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
   const tasksRef = useRef<TasksPanelHandle>(null);
   const activityRef = useRef<ActivityPanelHandle>(null);
   if (!model) return null;
+
+  // Force-stop eligibility mirrors the reach of the retired inline footer
+  // button (Session.tsx): any local session that isn't closed, including
+  // saved notLoaded panes (a pending or failed resume can still own a daemon)
+  // and panes with no navigation identity. The one exclusion is a session
+  // retained by its owning session - its notice directs the user to the owner
+  // instead (same predicate as Session.tsx's recoveryOwnerRef).
+  const recoveryOwnerRef =
+    !mutationStateAuthoritative &&
+    model.status.type !== "notLoaded" &&
+    model.status.type !== "restartRequired" &&
+    model.parentRef?.startsWith("local:")
+      ? model.parentRef
+      : undefined;
 
   const openDetails = () => {
     if (isMobile) detailsRef.current?.open();
@@ -213,11 +228,7 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
                 }
               },
               onForceStop:
-                sessionRef.startsWith("local:") &&
-                menuSession?.host_id === "local" &&
-                menuSession.top_level !== false &&
-                model.status.type !== "notLoaded" &&
-                model.status.type !== "closed"
+                sessionRef.startsWith("local:") && model.status.type !== "closed" && !recoveryOwnerRef
                   ? async () => {
                       try {
                         await threadsStore.getState().forceStop(sessionRef);

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.tsx
@@ -29,7 +29,7 @@ import { useClient } from "../../../shell/clientContext";
 import { closePanesForDeletedSessions } from "../../../shell/deletedSessionPanes";
 import { assignSessionPin, deleteSession, setArchived, unpinSession } from "../../../shell/rail/actions";
 import { navigate, paneToURL } from "../../../shell/routing";
-import { SessionMenu } from "../../../shell/sessionMenu/SessionMenu";
+import { SessionMenu, type SessionMenuProps } from "../../../shell/sessionMenu/SessionMenu";
 import { useIsMobile } from "../../../shell/useIsMobile";
 import { isPaneOpen, useWorkspaceStore, workspaceStore } from "../../../shell/workspace";
 import { useActivitySummaryStore } from "../../../stores/activitySummary";
@@ -51,7 +51,7 @@ import styles from "./sessionchrome.module.css";
 import { TasksPanel, type TasksPanelHandle, taskAggregateLabel } from "./TasksPanel";
 import "../../sessionPanels";
 
-export type SessionChromePlacement = "footer" | "composer";
+export type SessionChromePlacement = "footer" | "composer" | "menu";
 
 export interface SessionChromeProps {
   ref: string;
@@ -161,11 +161,101 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
   };
   const activityLabel = activitySummary?.counts?.complete ? `Activity · ${activitySummary.counts.active}` : "Activity";
 
+  // The menu's action adapters, shared by the composer and menu-only
+  // placements so the failure convention (SessionMenu.tsx's header comment:
+  // the adapter toasts with sessionActionError and rethrows) cannot drift
+  // between them.
+  const forceStopAction =
+    sessionRef.startsWith("local:") && model.status.type !== "closed" && !recoveryOwnerRef
+      ? async () => {
+          try {
+            await threadsStore.getState().forceStop(sessionRef);
+          } catch (err) {
+            toasts.push("error", sessionActionError("Couldn't force stop session", err));
+            throw err;
+          }
+          try {
+            await threadsStore.getState().refreshThread(sessionRef);
+          } catch (err) {
+            toasts.push("error", sessionActionError("Session stopped; couldn't refresh its view", err));
+          }
+        }
+      : undefined;
+  const shutdownAction = async () => {
+    const convergence = buildShutdownConvergence(sessionRef, {
+      pinSectionId: menuSession?.pin_section_id,
+      projectKey: location?.project_key,
+    });
+    const invalidation = convergence.arm();
+    try {
+      await threadsStore.getState().shutdown(sessionRef);
+      await convergence.converge(invalidation);
+    } catch (err) {
+      invalidation.cancel();
+      toasts.push("error", sessionActionError("Couldn't shut down session", err));
+      throw err;
+    }
+  };
+  const pinAction = async (target: Parameters<SessionMenuProps["actions"]["onPin"]>[0]) => {
+    try {
+      const result = await assignSessionPin(client, sessionRef, target);
+      navigationStore.getState().trackPinSection(result.assignment.section.id);
+      if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
+    } catch (err) {
+      toasts.push("error", sessionActionError("Couldn't assign pinned session", err));
+      throw err;
+    }
+  };
+  const unpinAction = async () => {
+    try {
+      const result = await unpinSession(client, sessionRef);
+      if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
+    } catch (err) {
+      toasts.push("error", sessionActionError("Couldn't unpin session", err));
+      throw err;
+    }
+  };
+  const archiveAction = async () => {
+    if (!menuSession) return;
+    try {
+      const result = await setArchived("session", menuSession.session_id, menuSession.tier !== "archived");
+      if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
+    } catch (err) {
+      toasts.push("error", sessionActionError("Couldn't update archive state", err));
+      throw err;
+    }
+  };
+  const deleteAction = async () => {
+    try {
+      const result = await deleteSession(client, sessionRef);
+      if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
+      closePanesForDeletedSessions(result.deleted);
+      if (result.skipped.length > 0) {
+        const reason = result.skipped[0]?.reason ?? "still in use";
+        toasts.push("warning", `Couldn't delete "${model.name}": ${reason}`);
+      }
+    } catch (err) {
+      toasts.push("error", sessionActionError(`Couldn't delete "${model.name}"`, err));
+      throw err;
+    }
+  };
+
   return (
     <>
+      {/* The "menu" placement (Session.tsx's notLoaded footer mount) renders
+          ONLY the actions group below: the pane footer already carries the
+          liveness line and any recovery notice, and the composer hides its
+          own chrome for exactly this state, so there is no status body to
+          compress and no second menu to dedupe against. */}
       <div
         className={placement === "composer" ? CLASS.inline : CLASS.chrome}
-        data-testid={placement === "composer" ? "session-chrome-inline" : "session-chrome"}
+        data-testid={
+          placement === "composer"
+            ? "session-chrome-inline"
+            : placement === "menu"
+              ? "session-chrome-menu"
+              : "session-chrome"
+        }
       >
         {placement === "composer" ? (
           <div className={CLASS.body} data-testid="session-chrome-inline-status">
@@ -175,7 +265,7 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
               in the real app. */}
             <GoalControl sessionRef={sessionRef} model={model} />
           </div>
-        ) : (
+        ) : placement === "menu" ? null : (
           /* .body owns compression (sessionchrome.module.css says why): its
            inline-size container progressively simplifies status content, so
            .right - and with it the "..." menu - always shares this one line. */
@@ -215,10 +305,6 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
                 else if (pane === "tasks") openTasks();
                 else openActivity();
               },
-              // Failure convention (SessionMenu.tsx's header comment): the
-              // ADAPTER toasts with sessionActionError and rethrows, so a
-              // rejected action leaves SessionMenu's dialog open with its
-              // confirm button re-enabled; only success closes it.
               onRename: async (name) => {
                 try {
                   await threadsStore.getState().rename(sessionRef, name);
@@ -227,81 +313,12 @@ export function SessionChrome({ ref: sessionRef, placement = "footer", onOpenTas
                   throw err;
                 }
               },
-              onForceStop:
-                sessionRef.startsWith("local:") && model.status.type !== "closed" && !recoveryOwnerRef
-                  ? async () => {
-                      try {
-                        await threadsStore.getState().forceStop(sessionRef);
-                      } catch (err) {
-                        toasts.push("error", sessionActionError("Couldn't force stop session", err));
-                        throw err;
-                      }
-                      try {
-                        await threadsStore.getState().refreshThread(sessionRef);
-                      } catch (err) {
-                        toasts.push("error", sessionActionError("Session stopped; couldn't refresh its view", err));
-                      }
-                    }
-                  : undefined,
-
-              onShutdown: async () => {
-                const convergence = buildShutdownConvergence(sessionRef, {
-                  pinSectionId: menuSession?.pin_section_id,
-                  projectKey: location?.project_key,
-                });
-                const invalidation = convergence.arm();
-                try {
-                  await threadsStore.getState().shutdown(sessionRef);
-                  await convergence.converge(invalidation);
-                } catch (err) {
-                  invalidation.cancel();
-                  toasts.push("error", sessionActionError("Couldn't shut down session", err));
-                  throw err;
-                }
-              },
-              onPin: async (target) => {
-                try {
-                  const result = await assignSessionPin(client, sessionRef, target);
-                  navigationStore.getState().trackPinSection(result.assignment.section.id);
-                  if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
-                } catch (err) {
-                  toasts.push("error", sessionActionError("Couldn't assign pinned session", err));
-                  throw err;
-                }
-              },
-              onUnpin: async () => {
-                try {
-                  const result = await unpinSession(client, sessionRef);
-                  if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
-                } catch (err) {
-                  toasts.push("error", sessionActionError("Couldn't unpin session", err));
-                  throw err;
-                }
-              },
-              onToggleArchive: async () => {
-                if (!menuSession) return;
-                try {
-                  const result = await setArchived("session", menuSession.session_id, menuSession.tier !== "archived");
-                  if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
-                } catch (err) {
-                  toasts.push("error", sessionActionError("Couldn't update archive state", err));
-                  throw err;
-                }
-              },
-              onDelete: async () => {
-                try {
-                  const result = await deleteSession(client, sessionRef);
-                  if (result.navigation) await navigationStore.getState().applyNavigationMutation(result.navigation);
-                  closePanesForDeletedSessions(result.deleted);
-                  if (result.skipped.length > 0) {
-                    const reason = result.skipped[0]?.reason ?? "still in use";
-                    toasts.push("warning", `Couldn't delete "${model.name}": ${reason}`);
-                  }
-                } catch (err) {
-                  toasts.push("error", sessionActionError(`Couldn't delete "${model.name}"`, err));
-                  throw err;
-                }
-              },
+              onForceStop: forceStopAction,
+              onShutdown: shutdownAction,
+              onPin: pinAction,
+              onUnpin: unpinAction,
+              onToggleArchive: archiveAction,
+              onDelete: deleteAction,
             }}
           />
         </div>


### PR DESCRIPTION
The session footer rendered an always-visible **Force stop…** button above the composer for every local non-closed session — healthy ones included. Force stop is a destructive recovery action; it belongs in the session **⋯** menu, which already had the item wired.

## Changes

- **Session.tsx** — remove the footer `SessionForceStopRecovery` render. The component stays for the "Loading transcript…" empty state, where an unresponsive session has no composer and therefore no menu, so that recovery path is preserved.
- **SessionChrome.tsx** — widen the menu's `onForceStop` gate to any local non-closed session so nothing the inline button reached is lost: saved `notLoaded` panes (a pending or failed resume can still own a daemon) and panes without navigation identity keep force stop. A session retained by its owning session remains excluded — its notice directs recovery to the owner.
- **Session.test.tsx** — drive the seven affected tests through the real menu path (session actions → Force stop… → dialog). The retained-child test now asserts the menu itself excludes an owner-retained session; the failed-initial-read tests still cover the loading-state button.

The rail row menu's gating is unchanged.

## Verification

- `make test-web` — PASS (web-typecheck, web-test, web-lint)
- Affected suites: Session.test.tsx, SessionChrome.edge.test.tsx, ForceStopDialog.test.tsx — 93/93 pass