### PR TITLE
fix(webui): self-source watch prose uses this session label

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.test.ts
@@ -775,6 +775,38 @@ Note: tighten the pattern
   expect(n.prose).toContain("Note: tighten the pattern");
 });
 
+// --- Follow-on: self-source prose uses the human label ---------------------
+// Synthesized watch prose must map the producer's self job id to "this
+// session" like titles do — "on self" leaks internal vocabulary the card
+// suppresses.
+
+test("a self-source fire synthesizes prose on this session, not self", () => {
+  const block = `<job-notification job_id="self" event="watch" job_type="watch" status="watch" reason="output_match: ready" output_bytes="0">
+Job self watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.prose).toContain("on this session");
+  expect(n.prose).not.toContain("on self");
+});
+
+test("a self-source event fire synthesizes prose on this session, not self", () => {
+  const block = `<job-notification job_id="self" event="watch" job_type="watch" status="watch" reason="event: assistant.tool" output_bytes="0">
+Job self watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.prose).toContain("on this session");
+  expect(n.prose).not.toContain("on self");
+});
+
+test("a self-source progress tick synthesizes prose on this session, not self", () => {
+  const block = `<job-notification job_id="self" event="watch" job_type="watch" status="watch" reason="progress_tick" output_bytes="0">
+Job self watch. Output is available through read_transcript if needed.
+</job-notification>`;
+  const n = notif(notificationsOf(parseSteeringNotifications(block)), 0);
+  expect(n.prose).toContain("on this session");
+  expect(n.prose).not.toContain("on self");
+});
+
 // --- RoboRev combined review (322f7aa): dot-all reasons (L1) ---------------
 // Matched output can contain newlines, and the reason attr carries raw text
 // (only entity-escaped). A multiline pattern must title and synthesize, not

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/steeringClassify.ts
@@ -530,6 +530,10 @@ function watchNoteSection(bodyText: string): string | undefined {
 function watchProse(attrs: Record<string, string>, bodyText: string): string {
   const jobId = (attrs.job_id ?? "").trim();
   if (!jobId) return bodyText;
+  // The producer's self job id is internal vocabulary: titles map it to
+  // "this session" (titleForJobNotification), so synthesized prose must too
+  // ("Matched … on self" leaks the same token the card suppresses).
+  const jobLabel = jobId === "self" ? "this session" : jobId;
   const reason = decodeNotificationEntities(attrs.reason ?? "").trim();
   // The producer appends the watch's own note to every fire body
   // (withNotificationNote). Synthesized prose replaces the generic lead
@@ -558,10 +562,10 @@ function watchProse(attrs: Record<string, string>, bodyText: string): string {
   // Value patterns are dot-all: matched output can span lines, and the
   // reason attr carries raw text (only entity-escaped, never line-folded).
   const outputMatch = /^output_match:\s*([\s\S]+)$/.exec(reason)?.[1]?.trim();
-  if (outputMatch) return withNote(escapeNotificationEntities(`Matched output_match: ${outputMatch} on ${jobId}.`));
+  if (outputMatch) return withNote(escapeNotificationEntities(`Matched output_match: ${outputMatch} on ${jobLabel}.`));
   const eventFire = /^event:\s*([\s\S]+)$/.exec(reason)?.[1]?.trim();
-  if (eventFire) return withNote(escapeNotificationEntities(`Watch event triggered: ${eventFire} on ${jobId}.`));
-  if (/^progress_tick$/.test(reason)) return withNote(escapeNotificationEntities(`Progress tick on ${jobId}.`));
+  if (eventFire) return withNote(escapeNotificationEntities(`Watch event triggered: ${eventFire} on ${jobLabel}.`));
+  if (/^progress_tick$/.test(reason)) return withNote(escapeNotificationEntities(`Progress tick on ${jobLabel}.`));
   // Not a recognized trigger reason — the body is whatever the producer
   // sent; only the exact generic sentence is worth replacing, with the
   // escaped reason as the honest fallback.


### PR DESCRIPTION
Follow-on to #954 (merged as 8fee779bd).

Synthesized watch prose interpolated the raw `job_id`, so a self-source watch rendered `on self` while titles and the `job_watch` renderer use `this session`. Applies the same `self`→`this session` mapping from `titleForJobNotification` to the output_match, event, and progress_tick prose syntheses in `watchProse`.

Gates: 79/79 steeringClassify vitest (3 new regression tests), 1781 transcript-wide, `tsc` clean, `biome` clean.