### PR TITLE
feat(webui): drop the idle "Older turns" banner from the transcript

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
@@ -372,7 +372,10 @@ test("omits the old live Detail toolbar while transcript and older-history conte
   );
 
   expect(await screen.findByText("hello")).toBeTruthy();
-  expect(screen.getByTestId("load-older-row").textContent).not.toBe("");
+  // Idle paging is silent now (no "Older turns" banner); the row and its
+  // automatic-fetch sentinel are what must remain reachable.
+  expect(screen.getByTestId("load-older-row")).toBeTruthy();
+  expect(screen.getByTestId("load-older-sentinel")).toBeTruthy();
   expect(screen.queryByRole("button", { name: /^Detail:/ })).toBeNull();
   transcriptDisplayStore.setState({ viewport: "desktop" });
   transcriptDisplayStore.getState().setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }));

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/LoadOlderRow.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/LoadOlderRow.test.tsx
@@ -93,9 +93,9 @@ test("shows a quiet loading state while a page is in flight", () => {
   expect(screen.getByTestId("load-older-row").textContent).toMatch(/loading older turns/i);
 });
 
-test("idle with more history to fetch, it still says what it is - never an empty row", () => {
+test("idle with more history to fetch, it shows no banner at all", () => {
   render(<LoadOlderRow onLoad={() => {}} loading={false} error={null} />);
-  expect(screen.getByTestId("load-older-row").textContent).toMatch(/older turns/i);
+  expect(screen.queryByText(/older turns/i)).toBeNull();
 });
 
 test("a failed fetch surfaces inline, announced, with a Retry - never silently", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/LoadOlderRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/LoadOlderRow.tsx
@@ -10,14 +10,14 @@
 // that fires without a scroll event at all, which is what makes a short first
 // page fill itself in.
 //
-// The row itself renders one of three things, and never nothing: a quiet
-// "Loading older turns…" while a page is in flight, an error with a retry
-// button when one failed, or - idle, with more history to fetch - a quiet
-// "Older turns" label. The idle label is deliberately not a button: it is a
-// place-marker for automatic work, and the only pressable thing here is the
-// retry, which exists because Jesse ruled out a fallback "load more" button but
-// silent failure is not an option. Retry is also the accessible escape hatch: a
-// failed fetch must be recoverable without pixel-precise scrolling.
+// The row itself renders one of two things, and never less when it matters: a
+// quiet "Loading older turns…" while a page is in flight, or an error with a
+// retry button when one failed. Idle - with more history to fetch - it renders
+// nothing: paging is automatic, so a standing "Older turns" banner would only
+// narrate work the reader never asked about. The only pressable thing here is
+// the retry, which exists because Jesse ruled out a fallback "load more" button
+// but silent failure is not an option. Retry is also the accessible escape
+// hatch: a failed fetch must be recoverable without pixel-precise scrolling.
 import { useEffect, useRef } from "react";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import styles from "./loadolderrow.module.css";
@@ -92,9 +92,9 @@ export function LoadOlderRow({ onLoad, loading, error }: LoadOlderRowProps) {
             Retry
           </button>
         </>
-      ) : (
-        <span className={CLASS.label}>{loading ? "Loading older turns…" : "Older turns"}</span>
-      )}
+      ) : loading ? (
+        <span className={CLASS.label}>Loading older turns…</span>
+      ) : null}
     </div>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/LoadOlderRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/LoadOlderRow.tsx
@@ -10,14 +10,13 @@
 // that fires without a scroll event at all, which is what makes a short first
 // page fill itself in.
 //
-// The row itself renders one of two things, and never less when it matters: a
-// quiet "Loading older turns…" while a page is in flight, or an error with a
-// retry button when one failed. Idle - with more history to fetch - it renders
-// nothing: paging is automatic, so a standing "Older turns" banner would only
-// narrate work the reader never asked about. The only pressable thing here is
-// the retry, which exists because Jesse ruled out a fallback "load more" button
-// but silent failure is not an option. Retry is also the accessible escape
-// hatch: a failed fetch must be recoverable without pixel-precise scrolling.
+// The row renders a quiet "Loading older turns…" while a page is in flight,
+// an error with a retry button when one failed, and nothing when idle: paging
+// is automatic, so a standing "Older turns" banner would only narrate work the
+// reader never asked about. The only pressable thing here is the retry, which
+// exists because Jesse ruled out a fallback "load more" button but silent
+// failure is not an option. Retry is also the accessible escape hatch: a
+// failed fetch must be recoverable without pixel-precise scrolling.
 import { useEffect, useRef } from "react";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import styles from "./loadolderrow.module.css";
@@ -84,7 +83,7 @@ export function LoadOlderRow({ onLoad, loading, error }: LoadOlderRowProps) {
       {error !== null ? (
         <>
           {/* role=alert: a failure the reader did not ask for and cannot see
-              coming needs announcing, unlike the two quiet states. */}
+              coming needs announcing, unlike the quiet loading state. */}
           <span role="alert" className={CLASS.error}>
             {error}
           </span>
@@ -92,9 +91,9 @@ export function LoadOlderRow({ onLoad, loading, error }: LoadOlderRowProps) {
             Retry
           </button>
         </>
-      ) : loading ? (
-        <span className={CLASS.label}>Loading older turns…</span>
-      ) : null}
+      ) : (
+        loading && <span className={CLASS.label}>Loading older turns…</span>
+      )}
     </div>
   );
 }

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/flow/loadolderrow.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/flow/loadolderrow.module.css
@@ -21,7 +21,7 @@
  * row pinned at the top of the transcript would compete with it permanently.
  * The failure is carried by the words ("Couldn't load older turns: …"), the
  * role=alert announcement, and the Retry beside it; weight and full-contrast
- * ink are what lift it off the quiet idle label. Earning an allowlist entry
+ * ink lift it off the quiet row around it. Earning an allowlist entry
  * would mean promoting a one-line paging notice to a widget directory plus a
  * gallery section, which is more machinery than this needs. */
 .error {

--- a/cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
@@ -229,7 +229,10 @@ test("keeps transcript/history and projection announcements without standalone D
   );
 
   expect(await screen.findByText("read me")).toBeTruthy();
-  expect(screen.getByTestId("load-older-row").textContent).not.toBe("");
+  // Idle paging is silent now (no "Older turns" banner); the row and its
+  // automatic-fetch sentinel are what must remain reachable.
+  expect(screen.getByTestId("load-older-row")).toBeTruthy();
+  expect(screen.getByTestId("load-older-sentinel")).toBeTruthy();
   expect(screen.queryByRole("button", { name: /^Detail:/ })).toBeNull();
   expect(screen.queryByRole("menuitem", { name: "Verbosity…" })).toBeNull();
   transcriptDisplayStore.setState({ viewport: "desktop" });


### PR DESCRIPTION
## What

Paging for older turns is automatic (IntersectionObserver sentinel), so the idle "Older turns" label only narrated work the reader never asked about. The load-older row now renders nothing while idle.

Unchanged: the sentinel and its automatic fetch, the "Loading older turns…" state, and the error + Retry path (still announced with role=alert).

## Verification

- TDD: new test "idle with more history to fetch, it shows no banner at all" confirmed failing before the change, passing after
- Two regression guards that asserted the idle row had non-empty text (Session.test.tsx, Transcript.test.tsx) re-anchored to row + sentinel reachability
- `make test-web`: PASS (web-typecheck, web-test 9783 tests, web-lint/Biome)
- simplify-code pass: 4 read-only reviewers; stale comments fixed, idle branch simplified to a boolean short-circuit; full gate re-run green