### PR TITLE
fix(hub): bind device authorization polls to their provider

### DIFF
--- a/cmd/evener-hub/app_auth.go
+++ b/cmd/evener-hub/app_auth.go
@@ -583,6 +583,9 @@ func (c *hubAuthController) DevicePoll(ctx context.Context, params appwire.AuthD
 	if !ok {
 		return appwire.AuthDevicePollResponse{State: "expired"}, nil
 	}
+	if flow.Provider != provider {
+		return appwire.AuthDevicePollResponse{}, appwire.InvalidParams("auth device provider does not match flow")
+	}
 	if c.now().Sub(flow.StartedAt) >= 15*time.Minute {
 		c.mu.Lock()
 		delete(c.deviceFlows, flowID)

--- a/cmd/evener-hub/app_auth_device_binding_test.go
+++ b/cmd/evener-hub/app_auth_device_binding_test.go
@@ -1,0 +1,65 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	authopenai "primeradiant.com/evener/auth/openai"
+	"primeradiant.com/evener/auth/openai/oaitest"
+)
+
+func TestAuth_DevicePollRejectsAFlowForAnotherCodexInstance(t *testing.T) {
+	oaitest.IsolateOpenAIAuth(t)
+	dir := t.TempDir()
+	stateDir := t.TempDir()
+	providers := writeProvidersToml(t, dir, "[providers.alpha]\nbase = \"openai-codex\"\n[providers.beta]\nbase = \"openai-codex\"\n")
+	c := newTestAuthController(t, dir, stateDir, providers)
+	c.generateState = func() (string, error) { return "flow-alpha", nil }
+	c.requestDeviceCode = func(context.Context, *http.Client, authopenai.Config) (authopenai.DeviceCode, error) {
+		return authopenai.DeviceCode{UserCode: "U", VerificationURL: "https://x", DeviceAuthID: "d", Interval: time.Second}, nil
+	}
+	pollCalls := 0
+	c.pollDeviceOnce = func(context.Context, *http.Client, authopenai.Config, authopenai.DeviceCode) (authopenai.DeviceCodeSuccess, bool, error) {
+		pollCalls++
+		if pollCalls == 1 {
+			return authopenai.DeviceCodeSuccess{}, true, nil
+		}
+		return authopenai.DeviceCodeSuccess{AuthorizationCode: "code", CodeVerifier: "verifier"}, false, nil
+	}
+	c.exchangeDevice = func(context.Context, *http.Client, authopenai.Config, string, string) (authopenai.TokenSet, error) {
+		return authopenai.TokenSet{AccessToken: "access", RefreshToken: "refresh", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}, nil
+	}
+	start, err := c.DeviceStart(context.Background(), appwire.AuthDeviceStartParams{Provider: "alpha"})
+	if err != nil {
+		t.Fatalf("DeviceStart: %v", err)
+	}
+	_, err = c.DevicePoll(context.Background(), appwire.AuthDevicePollParams{Provider: "beta", FlowID: start.FlowID})
+	if err == nil {
+		t.Fatal("DevicePoll(beta) succeeded for alpha flow")
+	}
+	var wireErr appwire.WireError
+	if !errors.As(err, &wireErr) || wireErr.Code != appwire.CodeInvalidParams {
+		t.Fatalf("DevicePoll(beta) error = %v, want invalid params", err)
+	}
+	if pollCalls != 0 {
+		t.Fatalf("pollDeviceOnce called %d times for mismatched provider", pollCalls)
+	}
+	if _, loadErr := authopenai.LoadAuth(stateDir, "beta"); !errors.Is(loadErr, authopenai.ErrAuthNotFound) {
+		t.Fatalf("beta auth file error = %v, want not found", loadErr)
+	}
+	pending, err := c.DevicePoll(context.Background(), appwire.AuthDevicePollParams{Provider: "alpha", FlowID: start.FlowID})
+	if err != nil || pending.State != "pending" {
+		t.Fatalf("original alpha flow = %+v err=%v, want pending", pending, err)
+	}
+	authorized, err := c.DevicePoll(context.Background(), appwire.AuthDevicePollParams{Provider: "alpha", FlowID: start.FlowID})
+	if err != nil || authorized.State != "authorized" || authorized.Status == nil || authorized.Status.Provider != "alpha" {
+		t.Fatalf("original alpha flow = %+v err=%v, want authorized alpha", authorized, err)
+	}
+	if _, loadErr := authopenai.LoadAuth(stateDir, "beta"); !errors.Is(loadErr, authopenai.ErrAuthNotFound) {
+		t.Fatalf("beta auth file after alpha success error = %v, want not found", loadErr)
+	}
+}


### PR DESCRIPTION
A device sign-in flow started for one provider instance could be polled using another instance's name, allowing authorization to proceed toward the wrong credential record. Reject that mismatch before polling or exchanging tokens, while leaving the original flow available to its provider.

This is a focused prerequisite for the native iPhone checkpoint. It changes only device-flow binding and its regression test.

Validation:
- The regression fails on main before the guard and passes with it.
- Verifies invalid-params rejection, no polling or credential write for the wrong instance, and successful continuation of the original flow.
- All `TestAuth_` tests and `go vet ./cmd/evener-hub` pass.
- Independent code review found no actionable issue; CI runs on this PR's head.
