### PR TITLE
fix(hub): report actual stored credential removal on logout

### DIFF
--- a/cmd/evener-hub/app_auth.go
+++ b/cmd/evener-hub/app_auth.go
@@ -64,8 +64,8 @@ type hubAuthController struct {
 	// record written between those two steps is one the check never saw and
 	// the move would overwrite. Writers take the read side — they are
 	// already safe against each other through the credentials store's own
-	// mutex and the OAuth state files — and the rename takes it exclusively
-	// for the whole check-then-move (hubInstancesController.Edit).
+	// mutex and the OAuth state files. Rename and logout take it exclusively
+	// for their complete check-and-write operations.
 	credMu sync.RWMutex
 
 	mu          sync.Mutex
@@ -341,7 +341,7 @@ func (c *hubAuthController) Logout(params appwire.AuthLogoutParams) (appwire.Aut
 	// authenticates from.
 	codex := false
 	removed := false
-	if err := c.credentialWrite(func() error {
+	if err := c.credentialWriteExclusive(func() error {
 		codex = c.instanceIsCodex(name)
 		if !codex {
 			_, hadFile := c.creds.Get(name)
@@ -396,6 +396,14 @@ func (c *hubAuthController) Logout(params appwire.AuthLogoutParams) (appwire.Aut
 func (c *hubAuthController) credentialWrite(write func() error) error {
 	c.credMu.RLock()
 	defer c.credMu.RUnlock()
+	return write()
+}
+
+// credentialWriteExclusive keeps a check-and-remove operation together against
+// other controller credential writers.
+func (c *hubAuthController) credentialWriteExclusive(write func() error) error {
+	c.credMu.Lock()
+	defer c.credMu.Unlock()
 	return write()
 }
 

--- a/cmd/evener-hub/app_auth.go
+++ b/cmd/evener-hub/app_auth.go
@@ -344,10 +344,11 @@ func (c *hubAuthController) Logout(params appwire.AuthLogoutParams) (appwire.Aut
 	if err := c.credentialWrite(func() error {
 		codex = c.instanceIsCodex(name)
 		if !codex {
+			_, hadFile := c.creds.Get(name)
 			if clrErr := c.clearCredential(name); clrErr != nil {
 				return clrErr
 			}
-			removed = true
+			removed = hadFile
 			return nil
 		}
 		// The Codex transport: clear the effective layer only. An OAuth record

--- a/cmd/evener-hub/app_auth_logout_atomic_test.go
+++ b/cmd/evener-hub/app_auth_logout_atomic_test.go
@@ -1,0 +1,73 @@
+package hub
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/auth/openai/oaitest"
+)
+
+func TestAuth_LogoutWaitsForAnotherCredentialWrite(t *testing.T) {
+	oaitest.IsolateOpenAIAuth(t)
+	dir := t.TempDir()
+	ctrl := newTestAuthController(t, dir, filepath.Join(dir, "state"), writeProvidersToml(t, dir, bearerInstanceToml))
+	originalSet := ctrl.setCredential
+	setEntered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	ctrl.setCredential = func(name, value string) error {
+		close(setEntered)
+		<-release
+		return originalSet(name, value)
+	}
+	setResult := make(chan error, 1)
+	go func() {
+		_, err := ctrl.ApiKeySet(appwire.AuthApiKeySetParams{Provider: "work-ant", Value: "sk-work"})
+		setResult <- err
+	}()
+	<-setEntered
+
+	cleared := make(chan struct{})
+	originalClear := ctrl.clearCredential
+	ctrl.clearCredential = func(name string) error {
+		close(cleared)
+		return originalClear(name)
+	}
+	type logoutResult struct {
+		response appwire.AuthLogoutResponse
+		err      error
+	}
+	logout := make(chan logoutResult, 1)
+	go func() {
+		response, err := ctrl.Logout(appwire.AuthLogoutParams{Provider: "work-ant"})
+		logout <- logoutResult{response: response, err: err}
+	}()
+
+	select {
+	case <-cleared:
+		t.Fatal("Logout entered credential removal while ApiKeySet held the credential write")
+	case <-time.After(time.Second):
+	}
+	releaseOnce.Do(func() { close(release) })
+	if err := <-setResult; err != nil {
+		t.Fatalf("ApiKeySet: %v", err)
+	}
+	select {
+	case result := <-logout:
+		if result.err != nil {
+			t.Fatalf("Logout: %v", result.err)
+		}
+		if !result.response.Removed {
+			t.Fatalf("Logout Removed=%v, want true", result.response.Removed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Logout did not complete after the credential write released")
+	}
+	if value, ok := ctrl.creds.Get("work-ant"); ok || value != "" {
+		t.Fatalf("credential remains after Logout: value=%q present=%v", value, ok)
+	}
+}

--- a/cmd/evener-hub/app_auth_logout_result_test.go
+++ b/cmd/evener-hub/app_auth_logout_result_test.go
@@ -1,0 +1,52 @@
+package hub
+
+import (
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/auth/openai/oaitest"
+)
+
+func TestAuth_NonCodexLogoutReportsActualStoredRemoval(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		env        map[string]string
+		stored     bool
+		wantRemove bool
+		wantSource string
+	}{
+		{name: "absent", env: map[string]string{}, wantSource: "none"},
+		{name: "environment only", env: map[string]string{"WORK_ANT_KEY": "env-key"}, wantSource: "env:WORK_ANT_KEY"},
+		{name: "stored", env: map[string]string{}, stored: true, wantRemove: true, wantSource: "none"},
+		{name: "stored shadowed by environment", env: map[string]string{"WORK_ANT_KEY": "env-key"}, stored: true, wantRemove: true, wantSource: "env:WORK_ANT_KEY"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oaitest.IsolateOpenAIAuth(t)
+			dir := t.TempDir()
+			c := newTestAuthController(t, dir, filepath.Join(dir, "state"), writeProvidersToml(t, dir, bearerInstanceToml), tc.env)
+			if tc.stored {
+				if err := c.creds.Set("work-ant", "stored-key"); err != nil {
+					t.Fatalf("Set: %v", err)
+				}
+				if err := c.reg.Reload(); err != nil {
+					t.Fatalf("Reload: %v", err)
+				}
+			}
+			before, err := c.Status(appwire.AuthStatusParams{Provider: "work-ant"})
+			if err != nil {
+				t.Fatalf("Status before logout: %v", err)
+			}
+			resp, err := c.Logout(appwire.AuthLogoutParams{Provider: "work-ant"})
+			if err != nil {
+				t.Fatalf("Logout: %v", err)
+			}
+			if resp.Removed != tc.wantRemove {
+				t.Fatalf("Removed=%v, want %v (before=%+v)", resp.Removed, tc.wantRemove, before)
+			}
+			if resp.Status.ActiveSource != tc.wantSource {
+				t.Fatalf("source after logout=%q, want %q", resp.Status.ActiveSource, tc.wantSource)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Logout now reports whether it actually removed a stored credential. A missing credential or environment-only credential returns `removed: false`; removing a stored key returns `true`, including when an environment key remains active.

Keep the credential-layer check and removal under the existing controller lock exclusively, so a concurrent API-key write cannot interleave and make the result wrong. Registry reload remains outside that lock.

Validation: regression tests fail before each fix and pass afterward; all auth tests pass with the race detector, focused credential-store race tests pass, and package vet passes. Independent Luna review covers the locking and response behavior. Full-package macOS updater path failures were isolated and fixed separately in #1069.

This is a small prerequisite extracted from the preserved iPhone checkpoint. It includes no native UI or higher-level TypeScript state changes.
