### PR TITLE
fix(hub): return an empty array when no sessions are listed

### DIFF
--- a/cmd/evener-hub/app_threadlist.go
+++ b/cmd/evener-hub/app_threadlist.go
@@ -13,7 +13,7 @@ import (
 )
 
 func hubThreadList(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
-	var threads []appwire.Thread
+	threads := make([]appwire.Thread, 0)
 	liveIDs := map[string]struct{}{}
 	for _, source := range sources.All() {
 		if !sourceAllowedForList(source.ID(), params) {

--- a/cmd/evener-hub/app_threadlist_empty_test.go
+++ b/cmd/evener-hub/app_threadlist_empty_test.go
@@ -1,0 +1,34 @@
+package hub
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func TestHubThreadListEmptyDataIsArray(t *testing.T) {
+	response, err := hubThreadList(context.Background(), hubcore.WebConfig{}, appsource.NewRegistry(), appwire.ThreadListParams{})
+	if err != nil {
+		t.Fatalf("hubThreadList: %v", err)
+	}
+	if response.Data == nil || len(response.Data) != 0 {
+		t.Fatalf("thread list data = %#v, want non-nil empty slice", response.Data)
+	}
+	wire, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal thread list: %v", err)
+	}
+	var decoded struct {
+		Data []appwire.Thread `json:"data"`
+	}
+	if err := json.Unmarshal(wire, &decoded); err != nil {
+		t.Fatalf("unmarshal thread list: %v", err)
+	}
+	if decoded.Data == nil || len(decoded.Data) != 0 {
+		t.Fatalf("serialized thread list data = %#v, want empty JSON array", decoded.Data)
+	}
+}


### PR DESCRIPTION
An empty hub currently returns `data: null` from `thread/list`, violating the array shape expected by typed clients. Initialize the accumulator as an empty slice so a successful empty response contains `data: []`.

This changes one production line. Session-list performance and source fanout remain separate changes.

Validation:
- Regression fails on main before the change and passes afterward.
- Calls real `hubThreadList` with an empty registry and verifies the structured response and serialized JSON array contract.
- All `ThreadList` tests and `go vet ./cmd/evener-hub` pass.
- Independent review found no actionable issue; CI runs on this PR's head.
