### PR TITLE
fix(hub): preserve restart entrypoints across directory aliases

### DIFF
--- a/cmd/evener-hub/app_update.go
+++ b/cmd/evener-hub/app_update.go
@@ -272,8 +272,11 @@ func hubRestartArgs(args []string) []string {
 func restartBinary(installed string) string {
 	if args := hubProcessArgs(); len(args) > 0 && args[0] != "" {
 		entry := canonicalInvocationPath(args[0])
-		if resolved, err := filepath.EvalSymlinks(entry); err == nil && resolved == installed {
-			return entry
+		if resolved, err := filepath.EvalSymlinks(entry); err == nil {
+			installedResolved, installedErr := filepath.EvalSymlinks(installed)
+			if installedErr == nil && resolved == installedResolved {
+				return entry
+			}
 		}
 	}
 	return installed

--- a/cmd/evener-hub/app_update_invocation_test.go
+++ b/cmd/evener-hub/app_update_invocation_test.go
@@ -19,6 +19,10 @@ func TestHubUpdateApplyPrefersInvocationPath(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
 	stubUpdateAvailable(t)
 	root := t.TempDir()
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
 	shareBin := filepath.Join(root, "share", "evener", "bin")
 	if err := os.MkdirAll(shareBin, 0o755); err != nil {
 		t.Fatal(err)
@@ -52,14 +56,14 @@ func TestHubUpdateApplyPrefersInvocationPath(t *testing.T) {
 	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"}); err != nil {
 		t.Fatalf("hubUpdateApply: %v", err)
 	}
-	if gotOpts.Prefix != root {
-		t.Fatalf("Prefix = %q, want %q", gotOpts.Prefix, root)
+	if gotOpts.Prefix != resolvedRoot {
+		t.Fatalf("Prefix = %q, want %q", gotOpts.Prefix, resolvedRoot)
 	}
 	if gotOpts.BinDir != customBin {
 		t.Fatalf("BinDir = %q, want the invocation dir %q", gotOpts.BinDir, customBin)
 	}
-	if gotOpts.ShareBinDir != shareBin {
-		t.Fatalf("ShareBinDir = %q, want %q", gotOpts.ShareBinDir, shareBin)
+	if gotOpts.ShareBinDir != filepath.Join(resolvedRoot, "share", "evener", "bin") {
+		t.Fatalf("ShareBinDir = %q, want %q", gotOpts.ShareBinDir, filepath.Join(resolvedRoot, "share", "evener", "bin"))
 	}
 }
 
@@ -137,8 +141,13 @@ func TestHubRestartPreservesEntrypoint(t *testing.T) {
 	if err := os.MkdirAll(shareBin, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	installed := filepath.Join(shareBin, "evener")
-	if err := os.WriteFile(installed, []byte("binary"), 0o755); err != nil {
+	aliasParent := t.TempDir()
+	realRoot := filepath.Join(aliasParent, "root-alias")
+	if err := os.Symlink(root, realRoot); err != nil {
+		t.Fatal(err)
+	}
+	installed := filepath.Join(realRoot, "share", "evener", "bin", "evener")
+	if err := os.WriteFile(filepath.Join(shareBin, "evener"), []byte("binary"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	customBin := filepath.Join(t.TempDir(), "custom-bin")
@@ -146,7 +155,7 @@ func TestHubRestartPreservesEntrypoint(t *testing.T) {
 		t.Fatal(err)
 	}
 	link := filepath.Join(customBin, "evener")
-	if err := os.Symlink(installed, link); err != nil {
+	if err := os.Symlink(filepath.Join(shareBin, "evener"), link); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/evener-hub/app_update_prefix_test.go
+++ b/cmd/evener-hub/app_update_prefix_test.go
@@ -53,6 +53,10 @@ func TestHubUpdateApplyResolvesBinSymlinkEntrypoint(t *testing.T) {
 	setBuild(t, "3b1c5f8", "snapshot")
 	stubUpdateAvailable(t)
 	root := t.TempDir()
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
 	shareBin := filepath.Join(root, "share", "evener", "bin")
 	if err := os.MkdirAll(shareBin, 0o755); err != nil {
 		t.Fatal(err)
@@ -83,14 +87,14 @@ func TestHubUpdateApplyResolvesBinSymlinkEntrypoint(t *testing.T) {
 	if _, err := hubUpdateApply(context.Background(), appwire.UpdateApplyParams{Channel: "snapshot"}); err != nil {
 		t.Fatalf("hubUpdateApply: %v", err)
 	}
-	if gotOpts.Prefix != root {
-		t.Fatalf("Prefix = %q, want %q", gotOpts.Prefix, root)
+	if gotOpts.Prefix != resolvedRoot {
+		t.Fatalf("Prefix = %q, want %q", gotOpts.Prefix, resolvedRoot)
 	}
 	if gotOpts.BinDir != binDir {
 		t.Fatalf("BinDir = %q, want %q", gotOpts.BinDir, binDir)
 	}
-	if gotOpts.ShareBinDir != shareBin {
-		t.Fatalf("ShareBinDir = %q, want %q", gotOpts.ShareBinDir, shareBin)
+	if gotOpts.ShareBinDir != filepath.Join(resolvedRoot, "share", "evener", "bin") {
+		t.Fatalf("ShareBinDir = %q, want %q", gotOpts.ShareBinDir, filepath.Join(resolvedRoot, "share", "evener", "bin"))
 	}
 }
 


### PR DESCRIPTION
After a hub update, a custom launch path could be discarded when the invocation and installed binary reached the same file through different parent-directory symlinks. Resolve both paths before comparing them, preserving the original entrypoint when they match and retaining the installed-path fallback otherwise.

Use an explicit directory alias in the regression so the defect is exercised on Linux as well as macOS. Canonicalize installation-root expectations in the adjacent tests to remove their `/var` versus `/private/var` assumptions.

Validation:
- Reproduced the three failing update-path tests before the correction; they pass afterward.
- Full `go test ./cmd/evener-hub -count=1` passes on the candidate.
- Focused update tests pass under `-race`; `go vet ./cmd/evener-hub` passes.
- Independent review found no actionable issue.

This is a separate prerequisite discovered while qualifying the native checkpoint. It resolves the existing macOS package failures noted in #1067.
