### PR TITLE
fix(server): include build version in AppWire initialization

### DIFF
--- a/server/appwire_server_test.go
+++ b/server/appwire_server_test.go
@@ -650,6 +650,22 @@ func TestServerAppWireThreadReadUsesCommunicateAsAssistantMessage(t *testing.T) 
 	}
 }
 
+func TestServerAppWireInitializeReportsBuildVersion(t *testing.T) {
+	srv := NewServer(ServerConfig{})
+	conn := srv.AppServer().NewConnection("test")
+	resp := conn.HandleMessage(context.Background(), appwire.RequestMessage(appwire.NewIntID(1), appwire.MethodInitialize, appwire.InitializeParams{ProtocolVersion: appwire.ProtocolVersion}))
+	if resp.Kind() != appwire.MessageResponse {
+		t.Fatalf("resp=%v", resp.Kind())
+	}
+	data, ok := resp.Response.Result.(appwire.InitializeResponse)
+	if !ok {
+		t.Fatalf("result=%T", resp.Response.Result)
+	}
+	if strings.TrimSpace(data.ServerInfo.Version) == "" {
+		t.Fatal("initialize must report a build version so strict AppWire clients can connect")
+	}
+}
+
 func TestServerAppWireInitializeAdvertisesTurnList(t *testing.T) {
 	srv := NewServer(ServerConfig{})
 	conn := srv.AppServer().NewConnection("test")

--- a/server/server.go
+++ b/server/server.go
@@ -9,6 +9,7 @@ import (
 
 	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/buildinfo"
 	"primeradiant.com/evener/internal/appprojector"
 	"primeradiant.com/evener/internal/appserver"
 	"primeradiant.com/evener/internal/httpguard"
@@ -434,6 +435,7 @@ func NewServer(cfg ServerConfig) *Server {
 		mux: http.NewServeMux(),
 		appServer: appserver.NewServer(appserver.ServerConfig{
 			ServerName: "evener-serve",
+			Version:    buildinfo.Version(),
 			SourceID:   "local",
 			SubscriptionAdmissionResolver: func(msg appwire.Message) (string, bool) {
 				if msg.Request == nil || (msg.Request.Method != appwire.MethodThreadRead && msg.Request.Method != appwire.MethodThreadUnsubscribe) {


### PR DESCRIPTION
The daemon now includes its build version in the AppWire initialize response. Strict clients can validate the server identity and complete the handshake.

Regression fails on main before the fix. All TestServerAppWire tests and server vet pass; independent Luna review is clean.

This is a focused prerequisite from the preserved iPhone checkpoint, based on current main. It includes no native UI or higher-level TypeScript state extraction.
