### PR TITLE
fix(hub): return an empty array for subagent previews

### DIFF
--- a/cmd/evener-hub/app_subagent_preview.go
+++ b/cmd/evener-hub/app_subagent_preview.go
@@ -33,7 +33,7 @@ func subagentPreviewFromThread(thread appwire.Thread, ref string, limit int) app
 		}
 	}
 	start := max(len(all)-limit, 0)
-	items := append([]appwire.ThreadItem(nil), all[start:]...)
+	items := append([]appwire.ThreadItem{}, all[start:]...)
 	return appwire.EvenerSubagentPreviewResponse{
 		Ref:       ref,
 		Items:     items,

--- a/cmd/evener-hub/app_subagent_preview_test.go
+++ b/cmd/evener-hub/app_subagent_preview_test.go
@@ -1,10 +1,30 @@
 package hub
 
 import (
+	"encoding/json"
 	"testing"
 
 	"primeradiant.com/evener/appwire"
 )
+
+func TestSubagentPreviewEmptyItemsAreAJSONList(t *testing.T) {
+	resp := subagentPreviewFromThread(appwire.Thread{}, "local:empty", 0)
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(raw, &wire); err != nil {
+		t.Fatal(err)
+	}
+	items, ok := wire["items"].([]any)
+	if !ok || len(items) != 0 {
+		t.Fatalf("items must be an empty JSON array, got %#v", wire["items"])
+	}
+	if wire["ref"] != "local:empty" || wire["truncated"] != false {
+		t.Fatalf("invalid empty preview metadata: %#v", wire)
+	}
+}
 
 func TestSubagentPreviewBoundsLatestDirectItems(t *testing.T) {
 	resp := subagentPreviewFromThread(appwire.Thread{


### PR DESCRIPTION
An empty subagent preview now returns `items: []`, preserving the response array contract and its existing reference and truncation metadata.

The serialized-response regression fails before the fix. All subagent preview tests pass with the race detector, hub vet passes, and independent Luna review is clean.

This is a focused prerequisite from the preserved iPhone checkpoint, based on current main. It includes no native UI or higher-level TypeScript state extraction.
