### PR TITLE
fix(appwire): omit absent images from steering notifications

### DIFF
--- a/internal/appprojector/appwire_projection.go
+++ b/internal/appprojector/appwire_projection.go
@@ -937,16 +937,13 @@ func (p *AppEventProjector) Project(event events.SessionEvent) (out []AppNotific
 		if strings.TrimSpace(text) == "" {
 			text = apptranscript.ImagePlaceholder(len(images))
 		}
-		// Still map[string]any, not appwire.EvenerSteeringInjectedParams (kcb5):
-		// images is nil whenever a steer carries no images (the common case) -
-		// this map always emits "images" anyway (as null), but Images is tagged
-		// `omitempty` on the struct, so a typed literal would drop the key
-		// entirely instead. Not provably byte-identical; left as a map.
 		params := map[string]any{
 			"threadId": p.threadID,
 			"ref":      p.ref,
 			"text":     text,
-			"images":   images,
+		}
+		if len(images) > 0 {
+			params["images"] = images
 		}
 		// User-sent steering carries its provenance so the web UI renders it
 		// as a user message rather than a system steering divider (issue #24).

--- a/internal/appprojector/appwire_projection_test.go
+++ b/internal/appprojector/appwire_projection_test.go
@@ -1500,21 +1500,39 @@ func TestAppEventProjectorProjectsQueueChanged(t *testing.T) {
 }
 
 func TestAppEventProjectorProjectsSteeringInjected(t *testing.T) {
-	projector := NewAppEventProjector("th_1", "local:th_1")
-	out := projector.Project(events.SessionEvent{
-		Kind:      events.EventSteeringInjected,
-		SessionID: "th_1",
-		Data:      events.SteeringInjectedData{Text: "stay focused"},
-	})
-	if len(out) != 1 || out[0].Method != appwire.NotifyEvenerSteeringInjected {
-		t.Fatalf("out=%+v", out)
-	}
-	params, ok := out[0].Params.(map[string]any)
-	if !ok {
-		t.Fatalf("params=%T", out[0].Params)
-	}
-	if params["threadId"] != "th_1" || params["ref"] != "local:th_1" || params["text"] != "stay focused" {
-		t.Fatalf("params=%+v", params)
+	for name, images := range map[string][]events.UserInputImage{
+		"nil":   nil,
+		"empty": {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			projector := NewAppEventProjector("th_1", "local:th_1")
+			out := projector.Project(events.SessionEvent{
+				Kind:      events.EventSteeringInjected,
+				SessionID: "th_1",
+				Data:      events.SteeringInjectedData{Text: "stay focused", Images: images},
+			})
+			if len(out) != 1 || out[0].Method != appwire.NotifyEvenerSteeringInjected {
+				t.Fatalf("out=%+v", out)
+			}
+			params, ok := out[0].Params.(map[string]any)
+			if !ok {
+				t.Fatalf("params=%T", out[0].Params)
+			}
+			if params["threadId"] != "th_1" || params["ref"] != "local:th_1" || params["text"] != "stay focused" {
+				t.Fatalf("params=%+v", params)
+			}
+			wire, err := json.Marshal(out[0].Params)
+			if err != nil {
+				t.Fatalf("marshal params: %v", err)
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(wire, &payload); err != nil {
+				t.Fatalf("unmarshal params: %v", err)
+			}
+			if _, present := payload["images"]; present {
+				t.Fatalf("wire payload contains images for %s input: %s", name, wire)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Text-only steering notifications now omit the optional images field rather than emitting null. Real image attachments continue through the existing projection path.

Both nil and empty image cases fail the wire-contract regression before the fix. The full projector suite passes with the race detector, including existing image-bearing steering coverage; vet and independent Luna review pass.

This is a focused prerequisite from the preserved iPhone checkpoint, based on current main. It includes no native UI or higher-level TypeScript state extraction.
