### PR TITLE
fix(transcript): preserve goal continuation identity on reload

### DIFF
--- a/agent/schema/turn.go
+++ b/agent/schema/turn.go
@@ -157,6 +157,12 @@ type ModelSwitchInfo struct {
 	NewModel    string `json:"new_model"`
 }
 
+// GoalContinuationInfo keeps the human-facing notice separate from the full
+// continuation input in Message, which remains available to resumed models.
+type GoalContinuationInfo struct {
+	Text string `json:"text"`
+}
+
 // Turn is the Session's typed history item. Steering turns are kept distinct for observability,
 // but are converted to user-role messages when building the LLM request.
 type Turn struct {
@@ -175,15 +181,18 @@ type Turn struct {
 	// SteeringKind records what a TurnSteering entry was (events.SteeringKind*),
 	// so a reloaded transcript labels a steer the same way the live path did.
 	SteeringKind string `json:"steering_kind,omitempty"`
+	// GoalContinuation marks goal-engine steering that opens a fresh logical
+	// turn and displays a compact notice rather than its model instructions.
+	GoalContinuation *GoalContinuationInfo `json:"goal_continuation,omitempty"`
 	// AttentionID identifies steering that requires durable terminal cleanup.
 	// It is empty for ordinary steering and all non-steering turns.
 	AttentionID string `json:"attention_id,omitempty"`
 	// AttentionResolution is set only on TurnAttentionResolution turns.
 	AttentionResolution     *AttentionResolutionInfo `json:"attention_resolution,omitempty"`
 	DelegateDeliveryCommits []DelegateDeliveryCommit `json:"delegate_delivery_commits,omitempty"`
-	// ClientMutationID and StableTurnID identify retry-safe client-authored
-	// user and steering turns across live events, transcript recovery, and
-	// mutation replay.
+	// ClientMutationID identifies retry-safe client-authored input. StableTurnID
+	// preserves the logical turn identity across live events and transcript
+	// recovery for both client input and daemon goal continuations.
 	ClientMutationID string `json:"client_mutation_id,omitempty"`
 	StableTurnID     string `json:"stable_turn_id,omitempty"`
 	// Error carries the diagnostic of a terminally failed turn. Set only on

--- a/agent/session_goal_transcript_test.go
+++ b/agent/session_goal_transcript_test.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/llm"
+)
+
+func TestGoalContinuationPersistsDisplayAndModelInput(t *testing.T) {
+	t.Parallel()
+	client := llm.NewClient()
+	client.Register(&fakeAdapter{name: "openai"})
+	dir := t.TempDir()
+	sess, err := NewSession(client, NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(dir), SessionConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(sess.Close)
+	path := filepath.Join(dir, "goal.transcript.jsonl")
+	writer, err := transcript.NewWriter(path, transcript.Header{SessionID: sess.ID()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.attachTranscript(writer)
+	const objective = "d27552e0-5245-49e0-819d-4d8876602c94"
+	const input = "e83bb9b1-7447-4fa2-9dba-e4cbfce61a17"
+	const turnID = "turn_goal_1"
+	sess.getOrCreateGoalStore().Set(objective, time.Now())
+	stop := drainEvents(sess)
+	sess.acceptContinuationInput(context.Background(), input, turnID)
+	sess.mu.Lock()
+	live := sess.history[len(sess.history)-1]
+	sess.mu.Unlock()
+	sess.Close()
+	evs := stop()
+	var notice events.GoalContinuationData
+	for _, ev := range evs {
+		if ev.Kind == events.EventGoalContinuation {
+			notice = ev.Data.(events.GoalContinuationData)
+		}
+	}
+	if notice.Text == "" || notice.StableTurnID != turnID {
+		t.Fatal("continuation event lost its notice or reserved turn identity")
+	}
+	_, entries, _, err := readTranscript(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("persisted %d entries, want one continuation", len(entries))
+	}
+	persisted := entries[0].Turn
+	if !reflect.DeepEqual(live, persisted) {
+		t.Fatal("persisted continuation differs from live model history")
+	}
+	if persisted.Kind != schema.TurnSteering || persisted.Message.Text() != input {
+		t.Fatal("continuation model input did not survive persistence")
+	}
+	if persisted.GoalContinuation == nil || persisted.GoalContinuation.Text != notice.Text || persisted.StableTurnID != notice.StableTurnID {
+		t.Fatal("persisted continuation lost the live display notice or turn identity")
+	}
+}

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -2070,7 +2070,10 @@ func (s *Session) acceptContinuationInput(_ context.Context, input, stableTurnID
 		marker = "Continuing toward: " + snap.Objective
 	}
 	s.emit(events.EventGoalContinuation, events.GoalContinuationData{Text: marker, StableTurnID: stableTurnID})
-	s.appendTurn(schema.TurnSteering, llm.User(input))
+	turn := schema.NewTurn(schema.TurnSteering, llm.User(input))
+	turn.GoalContinuation = &schema.GoalContinuationInfo{Text: marker}
+	turn.StableTurnID = stableTurnID
+	s.recordTurn(turn, turn)
 
 	// Drain any pending steering messages before the first LLM call (spec 2.5).
 	s.injectDrainedSteering()

--- a/internal/apptranscript/apptranscript.go
+++ b/internal/apptranscript/apptranscript.go
@@ -431,6 +431,17 @@ func ProjectTurn(turnID string, turnIndex int, turn schema.Turn, toolNames map[s
 			ClientMutationID:     turn.ClientMutationID,
 		}}
 	case schema.TurnSteering:
+		if turn.GoalContinuation != nil {
+			return []appwire.ThreadItem{{
+				Type:                 "systemMessage",
+				ID:                   fmt.Sprintf("item_goal_continuation_%d", turnIndex),
+				TurnID:               turnID,
+				TranscriptEntryIndex: turnIndex,
+				Description:          "Goal",
+				Text:                 turn.GoalContinuation.Text,
+				Status:               appwire.TurnStatusCompleted,
+			}}
+		}
 		images := ImagesFromContent(turn.Message.Content, imageProjector)
 		text := turn.Message.Text()
 		if text == "" && len(images) > 0 {

--- a/internal/apptranscript/goal_continuation_test.go
+++ b/internal/apptranscript/goal_continuation_test.go
@@ -1,0 +1,88 @@
+package apptranscript
+
+import (
+	"reflect"
+	"testing"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+func TestGoalContinuationSavedProjection(t *testing.T) {
+	const notice = "672edce7-238a-4cd9-92a7-36290a41d193"
+	const input = "3eec9a93-2687-4d66-871c-9c71f3e61a5f"
+	goal := transcript.Entry{Kind: "entry", Seq: 3, Turn: schema.Turn{
+		Kind: schema.TurnSteering, Message: llm.User(input), StableTurnID: "turn_goal",
+		GoalContinuation: &schema.GoalContinuationInfo{Text: notice},
+	}}
+	ordinary := transcript.Entry{Kind: "entry", Seq: 4, Turn: schema.NewTurn(schema.TurnSteering, llm.User(notice))}
+	path := writeEntries(t, reservedUserEntry(1, input, "turn_user"), assistantTextEntry(2, input), goal, ordinary, assistantTextEntry(5, input))
+	full := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
+	if got := turnIDs(full); !reflect.DeepEqual(got, []string{"turn_user", "turn_goal"}) {
+		t.Fatalf("turn IDs = %v, want distinct user and goal turns", got)
+	}
+	if len(full[1].Items) != 3 {
+		t.Fatalf("goal turn has %d items, want notice, ordinary steering, and reply", len(full[1].Items))
+	}
+	item := full[1].Items[0]
+	if item.Type != "systemMessage" || item.Text != notice || item.TurnID != "turn_goal" {
+		t.Fatal("saved goal notice does not match the live item contract")
+	}
+	if full[1].Items[1].Type != "steering" || full[1].Items[1].Text != notice {
+		t.Fatal("ordinary steering was misclassified from its text")
+	}
+	for _, cache := range []*TurnCache{NewTurnCache(), NewTurnCache()} {
+		latest, cursor := requireLatestFromFile(t, cache, path, testMaxLineBytes, 1, boundedTestProjector)
+		want, wantCursor := latestGroupedTurns(full, 1)
+		if !reflect.DeepEqual(latest, want) || cursor != wantCursor {
+			t.Fatal("bounded goal read differs from full projection")
+		}
+		page := requirePageFromFile(t, cache, path, testMaxLineBytes, cursor, 1, boundedTestProjector)
+		if !reflect.DeepEqual(page.Turns, full[:1]) || page.NextCursor != "" {
+			t.Fatal("paging across a goal opener changed the prior turn")
+		}
+		count, err := cache.TurnCountFromFile(path, testMaxLineBytes, boundedTestProjector)
+		if err != nil || count != 2 {
+			t.Fatalf("indexed count = %d, err = %v; want 2", count, err)
+		}
+		window, _, err := cache.LatestItemWindowFromFile(path, testMaxLineBytes, ItemWindowOptions{ThreadRef: "local:th_1", Limit: 10}, boundedTestProjector)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var items []appwire.ThreadItem
+		for _, candidate := range window.Candidates {
+			items = append(items, candidate.Item)
+		}
+		wantItems := append(append([]appwire.ThreadItem{}, full[0].Items...), full[1].Items...)
+		if !reflect.DeepEqual(items, wantItems) {
+			t.Fatal("item paging changed goal item identity or display")
+		}
+	}
+}
+
+func TestGoalContinuationAppendedToIndexedTranscript(t *testing.T) {
+	const input = "a0f00f5a-0685-42d8-932d-2f606c4bb3f8"
+	path := writeEntries(t, reservedUserEntry(1, input, "turn_user"), assistantTextEntry(2, input))
+	cache := NewTurnCache()
+	requireLatestFromFile(t, cache, path, testMaxLineBytes, 1, boundedTestProjector)
+	goal := transcript.Entry{Kind: "entry", Seq: 3, Turn: schema.Turn{
+		Kind: schema.TurnSteering, Message: llm.User(input), StableTurnID: "turn_goal",
+		GoalContinuation: &schema.GoalContinuationInfo{Text: "29294482-adcf-430d-af21-9c8716a8c911"},
+	}}
+	appendFile(t, path, marshalEntryLine(t, goal))
+	latest, _ := requireLatestFromFile(t, cache, path, testMaxLineBytes, 1, boundedTestProjector)
+	if len(latest) != 1 || latest[0].ID != "turn_goal" || len(latest[0].Items) != 1 {
+		t.Fatal("appended goal notice did not open its own indexed turn")
+	}
+	appendFile(t, path, marshalEntryLine(t, assistantTextEntry(4, input)))
+	full := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
+	for _, reader := range []*TurnCache{cache, NewTurnCache()} {
+		latest, cursor := requireLatestFromFile(t, reader, path, testMaxLineBytes, 1, boundedTestProjector)
+		want, wantCursor := latestGroupedTurns(full, 1)
+		if !reflect.DeepEqual(latest, want) || cursor != wantCursor || len(latest[0].Items) != 2 {
+			t.Fatal("appended reply lost its goal opener across incremental or saved-index reads")
+		}
+	}
+}

--- a/internal/apptranscript/logical_turn.go
+++ b/internal/apptranscript/logical_turn.go
@@ -19,9 +19,9 @@ import (
 //
 // The grouping rule reproduces the live allocation from the file alone:
 //
-//   - USER_INPUT opens a logical turn. STEERING joins that open turn because
-//     live steering is attached to the active turn; only a steer with no open
-//     group starts a group of its own.
+//   - USER_INPUT and typed goal-continuation STEERING open a logical turn.
+//     Ordinary STEERING joins the open turn because live steering attaches
+//     to the active turn; with no open group it starts a group of its own.
 //   - CONTINUATIONS extend the open logical turn: ASSISTANT, TOOL,
 //     TOOL_RESULTS, and TURN_FAILURE (a failure closes nothing — the daemon
 //     may retry after a failure, and grouping it into the opener's turn keeps
@@ -32,13 +32,13 @@ import (
 //     turn, grouped with nothing, and CLOSES the open group. This matches live
 //     gap-turn semantics.
 //
-// Turn ids are exact for client-mutation turns (the opener's persisted
+// Turn ids are exact for client-mutation and goal turns (the opener's persisted
 // StableTurnID or its entry-index fallback) and stable-but-not-live-identical
-// for daemon-minted/continuation turns.
+// for other daemon-minted turns.
 
-// opensLogicalTurn reports whether a turn kind starts a new logical turn.
-func opensLogicalTurn(kind schema.TurnKind) bool {
-	return kind == schema.TurnUserInput
+// opensLogicalTurn distinguishes top-level goal input from ordinary steering.
+func opensLogicalTurn(kind schema.TurnKind, goalContinuation bool) bool {
+	return kind == schema.TurnUserInput || kind == schema.TurnSteering && goalContinuation
 }
 
 // continuesLogicalTurn reports whether a turn kind extends the open logical
@@ -56,7 +56,7 @@ func continuesLogicalTurn(kind schema.TurnKind) bool {
 // continuations once this kind has been appended: openers and continuations
 // leave a group open; standalone kinds close it.
 func groupOpenAfter(kind schema.TurnKind) bool {
-	return opensLogicalTurn(kind) || continuesLogicalTurn(kind)
+	return opensLogicalTurn(kind, false) || continuesLogicalTurn(kind)
 }
 
 // recordStartsGroup reports whether a record of this kind starts a new
@@ -64,8 +64,8 @@ func groupOpenAfter(kind schema.TurnKind) bool {
 // there is none). Openers always start a group; continuations join the open
 // group (start one only when the previous record closed it); standalone kinds
 // always start — and close — their own group.
-func recordStartsGroup(kind, prevKind schema.TurnKind) bool {
-	if opensLogicalTurn(kind) {
+func recordStartsGroup(kind, prevKind schema.TurnKind, goalContinuation bool) bool {
+	if opensLogicalTurn(kind, goalContinuation) {
 		return true
 	}
 	if continuesLogicalTurn(kind) {
@@ -104,7 +104,7 @@ type logicalTurnAccumulator struct {
 func (a *logicalTurnAccumulator) appendEntry(entry schema.Turn, entryIndex int, items []appwire.ThreadItem) {
 	kind := entry.Kind
 	switch {
-	case opensLogicalTurn(kind):
+	case opensLogicalTurn(kind, entry.GoalContinuation != nil):
 		a.turns = append(a.turns, groupedTurn{turnID: persistedTurnID(entry, entryIndex)})
 		a.open = true
 	case continuesLogicalTurn(kind) && a.open && len(a.turns) > 0:

--- a/internal/apptranscript/turn_index.go
+++ b/internal/apptranscript/turn_index.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	turnIndexVersion        = 11
+	turnIndexVersion        = 12
 	turnIndexJournalVersion = 3
 	turnIndexAnchorBytes    = 256
 
@@ -164,10 +164,13 @@ type indexedTurn struct {
 	// number of items this record contributes to its group's MERGED count
 	// and GroupCalls the call ids its merged items introduce (the counting
 	// form of mergeGroupedItems).
-	TurnKind   schema.TurnKind `json:"turn_kind,omitempty"`
-	TurnID     string          `json:"turn_id,omitempty"`
-	GroupItems uint32          `json:"group_items,omitempty"`
-	GroupCalls []string        `json:"group_calls,omitempty"`
+	TurnKind schema.TurnKind `json:"turn_kind,omitempty"`
+	// GoalContinuation distinguishes a top-level goal opener from ordinary
+	// steering without retaining model or display text in the derived index.
+	GoalContinuation bool     `json:"goal_continuation,omitempty"`
+	TurnID           string   `json:"turn_id,omitempty"`
+	GroupItems       uint32   `json:"group_items,omitempty"`
+	GroupCalls       []string `json:"group_calls,omitempty"`
 }
 
 // groupRole classifies a record within its logical turn group.
@@ -185,9 +188,9 @@ const (
 )
 
 // groupRoleFor classifies a turn kind's role in a logical turn.
-func groupRoleFor(kind schema.TurnKind) groupRole {
+func groupRoleFor(kind schema.TurnKind, goalContinuation bool) groupRole {
 	switch {
-	case opensLogicalTurn(kind):
+	case opensLogicalTurn(kind, goalContinuation):
 		return groupOpener
 	case continuesLogicalTurn(kind):
 		return groupContinuation
@@ -255,7 +258,7 @@ func (d turnIndexDisk) logicalTurnCount() int {
 	groupItems := uint64(0)
 	for i := range n {
 		record := d.recordAt(i)
-		if i > 0 && recordStartsGroup(record.TurnKind, d.recordAt(i-1).TurnKind) {
+		if i > 0 && recordStartsGroup(record.TurnKind, d.recordAt(i-1).TurnKind, record.GoalContinuation) {
 			// The previous group just closed: count it when it projected
 			// items.
 			if groupItems > 0 {
@@ -300,7 +303,7 @@ func (d turnIndexDisk) indexedGroups() []indexedGroup {
 	n := d.recordCount()
 	for i := range n {
 		record := d.recordAt(i)
-		role := groupRoleFor(record.TurnKind)
+		role := groupRoleFor(record.TurnKind, record.GoalContinuation)
 		join := role == groupContinuation && len(groups) > 0 && groups[len(groups)-1].open
 		if join {
 			group := &groups[len(groups)-1]
@@ -885,6 +888,7 @@ func scanTurnIndexWithCommitContext(ctx context.Context, file *os.File, transcri
 			}
 			entryIndex++
 			record := indexedTurn{Offset: offset, Length: length, Index: entryIndex, Kind: entry.Kind, TurnKind: entry.Turn.Kind}
+			record.GoalContinuation = entry.Turn.Kind == schema.TurnSteering && entry.Turn.GoalContinuation != nil
 			record.ToolSeed, record.ToolChanges = toolProjectionState(entry, projectNames)
 			// Logical-group bookkeeping runs BEFORE projection: the entry is
 			// projected under its group's turn id (the opener's), exactly
@@ -897,7 +901,7 @@ func scanTurnIndexWithCommitContext(ctx context.Context, file *os.File, transcri
 			} else if n := index.recordCount(); n > 0 {
 				prevKind = index.recordAt(n - 1).TurnKind
 			}
-			if recordStartsGroup(entry.Turn.Kind, prevKind) {
+			if recordStartsGroup(entry.Turn.Kind, prevKind, record.GoalContinuation) {
 				openTurnID = record.TurnID
 				openCalls = map[string]bool{}
 			} else if openCalls == nil || openTurnID == "" {
@@ -1158,7 +1162,7 @@ func projectIndexedRangeObservedContext(ctx context.Context, path string, index 
 		// groups: find where this group's span ends, then decide whether to
 		// project it.
 		spanEnd := i + 1
-		for spanEnd < n && !recordStartsGroup(index.recordAt(spanEnd).TurnKind, index.recordAt(spanEnd-1).TurnKind) {
+		for spanEnd < n && !recordStartsGroup(index.recordAt(spanEnd).TurnKind, index.recordAt(spanEnd-1).TurnKind, index.recordAt(spanEnd).GoalContinuation) {
 			spanEnd++
 		}
 		groupItems := uint64(0)
@@ -1769,7 +1773,7 @@ func openGroupState(index turnIndexDisk) (string, map[string]bool) {
 			calls[id] = true
 		}
 		turnID = record.TurnID
-		if i == 0 || recordStartsGroup(record.TurnKind, index.recordAt(i-1).TurnKind) {
+		if i == 0 || recordStartsGroup(record.TurnKind, index.recordAt(i-1).TurnKind, record.GoalContinuation) {
 			break
 		}
 	}


### PR DESCRIPTION
Goal continuations now retain their display notice and stable turn identity in persisted history. Full reads, indexed reads and pagination place the continuation and its replies in their own logical turn, matching the live stream. The complete model input remains available for model replay.

Keep the typed persistence field, producer change, transcript projection and index grouping together. The derived index version advances so existing caches rebuild with the correct grouping. Unrelated shutdown and environment-event changes are excluded.

Three regressions fail before the fix and pass afterward. The full transcript suite passes with the race detector, relevant vet passes, and independent Luna review is clean.

Extracted as a focused prerequisite from the preserved iPhone checkpoint.
