### PR TITLE
fix(client): validate and publish successful AppWire handshakes

### DIFF
--- a/cmd/evener-hub/frontend/src/protocol/client.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.test.ts
@@ -96,6 +96,30 @@ describe("decodeInitializeResponse", () => {
     ).toThrow("invalid initialize response");
   });
 
+  test.each([
+    ["serverInfo", { ...FAKE_INITIALIZE_RESULT, serverInfo: { name: "hub" } }],
+    ["protocolVersion", { ...FAKE_INITIALIZE_RESULT, protocolVersion: "" }],
+    ["sourceId", { ...FAKE_INITIALIZE_RESULT, sourceId: "" }],
+    ["features", { ...FAKE_INITIALIZE_RESULT, features: { ...FAKE_INITIALIZE_RESULT.features, tasks: "yes" } }],
+    ["navigation", { ...FAKE_INITIALIZE_RESULT, navigation: null }],
+    [
+      "navigation.readVersions",
+      {
+        ...FAKE_INITIALIZE_RESULT,
+        navigation: { version: 1, generationId: "generation", sequence: 0, readVersions: [0] },
+      },
+    ],
+  ])("reports the malformed initialize field %s without payload values", (field, value) => {
+    let error: unknown;
+    try {
+      decodeInitializeResponse(value);
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toMatchObject({ field, name: "InitializeValidationError" });
+    expect(error).toHaveProperty("message", `invalid initialize response at ${field}`);
+  });
+
   test("accepts and preserves maximum safe navigation integers", () => {
     const response = {
       ...FAKE_INITIALIZE_RESULT,
@@ -464,8 +488,10 @@ describe("AppwireClient", () => {
     await flushUntil(() => reconnectSocket.sent.length > 0);
     const reconnect = lastSentFrame(reconnectSocket);
     reconnectSocket.receive({ id: reconnect.id, result: { protocolVersion: APPWIRE_PROTOCOL_VERSION } });
-    await flushUntil(() => client.state === "reconnecting");
+    await flushUntil(() => client.state === "closed");
 
+    expect(client.state).toBe("closed");
+    expect(client.terminalReason).toBe("protocol");
     expect(versions).toEqual(["0.0.0-test"]);
   });
 

--- a/cmd/evener-hub/frontend/src/protocol/client.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.test.ts
@@ -229,6 +229,57 @@ describe("AppwireClient", () => {
     expect(client.terminalReason).toBe("protocol");
   });
 
+  test("a malformed initial handshake is a terminal protocol failure", async () => {
+    const fake = new FakeSocket();
+    const client = new AppwireClient({ url: "ws://x/rpc", socketFactory: () => fake });
+    const connecting = connectReady(fake, client);
+    await flushUntil(() => fake.sent.length > 0);
+    fake.receive({ id: lastSentFrame(fake).id, result: { ...FAKE_INITIALIZE_RESULT, features: null } });
+
+    await expect(connecting).rejects.toThrow("invalid initialize response");
+    expect(client.state).toBe("closed");
+    expect(client.terminalReason).toBe("protocol");
+  });
+
+  test("a malformed reconnect handshake closes without retrying or publishing ready", async () => {
+    const sockets: FakeSocket[] = [];
+    const client = new AppwireClient({
+      url: "ws://x/rpc",
+      socketFactory: () => {
+        const socket = new FakeSocket({ autoInitialize: sockets.length === 0 });
+        sockets.push(socket);
+        return socket;
+      },
+    });
+    const ready = vi.fn();
+    const handshakes = vi.fn();
+    client.onReady(ready);
+    client.onHandshakeResult(handshakes);
+    const connecting = client.connect();
+    const initial = sockets[0];
+    if (!initial) throw new Error("expected initial socket");
+    initial.open();
+    await connecting;
+    initial.closeFromServer(1006);
+    await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS);
+    const reconnect = sockets[1];
+    if (!reconnect) throw new Error("expected reconnect socket");
+    reconnect.open();
+    await flushUntil(() => reconnect.sent.length > 0);
+    reconnect.receive({
+      id: lastSentFrame(reconnect).id,
+      result: { ...FAKE_INITIALIZE_RESULT, serverInfo: { name: "hub" } },
+    });
+    await flushUntil(() => reconnect.closeRequests.length > 0);
+
+    expect(client.state).toBe("closed");
+    expect(client.terminalReason).toBe("protocol");
+    await vi.runAllTimersAsync();
+    expect(sockets).toHaveLength(2);
+    expect(ready).toHaveBeenCalledTimes(1);
+    expect(handshakes).toHaveBeenCalledTimes(1);
+  });
+
   test("connect is idempotent across concurrent callers", async () => {
     const fake = new FakeSocket({ autoInitialize: true });
     let socketsCreated = 0;

--- a/cmd/evener-hub/frontend/src/protocol/client.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.test.ts
@@ -6,6 +6,7 @@ import {
   APPWIRE_PROTOCOL_VERSION,
   AppwireClient,
   type ConnectionState,
+  decodeInitializeResponse,
   RECONNECT_BASE_MS,
 } from "./client";
 import { ConnectionClosedError, RequestTimeoutError, WireError } from "./errors";
@@ -61,6 +62,68 @@ describe("rpcURLFromLocation", () => {
 
   test("upgrades http to ws", () => {
     expect(rpcURLFromLocation({ protocol: "http:", host: "localhost:5173" })).toBe("ws://localhost:5173/rpc");
+  });
+});
+
+describe("decodeInitializeResponse", () => {
+  test("accepts and preserves the exact typed handshake identity", () => {
+    expect(decodeInitializeResponse(FAKE_INITIALIZE_RESULT)).toEqual(FAKE_INITIALIZE_RESULT);
+  });
+
+  test("accepts and preserves known optional navigation and feature fields", () => {
+    const response = {
+      ...FAKE_INITIALIZE_RESULT,
+      features: { ...FAKE_INITIALIZE_RESULT.features, transcriptDisplaySettings: true },
+      navigation: { version: 1, generationId: "test-navigation-generation", sequence: 0 },
+    };
+    expect(decodeInitializeResponse(response)).toEqual(response);
+  });
+
+  test.each([true, false])("accepts the v4 keybindings capability %s", (keybindingsSettings) => {
+    const response = {
+      ...FAKE_INITIALIZE_RESULT,
+      features: { ...FAKE_INITIALIZE_RESULT.features, keybindingsSettings },
+    };
+    expect(decodeInitializeResponse(response)).toEqual(response);
+  });
+
+  test("rejects a malformed v4 keybindings capability", () => {
+    expect(() =>
+      decodeInitializeResponse({
+        ...FAKE_INITIALIZE_RESULT,
+        features: { ...FAKE_INITIALIZE_RESULT.features, keybindingsSettings: "yes" },
+      }),
+    ).toThrow("invalid initialize response");
+  });
+
+  test("accepts and preserves maximum safe navigation integers", () => {
+    const response = {
+      ...FAKE_INITIALIZE_RESULT,
+      navigation: {
+        version: Number.MAX_SAFE_INTEGER,
+        generationId: "maximum-safe-navigation-generation",
+        sequence: Number.MAX_SAFE_INTEGER,
+      },
+    };
+    expect(decodeInitializeResponse(response)).toEqual(response);
+  });
+
+  test.each([
+    ["missing server version", { ...FAKE_INITIALIZE_RESULT, serverInfo: { name: "hub" } }],
+    ["empty protocol", { ...FAKE_INITIALIZE_RESULT, protocolVersion: "" }],
+    [
+      "malformed features",
+      { ...FAKE_INITIALIZE_RESULT, features: { ...FAKE_INITIALIZE_RESULT.features, tasks: "yes" } },
+    ],
+    ["extra top-level key", { ...FAKE_INITIALIZE_RESULT, bearerToken: "never" }],
+    ["null navigation", { ...FAKE_INITIALIZE_RESULT, navigation: null }],
+    ["incomplete navigation", { ...FAKE_INITIALIZE_RESULT, navigation: { version: 1, generationId: "generation" } }],
+    [
+      "malformed navigation",
+      { ...FAKE_INITIALIZE_RESULT, navigation: { version: "1", generationId: "generation", sequence: 0 } },
+    ],
+  ])("rejects %s", (_name, value) => {
+    expect(() => decodeInitializeResponse(value)).toThrow("invalid initialize response");
   });
 });
 
@@ -285,6 +348,74 @@ describe("AppwireClient", () => {
 
     await terminalRejection;
     expect(socketsCreated).toBe(1);
+  });
+
+  test("publishes each strictly decoded initial and reconnect handshake exactly once", async () => {
+    const sockets: FakeSocket[] = [];
+    const client = new AppwireClient({
+      url: "ws://x/rpc",
+      socketFactory: () => {
+        const socket = new FakeSocket();
+        sockets.push(socket);
+        return socket;
+      },
+    });
+    const versions: string[] = [];
+    client.onHandshakeResult((result) => versions.push(result.serverInfo.version));
+
+    const connecting = client.connect();
+    const initialSocket = sockets[0];
+    if (!initialSocket) throw new Error("expected initial socket");
+    initialSocket.open();
+    await flushUntil(() => initialSocket.sent.length > 0);
+    const initial = lastSentFrame(initialSocket);
+    initialSocket.receive({ id: initial.id, result: FAKE_INITIALIZE_RESULT });
+    await connecting;
+    expect(versions).toEqual(["0.0.0-test"]);
+
+    initialSocket.closeFromServer(1006);
+    await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS);
+    const reconnectSocket = sockets[1];
+    if (!reconnectSocket) throw new Error("expected reconnect socket");
+    reconnectSocket.open();
+    await flushUntil(() => reconnectSocket.sent.length > 0);
+    const reconnect = lastSentFrame(reconnectSocket);
+    reconnectSocket.receive({
+      id: reconnect.id,
+      result: { ...FAKE_INITIALIZE_RESULT, serverInfo: { name: "new-hub", version: "2.0.0" } },
+    });
+    await flushUntil(() => client.state === "ready");
+
+    expect(versions).toEqual(["0.0.0-test", "2.0.0"]);
+  });
+
+  test("does not publish a malformed reconnect handshake", async () => {
+    const sockets: FakeSocket[] = [];
+    const client = new AppwireClient({
+      url: "ws://x/rpc",
+      socketFactory: () => {
+        const socket = new FakeSocket({ autoInitialize: sockets.length === 0 });
+        sockets.push(socket);
+        return socket;
+      },
+    });
+    const versions: string[] = [];
+    client.onHandshakeResult((result) => versions.push(result.serverInfo.version));
+
+    const connecting = client.connect();
+    sockets[0]?.open();
+    await connecting;
+    sockets[0]?.closeFromServer(1006);
+    await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS);
+    const reconnectSocket = sockets[1];
+    if (!reconnectSocket) throw new Error("expected reconnect socket");
+    reconnectSocket.open();
+    await flushUntil(() => reconnectSocket.sent.length > 0);
+    const reconnect = lastSentFrame(reconnectSocket);
+    reconnectSocket.receive({ id: reconnect.id, result: { protocolVersion: APPWIRE_PROTOCOL_VERSION } });
+    await flushUntil(() => client.state === "reconnecting");
+
+    expect(versions).toEqual(["0.0.0-test"]);
   });
 
   test("request resolves the matching id and types the result", async () => {

--- a/cmd/evener-hub/frontend/src/protocol/client.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.ts
@@ -34,9 +34,12 @@ class ProtocolVersionMismatchError extends Error {
 }
 
 class InitializeValidationError extends Error {
-  constructor() {
-    super("invalid initialize response");
+  readonly field: string;
+
+  constructor(field: string) {
+    super(`invalid initialize response at ${field}`);
     this.name = "InitializeValidationError";
+    this.field = field;
   }
 }
 
@@ -146,7 +149,7 @@ export function decodeInitializeResponse(value: unknown): InitializeResponse {
     !isRecord(value) ||
     !hasRequiredAndOptionalKeys(value, INITIALIZE_RESPONSE_KEYS, INITIALIZE_RESPONSE_OPTIONAL_KEYS)
   ) {
-    throw new InitializeValidationError();
+    throw new InitializeValidationError("response");
   }
   const serverInfo = value.serverInfo;
   const features = value.features;
@@ -157,31 +160,50 @@ export function decodeInitializeResponse(value: unknown): InitializeResponse {
     typeof serverInfo.name !== "string" ||
     serverInfo.name.trim() === "" ||
     typeof serverInfo.version !== "string" ||
-    serverInfo.version.trim() === "" ||
-    typeof value.protocolVersion !== "string" ||
-    value.protocolVersion.trim() === "" ||
-    typeof value.sourceId !== "string" ||
-    value.sourceId.trim() === "" ||
+    serverInfo.version.trim() === ""
+  ) {
+    throw new InitializeValidationError("serverInfo");
+  }
+  if (typeof value.protocolVersion !== "string" || value.protocolVersion.trim() === "") {
+    throw new InitializeValidationError("protocolVersion");
+  }
+  if (typeof value.sourceId !== "string" || value.sourceId.trim() === "") {
+    throw new InitializeValidationError("sourceId");
+  }
+  if (
     !isRecord(features) ||
     !hasRequiredAndOptionalKeys(features, FEATURE_KEYS, FEATURE_OPTIONAL_KEYS) ||
     FEATURE_KEYS.some((key) => typeof features[key] !== "boolean") ||
-    FEATURE_OPTIONAL_KEYS.some((key) => Object.hasOwn(features, key) && typeof features[key] !== "boolean") ||
-    (Object.hasOwn(value, "navigation") &&
-      (!isRecord(navigation) ||
-        !hasRequiredAndOptionalKeys(navigation, NAVIGATION_CAPABILITY_KEYS, ["readVersions"]) ||
-        (Object.hasOwn(navigation, "readVersions") &&
-          (!Array.isArray(navigation.readVersions) ||
-            navigation.readVersions.some((version) => !Number.isSafeInteger(version) || version < 1))) ||
-        typeof navigation.version !== "number" ||
-        !Number.isSafeInteger(navigation.version) ||
-        navigation.version < 1 ||
-        typeof navigation.generationId !== "string" ||
-        navigation.generationId.trim() === "" ||
-        typeof navigation.sequence !== "number" ||
-        !Number.isSafeInteger(navigation.sequence) ||
-        navigation.sequence < 0))
+    FEATURE_OPTIONAL_KEYS.some((key) => Object.hasOwn(features, key) && typeof features[key] !== "boolean")
   ) {
-    throw new InitializeValidationError();
+    throw new InitializeValidationError("features");
+  }
+  if (Object.hasOwn(value, "navigation")) {
+    if (
+      !isRecord(navigation) ||
+      !hasRequiredAndOptionalKeys(navigation, NAVIGATION_CAPABILITY_KEYS, ["readVersions"])
+    ) {
+      throw new InitializeValidationError("navigation");
+    }
+    if (
+      Object.hasOwn(navigation, "readVersions") &&
+      (!Array.isArray(navigation.readVersions) ||
+        navigation.readVersions.some((version) => !Number.isSafeInteger(version) || version < 1))
+    ) {
+      throw new InitializeValidationError("navigation.readVersions");
+    }
+    if (
+      typeof navigation.version !== "number" ||
+      !Number.isSafeInteger(navigation.version) ||
+      navigation.version < 1 ||
+      typeof navigation.generationId !== "string" ||
+      navigation.generationId.trim() === "" ||
+      typeof navigation.sequence !== "number" ||
+      !Number.isSafeInteger(navigation.sequence) ||
+      navigation.sequence < 0
+    ) {
+      throw new InitializeValidationError("navigation");
+    }
   }
   return value as unknown as InitializeResponse;
 }

--- a/cmd/evener-hub/frontend/src/protocol/client.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.ts
@@ -33,6 +33,13 @@ class ProtocolVersionMismatchError extends Error {
   }
 }
 
+class InitializeValidationError extends Error {
+  constructor() {
+    super("invalid initialize response");
+    this.name = "InitializeValidationError";
+  }
+}
+
 // HandshakeRejectedError marks an initialize the server REFUSED, as opposed to
 // one it answered with a version we do not speak. A daemon that disagrees about
 // the protocol rejects with InvalidRequest rather than replying with its own
@@ -139,7 +146,7 @@ export function decodeInitializeResponse(value: unknown): InitializeResponse {
     !isRecord(value) ||
     !hasRequiredAndOptionalKeys(value, INITIALIZE_RESPONSE_KEYS, INITIALIZE_RESPONSE_OPTIONAL_KEYS)
   ) {
-    throw new Error("invalid initialize response");
+    throw new InitializeValidationError();
   }
   const serverInfo = value.serverInfo;
   const features = value.features;
@@ -174,7 +181,7 @@ export function decodeInitializeResponse(value: unknown): InitializeResponse {
         !Number.isSafeInteger(navigation.sequence) ||
         navigation.sequence < 0))
   ) {
-    throw new Error("invalid initialize response");
+    throw new InitializeValidationError();
   }
   return value as unknown as InitializeResponse;
 }
@@ -460,7 +467,11 @@ export class AppwireClient {
   // connect (performHandshake) and every reconnect attempt, so both paths
   // leave the same evidence for ConnectionBanner's "reload this page" copy.
   private noteProtocolFailure(error: unknown): boolean {
-    if (error instanceof ProtocolVersionMismatchError || error instanceof HandshakeRejectedError) {
+    if (
+      error instanceof ProtocolVersionMismatchError ||
+      error instanceof HandshakeRejectedError ||
+      error instanceof InitializeValidationError
+    ) {
       this.terminalReasonValue = "protocol";
       return true;
     }

--- a/cmd/evener-hub/frontend/src/protocol/client.ts
+++ b/cmd/evener-hub/frontend/src/protocol/client.ts
@@ -99,6 +99,86 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
+const INITIALIZE_RESPONSE_KEYS = ["serverInfo", "protocolVersion", "sourceId", "features"] as const;
+const INITIALIZE_RESPONSE_OPTIONAL_KEYS = ["navigation"] as const;
+
+const FEATURE_KEYS = [
+  "threadList",
+  "threadTurnsList",
+  "turnStart",
+  "turnSteer",
+  "threadClear",
+  "threadShutdown",
+  "forkFromTurn",
+  "tasks",
+  "transcriptList",
+  "modelList",
+  "directoryComplete",
+  "auth",
+] as const;
+const FEATURE_OPTIONAL_KEYS = ["transcriptDisplaySettings", "keybindingsSettings"] as const;
+const NAVIGATION_CAPABILITY_KEYS = ["version", "generationId", "sequence"] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasRequiredAndOptionalKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+): boolean {
+  const actual = Object.keys(value);
+  const allowed = new Set([...required, ...optional]);
+  return required.every((key) => Object.hasOwn(value, key)) && actual.every((key) => allowed.has(key));
+}
+
+/** Runtime boundary for the untyped JSON-RPC initialize result. */
+export function decodeInitializeResponse(value: unknown): InitializeResponse {
+  if (
+    !isRecord(value) ||
+    !hasRequiredAndOptionalKeys(value, INITIALIZE_RESPONSE_KEYS, INITIALIZE_RESPONSE_OPTIONAL_KEYS)
+  ) {
+    throw new Error("invalid initialize response");
+  }
+  const serverInfo = value.serverInfo;
+  const features = value.features;
+  const navigation = value.navigation;
+  if (
+    !isRecord(serverInfo) ||
+    !hasRequiredAndOptionalKeys(serverInfo, ["name", "version"]) ||
+    typeof serverInfo.name !== "string" ||
+    serverInfo.name.trim() === "" ||
+    typeof serverInfo.version !== "string" ||
+    serverInfo.version.trim() === "" ||
+    typeof value.protocolVersion !== "string" ||
+    value.protocolVersion.trim() === "" ||
+    typeof value.sourceId !== "string" ||
+    value.sourceId.trim() === "" ||
+    !isRecord(features) ||
+    !hasRequiredAndOptionalKeys(features, FEATURE_KEYS, FEATURE_OPTIONAL_KEYS) ||
+    FEATURE_KEYS.some((key) => typeof features[key] !== "boolean") ||
+    FEATURE_OPTIONAL_KEYS.some((key) => Object.hasOwn(features, key) && typeof features[key] !== "boolean") ||
+    (Object.hasOwn(value, "navigation") &&
+      (!isRecord(navigation) ||
+        !hasRequiredAndOptionalKeys(navigation, NAVIGATION_CAPABILITY_KEYS, ["readVersions"]) ||
+        (Object.hasOwn(navigation, "readVersions") &&
+          (!Array.isArray(navigation.readVersions) ||
+            navigation.readVersions.some((version) => !Number.isSafeInteger(version) || version < 1))) ||
+        typeof navigation.version !== "number" ||
+        !Number.isSafeInteger(navigation.version) ||
+        navigation.version < 1 ||
+        typeof navigation.generationId !== "string" ||
+        navigation.generationId.trim() === "" ||
+        typeof navigation.sequence !== "number" ||
+        !Number.isSafeInteger(navigation.sequence) ||
+        navigation.sequence < 0))
+  ) {
+    throw new Error("invalid initialize response");
+  }
+  return value as unknown as InitializeResponse;
+}
+
 export class AppwireClient {
   private readonly url: string;
   private readonly socketFactory: (url: string) => WebSocketLike;
@@ -123,6 +203,7 @@ export class AppwireClient {
   private handshakeReject: ((err: Error) => void) | null = null;
   private readonly notificationHandlers = new Set<(n: AnyNotification) => void>();
   private readonly stateChangeHandlers = new Set<(s: ConnectionState) => void>();
+  private readonly handshakeResultHandlers = new Set<(result: InitializeResponse) => void>();
   private readonly readyHandlers = new Set<(initialize: InitializeResponse) => void>();
   private connectPromise: Promise<InitializeResponse> | null = null;
   private latestInitialize: InitializeResponse | null = null;
@@ -322,6 +403,16 @@ export class AppwireClient {
     };
   }
 
+  // Publishes the strictly decoded initialize result for every socket that
+  // completes the handshake, including automatic reconnects. Results are
+  // emitted only while that socket is still the client's current generation.
+  onHandshakeResult(cb: (result: InitializeResponse) => void): () => void {
+    this.handshakeResultHandlers.add(cb);
+    return () => {
+      this.handshakeResultHandlers.delete(cb);
+    };
+  }
+
   // onReady fires on every transition into "ready", including future
   // reconnects.
   onReady(cb: (initialize: InitializeResponse) => void): () => void {
@@ -403,7 +494,7 @@ export class AppwireClient {
     socket.onerror = () => this.handleSocketError();
     socket.onclose = (ev) => this.handleSocketLoss(socket, ev.code);
 
-    const result = await this.request("initialize", {
+    const rawResult = await this.request("initialize", {
       protocolVersion: APPWIRE_PROTOCOL_VERSION,
       clientInfo: this.clientInfo,
       capabilities: DEFAULT_CAPABILITIES,
@@ -413,16 +504,31 @@ export class AppwireClient {
       }
       throw error;
     });
+    const result = decodeInitializeResponse(rawResult);
     if (result.protocolVersion !== APPWIRE_PROTOCOL_VERSION) {
       throw new ProtocolVersionMismatchError(result.protocolVersion);
     }
     this.sendFrame({ method: "initialized", params: {} });
     this.enterReady(result);
+    if (!this.isClosed() && this.socket === socket) {
+      this.publishHandshakeResult(result);
+    }
     // The handshake itself genuinely succeeded, so this still resolves with
     // `result` even if a reentrant close() just ran: only the side effect
     // (arming a timer this client will never get to disarm again) is guarded.
     if (!this.isClosed()) this.armHeartbeat();
     return result;
+  }
+
+  private publishHandshakeResult(result: InitializeResponse): void {
+    for (const cb of Array.from(this.handshakeResultHandlers)) {
+      try {
+        cb(result);
+      } catch {
+        // A subscriber cannot turn a successful protocol handshake into a
+        // connection failure.
+      }
+    }
   }
 
   // teardownFailedSocket clears a socket that dialAndHandshake failed to
@@ -639,7 +745,10 @@ export class AppwireClient {
       return;
     }
     if (msg.method) {
-      const notification = { method: msg.method, params: msg.params ?? {} } as AnyNotification;
+      const notification = {
+        method: msg.method,
+        params: msg.params ?? {},
+      } as AnyNotification;
       for (const handler of Array.from(this.notificationHandlers)) {
         try {
           handler(notification);


### PR DESCRIPTION
The TypeScript client validates the initialize JSON at runtime before entering ready state. Consumers can observe each successful initial connection or reconnect through onHandshakeResult. Malformed responses close with a terminal protocol reason, stop reconnect retries, and are not published as successful handshakes. Validation errors identify a static field path without echoing server payload values.

The prerequisites #1081 and #1071 are merged. This branch is refreshed onto main e80594562, and its diff is confined to client.ts and client.test.ts. The refreshed files are byte-identical to the reviewed client update, and all 87 focused tests pass again; fresh main-targeted CI and RoboRev are running.

The selected checkpoint retains its strict initialize schema. The takeover instructions require updating the boundary against current server serialization rather than broadly relaxing validation. Required fields, known optional capabilities, navigation readVersions and integer bounds are checked; unknown fields remain rejected. Supporting additive unknown fields would be a separate protocol-evolution decision. The review's early reconnect assertion is fixed by awaiting terminal close, and its diagnostic gap is fixed with field-specific errors.

All 87 focused client and reconnect tests pass, including red/green malformed-response and diagnostic regressions. Biome passes, and root reviewed the final decoder branches. The canonical local web gate passes with the separate provider-dialog import synchronization in #1079; the temporary overlay is removed from this branch. Fresh CI and RoboRev apply to the published head.

Extracted as a focused prerequisite from the preserved iPhone checkpoint. Higher-level state extraction has not started.
