### PR TITLE
perf(hub): skip persisted task and delegate detail in session lists

### DIFF
--- a/cmd/evener-hub/app_threadlist.go
+++ b/cmd/evener-hub/app_threadlist.go
@@ -52,7 +52,7 @@ func hubThreadList(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 			if _, ok := liveIDs[threadListSourceKey("local", entry.ID)]; ok {
 				continue
 			}
-			thread, err := pastEntryThread(ctx, cfg, entry, false)
+			thread, err := pastEntryThreadForList(ctx, cfg, entry)
 			if err != nil {
 				return appwire.ThreadListResponse{}, err
 			}
@@ -159,7 +159,7 @@ func mergePastMetadataForList(ctx context.Context, cfg hubcore.WebConfig, source
 	if !ok {
 		return live, nil
 	}
-	past, err := pastEntryThread(ctx, cfg, entry, false)
+	past, err := pastEntryThreadForList(ctx, cfg, entry)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return appwire.Thread{}, ctxErr

--- a/cmd/evener-hub/app_threadlist_metadata_test.go
+++ b/cmd/evener-hub/app_threadlist_metadata_test.go
@@ -1,0 +1,90 @@
+package hub
+
+import (
+	"context"
+	"testing"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/task"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/identifier"
+)
+
+func TestHubThreadListPastRowsKeepCheapMetadataWithoutHydratingDetail(t *testing.T) {
+	cfg, sessionID, stateDir := seedPastSessionWithTasks(t, []task.TaskInput{
+		{Type: task.TaskTypeImplement, Description: "distinctive persisted detail", Prompt: "ship it"},
+	})
+	meta, err := schema.LoadSessionMeta(stateDir, sessionID)
+	if err != nil {
+		t.Fatalf("load fixture metadata: %v", err)
+	}
+	meta.Goal = &schema.GoalSnapshot{Objective: "persisted list goal", Status: "active", Iterations: 3}
+	meta.WorkMillis = 4200
+	meta.CumulativeUsage = schema.CumulativeUsage{InputTokens: 600, OutputTokens: 400, TotalTokens: 1000}
+	meta.VisionModel = "off"
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatalf("save fixture metadata: %v", err)
+	}
+	if _, err := cfg.Past.Rebuild(); err != nil {
+		t.Fatalf("rebuild fixture index: %v", err)
+	}
+
+	response, err := hubThreadList(context.Background(), cfg, appsource.NewRegistry(), appwire.ThreadListParams{})
+	if err != nil {
+		t.Fatalf("hubThreadList: %v", err)
+	}
+	if len(response.Data) != 1 {
+		t.Fatalf("thread list = %+v, want one past row", response.Data)
+	}
+	row := response.Data[0]
+	if row.ID != sessionID || row.ModelProvider != "gpt-5" || row.CWD != "/tmp/project" {
+		t.Fatalf("past row metadata = %+v, want session/model/cwd preserved", row)
+	}
+	if row.Evener.Tasks != nil {
+		t.Fatalf("past list hydrated task detail = %+v, want absent", row.Evener.Tasks)
+	}
+	if row.Evener.Capabilities == (appwire.ThreadCapabilities{}) {
+		t.Fatal("past list dropped cheap capability metadata")
+	}
+	if row.Evener.Goal == nil || row.Evener.Goal.Objective != "persisted list goal" || row.Evener.WorkMillis != 4200 || row.Evener.Usage == nil || row.Evener.Usage.TotalTokens != 1000 || row.Evener.VisionModel != "off" {
+		t.Fatalf("past list cheap metadata = %+v, want persisted goal/usage/work/cost/vision", row.Evener)
+	}
+
+	detail, ok, err := pastThreadForRead(context.Background(), cfg, appwire.ThreadReadParams{Ref: "local:" + sessionID})
+	if err != nil || !ok {
+		t.Fatalf("pastThreadForRead = (%+v, %t, %v), want detail", detail, ok, err)
+	}
+	if detail.Evener.Tasks == nil || detail.Evener.Tasks.Total != 1 || detail.Evener.Tasks.Remaining != 1 {
+		t.Fatalf("past thread detail = %+v, want persisted task", detail.Evener.Tasks)
+	}
+	if detail.Evener.Goal == nil || detail.Evener.Goal.Objective != "persisted list goal" || detail.Evener.WorkMillis != 4200 || detail.Evener.Usage == nil || detail.Evener.Usage.TotalTokens != 1000 || detail.Evener.Cost != row.Evener.Cost || detail.Evener.VisionModel != "off" {
+		t.Fatalf("past thread cheap metadata = %+v, want same persisted values", detail.Evener)
+	}
+}
+
+func TestPastThreadReadPreservesProjectIdentity(t *testing.T) {
+	cfg, sessionID, stateDir := seedPastSessionWithTasks(t, nil)
+	meta, err := schema.LoadSessionMeta(stateDir, sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.EnvInfo.WorkingDir = t.TempDir()
+	project, err := identifier.ResolveProject(meta.EnvInfo.WorkingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := schema.SaveSessionMeta(stateDir, meta); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cfg.Past.Rebuild(); err != nil {
+		t.Fatal(err)
+	}
+	thread, ok, err := pastThreadForRead(context.Background(), cfg, appwire.ThreadReadParams{Ref: "local:" + sessionID})
+	if err != nil || !ok {
+		t.Fatalf("pastThreadForRead = (%t, %v), want detail", ok, err)
+	}
+	if thread.ProjectID != project.ID || thread.ProjectPath != project.CanonicalPath {
+		t.Fatalf("project = (%q, %q), want (%q, %q)", thread.ProjectID, thread.ProjectPath, project.ID, project.CanonicalPath)
+	}
+}

--- a/cmd/evener-hub/app_threadread.go
+++ b/cmd/evener-hub/app_threadread.go
@@ -442,7 +442,10 @@ func pastThreadCapabilities() appwire.ThreadCapabilities {
 	return caps
 }
 
-func pastEntryThread(ctx context.Context, cfg hubcore.WebConfig, entry hubcore.PastEntry, includeTurns bool) (appwire.Thread, error) {
+func pastEntryThreadForList(ctx context.Context, cfg hubcore.WebConfig, entry hubcore.PastEntry) (appwire.Thread, error) {
+	if err := ctx.Err(); err != nil {
+		return appwire.Thread{}, err
+	}
 	title := schema.SessionDisplayName(entry.Meta)
 	if title == "" {
 		title = entry.Meta.ID
@@ -511,7 +514,6 @@ func pastEntryThread(ctx context.Context, cfg hubcore.WebConfig, entry hubcore.P
 			ParentRef:    parentRef,
 			Kind:         kind,
 			Profile:      entry.Meta.ProfileID,
-			Tasks:        persistedTaskAggregate(entry.StateDir, entry.Meta.ID),
 			Goal:         persistedGoalState(entry.Meta.Goal),
 			Capabilities: pastThreadCapabilities(),
 			WorkMillis:   entry.Meta.WorkMillis,
@@ -532,6 +534,15 @@ func pastEntryThread(ctx context.Context, cfg hubcore.WebConfig, entry hubcore.P
 		thread.Evener.Capabilities = appwire.ThreadCapabilities{}
 	}
 	thread.Evener.VisionModel = entry.Meta.VisionModel
+	return thread, nil
+}
+
+func pastEntryThread(ctx context.Context, cfg hubcore.WebConfig, entry hubcore.PastEntry, includeTurns bool) (appwire.Thread, error) {
+	thread, err := pastEntryThreadForList(ctx, cfg, entry)
+	if err != nil {
+		return appwire.Thread{}, err
+	}
+	thread.Evener.Tasks = persistedTaskAggregate(entry.StateDir, entry.Meta.ID)
 	delegates, delegateDiagnostics, err := pastEntryDelegateStatus(ctx, entry)
 	if err != nil {
 		return appwire.Thread{}, err
@@ -555,14 +566,15 @@ func pastEntryThread(ctx context.Context, cfg hubcore.WebConfig, entry hubcore.P
 		thread.Evener.Diagnostics.DelegateDiagnostics = append(thread.Evener.Diagnostics.DelegateDiagnostics, delegateDiagnostics...)
 	}
 	if includeTurns {
-		var err error
 		thread.Turns, err = pastEntryTurns(cfg, entry)
 		if err != nil {
 			return appwire.Thread{}, err
 		}
 		thread = reconcileAndEnrichPastThread(entry, thread)
 	}
-	annotateThreadProjects([]appwire.Thread{thread})
+	annotated := []appwire.Thread{thread}
+	annotateThreadProjects(annotated)
+	thread = annotated[0]
 	return thread, nil
 }
 


### PR DESCRIPTION
Session lists currently hydrate persisted task aggregates and delegate history for every past row, including rows used only to fill missing metadata on a live session. Share the existing list projection and reserve that history hydration for detailed reads.

The list retains goals, usage, cost, capabilities, vision settings and the existing v5 recovery/ownership checks. Live-row merge semantics remain unchanged. Project resolution runs once for the list, and detailed reads now retain their project annotation instead of discarding a modified struct copy.

Validation: real past-session fixture regression fails with task hydration on the old list path and passes after the split; a separate project-identity regression reproduces the discarded-copy defect. Focused race tests cover list metadata, detailed project identity, cancellation and delegate diagnostics. The full hub package and vet pass. Independent Luna review found no remaining issue in the selected scope.

This reduces unnecessary history reads; it does not claim a measured latency improvement or eliminate recovery/ownership I/O. It is a focused prerequisite for the preserved iPhone checkpoint.
