### PR TITLE
test(web): await provider dialog import before asserting its state

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -252,8 +252,11 @@ test("missing credentials surface setup in the composer without opening a dialog
   await user.type(screen.getByRole("textbox", { name: "Prompt" }), "draft-sentinel");
   await setWorkingDir(user, "/tmp/my-project");
   expect((screen.getByRole("button", { name: "Start" }) as HTMLButtonElement).disabled).toBe(true);
-  await user.click(connect);
-  await screen.findByRole("dialog");
+  await act(async () => {
+    await user.click(connect);
+    await vi.dynamicImportSettled();
+  });
+  expect(screen.getByRole("dialog")).toBeTruthy();
   await user.keyboard("{Escape}");
   expect((screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement).value).toBe("draft-sentinel");
   expectWorkingDir("/tmp/my-project");


### PR DESCRIPTION
The first provider-setup test opens a lazy-loaded dialog after editing its draft. Await the actual dynamic import and React commit before checking the dialog, using the same synchronization already present in the later provider-setup test.

The broad frontend run exposed a timeout here followed by two failed provider-setup cases; the other 9,797 tests passed. The focused three cases and complete 91-test Spawn suite pass independently. Assertions still verify that the dialog stays closed until requested, provider setup blocks Start, and closing the dialog preserves the draft and directory. No timeout or runtime behavior changes.

The complete 91-test Spawn suite passes on this isolated candidate. The canonical frontend gate (tests, TypeScript and lint) passes with this correction applied to the #1076 validation checkout. This test-only correction was found while validating the iPhone prerequisite batch and is separated for review.
