### PR TITLE
fix(web): ride the two-level body chevron inline with the summary text

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolRow.tsx
@@ -448,6 +448,29 @@ export function ToolRow({
     );
   }
 
+  // When the summary is not visible but the body is expanded, the body
+  // chevron rides the intent line (data-intent-trailing makes the intent
+  // button shrink to share it). When the summary is visible, the body
+  // chevron rides INLINE at the end of the summary text - a sibling of the
+  // words it opens, never sprung to the line's far edge - while the
+  // .bodyTrigger button stays behind it as an empty full-line overlay so
+  // the whole line still toggles the body.
+  const bodyTriggerOnIntentLine = twoLevel && !summaryVisible && expanded;
+  const bodyTriggerOnSummaryLine = twoLevel && summaryVisible;
+  // The inline slot exists only when there is summary text to carry the
+  // chevron; a summary-less line keeps the chevron inside the button.
+  const bodyChevronInline = bodyTriggerOnSummaryLine && hasSummary;
+  const bodyChevron = (
+    <span
+      className={CLASS.chevron}
+      aria-hidden="true"
+      data-open={expanded ? "true" : "false"}
+      data-testid="tool-row-body-chevron"
+    >
+      <Chevron />
+    </span>
+  );
+
   const summaryContent = (
     <>
       {hasSummary && (
@@ -474,6 +497,12 @@ export function ToolRow({
           {hasIntent && trailing && anchorSplit === undefined ? (
             <span className={CLASS.summaryTrailing}>{trailing}</span>
           ) : null}
+          {/* The two-level body chevron rides inline at the end of the summary
+              text, after the trailing control - the same end-of-text slot the
+              grammar gives every chevron. The .bodyTrigger overlay button
+              (below) carries the click target; this span sits inside the
+              pointer-events-none .summary, so it never double-hits. */}
+          {bodyChevronInline ? bodyChevron : null}
         </span>
       )}
       {/* Rows with no intent trail the control at the summary line's end. An
@@ -498,9 +527,11 @@ export function ToolRow({
   // coexists with the intent button's summary disclosure in two-level mode.
   // On the summary line it is an OVERLAY (absolute, full width/height) so the
   // entire summary line is clickable to toggle the body — same pattern as the
-  // intent-less overlay trigger. The chevron rides at the end as a visual
-  // indicator. On the intent line (summary hidden, body expanded) it is a
-  // normal flex item beside the intent button.
+  // intent-less overlay trigger. Its chevron rides INLINE at the end of the
+  // summary text instead (the span rendered inside .summary above), so it hugs
+  // the words it opens; only a summary-less line keeps the chevron inside the
+  // button. On the intent line (summary hidden, body expanded) it is a normal
+  // flex item beside the intent button.
   const bodyTriggerButton = twoLevel ? (
     <button
       type="button"
@@ -511,17 +542,9 @@ export function ToolRow({
       aria-label={summaryLabel}
       onClick={() => onToggle?.()}
     >
-      <span className={CLASS.chevron} aria-hidden="true" data-open={expanded ? "true" : "false"}>
-        <Chevron />
-      </span>
+      {bodyChevronInline ? null : bodyChevron}
     </button>
   ) : null;
-  // When the summary is not visible but the body is expanded, the body
-  // chevron rides the intent line (data-intent-trailing makes the intent
-  // button shrink to share it). When the summary is visible, the body
-  // chevron rides the end of the summary line instead.
-  const bodyTriggerOnIntentLine = twoLevel && !summaryVisible && expanded;
-  const bodyTriggerOnSummaryLine = twoLevel && summaryVisible;
 
   // Intent button attributes differ between two-level and legacy modes.
   // In two-level mode the intent button controls the summary disclosure;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolRowGrammar.test.tsx
@@ -1631,9 +1631,9 @@ test("two-level: the body chevron's chevron span rotates with expanded state", (
       onToggleSummary={() => {}}
     />,
   );
-  const bodyTrigger = screen.getByTestId("tool-row-body-trigger");
-  const chevron = bodyTrigger.querySelector("[data-open]");
-  expect(chevron?.getAttribute("data-open")).toBe("false");
+  // The chevron rides inline in the summary, not inside the overlay button.
+  const chevron = screen.getByTestId("tool-row-body-chevron");
+  expect(chevron.getAttribute("data-open")).toBe("false");
   rerender(
     <ToolRow
       summary="npm test -- src/foo"
@@ -1646,9 +1646,48 @@ test("two-level: the body chevron's chevron span rotates with expanded state", (
       onToggleSummary={() => {}}
     />,
   );
-  const bodyTriggerOpen = screen.getByTestId("tool-row-body-trigger");
-  const chevronOpen = bodyTriggerOpen.querySelector("[data-open]");
-  expect(chevronOpen?.getAttribute("data-open")).toBe("true");
+  const chevronOpen = screen.getByTestId("tool-row-body-chevron");
+  expect(chevronOpen.getAttribute("data-open")).toBe("true");
+});
+
+test("two-level: the body chevron rides inline at the end of the summary text, not in the overlay button", () => {
+  render(
+    <ToolRow
+      summary="npm test -- src/foo"
+      intent="Running the foo tests"
+      failed={false}
+      expandable
+      expanded={false}
+      onToggle={() => {}}
+      summaryOpen
+      onToggleSummary={() => {}}
+    />,
+  );
+  // The chevron span is a child of the summary (inline at the end of the
+  // text)...
+  const summary = screen.getByTestId("tool-row-summary");
+  expect(summary.contains(screen.getByTestId("tool-row-body-chevron"))).toBe(true);
+  // ...and the overlay button is empty - it carries the click target only.
+  const bodyTrigger = screen.getByTestId("tool-row-body-trigger");
+  expect(bodyTrigger.querySelector("[data-open]")).toBeNull();
+});
+
+test("two-level: a summary-less line keeps the body chevron inside the button", () => {
+  render(
+    <ToolRow
+      summary=""
+      intent="Running the foo tests"
+      failed={false}
+      expandable
+      expanded={false}
+      onToggle={() => {}}
+      summaryOpen
+      onToggleSummary={() => {}}
+    />,
+  );
+  const bodyTrigger = screen.getByTestId("tool-row-body-trigger");
+  expect(bodyTrigger.querySelector("[data-open]")?.getAttribute("data-open")).toBe("false");
+  expect(screen.queryByTestId("tool-row-summary")).toBeNull();
 });
 
 // --- the intent-trailing control and the clamp's clip ------------------------

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/toolcallitem.module.css
@@ -341,13 +341,22 @@
 }
 
 /* When a .bodyTrigger chevron shares the summary line (two-level disclosure at
-   tools/activity/full), the demoted summary must leave room for it instead of
-   demanding 100% — otherwise the chevron's intrinsic width overflows the
-   container. flex-shrink:1 and flex-basis:auto let the summary shrink to fit
-   alongside the flex:none body trigger; min-width:0 + the .clamped
-   overflow:hidden clip the nowrap text to the shrunken width. */
+   tools/activity/full), the chevron rides INLINE at the end of the summary
+   text (ToolRow's bodyChevronInline) and the button is an empty OVERLAY, so
+   the demoted summary can keep its full basis: nothing else needs a share of
+   the line. The overlay is absolute (out of flow) and takes no width. */
 .summaryLine[data-body-trigger="true"] {
   position: relative;
+}
+
+/* The body chevron rides INLINE at the end of the summary text (ToolRow's
+   bodyChevronInline). Inside the collapsed line's .clamped flex row it is a
+   flex-none item that never shrinks - the head's ellipsis absorbs the
+   pressure, the same seat .summaryTrailing takes. Scoped by [data-open]
+   (every .chevron carries it) so specificity does not descend below the
+   .chevron base rule. */
+.clamped [data-open] {
+  flex: none;
 }
 
 .summaryLine[data-body-trigger="true"] .bodyTrigger {
@@ -369,11 +378,6 @@
 .summaryLine[data-body-trigger="true"] .summary select,
 .summaryLine[data-body-trigger="true"] .summary textarea {
   pointer-events: auto;
-}
-
-.summaryLine[data-body-trigger="true"] .demoted {
-  flex: 0 1 auto;
-  min-width: 0;
 }
 
 /* The COLLAPSED second line's truncation (ToolRow.tsx's grammar): a


### PR DESCRIPTION
## What

Follow-up to #1064 (merged). On two-level disclosure rows, the body chevron on the `Ran …` summary line detached to the line's far edge — the `.bodyTrigger` button is an absolute full-line overlay and `justify-content: flex-end` seated its chevron at the edge regardless of where the text ended. On a short summary the chevron read as sitting on its own line.

## Change

The chevron now renders **inline at the end of the summary text** (inside the `.demoted` span, after the trailing control) — the same end-of-text slot the row grammar gives every chevron. The `.bodyTrigger` button stays behind it as an **empty full-line overlay**, so the whole line remains the click target and hover surface. A summary-less line keeps the chevron inside the button.

CSS cleanup that follows from the empty overlay:
- removed `.summaryLine[data-body-trigger="true"] .demoted { flex: 0 1 auto; min-width: 0 }` — the overlay is out of flow and takes no width, so the demoted summary keeps its full basis
- added `.clamped [data-open] { flex: none }` so the inline chevron never shrinks inside the collapsed middle-truncation row (the head's ellipsis absorbs the pressure, same seat `.summaryTrailing` takes)

## Verification

- `make test-web` PASS (typecheck + 9785 tests + biome) — one gate rerun hit two unrelated load flakes (Spawn timeout, Composer recovery-resend) that pass in isolation 91/91 and 3×167/167 and did not involve any touched file
- `make test-web-browser` PASS — layoutguard, overflowguard, shellguard, spawnguard, transcriptscrollguard
- New grammar tests pin: the chevron span lives inside the summary (not the button), the button renders no chevron when inline, the rotation testid follows the new location, and a summary-less line keeps the in-button fallback