### PR TITLE
fix(daemon): retry interrupted Linux process-exit probes

### DIFF
--- a/cmd/evener-hub/internal/daemonprocess/process_linux.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_linux.go
@@ -40,8 +40,18 @@ func (p *linuxProcess) kill() error {
 	return err
 }
 func (p *linuxProcess) exited() (bool, error) {
+	return p.exitedWith(unix.Poll)
+}
+
+func (p *linuxProcess) exitedWith(poll func([]unix.PollFd, int) (int, error)) (bool, error) {
 	fds := []unix.PollFd{{Fd: int32(p.fd), Events: unix.POLLIN}}
-	_, err := unix.Poll(fds, 0)
+	var err error
+	for {
+		_, err = poll(fds, 0)
+		if !errors.Is(err, unix.EINTR) {
+			break
+		}
+	}
 	if err != nil {
 		return false, err
 	}

--- a/cmd/evener-hub/internal/daemonprocess/process_linux_test.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_linux_test.go
@@ -13,17 +13,18 @@ import (
 func TestLinuxProcessExitedHandlesInterruptedPoll(t *testing.T) {
 	realErr := errors.New("poll failed")
 	for _, tc := range []struct {
-		name      string
-		revents   int16
-		pollErr   error
-		wantGone  bool
-		wantErr   error
-		wantCalls int
+		name        string
+		revents     int16
+		injectEINTR bool
+		wantRealErr bool
+		wantGone    bool
+		wantErr     error
+		wantCalls   int
 	}{
-		{name: "EINTR then live", pollErr: unix.EINTR, wantCalls: 2},
-		{name: "EINTR then exited", pollErr: unix.EINTR, revents: unix.POLLIN, wantGone: true, wantCalls: 2},
-		{name: "EINTR then hangup", pollErr: unix.EINTR, revents: unix.POLLHUP, wantGone: true, wantCalls: 2},
-		{name: "EINTR then real error", pollErr: unix.EINTR, wantErr: realErr, wantCalls: 2},
+		{name: "EINTR then live", injectEINTR: true, wantCalls: 2},
+		{name: "EINTR then exited", injectEINTR: true, revents: unix.POLLIN, wantGone: true, wantCalls: 2},
+		{name: "EINTR then hangup", injectEINTR: true, revents: unix.POLLHUP, wantGone: true, wantCalls: 2},
+		{name: "EINTR then real error", injectEINTR: true, wantRealErr: true, wantErr: realErr, wantCalls: 2},
 		{name: "closed descriptor", revents: unix.POLLNVAL, wantErr: os.ErrClosed, wantCalls: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -33,11 +34,11 @@ func TestLinuxProcessExitedHandlesInterruptedPoll(t *testing.T) {
 				if timeout != 0 {
 					t.Fatalf("poll timeout = %d; want 0", timeout)
 				}
-				if calls == 1 && tc.pollErr == unix.EINTR {
+				if calls == 1 && tc.injectEINTR {
 					return 0, unix.EINTR
 				}
 				fds[0].Revents = tc.revents
-				if tc.wantErr == realErr {
+				if tc.wantRealErr {
 					return 0, realErr
 				}
 				return 1, nil

--- a/cmd/evener-hub/internal/daemonprocess/process_linux_test.go
+++ b/cmd/evener-hub/internal/daemonprocess/process_linux_test.go
@@ -2,11 +2,56 @@ package daemonprocess
 
 import (
 	"encoding/binary"
+	"errors"
+	"os"
 	"testing"
 	"time"
 
 	"golang.org/x/sys/unix"
 )
+
+func TestLinuxProcessExitedHandlesInterruptedPoll(t *testing.T) {
+	realErr := errors.New("poll failed")
+	for _, tc := range []struct {
+		name      string
+		revents   int16
+		pollErr   error
+		wantGone  bool
+		wantErr   error
+		wantCalls int
+	}{
+		{name: "EINTR then live", pollErr: unix.EINTR, wantCalls: 2},
+		{name: "EINTR then exited", pollErr: unix.EINTR, revents: unix.POLLIN, wantGone: true, wantCalls: 2},
+		{name: "EINTR then hangup", pollErr: unix.EINTR, revents: unix.POLLHUP, wantGone: true, wantCalls: 2},
+		{name: "EINTR then real error", pollErr: unix.EINTR, wantErr: realErr, wantCalls: 2},
+		{name: "closed descriptor", revents: unix.POLLNVAL, wantErr: os.ErrClosed, wantCalls: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			poll := func(fds []unix.PollFd, timeout int) (int, error) {
+				calls++
+				if timeout != 0 {
+					t.Fatalf("poll timeout = %d; want 0", timeout)
+				}
+				if calls == 1 && tc.pollErr == unix.EINTR {
+					return 0, unix.EINTR
+				}
+				fds[0].Revents = tc.revents
+				if tc.wantErr == realErr {
+					return 0, realErr
+				}
+				return 1, nil
+			}
+			gotGone, gotErr := (&linuxProcess{fd: 1}).exitedWith(poll)
+			if gotGone != tc.wantGone || !errors.Is(gotErr, tc.wantErr) {
+				t.Fatalf("exited = (%v, %v), want (%v, %v)", gotGone, gotErr, tc.wantGone, tc.wantErr)
+			}
+			if calls != tc.wantCalls {
+				t.Fatalf("poll calls = %d, want %d", calls, tc.wantCalls)
+			}
+		})
+	}
+}
 
 func TestLinuxLockEvidence(t *testing.T) {
 	for _, tt := range []struct {


### PR DESCRIPTION
An interrupted Linux pidfd poll currently becomes a hard error from daemon ownership verification or exit waiting. Repeat the nonblocking exit-status probe on EINTR, retaining the existing live/exited/closed-descriptor result and propagating other errors.

The default test run on #1076 exposed an `interrupted system call` during `TestNativeControllerKillsOnlyOwnedChild/locked` on Ubuntu. That log does not identify the exact syscall; deterministic OS-boundary tests reproduce this uncovered poll path and demonstrate the correction without timing-dependent signal injection.

The regression covers EINTR followed by live status, exit, hangup and a real error, plus closed descriptor handling. Four cases fail behaviorally without the retry. The full daemonprocess package passes with race detection in an offline Linux Go 1.27 container; Linux vet and native Darwin package tests also pass. Independent Luna review is clean. Process signaling and termination code are untouched.

Land this before refreshing the blocked Go check on #1076.
