### PR TITLE
test(appwire): prevent full-queue observation from blocking admission

### DIFF
--- a/internal/appserver/request_admission_test.go
+++ b/internal/appserver/request_admission_test.go
@@ -2,6 +2,7 @@ package appserver
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -82,8 +83,8 @@ func TestRequestAdmissionFailureKeepsConnectionUsable(t *testing.T) {
 
 func TestRecoveryConnectionReachesHandlerWhilePrimaryQueueIsFull(t *testing.T) {
 	server := NewServer(ServerConfig{})
-	blocked := make(chan struct{}, 1)
-	server.blockedEnqueue = func() { blocked <- struct{}{} }
+	blocked := make(chan struct{})
+	server.blockedEnqueue = sync.OnceFunc(func() { close(blocked) })
 	started, release := parkThreadList(t, server)
 	enteredRecovery := make(chan struct{})
 	HandleTyped(server.Router(), appwire.MethodEvenerThreadForceStop, func(context.Context, appwire.ThreadForceStopParams) (appwire.EmptyResponse, error) {
@@ -111,8 +112,8 @@ func TestConnectionAdmissionPrecedesUnreadBacklog(t *testing.T) {
 	server := NewServer(ServerConfig{ConnectionAdmissionContext: func(ctx context.Context) context.Context {
 		return context.WithValue(ctx, requestAdmissionTestKey{}, generation.Load())
 	}})
-	blocked := make(chan struct{}, 1)
-	server.blockedEnqueue = func() { blocked <- struct{}{} }
+	blocked := make(chan struct{})
+	server.blockedEnqueue = sync.OnceFunc(func() { close(blocked) })
 	started, release := parkThreadList(t, server)
 	var resumed, mutated atomic.Int32
 	check := func(ctx context.Context) error {


### PR DESCRIPTION
The admission tests can hang after the full-queue observation fires repeatedly. Their buffered notification channel can fill again after the first observation is consumed, blocking the receive loop inside the test hook.

Use a one-shot channel close for both admission tests that only need to observe the first full-queue transition. Repeated callbacks return immediately, while all admission, recovery and stale-request assertions remain intact.

The CI stack trace identifies the blocked channel send. Both affected tests pass 20 repetitions with race detection; the full appserver package passes with race detection, vet and scoped golangci-lint. Independent root review confirms the change is confined to the test hook. No production queue behavior or timeout changes.
