### PR TITLE
fix(web): let Vite own browser guard port allocation

### DIFF
--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { stripVTControlCharacters } from "node:util";
 
 const CHROME_CANDIDATES = [
   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
@@ -14,11 +15,30 @@ const CHROME_CANDIDATES = [
 const CHILD_EXIT_GRACE_MS = 2_000;
 const SIGNAL_EXIT_CODES = { SIGINT: 130, SIGTERM: 143 };
 const DEVTOOLS_ANNOUNCEMENT_PREFIX = "DevTools listening on ";
+const VITE_READY_TIMEOUT_MS = 30_000;
+const VITE_LOCAL_ANNOUNCEMENT = /Local:\s+http:\/\/(\[[^\]]+\]|[^/:\s]+):(\d+)(?:\/\s*)?$/;
 
 function isLoopbackHost(hostname) {
   if (hostname === "localhost" || hostname === "[::1]") return true;
   const octets = hostname.split(".");
-  return octets.length === 4 && octets[0] === "127" && octets.every((octet) => /^(0|[1-9]\d*)$/.test(octet) && Number(octet) <= 255);
+  return (
+    octets.length === 4 &&
+    octets[0] === "127" &&
+    octets.every((octet) => /^(0|[1-9]\d*)$/.test(octet) && Number(octet) <= 255)
+  );
+}
+
+/** Parse Vite's local URL announcement after it has bound its listening socket. */
+export function parseViteReadyAnnouncement(line) {
+  const normalized = stripVTControlCharacters(line).trim();
+  const match = normalized.match(VITE_LOCAL_ANNOUNCEMENT);
+  if (!match) return null;
+  const hostname = match[1];
+  const port = Number(match[2]);
+  if (!isLoopbackHost(hostname) || !Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`invalid Vite local announcement: ${normalized}`);
+  }
+  return { host: hostname, port };
 }
 
 /** Parse one complete Chrome stderr announcement, or ignore an unrelated line. */
@@ -86,10 +106,7 @@ export function describeBrowserStartupFailure({
   viteStderr = "",
 }) {
   const message = error instanceof Error ? error.message : String(error);
-  const lines = [
-    `browser guard startup failed (environment problem, not a test case failure): ${message}`,
-    "",
-  ];
+  const lines = [`browser guard startup failed (environment problem, not a test case failure): ${message}`, ""];
   // Name the subsystem that actually failed. One try now covers the launch,
   // Vite and Chrome, and remediation aimed at the wrong one is worse than none:
   // a dead Vite told to "install Chrome" sends the reader looking in the wrong
@@ -223,7 +240,7 @@ export function listSystemProcesses({ processCommand = ["/bin/ps"] } = {}) {
   // than pgrep's comm name, also works on Linux where comm is truncated to 15
   // bytes and would miss chrome_crashpad_handler.
   const filter =
-    "{ line=$0; sub(/^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+/, \"\", line); " +
+    '{ line=$0; sub(/^[[:space:]]*[0-9]+[[:space:]]+[0-9]+[[:space:]]+/, "", line); ' +
     // Keep the filter narrow, but leave argv0 validation to the JS parser. The
     // second condition rejects an absolute path appearing after an unrelated
     // argv0 while still allowing the spaces in a normal macOS Chrome path.
@@ -680,15 +697,35 @@ export async function startBrowserGuard({
   processTarget = process,
   scheduleEscalation = setTimeout,
   cancelEscalation = clearTimeout,
+  signal = null,
+  startupTimeoutMs = VITE_READY_TIMEOUT_MS,
 }) {
   const resolvedChrome = chromeBinary ?? findChrome();
-  const vitePort = await findAvailablePort();
+  const vitePort = 0;
+  let actualVitePort = vitePort;
   const profileDir = mkdtempSync(path.join(tmpdir(), profilePrefix));
   let vite = null;
   let chrome = null;
   let viteErr = "";
   let chromeErr = "";
   let viteLaunchError = null;
+  let viteReadySettled = false;
+  let resolveViteReady;
+  let rejectViteReady;
+  const viteReady = new Promise((resolve, reject) => {
+    resolveViteReady = (address) => {
+      if (viteReadySettled) return;
+      viteReadySettled = true;
+      resolve(address);
+    };
+    rejectViteReady = (error) => {
+      if (viteReadySettled) return;
+      viteReadySettled = true;
+      reject(error);
+    };
+  });
+  viteReady.catch(() => {});
+  let viteLineBuffer = "";
   let chromeLaunchError = null;
   let chromeArgv = [];
   let chromeEndpoint = null;
@@ -734,21 +771,11 @@ export async function startBrowserGuard({
   });
 
   try {
-    vite = spawnProcess(
-      "./node_modules/.bin/vite",
-      [
-        "--config",
-        "scripts/browserguard.vite.config.mjs",
-        "--port",
-        String(vitePort),
-        "--strictPort",
-        "--host",
-        "127.0.0.1",
-        "--clearScreen",
-        "false",
-      ],
-      { cwd: frontend, stdio: ["ignore", "ignore", "pipe"], detached: useProcessGroups },
-    );
+    vite = spawnProcess(process.execPath, ["scripts/browserguard-vite.mjs"], {
+      cwd: frontend,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: useProcessGroups,
+    });
     lifecycle.addChild(vite, {
       processGroupId: useProcessGroups && Number.isInteger(vite.pid) ? vite.pid : null,
     });
@@ -765,10 +792,52 @@ export async function startBrowserGuard({
     // dead Chrome is never blamed on a healthy Vite.
     vite.on("error", (error) => {
       viteLaunchError ??= error;
+      rejectViteReady(error);
+    });
+    vite.once("exit", (code, signal) => {
+      if (!viteReadySettled) {
+        const error = new Error(`Vite exited before readiness (code ${code ?? "unknown"}, signal ${signal ?? "none"})`);
+        viteLaunchError ??= error;
+        rejectViteReady(error);
+      }
+    });
+    vite.stdout?.on("data", (chunk) => {
+      viteLineBuffer += chunk.toString();
+      const lines = viteLineBuffer.split(/\r\n|\r|\n/);
+      viteLineBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        let address;
+        try {
+          address = parseViteReadyAnnouncement(line);
+        } catch (error) {
+          viteLaunchError ??= error;
+          rejectViteReady(error);
+          continue;
+        }
+        if (address) resolveViteReady(address);
+      }
     });
     vite.stderr?.on("data", (chunk) => {
       viteErr += chunk;
     });
+    let viteReadyTimer;
+    try {
+      const viteAddress = await withAbort(
+        Promise.race([
+          viteReady,
+          new Promise((_, reject) => {
+            viteReadyTimer = setTimeout(
+              () => reject(new Error(`Vite readiness timed out after ${startupTimeoutMs}ms`)),
+              startupTimeoutMs,
+            );
+          }),
+        ]),
+        signal,
+      );
+      actualVitePort = viteAddress.port;
+    } finally {
+      clearTimeout(viteReadyTimer);
+    }
     chromeArgv = [
       "--headless=new",
       "--disable-gpu",
@@ -783,19 +852,15 @@ export async function startBrowserGuard({
       ...chromeArgs,
       "about:blank",
     ];
-    chrome = spawnProcess(
-      resolvedChrome,
-      chromeArgv,
-      {
-        // Chrome's stderr is the only thing that says WHY it would not start (a
-        // missing dylib, a sandbox denial, a profile it cannot write).
-        // Discarding it left a failed launch looking like a bare 30s
-        // waitForHttp timeout beside an irrelevant Vite log (kata 3htx).
-        stdio: ["ignore", "ignore", "pipe"],
-        env: chromeProfileEnvironment(profileDir),
-        detached: useProcessGroups,
-      },
-    );
+    chrome = spawnProcess(resolvedChrome, chromeArgv, {
+      // Chrome's stderr is the only thing that says WHY it would not start (a
+      // missing dylib, a sandbox denial, a profile it cannot write).
+      // Discarding it left a failed launch looking like a bare 30s
+      // waitForHttp timeout beside an irrelevant Vite log (kata 3htx).
+      stdio: ["ignore", "ignore", "pipe"],
+      env: chromeProfileEnvironment(profileDir),
+      detached: useProcessGroups,
+    });
     chrome.on("error", (error) => {
       failChrome(error);
     });
@@ -817,9 +882,7 @@ export async function startBrowserGuard({
         // endpoint invalidates startup rather than making listener order decide
         // which browser to measure or close.
         if (chromeEndpoint && chromeEndpoint.url !== endpoint.url) {
-          const error = new Error(
-            `conflicting DevTools announcements: ${chromeEndpoint.url} and ${endpoint.url}`,
-          );
+          const error = new Error(`conflicting DevTools announcements: ${chromeEndpoint.url} and ${endpoint.url}`);
           failChrome(error);
           continue;
         }
@@ -844,7 +907,7 @@ export async function startBrowserGuard({
   }
 
   return {
-    vitePort,
+    vitePort: actualVitePort,
     getChromeEndpoint: () => chromeEndpoint,
     profileDir,
     getViteError: () => viteErr,

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -106,14 +106,16 @@ export function describeBrowserStartupFailure({
   viteStderr = "",
 }) {
   const message = error instanceof Error ? error.message : String(error);
+  const effectiveSubsystem = error?.browserGuardSubsystem ?? subsystem;
+  const effectiveViteStderr = error?.browserGuardViteStderr ?? viteStderr;
   const lines = [`browser guard startup failed (environment problem, not a test case failure): ${message}`, ""];
   // Name the subsystem that actually failed. One try now covers the launch,
   // Vite and Chrome, and remediation aimed at the wrong one is worse than none:
   // a dead Vite told to "install Chrome" sends the reader looking in the wrong
   // place with an authoritative-looking checklist.
-  if (subsystem === "vite") {
+  if (effectiveSubsystem === "vite") {
     lines.push(
-      `vite stderr: ${viteStderr.trim() || "(none)"}`,
+      `vite stderr: ${effectiveViteStderr.trim() || "(none)"}`,
       "",
       "To fix:",
       "  1. Read the vite stderr above - a port clash, a failed transform and a",
@@ -137,7 +139,7 @@ export function describeBrowserStartupFailure({
     `Chrome binary: ${chromeBinary || "(none found)"}`,
     `Chrome argv: ${chromeArgv.join(" ")}`,
     `chrome stderr: ${chromeStderr.trim() || "(none)"}`,
-    `vite stderr: ${viteStderr.trim() || "(none)"}`,
+    `vite stderr: ${effectiveViteStderr.trim() || "(none)"}`,
     "",
     "To fix:",
     `  1. Confirm the binary above exists and runs: "${chromeBinary}" --version`,
@@ -710,6 +712,7 @@ export async function startBrowserGuard({
   let chromeErr = "";
   let viteLaunchError = null;
   let viteReadySettled = false;
+  let viteReadySucceeded = false;
   let resolveViteReady;
   let rejectViteReady;
   const viteReady = new Promise((resolve, reject) => {
@@ -835,6 +838,7 @@ export async function startBrowserGuard({
         signal,
       );
       actualVitePort = viteAddress.port;
+      viteReadySucceeded = true;
     } finally {
       clearTimeout(viteReadyTimer);
     }
@@ -903,6 +907,12 @@ export async function startBrowserGuard({
     });
   } catch (error) {
     await lifecycle.cleanup();
+    if (!viteReadySucceeded) {
+      const startupError = new Error(error instanceof Error ? error.message : String(error), { cause: error });
+      startupError.browserGuardSubsystem = "vite";
+      startupError.browserGuardViteStderr = viteErr;
+      throw startupError;
+    }
     throw error;
   }
 

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, realpathSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -21,6 +22,7 @@ class FakeChild extends EventEmitter {
     this.signalCode = null;
     this.signals = [];
     this.stderr = new EventEmitter();
+    this.stdout = new EventEmitter();
   }
 
   kill(signal) {
@@ -85,6 +87,9 @@ async function startFakeGuard(options = {}) {
     spawnProcess(command, args, spawnOptions) {
       const child = new FakeChild(command, args, spawnOptions);
       children.push(child);
+      if (command === process.execPath) {
+        queueMicrotask(() => child.stdout.emit("data", "  ➜  Local:   http://127.0.0.1:4173/\n"));
+      }
       return child;
     },
     ...options,
@@ -92,12 +97,103 @@ async function startFakeGuard(options = {}) {
   return { guard, children };
 }
 
+test("starts concurrent guards on Vite-owned ports and reaps their listeners", async (context) => {
+  const guards = [];
+  const viteChildren = [];
+  context.after(async () => {
+    await Promise.all(guards.map((guard) => guard.cleanup()));
+  });
+  const start = async () => {
+    const guard = await startBrowserGuard({
+      frontend: process.cwd(),
+      profilePrefix: "browser-guard-vite-test-",
+      chromeBinary: "/fake/chrome",
+      useProcessGroups: false,
+      spawnProcess(command, args, options) {
+        if (command === process.execPath) {
+          const child = spawn(command, args, options);
+          viteChildren.push(child);
+          return child;
+        }
+        const child = new FakeChild(command, args, options);
+        child.kill = (signal) => {
+          child.signals.push(signal);
+          queueMicrotask(() => child.exit(signal));
+          return true;
+        };
+        return child;
+      },
+    });
+    guards.push(guard);
+    return guard;
+  };
+  const results = await Promise.allSettled([start(), start()]);
+  for (const result of results) {
+    if (result.status === "rejected") throw result.reason;
+  }
+  assert.equal(guards.length, 2);
+  assert.notEqual(guards[0].vitePort, guards[1].vitePort);
+  for (const guard of guards) {
+    const response = await fetch(`http://127.0.0.1:${guard.vitePort}/spawnguard.html`, {
+      signal: AbortSignal.timeout(30_000),
+    });
+    await response.text();
+    assert.equal(response.status, 200);
+  }
+  await Promise.all(guards.map((guard) => guard.cleanup()));
+  for (const child of viteChildren) {
+    assert.ok(child.exitCode !== null || child.signalCode !== null, "Vite listener process must exit");
+  }
+  for (const guard of guards) assert.equal(existsSync(guard.profileDir), false);
+});
+
+test("aborts Vite startup and removes its owned profile", async () => {
+  const controller = new AbortController();
+  const profilePrefix = `browser-guard-abort-${randomUUID()}-`;
+  const children = [];
+  let profileDir;
+  await assert.rejects(
+    startBrowserGuard({
+      frontend: process.cwd(),
+      profilePrefix,
+      chromeBinary: "/fake/chrome",
+      signal: controller.signal,
+      spawnProcess(command, args, options) {
+        const entry = readdirSync(tmpdir()).find((name) => name.startsWith(profilePrefix));
+        assert.ok(entry, "startup must own a profile before launching its child");
+        profileDir = path.join(tmpdir(), entry);
+        const child = new FakeChild(command, args, options);
+        child.kill = (signal) => {
+          child.signals.push(signal);
+          queueMicrotask(() => child.exit(signal));
+          return true;
+        };
+        children.push(child);
+        queueMicrotask(() => controller.abort(new Error("cancelled Vite startup")));
+        return child;
+      },
+    }),
+    /cancelled Vite startup/,
+  );
+  assert.deepEqual(children.map((child) => child.signals), [["SIGTERM"]]);
+  assert.equal(existsSync(profileDir), false);
+});
+
 test("allocates distinct local ports", async () => {
   const first = await findAvailablePort();
   const second = await findAvailablePort([first]);
   assert.notEqual(first, second);
   assert.ok(first > 0);
   assert.ok(second > 0);
+});
+
+test("accepts Vite readiness only after a loopback listener announcement", () => {
+  assert.equal(browserGuardProcess.parseViteReadyAnnouncement("ready in 42ms"), null);
+  assert.deepEqual(browserGuardProcess.parseViteReadyAnnouncement("  ➜  Local:   http://127.0.0.1:4173/"), {
+    host: "127.0.0.1",
+    port: 4173,
+  });
+  assert.throws(() => browserGuardProcess.parseViteReadyAnnouncement("➜  Local: http://192.0.2.1:4173/"));
 });
 
 test("parses only valid loopback DevTools announcement lines", () => {
@@ -616,8 +712,7 @@ test("does not signal a same-PID same-argv helper in a reused process group", as
     pgid: 300,
     databaseArg: "--database=/private/tmp/browser-profile/Crashpad",
   };
-  const reusedGroup =
-    "  510   777 /usr/bin/chrome_crashpad_handler --database=/private/tmp/browser-profile/Crashpad";
+  const reusedGroup = "  510   777 /usr/bin/chrome_crashpad_handler --database=/private/tmp/browser-profile/Crashpad";
 
   const signals = [];
   const lifecycle = browserGuardProcess.createBrowserProcessCleanup({
@@ -691,6 +786,7 @@ test("cleans Vite when Chrome startup throws", async () => {
     calls++;
     if (calls === 1) {
       const child = new FakeChild(command);
+      queueMicrotask(() => child.stdout.emit("data", "Local: http://127.0.0.1:4173/\n"));
       child.kill = (signal) => {
         killed.push([command, signal]);
         queueMicrotask(() => child.exit(signal));
@@ -710,7 +806,34 @@ test("cleans Vite when Chrome startup throws", async () => {
     }),
     /chrome startup failed/,
   );
-  assert.deepEqual(killed, [["./node_modules/.bin/vite", "SIGTERM"]]);
+  assert.deepEqual(killed, [[process.execPath, "SIGTERM"]]);
+});
+
+test("times out Vite startup and cleans its owned child", async () => {
+  const children = [];
+  await assert.rejects(
+    startBrowserGuard({
+      frontend: process.cwd(),
+      profilePrefix: "browser-guard-test-",
+      chromeBinary: "/fake/chrome",
+      startupTimeoutMs: 5,
+      spawnProcess(command) {
+        const child = new FakeChild(command);
+        child.kill = (signal) => {
+          child.signals.push(signal);
+          queueMicrotask(() => child.exit(signal));
+          return true;
+        };
+        children.push(child);
+        return child;
+      },
+    }),
+    /Vite readiness timed out after 5ms/,
+  );
+  assert.deepEqual(
+    children.map((child) => child.signals),
+    [["SIGTERM"]],
+  );
 });
 
 test("waits for every child to exit before removing the browser profile", async () => {
@@ -1097,9 +1220,7 @@ test("cleans up through the announced endpoint host", async (context) => {
   const cleanup = guard.cleanup();
   for (const child of children) child.exit();
   await cleanup;
-  assert.deepEqual(endpoints, [
-    { url: "ws://[::1]:43214/devtools/browser/cleanup", host: "[::1]", port: 43214 },
-  ]);
+  assert.deepEqual(endpoints, [{ url: "ws://[::1]:43214/devtools/browser/cleanup", host: "[::1]", port: 43214 }]);
 });
 
 test("requestBrowserClose uses the announced host and port", async () => {
@@ -1132,7 +1253,10 @@ test("requestBrowserClose uses the announced host and port", async () => {
     FakeWebSocket,
   );
   assert.deepEqual(requests, ["http://[::1]:43215/json/version"]);
-  assert.deepEqual(sockets.map((socket) => socket.url), ["ws://[::1]:43215/devtools/browser/close"]);
+  assert.deepEqual(
+    sockets.map((socket) => socket.url),
+    ["ws://[::1]:43215/devtools/browser/close"],
+  );
 });
 
 test("fails the readiness handoff immediately when Chrome start fails", async (context) => {
@@ -1184,7 +1308,11 @@ test("a real non-executable Chrome is named by the diagnostic and still gets cle
       // is about Chrome's launch, and booting a dev server to prove it would
       // cost seconds and prove nothing extra.
       if (calls === 1) {
-        const child = spawn("/bin/sleep", ["30"], options);
+        const child = spawn(
+          process.execPath,
+          ["-e", "console.log('Local: http://127.0.0.1:4173/'); setTimeout(() => {}, 30_000);"],
+          options,
+        );
         viteStandIn.push(child);
         return child;
       }

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
-import { existsSync, mkdtempSync, realpathSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -175,7 +175,10 @@ test("aborts Vite startup and removes its owned profile", async () => {
     }),
     /cancelled Vite startup/,
   );
-  assert.deepEqual(children.map((child) => child.signals), [["SIGTERM"]]);
+  assert.deepEqual(
+    children.map((child) => child.signals),
+    [["SIGTERM"]],
+  );
   assert.equal(existsSync(profileDir), false);
 });
 
@@ -995,6 +998,62 @@ test("the diagnostic blames vite for a vite failure and does not send the reader
   assert.match(message, /Chrome is not implicated/);
   assert.doesNotMatch(message, /install Chrome/);
 });
+
+for (const scenario of [
+  { name: "Vite exit", reason: null },
+  { name: "primitive cancellation", reason: "fixture cancellation" },
+  { name: "frozen cancellation", reason: Object.freeze(new Error("fixture cancellation")) },
+]) {
+  test(`retains startup diagnostics and cleanup after ${scenario.name}`, async (context) => {
+    const vite = new FakeChild(process.execPath);
+    vite.kill = (signal) => {
+      vite.signals.push(signal);
+      queueMicrotask(() => vite.exit(signal));
+      return true;
+    };
+    const controller = new AbortController();
+    const profilePrefix = `browser-guard-failure-${randomUUID()}-`;
+    const stderr = "fixture-vite-startup-stderr";
+    let profileDir;
+    let spawnCount = 0;
+    context.after(() => {
+      vite.exit();
+      if (profileDir) rmSync(profileDir, { recursive: true, force: true });
+    });
+    const startup = startBrowserGuard({
+      frontend: process.cwd(),
+      profilePrefix,
+      chromeBinary: "/fake/chrome",
+      signal: controller.signal,
+      spawnProcess() {
+        spawnCount++;
+        const entry = readdirSync(tmpdir()).find((name) => name.startsWith(profilePrefix));
+        assert.ok(entry, "startup must create its owned profile");
+        profileDir = path.join(tmpdir(), entry);
+        return vite;
+      },
+    });
+    vite.stderr.emit("data", stderr);
+    if (scenario.reason === null) vite.exit();
+    else controller.abort(scenario.reason);
+    await assert.rejects(startup, (error) => {
+      assert.equal(error.browserGuardSubsystem, "vite");
+      assert.equal(error.browserGuardViteStderr, stderr);
+      if (scenario.reason !== null) {
+        assert.equal(error.cause, scenario.reason);
+        assert.equal(error.message, "fixture cancellation");
+      } else {
+        assert.ok(error.cause instanceof Error);
+      }
+      const message = browserGuardProcess.describeBrowserStartupFailure({ error, subsystem: "launch" });
+      assert.ok(message.includes(stderr), "diagnostic must retain the captured Vite failure");
+      return true;
+    });
+    assert.equal(spawnCount, 1, "Chrome must not start after Vite startup failed");
+    if (scenario.reason !== null) assert.deepEqual(vite.signals, ["SIGTERM"]);
+    assert.equal(existsSync(profileDir), false, "startup must remove its owned profile before rejecting");
+  });
+}
 
 test("a browser binary that could not be resolved says nothing was spawned", () => {
   const message = browserGuardProcess.describeBrowserStartupFailure({

--- a/cmd/evener-hub/frontend/scripts/browserguard-vite.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserguard-vite.mjs
@@ -5,15 +5,19 @@ const server = await createServer({
   configFile: fileURLToPath(new URL("./browserguard.vite.config.mjs", import.meta.url)),
   server: { host: "127.0.0.1", port: 0, strictPort: true },
 });
-// Vite's CLI normalizes port 0 to its default; bind the already-created
-// HTTP server directly so the OS owns one random port for this child.
 // Vite normalizes port zero to its default in server.listen(). Its HTTP
 // listener retains the initialization wrapper and lets the OS own allocation.
+const httpServer = server.httpServer;
+if (!httpServer) throw new Error("Vite did not create an HTTP server");
 await new Promise((resolve, reject) => {
-  server.httpServer.once("error", reject);
-  server.httpServer.listen({ host: "127.0.0.1", port: 0 }, resolve);
+  const onError = (error) => reject(error);
+  httpServer.once("error", onError);
+  httpServer.listen({ host: "127.0.0.1", port: 0 }, () => {
+    httpServer.removeListener("error", onError);
+    resolve();
+  });
 });
-const address = server.httpServer?.address();
+const address = httpServer.address();
 if (!address || typeof address === "string") {
   await server.close();
   throw new Error("Vite did not expose a bound TCP address");

--- a/cmd/evener-hub/frontend/scripts/browserguard-vite.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserguard-vite.mjs
@@ -1,0 +1,36 @@
+import { fileURLToPath } from "node:url";
+import { createServer } from "vite";
+
+const server = await createServer({
+  configFile: fileURLToPath(new URL("./browserguard.vite.config.mjs", import.meta.url)),
+  server: { host: "127.0.0.1", port: 0, strictPort: true },
+});
+// Vite's CLI normalizes port 0 to its default; bind the already-created
+// HTTP server directly so the OS owns one random port for this child.
+// Vite normalizes port zero to its default in server.listen(). Its HTTP
+// listener retains the initialization wrapper and lets the OS own allocation.
+await new Promise((resolve, reject) => {
+  server.httpServer.once("error", reject);
+  server.httpServer.listen({ host: "127.0.0.1", port: 0 }, resolve);
+});
+const address = server.httpServer?.address();
+if (!address || typeof address === "string") {
+  await server.close();
+  throw new Error("Vite did not expose a bound TCP address");
+}
+process.stdout.write(`Local: http://127.0.0.1:${address.port}/\n`);
+
+let closing;
+const close = () => {
+  closing ??= server.close();
+  return closing;
+};
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, async () => {
+    try {
+      await close();
+    } finally {
+      process.exit(0);
+    }
+  });
+}


### PR DESCRIPTION
Browser guards can fail before opening Chrome because their temporary port-availability probe releases the port before Vite binds it. CI captured Vite rejecting the selected port as already in use.

Start a tracked Node child that creates the existing Vite configuration, binds the HTTP listener directly to loopback port zero, and announces the actual bound address. The parent waits for that announcement with cancellation, launch/exit error handling and a bounded readiness timeout. The serving process owns port allocation throughout startup. The helper checks that Vite created an HTTP server and removes its temporary bind-error listener on success so later runtime errors are not swallowed. Direct HTTP binding retains Vite's initialization wrapper; this Vite release otherwise normalizes port zero to its default in server.listen(). Existing child/process-group cleanup remains responsible for Vite and Chrome.

Validation: all 64 Node script tests pass, including two concurrent real Vite listeners serving the harness through startBrowserGuard, awaited listener-process/profile cleanup, and cancellation during startup. All five canonical browser guards pass (layout, overflow, shell, spawn and transcript scrolling). Independent lifecycle review coverage gaps are exercised by the real-server and cancellation tests. The later RoboRev bind-error listener finding is corrected, and all 64 Node tests and five canonical browser guards pass again on that correction. No layout assertions or timeouts were weakened.

Vite failures before readiness now carry their subsystem and captured stderr through the existing caller diagnostics. Cleanup finishes before an owned error wraps the original cause, so primitive or frozen cancellation reasons cannot skip child/profile cleanup. Three regressions fail against the previous implementation and pass for early Vite exit, primitive cancellation and frozen cancellation. The final 64-test script suite and all five canonical browser guards pass.
