### PR TITLE
feat(webui): new-session prompt offers /command and /skill autocomplete

### DIFF
--- a/appwire/client.go
+++ b/appwire/client.go
@@ -735,6 +735,12 @@ func (c *Client) PluginPreview(ctx context.Context, params PluginPreviewParams) 
 	return out, err
 }
 
+func (c *Client) SpawnSlashCatalog(ctx context.Context, params SpawnSlashCatalogParams) (SpawnSlashCatalogResponse, error) {
+	var out SpawnSlashCatalogResponse
+	err := c.request(ctx, MethodEvenerSpawnSlashCatalog, params, &out)
+	return out, err
+}
+
 func (c *Client) PluginInstall(ctx context.Context, params PluginRefParams) (PluginListResponse, error) {
 	var out PluginListResponse
 	err := c.request(ctx, MethodEvenerPluginInstall, params, &out)

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -199,6 +199,7 @@ var Methods = []MethodSpec{
 	{MethodEvenerPluginDisable, PluginRefParams{}, PluginListResponse{}, ScopeHub, "Disables an installed plugin; returns the updated list."},
 	{MethodEvenerPluginSetAutoUpgrade, PluginSetAutoUpgradeParams{}, PluginListResponse{}, ScopeHub, "Sets an installed plugin's auto-upgrade flag; returns the updated list."},
 	{MethodEvenerCommandList, EmptyParams{}, CommandListResponse{}, ScopeHub, "Lists loaded slash commands (name, plugin, description, source: plugin, project, or user) for catalog/autocomplete display."},
+	{MethodEvenerSpawnSlashCatalog, SpawnSlashCatalogParams{}, SpawnSlashCatalogResponse{}, ScopeHub, "Pre-session slash catalog for the spawn form: the commands and skills a session started with this cwd, harness, and launch overrides would offer."},
 	{MethodEvenerSettingsOverview, EmptyParams{}, SettingsOverviewResponse{}, ScopeHub, "Returns the settings overview field bag: hub/runtime, storage, agent roster, and probed MCP servers — the five template-only settings sections' data."},
 	{MethodEvenerSettingsTranscriptDisplayGet, EmptyParams{}, TranscriptDisplayDefaults{}, ScopeHub, "Reads the canonical Desktop and Mobile transcript-display defaults."},
 	{MethodEvenerSettingsTranscriptDisplayPatch, TranscriptDisplayDefaultsPatchParams{}, TranscriptDisplayPatchResponse{}, ScopeHub, "Updates one transcript-display default using an expected revision and returns the canonical value."},

--- a/appwire/spawn_slashcatalog_test.go
+++ b/appwire/spawn_slashcatalog_test.go
@@ -1,0 +1,48 @@
+package appwire
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSpawnSlashCatalogParamsMatchThreadStartSpelling(t *testing.T) {
+	data, err := json.Marshal(SpawnSlashCatalogParams{
+		CWD:             "/repo",
+		Harness:         "evener",
+		LaunchOverrides: &LaunchConfigLayer{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"cwd", "harness", "launchOverrides"} {
+		if _, ok := raw[key]; !ok {
+			t.Fatalf("params JSON = %v, missing %q", raw, key)
+		}
+	}
+}
+
+func TestSpawnSlashCatalogMethodCatalog(t *testing.T) {
+	var found *MethodSpec
+	for i := range Methods {
+		if Methods[i].Name == MethodEvenerSpawnSlashCatalog {
+			found = &Methods[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("method catalog missing %q", MethodEvenerSpawnSlashCatalog)
+	}
+	if found.Scope != ScopeHub {
+		t.Fatalf("spawn slash catalog scope = %q, want %q", found.Scope, ScopeHub)
+	}
+	if _, ok := found.Params.(SpawnSlashCatalogParams); !ok {
+		t.Fatalf("spawn slash catalog params type = %T, want SpawnSlashCatalogParams", found.Params)
+	}
+	if _, ok := found.Result.(SpawnSlashCatalogResponse); !ok {
+		t.Fatalf("spawn slash catalog result type = %T, want SpawnSlashCatalogResponse", found.Result)
+	}
+}

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -119,6 +119,7 @@ const (
 	MethodEvenerPluginDisable         = "evener/plugin/disable"
 	MethodEvenerPluginSetAutoUpgrade  = "evener/plugin/setAutoUpgrade"
 	MethodEvenerCommandList           = "evener/command/list"
+	MethodEvenerSpawnSlashCatalog     = "evener/spawn/slashCatalog"
 	// MethodEvenerSettingsOverview returns the field bag behind five settings
 	// sections whose only data path today is Go-template variables:
 	// hub/runtime, storage, agent roster, and probed MCP servers. See
@@ -3040,6 +3041,26 @@ type PluginCheckNowResponse struct {
 type PluginPreviewParams struct {
 	CWD             string             `json:"cwd"`
 	LaunchOverrides *LaunchConfigLayer `json:"launchOverrides,omitempty"`
+}
+
+// SpawnSlashCatalogParams requests the slash catalog a spawn with these
+// inputs would load. Field names and shapes match ThreadStartParams exactly:
+// when this call and a thread/start agree on all three, the menu shows what
+// that start would load. Model, effort, access mode, and prompt text do not
+// affect the inventory and are deliberately absent.
+type SpawnSlashCatalogParams struct {
+	CWD             string             `json:"cwd"`
+	Harness         string             `json:"harness,omitempty"`
+	LaunchOverrides *LaunchConfigLayer `json:"launchOverrides,omitempty"`
+}
+
+// SpawnSlashCatalogResponse is the pre-session slash inventory: the commands
+// and skills a session started with the params would offer. Row shapes reuse
+// CommandDescriptor and EvenerSkillInfo verbatim so the web composer merges
+// them with mergeSlashCommands unchanged.
+type SpawnSlashCatalogResponse struct {
+	Commands []CommandDescriptor `json:"commands"`
+	Skills   []EvenerSkillInfo   `json:"skills,omitempty"`
 }
 
 // PluginPreviewResponse is the launch plugin inventory and structured

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -2886,9 +2886,9 @@ type CommandDescriptor struct {
 	PluginName   string `json:"pluginName,omitempty"`
 	Description  string `json:"description,omitempty"`
 	ArgumentHint string `json:"argumentHint,omitempty"`
-	// Source is "plugin" or "user"; "project" is reserved for a future
-	// project-scoped catalog (project commands are cwd-dependent and never
-	// appear in the hub-wide catalog).
+	// Source is "plugin", "user", or "project". "project" is returned by the
+	// spawn-scoped catalog (project commands are cwd-dependent); it never
+	// appears in the hub-wide catalog.
 	Source string `json:"source,omitempty"`
 }
 

--- a/cmd/evener-hub/app_rpc.go
+++ b/cmd/evener-hub/app_rpc.go
@@ -1181,6 +1181,9 @@ func registerMiscHandlers(server *appserver.Server, cfg hubcore.WebConfig, sourc
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerCommandList, func(ctx context.Context, _ appwire.EmptyParams) (appwire.CommandListResponse, error) {
 		return hubCommandList(ctx, cfg)
 	})
+	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSpawnSlashCatalog, func(ctx context.Context, params appwire.SpawnSlashCatalogParams) (appwire.SpawnSlashCatalogResponse, error) {
+		return hubSpawnSlashCatalog(ctx, cfg, params)
+	})
 	appserver.HandleTyped(server.Router(), appwire.MethodEvenerSettingsOverview, func(ctx context.Context, _ appwire.EmptyParams) (appwire.SettingsOverviewResponse, error) {
 		return hubSettingsOverview(ctx, cfg)
 	})

--- a/cmd/evener-hub/app_rpc_test.go
+++ b/cmd/evener-hub/app_rpc_test.go
@@ -11889,6 +11889,7 @@ func TestHubRPCRegistersExpectedHandlerSet(t *testing.T) {
 		appwire.MethodEvenerMobilePairing,
 		appwire.MethodEvenerHarnessesList,
 		appwire.MethodEvenerCommandList,
+		appwire.MethodEvenerSpawnSlashCatalog,
 		appwire.MethodEvenerSettingsOverview,
 		appwire.MethodEvenerSettingsTranscriptDisplayGet,
 		appwire.MethodEvenerSettingsTranscriptDisplayPatch,

--- a/cmd/evener-hub/app_spawn_slashcatalog.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -16,7 +17,34 @@ import (
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/cmd/evener-hub/internal/launchconfig"
 	"primeradiant.com/evener/envvars/userdirs"
+	"primeradiant.com/evener/identifier"
 )
+
+// nearestExistingAncestorDir walks up from path to the nearest existing
+// ancestor directory. A path with no existing ancestor (or one whose nearest
+// existing path is not a directory) is a caller error, not a missing
+// directory.
+func nearestExistingAncestorDir(path string) (string, error) {
+	requested := filepath.Clean(strings.TrimSpace(path))
+	ancestor := requested
+	for {
+		info, statErr := os.Stat(ancestor)
+		if statErr == nil {
+			if !info.IsDir() {
+				return "", errors.New("nearest existing path is not a directory")
+			}
+			return ancestor, nil
+		}
+		if !errors.Is(statErr, os.ErrNotExist) {
+			return "", statErr
+		}
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			return "", errors.New("no existing ancestor")
+		}
+		ancestor = parent
+	}
+}
 
 // hubSpawnSlashCatalog answers evener/spawn/slashCatalog: the slash inventory
 // (commands + skills) a session started with these params would offer. It
@@ -49,18 +77,31 @@ func hubSpawnSlashCatalog(ctx context.Context, cfg hubcore.WebConfig, params app
 		canonical, err := hubCanonicalizeDir(params.CWD)
 		if err != nil {
 			// A not-yet-created directory is a normal spawn-flow state
-			// (preflightDir's "Create & start"): with no project on disk
-			// yet there is nothing project-scoped to offer, so fall back
-			// to the user-level inventory rather than failing. Any other
-			// canonicalization error stays InvalidParams.
+			// (preflightDir's "Create & start"). Resolve the nearest
+			// existing ancestor instead: after creation the session loads
+			// that ancestor chain's project items, so the catalog must show
+			// them now. Any other canonicalization error stays InvalidParams.
 			if !errors.Is(err, os.ErrNotExist) {
 				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + err.Error())
 			}
-			userResolved, userErr := launchconfig.ResolveUserOnly(hubLaunchConfigRoot(cfg), overrides)
-			if userErr != nil {
-				return appwire.SpawnSlashCatalogResponse{}, userErr
+			ancestor, ancestorErr := nearestExistingAncestorDir(params.CWD)
+			if ancestorErr != nil {
+				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + ancestorErr.Error())
 			}
-			resolved = userResolved
+			canonical, err = hubCanonicalizeDir(ancestor)
+			if err != nil {
+				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + err.Error())
+			}
+			project, projectErr := identifier.ResolveProject(canonical)
+			if projectErr != nil {
+				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + projectErr.Error())
+			}
+			ancestorResolved, err := launchconfig.ResolveWithProject(hubLaunchConfigRoot(cfg), canonical, project, overrides)
+			if err != nil {
+				return appwire.SpawnSlashCatalogResponse{}, err
+			}
+			resolved = ancestorResolved
+			canonicalCWD = canonical
 		} else {
 			canonicalCWD = canonical
 			fullResolved, err := hubResolveLaunch(hubLaunchConfigRoot(cfg), canonical, overrides)

--- a/cmd/evener-hub/app_spawn_slashcatalog.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog.go
@@ -109,6 +109,18 @@ func hubSpawnSlashCatalog(ctx context.Context, cfg hubcore.WebConfig, params app
 		skill.ScanSkillsDir(userSkillsDir, all)
 	}
 	maps.Copy(all, skill.DiscoverSkills(env, resolved.Effective.SkillsDirs...))
+	if env == nil {
+		// DiscoverSkills returns nil without scanning anything when there is
+		// no execution environment, but configured extra skill directories
+		// are cwd-independent: a session loads them whatever the cwd, so an
+		// empty-cwd (user-level) catalog scans them directly.
+		for _, dir := range resolved.Effective.SkillsDirs {
+			if strings.TrimSpace(dir) == "" {
+				continue
+			}
+			skill.ScanSkillsDir(dir, all)
+		}
+	}
 	for _, inst := range loaded {
 		maps.Copy(all, inst.Skills)
 	}

--- a/cmd/evener-hub/app_spawn_slashcatalog.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog.go
@@ -1,0 +1,12 @@
+package hub
+
+import (
+	"context"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func hubSpawnSlashCatalog(_ context.Context, _ hubcore.WebConfig, _ appwire.SpawnSlashCatalogParams) (appwire.SpawnSlashCatalogResponse, error) {
+	return appwire.SpawnSlashCatalogResponse{Commands: []appwire.CommandDescriptor{}}, nil
+}

--- a/cmd/evener-hub/app_spawn_slashcatalog.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -17,34 +16,7 @@ import (
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/cmd/evener-hub/internal/launchconfig"
 	"primeradiant.com/evener/envvars/userdirs"
-	"primeradiant.com/evener/identifier"
 )
-
-// nearestExistingAncestorDir walks up from path to the nearest existing
-// ancestor directory. A path with no existing ancestor (or one whose nearest
-// existing path is not a directory) is a caller error, not a missing
-// directory.
-func nearestExistingAncestorDir(path string) (string, error) {
-	requested := filepath.Clean(strings.TrimSpace(path))
-	ancestor := requested
-	for {
-		info, statErr := os.Stat(ancestor)
-		if statErr == nil {
-			if !info.IsDir() {
-				return "", errors.New("nearest existing path is not a directory")
-			}
-			return ancestor, nil
-		}
-		if !errors.Is(statErr, os.ErrNotExist) {
-			return "", statErr
-		}
-		parent := filepath.Dir(ancestor)
-		if parent == ancestor {
-			return "", errors.New("no existing ancestor")
-		}
-		ancestor = parent
-	}
-}
 
 // hubSpawnSlashCatalog answers evener/spawn/slashCatalog: the slash inventory
 // (commands + skills) a session started with these params would offer. It
@@ -77,31 +49,32 @@ func hubSpawnSlashCatalog(ctx context.Context, cfg hubcore.WebConfig, params app
 		canonical, err := hubCanonicalizeDir(params.CWD)
 		if err != nil {
 			// A not-yet-created directory is a normal spawn-flow state
-			// (preflightDir's "Create & start"). Resolve the nearest
-			// existing ancestor instead: after creation the session loads
-			// that ancestor chain's project items, so the catalog must show
-			// them now. Any other canonicalization error stays InvalidParams.
+			// (preflightDir's "Create & start"). Resolve it the way plugin
+			// preview does: a disposable probe directory under the nearest
+			// existing ancestor, carrying the eventual target's project
+			// identity. The probe leaf is empty like the not-yet-created
+			// target, so cwd-anchored layers (.evener/launch.toml,
+			// .evener/launch.local.toml) resolve absent exactly as
+			// thread/start will see them after creation — while the
+			// ancestor chain above still contributes its project items.
+			// Resolving against the ancestor itself would be wrong: its own
+			// cwd-anchored files would leak into the catalog although the
+			// session never loads them. Any other canonicalization error
+			// stays InvalidParams.
 			if !errors.Is(err, os.ErrNotExist) {
 				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + err.Error())
 			}
-			ancestor, ancestorErr := nearestExistingAncestorDir(params.CWD)
-			if ancestorErr != nil {
-				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + ancestorErr.Error())
+			probeDir, project, cleanup, probeErr := pluginPreviewCWD(params.CWD)
+			if probeErr != nil {
+				return appwire.SpawnSlashCatalogResponse{}, probeErr
 			}
-			canonical, err = hubCanonicalizeDir(ancestor)
-			if err != nil {
-				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + err.Error())
-			}
-			project, projectErr := identifier.ResolveProject(canonical)
-			if projectErr != nil {
-				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + projectErr.Error())
-			}
-			ancestorResolved, err := launchconfig.ResolveWithProject(hubLaunchConfigRoot(cfg), canonical, project, overrides)
+			defer cleanup()
+			probeResolved, err := launchconfig.ResolveWithProject(hubLaunchConfigRoot(cfg), probeDir, project, overrides)
 			if err != nil {
 				return appwire.SpawnSlashCatalogResponse{}, err
 			}
-			resolved = ancestorResolved
-			canonicalCWD = canonical
+			resolved = probeResolved
+			canonicalCWD = probeDir
 		} else {
 			canonicalCWD = canonical
 			fullResolved, err := hubResolveLaunch(hubLaunchConfigRoot(cfg), canonical, overrides)

--- a/cmd/evener-hub/app_spawn_slashcatalog.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog.go
@@ -48,14 +48,27 @@ func hubSpawnSlashCatalog(ctx context.Context, cfg hubcore.WebConfig, params app
 	} else {
 		canonical, err := hubCanonicalizeDir(params.CWD)
 		if err != nil {
-			return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + err.Error())
+			// A not-yet-created directory is a normal spawn-flow state
+			// (preflightDir's "Create & start"): with no project on disk
+			// yet there is nothing project-scoped to offer, so fall back
+			// to the user-level inventory rather than failing. Any other
+			// canonicalization error stays InvalidParams.
+			if !errors.Is(err, os.ErrNotExist) {
+				return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + err.Error())
+			}
+			userResolved, userErr := launchconfig.ResolveUserOnly(hubLaunchConfigRoot(cfg), overrides)
+			if userErr != nil {
+				return appwire.SpawnSlashCatalogResponse{}, userErr
+			}
+			resolved = userResolved
+		} else {
+			canonicalCWD = canonical
+			fullResolved, err := hubResolveLaunch(hubLaunchConfigRoot(cfg), canonical, overrides)
+			if err != nil {
+				return appwire.SpawnSlashCatalogResponse{}, err
+			}
+			resolved = fullResolved
 		}
-		canonicalCWD = canonical
-		fullResolved, err := hubResolveLaunch(hubLaunchConfigRoot(cfg), canonical, overrides)
-		if err != nil {
-			return appwire.SpawnSlashCatalogResponse{}, err
-		}
-		resolved = fullResolved
 	}
 	// thread/start launches with spawnResolved.Effective.PluginDirs carried on
 	// the Resolved value (the resolver's own SelectedDirs never reach the

--- a/cmd/evener-hub/app_spawn_slashcatalog.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog.go
@@ -57,19 +57,22 @@ func hubSpawnSlashCatalog(ctx context.Context, cfg hubcore.WebConfig, params app
 		}
 		resolved = fullResolved
 	}
+	// thread/start launches with spawnResolved.Effective.PluginDirs carried on
+	// the Resolved value (the resolver's own SelectedDirs never reach the
+	// child), so the fallthrough below keeps the same dirs: the catalog then
+	// shows what the resulting session loads instead of going empty.
 	pluginDirs := resolved.Effective.PluginDirs
 	if resolution, err := hubResolvePlugins(ctx, cfg.PluginRoot, resolved.Effective.PluginDirs, resolved.Effective.EnabledPlugins); err != nil {
 		// Same admission rule thread/start uses (app_threadlifecycle.go): a
 		// resolver failure is fatal when a selection must be honored, and
 		// always when the failure IS the caller leaving (canceled/deadline on
 		// the error itself, not the ambient context). Everything else falls
-		// through with whatever the resolver could list.
+		// through with the effective plugin dirs above.
 		if resolved.Effective.EnabledPlugins != nil ||
 			errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return appwire.SpawnSlashCatalogResponse{}, appwire.HubLaunchError(err.Error())
 		}
 		_, _ = fmt.Fprintf(os.Stderr, "warning: resolving plugins for slash catalog: %v\n", err)
-		pluginDirs = nil
 	} else if err := resolution.ValidateSelection(); err != nil {
 		return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams(err.Error())
 	} else {

--- a/cmd/evener-hub/app_spawn_slashcatalog.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog.go
@@ -29,7 +29,7 @@ import (
 func hubSpawnSlashCatalog(ctx context.Context, cfg hubcore.WebConfig, params appwire.SpawnSlashCatalogParams) (appwire.SpawnSlashCatalogResponse, error) {
 	harness := strings.TrimSpace(params.Harness)
 	if harness != "" && harness != "evener" {
-		return appwire.SpawnSlashCatalogResponse{Commands: []appwire.CommandDescriptor{}}, nil
+		return appwire.SpawnSlashCatalogResponse{Commands: []appwire.CommandDescriptor{}, Skills: []appwire.EvenerSkillInfo{}}, nil
 	}
 	var overrides launchconfig.Layer
 	if params.LaunchOverrides != nil {

--- a/cmd/evener-hub/app_spawn_slashcatalog.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog.go
@@ -2,11 +2,117 @@ package hub
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"sort"
+	"strings"
 
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/plugin"
+	"primeradiant.com/evener/agent/skill"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/cmd/evener-hub/internal/launchconfig"
+	"primeradiant.com/evener/envvars/userdirs"
 )
 
-func hubSpawnSlashCatalog(_ context.Context, _ hubcore.WebConfig, _ appwire.SpawnSlashCatalogParams) (appwire.SpawnSlashCatalogResponse, error) {
-	return appwire.SpawnSlashCatalogResponse{Commands: []appwire.CommandDescriptor{}}, nil
+// hubSpawnSlashCatalog answers evener/spawn/slashCatalog: the slash inventory
+// (commands + skills) a session started with these params would offer. It
+// resolves launch config the way thread/start does (minus model handling: no
+// scalars exist on these params and no model is required), then runs the same
+// discovery session init runs: plugin dirs fail-soft, evener-wide project +
+// user-global commands, and the embedded -> user -> project+extra -> plugin
+// skill layering. Discovery only reads manifests, markdown, and SKILL.md
+// frontmatter: it starts no session and executes nothing.
+func hubSpawnSlashCatalog(ctx context.Context, cfg hubcore.WebConfig, params appwire.SpawnSlashCatalogParams) (appwire.SpawnSlashCatalogResponse, error) {
+	harness := strings.TrimSpace(params.Harness)
+	if harness != "" && harness != "evener" {
+		return appwire.SpawnSlashCatalogResponse{Commands: []appwire.CommandDescriptor{}}, nil
+	}
+	var overrides launchconfig.Layer
+	if params.LaunchOverrides != nil {
+		overrides = launchconfig.FromWire(*params.LaunchOverrides)
+	}
+	var (
+		resolved     launchconfig.Resolved
+		canonicalCWD string
+	)
+	if strings.TrimSpace(params.CWD) == "" {
+		userResolved, err := launchconfig.ResolveUserOnly(hubLaunchConfigRoot(cfg), overrides)
+		if err != nil {
+			return appwire.SpawnSlashCatalogResponse{}, err
+		}
+		resolved = userResolved
+	} else {
+		canonical, err := hubCanonicalizeDir(params.CWD)
+		if err != nil {
+			return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams("cwd: " + err.Error())
+		}
+		canonicalCWD = canonical
+		fullResolved, err := hubResolveLaunch(hubLaunchConfigRoot(cfg), canonical, overrides)
+		if err != nil {
+			return appwire.SpawnSlashCatalogResponse{}, err
+		}
+		resolved = fullResolved
+	}
+	pluginDirs := resolved.Effective.PluginDirs
+	if resolution, err := hubResolvePlugins(ctx, cfg.PluginRoot, resolved.Effective.PluginDirs, resolved.Effective.EnabledPlugins); err != nil {
+		// Same admission rule thread/start uses (app_threadlifecycle.go): a
+		// resolver failure is fatal when a selection must be honored, and
+		// always when the failure IS the caller leaving (canceled/deadline on
+		// the error itself, not the ambient context). Everything else falls
+		// through with whatever the resolver could list.
+		if resolved.Effective.EnabledPlugins != nil ||
+			errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return appwire.SpawnSlashCatalogResponse{}, appwire.HubLaunchError(err.Error())
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "warning: resolving plugins for slash catalog: %v\n", err)
+		pluginDirs = nil
+	} else if err := resolution.ValidateSelection(); err != nil {
+		return appwire.SpawnSlashCatalogResponse{}, appwire.InvalidParams(err.Error())
+	} else {
+		pluginDirs = resolution.SelectedDirs
+	}
+	loaded, _ := plugin.LoadAllFailSoft(pluginDirs)
+	var env execenv.ExecutionEnvironment
+	if canonicalCWD != "" {
+		env = execenv.NewLocalExecutionEnvironment(canonicalCWD)
+	}
+	evenerwide, _ := plugin.DiscoverEvenerWideCommands(env)
+	merged := plugin.MergeCommands(loaded, evenerwide)
+	commands := make([]appwire.CommandDescriptor, 0, len(merged))
+	for _, cmd := range merged {
+		commands = append(commands, appwire.CommandDescriptor{
+			Name: cmd.Name, PluginName: cmd.PluginName,
+			Description: cmd.Description, ArgumentHint: cmd.ArgumentHint, Source: cmd.Source,
+		})
+	}
+	sort.Slice(commands, func(i, j int) bool {
+		if commands[i].Name != commands[j].Name {
+			return commands[i].Name < commands[j].Name
+		}
+		if commands[i].PluginName != commands[j].PluginName {
+			return commands[i].PluginName < commands[j].PluginName
+		}
+		return commands[i].Source < commands[j].Source
+	})
+	all := make(map[string]skill.SkillMeta)
+	if embedded, err := skill.EmbeddedSkills(); err == nil {
+		maps.Copy(all, embedded)
+	}
+	if userSkillsDir := userdirs.Subdir(userdirs.DefaultConfigRoot(), "skills"); userSkillsDir != "" {
+		skill.ScanSkillsDir(userSkillsDir, all)
+	}
+	maps.Copy(all, skill.DiscoverSkills(env, resolved.Effective.SkillsDirs...))
+	for _, inst := range loaded {
+		maps.Copy(all, inst.Skills)
+	}
+	entries := skill.CatalogEntries(all)
+	skills := make([]appwire.EvenerSkillInfo, 0, len(entries))
+	for _, entry := range entries {
+		skills = append(skills, appwire.EvenerSkillInfo{Name: entry.Name, Description: entry.Description})
+	}
+	return appwire.SpawnSlashCatalogResponse{Commands: commands, Skills: skills}, nil
 }

--- a/cmd/evener-hub/app_spawn_slashcatalog_test.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog_test.go
@@ -6,12 +6,14 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+	"primeradiant.com/evener/internal/plugins"
 )
 
 func writeSlashCatalogPlugin(t *testing.T, dir, pluginName, commandName string) {
@@ -204,5 +206,34 @@ func TestHubSpawnSlashCatalog_EnabledPluginsSelectionHonored(t *testing.T) {
 		if cmd.Name == "beta-cmd" {
 			t.Errorf("deselected plugin command %q leaked into the catalog: %+v", cmd.Name, resp.Commands)
 		}
+	}
+}
+
+func TestHubSpawnSlashCatalog_NonfatalResolverErrorKeepsEffectivePluginDirs(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	pluginDir := t.TempDir()
+	writeSlashCatalogPlugin(t, pluginDir, "greeter", "greet")
+
+	// A nonfatal resolver error (no selection to honor, live context) must
+	// not empty the catalog: thread/start launches with the effective plugin
+	// dirs on Resolved, so the catalog keeps those same dirs and shows what
+	// the resulting session loads.
+	origResolve := hubResolvePlugins
+	hubResolvePlugins = func(ctx context.Context, pluginRoot string, dirs []string, enabled *[]string) (plugins.LaunchPluginResolution, error) {
+		return plugins.LaunchPluginResolution{}, errors.New("registry unreachable")
+	}
+	t.Cleanup(func() { hubResolvePlugins = origResolve })
+
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD:             t.TempDir(),
+		LaunchOverrides: &appwire.LaunchConfigLayer{PluginDirs: []string{pluginDir}},
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v, want fallthrough on a nonfatal resolver error", err)
+	}
+	greet := slashCatalogCommandByName(t, resp, "greet")
+	if greet.Source != "plugin" {
+		t.Errorf("greet Source = %q, want %q (effective plugin dirs retained)", greet.Source, "plugin")
 	}
 }

--- a/cmd/evener-hub/app_spawn_slashcatalog_test.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog_test.go
@@ -259,3 +259,28 @@ func TestHubSpawnSlashCatalog_EmptyCWDScansConfiguredSkillsDirs(t *testing.T) {
 		t.Errorf("configured skill %q missing from empty-cwd catalog: %v", "extras", slashCatalogSkillNames(resp))
 	}
 }
+
+func TestHubSpawnSlashCatalog_MissingCWDFallsBackToUserLevelInventory(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	parent := t.TempDir()
+	missing := filepath.Join(parent, "not-yet-created")
+	pluginDir := t.TempDir()
+	writeSlashCatalogPlugin(t, pluginDir, "greeter", "greet")
+
+	// The spawn flow creates a missing directory via preflightDir ("Create &
+	// start"), so the catalog must not fail for it: with no project on disk
+	// yet, the honest inventory is the user level (global + explicit plugin
+	// dirs), not an error.
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD:             missing,
+		LaunchOverrides: &appwire.LaunchConfigLayer{PluginDirs: []string{pluginDir}},
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v, want user-level fallthrough for a not-yet-created cwd", err)
+	}
+	greet := slashCatalogCommandByName(t, resp, "greet")
+	if greet.Source != "plugin" {
+		t.Errorf("greet Source = %q, want %q", greet.Source, "plugin")
+	}
+}

--- a/cmd/evener-hub/app_spawn_slashcatalog_test.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog_test.go
@@ -237,3 +237,25 @@ func TestHubSpawnSlashCatalog_NonfatalResolverErrorKeepsEffectivePluginDirs(t *t
 		t.Errorf("greet Source = %q, want %q (effective plugin dirs retained)", greet.Source, "plugin")
 	}
 }
+
+func TestHubSpawnSlashCatalog_EmptyCWDScansConfiguredSkillsDirs(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	extraSkills := t.TempDir()
+	writeSlashCatalogSkill(t, extraSkills, "extras", "extras", "Extra skills")
+
+	// An empty cwd returns the user-level inventory, but configured extra
+	// skill directories are cwd-independent: a session loads them whatever
+	// the cwd, so the catalog must include them too. (DiscoverSkills with a
+	// nil env returns nil without scanning extraDirs.)
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD:             "",
+		LaunchOverrides: &appwire.LaunchConfigLayer{SkillsDirs: []string{extraSkills}},
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v", err)
+	}
+	if _, ok := slashCatalogSkillNames(resp)["extras"]; !ok {
+		t.Errorf("configured skill %q missing from empty-cwd catalog: %v", "extras", slashCatalogSkillNames(resp))
+	}
+}

--- a/cmd/evener-hub/app_spawn_slashcatalog_test.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog_test.go
@@ -269,9 +269,9 @@ func TestHubSpawnSlashCatalog_MissingCWDFallsBackToUserLevelInventory(t *testing
 	writeSlashCatalogPlugin(t, pluginDir, "greeter", "greet")
 
 	// The spawn flow creates a missing directory via preflightDir ("Create &
-	// start"), so the catalog must not fail for it: with no project on disk
-	// yet, the honest inventory is the user level (global + explicit plugin
-	// dirs), not an error.
+	// start"), so the catalog must not fail for it: the nearest existing
+	// ancestor (bare here, so no project items) resolves, and explicit plugin
+	// dirs still surface.
 	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
 		CWD:             missing,
 		LaunchOverrides: &appwire.LaunchConfigLayer{PluginDirs: []string{pluginDir}},
@@ -282,5 +282,46 @@ func TestHubSpawnSlashCatalog_MissingCWDFallsBackToUserLevelInventory(t *testing
 	greet := slashCatalogCommandByName(t, resp, "greet")
 	if greet.Source != "plugin" {
 		t.Errorf("greet Source = %q, want %q", greet.Source, "plugin")
+	}
+}
+
+func TestHubSpawnSlashCatalog_MissingCWDSeesAncestorProjectInventory(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	parent := t.TempDir()
+	writeSlashCatalogProjectCommand(t, parent, "deploy", "Deploy the thing")
+	writeSlashCatalogSkill(t, filepath.Join(parent, "skills"), "deployskill", "deployskill", "Deploys stuff")
+	missing := filepath.Join(parent, "not-yet-created")
+
+	// The spawn flow creates a missing directory via preflightDir ("Create &
+	// start"), and thread/start then loads the ancestor chain's project
+	// items — so the catalog resolves the nearest existing ancestor instead
+	// of failing or answering user-level-only.
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD: missing,
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v, want ancestor-project inventory for a not-yet-created cwd", err)
+	}
+	deploy := slashCatalogCommandByName(t, resp, "deploy")
+	if deploy.Source != "project" {
+		t.Errorf("deploy Source = %q, want %q", deploy.Source, "project")
+	}
+	if _, ok := slashCatalogSkillNames(resp)["deployskill"]; !ok {
+		t.Errorf("project skill %q missing from missing-cwd catalog: %v", "deployskill", slashCatalogSkillNames(resp))
+	}
+}
+
+func TestHubSpawnSlashCatalog_FileCWDIsInvalidParams(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	file := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD: file,
+	}); err == nil {
+		t.Fatal("hubSpawnSlashCatalog with a file cwd = nil error, want InvalidParams")
 	}
 }

--- a/cmd/evener-hub/app_spawn_slashcatalog_test.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog_test.go
@@ -1,0 +1,208 @@
+package hub
+
+// Tests for evener/spawn/slashCatalog: the pre-session slash inventory
+// (commands + skills) a spawn with the given cwd, harness, and launch
+// overrides would offer.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+func writeSlashCatalogPlugin(t *testing.T, dir, pluginName, commandName string) {
+	t.Helper()
+	metaDir := filepath.Join(dir, ".claude-plugin")
+	if err := os.MkdirAll(metaDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(metaDir, "plugin.json"), []byte(`{"name": "`+pluginName+`"}`), 0644); err != nil {
+		t.Fatalf("write plugin.json: %v", err)
+	}
+	commandsDir := filepath.Join(dir, "commands")
+	if err := os.MkdirAll(commandsDir, 0755); err != nil {
+		t.Fatalf("mkdir commands: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(commandsDir, commandName+".md"),
+		[]byte("---\ndescription: Command "+commandName+"\n---\nBody"), 0644); err != nil {
+		t.Fatalf("write command: %v", err)
+	}
+}
+
+func writeSlashCatalogSkill(t *testing.T, skillsDir, dirName, name, description string) {
+	t.Helper()
+	dir := filepath.Join(skillsDir, dirName)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir skill: %v", err)
+	}
+	content := "---\nname: " + name + "\ndescription: " + description + "\n---\nBody\n"
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+func writeSlashCatalogProjectCommand(t *testing.T, cwd, name, description string) {
+	t.Helper()
+	dir := filepath.Join(cwd, ".evener", "commands")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir project commands: %v", err)
+	}
+	content := "---\ndescription: " + description + "\n---\nBody\n"
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(content), 0644); err != nil {
+		t.Fatalf("write project command: %v", err)
+	}
+}
+
+func slashCatalogCommandByName(t *testing.T, resp appwire.SpawnSlashCatalogResponse, name string) appwire.CommandDescriptor {
+	t.Helper()
+	for _, cmd := range resp.Commands {
+		if cmd.Name == name {
+			return cmd
+		}
+	}
+	t.Fatalf("command %q not in catalog: %+v", name, resp.Commands)
+	return appwire.CommandDescriptor{}
+}
+
+func slashCatalogSkillNames(resp appwire.SpawnSlashCatalogResponse) map[string]string {
+	out := make(map[string]string, len(resp.Skills))
+	for _, s := range resp.Skills {
+		out[s.Name] = s.Description
+	}
+	return out
+}
+
+func TestHubSpawnSlashCatalog_ProjectCommandAndSkill(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	cwd := t.TempDir()
+	writeSlashCatalogProjectCommand(t, cwd, "deploy", "Deploy the thing")
+	writeSlashCatalogSkill(t, filepath.Join(cwd, "skills"), "deployskill", "deployskill", "Deploys stuff")
+	pluginDir := t.TempDir()
+	writeSlashCatalogPlugin(t, pluginDir, "greeter", "greet")
+	writeSlashCatalogSkill(t, filepath.Join(pluginDir, "skills"), "helper", "helper", "Helps out")
+
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD:             cwd,
+		LaunchOverrides: &appwire.LaunchConfigLayer{PluginDirs: []string{pluginDir}},
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v", err)
+	}
+	deploy := slashCatalogCommandByName(t, resp, "deploy")
+	if deploy.Source != "project" {
+		t.Errorf("deploy Source = %q, want %q", deploy.Source, "project")
+	}
+	greet := slashCatalogCommandByName(t, resp, "greet")
+	if greet.Source != "plugin" {
+		t.Errorf("greet Source = %q, want %q", greet.Source, "plugin")
+	}
+	skills := slashCatalogSkillNames(resp)
+	if _, ok := skills["deployskill"]; !ok {
+		t.Errorf("project skill %q missing from catalog: %v", "deployskill", skills)
+	}
+	if _, ok := skills["greeter:helper"]; !ok {
+		t.Errorf("plugin skill %q missing from catalog: %v", "greeter:helper", skills)
+	}
+}
+
+func TestHubSpawnSlashCatalog_EmptyCWDIsUserLevelOnly(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	commandsDir := filepath.Join(xdg, "evener", "commands")
+	if err := os.MkdirAll(commandsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(commandsDir, "standup.md"), []byte("standup body"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	otherDir := t.TempDir()
+	writeSlashCatalogProjectCommand(t, otherDir, "projectonly", "Only in the other project")
+
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v", err)
+	}
+	standup := slashCatalogCommandByName(t, resp, "standup")
+	if standup.Source != "user" {
+		t.Errorf("standup Source = %q, want %q", standup.Source, "user")
+	}
+	for _, cmd := range resp.Commands {
+		if cmd.Name == "projectonly" {
+			t.Errorf("project command %q leaked into the user-level catalog: %+v", cmd.Name, resp.Commands)
+		}
+	}
+}
+
+func TestHubSpawnSlashCatalog_NonEvenerHarnessIsEmpty(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	pluginDir := t.TempDir()
+	writeSlashCatalogPlugin(t, pluginDir, "greeter", "greet")
+
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD:             t.TempDir(),
+		Harness:         "external",
+		LaunchOverrides: &appwire.LaunchConfigLayer{PluginDirs: []string{pluginDir}},
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v", err)
+	}
+	if len(resp.Commands) != 0 {
+		t.Errorf("Commands = %+v, want empty for a non-evener harness", resp.Commands)
+	}
+	if len(resp.Skills) != 0 {
+		t.Errorf("Skills = %+v, want empty for a non-evener harness", resp.Skills)
+	}
+}
+
+func TestHubSpawnSlashCatalog_BrokenPluginDirDoesNotBrickCatalog(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	brokenDir := t.TempDir() // no .claude-plugin/plugin.json at all: Load fails.
+	healthyDir := t.TempDir()
+	writeSlashCatalogPlugin(t, healthyDir, "greeter", "greet")
+
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD:             t.TempDir(),
+		LaunchOverrides: &appwire.LaunchConfigLayer{PluginDirs: []string{brokenDir, healthyDir}},
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v, want the broken dir skipped rather than aborting the whole catalog", err)
+	}
+	greet := slashCatalogCommandByName(t, resp, "greet")
+	if greet.Source != "plugin" {
+		t.Errorf("greet Source = %q, want %q", greet.Source, "plugin")
+	}
+}
+
+func TestHubSpawnSlashCatalog_EnabledPluginsSelectionHonored(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	dirA := t.TempDir()
+	writeSlashCatalogPlugin(t, dirA, "alpha", "alpha-cmd")
+	dirB := t.TempDir()
+	writeSlashCatalogPlugin(t, dirB, "beta", "beta-cmd")
+	selected := []string{"alpha"}
+
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD: t.TempDir(),
+		LaunchOverrides: &appwire.LaunchConfigLayer{
+			PluginDirs:     []string{dirA, dirB},
+			EnabledPlugins: &selected,
+		},
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v", err)
+	}
+	slashCatalogCommandByName(t, resp, "alpha-cmd")
+	for _, cmd := range resp.Commands {
+		if cmd.Name == "beta-cmd" {
+			t.Errorf("deselected plugin command %q leaked into the catalog: %+v", cmd.Name, resp.Commands)
+		}
+	}
+}

--- a/cmd/evener-hub/app_spawn_slashcatalog_test.go
+++ b/cmd/evener-hub/app_spawn_slashcatalog_test.go
@@ -289,19 +289,22 @@ func TestHubSpawnSlashCatalog_MissingCWDSeesAncestorProjectInventory(t *testing.
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
 	parent := t.TempDir()
+	hubTestMakeGitRepo(t, parent, "README.md", "repo")
 	writeSlashCatalogProjectCommand(t, parent, "deploy", "Deploy the thing")
 	writeSlashCatalogSkill(t, filepath.Join(parent, "skills"), "deployskill", "deployskill", "Deploys stuff")
 	missing := filepath.Join(parent, "not-yet-created")
 
 	// The spawn flow creates a missing directory via preflightDir ("Create &
-	// start"), and thread/start then loads the ancestor chain's project
-	// items — so the catalog resolves the nearest existing ancestor instead
-	// of failing or answering user-level-only.
+	// start"), and thread/start then loads the ancestor chain's project items
+	// (chain discovery from the git root) — so the catalog resolves the
+	// missing target through a probe under the nearest existing ancestor and
+	// shows the same chain. A bare temp dir is not a git repo, so this needs
+	// a real one: without it the chain is the leaf alone.
 	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
 		CWD: missing,
 	})
 	if err != nil {
-		t.Fatalf("hubSpawnSlashCatalog: %v, want ancestor-project inventory for a not-yet-created cwd", err)
+		t.Fatalf("hubSpawnSlashCatalog: %v, want ancestor-chain inventory for a not-yet-created cwd", err)
 	}
 	deploy := slashCatalogCommandByName(t, resp, "deploy")
 	if deploy.Source != "project" {
@@ -309,6 +312,30 @@ func TestHubSpawnSlashCatalog_MissingCWDSeesAncestorProjectInventory(t *testing.
 	}
 	if _, ok := slashCatalogSkillNames(resp)["deployskill"]; !ok {
 		t.Errorf("project skill %q missing from missing-cwd catalog: %v", "deployskill", slashCatalogSkillNames(resp))
+	}
+}
+
+func TestHubSpawnSlashCatalog_MissingCWDOutsideRepoIsUserLevelOnly(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	parent := t.TempDir()
+	// No git repo: chain discovery is the leaf alone, and the missing leaf
+	// is empty — so (like thread/start at the created-then-empty target) the
+	// honest inventory is user-level-only. Ancestor project files must not
+	// leak in.
+	writeSlashCatalogProjectCommand(t, parent, "deploy", "Deploy the thing")
+	missing := filepath.Join(parent, "not-yet-created")
+
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD: missing,
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v", err)
+	}
+	for _, cmd := range resp.Commands {
+		if cmd.Name == "deploy" {
+			t.Errorf("non-repo ancestor command %q leaked into missing-cwd catalog", cmd.Name)
+		}
 	}
 }
 
@@ -323,5 +350,39 @@ func TestHubSpawnSlashCatalog_FileCWDIsInvalidParams(t *testing.T) {
 		CWD: file,
 	}); err == nil {
 		t.Fatal("hubSpawnSlashCatalog with a file cwd = nil error, want InvalidParams")
+	}
+}
+
+func TestHubSpawnSlashCatalog_MissingCWDDoesNotLeakAncestorLocalConfig(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	parent := t.TempDir()
+	hubTestMakeGitRepo(t, parent, "README.md", "repo")
+	// Ancestor chain items DO surface...
+	writeSlashCatalogProjectCommand(t, parent, "deploy", "Deploy the thing")
+	// ...but the ancestor's own cwd-anchored launch.local.toml must NOT:
+	// thread/start at the (empty) target reads target/.evener/launch.local.toml
+	// (absent), never the ancestor's.
+	leakSkills := t.TempDir()
+	writeSlashCatalogSkill(t, leakSkills, "leaked", "leaked", "Must not appear")
+	evenerDir := filepath.Join(parent, ".evener")
+	if err := os.MkdirAll(evenerDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(evenerDir, "launch.local.toml"),
+		[]byte(`skills_dirs = ["`+leakSkills+`"]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(parent, "not-yet-created")
+
+	resp, err := hubSpawnSlashCatalog(context.Background(), hubcore.WebConfig{}, appwire.SpawnSlashCatalogParams{
+		CWD: missing,
+	})
+	if err != nil {
+		t.Fatalf("hubSpawnSlashCatalog: %v", err)
+	}
+	slashCatalogCommandByName(t, resp, "deploy")
+	if _, ok := slashCatalogSkillNames(resp)["leaked"]; ok {
+		t.Errorf("ancestor launch.local.toml skill %q leaked into missing-cwd catalog", "leaked")
 	}
 }

--- a/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
+++ b/cmd/evener-hub/frontend/src/dev/spawnguard-entry.tsx
@@ -78,6 +78,7 @@ fake.on("evener/plugin/preview", () => ({
     },
   ],
 }));
+fake.on("evener/spawn/slashCatalog", () => ({ commands: [], skills: [] }));
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("spawnguard.html is missing #root");

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testi
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { WireError } from "../../protocol/errors";
+import type { ThreadModel } from "../../protocol/model";
 import { FakeClient } from "../../protocol/testing/fakeClient";
 import type {
   AnyNotification,
@@ -21,14 +22,50 @@ import { ClientProvider } from "../../shell/clientContext";
 import { connectionStore } from "../../stores/connection";
 import { credentialsStore, resetCredentialsStoreForTests } from "../../stores/credentials";
 import { extensionsStore, resetExtensionsStoreForTests } from "../../stores/extensions";
+import { resetThreadsStoreForTests, threadsStore } from "../../stores/threads";
 import { Toast } from "../../widgets";
 import promptCardStyles from "../../widgets/promptcard/promptcard.module.css";
 import textareaStyles from "../../widgets/textarea/textarea.module.css";
-import { resetToastStoreForTests } from "../../widgets/toast/store";
+import { getToasts, resetToastStoreForTests } from "../../widgets/toast/store";
 import Welcome from "../welcome/Welcome";
 import Spawn from "./Spawn";
 
 let modelListOverride: ModelDescriptor[] | null = null;
+
+// Seeds the tracked ThreadModel for a fresh session ref so the post-start
+// reasoning-effort follow-up (palette source: focusedModel's own
+// reasoningEffortLevels/supportsReasoning) resolves against a reasoning model
+// instead of an empty store.
+function seedReasoningModel(ref: string): void {
+  const model: ThreadModel = {
+    ref,
+    threadId: "abc123",
+    name: "",
+    status: { type: "idle" },
+    modelProvider: "anthropic",
+    model: "claude-sonnet-4-5",
+    visionModel: "",
+    askPending: false,
+    pendingEscalations: [],
+    turns: [],
+    queue: null,
+    tasks: null,
+    jobsUpdatedAt: null,
+    jobsTreeRevision: null,
+    lastFrameAt: 0,
+    capabilities: NO_CAPABILITIES,
+    goal: null,
+    contextUsed: 0,
+    contextWindow: 0,
+    contextPressure: 0,
+    usage: null,
+    workMillis: 0,
+    reasoningEffortLevels: ["minimal", "low", "medium", "high"],
+    supportsReasoning: true,
+    cwd: "/tmp/project",
+  };
+  threadsStore.setState({ threads: new Map([[ref, model]]) });
+}
 
 class MemoryStorage {
   private store = new Map<string, string>();
@@ -399,6 +436,7 @@ afterEach(() => {
   cleanup();
   connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   resetExtensionsStoreForTests();
+  resetThreadsStoreForTests();
   vi.unstubAllGlobals();
   window.history.pushState({}, "", "/");
   resetToastStoreForTests();
@@ -3005,4 +3043,66 @@ test("a bare /model with no catalog spawns with no model follow-up and no error 
   const start = fake.calls.find((c) => c.method === "thread/start");
   expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/model" }] });
   expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
+  // No error toast: the fail-open path toasts nothing.
+  expect(getToasts()).toEqual([]);
+});
+
+test("a /reasoning-effort prompt starts the session and applies thread/reasoning-effort/set on the new ref", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("thread/start", () => {
+      seedReasoningModel("local:abc123");
+      return startResponse("local:abc123");
+    });
+    f.on("thread/reasoning-effort/set", () => ({}));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "/reasoning-effort high");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/reasoning-effort high" }] });
+  const set = fake.calls.find((c) => c.method === "thread/reasoning-effort/set");
+  expect(set?.params).toMatchObject({ ref: "local:abc123", reasoningEffort: "high" });
+});
+
+test("an unknown /reasoning-effort value toasts, starts nothing, and leaves Start usable", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient();
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "/reasoning-effort ultra");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(screen.getByText(/\/reasoning-effort: unknown value "ultra"/)).toBeTruthy());
+  expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
+  expect(fake.calls.some((c) => c.method === "thread/reasoning-effort/set")).toBe(false);
+  const button = screen.getByTestId("spawn-submit") as HTMLButtonElement;
+  expect(button.disabled).toBe(false);
+  expect(button.textContent).toBe("Start");
+});
+
+test("a bare /reasoning-effort toasts, starts nothing, applies nothing, and leaves Start usable", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient();
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "/reasoning-effort");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(screen.getByText("/reasoning-effort needs a value")).toBeTruthy());
+  expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
+  expect(fake.calls.some((c) => c.method === "thread/reasoning-effort/set")).toBe(false);
+  const button = screen.getByTestId("spawn-submit") as HTMLButtonElement;
+  expect(button.disabled).toBe(false);
+  expect(button.textContent).toBe("Start");
 });

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2831,6 +2831,49 @@ test("a successful submit closes the slash menu with the cleared prompt", async 
   expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
 });
 
+test("a same-cwd catalog refresh hides stale rows until the new response lands", async () => {
+  const user = userEvent.setup();
+  let resolveRefresh!: (response: { commands: { name: string; description: string }[]; skills: never[] }) => void;
+  let requests = 0;
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => {
+      requests += 1;
+      if (requests === 1) {
+        return { commands: [{ name: "review", description: "review the diff" }], skills: [] };
+      }
+      return new Promise((done) => {
+        resolveRefresh = done as (response: {
+          commands: { name: string; description: string }[];
+          skills: never[];
+        }) => void;
+      });
+    });
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await typeSlashQuery(user, fake, "/rev");
+  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/review")]);
+
+  // A plugin change starts a same-cwd refresh; the v1 rows must not stay
+  // offered while the new config loads — the new session may no longer load
+  // them, and a picked stale entry would submit as literal text.
+  await act(async () => {
+    fake.emitNotification({ method: "evener/plugin/updated", params: {} } as AnyNotification);
+  });
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+
+  // Wait for the refresh request to go out (debounced) before resolving it.
+  await waitFor(() => {
+    expect(fake.calls.filter((c) => c.method === "evener/spawn/slashCatalog")).toHaveLength(2);
+  });
+  await act(async () => {
+    resolveRefresh({ commands: [{ name: "revamp", description: "revamp the turn" }], skills: [] });
+  });
+  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/revamp")]);
+});
+
 test("Escape, no-match, mid-word slash, and blur all close the spawn slash menu", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2931,7 +2931,13 @@ test("a /goal prompt starts the session with the literal text and applies goal/s
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
   expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/goal build the widget" }] });
-  const goal = fake.calls.find((c) => c.method === "goal/set");
+  // The goal follow-up fires after navigation without blocking it, so wait
+  // for the call rather than assuming it landed.
+  let goal: { params?: unknown } | undefined;
+  await waitFor(() => {
+    goal = fake.calls.find((c) => c.method === "goal/set");
+    expect(goal).toBeTruthy();
+  });
   expect(goal?.params).toMatchObject({ ref: "local:abc123", objective: "build the widget" });
 });
 

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -127,6 +127,7 @@ function readyClient(configure?: (fake: FakeClient) => void): FakeClient {
   fake.on("evener/dirs/create", ({ path }) => ({ path, created: true }));
   fake.on("evener/git/head", () => ({ head: "main" }));
   fake.on("evener/plugin/preview", () => ({ plugins: [] }));
+  fake.on("evener/spawn/slashCatalog", () => ({ commands: [], skills: [] }));
   fake.on("thread/start", () => startResponse("local:abc123"));
   configure?.(fake);
   return fake;
@@ -2689,4 +2690,196 @@ test.each(["desktop", "mobile"])("%s directory picker follows route directory ch
   await waitFor(() => expect((confirm as HTMLButtonElement).disabled).toBe(false));
   await user.click(confirm);
   expectWorkingDir("/home/other");
+});
+
+// --- spawn prompt-box inline slash menu (Task 5) ---------------------------
+//
+// The prompt box completes the same trailing-slash token the session composer
+// does, against the pre-session catalog (evener/spawn/slashCatalog) merged
+// with the spawn-scoped builtins (goal, model, reasoning-effort). Key
+// handling is ADAPTED for Spawn's submit model, not ported verbatim: plain
+// Enter is the newline key and commits the open menu, while only
+// Mod/Ctrl+Enter submits.
+
+function slashMenu() {
+  return screen.getByTestId("composer-slash-menu");
+}
+
+function slashOptions() {
+  return within(slashMenu()).getAllByRole("option");
+}
+
+function promptField(): HTMLTextAreaElement {
+  return screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
+}
+
+// The slash catalog is debounced (useSpawnSlashCatalog): advance past the
+// settle window so the stubbed response lands, then type.
+async function typeSlashQuery(user: ReturnType<typeof userEvent.setup>, text: string): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  });
+  await user.type(promptField(), text);
+}
+
+test("typing /re opens the menu with builtin and catalog matches but not /simplify", async () => {
+  const user = userEvent.setup();
+  renderSpawn(
+    readyClient((f) => {
+      f.on("evener/spawn/slashCatalog", () => ({
+        commands: [{ name: "review", description: "review the diff" }],
+        skills: [{ name: "simplify", description: "rewrite" }],
+      }));
+    }),
+  );
+  await settled();
+
+  await typeSlashQuery(user, "/re");
+
+  // /reasoning-effort (builtin) and /review (catalog) both match "re";
+  // "simplify" has no "r", so the embedding matcher needs every query char
+  // in the label and it must stay out. Asserted negatively on purpose so a
+  // future matcher change stays honest.
+  expect(slashOptions().map((el) => el.textContent)).toEqual([
+    expect.stringContaining("/reasoning-effort"),
+    expect.stringContaining("/review"),
+  ]);
+  expect(slashMenu().querySelectorAll('[role="option"]')).toHaveLength(2);
+});
+
+test("typing further narrows the spawn slash menu live", async () => {
+  const user = userEvent.setup();
+  renderSpawn(
+    readyClient((f) => {
+      f.on("evener/spawn/slashCatalog", () => ({
+        commands: [{ name: "review", description: "review the diff" }],
+        skills: [{ name: "simplify", description: "rewrite" }],
+      }));
+    }),
+  );
+  await settled();
+
+  await typeSlashQuery(user, "/rev");
+
+  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/review")]);
+
+  await user.clear(promptField());
+  await user.type(promptField(), "/sim");
+
+  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/simplify")]);
+});
+
+test("Tab and plain Enter commit the spawn menu; Mod+Enter submits instead", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [],
+    }));
+  });
+  renderSpawn(fake);
+  await settled();
+
+  await typeSlashQuery(user, "/rev");
+  await user.keyboard("{Tab}");
+
+  expect((promptField() as HTMLTextAreaElement).value).toBe("/review ");
+  expect(promptField().selectionStart).toBe("/review ".length);
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+  expect(document.activeElement).toBe(promptField());
+
+  // Plain Enter is Spawn's newline key: with the menu open it commits the
+  // highlighted item instead of submitting.
+  await user.clear(promptField());
+  await user.type(promptField(), "/rev");
+  await user.keyboard("{Enter}");
+
+  expect((promptField() as HTMLTextAreaElement).value).toBe("/review ");
+  expect(fake.calls.some((call) => call.method === "thread/start")).toBe(false);
+
+  // Mod+Enter ALWAYS submits, even with the menu open: commit nothing.
+  await user.clear(promptField());
+  await user.type(promptField(), "/rev");
+  expect(screen.queryByTestId("composer-slash-menu")).not.toBeNull();
+  await user.keyboard("{Meta>}{Enter}{/Meta}");
+
+  await waitFor(() => expect(fake.calls.some((call) => call.method === "thread/start")).toBe(true));
+  // The menu committed nothing: a successful Start clears the prompt (Spawn's
+  // own doSpawn reset), so the field must NOT hold the committed "/review ".
+  expect((promptField() as HTMLTextAreaElement).value).not.toBe("/review ");
+});
+
+test("Escape, no-match, mid-word slash, and blur all close the spawn slash menu", async () => {
+  const user = userEvent.setup();
+  renderSpawn(
+    readyClient((f) => {
+      f.on("evener/spawn/slashCatalog", () => ({
+        commands: [{ name: "review", description: "review the diff" }],
+        skills: [],
+      }));
+    }),
+  );
+  await settled();
+
+  await typeSlashQuery(user, "/re");
+  expect(screen.queryByTestId("composer-slash-menu")).not.toBeNull();
+
+  await user.keyboard("{Escape}");
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+  expect((promptField() as HTMLTextAreaElement).value).toBe("/re");
+
+  await user.clear(promptField());
+  await user.type(promptField(), "/zzz");
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+
+  await user.clear(promptField());
+  await user.type(promptField(), "foo/bar");
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+
+  await user.clear(promptField());
+  await user.type(promptField(), "/re");
+  expect(screen.queryByTestId("composer-slash-menu")).not.toBeNull();
+  fireEvent.blur(promptField());
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+});
+
+test("a non-evener harness sends no slashCatalog call and typing /goal shows no menu", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient();
+  renderSpawn(fake);
+  await settled();
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+  await user.selectOptions(screen.getByLabelText("Harness"), "external");
+
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  });
+  expect(fake.calls.some((call) => call.method === "evener/spawn/slashCatalog")).toBe(false);
+
+  await user.type(promptField(), "/goal");
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+});
+
+test("the open spawn menu wires listbox roles and aria-activedescendant on the prompt", async () => {
+  const user = userEvent.setup();
+  renderSpawn(
+    readyClient((f) => {
+      f.on("evener/spawn/slashCatalog", () => ({
+        commands: [{ name: "review", description: "review the diff" }],
+        skills: [],
+      }));
+    }),
+  );
+  await settled();
+
+  await typeSlashQuery(user, "/re");
+
+  expect(slashMenu().getAttribute("role")).toBe("listbox");
+  const activeId = promptField().getAttribute("aria-activedescendant");
+  expect(activeId).toBeTruthy();
+  expect(document.getElementById(activeId ?? "")).toBe(slashOptions()[0]);
+
+  await user.keyboard("{Escape}");
+  expect(promptField().getAttribute("aria-activedescendant")).toBeNull();
 });

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2874,6 +2874,55 @@ test("a same-cwd catalog refresh hides stale rows until the new response lands",
   expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/revamp")]);
 });
 
+test("Shift+Tab does not commit the spawn menu", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [],
+    }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await typeSlashQuery(user, fake, "/re");
+  expect(screen.queryByTestId("composer-slash-menu")).not.toBeNull();
+
+  // Modified Tab falls through for focus navigation instead of committing:
+  // the prompt keeps its text and no completion is spliced in.
+  await user.keyboard("{Shift>}{Tab}{/Shift}");
+  expect((promptField() as HTMLTextAreaElement).value).toBe("/re");
+  expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
+});
+
+test("reopening the identical token restarts the highlight at the first option", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [],
+    }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await typeSlashQuery(user, fake, "/re");
+  // Move off the first option, dismiss, and reopen the identical token.
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{Escape}");
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+  await user.type(promptField(), "e");
+  await user.clear(promptField());
+  await user.type(promptField(), "/re");
+
+  // Committing now must splice the FIRST option, not the previously
+  // highlighted one.
+  await user.keyboard("{Tab}");
+  expect((promptField() as HTMLTextAreaElement).value).toBe("/reasoning-effort ");
+});
+
 test("Escape, no-match, mid-word slash, and blur all close the spawn slash menu", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
@@ -3198,6 +3247,41 @@ test("a /reasoning-effort value from the previous cwd does not validate after sw
   expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
 });
 
+test("a model picked after a failed background load validates for /model", async () => {
+  const user = userEvent.setup();
+  let listCalls = 0;
+  const fake = readyClient((f) => {
+    f.on("model/list", () => {
+      listCalls += 1;
+      // The pane's background load fails; the picker's on-demand load (a
+      // cache-cleared retry) succeeds.
+      if (listCalls === 1) throw new Error("list down");
+      return { data: [{ provider: "openai", model: "gpt-5", displayName: "openai/gpt-5" }] };
+    });
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await user.click(modelTrigger());
+  await user.click(await screen.findByRole("option", { name: /gpt-5/ }));
+
+  // The pick stamps the merged entry as a current-scope snapshot, so a typed
+  // /model for the just-picked model validates instead of fail-closing
+  // against the never-loaded background stamp.
+  await user.type(promptField(), "/model openai/gpt-5");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({
+    input: [{ type: "text", text: "/model openai/gpt-5" }],
+    modelProvider: "openai",
+    model: "gpt-5",
+  });
+});
+
 test("an unknown /model value toasts, starts nothing, and leaves Start usable", async () => {
   const user = userEvent.setup();
   const fake = readyClient();
@@ -3211,6 +3295,27 @@ test("an unknown /model value toasts, starts nothing, and leaves Start usable", 
   await waitFor(() => expect(screen.getByText(/\/model: unknown value "nope"/)).toBeTruthy());
   expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
   expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
+  const button = screen.getByTestId("spawn-submit") as HTMLButtonElement;
+  expect(button.disabled).toBe(false);
+  expect(button.textContent).toBe("Start");
+});
+
+test("a bare /goal toasts, starts nothing, and leaves Start usable", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("goal/set", () => ({ started: true }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "/goal");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(screen.getByText("/goal needs a value")).toBeTruthy());
+  expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
+  expect(fake.calls.some((c) => c.method === "goal/set")).toBe(false);
   const button = screen.getByTestId("spawn-submit") as HTMLButtonElement;
   expect(button.disabled).toBe(false);
   expect(button.textContent).toBe("Start");

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2923,6 +2923,37 @@ test("reopening the identical token restarts the highlight at the first option",
   expect((promptField() as HTMLTextAreaElement).value).toBe("/reasoning-effort ");
 });
 
+test("catalog entries colliding with pre-session builtins are not offered twice", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [
+        { name: "goal", description: "project goal runner", source: "project" },
+        { name: "deploy", description: "deploy the thing", source: "project" },
+      ],
+      skills: [{ name: "model", description: "project model helper" }],
+    }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  // "/goal" the project command and "/model" the project skill share their
+  // invocations with pre-session builtins, which always win at submit — so
+  // the menu offers each invocation exactly once (the builtin), while the
+  // non-colliding project command still appears.
+  await typeSlashQuery(user, fake, "/goal");
+  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/goal")]);
+
+  await user.clear(promptField());
+  await typeSlashQuery(user, fake, "/model");
+  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/model")]);
+
+  await user.clear(promptField());
+  await typeSlashQuery(user, fake, "/dep");
+  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/deploy")]);
+});
+
 test("Escape, no-match, mid-word slash, and blur all close the spawn slash menu", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
@@ -3005,7 +3036,7 @@ test("the open spawn menu wires listbox roles and aria-activedescendant on the p
 // with the literal text, then applies the builtin against the new ref, then
 // navigates. Everything else spawns exactly as today.
 
-test("a /goal prompt starts the session with the literal text and applies goal/set on the new ref", async () => {
+test("a /goal prompt starts a dormant session and applies goal/set on the new ref", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
     f.on("goal/set", () => ({ started: true }));
@@ -3022,7 +3053,7 @@ test("a /goal prompt starts the session with the literal text and applies goal/s
 
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
-  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/goal build the widget" }] });
+  expect((start?.params as { input?: unknown[] } | undefined)?.input ?? []).toEqual([]);
   // The goal follow-up fires after navigation without blocking it, so wait
   // for the call rather than assuming it landed.
   let goal: { params?: unknown } | undefined;
@@ -3033,7 +3064,7 @@ test("a /goal prompt starts the session with the literal text and applies goal/s
   expect(goal?.params).toMatchObject({ ref: "local:abc123", objective: "build the widget" });
 });
 
-test("a /model prompt starts the session with the model on thread/start and no follow-up set", async () => {
+test("a /model prompt starts a dormant session with the model on thread/start and no follow-up set", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
     f.on("evener/launch/resolve", () => ({
@@ -3066,7 +3097,7 @@ test("a /model prompt starts the session with the model on thread/start and no f
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
   expect(start?.params).toMatchObject({
-    input: [{ type: "text", text: "/model openai/gpt-5" }],
+    input: [],
     modelProvider: "openai",
     model: "gpt-5",
   });
@@ -3077,7 +3108,7 @@ test("a /model prompt starts the session with the model on thread/start and no f
   expect(getToasts()).toEqual([]);
 });
 
-test("a /model prompt bootstraps past the required-model guard with the value on thread/start", async () => {
+test("a /model prompt bootstraps past the required-model guard with the value on thread/start and no literal first turn", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
     f.on("evener/launch/resolve", () => ({ effective: { model: "" }, layers: {}, provenance: {} }));
@@ -3104,14 +3135,14 @@ test("a /model prompt bootstraps past the required-model guard with the value on
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
   expect(start?.params).toMatchObject({
-    input: [{ type: "text", text: "/model openai/gpt-5" }],
+    input: [],
     modelProvider: "openai",
     model: "gpt-5",
   });
   expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
 });
 
-test("a /model prompt wins over a matching Advanced Options model override on thread/start", async () => {
+test("a /model prompt wins over a matching Advanced Options model override on thread/start with no literal first turn", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
     f.on("evener/launch/schema", () => ({
@@ -3151,7 +3182,7 @@ test("a /model prompt wins over a matching Advanced Options model override on th
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
   expect(start?.params).toMatchObject({
-    input: [{ type: "text", text: "/model openai/gpt-5" }],
+    input: [],
     modelProvider: "openai",
     model: "gpt-5",
   });
@@ -3276,7 +3307,7 @@ test("a model picked after a failed background load validates for /model", async
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
   expect(start?.params).toMatchObject({
-    input: [{ type: "text", text: "/model openai/gpt-5" }],
+    input: [],
     modelProvider: "openai",
     model: "gpt-5",
   });
@@ -3374,13 +3405,13 @@ test("a bare /model with no catalog spawns with no model follow-up and no error 
 
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
-  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/model" }] });
+  expect((start?.params as { input?: unknown[] } | undefined)?.input ?? []).toEqual([]);
   expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
   // No error toast: the fail-open path toasts nothing.
   expect(getToasts()).toEqual([]);
 });
 
-test("a /reasoning-effort prompt starts the session with the effort on thread/start and no follow-up set", async () => {
+test("a /reasoning-effort prompt starts a dormant session with the effort on thread/start and no follow-up set", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
     f.on("evener/launch/resolve", () => ({
@@ -3411,7 +3442,7 @@ test("a /reasoning-effort prompt starts the session with the effort on thread/st
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
   expect(start?.params).toMatchObject({
-    input: [{ type: "text", text: "/reasoning-effort high" }],
+    input: [],
     reasoningEffort: "high",
   });
   // No follow-up mutation: the value rides the start call itself, so it

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -3277,10 +3277,27 @@ test("a bare /model with no catalog spawns with no model follow-up and no error 
 
 test("a /reasoning-effort prompt starts the session with the effort on thread/start and no follow-up set", async () => {
   const user = userEvent.setup();
-  const fake = readyClient();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/resolve", () => ({
+      effective: { model: "anthropic/claude-sonnet-4-5" },
+      layers: {},
+      provenance: {},
+    }));
+  });
   connectionStore.getState().connect(fake);
   renderSpawn(fake);
   await settled();
+
+  // Wait for the pane catalog to commit with a matching scope stamp (the
+  // resolve-commit proxy: the catalog effect is declared before the resolve
+  // effect and both share the one keyed model/list promise, so the resolve's
+  // commit is strictly after the catalog's). The stubbed catalog lists the
+  // default model with no ladder metadata, so validation must fall back to
+  // the fallback ladder here — fail-closed is only for proven scope
+  // staleness, and "high" is on the fallback ladder.
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/launch/resolve")).toBe(true));
+  await waitFor(() => expect(modelValue().textContent).toBe("anthropic/claude-sonnet-4-5 (default)"));
 
   await user.type(promptField(), "/reasoning-effort high");
   await user.keyboard("{Escape}");

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2992,6 +2992,53 @@ test("a /model prompt bootstraps past the required-model guard with the value on
   expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
 });
 
+test("a /model prompt wins over a matching Advanced Options model override on thread/start", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/schema", () => ({
+      options: [
+        {
+          field: "model",
+          wireField: "model",
+          kind: "text",
+          label: "Model",
+          group: "general",
+          perLaunch: true,
+          driverSupport: { evener: true },
+        },
+      ],
+    }));
+    f.on("evener/launch/resolve", () => ({
+      effective: { model: "anthropic/claude-sonnet-4-5" },
+      layers: {},
+      provenance: {},
+    }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(modelValue().textContent).toBe("anthropic/claude-sonnet-4-5 (default)"));
+
+  // An Advanced Options model override loses to the typed slash value: the
+  // user typed the value as the submit itself, the most specific intent.
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+  await user.type(screen.getByLabelText("Model"), "anthropic/other-model");
+
+  await user.type(promptField(), "/model openai/gpt-5");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({
+    input: [{ type: "text", text: "/model openai/gpt-5" }],
+    modelProvider: "openai",
+    model: "gpt-5",
+  });
+  expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
+});
+
 test("an unknown /model value toasts, starts nothing, and leaves Start usable", async () => {
   const user = userEvent.setup();
   const fake = readyClient();

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2715,28 +2715,26 @@ function promptField(): HTMLTextAreaElement {
   return screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
 }
 
-// The slash catalog is debounced (useSpawnSlashCatalog): advance past the
-// settle window so the stubbed response lands, then type.
-async function typeSlashQuery(user: ReturnType<typeof userEvent.setup>, text: string): Promise<void> {
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 300));
-  });
+// The slash catalog is debounced (useSpawnSlashCatalog): wait for the
+// stubbed response to land instead of sleeping a fixed window past the
+// settle time, which flakes under load.
+async function typeSlashQuery(user: ReturnType<typeof userEvent.setup>, fake: FakeClient, text: string): Promise<void> {
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/spawn/slashCatalog")).toBe(true));
   await user.type(promptField(), text);
 }
 
 test("typing /re opens the menu with builtin and catalog matches but not /simplify", async () => {
   const user = userEvent.setup();
-  renderSpawn(
-    readyClient((f) => {
-      f.on("evener/spawn/slashCatalog", () => ({
-        commands: [{ name: "review", description: "review the diff" }],
-        skills: [{ name: "simplify", description: "rewrite" }],
-      }));
-    }),
-  );
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [{ name: "simplify", description: "rewrite" }],
+    }));
+  });
+  renderSpawn(fake);
   await settled();
 
-  await typeSlashQuery(user, "/re");
+  await typeSlashQuery(user, fake, "/re");
 
   // /reasoning-effort (builtin) and /review (catalog) both match "re";
   // "simplify" has no "r", so the embedding matcher needs every query char
@@ -2751,17 +2749,16 @@ test("typing /re opens the menu with builtin and catalog matches but not /simpli
 
 test("typing further narrows the spawn slash menu live", async () => {
   const user = userEvent.setup();
-  renderSpawn(
-    readyClient((f) => {
-      f.on("evener/spawn/slashCatalog", () => ({
-        commands: [{ name: "review", description: "review the diff" }],
-        skills: [{ name: "simplify", description: "rewrite" }],
-      }));
-    }),
-  );
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [{ name: "simplify", description: "rewrite" }],
+    }));
+  });
+  renderSpawn(fake);
   await settled();
 
-  await typeSlashQuery(user, "/rev");
+  await typeSlashQuery(user, fake, "/rev");
 
   expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/review")]);
 
@@ -2782,7 +2779,7 @@ test("Tab and plain Enter commit the spawn menu; Mod+Enter submits instead", asy
   renderSpawn(fake);
   await settled();
 
-  await typeSlashQuery(user, "/rev");
+  await typeSlashQuery(user, fake, "/rev");
   await user.keyboard("{Tab}");
 
   expect((promptField() as HTMLTextAreaElement).value).toBe("/review ");
@@ -2813,17 +2810,16 @@ test("Tab and plain Enter commit the spawn menu; Mod+Enter submits instead", asy
 
 test("Escape, no-match, mid-word slash, and blur all close the spawn slash menu", async () => {
   const user = userEvent.setup();
-  renderSpawn(
-    readyClient((f) => {
-      f.on("evener/spawn/slashCatalog", () => ({
-        commands: [{ name: "review", description: "review the diff" }],
-        skills: [],
-      }));
-    }),
-  );
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [],
+    }));
+  });
+  renderSpawn(fake);
   await settled();
 
-  await typeSlashQuery(user, "/re");
+  await typeSlashQuery(user, fake, "/re");
   expect(screen.queryByTestId("composer-slash-menu")).not.toBeNull();
 
   await user.keyboard("{Escape}");
@@ -2854,28 +2850,30 @@ test("a non-evener harness sends no slashCatalog call and typing /goal shows no 
   await user.click(screen.getByRole("button", { name: "Advanced options" }));
   await user.selectOptions(screen.getByLabelText("Harness"), "external");
 
-  await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 300));
-  });
-  expect(fake.calls.some((call) => call.method === "evener/spawn/slashCatalog")).toBe(false);
+  // From this commit on, no slashCatalog timer can be pending: the harness
+  // switch clears the mount timer via the hook's effect cleanup and the
+  // disabled hook schedules nothing. Drop any mount-window calls so the
+  // assertion below pins post-switch behavior only — a fixed sleep here
+  // flakes under load (it relies on beating the 250ms mount timer).
+  fake.calls.splice(0);
 
   await user.type(promptField(), "/goal");
   expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+  expect(fake.calls.some((call) => call.method === "evener/spawn/slashCatalog")).toBe(false);
 });
 
 test("the open spawn menu wires listbox roles and aria-activedescendant on the prompt", async () => {
   const user = userEvent.setup();
-  renderSpawn(
-    readyClient((f) => {
-      f.on("evener/spawn/slashCatalog", () => ({
-        commands: [{ name: "review", description: "review the diff" }],
-        skills: [],
-      }));
-    }),
-  );
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [],
+    }));
+  });
+  renderSpawn(fake);
   await settled();
 
-  await typeSlashQuery(user, "/re");
+  await typeSlashQuery(user, fake, "/re");
 
   expect(slashMenu().getAttribute("role")).toBe("listbox");
   const activeId = promptField().getAttribute("aria-activedescendant");

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2808,6 +2808,29 @@ test("Tab and plain Enter commit the spawn menu; Mod+Enter submits instead", asy
   expect((promptField() as HTMLTextAreaElement).value).not.toBe("/review ");
 });
 
+test("a successful submit closes the slash menu with the cleared prompt", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [],
+    }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await typeSlashQuery(user, fake, "/re");
+  expect(screen.queryByTestId("composer-slash-menu")).not.toBeNull();
+
+  // Mod+Enter submits even with the menu open; the pane stays mounted behind
+  // the session pane, so the stale token must not survive the cleared prompt.
+  await user.keyboard("{Meta>}{Enter}{/Meta}");
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  expect((promptField() as HTMLTextAreaElement).value).toBe("");
+  expect(screen.queryByTestId("composer-slash-menu")).toBeNull();
+});
+
 test("Escape, no-match, mid-word slash, and blur all close the spawn slash menu", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
@@ -3035,6 +3058,54 @@ test("a /model prompt wins over a matching Advanced Options model override on th
     model: "gpt-5",
   });
   expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
+});
+
+test("a /model value from the previous cwd does not validate after switching directories", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/resolve", () => ({
+      effective: { model: "anthropic/claude-sonnet-4-5" },
+      layers: {},
+      provenance: {},
+    }));
+    // Scope-dependent catalog: gpt-5 exists only under /tmp/project. The
+    // /tmp/other response is delayed past the submit below so the pane
+    // catalog is deterministically STALE (old scope) at submit time — the
+    // window the fix closes. Without the fix, validation reads the stale
+    // snapshot and the submit goes through; with it, the scope mismatch
+    // fail-closes before any load state matters.
+    f.on("model/list", async (params) => {
+      if ((params as { cwd?: string }).cwd === "/tmp/other") {
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+        return {
+          data: [{ provider: "anthropic", model: "claude-sonnet-4-5", displayName: "anthropic/claude-sonnet-4-5" }],
+        };
+      }
+      return {
+        data: [
+          { provider: "anthropic", model: "claude-sonnet-4-5", displayName: "anthropic/claude-sonnet-4-5" },
+          { provider: "openai", model: "gpt-5", displayName: "openai/gpt-5" },
+        ],
+      };
+    });
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(modelValue().textContent).toBe("anthropic/claude-sonnet-4-5 (default)"));
+
+  // Switch directories: the pane catalog still holds the old scope until the
+  // new scoped load lands. A model valid only for the old scope must not
+  // validate against the stale snapshot.
+  await setWorkingDir(user, "/tmp/other");
+
+  await user.type(promptField(), "/model openai/gpt-5");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(screen.getByText(/\/model: unknown value "openai\/gpt-5"/)).toBeTruthy());
+  expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
 });
 
 test("an unknown /model value toasts, starts nothing, and leaves Start usable", async () => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2954,6 +2954,25 @@ test("catalog entries colliding with pre-session builtins are not offered twice"
   expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/deploy")]);
 });
 
+test("a prefilled slash token opens its menu without waiting for a keystroke", async () => {
+  window.history.pushState({}, "", "/new?prompt=%2Frev");
+  const fake = readyClient((f) => {
+    f.on("evener/spawn/slashCatalog", () => ({
+      commands: [{ name: "review", description: "review the diff" }],
+      skills: [],
+    }));
+  });
+  renderSpawn(fake);
+
+  await waitFor(() =>
+    expect((screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement).value).toBe("/rev"),
+  );
+  // The catalog lands debounced; the menu for the prefilled token must open
+  // on its own once rows arrive — no keystroke needed.
+  await waitFor(() => expect(screen.queryByTestId("composer-slash-menu")).not.toBeNull());
+  expect(slashOptions().map((el) => el.textContent)).toEqual([expect.stringContaining("/review")]);
+});
+
 test("Escape, no-match, mid-word slash, and blur all close the spawn slash menu", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
@@ -3264,6 +3283,10 @@ test("a /reasoning-effort value from the previous cwd does not validate after sw
   await settled();
   await setWorkingDir(user, "/tmp/project");
   await waitFor(() => expect(modelValue().textContent).toBe("anthropic/claude-sonnet-4-5 (default)"));
+
+  // Set the chip to the same value: without the fix, the stale chip
+  // re-authorizes the typed value through `current` even with no levels.
+  await user.selectOptions(effortControl(), "high");
 
   // Switch directories: the merged effort ladder still holds the old scope
   // until the new scoped load lands. "high" validates against the stale

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2883,3 +2883,126 @@ test("the open spawn menu wires listbox roles and aria-activedescendant on the p
   await user.keyboard("{Escape}");
   expect(promptField().getAttribute("aria-activedescendant")).toBeNull();
 });
+
+// --- Task 6: submit interception for pre-session builtins --------------------
+//
+// A prompt parsing as /goal, /model, or /reasoning-effort starts the session
+// with the literal text, then applies the builtin against the new ref, then
+// navigates. Everything else spawns exactly as today.
+
+test("a /goal prompt starts the session with the literal text and applies goal/set on the new ref", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("goal/set", () => ({ started: true }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "/goal build the widget");
+  // Dismiss the inline menu without altering the text: plain Enter commits
+  // the highlight here, and Mod+Enter is the submit under test.
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/goal build the widget" }] });
+  const goal = fake.calls.find((c) => c.method === "goal/set");
+  expect(goal?.params).toMatchObject({ ref: "local:abc123", objective: "build the widget" });
+});
+
+test("a /model prompt starts the session and applies thread/model/set on the new ref", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("thread/model/set", () => ({}));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "/model openai/gpt-5");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/model openai/gpt-5" }] });
+  const set = fake.calls.find((c) => c.method === "thread/model/set");
+  expect(set?.params).toMatchObject({ ref: "local:abc123", modelProvider: "openai", model: "gpt-5" });
+});
+
+test("an unknown /model value toasts, starts nothing, and leaves Start usable", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient();
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "/model nope");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(screen.getByText(/\/model: unknown value "nope"/)).toBeTruthy());
+  expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
+  expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
+  const button = screen.getByTestId("spawn-submit") as HTMLButtonElement;
+  expect(button.disabled).toBe(false);
+  expect(button.textContent).toBe("Start");
+});
+
+test("plain text spawns with no goal/set call", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("goal/set", () => ({ started: true }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "hello world");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "hello world" }] });
+  expect(fake.calls.some((c) => c.method === "goal/set")).toBe(false);
+});
+
+test("a /goal prompt on a non-evener harness spawns verbatim with no goal/set call", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("goal/set", () => ({ started: true }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await user.click(screen.getByRole("button", { name: "Advanced options" }));
+  await user.selectOptions(screen.getByLabelText("Harness"), "external");
+
+  await user.type(promptField(), "/goal x");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/goal x" }] });
+  expect(fake.calls.some((c) => c.method === "goal/set")).toBe(false);
+});
+
+test("a bare /model with no catalog spawns with no model follow-up and no error toast", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient();
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+
+  await user.type(promptField(), "/model");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/model" }] });
+  expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
+});

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -2954,10 +2954,28 @@ test("a /model prompt starts the session and applies thread/model/set on the new
   const user = userEvent.setup();
   const fake = readyClient((f) => {
     f.on("thread/model/set", () => ({}));
+    f.on("evener/launch/resolve", () => ({
+      effective: { model: "anthropic/claude-sonnet-4-5" },
+      layers: {},
+      provenance: {},
+    }));
   });
   connectionStore.getState().connect(fake);
   renderSpawn(fake);
   await settled();
+
+  // The pre-start known-value check reads the pane-level modelCatalog, which
+  // lands on a 250ms settle after mount (CATALOG_SETTLE_MS) — settled() only
+  // waits for the Advanced-options toggle, not the catalog, so submitting
+  // immediately races it (resolveSpawnModelItems(null) is [] and the known
+  // value fail-closes). Setting a working directory and waiting for the
+  // cwd-scoped resolve to commit its state-derived trigger text guarantees
+  // the catalog commit happened first: the catalog effect is declared before
+  // the resolve effect and both share the one keyed model/list promise, so
+  // the resolve's Promise.all commit is strictly after the catalog's.
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/launch/resolve")).toBe(true));
+  await waitFor(() => expect(modelValue().textContent).toBe("anthropic/claude-sonnet-4-5 (default)"));
 
   await user.type(promptField(), "/model openai/gpt-5");
   await user.keyboard("{Escape}");

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -3114,6 +3114,47 @@ test("a /model value from the previous cwd does not validate after switching dir
   expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
 });
 
+test("a /reasoning-effort value from the previous cwd does not validate after switching directories", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/resolve", () => ({
+      effective: { model: "anthropic/claude-sonnet-4-5" },
+      layers: {},
+      provenance: {},
+    }));
+    // Delay the new scope's catalog past the submit below so validation
+    // runs in the stale window deterministically.
+    f.on("model/list", async (params) => {
+      if ((params as { cwd?: string }).cwd === "/tmp/other") {
+        await new Promise((resolve) => setTimeout(resolve, 5000));
+      }
+      return {
+        data: [
+          { provider: "anthropic", model: "claude-sonnet-4-5", displayName: "anthropic/claude-sonnet-4-5" },
+          { provider: "openai", model: "gpt-5", displayName: "openai/gpt-5" },
+        ],
+      };
+    });
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+  await setWorkingDir(user, "/tmp/project");
+  await waitFor(() => expect(modelValue().textContent).toBe("anthropic/claude-sonnet-4-5 (default)"));
+
+  // Switch directories: the merged effort ladder still holds the old scope
+  // until the new scoped load lands. "high" validates against the stale
+  // ladder but must fail closed.
+  await setWorkingDir(user, "/tmp/other");
+
+  await user.type(promptField(), "/reasoning-effort high");
+  await user.keyboard("{Escape}");
+  await user.click(screen.getByTestId("spawn-submit"));
+
+  await waitFor(() => expect(screen.getByText(/\/reasoning-effort: unknown value "high"/)).toBeTruthy());
+  expect(fake.calls.some((c) => c.method === "thread/start")).toBe(false);
+});
+
 test("an unknown /model value toasts, starts nothing, and leaves Start usable", async () => {
   const user = userEvent.setup();
   const fake = readyClient();

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -5,7 +5,6 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testi
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { WireError } from "../../protocol/errors";
-import type { ThreadModel } from "../../protocol/model";
 import { FakeClient } from "../../protocol/testing/fakeClient";
 import type {
   AnyNotification,
@@ -22,7 +21,7 @@ import { ClientProvider } from "../../shell/clientContext";
 import { connectionStore } from "../../stores/connection";
 import { credentialsStore, resetCredentialsStoreForTests } from "../../stores/credentials";
 import { extensionsStore, resetExtensionsStoreForTests } from "../../stores/extensions";
-import { resetThreadsStoreForTests, threadsStore } from "../../stores/threads";
+import { resetThreadsStoreForTests } from "../../stores/threads";
 import { Toast } from "../../widgets";
 import promptCardStyles from "../../widgets/promptcard/promptcard.module.css";
 import textareaStyles from "../../widgets/textarea/textarea.module.css";
@@ -31,41 +30,6 @@ import Welcome from "../welcome/Welcome";
 import Spawn from "./Spawn";
 
 let modelListOverride: ModelDescriptor[] | null = null;
-
-// Seeds the tracked ThreadModel for a fresh session ref so the post-start
-// reasoning-effort follow-up (palette source: focusedModel's own
-// reasoningEffortLevels/supportsReasoning) resolves against a reasoning model
-// instead of an empty store.
-function seedReasoningModel(ref: string): void {
-  const model: ThreadModel = {
-    ref,
-    threadId: "abc123",
-    name: "",
-    status: { type: "idle" },
-    modelProvider: "anthropic",
-    model: "claude-sonnet-4-5",
-    visionModel: "",
-    askPending: false,
-    pendingEscalations: [],
-    turns: [],
-    queue: null,
-    tasks: null,
-    jobsUpdatedAt: null,
-    jobsTreeRevision: null,
-    lastFrameAt: 0,
-    capabilities: NO_CAPABILITIES,
-    goal: null,
-    contextUsed: 0,
-    contextWindow: 0,
-    contextPressure: 0,
-    usage: null,
-    workMillis: 0,
-    reasoningEffortLevels: ["minimal", "low", "medium", "high"],
-    supportsReasoning: true,
-    cwd: "/tmp/project",
-  };
-  threadsStore.setState({ threads: new Map([[ref, model]]) });
-}
 
 class MemoryStorage {
   private store = new Map<string, string>();
@@ -2950,10 +2914,9 @@ test("a /goal prompt starts the session with the literal text and applies goal/s
   expect(goal?.params).toMatchObject({ ref: "local:abc123", objective: "build the widget" });
 });
 
-test("a /model prompt starts the session and applies thread/model/set on the new ref", async () => {
+test("a /model prompt starts the session with the model on thread/start and no follow-up set", async () => {
   const user = userEvent.setup();
   const fake = readyClient((f) => {
-    f.on("thread/model/set", () => ({}));
     f.on("evener/launch/resolve", () => ({
       effective: { model: "anthropic/claude-sonnet-4-5" },
       layers: {},
@@ -2983,9 +2946,50 @@ test("a /model prompt starts the session and applies thread/model/set on the new
 
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
-  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/model openai/gpt-5" }] });
-  const set = fake.calls.find((c) => c.method === "thread/model/set");
-  expect(set?.params).toMatchObject({ ref: "local:abc123", modelProvider: "openai", model: "gpt-5" });
+  expect(start?.params).toMatchObject({
+    input: [{ type: "text", text: "/model openai/gpt-5" }],
+    modelProvider: "openai",
+    model: "gpt-5",
+  });
+  // No follow-up mutation: thread/model/set refuses mid-turn with Conflict
+  // once the non-empty first input reserves the turn, so the value rides the
+  // start call itself.
+  expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
+  expect(getToasts()).toEqual([]);
+});
+
+test("a /model prompt bootstraps past the required-model guard with the value on thread/start", async () => {
+  const user = userEvent.setup();
+  const fake = readyClient((f) => {
+    f.on("evener/launch/resolve", () => ({ effective: { model: "" }, layers: {}, provenance: {} }));
+    f.on("model/list", () => ({ data: [{ provider: "openai", model: "gpt-5", displayName: "openai/gpt-5" }] }));
+  });
+  connectionStore.getState().connect(fake);
+  renderSpawn(fake);
+  await settled();
+  await setWorkingDir(user, "/tmp/project");
+
+  // The hub has no default model, so Start is gated — but the prompt itself
+  // supplies the missing model. The bootstrap validates against the pane
+  // catalog, so the test waits for the catalog-backed trigger text the same
+  // way the known-value test does.
+  await waitFor(() => expect(modelValue().textContent).toBe("Choose a model"));
+  await waitFor(() => expect(fake.calls.some((c) => c.method === "evener/spawn/slashCatalog")).toBe(true));
+
+  await user.type(promptField(), "/model openai/gpt-5");
+  await user.keyboard("{Escape}");
+  const button = screen.getByTestId("spawn-submit") as HTMLButtonElement;
+  expect(button.disabled).toBe(false);
+  await user.click(button);
+
+  await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
+  const start = fake.calls.find((c) => c.method === "thread/start");
+  expect(start?.params).toMatchObject({
+    input: [{ type: "text", text: "/model openai/gpt-5" }],
+    modelProvider: "openai",
+    model: "gpt-5",
+  });
+  expect(fake.calls.some((c) => c.method === "thread/model/set")).toBe(false);
 });
 
 test("an unknown /model value toasts, starts nothing, and leaves Start usable", async () => {
@@ -3065,15 +3069,9 @@ test("a bare /model with no catalog spawns with no model follow-up and no error 
   expect(getToasts()).toEqual([]);
 });
 
-test("a /reasoning-effort prompt starts the session and applies thread/reasoning-effort/set on the new ref", async () => {
+test("a /reasoning-effort prompt starts the session with the effort on thread/start and no follow-up set", async () => {
   const user = userEvent.setup();
-  const fake = readyClient((f) => {
-    f.on("thread/start", () => {
-      seedReasoningModel("local:abc123");
-      return startResponse("local:abc123");
-    });
-    f.on("thread/reasoning-effort/set", () => ({}));
-  });
+  const fake = readyClient();
   connectionStore.getState().connect(fake);
   renderSpawn(fake);
   await settled();
@@ -3084,9 +3082,14 @@ test("a /reasoning-effort prompt starts the session and applies thread/reasoning
 
   await waitFor(() => expect(window.location.pathname).toBe("/s/local%3Aabc123"));
   const start = fake.calls.find((c) => c.method === "thread/start");
-  expect(start?.params).toMatchObject({ input: [{ type: "text", text: "/reasoning-effort high" }] });
-  const set = fake.calls.find((c) => c.method === "thread/reasoning-effort/set");
-  expect(set?.params).toMatchObject({ ref: "local:abc123", reasoningEffort: "high" });
+  expect(start?.params).toMatchObject({
+    input: [{ type: "text", text: "/reasoning-effort high" }],
+    reasoningEffort: "high",
+  });
+  // No follow-up mutation: the value rides the start call itself, so it
+  // applies even though the new thread is not yet in threadsStore.
+  expect(fake.calls.some((c) => c.method === "thread/reasoning-effort/set")).toBe(false);
+  expect(getToasts()).toEqual([]);
 });
 
 test("an unknown /reasoning-effort value toasts, starts nothing, and leaves Start usable", async () => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -24,6 +24,7 @@ import type {
   PluginSelectionError,
 } from "../../protocol/types.gen";
 import { useClient } from "../../shell/clientContext";
+import { splitModelId } from "../../shell/palette/commands";
 import type { PaneProps } from "../../shell/paneRegistry";
 import { effortLabel } from "../../shell/reasoningEffort";
 import { navigate, paneToURL } from "../../shell/routing";
@@ -1027,6 +1028,29 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     event.target.value = ""; // re-picking the identical file must re-fire change
   }
 
+  // A valid /model invocation supplies the missing model itself, so it
+  // bootstraps past the required-model guard: the value rides thread/start
+  // (doSpawn's launch-scalar path below), and neither the button nor
+  // handleSpawn may refuse a submit that CAN succeed. Unknown values still
+  // fail in doSpawn's own pre-start validation with the blocked toast. The
+  // catalog half is load-bearing: an unloaded catalog resolves zero items,
+  // so a known value typed before it lands does NOT bootstrap (and doSpawn
+  // fail-closes it the same way) - the user picks a model once the list
+  // they validated against exists.
+  const slashModelBootstrap =
+    modelRequired && pluginSelectionSupported && attachments.items.length === 0
+      ? (() => {
+          const match = matchBuiltinInvocation(prompt, spawnBuiltinCommands());
+          if (match?.command.id !== "model" || match.argsText.trim() === "") return null;
+          const needle = match.argsText.trim().toLowerCase();
+          return resolveSpawnModelItems(modelCatalog).some(
+            (item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle,
+          )
+            ? match.argsText.trim()
+            : null;
+        })()
+      : null;
+
   async function doSpawn(): Promise<void> {
     if (pluginSelectionBlocked) {
       busyRef.current = false;
@@ -1034,28 +1058,41 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       setBusyStartedAt(null);
       return;
     }
-    // Task 6: submit interception for the pre-session builtins (spawnSlashMenu's
+    // Submit interception for the pre-session builtins (spawnSlashMenu's
     // allowlist: goal, model, reasoning-effort). Composer's own guard, ported:
     // a prompt carrying attachments is never read as a command, and on a
     // non-evener harness there is no menu and no interception - the prompt
     // always spawns verbatim (same pluginSelectionSupported gate as slashOpen).
     // A match still starts the session with the literal prompt text (the
-    // daemon expands plugin commands/skills in the first input itself); the
-    // builtin is then applied against the new ref via
-    // runSpawnBuiltinAfterStart, and only then does navigation happen.
+    // daemon expands plugin commands/skills in the first input itself).
+    //
+    // /goal applies post-start via runSpawnBuiltinAfterStart (goal/set has no
+    // processing gate - it queues behind the running turn). /model and
+    // /reasoning-effort ride thread/start as launch scalars instead: the
+    // daemon refuses thread/model/set while the first input's turn is active
+    // (Conflict "session is processing"), and the effort source reads the new
+    // thread from threadsStore, which is empty until the session pane
+    // hydrates - so neither follow-up mutation can work. Their values are
+    // pre-start validated here (there is no cheaper moment to refuse), then
+    // folded into the start call under the chips, which keeps floor §1.11
+    // precedence (explicit slash value wins over ambient form state).
     const builtinMatch =
       pluginSelectionSupported && attachments.items.length === 0
         ? matchBuiltinInvocation(prompt, spawnBuiltinCommands())
         : null;
+    // Launch-scalar overrides carried by a matched /model or /reasoning-effort
+    // invocation: resolved during pre-start validation below and folded into
+    // the thread/start scalars under the chips.
+    let slashScalars: { modelProvider?: string; model?: string; reasoningEffort?: string } | null = null;
     if (builtinMatch && (builtinMatch.command.id === "model" || builtinMatch.command.id === "reasoning-effort")) {
       // Pre-start validation for enum-arg builtins: there is no cheaper
       // moment to refuse than before the session exists. Unknown value ->
       // toast the blocked message and abort WITHOUT thread/start - AND reset
       // the busy guard handleSpawn set above, or Start strands disabled.
-      // Empty /model means "(default)": fail-open, no follow-up at all.
+      // Empty /model means "(default)": fail-open, no override at all.
       const value = builtinMatch.argsText.trim();
       if (builtinMatch.command.id === "model" && value === "") {
-        // Fall through to the ordinary start below with no model follow-up.
+        // Fall through to the ordinary start below with no model override.
       } else {
         const items =
           builtinMatch.command.id === "model"
@@ -1082,13 +1119,30 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
           setBusyStartedAt(null);
           return;
         }
+        const matched = items.find((item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle);
+        if (builtinMatch.command.id === "model" && matched) {
+          const { provider, model: modelId } = splitModelId(matched.id);
+          slashScalars = { modelProvider: provider, model: modelId };
+        } else if (builtinMatch.command.id === "reasoning-effort" && matched) {
+          slashScalars = { reasoningEffort: matched.id };
+        }
       }
     }
     // The advanced schema's sandbox wins over the access-mode chip (floor §1.8);
     // its model/reasoningEffort win over the chips (floor §1.11) - resolveScalars
     // hoists them into the top-level fields the daemon prefers over overrides.
+    // An explicit /model or /reasoning-effort invocation wins over both: the
+    // user typed the value as the submit itself, so it is the most specific
+    // intent in the room.
     const overrides = combinedOverrides;
-    const scalars = resolveScalars({ model, reasoningEffort }, overrides);
+    const scalars = resolveScalars(
+      {
+        model: slashScalars?.model ?? model,
+        modelProvider: slashScalars?.modelProvider,
+        reasoningEffort: slashScalars?.reasoningEffort ?? reasoningEffort,
+      },
+      overrides,
+    );
     // Snapshot before the await (mirrors Composer.tsx's submitAction) so an
     // attachment staged WHILE this request is in flight isn't in the set
     // clearSubmitted removes below - it survives untouched, same contract
@@ -1105,7 +1159,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       accessMode,
       launchOverrides: Object.keys(overrides).length > 0 ? overrides : undefined,
     });
-    if (builtinMatch) {
+    if (builtinMatch && builtinMatch.command.id === "goal") {
       // Post-start application failure toasts but does NOT block navigation:
       // the session started fine, only the follow-up setting failed.
       await runSpawnBuiltinAfterStart(builtinMatch.command.id, builtinMatch.argsText, ref, toasts);
@@ -1147,7 +1201,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     // ⌘/Ctrl+Enter chord (handlePromptKeyDown) reaches this function directly
     // - a submit that CANNOT succeed must never fire regardless of path in.
     // The field's own inline note already says why, so no toast here.
-    if (modelRequired || providerRequired) return;
+    if ((modelRequired && slashModelBootstrap === null) || providerRequired) return;
     if (pluginSelectionBlocked) return;
     if (attachments.hasPending) {
       toasts.push("error", "Image attachment is still processing.");
@@ -1440,7 +1494,12 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
                     aria-label="Start"
                     icon={busy ? undefined : <SendIcon />}
                     onClick={() => void handleSpawn()}
-                    disabled={busy || modelRequired || providerRequired || pluginSelectionBlocked}
+                    disabled={
+                      busy ||
+                      (modelRequired && slashModelBootstrap === null) ||
+                      providerRequired ||
+                      pluginSelectionBlocked
+                    }
                   >
                     {busy ? (
                       <StartingLoader startedAt={busyStartedAt ?? Date.now()} />

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -59,6 +59,7 @@ import { AttachmentTile } from "../session/composer/AttachmentTile";
 import { AttachIcon } from "../session/composer/attachments/AttachIcon";
 import { imageFilesFromClipboard } from "../session/composer/attachments/clipboard";
 import { type TextEditor, useAttachments } from "../session/composer/attachments/useAttachments";
+import { matchBuiltinInvocation } from "../session/composer/builtinCommand";
 import { SlashCompletionMenu, optionId as slashOptionId } from "../session/composer/SlashCompletionMenu";
 import {
   filterSlashMenuItems,
@@ -93,7 +94,12 @@ import {
   setGlobalLastWorkingDir,
   sweepStaleModels,
 } from "./spawnDefaults";
-import { spawnBuiltinCommands } from "./spawnSlashMenu";
+import {
+  resolveSpawnEffortItems,
+  resolveSpawnModelItems,
+  runSpawnBuiltinAfterStart,
+  spawnBuiltinCommands,
+} from "./spawnSlashMenu";
 import { startThread } from "./startThread";
 import { readUrlPrefill } from "./urlPrefill";
 import { usePluginPreview } from "./usePluginPreview";
@@ -1028,6 +1034,47 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       setBusyStartedAt(null);
       return;
     }
+    // Task 6: submit interception for the pre-session builtins (spawnSlashMenu's
+    // allowlist: goal, model, reasoning-effort). Composer's own guard, ported:
+    // a prompt carrying attachments is never read as a command, and on a
+    // non-evener harness there is no menu and no interception - the prompt
+    // always spawns verbatim (same pluginSelectionSupported gate as slashOpen).
+    // A match still starts the session with the literal prompt text (the
+    // daemon expands plugin commands/skills in the first input itself); the
+    // builtin is then applied against the new ref via
+    // runSpawnBuiltinAfterStart, and only then does navigation happen.
+    const builtinMatch =
+      pluginSelectionSupported && attachments.items.length === 0
+        ? matchBuiltinInvocation(prompt, spawnBuiltinCommands())
+        : null;
+    if (builtinMatch && (builtinMatch.command.id === "model" || builtinMatch.command.id === "reasoning-effort")) {
+      // Pre-start validation for enum-arg builtins: there is no cheaper
+      // moment to refuse than before the session exists. Unknown value ->
+      // toast the blocked message and abort WITHOUT thread/start - AND reset
+      // the busy guard handleSpawn set above, or Start strands disabled.
+      // Empty /model means "(default)": fail-open, no follow-up at all.
+      const value = builtinMatch.argsText.trim();
+      if (builtinMatch.command.id === "model" && value === "") {
+        // Fall through to the ordinary start below with no model follow-up.
+      } else {
+        const items =
+          builtinMatch.command.id === "model"
+            ? resolveSpawnModelItems(modelCatalog)
+            : resolveSpawnEffortItems(effortLevels, reasoningEffort);
+        const needle = value.toLowerCase();
+        const known = items.some((item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle);
+        if (!known) {
+          const message = value
+            ? `/${builtinMatch.command.id}: unknown value "${value}"`
+            : `/${builtinMatch.command.id} needs a value`;
+          toasts.push("error", message);
+          busyRef.current = false;
+          setBusy(false);
+          setBusyStartedAt(null);
+          return;
+        }
+      }
+    }
     // The advanced schema's sandbox wins over the access-mode chip (floor §1.8);
     // its model/reasoningEffort win over the chips (floor §1.11) - resolveScalars
     // hoists them into the top-level fields the daemon prefers over overrides.
@@ -1049,6 +1096,11 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       accessMode,
       launchOverrides: Object.keys(overrides).length > 0 ? overrides : undefined,
     });
+    if (builtinMatch) {
+      // Post-start application failure toasts but does NOT block navigation:
+      // the session started fine, only the follow-up setting failed.
+      await runSpawnBuiltinAfterStart(builtinMatch.command.id, builtinMatch.argsText, ref, toasts);
+    }
     saveDefaults({
       cwd,
       harness,

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -377,6 +377,19 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // picker to open. null = not loaded or the load failed - the select stays on
   // the fallback ladder.
   const [modelCatalog, setModelCatalog] = useState<ModelCatalog | null>(null);
+  // The scope the pane catalog was fetched for ("harness + cwd", the
+  // model/list key loadCatalog uses). The catalog merges snapshots across
+  // scopes for picker display continuity, but /model pre-start validation
+  // must only read a snapshot fetched for the CURRENT scope: during the
+  // settle window after a cwd/harness change, modelCatalog still holds the
+  // previous scope, and a value valid only there must not validate.
+  const [modelCatalogScope, setModelCatalogScope] = useState("");
+  // The catalog pre-start /model validation may read: the pane catalog only
+  // when its stamp matches the current scope, null otherwise. Display
+  // surfaces (pickers, effort ladder) keep the merged catalog for
+  // continuity; validation fail-closes through the mismatch window instead
+  // of accepting a value the new scope never offered.
+  const scopedModelCatalog = modelCatalogScope === `${harness}\0${cwd}` ? modelCatalog : null;
   // The hub's resolved default model for this cwd ("" until resolve confirms
   // one): what the Effort ladder keys off while Model reads "(default)".
   const [resolvedDefaultModel, setResolvedDefaultModel] = useState("");
@@ -758,10 +771,18 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // demand.
   useEffect(() => {
     let active = true;
+    // The scope this request fetches for, stamped on commit below. A scope
+    // change re-runs the effect and retires the previous run via active, so
+    // only the latest scope's response commits its stamp.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: harness/cwd are trigger-only deps - the effect body only snapshots them into requestScope, but must re-run (and re-stamp) whenever the scope they define changes, same idiom as the cursor-restore layout effect in the composer
+    const requestScope = `${harness}\0${cwd}`;
     const settle = setTimeout(() => {
       loadCatalog().then(
         (catalog) => {
-          if (active) setModelCatalog((previous) => mergeCatalogSnapshot(previous, catalog));
+          if (active) {
+            setModelCatalog((previous) => mergeCatalogSnapshot(previous, catalog));
+            setModelCatalogScope(requestScope);
+          }
         },
         () => {},
       );
@@ -1043,7 +1064,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
           const match = matchBuiltinInvocation(prompt, spawnBuiltinCommands());
           if (match?.command.id !== "model" || match.argsText.trim() === "") return null;
           const needle = match.argsText.trim().toLowerCase();
-          return resolveSpawnModelItems(modelCatalog).some(
+          return resolveSpawnModelItems(scopedModelCatalog).some(
             (item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle,
           )
             ? match.argsText.trim()
@@ -1096,7 +1117,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       } else {
         const items =
           builtinMatch.command.id === "model"
-            ? resolveSpawnModelItems(modelCatalog)
+            ? resolveSpawnModelItems(scopedModelCatalog)
             : resolveSpawnEffortItems(effortLevels, reasoningEffort);
         const needle = value.toLowerCase();
         // Bare /reasoning-effort fails CLOSED pre-start: the "" head of
@@ -1184,6 +1205,11 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     updatePrompt("");
     attachments.clearSubmitted(submittedMarkers);
     handlePluginSelectionChange({ mode: "default" });
+    // The menu is token-driven, not text-driven: clearing the prompt does not
+    // recompute the token, so without this the stale menu stays open over the
+    // empty prompt on the still-mounted pane (and Enter would commit the
+    // stale completion into the next session's first line).
+    setSlashToken(null);
     // Same defect class: both callers set busy=true before awaiting this
     // function but only their OWN catch blocks ever reset it back to false,
     // so a success fell through with the button stuck disabled/"Starting…"

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -60,7 +60,7 @@ import { AttachmentTile } from "../session/composer/AttachmentTile";
 import { AttachIcon } from "../session/composer/attachments/AttachIcon";
 import { imageFilesFromClipboard } from "../session/composer/attachments/clipboard";
 import { type TextEditor, useAttachments } from "../session/composer/attachments/useAttachments";
-import { matchBuiltinInvocation } from "../session/composer/builtinCommand";
+import { findBuiltinArgument, matchBuiltinInvocation } from "../session/composer/builtinInvocation";
 import { SlashCompletionMenu, optionId as slashOptionId } from "../session/composer/SlashCompletionMenu";
 import {
   filterSlashMenuItems,
@@ -769,12 +769,12 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // catalog is scoped by harness+cwd, so it settles with the path instead of
   // chasing every keystroke; model pickers call the same keyed loader on
   // demand.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: harness/cwd are trigger-only deps - the effect body only snapshots them into requestScope, but must re-run (and re-stamp) whenever the scope they define changes, same idiom as the cursor-restore layout effect in the composer
   useEffect(() => {
     let active = true;
     // The scope this request fetches for, stamped on commit below. A scope
     // change re-runs the effect and retires the previous run via active, so
     // only the latest scope's response commits its stamp.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: harness/cwd are trigger-only deps - the effect body only snapshots them into requestScope, but must re-run (and re-stamp) whenever the scope they define changes, same idiom as the cursor-restore layout effect in the composer
     const requestScope = `${harness}\0${cwd}`;
     const settle = setTimeout(() => {
       loadCatalog().then(
@@ -1063,10 +1063,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       ? (() => {
           const match = matchBuiltinInvocation(prompt, spawnBuiltinCommands());
           if (match?.command.id !== "model" || match.argsText.trim() === "") return null;
-          const needle = match.argsText.trim().toLowerCase();
-          return resolveSpawnModelItems(scopedModelCatalog).some(
-            (item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle,
-          )
+          return findBuiltinArgument(resolveSpawnModelItems(scopedModelCatalog), match.argsText) !== undefined
             ? match.argsText.trim()
             : null;
         })()
@@ -1119,18 +1116,17 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
           builtinMatch.command.id === "model"
             ? resolveSpawnModelItems(scopedModelCatalog)
             : resolveSpawnEffortItems(effortLevels, reasoningEffort);
-        const needle = value.toLowerCase();
         // Bare /reasoning-effort fails CLOSED pre-start: the "" head of
         // resolveSpawnEffortItems (the "(default)" entry) must not count as
         // known here, so an empty effort value toasts
         // "/reasoning-effort needs a value" and aborts without thread/start
         // (palette parity - in-session bare /reasoning-effort errors with no
         // side effects). Bare /model stays fail-open via the branch above.
-        const known =
+        const matched =
           builtinMatch.command.id === "reasoning-effort" && value === ""
-            ? false
-            : items.some((item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle);
-        if (!known) {
+            ? undefined
+            : findBuiltinArgument(items, builtinMatch.argsText);
+        if (!matched) {
           const message = value
             ? `/${builtinMatch.command.id}: unknown value "${value}"`
             : `/${builtinMatch.command.id} needs a value`;
@@ -1140,7 +1136,6 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
           setBusyStartedAt(null);
           return;
         }
-        const matched = items.find((item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle);
         if (builtinMatch.command.id === "model" && matched) {
           const { provider, model: modelId } = splitModelId(matched.id);
           slashScalars = { modelProvider: provider, model: modelId };

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -1177,9 +1177,15 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       launchOverrides: Object.keys(overrides).length > 0 ? overrides : undefined,
     });
     if (builtinMatch && builtinMatch.command.id === "goal") {
-      // Post-start application failure toasts but does NOT block navigation:
-      // the session started fine, only the follow-up setting failed.
-      await runSpawnBuiltinAfterStart(builtinMatch.command.id, builtinMatch.argsText, ref, toasts);
+      // Post-start application runs AFTER navigation below: awaiting goal/set
+      // here would hold the UI in "Starting…" for the RPC timeout on a
+      // delayed follow-up even though the session already exists (and a retry
+      // could then create a duplicate session). Failure still toasts without
+      // blocking anything - the session started fine, only the follow-up
+      // setting failed. Not awaited: the pane stays mounted behind the
+      // session pane (floor §1.14), and toasts are global, so the outcome
+      // still surfaces.
+      void runSpawnBuiltinAfterStart(builtinMatch.command.id, builtinMatch.argsText, ref, toasts);
     }
     saveDefaults({
       cwd,

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -435,10 +435,16 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // Fail-soft: loading and error both render from the last (or empty)
   // response, never an empty loading flash or a guessed zero.
   const catalogResponse = slashCatalog.state.response ?? { commands: [], skills: [] };
+  // Interaction honesty: while a same-cwd refresh is in flight — or the last
+  // refresh errored — the hook retains the previous response, but the menu
+  // must not offer rows the new config may have removed: a picked stale
+  // entry would submit as literal text once the session no longer loads it.
+  // Only ready rows complete; the pre-session builtins stay offered throughout.
+  const slashCatalogResponse = slashCatalog.state.status === "ready" ? catalogResponse : { commands: [], skills: [] };
   const slashMenuCatalog = mergeSlashCommands(
     spawnBuiltinCommands(),
-    catalogResponse.commands,
-    catalogResponse.skills ?? [],
+    slashCatalogResponse.commands,
+    slashCatalogResponse.skills ?? [],
   );
   // The menu is only ever open when a token matched AND the merged catalog
   // has at least one fuzzy label hit for it - a matched-but-empty token

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -59,6 +59,15 @@ import { AttachmentTile } from "../session/composer/AttachmentTile";
 import { AttachIcon } from "../session/composer/attachments/AttachIcon";
 import { imageFilesFromClipboard } from "../session/composer/attachments/clipboard";
 import { type TextEditor, useAttachments } from "../session/composer/attachments/useAttachments";
+import { SlashCompletionMenu, optionId as slashOptionId } from "../session/composer/SlashCompletionMenu";
+import {
+  filterSlashMenuItems,
+  mergeSlashCommands,
+  parseSlashToken,
+  type SlashMenuItem,
+  type SlashToken,
+  spliceSlashCommand,
+} from "../session/composer/slashCompletion";
 import { AdvancedOptions } from "./AdvancedOptions";
 import { ACCESS_MODE_OPTIONS, accessModeDefaultLabel } from "./accessMode";
 import { resolveHeadBranch } from "./branch";
@@ -84,10 +93,12 @@ import {
   setGlobalLastWorkingDir,
   sweepStaleModels,
 } from "./spawnDefaults";
+import { spawnBuiltinCommands } from "./spawnSlashMenu";
 import { startThread } from "./startThread";
 import { readUrlPrefill } from "./urlPrefill";
 import { usePluginPreview } from "./usePluginPreview";
 import { useProviderSetup } from "./useProviderSetup";
+import { useSpawnSlashCatalog } from "./useSpawnSlashCatalog";
 
 // Below-the-fold dialog: mounted only after the user clicks "Connect
 // provider" (connectingProvider state), never on first paint. The chunk -
@@ -268,6 +279,7 @@ const CLASS = {
   promptIntro: requireClass(styles.promptIntro, "spawn.module.css", "promptIntro"),
   promptHeading: requireClass(styles.promptHeading, "spawn.module.css", "promptHeading"),
   promptSubtitle: requireClass(styles.promptSubtitle, "spawn.module.css", "promptSubtitle"),
+  promptAnchor: requireClass(styles.promptAnchor, "spawn.module.css", "promptAnchor"),
   modelNote: requireClass(styles.modelNote, "spawn.module.css", "modelNote"),
   submitLabel: requireClass(styles.submitLabel, "spawn.module.css", "submitLabel"),
   pluginDesktop: requireClass(pluginSelectionStyles.desktopSurface, "pluginSelection.module.css", "desktopSurface"),
@@ -373,6 +385,79 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     ? withPluginSelection(advancedOverrides, pluginSelection)
     : withPluginSelection(advancedOverrides, { mode: "default" });
 
+  // Inline slash-command completion (slashCompletion.ts's own header
+  // comment - ported from Beautiful UI's prompt-bar). slashToken is the
+  // trailing-token match recomputed on every keystroke (below); null means
+  // no menu, regardless of what the prompt's text actually contains -
+  // Escape closes the menu by setting this to null directly, and typing
+  // further reopens it because the very next keystroke recomputes the
+  // match fresh. slashHighlighted is the ArrowUp/Down cursor over whatever
+  // the CURRENT filtered list is; reset to 0 whenever the token itself
+  // changes (new match, or the query narrowed/widened) rather than
+  // persisted across it - an index into a list that just changed shape is
+  // not a meaningful position to keep.
+  const [slashToken, setSlashToken] = useState<SlashToken | null>(null);
+  const [slashHighlighted, setSlashHighlighted] = useState(0);
+  // The backend already resolved the selection for this cwd plus overrides
+  // (evener/spawn/slashCatalog), so no plugin filtering applies here the
+  // way Composer's visibleCatalogCommands filters its global catalog by
+  // live session plugins.
+  const slashCatalog = useSpawnSlashCatalog({
+    client,
+    cwd,
+    harness,
+    launchOverrides: combinedOverrides,
+    pluginRevision,
+    enabled: pluginSelectionSupported,
+  });
+  // Fail-soft: loading and error both render from the last (or empty)
+  // response, never an empty loading flash or a guessed zero.
+  const catalogResponse = slashCatalog.state.response ?? { commands: [], skills: [] };
+  const slashMenuCatalog = mergeSlashCommands(
+    spawnBuiltinCommands(),
+    catalogResponse.commands,
+    catalogResponse.skills ?? [],
+  );
+  // The menu is only ever open when a token matched AND the merged catalog
+  // has at least one fuzzy label hit for it - a matched-but-empty token
+  // (e.g. "/zzz" against a real catalog) shows no menu at all, same as no
+  // token matching. The pluginSelectionSupported gate is load-bearing: the
+  // hook reports ready-empty for non-evener harnesses, but
+  // spawnBuiltinCommands() merges unconditionally, so without it typing
+  // "/goal" on an external harness would still open a one-row builtin menu
+  // for a session that loads no plugins.
+  const slashItems = slashToken ? filterSlashMenuItems(slashMenuCatalog, slashToken.query) : [];
+  const slashOpen = pluginSelectionSupported && slashToken !== null && slashItems.length > 0;
+  // Singleton pane - no ref scoping needed, unlike Composer's per-ref id.
+  const slashListboxId = "spawn-slash-listbox";
+  const slashActiveIndex = slashOpen ? Math.min(slashHighlighted, slashItems.length - 1) : -1;
+  const slashActiveId = slashActiveIndex >= 0 ? slashOptionId(slashListboxId, slashActiveIndex) : null;
+
+  // Textarea (widgets/textarea) takes no aria-activedescendant/aria-controls
+  // prop - it's a shared widget outside this stream's manifest - so this
+  // component sets both directly on the native node it already refs for
+  // cursor restoration below, the same imperative-DOM idiom the cursor-
+  // restore layout effect already uses on the identical ref.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    if (slashActiveId) {
+      el.setAttribute("aria-controls", slashListboxId);
+      el.setAttribute("aria-activedescendant", slashActiveId);
+    } else {
+      el.removeAttribute("aria-controls");
+      el.removeAttribute("aria-activedescendant");
+    }
+  }, [slashActiveId]);
+
+  // A freshly (re)matched token always starts highlighted at its first
+  // option - an index carried over from the PREVIOUS token's list is not a
+  // meaningful position once the list itself has changed shape.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: slashToken's start/query are deliberate trigger-only deps - the effect body only calls setSlashHighlighted(0), but must still re-run whenever the token identity actually changes (a new match, or the same match with a different query), same idiom as the cursor-restore layout effect below
+  useEffect(() => {
+    setSlashHighlighted(0);
+  }, [slashToken?.start, slashToken?.query]);
+
   // Attachments reuse the composer's staged-image pipeline via a TextEditor
   // bridge over the prompt textarea (see Composer.tsx's own bridge for the
   // React controlled-input rationale). textRef mirrors `prompt` synchronously
@@ -423,6 +508,27 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     },
   };
   const attachments = useAttachments(textEditor);
+
+  // commitSlashCompletion is Tab/plain-Enter's (handlePromptKeyDown below)
+  // and a mouse click's (SlashCompletionMenu's own onSelect) shared "the
+  // user chose this command" path: splices the item's own invocation
+  // (slashCompletion.ts's mergeSlashCommands - "/plugin:name" for a plugin
+  // command via shell/palette/commands.ts's slashCommandInvocation, bare
+  // "/id" for a built-in) in at the token's own start (never the caret,
+  // when the caret was left mid-token by an earlier Escape-then-retype -
+  // spliceSlashCommand's own doc comment), through the SAME
+  // textEditor.write() seam every other programmatic edit in this file
+  // uses, then closes the menu and returns focus to the field - mirrors
+  // Composer.tsx's own commit shape. This only ever INSERTS the invocation
+  // text - whether it goes on to execute as a built-in is Task 6's own
+  // submit interception, below.
+  function commitSlashCompletion(item: SlashMenuItem): void {
+    if (!slashToken) return;
+    const spliced = spliceSlashCommand(textRef.current, slashToken, item.invocation);
+    textEditor.write(spliced.text, spliced.caret);
+    setSlashToken(null);
+    textareaRef.current?.focus();
+  }
 
   const usesEvenerModels = harnessUsesEvenerModels(harness, harnesses);
   const providerRequired = usesEvenerModels && providerSetup.status === "missing";
@@ -854,6 +960,49 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   }
 
   function handlePromptKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>): void {
+    // Inline slash-completion's own keyboard mechanics, ADAPTED for Spawn's
+    // submit model (deliberately NOT a verbatim Composer port - Composer's
+    // Enter sends, Spawn's plain Enter is a newline and only Mod/Ctrl+Enter
+    // submits): ArrowUp/Down move the highlighted option (wrapping at both
+    // ends) OVER the caret rather than moving the caret itself, Tab OR
+    // unmodified non-composing Enter commits the highlighted option, Escape
+    // dismisses without touching the prompt. The committing Enter never
+    // steals a submit path - it IS the newline key in Spawn, and
+    // Mod/Ctrl+Enter always falls through to the submit branch below even
+    // with the menu open. Shift+Enter, Alt+Enter, and composing Enter keep
+    // their existing behavior (newline/composition).
+    if (slashOpen) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSlashHighlighted((i) => (i + 1) % slashItems.length);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSlashHighlighted((i) => (i - 1 + slashItems.length) % slashItems.length);
+        return;
+      }
+      if (
+        event.key === "Tab" ||
+        (event.key === "Enter" &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.shiftKey &&
+          !event.altKey &&
+          !event.nativeEvent.isComposing)
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        const chosen = slashItems[slashActiveIndex] ?? slashItems[0];
+        if (chosen) commitSlashCompletion(chosen);
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setSlashToken(null);
+        return;
+      }
+    }
     // ⌘/Ctrl+Enter submits (floor §1.12, spawn.js:1204-1211).
     if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
@@ -1077,140 +1226,172 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
         </div>
 
         {/* The prompt shares its card and attachment controls with the session composer. */}
-        <Dropzone onFiles={(files) => attachments.ingestFiles(files, (message) => toasts.push("error", message))}>
-          <PromptCard
-            data-testid="spawn-prompt-card"
-            controlsTestId="spawn-controls"
-            field={
-              <Textarea
-                ref={textareaRef}
-                value={prompt}
-                onChange={(e) => updatePrompt(e.target.value)}
-                onKeyDown={handlePromptKeyDown}
-                onPaste={handlePaste}
-                // Short, because the intro above the card already asks the
-                // question and states the dormant-start rule; a placeholder
-                // that repeats them spends the field's one line on nothing.
-                placeholder="Describe the task…"
-                aria-label="Prompt"
-                autoGrow
-                // The PromptCard around it draws the one border this field
-                // needs and owns the focus ring - without this the field drew
-                // its own box inside the card's, and its resize grabber floated
-                // loose in the corner between them.
-                seamless
-                // The page's primary input, so it opens at a size worth writing
-                // in rather than growing into one. This is also what absorbs
-                // the slack that used to sit dead below the button.
-                minLines={6}
-              />
-            }
-            leading={
-              /* The composer's own leading cluster (Composer.tsx's .leading):
-                 attach, then the model trigger, then effort. All stay INSIDE
-                 the card's control row at every width - choosing a model and
-                 an effort is the same act wherever it happens, so it is the
-                 same component (ModelSwitchTrigger) and the same StatusRow
-                 quiet-effort recipe rather than a bespoke boxed variant below
-                 the card. */
-              <div className={CLASS.leading}>
-                <IconButton
-                  label="Attach image"
-                  icon={<AttachIcon />}
-                  variant="quiet"
-                  size="xs"
-                  type="button"
-                  data-testid="spawn-attach"
-                  onClick={() => fileInputRef.current?.click()}
+        {/* The positioned anchor for the inline slash menu above the card -
+            PromptCard's props are field/leading/actions only, so the menu
+            cannot go inside it (nor is Composer's own menu inside its card
+            either - it sits in Composer.tsx's positioned .formAnchor
+            wrapper). Rendered as this wrapper's first child, mirroring
+            Composer's anchor-above-card placement. */}
+        <div className={CLASS.promptAnchor}>
+          {slashOpen && (
+            <SlashCompletionMenu
+              id={slashListboxId}
+              items={slashItems}
+              highlightedIndex={slashActiveIndex}
+              onSelect={commitSlashCompletion}
+            />
+          )}
+          <Dropzone onFiles={(files) => attachments.ingestFiles(files, (message) => toasts.push("error", message))}>
+            <PromptCard
+              data-testid="spawn-prompt-card"
+              controlsTestId="spawn-controls"
+              field={
+                <Textarea
+                  ref={textareaRef}
+                  value={prompt}
+                  onChange={(e) => {
+                    updatePrompt(e.target.value);
+                    // Every keystroke re-evaluates the trailing-token match
+                    // fresh - a token Escape just closed reopens on the very
+                    // next text change rather than staying closed
+                    // indefinitely.
+                    const caret = e.target.selectionStart ?? e.target.value.length;
+                    setSlashToken(parseSlashToken(e.target.value, caret));
+                  }}
+                  onKeyDown={handlePromptKeyDown}
+                  onPaste={handlePaste}
+                  // Blur is the slash menu's own "clicked/tabbed away
+                  // entirely" close: without it a Tab-away leaves a stale
+                  // menu. SlashCompletionMenu's own options preventDefault()
+                  // on their mousedown specifically so a MOUSE click on an
+                  // option never reaches this handler in the first place -
+                  // see that component's own comment - so this only ever
+                  // fires for a genuine "focus left the field".
+                  onBlur={() => setSlashToken(null)}
+                  // Short, because the intro above the card already asks the
+                  // question and states the dormant-start rule; a placeholder
+                  // that repeats them spends the field's one line on nothing.
+                  placeholder="Describe the task…"
+                  aria-label="Prompt"
+                  autoGrow
+                  // The PromptCard around it draws the one border this field
+                  // needs and owns the focus ring - without this the field drew
+                  // its own box inside the card's, and its resize grabber floated
+                  // loose in the corner between them.
+                  seamless
+                  // The page's primary input, so it opens at a size worth writing
+                  // in rather than growing into one. This is also what absorbs
+                  // the slack that used to sit dead below the button.
+                  minLines={6}
                 />
-                {/* The label follows the same rules the old desktop field's
-                    did - the required-choice word when the hub has confirmed
-                    no default (kata xgk8), otherwise the chosen model, the
-                    resolved default model's own "<model> (default)", or
-                    plain "(default)" until the resolve lands. */}
-                <span className={CLASS.modelTrigger} data-testid="spawn-model-slot">
-                  <ModelSwitchTrigger
-                    label={
-                      modelRequired
-                        ? MODEL_CHOOSE_LABEL
-                        : model || (resolvedDefaultModel !== "" ? `${resolvedDefaultModel} (default)` : "(default)")
-                    }
-                    value={model}
-                    loadCatalog={loadCatalog}
-                    onPick={handleModelPickEntry}
-                    data-testid="spawn-model-trigger"
-                    valueTestId="spawn-model-value"
+              }
+              leading={
+                /* The composer's own leading cluster (Composer.tsx's .leading):
+                   attach, then the model trigger, then effort. All stay INSIDE
+                   the card's control row at every width - choosing a model and
+                   an effort is the same act wherever it happens, so it is the
+                   same component (ModelSwitchTrigger) and the same StatusRow
+                   quiet-effort recipe rather than a bespoke boxed variant below
+                   the card. */
+                <div className={CLASS.leading}>
+                  <IconButton
+                    label="Attach image"
+                    icon={<AttachIcon />}
+                    variant="quiet"
+                    size="xs"
+                    type="button"
+                    data-testid="spawn-attach"
+                    onClick={() => fileInputRef.current?.click()}
                   />
-                </span>
-                {/* StatusRow's quiet-effort recipe (statusrow.module.css's
-                    .effortTrigger): the current value IS the visible control -
-                    a real native <select> laid over its own readout at zero
-                    opacity - so the row stays one quiet line instead of
-                    growing a bordered box. The readout renders the SELECTED
-                    option's own label - including the resolved default's
-                    ("high (default)"), never the bare value - so what the
-                    user sees is what the select holds. Same ladder contract
-                    the removed FormRow select kept: the selected model's own
-                    levels, the fallback ladder when the catalog can't say,
-                    and a disabled control when the model cannot reason at all
-                    (effortDisabled) rather than no control - pre-launch the
-                    setting is still discoverable beside the model it belongs
-                    to. */}
-                <span
-                  className={CLASS.effortTrigger}
-                  data-testid="spawn-effort"
-                  data-disabled={effortDisabled ? "true" : undefined}
-                >
-                  <span className={CLASS.effortSeparator} aria-hidden="true">
-                    ·
+                  {/* The label follows the same rules the old desktop field's
+                      did - the required-choice word when the hub has confirmed
+                      no default (kata xgk8), otherwise the chosen model, the
+                      resolved default model's own "<model> (default)", or
+                      plain "(default)" until the resolve lands. */}
+                  <span className={CLASS.modelTrigger} data-testid="spawn-model-slot">
+                    <ModelSwitchTrigger
+                      label={
+                        modelRequired
+                          ? MODEL_CHOOSE_LABEL
+                          : model || (resolvedDefaultModel !== "" ? `${resolvedDefaultModel} (default)` : "(default)")
+                      }
+                      value={model}
+                      loadCatalog={loadCatalog}
+                      onPick={handleModelPickEntry}
+                      data-testid="spawn-model-trigger"
+                      valueTestId="spawn-model-value"
+                    />
                   </span>
-                  <span className={CLASS.effortValue} data-testid="spawn-effort-value" aria-hidden="true">
-                    {effortOptions.find((option) => option.value === reasoningEffort)?.label ??
-                      effortLabel(reasoningEffort, effortLevels)}
-                  </span>
-                  <span className={CLASS.effortChevron} aria-hidden="true">
-                    <Chevron direction="down" />
-                  </span>
-                  <label className={CLASS.srOnly} htmlFor="spawn-reasoning-effort">
-                    Prompt reasoning effort
-                  </label>
-                  <select
-                    id="spawn-reasoning-effort"
-                    className={CLASS.effortSelect}
-                    value={reasoningEffort}
-                    onChange={(e) => setReasoningEffort(e.target.value)}
-                    disabled={effortDisabled}
+                  {/* StatusRow's quiet-effort recipe (statusrow.module.css's
+                      .effortTrigger): the current value IS the visible control -
+                      a real native <select> laid over its own readout at zero
+                      opacity - so the row stays one quiet line instead of
+                      growing a bordered box. The readout renders the SELECTED
+                      option's own label - including the resolved default's
+                      ("high (default)"), never the bare value - so what the
+                      user sees is what the select holds. Same ladder contract
+                      the removed FormRow select kept: the selected model's own
+                      levels, the fallback ladder when the catalog can't say,
+                      and a disabled control when the model cannot reason at all
+                      (effortDisabled) rather than no control - pre-launch the
+                      setting is still discoverable beside the model it belongs
+                      to. */}
+                  <span
+                    className={CLASS.effortTrigger}
+                    data-testid="spawn-effort"
+                    data-disabled={effortDisabled ? "true" : undefined}
                   >
-                    {effortOptions.map((option) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
-                  </select>
-                </span>
-              </div>
-            }
-            actions={
-              <Tooltip label={`Start the agent · ${chordLabel(["Mod", "Enter"])}`}>
-                <Button
-                  variant="primary"
-                  size="xs"
-                  data-testid="spawn-submit"
-                  aria-label="Start"
-                  icon={busy ? undefined : <SendIcon />}
-                  onClick={() => void handleSpawn()}
-                  disabled={busy || modelRequired || providerRequired || pluginSelectionBlocked}
-                >
-                  {busy ? (
-                    <StartingLoader startedAt={busyStartedAt ?? Date.now()} />
-                  ) : (
-                    <span className={CLASS.submitLabel}>Start</span>
-                  )}
-                </Button>
-              </Tooltip>
-            }
-          />
-        </Dropzone>
+                    <span className={CLASS.effortSeparator} aria-hidden="true">
+                      ·
+                    </span>
+                    <span className={CLASS.effortValue} data-testid="spawn-effort-value" aria-hidden="true">
+                      {effortOptions.find((option) => option.value === reasoningEffort)?.label ??
+                        effortLabel(reasoningEffort, effortLevels)}
+                    </span>
+                    <span className={CLASS.effortChevron} aria-hidden="true">
+                      <Chevron direction="down" />
+                    </span>
+                    <label className={CLASS.srOnly} htmlFor="spawn-reasoning-effort">
+                      Prompt reasoning effort
+                    </label>
+                    <select
+                      id="spawn-reasoning-effort"
+                      className={CLASS.effortSelect}
+                      value={reasoningEffort}
+                      onChange={(e) => setReasoningEffort(e.target.value)}
+                      disabled={effortDisabled}
+                    >
+                      {effortOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </span>
+                </div>
+              }
+              actions={
+                <Tooltip label={`Start the agent · ${chordLabel(["Mod", "Enter"])}`}>
+                  <Button
+                    variant="primary"
+                    size="xs"
+                    data-testid="spawn-submit"
+                    aria-label="Start"
+                    icon={busy ? undefined : <SendIcon />}
+                    onClick={() => void handleSpawn()}
+                    disabled={busy || modelRequired || providerRequired || pluginSelectionBlocked}
+                  >
+                    {busy ? (
+                      <StartingLoader startedAt={busyStartedAt ?? Date.now()} />
+                    ) : (
+                      <span className={CLASS.submitLabel}>Start</span>
+                    )}
+                  </Button>
+                </Tooltip>
+              }
+            />
+          </Dropzone>
+        </div>
         {providerRequired && (
           <div className={CLASS.notice} role="status">
             <span>Connect a provider to use a model. Sign in or add an API key here.</span>

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -1142,17 +1142,22 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       } else {
         // Effort validation reads the scope-stamped catalog, not the merged
         // display ladder: same staleness hole as /model (a value valid only
-        // in the previous scope must not validate). No stamp yet (never
-        // loaded or last refresh failed) falls back to the fallback ladder —
-        // the pre-load status quo — while a stamp for ANOTHER scope
-        // fail-closes to no levels.
+        // in the previous scope must not validate). Only PROVEN staleness
+        // fail-closes (a stamp for another scope/loader): an unknown ladder
+        // with no stamp — never loaded, failed refresh, or an entry without
+        // ladder metadata — falls back to the fallback ladder, the pre-load
+        // status quo. Conflating "don't know" with "known empty" would
+        // refuse valid values whenever the catalog lists the model without
+        // ladder details.
+        const scopeMismatch =
+          modelCatalogStamp !== null &&
+          (modelCatalogStamp.scope !== `${harness}\0${cwd}` || modelCatalogStamp.loader !== loadCatalog);
         const scopedEffortEntry =
           effortModel === ""
             ? undefined
             : scopedModelCatalog?.models.find((entry) => `${entry.provider}/${entry.model}` === effortModel);
         const scopedKnownEffortLevels = catalogEffortLevels(scopedEffortEntry);
-        const scopedEffortLevels =
-          scopedKnownEffortLevels ?? (modelCatalogStamp === null ? FALLBACK_EFFORT_LEVELS : []);
+        const scopedEffortLevels = scopeMismatch ? [] : (scopedKnownEffortLevels ?? FALLBACK_EFFORT_LEVELS);
         const items =
           builtinMatch.command.id === "model"
             ? resolveSpawnModelItems(scopedModelCatalog)

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -480,11 +480,16 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
 
   // A freshly (re)matched token always starts highlighted at its first
   // option - an index carried over from the PREVIOUS token's list is not a
-  // meaningful position once the list itself has changed shape.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: slashToken's start/query are deliberate trigger-only deps - the effect body only calls setSlashHighlighted(0), but must still re-run whenever the token identity actually changes (a new match, or the same match with a different query), same idiom as the cursor-restore layout effect below
+  // meaningful position once the list itself has changed shape. The presence
+  // flip covers Escape-dismiss→retype of the identical token (same start and
+  // query, so those deps alone would keep a stale index): reopening always
+  // restarts at the first option. Deliberately stricter than the composer's
+  // twin effect, which keeps the index across an identical-token reopen.
+  const slashTokenPresent = slashToken !== null;
+  // biome-ignore lint/correctness/useExhaustiveDependencies: slashToken's start/query/presence are deliberate trigger-only deps - the effect body only calls setSlashHighlighted(0), but must still re-run whenever the token identity actually changes (a new match, the same match with a different query, or a dismiss→reopen flip), same idiom as the cursor-restore layout effect below
   useEffect(() => {
     setSlashHighlighted(0);
-  }, [slashToken?.start, slashToken?.query]);
+  }, [slashToken?.start, slashToken?.query, slashTokenPresent]);
 
   // Attachments reuse the composer's staged-image pipeline via a TextEditor
   // bridge over the prompt textarea (see Composer.tsx's own bridge for the
@@ -1013,6 +1018,12 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       }
       return { models: [...models, entry], recent, diagnostics };
     });
+    // The picker loads through the same keyed loadCatalog the pane effect
+    // uses, so a successful pick is a current-scope validation snapshot even
+    // when the background load failed (or hasn't landed): stamp it, or a
+    // typed /model for the just-picked model stays refused against the stale
+    // (usually null) stamp.
+    setModelCatalogStamp({ scope: `${harness}\0${cwd}`, loader: loadCatalog });
   }
 
   function handlePromptKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>): void {
@@ -1020,9 +1031,10 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     // submit model (deliberately NOT a verbatim Composer port - Composer's
     // Enter sends, Spawn's plain Enter is a newline and only Mod/Ctrl+Enter
     // submits): ArrowUp/Down move the highlighted option (wrapping at both
-    // ends) OVER the caret rather than moving the caret itself, Tab OR
-    // unmodified non-composing Enter commits the highlighted option, Escape
-    // dismisses without touching the prompt. The committing Enter never
+    // ends) OVER the caret rather than moving the caret itself, unmodified Tab
+    // OR unmodified non-composing Enter commits the highlighted option,
+    // Escape dismisses without touching the prompt. Modified Tab (notably
+    // Shift+Tab) falls through for focus navigation. The committing Enter never
     // steals a submit path - it IS the newline key in Spawn, and
     // Mod/Ctrl+Enter always falls through to the submit branch below even
     // with the menu open. Shift+Enter, Alt+Enter, and composing Enter keep
@@ -1039,7 +1051,7 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
         return;
       }
       if (
-        event.key === "Tab" ||
+        (event.key === "Tab" && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) ||
         (event.key === "Enter" &&
           !event.metaKey &&
           !event.ctrlKey &&
@@ -1130,6 +1142,17 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     // invocation: resolved during pre-start validation below and folded into
     // the thread/start scalars under the chips.
     let slashScalars: { modelProvider?: string; model?: string; reasoningEffort?: string } | null = null;
+    // Bare /goal fail-closes pre-start like bare /reasoning-effort: there is
+    // no goal to clear before the session exists, so starting one just to
+    // no-op its clearing is waste, and sending the literal "/goal" as the
+    // first turn is noise.
+    if (builtinMatch && builtinMatch.command.id === "goal" && builtinMatch.argsText.trim() === "") {
+      toasts.push("error", "/goal needs a value");
+      busyRef.current = false;
+      setBusy(false);
+      setBusyStartedAt(null);
+      return;
+    }
     if (builtinMatch && (builtinMatch.command.id === "model" || builtinMatch.command.id === "reasoning-effort")) {
       // Pre-start validation for enum-arg builtins: there is no cheaper
       // moment to refuse than before the session exists. Unknown value ->

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -1131,18 +1131,19 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     // The advanced schema's sandbox wins over the access-mode chip (floor §1.8);
     // its model/reasoningEffort win over the chips (floor §1.11) - resolveScalars
     // hoists them into the top-level fields the daemon prefers over overrides.
-    // An explicit /model or /reasoning-effort invocation wins over both: the
-    // user typed the value as the submit itself, so it is the most specific
-    // intent in the room.
+    // An explicit /model or /reasoning-effort invocation wins over ALL of
+    // that: the user typed the value as the submit itself, so it is the most
+    // specific intent in the room. The overlay applies AFTER resolveScalars
+    // (not as chip input to it) because resolveScalars gives overrides.model /
+    // overrides.reasoningEffort precedence - folding the slash value into the
+    // chips would let an Advanced Options value silently win instead.
     const overrides = combinedOverrides;
-    const scalars = resolveScalars(
-      {
-        model: slashScalars?.model ?? model,
-        modelProvider: slashScalars?.modelProvider,
-        reasoningEffort: slashScalars?.reasoningEffort ?? reasoningEffort,
-      },
-      overrides,
-    );
+    const resolved = resolveScalars({ model, reasoningEffort }, overrides);
+    const scalars: { modelProvider?: string; model?: string; reasoningEffort?: string } = {
+      modelProvider: slashScalars?.modelProvider ?? resolved.modelProvider,
+      model: slashScalars?.model ?? resolved.model,
+      reasoningEffort: slashScalars?.reasoningEffort ?? resolved.reasoningEffort,
+    };
     // Snapshot before the await (mirrors Composer.tsx's submitAction) so an
     // attachment staged WHILE this request is in flight isn't in the set
     // clearSubmitted removes below - it survives untouched, same contract

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -24,6 +24,7 @@ import type {
   PluginSelectionError,
 } from "../../protocol/types.gen";
 import { useClient } from "../../shell/clientContext";
+import { slashCommandInvocation } from "../../shell/palette/catalogCommands";
 import { splitModelId } from "../../shell/palette/commands";
 import type { PaneProps } from "../../shell/paneRegistry";
 import { effortLabel } from "../../shell/reasoningEffort";
@@ -96,6 +97,7 @@ import {
   sweepStaleModels,
 } from "./spawnDefaults";
 import {
+  PRE_SESSION_BUILTIN_IDS,
   resolveSpawnEffortItems,
   resolveSpawnModelItems,
   runSpawnBuiltinAfterStart,
@@ -441,10 +443,21 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // entry would submit as literal text once the session no longer loads it.
   // Only ready rows complete; the pre-session builtins stay offered throughout.
   const slashCatalogResponse = slashCatalog.state.status === "ready" ? catalogResponse : { commands: [], skills: [] };
+  // Pre-session builtins reserve their invocations: a catalog command or
+  // skill addressing the same "/name" would display as the builtin but always
+  // lose to it at submit (matchBuiltinInvocation runs first), so offering it
+  // is a lie. Plugin-qualified "/plugin:name" invocations never collide and
+  // pass through untouched.
+  // Pre-session builtins reserve their invocations: a catalog command or
+  // skill addressing the same "/name" would display as the builtin but always
+  // lose to it at submit (matchBuiltinInvocation runs first), so offering it
+  // is a lie. Plugin-qualified "/plugin:name" invocations never collide and
+  // pass through untouched.
+  const builtinInvocations = new Set(PRE_SESSION_BUILTIN_IDS.map((id) => `/${id}`));
   const slashMenuCatalog = mergeSlashCommands(
     spawnBuiltinCommands(),
-    slashCatalogResponse.commands,
-    slashCatalogResponse.skills ?? [],
+    slashCatalogResponse.commands.filter((c) => !builtinInvocations.has(slashCommandInvocation(c))),
+    (slashCatalogResponse.skills ?? []).filter((s) => !builtinInvocations.has(`/${s.name}`)),
   );
   // The menu is only ever open when a token matched AND the merged catalog
   // has at least one fuzzy label hit for it - a matched-but-empty token
@@ -1121,8 +1134,12 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     // a prompt carrying attachments is never read as a command, and on a
     // non-evener harness there is no menu and no interception - the prompt
     // always spawns verbatim (same pluginSelectionSupported gate as slashOpen).
-    // A match still starts the session with the literal prompt text (the
-    // daemon expands plugin commands/skills in the first input itself).
+    // A match is CONSUMED like in-session Composer: the invocation text is
+    // stripped from the start input (these builtins are frontend-only, so the
+    // daemon would only receive the literal slash line as noise), and the
+    // builtin applies through its own path instead. Non-builtin prompts
+    // (including plugin commands/skills) still spawn verbatim - the daemon
+    // expands those in the first input itself.
     //
     // /goal applies post-start via runSpawnBuiltinAfterStart (goal/set has no
     // processing gate - it queues behind the running turn). /model and
@@ -1236,7 +1253,10 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     const submittedMarkers = new Set(attachments.items.map((item) => item.marker));
     const { ref } = await startThread(client, {
       cwd,
-      prompt,
+      // A matched builtin is consumed: its invocation text is stripped so the
+      // session starts dormant/configured rather than with a literal slash
+      // line as its first turn. Anything else spawns verbatim.
+      prompt: builtinMatch ? "" : prompt,
       attachments: attachments.toInputAttachments(),
       harness: harness || undefined,
       modelProvider: scalars.modelProvider,

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -1062,7 +1062,16 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             ? resolveSpawnModelItems(modelCatalog)
             : resolveSpawnEffortItems(effortLevels, reasoningEffort);
         const needle = value.toLowerCase();
-        const known = items.some((item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle);
+        // Bare /reasoning-effort fails CLOSED pre-start: the "" head of
+        // resolveSpawnEffortItems (the "(default)" entry) must not count as
+        // known here, so an empty effort value toasts
+        // "/reasoning-effort needs a value" and aborts without thread/start
+        // (palette parity - in-session bare /reasoning-effort errors with no
+        // side effects). Bare /model stays fail-open via the branch above.
+        const known =
+          builtinMatch.command.id === "reasoning-effort" && value === ""
+            ? false
+            : items.some((item) => item.id.toLowerCase() === needle || item.label.toLowerCase() === needle);
         if (!known) {
           const message = value
             ? `/${builtinMatch.command.id}: unknown value "${value}"`

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -377,19 +377,21 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // picker to open. null = not loaded or the load failed - the select stays on
   // the fallback ladder.
   const [modelCatalog, setModelCatalog] = useState<ModelCatalog | null>(null);
-  // The scope the pane catalog was fetched for ("harness + cwd", the
-  // model/list key loadCatalog uses). The catalog merges snapshots across
-  // scopes for picker display continuity, but /model pre-start validation
-  // must only read a snapshot fetched for the CURRENT scope: during the
-  // settle window after a cwd/harness change, modelCatalog still holds the
-  // previous scope, and a value valid only there must not validate.
-  const [modelCatalogScope, setModelCatalogScope] = useState("");
-  // The catalog pre-start /model validation may read: the pane catalog only
-  // when its stamp matches the current scope, null otherwise. Display
-  // surfaces (pickers, effort ladder) keep the merged catalog for
-  // continuity; validation fail-closes through the mismatch window instead
-  // of accepting a value the new scope never offered.
-  const scopedModelCatalog = modelCatalogScope === `${harness}\0${cwd}` ? modelCatalog : null;
+  // Validity stamp for the pane catalog: the scope ("harness + cwd") the
+  // committed snapshot was fetched for, plus the loader identity that
+  // fetched it. The catalog merges snapshots across scopes for picker
+  // display continuity, but /model pre-start validation must only read a
+  // snapshot fetched for the CURRENT scope by the CURRENT loader: during
+  // the settle window after a cwd/harness change — or while a credential
+  // change-triggered refresh is pending — modelCatalog still holds the
+  // previous snapshot, and a value valid only there must not validate.
+  // null means never successfully loaded (or the last refresh failed):
+  // validation fail-closes through that window instead of accepting a
+  // value the current scope never offered.
+  const [modelCatalogStamp, setModelCatalogStamp] = useState<{
+    scope: string;
+    loader: () => Promise<ModelCatalog>;
+  } | null>(null);
   // The hub's resolved default model for this cwd ("" until resolve confirms
   // one): what the Effort ladder keys off while Model reads "(default)".
   const [resolvedDefaultModel, setResolvedDefaultModel] = useState("");
@@ -774,17 +776,26 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     let active = true;
     // The scope this request fetches for, stamped on commit below. A scope
     // change re-runs the effect and retires the previous run via active, so
-    // only the latest scope's response commits its stamp.
+    // only the latest scope's response commits its stamp. loadCatalog's own
+    // identity is the full refresh-trigger key (client, harness, cwd,
+    // instances, generation), so stamping it invalidates the snapshot across
+    // credential/client refreshes too — not just scope changes.
     const requestScope = `${harness}\0${cwd}`;
+    const requestLoader = loadCatalog;
     const settle = setTimeout(() => {
       loadCatalog().then(
         (catalog) => {
           if (active) {
             setModelCatalog((previous) => mergeCatalogSnapshot(previous, catalog));
-            setModelCatalogScope(requestScope);
+            setModelCatalogStamp({ scope: requestScope, loader: requestLoader });
           }
         },
-        () => {},
+        () => {
+          // Fail the stamp closed on refresh failure: the merged catalog
+          // keeps serving display, but validation must not accept values
+          // against a snapshot a failed refresh may have left behind.
+          if (active) setModelCatalogStamp(null);
+        },
       );
     }, CATALOG_SETTLE_MS);
     return () => {
@@ -792,6 +803,17 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       clearTimeout(settle);
     };
   }, [loadCatalog]);
+  // The catalog pre-start /model validation may read: the pane catalog only
+  // when its stamp matches the current scope AND the current loader, null
+  // otherwise. Display surfaces (pickers, effort ladder) keep the merged
+  // catalog for continuity; validation fail-closes through the mismatch
+  // window instead of accepting a value the new scope never offered.
+  const scopedModelCatalog =
+    modelCatalogStamp !== null &&
+    modelCatalogStamp.scope === `${harness}\0${cwd}` &&
+    modelCatalogStamp.loader === loadCatalog
+      ? modelCatalog
+      : null;
 
   // Branch HEAD resolution (floor §1.7): the readout is read-only, so HEAD is
   // its ONLY source - re-resolved on every working-dir change with no
@@ -1112,10 +1134,23 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
       if (builtinMatch.command.id === "model" && value === "") {
         // Fall through to the ordinary start below with no model override.
       } else {
+        // Effort validation reads the scope-stamped catalog, not the merged
+        // display ladder: same staleness hole as /model (a value valid only
+        // in the previous scope must not validate). No stamp yet (never
+        // loaded or last refresh failed) falls back to the fallback ladder —
+        // the pre-load status quo — while a stamp for ANOTHER scope
+        // fail-closes to no levels.
+        const scopedEffortEntry =
+          effortModel === ""
+            ? undefined
+            : scopedModelCatalog?.models.find((entry) => `${entry.provider}/${entry.model}` === effortModel);
+        const scopedKnownEffortLevels = catalogEffortLevels(scopedEffortEntry);
+        const scopedEffortLevels =
+          scopedKnownEffortLevels ?? (modelCatalogStamp === null ? FALLBACK_EFFORT_LEVELS : []);
         const items =
           builtinMatch.command.id === "model"
             ? resolveSpawnModelItems(scopedModelCatalog)
-            : resolveSpawnEffortItems(effortLevels, reasoningEffort);
+            : resolveSpawnEffortItems(scopedEffortLevels, reasoningEffort);
         // Bare /reasoning-effort fails CLOSED pre-start: the "" head of
         // resolveSpawnEffortItems (the "(default)" entry) must not count as
         // known here, so an empty effort value toasts

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -448,11 +448,6 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   // lose to it at submit (matchBuiltinInvocation runs first), so offering it
   // is a lie. Plugin-qualified "/plugin:name" invocations never collide and
   // pass through untouched.
-  // Pre-session builtins reserve their invocations: a catalog command or
-  // skill addressing the same "/name" would display as the builtin but always
-  // lose to it at submit (matchBuiltinInvocation runs first), so offering it
-  // is a lie. Plugin-qualified "/plugin:name" invocations never collide and
-  // pass through untouched.
   const builtinInvocations = new Set(PRE_SESSION_BUILTIN_IDS.map((id) => `/${id}`));
   const slashMenuCatalog = mergeSlashCommands(
     spawnBuiltinCommands(),
@@ -712,7 +707,14 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
   useEffect(() => {
     const urlPrefill = readUrlPrefill(window.location.search);
     const defaults = resolveInitialDefaults({ serverPrefillDir: urlPrefill.dir });
-    if (urlPrefill.prompt) updatePrompt(urlPrefill.prompt);
+    if (urlPrefill.prompt) {
+      updatePrompt(urlPrefill.prompt);
+      // Programmatic writes bypass the keystroke path's token recompute, so
+      // parse here with the caret at end-of-text (where focus lands below):
+      // a prefilled "/..." token opens its menu immediately instead of
+      // waiting for the next keystroke.
+      setSlashToken(parseSlashToken(urlPrefill.prompt, urlPrefill.prompt.length));
+    }
     if (defaults.harness) setHarness(defaults.harness);
     initialModelRef.current = defaults.model ?? "";
     if (defaults.model) setModel(defaults.model);
@@ -781,7 +783,10 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
     function onPopState(): void {
       const urlPrefill = readUrlPrefill(window.location.search);
       if (urlPrefill.dir) setCwd(urlPrefill.dir);
-      if (urlPrefill.prompt) updatePrompt(urlPrefill.prompt);
+      if (urlPrefill.prompt) {
+        updatePrompt(urlPrefill.prompt);
+        setSlashToken(parseSlashToken(urlPrefill.prompt, urlPrefill.prompt.length));
+      }
     }
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
@@ -1197,11 +1202,18 @@ export default function Spawn(_props: PaneProps<SpawnPaneParams>) {
             ? undefined
             : scopedModelCatalog?.models.find((entry) => `${entry.provider}/${entry.model}` === effortModel);
         const scopedKnownEffortLevels = catalogEffortLevels(scopedEffortEntry);
+        // Proven staleness fail-closes to no levels — and the chip value must
+        // not re-authorize itself through `current`: effortOptionLevels
+        // appends a missing current, so resolving against the chip would
+        // validate a value the new scope never offered. Passing "" keeps the
+        // stale chip out of the candidate set (bare effort fails closed on
+        // the empty query regardless).
         const scopedEffortLevels = scopeMismatch ? [] : (scopedKnownEffortLevels ?? FALLBACK_EFFORT_LEVELS);
+        const scopedEffortCurrent = scopeMismatch ? "" : reasoningEffort;
         const items =
           builtinMatch.command.id === "model"
             ? resolveSpawnModelItems(scopedModelCatalog)
-            : resolveSpawnEffortItems(scopedEffortLevels, reasoningEffort);
+            : resolveSpawnEffortItems(scopedEffortLevels, scopedEffortCurrent);
         // Bare /reasoning-effort fails CLOSED pre-start: the "" head of
         // resolveSpawnEffortItems (the "(default)" entry) must not count as
         // known here, so an empty effort value toasts

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawn.module.css
@@ -242,6 +242,16 @@
   min-width: 0;
   gap: var(--space-2);
 }
+
+/* Positions SlashCompletionMenu (an absolutely-positioned child) above the
+ * prompt card, without affecting this element's own layout - the same
+ * anchored-float recipe as the session composer's own .formAnchor
+ * (composer.module.css): the menu opens upward off the positioned ancestor
+ * it wraps. Without a positioned ancestor the menu's absolute positioning
+ * would anchor to the wrong box. */
+.promptAnchor {
+  position: relative;
+}
 .directoryButton {
   display: flex;
   align-items: center;

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.test.ts
@@ -75,6 +75,12 @@ describe("resolveSpawnEffortItems", () => {
     const items = resolveSpawnEffortItems(levels, "");
     expect(items.filter((item) => item.id === "none")).toHaveLength(1);
   });
+
+  test("does not duplicate none when current is none on a none-less ladder", () => {
+    const levels = ["low", "high"];
+    const items = resolveSpawnEffortItems(levels, "none");
+    expect(items.filter((item) => item.id === "none")).toHaveLength(1);
+  });
 });
 
 describe("runSpawnBuiltinAfterStart", () => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test, vi } from "vitest";
+import { effortLabel, effortOptionLevels } from "../../shell/reasoningEffort";
+import type { ModelCatalog } from "../../widgets/modelCatalog";
+import {
+  PRE_SESSION_BUILTIN_IDS,
+  resolveSpawnEffortItems,
+  resolveSpawnModelItems,
+  runSpawnBuiltinAfterStart,
+  spawnBuiltinCommands,
+} from "./spawnSlashMenu";
+
+test("pre-session builtins are exactly goal, model, reasoning-effort", () => {
+  expect([...PRE_SESSION_BUILTIN_IDS]).toEqual(["goal", "model", "reasoning-effort"]);
+  // Allowlist order, not registry order (registry order is model, reasoning-effort, goal).
+  expect(spawnBuiltinCommands().map((c) => c.id)).toEqual(["goal", "model", "reasoning-effort"]);
+});
+
+describe("resolveSpawnModelItems", () => {
+  test("maps provider/model ids with display labels", () => {
+    const catalog = {
+      models: [
+        {
+          provider: "anthropic",
+          model: "claude-sonnet-4",
+          displayName: "Claude Sonnet 4",
+        },
+      ],
+      recent: [],
+      diagnostics: [],
+    } as unknown as ModelCatalog;
+    expect(resolveSpawnModelItems(catalog)).toEqual([
+      { id: "anthropic/claude-sonnet-4", label: "Claude Sonnet 4", hint: "anthropic" },
+    ]);
+  });
+
+  test("falls back to id when displayName is empty", () => {
+    const catalog = {
+      models: [
+        {
+          provider: "openai",
+          model: "gpt-5",
+          displayName: "",
+        },
+      ],
+      recent: [],
+      diagnostics: [],
+    } as unknown as ModelCatalog;
+    expect(resolveSpawnModelItems(catalog)).toEqual([{ id: "openai/gpt-5", label: "openai/gpt-5", hint: "openai" }]);
+  });
+
+  test("null catalog yields []", () => {
+    expect(resolveSpawnModelItems(null)).toEqual([]);
+  });
+});
+
+describe("resolveSpawnEffortItems", () => {
+  test("follows effortOptionLevels", () => {
+    const levels = ["low", "medium", "high"];
+    const current = "medium";
+    expect(resolveSpawnEffortItems(levels, current)).toEqual(
+      effortOptionLevels(levels, current).map((l) => ({ id: l, label: effortLabel(l, levels) })),
+    );
+  });
+
+  test("includes default and none labels", () => {
+    const levels = ["low", "high"];
+    const items = resolveSpawnEffortItems(levels, "");
+    expect(items[0]).toEqual({ id: "", label: "(default)" });
+  });
+});
+
+describe("runSpawnBuiltinAfterStart", () => {
+  test("unknown model value yields blocked outcome message naming the value", async () => {
+    const toasts = { push: vi.fn() };
+    const outcome = await runSpawnBuiltinAfterStart("model", "nope", "ref_test", toasts);
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.message).toMatch(/\/model: unknown value "nope"/);
+    }
+    expect(toasts.push).toHaveBeenCalledWith("error", expect.stringContaining("nope"));
+  });
+
+  test("empty model value resolves to default even with null catalog", async () => {
+    const toasts = { push: vi.fn() };
+    const outcome = await runSpawnBuiltinAfterStart("model", "", "ref_test", toasts);
+    expect(outcome).toEqual({ ok: true });
+  });
+
+  test("empty model value with whitespace also resolves to default", async () => {
+    const toasts = { push: vi.fn() };
+    const outcome = await runSpawnBuiltinAfterStart("model", "   ", "ref_test", toasts);
+    expect(outcome).toEqual({ ok: true });
+  });
+});

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.test.ts
@@ -54,18 +54,26 @@ describe("resolveSpawnModelItems", () => {
 });
 
 describe("resolveSpawnEffortItems", () => {
-  test("follows effortOptionLevels", () => {
+  test("follows effortOptionLevels plus an unconditional none entry", () => {
     const levels = ["low", "medium", "high"];
     const current = "medium";
-    expect(resolveSpawnEffortItems(levels, current)).toEqual(
-      effortOptionLevels(levels, current).map((l) => ({ id: l, label: effortLabel(l, levels) })),
-    );
+    expect(resolveSpawnEffortItems(levels, current)).toEqual([
+      ...effortOptionLevels(levels, current).map((l) => ({ id: l, label: effortLabel(l, levels) })),
+      { id: "none", label: effortLabel("none", levels) },
+    ]);
   });
 
   test("includes default and none labels", () => {
     const levels = ["low", "high"];
     const items = resolveSpawnEffortItems(levels, "");
     expect(items[0]).toEqual({ id: "", label: "(default)" });
+    expect(items).toContainEqual({ id: "none", label: effortLabel("none", levels) });
+  });
+
+  test("does not duplicate none when the ladder lists it", () => {
+    const levels = ["low", "none", "high"];
+    const items = resolveSpawnEffortItems(levels, "");
+    expect(items.filter((item) => item.id === "none")).toHaveLength(1);
   });
 });
 

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
@@ -5,7 +5,6 @@ import {
   type CommandArgsEnumItem,
   type PaletteRunContext,
   type ScopedCommand,
-  splitModelId,
 } from "../../shell/palette/commands";
 import { effortLabel, effortOptionLevels } from "../../shell/reasoningEffort";
 import type { ToastKind } from "../../widgets";
@@ -134,9 +133,6 @@ export async function runSpawnBuiltinAfterStart(
         if (!toasted) toasts.push("error", message);
         return { ok: false, message };
       }
-      // Use splitModelId to satisfy the import and mirror the registry's own
-      // split, even though command.args.run does the same internally.
-      void splitModelId(item.id);
       const result = await command.args.run(wrappedCtx, item);
       if (isBlocked(result)) {
         const msg = (result as { message: string }).message;

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
@@ -42,7 +42,15 @@ export function resolveSpawnModelItems(catalog: ModelCatalog | null): CommandArg
 }
 
 export function resolveSpawnEffortItems(levels: string[], current: string): CommandArgsEnumItem[] {
-  return effortOptionLevels(levels, current).map((l) => ({ id: l, label: effortLabel(l, levels) }));
+  // Mirrors the Spawn effort selector's own option set (Spawn.tsx's
+  // effortOptions): the ladder levels plus an unconditional explicit "none"
+  // entry. A fresh form whose ladder excludes "none" still offers it, and the
+  // backend accepts it — so slash pre-start validation must too, or
+  // "/reasoning-effort none" fail-closes a value the selector happily sends.
+  return [
+    ...effortOptionLevels(levels, current).map((l) => ({ id: l, label: effortLabel(l, levels) })),
+    ...(!levels.includes("none") ? [{ id: "none", label: effortLabel("none", levels) }] : []),
+  ];
 }
 
 export async function runSpawnBuiltinAfterStart(
@@ -105,54 +113,19 @@ export async function runSpawnBuiltinAfterStart(
 
     const trimmed = argsText.trim();
 
-    if (id === "model") {
-      if (trimmed === "") {
-        return { ok: true };
-      }
-      // Resolve against the command's own source. In the pre-session caller
-      // (Task 6) unknown values are validated before start via
-      // resolveSpawnModelItems(modelCatalog); this post-start path validates
-      // again against the live source. When the source is unavailable (null
-      // catalog, tests) the unknown still fail-closes.
-      let items: CommandArgsEnumItem[] = [];
-      try {
-        items = await command.args.source(wrappedCtx);
-      } catch {
-        items = [];
-      }
-      // If the source returned nothing (e.g. in tests where listModels is not
-      // stubbed), fall back to an empty pre-session catalog for the fail-closed
-      // blocked message rather than throwing.
-      if (items.length === 0) {
-        items = resolveSpawnModelItems(null);
-      }
+    // Shared enum-arg runner: resolve the trimmed value against items, toast
+    // the blocked message on no match, run the matched item. Only the
+    // empty-value policy differs per command (model fail-opens to default,
+    // reasoning-effort fail-closes), so callers pass it in.
+    async function runEnumItem(items: CommandArgsEnumItem[], emptyMessage: string | null): Promise<BuiltinRunOutcome> {
       const needle = trimmed.toLowerCase();
       const item = items.find((it) => it.id.toLowerCase() === needle || it.label.toLowerCase() === needle);
       if (!item) {
-        const message = `/${id}: unknown value "${trimmed}"`;
-        if (!toasted) toasts.push("error", message);
-        return { ok: false, message };
-      }
-      const result = await command.args.run(wrappedCtx, item);
-      if (isBlocked(result)) {
-        const msg = (result as { message: string }).message;
-        if (!toasted) toasts.push("error", msg);
-        return { ok: false, message: msg };
-      }
-      return { ok: true };
-    }
-
-    if (id === "reasoning-effort") {
-      let items: CommandArgsEnumItem[] = [];
-      try {
-        items = await command.args.source(wrappedCtx);
-      } catch {
-        items = [];
-      }
-      const needle = trimmed.toLowerCase();
-      const item = items.find((it) => it.id.toLowerCase() === needle || it.label.toLowerCase() === needle);
-      if (!item) {
-        const message = trimmed ? `/${id}: unknown value "${trimmed}"` : `/${id} needs a value`;
+        const message = trimmed ? `/${id}: unknown value "${trimmed}"` : (emptyMessage ?? `/${id} needs a value`);
+        if (id === "model") {
+          if (!toasted) toasts.push("error", message);
+          return { ok: false, message };
+        }
         const b = blocked(message);
         if (!toasted) toasts.push("error", b.message);
         return { ok: false, message: b.message };
@@ -166,22 +139,40 @@ export async function runSpawnBuiltinAfterStart(
       return { ok: true };
     }
 
-    const items = await command.args.source(wrappedCtx);
-    const needle = trimmed.toLowerCase();
-    const item = items.find((it) => it.id.toLowerCase() === needle || it.label.toLowerCase() === needle);
-    if (!item) {
-      const message = trimmed ? `/${id}: unknown value "${trimmed}"` : `/${id} needs a value`;
-      const b = blocked(message);
-      if (!toasted) toasts.push("error", b.message);
-      return { ok: false, message: b.message };
+    async function enumItems(): Promise<CommandArgsEnumItem[]> {
+      try {
+        return await command.args.source(wrappedCtx);
+      } catch {
+        return [];
+      }
     }
-    const result = await command.args.run(wrappedCtx, item);
-    if (isBlocked(result)) {
-      const msg = (result as { message: string }).message;
-      if (!toasted) toasts.push("error", msg);
-      return { ok: false, message: msg };
+
+    if (id === "model") {
+      if (trimmed === "") {
+        return { ok: true };
+      }
+      // Resolve against the command's own source. In the pre-session caller
+      // (Task 6) unknown values are validated before start via
+      // resolveSpawnModelItems(modelCatalog); this post-start path validates
+      // again against the live source. When the source is unavailable (null
+      // catalog, tests) the unknown still fail-closes.
+      const items = await enumItems();
+      // If the source returned nothing (e.g. in tests where listModels is not
+      // stubbed), fall back to an empty pre-session catalog for the fail-closed
+      // blocked message rather than throwing.
+      return runEnumItem(items.length === 0 ? resolveSpawnModelItems(null) : items, null);
     }
-    return { ok: true };
+
+    if (id === "reasoning-effort") {
+      return runEnumItem(await enumItems(), `/${id} needs a value`);
+    }
+
+    // Unreachable: spawnBuiltinCommands() only ever yields the goal (free-arg,
+    // returned above), model, and reasoning-effort entries, so every id is
+    // handled. A defensive unknown-id refusal rather than a silent success.
+    const message = `/${id}: unknown value "${trimmed}"`;
+    if (!toasted) toasts.push("error", message);
+    return { ok: false, message };
   } catch (err) {
     const message = friendlyErrorMessage(err);
     if (!toasted) toasts.push("error", message);

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
@@ -9,6 +9,7 @@ import {
 import { effortLabel, effortOptionLevels } from "../../shell/reasoningEffort";
 import type { ToastKind } from "../../widgets";
 import type { ModelCatalog } from "../../widgets/modelCatalog";
+import { findBuiltinArgument } from "../session/composer/builtinInvocation";
 
 // The pre-session allowlist: the only session builtins the spawn box offers.
 // Turn-gated commands (steer, queue, interrupt, drain-as-steer) have no turn
@@ -121,8 +122,7 @@ export async function runSpawnBuiltinAfterStart(
     // empty-value policy differs per command (model fail-opens to default,
     // reasoning-effort fail-closes), so callers pass it in.
     async function runEnumItem(items: CommandArgsEnumItem[], emptyMessage: string | null): Promise<BuiltinRunOutcome> {
-      const needle = trimmed.toLowerCase();
-      const item = items.find((it) => it.id.toLowerCase() === needle || it.label.toLowerCase() === needle);
+      const item = findBuiltinArgument(items, argsText);
       if (!item) {
         const message = trimmed ? `/${id}: unknown value "${trimmed}"` : (emptyMessage ?? `/${id} needs a value`);
         if (id === "model") {

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
@@ -48,10 +48,11 @@ export function resolveSpawnEffortItems(levels: string[], current: string): Comm
   // entry. A fresh form whose ladder excludes "none" still offers it, and the
   // backend accepts it — so slash pre-start validation must too, or
   // "/reasoning-effort none" fail-closes a value the selector happily sends.
-  return [
-    ...effortOptionLevels(levels, current).map((l) => ({ id: l, label: effortLabel(l, levels) })),
-    ...(!levels.includes("none") ? [{ id: "none", label: effortLabel("none", levels) }] : []),
-  ];
+  // The presence check runs against the resolved list (not just the ladder):
+  // effortOptionLevels already appends `current`, so a current value of
+  // "none" on a none-less ladder must not produce two identical entries.
+  const base = effortOptionLevels(levels, current).map((l) => ({ id: l, label: effortLabel(l, levels) }));
+  return base.some((item) => item.id === "none") ? base : [...base, { id: "none", label: effortLabel("none", levels) }];
 }
 
 export async function runSpawnBuiltinAfterStart(

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
@@ -1,0 +1,194 @@
+import { friendlyErrorMessage } from "../../protocol/errors";
+import { blocked, isBlocked } from "../../shell/palette/blocked";
+import {
+  buildCommands,
+  type CommandArgsEnumItem,
+  type PaletteRunContext,
+  type ScopedCommand,
+  splitModelId,
+} from "../../shell/palette/commands";
+import { effortLabel, effortOptionLevels } from "../../shell/reasoningEffort";
+import type { ToastKind } from "../../widgets";
+import type { ModelCatalog } from "../../widgets/modelCatalog";
+
+// The pre-session allowlist: the only session builtins the spawn box offers.
+// Turn-gated commands (steer, queue, interrupt, drain-as-steer) have no turn
+// yet; the session-only remainder (compact, clear, aside, shutdown, copy-id,
+// tasks, status, project) each needs an existing session to act on. These
+// three configure the session being started, so they make sense before one
+// exists.
+export const PRE_SESSION_BUILTIN_IDS = ["goal", "model", "reasoning-effort"] as const;
+
+export type BuiltinRunOutcome = { ok: true } | { ok: false; message: string };
+
+export function spawnBuiltinCommands(): ScopedCommand[] {
+  const byId = new Map(
+    buildCommands()
+      .filter((c) => c.scope === "session")
+      .map((c) => [c.id, c]),
+  );
+  // Allowlist order, not registry order: mergeSlashCommands renders builtins
+  // in this array's order, and the menu should read goal, model,
+  // reasoning-effort regardless of where the registry lists them.
+  return PRE_SESSION_BUILTIN_IDS.map((id) => byId.get(id)).filter((c): c is ScopedCommand => c !== undefined);
+}
+
+export function resolveSpawnModelItems(catalog: ModelCatalog | null): CommandArgsEnumItem[] {
+  if (!catalog) return [];
+  return catalog.models.map((m) => ({
+    id: `${m.provider}/${m.model}`,
+    label: m.displayName || `${m.provider}/${m.model}`,
+    hint: m.provider,
+  }));
+}
+
+export function resolveSpawnEffortItems(levels: string[], current: string): CommandArgsEnumItem[] {
+  return effortOptionLevels(levels, current).map((l) => ({ id: l, label: effortLabel(l, levels) }));
+}
+
+export async function runSpawnBuiltinAfterStart(
+  id: string,
+  argsText: string,
+  ref: string,
+  toasts: { push(kind: ToastKind, text: string): void },
+): Promise<BuiltinRunOutcome> {
+  const command = spawnBuiltinCommands().find((c) => c.id === id);
+  if (!command) {
+    const message = `/${id}: unknown value "${argsText.trim()}"`;
+    toasts.push("error", message);
+    return { ok: false, message };
+  }
+
+  const ctx: PaletteRunContext = {
+    sessionRef: ref,
+    onPage: "spawn",
+    toasts,
+    ui: { clearToSearch: () => {}, showHelp: () => {} },
+  };
+
+  let toasted = false;
+  const wrappedCtx: PaletteRunContext = {
+    ...ctx,
+    toasts: {
+      push: (kind, text) => {
+        toasted = true;
+        toasts.push(kind, text);
+      },
+    },
+  };
+
+  if (command.unavailableReason) {
+    const message = `/${command.id} is ${command.unavailableReason}`;
+    toasts.push("error", message);
+    return { ok: false, message };
+  }
+
+  try {
+    if (!command.args) {
+      const result = await command.run?.(wrappedCtx);
+      if (isBlocked(result)) {
+        const msg = (result as { message: string }).message;
+        if (!toasted) toasts.push("error", msg);
+        return { ok: false, message: msg };
+      }
+      return { ok: true };
+    }
+
+    if (command.args.kind === "free") {
+      const result = await command.args.run(wrappedCtx, argsText);
+      if (isBlocked(result)) {
+        const msg = (result as { message: string }).message;
+        if (!toasted) toasts.push("error", msg);
+        return { ok: false, message: msg };
+      }
+      return { ok: true };
+    }
+
+    const trimmed = argsText.trim();
+
+    if (id === "model") {
+      if (trimmed === "") {
+        return { ok: true };
+      }
+      // Resolve against the command's own source. In the pre-session caller
+      // (Task 6) unknown values are validated before start via
+      // resolveSpawnModelItems(modelCatalog); this post-start path validates
+      // again against the live source. When the source is unavailable (null
+      // catalog, tests) the unknown still fail-closes.
+      let items: CommandArgsEnumItem[] = [];
+      try {
+        items = await command.args.source(wrappedCtx);
+      } catch {
+        items = [];
+      }
+      // If the source returned nothing (e.g. in tests where listModels is not
+      // stubbed), fall back to an empty pre-session catalog for the fail-closed
+      // blocked message rather than throwing.
+      if (items.length === 0) {
+        items = resolveSpawnModelItems(null);
+      }
+      const needle = trimmed.toLowerCase();
+      const item = items.find((it) => it.id.toLowerCase() === needle || it.label.toLowerCase() === needle);
+      if (!item) {
+        const message = `/${id}: unknown value "${trimmed}"`;
+        if (!toasted) toasts.push("error", message);
+        return { ok: false, message };
+      }
+      // Use splitModelId to satisfy the import and mirror the registry's own
+      // split, even though command.args.run does the same internally.
+      void splitModelId(item.id);
+      const result = await command.args.run(wrappedCtx, item);
+      if (isBlocked(result)) {
+        const msg = (result as { message: string }).message;
+        if (!toasted) toasts.push("error", msg);
+        return { ok: false, message: msg };
+      }
+      return { ok: true };
+    }
+
+    if (id === "reasoning-effort") {
+      let items: CommandArgsEnumItem[] = [];
+      try {
+        items = await command.args.source(wrappedCtx);
+      } catch {
+        items = [];
+      }
+      const needle = trimmed.toLowerCase();
+      const item = items.find((it) => it.id.toLowerCase() === needle || it.label.toLowerCase() === needle);
+      if (!item) {
+        const message = trimmed ? `/${id}: unknown value "${trimmed}"` : `/${id} needs a value`;
+        const b = blocked(message);
+        if (!toasted) toasts.push("error", b.message);
+        return { ok: false, message: b.message };
+      }
+      const result = await command.args.run(wrappedCtx, item);
+      if (isBlocked(result)) {
+        const msg = (result as { message: string }).message;
+        if (!toasted) toasts.push("error", msg);
+        return { ok: false, message: msg };
+      }
+      return { ok: true };
+    }
+
+    const items = await command.args.source(wrappedCtx);
+    const needle = trimmed.toLowerCase();
+    const item = items.find((it) => it.id.toLowerCase() === needle || it.label.toLowerCase() === needle);
+    if (!item) {
+      const message = trimmed ? `/${id}: unknown value "${trimmed}"` : `/${id} needs a value`;
+      const b = blocked(message);
+      if (!toasted) toasts.push("error", b.message);
+      return { ok: false, message: b.message };
+    }
+    const result = await command.args.run(wrappedCtx, item);
+    if (isBlocked(result)) {
+      const msg = (result as { message: string }).message;
+      if (!toasted) toasts.push("error", msg);
+      return { ok: false, message: msg };
+    }
+    return { ok: true };
+  } catch (err) {
+    const message = friendlyErrorMessage(err);
+    if (!toasted) toasts.push("error", message);
+    return { ok: false, message };
+  }
+}

--- a/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/spawnSlashMenu.ts
@@ -111,6 +111,9 @@ export async function runSpawnBuiltinAfterStart(
       return { ok: true };
     }
 
+    // Narrowed once for the closures below: after the free-arg return, args
+    // is enum-kind, but closures don't inherit narrowing.
+    const enumArgs = command.args;
     const trimmed = argsText.trim();
 
     // Shared enum-arg runner: resolve the trimmed value against items, toast
@@ -130,7 +133,7 @@ export async function runSpawnBuiltinAfterStart(
         if (!toasted) toasts.push("error", b.message);
         return { ok: false, message: b.message };
       }
-      const result = await command.args.run(wrappedCtx, item);
+      const result = await enumArgs.run(wrappedCtx, item);
       if (isBlocked(result)) {
         const msg = (result as { message: string }).message;
         if (!toasted) toasts.push("error", msg);
@@ -141,7 +144,7 @@ export async function runSpawnBuiltinAfterStart(
 
     async function enumItems(): Promise<CommandArgsEnumItem[]> {
       try {
-        return await command.args.source(wrappedCtx);
+        return await enumArgs.source(wrappedCtx);
       } catch {
         return [];
       }

--- a/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.test.ts
@@ -1,0 +1,272 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { FakeClient } from "../../protocol/testing/fakeClient";
+import type { SpawnSlashCatalogResponse } from "../../protocol/types.gen";
+import { useSpawnSlashCatalog } from "./useSpawnSlashCatalog";
+
+const RESPONSE: SpawnSlashCatalogResponse = { commands: [], skills: [] };
+
+function flush(): Promise<void> {
+  return Promise.resolve();
+}
+
+describe("useSpawnSlashCatalog", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("loads one catalog after the declared debounce with spawn-shaped params", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    client.on("evener/spawn/slashCatalog", (params) => {
+      expect(params).toEqual({ cwd: "/repo", harness: "evener", launchOverrides: { enabledPlugins: ["a"] } });
+      return { commands: [], skills: [] };
+    });
+    const { result } = renderHook(() =>
+      useSpawnSlashCatalog({
+        client,
+        cwd: "/repo",
+        harness: "evener",
+        launchOverrides: { enabledPlugins: ["a"] },
+        pluginRevision: 0,
+      }),
+    );
+    expect(result.current.state).toEqual({ status: "loading" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "ready", response: RESPONSE });
+    expect(client.calls.filter((call) => call.method === "evener/spawn/slashCatalog")).toHaveLength(1);
+  });
+
+  test("coalesces cwd changes and does not guess catalog while loading", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    let resolve!: (response: SpawnSlashCatalogResponse) => void;
+    client.on("evener/spawn/slashCatalog", () => new Promise((done) => (resolve = done)));
+    const { result, rerender } = renderHook(
+      ({ cwd }: { cwd: string }) =>
+        useSpawnSlashCatalog({ client, cwd, harness: "evener", launchOverrides: {}, pluginRevision: 0 }),
+      { initialProps: { cwd: "/one" } },
+    );
+    rerender({ cwd: "/two" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    expect(client.calls.filter((call) => call.method === "evener/spawn/slashCatalog")).toHaveLength(1);
+    expect(result.current.state).toEqual({ status: "loading" });
+    await act(async () => {
+      resolve(RESPONSE);
+      await flush();
+    });
+    expect(result.current.state.status).toBe("ready");
+  });
+
+  test("ignores a late response whose key is stale", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    const responses: Array<(response: SpawnSlashCatalogResponse) => void> = [];
+    client.on("evener/spawn/slashCatalog", () => new Promise((resolve) => responses.push(resolve)));
+    const { result, rerender } = renderHook(
+      ({ cwd }: { cwd: string }) =>
+        useSpawnSlashCatalog({ client, cwd, harness: "evener", launchOverrides: {}, pluginRevision: 0 }),
+      { initialProps: { cwd: "/one" } },
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    rerender({ cwd: "/two" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    await act(async () => {
+      responses[0]!({
+        commands: [{ name: "stale", source: "test" }],
+        skills: [],
+      });
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "loading" });
+    await act(async () => {
+      responses[1]!(RESPONSE);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "ready", response: RESPONSE });
+  });
+
+  test("keeps the previous response mounted while a same-cwd refresh loads", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    const responseA: SpawnSlashCatalogResponse = {
+      commands: [{ name: "a", source: "test" }],
+      skills: [],
+    };
+    let resolveRefresh!: (response: SpawnSlashCatalogResponse) => void;
+    let requests = 0;
+    client.on("evener/spawn/slashCatalog", () => {
+      requests += 1;
+      if (requests === 1) return responseA;
+      return new Promise<SpawnSlashCatalogResponse>((done) => (resolveRefresh = done));
+    });
+    const { result, rerender } = renderHook(
+      ({ overrides }: { overrides: Record<string, unknown> }) =>
+        useSpawnSlashCatalog({
+          client,
+          cwd: "/repo",
+          harness: "evener",
+          // cast through unknown to satisfy LaunchConfigLayer without importing extra typing
+          launchOverrides: overrides as unknown as import("../../protocol/types.gen").LaunchConfigLayer,
+          pluginRevision: 0,
+        }),
+      { initialProps: { overrides: {} as Record<string, unknown> } },
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "ready", response: responseA });
+
+    rerender({ overrides: { enabledPlugins: ["a"] } });
+    expect(result.current.state).toEqual({ status: "loading", response: responseA });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+    await act(async () => {
+      resolveRefresh(RESPONSE);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "ready", response: RESPONSE });
+  });
+
+  test("does not reuse a successful response after a changed request fails", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    const responseA: SpawnSlashCatalogResponse = {
+      commands: [{ name: "request-a", source: "test" }],
+      skills: [],
+    };
+    let requests = 0;
+    client.on("evener/spawn/slashCatalog", () => {
+      requests += 1;
+      if (requests === 1) return responseA;
+      throw new Error("catalog failed for request B");
+    });
+    const { result, rerender } = renderHook(
+      ({ cwd }: { cwd: string }) =>
+        useSpawnSlashCatalog({ client, cwd, harness: "evener", launchOverrides: {}, pluginRevision: 0 }),
+      { initialProps: { cwd: "/request-a" } },
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "ready", response: responseA });
+
+    rerender({ cwd: "/request-b" });
+    expect(result.current.state).toEqual({ status: "loading" });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+
+    expect(result.current.state).toEqual({ status: "error", message: "catalog failed for request B" });
+  });
+
+  test("retry reloads the same key and revision refresh starts a new request", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    client.on("evener/spawn/slashCatalog", () => RESPONSE);
+    const { result, rerender } = renderHook(
+      ({ revision }: { revision: number }) =>
+        useSpawnSlashCatalog({
+          client,
+          cwd: "/repo",
+          harness: "evener",
+          launchOverrides: {},
+          pluginRevision: revision,
+        }),
+      { initialProps: { revision: 0 } },
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(client.calls.filter((call) => call.method === "evener/spawn/slashCatalog")).toHaveLength(1);
+    act(() => result.current.retry());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    rerender({ revision: 1 });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(client.calls.filter((call) => call.method === "evener/spawn/slashCatalog")).toHaveLength(3);
+  });
+
+  test("reports request errors and retry can recover", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    client.on("evener/spawn/slashCatalog", () => {
+      throw new Error("catalog failed");
+    });
+    const { result } = renderHook(() =>
+      useSpawnSlashCatalog({ client, cwd: "/repo", harness: "evener", launchOverrides: {}, pluginRevision: 0 }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "error", message: "catalog failed" });
+  });
+
+  test("enabled=false reports ready-empty with no request", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    client.on("evener/spawn/slashCatalog", () => RESPONSE);
+    const { result } = renderHook(() =>
+      useSpawnSlashCatalog({
+        client,
+        cwd: "/repo",
+        harness: "external",
+        launchOverrides: {},
+        pluginRevision: 0,
+        enabled: false,
+      }),
+    );
+    expect(result.current.state).toEqual({ status: "ready", response: { commands: [], skills: [] } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      await flush();
+    });
+    expect(client.calls.filter((call) => call.method === "evener/spawn/slashCatalog")).toHaveLength(0);
+    expect(result.current.state).toEqual({ status: "ready", response: { commands: [], skills: [] } });
+  });
+
+  test("omits empty harness and launchOverrides but always sends cwd", async () => {
+    vi.useFakeTimers();
+    const client = new FakeClient();
+    client.on("evener/spawn/slashCatalog", (params) => {
+      expect(params).toEqual({ cwd: "" });
+      return RESPONSE;
+    });
+    const { result } = renderHook(() =>
+      useSpawnSlashCatalog({
+        client,
+        cwd: "",
+        harness: "",
+        launchOverrides: {},
+        pluginRevision: 0,
+      }),
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+      await flush();
+    });
+    expect(result.current.state).toEqual({ status: "ready", response: RESPONSE });
+    expect(client.calls.filter((call) => call.method === "evener/spawn/slashCatalog")).toHaveLength(1);
+  });
+});

--- a/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.test.ts
@@ -270,3 +270,37 @@ describe("useSpawnSlashCatalog", () => {
     expect(client.calls.filter((call) => call.method === "evener/spawn/slashCatalog")).toHaveLength(1);
   });
 });
+
+test("drops a late response from a replaced client", async () => {
+  vi.useFakeTimers();
+  const clientA = new FakeClient();
+  const clientB = new FakeClient();
+  let resolveA!: (response: SpawnSlashCatalogResponse) => void;
+  clientA.on("evener/spawn/slashCatalog", () => new Promise((done) => (resolveA = done)));
+  clientB.on("evener/spawn/slashCatalog", () => RESPONSE);
+  const { result, rerender } = renderHook(
+    ({ client }: { client: FakeClient }) =>
+      useSpawnSlashCatalog({ client, cwd: "/repo", harness: "evener", launchOverrides: {}, pluginRevision: 0 }),
+    { initialProps: { client: clientA } },
+  );
+  // Fire A's request, then swap the client before it resolves.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(250);
+  });
+  expect(clientA.calls.filter((call) => call.method === "evener/spawn/slashCatalog")).toHaveLength(1);
+  rerender({ client: clientB });
+  await act(async () => {
+    resolveA({
+      commands: [{ name: "stale-client", source: "test" }],
+      skills: [],
+    });
+    await flush();
+  });
+  // A's late response commits nothing; B's request serves the state.
+  expect(result.current.state.status).not.toBe("ready");
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(250);
+    await flush();
+  });
+  expect(result.current.state).toEqual({ status: "ready", response: RESPONSE });
+});

--- a/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { errorText } from "../../protocol/errors";
+import type { AppwireClientLike } from "../../protocol/testing/fakeClient";
+import type { LaunchConfigLayer, SpawnSlashCatalogResponse } from "../../protocol/types.gen";
+
+export const SPAWN_SLASH_CATALOG_DEBOUNCE_MS = 250;
+
+export type SpawnSlashCatalogLoadState =
+  | { status: "loading"; response?: SpawnSlashCatalogResponse }
+  | { status: "ready"; response: SpawnSlashCatalogResponse }
+  | { status: "error"; message: string; response?: SpawnSlashCatalogResponse };
+
+export interface UseSpawnSlashCatalogArgs {
+  client: AppwireClientLike;
+  cwd: string;
+  harness?: string;
+  launchOverrides: LaunchConfigLayer;
+  pluginRevision: number;
+  enabled?: boolean;
+}
+
+export function useSpawnSlashCatalog(args: UseSpawnSlashCatalogArgs): {
+  state: SpawnSlashCatalogLoadState;
+  retry(): void;
+} {
+  const { client, cwd, harness = "", launchOverrides, pluginRevision, enabled = true } = args;
+  const [retryRevision, setRetryRevision] = useState(0);
+  const [state, setState] = useState<SpawnSlashCatalogLoadState>({ status: "loading" });
+  const latestKey = useRef("");
+  const lastResponse = useRef<{ cwd: string; logicalKey: string; response: SpawnSlashCatalogResponse } | null>(null);
+  const launchOverridesRef = useRef(launchOverrides);
+  launchOverridesRef.current = launchOverrides;
+  const harnessRef = useRef(harness);
+  harnessRef.current = harness;
+  const serializedOverrides = JSON.stringify(launchOverrides);
+
+  const retry = useCallback(() => setRetryRevision((revision) => revision + 1), []);
+
+  useEffect(() => {
+    if (!enabled) {
+      latestKey.current = "";
+      lastResponse.current = null;
+      setState({ status: "ready", response: { commands: [], skills: [] } });
+      return undefined;
+    }
+
+    const baseKey = `${cwd}\u0000${serializedOverrides}\u0000${harness}`;
+    const logicalKey = `${baseKey}\u0000${pluginRevision}`;
+    const requestKey = `${logicalKey}\u0000${retryRevision}`;
+    latestKey.current = requestKey;
+    // Keep the previous response mounted while a same-cwd refresh (a selection
+    // toggle, a revision bump, a retry) is in flight, so the panel doesn't
+    // collapse to an empty loading state and back. A cwd change drops it: the
+    // stale list belongs to another directory.
+    const cached = lastResponse.current;
+    setState(
+      cached !== null && cached.cwd === cwd ? { status: "loading", response: cached.response } : { status: "loading" },
+    );
+
+    const timer = setTimeout(() => {
+      const currentOverrides = launchOverridesRef.current;
+      const currentHarness = harnessRef.current;
+      const hasOverrides = Object.keys(currentOverrides).length > 0;
+      const params = {
+        cwd,
+        ...(currentHarness ? { harness: currentHarness } : {}),
+        ...(hasOverrides ? { launchOverrides: currentOverrides } : {}),
+      };
+      void client.request("evener/spawn/slashCatalog", params).then(
+        (response) => {
+          if (latestKey.current === requestKey) {
+            lastResponse.current = { cwd, logicalKey, response };
+            setState({ status: "ready", response });
+          }
+        },
+        (error) => {
+          if (latestKey.current !== requestKey) return;
+          const cachedResponse = lastResponse.current;
+          const response = cachedResponse?.logicalKey === logicalKey ? cachedResponse.response : undefined;
+          setState(
+            response
+              ? { status: "error", message: errorText(error), response }
+              : { status: "error", message: errorText(error) },
+          );
+        },
+      );
+    }, SPAWN_SLASH_CATALOG_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [client, cwd, enabled, harness, pluginRevision, retryRevision, serializedOverrides]);
+
+  return { state, retry };
+}

--- a/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.ts
@@ -29,9 +29,15 @@ export function useSpawnSlashCatalog(args: UseSpawnSlashCatalogArgs): {
   const latestKey = useRef("");
   const lastResponse = useRef<{ cwd: string; logicalKey: string; response: SpawnSlashCatalogResponse } | null>(null);
   const launchOverridesRef = useRef(launchOverrides);
-  launchOverridesRef.current = launchOverrides;
   const harnessRef = useRef(harness);
-  harnessRef.current = harness;
+  // Latest-value sync for the debounced callback below: assigned in an effect,
+  // not the render body, so a concurrent render never tears the values. The
+  // effect runs before the settle timer it feeds can fire, so the callback
+  // always reads the current render's values.
+  useEffect(() => {
+    launchOverridesRef.current = launchOverrides;
+    harnessRef.current = harness;
+  }, [launchOverrides, harness]);
   const serializedOverrides = JSON.stringify(launchOverrides);
 
   const retry = useCallback(() => setRetryRevision((revision) => revision + 1), []);

--- a/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/useSpawnSlashCatalog.ts
@@ -38,6 +38,18 @@ export function useSpawnSlashCatalog(args: UseSpawnSlashCatalogArgs): {
     launchOverridesRef.current = launchOverrides;
     harnessRef.current = harness;
   }, [launchOverrides, harness]);
+  // Client generation: bumped whenever the client identity changes, stamped
+  // into the request guard below. A reconnect that swaps the client object
+  // while a request is in flight must not let the old client's late response
+  // commit under a reused key — the key alone only covers catalog inputs.
+  const clientGenerationRef = useRef(0);
+  const lastClientRef = useRef(client);
+  useEffect(() => {
+    if (lastClientRef.current !== client) {
+      lastClientRef.current = client;
+      clientGenerationRef.current += 1;
+    }
+  }, [client]);
   const serializedOverrides = JSON.stringify(launchOverrides);
 
   const retry = useCallback(() => setRetryRevision((revision) => revision + 1), []);
@@ -66,6 +78,7 @@ export function useSpawnSlashCatalog(args: UseSpawnSlashCatalogArgs): {
     const timer = setTimeout(() => {
       const currentOverrides = launchOverridesRef.current;
       const currentHarness = harnessRef.current;
+      const requestGeneration = clientGenerationRef.current;
       const hasOverrides = Object.keys(currentOverrides).length > 0;
       const params = {
         cwd,
@@ -74,13 +87,13 @@ export function useSpawnSlashCatalog(args: UseSpawnSlashCatalogArgs): {
       };
       void client.request("evener/spawn/slashCatalog", params).then(
         (response) => {
-          if (latestKey.current === requestKey) {
+          if (latestKey.current === requestKey && clientGenerationRef.current === requestGeneration) {
             lastResponse.current = { cwd, logicalKey, response };
             setState({ status: "ready", response });
           }
         },
         (error) => {
-          if (latestKey.current !== requestKey) return;
+          if (latestKey.current !== requestKey || clientGenerationRef.current !== requestGeneration) return;
           const cachedResponse = lastResponse.current;
           const response = cachedResponse?.logicalKey === logicalKey ? cachedResponse.response : undefined;
           setState(

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -1566,6 +1566,17 @@ export interface Source {
   online: boolean;
 }
 
+export interface SpawnSlashCatalogParams {
+  cwd: string;
+  harness?: string;
+  launchOverrides?: LaunchConfigLayer;
+}
+
+export interface SpawnSlashCatalogResponse {
+  commands: CommandDescriptor[];
+  skills?: EvenerSkillInfo[];
+}
+
 export interface TaskAggregate {
   total: number;
   done: number;
@@ -2249,6 +2260,7 @@ export const METHOD_NAMES = [
   "evener/plugin/disable",
   "evener/plugin/setAutoUpgrade",
   "evener/command/list",
+  "evener/spawn/slashCatalog",
   "evener/settings/overview",
   "evener/settings/transcriptDisplay/get",
   "evener/settings/transcriptDisplay/patch",
@@ -2437,6 +2449,7 @@ export interface MethodTypes {
   "evener/plugin/disable": { params: PluginRefParams; result: PluginListResponse };
   "evener/plugin/setAutoUpgrade": { params: PluginSetAutoUpgradeParams; result: PluginListResponse };
   "evener/command/list": { params: EmptyParams; result: CommandListResponse };
+  "evener/spawn/slashCatalog": { params: SpawnSlashCatalogParams; result: SpawnSlashCatalogResponse };
   "evener/settings/overview": { params: EmptyParams; result: SettingsOverviewResponse };
   "evener/settings/transcriptDisplay/get": { params: EmptyParams; result: TranscriptDisplayDefaults };
   "evener/settings/transcriptDisplay/patch": { params: TranscriptDisplayDefaultsPatchParams; result: TranscriptDisplayPatchResponse };

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -174,6 +174,7 @@ no router (reserved).
 | `evener/plugin/disable` | hub | `PluginRefParams` | `PluginListResponse` | Disables an installed plugin; returns the updated list. |
 | `evener/plugin/setAutoUpgrade` | hub | `PluginSetAutoUpgradeParams` | `PluginListResponse` | Sets an installed plugin's auto-upgrade flag; returns the updated list. |
 | `evener/command/list` | hub | `EmptyParams` | `CommandListResponse` | Lists loaded slash commands (name, plugin, description, source: plugin, project, or user) for catalog/autocomplete display. |
+| `evener/spawn/slashCatalog` | hub | `SpawnSlashCatalogParams` | `SpawnSlashCatalogResponse` | Pre-session slash catalog for the spawn form: the commands and skills a session started with this cwd, harness, and launch overrides would offer. |
 | `evener/settings/overview` | hub | `EmptyParams` | `SettingsOverviewResponse` | Returns the settings overview field bag: hub/runtime, storage, agent roster, and probed MCP servers — the five template-only settings sections' data. |
 | `evener/settings/transcriptDisplay/get` | hub | `EmptyParams` | `TranscriptDisplayDefaults` | Reads the canonical Desktop and Mobile transcript-display defaults. |
 | `evener/settings/transcriptDisplay/patch` | hub | `TranscriptDisplayDefaultsPatchParams` | `TranscriptDisplayPatchResponse` | Updates one transcript-display default using an expected revision and returns the canonical value. |
@@ -1472,6 +1473,23 @@ _(no fields)_
 | `storage` | `*appwire.SettingsStorageOverview` | yes |  |
 | `agents` | `[]appwire.SettingsAgentEntry` | yes |  |
 | `mcpDiscovered` | `*appwire.SettingsMCPOverview` | yes |  |
+
+
+### `SpawnSlashCatalogParams`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `cwd` | `string` |  |  |
+| `harness` | `string` | yes |  |
+| `launchOverrides` | `*appwire.LaunchConfigLayer` | yes |  |
+
+
+### `SpawnSlashCatalogResponse`
+
+| Field | Go type | Omitempty | Embedded |
+|-------|---------|-----------|----------|
+| `commands` | `[]appwire.CommandDescriptor` |  |  |
+| `skills` | `[]appwire.EvenerSkillInfo` | yes |  |
 
 
 ### `TaskListParams`


### PR DESCRIPTION
## Summary

The web "new session" prompt box now offers /command and /skill autocompletes matching what the spawned session would offer:

- New AppWire method `evener/spawn/slashCatalog` (types + catalog entry + hub handler) serving the pre-session command/skill catalog.
- Spawn inline slash menu reusing composer helpers, backed by a debounced pre-session slash catalog hook.
- Pre-session builtins (goal, model, reasoning-effort) with an allowlist and arg resolvers.
- Submit interception so pre-session builtins resolve before the session starts.

Base: 88dff8405. Branch: spawn-slash-autocomplete (10 commits). Plan: docs/superpowers/plans/2026-09-09-spawn-slash-autocomplete-plan.md.

## Test evidence

- AppWire and hub suites pass.
- Spawn suite: 106/106 pass.
- Full npm test: green.
- Final review: APPROVE.

## CI note

CI must run the browser geometry guards (spawnguard/layoutguard); no Chrome was available in the dev env, so those guards did not run locally.