### PR TITLE
Add session reconstruction from AgentsView archives

### DIFF
--- a/agent/session_client_mutation_persist.go
+++ b/agent/session_client_mutation_persist.go
@@ -45,7 +45,15 @@ func loadClientMutationSnapshotFS(fs afero.Fs, stateDir, sessionID string) (clie
 	if err != nil {
 		return clientMutationSnapshot{}, fmt.Errorf("read client mutation snapshot: %w", err)
 	}
+	snapshot, err := decodeClientMutationSnapshot(data, sessionID)
+	if err != nil {
+		return clientMutationSnapshot{}, err
+	}
+	forgetRunningTurnNoOneOwns(&snapshot)
+	return snapshot, nil
+}
 
+func decodeClientMutationSnapshot(data []byte, sessionID string) (clientMutationSnapshot, error) {
 	var snapshot clientMutationSnapshot
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.DisallowUnknownFields()
@@ -58,8 +66,27 @@ func loadClientMutationSnapshotFS(fs afero.Fs, stateDir, sessionID string) (clie
 	if err := validateClientMutationSnapshot(snapshot, sessionID); err != nil {
 		return clientMutationSnapshot{}, fmt.Errorf("validate client mutation snapshot: %w", err)
 	}
-	forgetRunningTurnNoOneOwns(&snapshot)
 	return snapshot, nil
+}
+
+// ClientMutationInputIdentities validates a persisted snapshot and maps stable
+// input turn IDs to their client mutation IDs. It reads only the supplied bytes;
+// no pending work is resumed or changed.
+func ClientMutationInputIdentities(data []byte, sessionID string) (map[string]string, error) {
+	snapshot, err := decodeClientMutationSnapshot(data, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	ids := map[string]string{}
+	for id, entry := range snapshot.Journal {
+		if entry.StableTurnID != "" && (entry.Method == "turn/start" || entry.Method == "turn/steer" || entry.Method == "turn/promoteQueuedAsSteer" || entry.Method == "turn/drainAsSteer" || entry.Method == "turn/queue") {
+			if previous := ids[entry.StableTurnID]; previous != "" && previous != id {
+				return nil, fmt.Errorf("ambiguous mutation identity for %s", entry.StableTurnID)
+			}
+			ids[entry.StableTurnID] = id
+		}
+	}
+	return ids, nil
 }
 
 // forgetRunningTurnNoOneOwns drops an ActiveTurnID that no pending execution

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -65,6 +65,9 @@ distinguish it from literal conversation text. Archived reasoning
 remains readable text, without invented provider signatures.
 Assistant tool markers are removed only when the entire content is the
 canonical marker-only block for its recorded calls; mixed text is retained.
+JSON-only failures and completed hooks regain the readable diagnostic used by
+native transcript rendering. Cache-write accounting prefers a supplied duration
+breakdown, falling back to the aggregate count when no breakdown is present.
 
 Attention resolutions retain their readable evidence in `source-snapshot.json`
 and are omitted from the runtime transcript. The archive lacks their originating

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -16,7 +16,12 @@ evener doctor reconstruct SESSION_ID \
 
 The mutation journal is optional. When supplied, client input identities are
 restored by matching its stable turn IDs. This preserves retry identity without
-mistaking an interrupt receipt for the original input.
+mistaking an interrupt receipt for the original input. Recorded turn failures
+also retain their matching mutation identity so native restore recognizes them
+instead of appending the same failure again.
+Supplied journals pass the same strict decoding and validation as native session
+restore; incomplete containers, malformed records, and mismatched record IDs
+are refused before staging any files.
 
 The output contains:
 
@@ -33,7 +38,7 @@ forked or delegated histories, incomplete message ordinals, duplicate call IDs
 or positions, gaps in a message's call indices, non-object tool arguments, and
 tool events that cannot be paired with
 their calls and transcript timestamps. Each call must have exactly one result
-event. Timestamps are compared as instants;
+event within its native tool round. Timestamps are compared as instants;
 multiple tool-result messages at the same instant are ambiguous and refused.
 Missing arguments become an empty object. Source schema mismatches fail explicitly.
 
@@ -47,7 +52,10 @@ This reconstructs normalized history. It cannot recreate original transcript
 bytes, media, provider signatures, all private runtime fields, or conversation
 after the archive's last synchronization. AgentsView can deliberately omit tool
 result bodies. Those are represented by explicit unavailable-content notices;
-recorded call IDs and result error status remain attached. Archived reasoning
+recorded call IDs and result error status remain attached. Result status determines
+whether output is an error; successful output keeps literal error-like prefixes.
+Text matching archive placeholders is retained because the archive cannot
+distinguish it from literal conversation text. Archived reasoning
 remains readable text, without invented provider signatures.
 
 Attention resolutions retain their readable evidence in `source-snapshot.json`

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -1,0 +1,67 @@
+# Reconstruct a missing session transcript
+
+`evener doctor reconstruct` stages an Evener transcript from a local AgentsView
+archive and surviving session metadata. It opens the archive read-only and never
+installs files into live session state or starts a daemon. Every run needs a new
+output directory; existing output is never overwritten.
+
+```sh
+evener doctor reconstruct SESSION_ID \
+  --agentsview-db /path/to/agentsview/sessions.db \
+  --meta /path/to/SESSION_ID.meta.json \
+  --mutations /path/to/SESSION_ID.json \
+  --output-dir /path/to/new-recovery-directory \
+  --json
+```
+
+The mutation journal is optional. When supplied, client input identities are
+restored by matching its stable turn IDs. This preserves retry identity without
+mistaking an interrupt receipt for the original input.
+
+The output contains:
+
+- `sessions/SESSION_ID.transcript.jsonl`, validated through Evener's strict native
+  decoder, including a clearly identified reconstruction notice.
+- `sessions/SESSION_ID.meta.json`, an unchanged copy of the supplied metadata.
+- `source-snapshot.json`, the selected archive records used in reconstruction.
+- `source-mutations.json`, when a mutation journal was supplied.
+- `report.json`, with the coverage cutoff, tool-output omissions, limitations,
+  and SHA-256 hashes of the transcript and source snapshot.
+
+Only root sessions with surviving metadata are supported. The command refuses
+forked or delegated histories, incomplete message ordinals, malformed tool
+arguments, and tool events that cannot be paired with their calls and transcript
+timestamps. Source schema mismatches fail explicitly.
+
+## Fidelity and installation
+
+This reconstructs normalized history. It cannot recreate original transcript
+bytes, media, provider signatures, all private runtime fields, or conversation
+after the archive's last synchronization. AgentsView can deliberately omit tool
+result bodies. Those are represented by explicit unavailable-content notices;
+recorded call IDs and result error status remain attached. Archived reasoning
+remains readable text, without invented provider signatures.
+
+Attention resolutions retain their readable evidence as historical system
+messages. The archive does not store the originating steering delivery IDs, so
+replaying the resolution alone as live attention bookkeeping would be invalid.
+The report counts these historical records explicitly.
+
+Review `report.json` and inspect the staged history before installation:
+
+```sh
+evener doctor transcript SESSION_ID \
+  --state-dir /path/to/new-recovery-directory \
+  --range last:10
+```
+
+Installing is a separate recovery operation. Preserve the staging bundle and
+original metadata and journals first. Verify there is no live owner of the
+session, then publish a separate copy of the staged transcript atomically to the
+original project's `sessions` directory, refusing an existing destination.
+Preserve the original metadata and other surviving state. Resume explicitly and
+verify the hub can read the restored history under the expected session identity.
+
+Jobs, delegates, task stores, queues, and process state need independent review.
+Reconstruction does not mean that old processes or claims of passing tests are
+current. The transcript notice makes that boundary visible when work resumes.

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -49,11 +49,11 @@ result bodies. Those are represented by explicit unavailable-content notices;
 recorded call IDs and result error status remain attached. Archived reasoning
 remains readable text, without invented provider signatures.
 
-Attention resolutions retain their readable evidence as historical steering
-notices. Steering preserves pending tool-round ordering. The archive does not
-store the originating steering delivery IDs, so
-replaying the resolution alone as live attention bookkeeping would be invalid.
-The report counts these historical records explicitly.
+Attention resolutions retain their readable evidence in `source-snapshot.json`
+and are omitted from the runtime transcript. The archive lacks their originating
+delivery IDs, so native attention replay would be invalid. Omitting these private
+records also keeps them out of model prompts and preserves pending tool rounds.
+The report counts them in `historical_attention_records`.
 
 Review `report.json` and inspect the staged history before installation:
 

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -42,8 +42,9 @@ result bodies. Those are represented by explicit unavailable-content notices;
 recorded call IDs and result error status remain attached. Archived reasoning
 remains readable text, without invented provider signatures.
 
-Attention resolutions retain their readable evidence as historical system
-messages. The archive does not store the originating steering delivery IDs, so
+Attention resolutions retain their readable evidence as historical steering
+notices. Steering preserves pending tool-round ordering. The archive does not
+store the originating steering delivery IDs, so
 replaying the resolution alone as live attention bookkeeping would be invalid.
 The report counts these historical records explicitly.
 

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -63,6 +63,8 @@ whether output is an error; successful output keeps literal error-like prefixes.
 Text matching archive placeholders is retained because the archive cannot
 distinguish it from literal conversation text. Archived reasoning
 remains readable text, without invented provider signatures.
+Assistant tool markers are removed only when the entire content is the
+canonical marker-only block for its recorded calls; mixed text is retained.
 
 Attention resolutions retain their readable evidence in `source-snapshot.json`
 and are omitted from the runtime transcript. The archive lacks their originating

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -29,9 +29,15 @@ The output contains:
   and SHA-256 hashes of the transcript and source snapshot.
 
 Only root sessions with surviving metadata are supported. The command refuses
-forked or delegated histories, incomplete message ordinals, malformed tool
-arguments, and tool events that cannot be paired with their calls and transcript
-timestamps. Source schema mismatches fail explicitly.
+forked or delegated histories, incomplete message ordinals, duplicate call
+positions, non-object tool arguments, and tool events that cannot be paired with
+their calls and transcript timestamps. Timestamps are compared as instants;
+multiple tool-result messages at the same instant are ambiguous and refused.
+Missing arguments become an empty object. Source schema mismatches fail explicitly.
+
+The transcript header preserves the surviving metadata's profile and model,
+falling back to the first archived assistant response only for missing fields.
+Each assistant turn retains its own archived response provider and model.
 
 ## Fidelity and installation
 

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -19,6 +19,9 @@ restored by matching its stable turn IDs. This preserves retry identity without
 mistaking an interrupt receipt for the original input. Recorded turn failures
 also retain their matching mutation identity so native restore recognizes them
 instead of appending the same failure again.
+Stable IDs are restored only on user inputs, steering, and failures; steering
+provenance is restored only on steering turns. The source snapshot keeps the
+original archived fields for every record.
 Supplied journals pass the same strict decoding and validation as native session
 restore; incomplete containers, malformed records, and mismatched record IDs
 are refused before staging any files.

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -29,8 +29,9 @@ The output contains:
   and SHA-256 hashes of the transcript and source snapshot.
 
 Only root sessions with surviving metadata are supported. The command refuses
-forked or delegated histories, incomplete message ordinals, duplicate call
-positions, non-object tool arguments, and tool events that cannot be paired with
+forked or delegated histories, incomplete message ordinals, duplicate call IDs
+or positions, gaps in a message's call indices, non-object tool arguments, and
+tool events that cannot be paired with
 their calls and transcript timestamps. Each call must have exactly one result
 event. Timestamps are compared as instants;
 multiple tool-result messages at the same instant are ambiguous and refused.

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -41,6 +41,10 @@ their calls and transcript timestamps. Each call must have exactly one result
 event within its native tool round. Timestamps are compared as instants;
 multiple tool-result messages at the same instant are ambiguous and refused.
 Missing arguments become an empty object. Source schema mismatches fail explicitly.
+Duplicate header fields and unknown tool-result statuses are refused. Successful
+`delegate`, `delegate_send`, and `job_status` results may carry the delegate's
+recorded lifecycle status, including a failed delegate; this does not make the
+status-query tool call itself an error.
 Generated records also pass native bounded framing: an encoded header or entry
 over the runtime's record-size limit is refused before staging any files.
 

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -41,6 +41,8 @@ their calls and transcript timestamps. Each call must have exactly one result
 event within its native tool round. Timestamps are compared as instants;
 multiple tool-result messages at the same instant are ambiguous and refused.
 Missing arguments become an empty object. Source schema mismatches fail explicitly.
+Generated records also pass native bounded framing: an encoded header or entry
+over the runtime's record-size limit is refused before staging any files.
 
 The transcript header preserves the surviving metadata's profile and model,
 falling back to the first archived assistant response only for missing fields.

--- a/cmd/evener-doctor/RECONSTRUCTION.md
+++ b/cmd/evener-doctor/RECONSTRUCTION.md
@@ -31,7 +31,8 @@ The output contains:
 Only root sessions with surviving metadata are supported. The command refuses
 forked or delegated histories, incomplete message ordinals, duplicate call
 positions, non-object tool arguments, and tool events that cannot be paired with
-their calls and transcript timestamps. Timestamps are compared as instants;
+their calls and transcript timestamps. Each call must have exactly one result
+event. Timestamps are compared as instants;
 multiple tool-result messages at the same instant are ambiguous and refused.
 Missing arguments become an empty object. Source schema mismatches fail explicitly.
 

--- a/cmd/evener-doctor/main.go
+++ b/cmd/evener-doctor/main.go
@@ -52,6 +52,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 	switch sub {
 	case "locate":
 		return cmdLocate(rest, stdout, stderr)
+	case "reconstruct":
+		return cmdReconstruct(rest, stdout, stderr)
 	case "transcript":
 		return cmdTranscript(rest, stdout, stderr)
 	case "apilog":
@@ -93,6 +95,7 @@ USAGE:
 
 SUBCOMMANDS:
   locate      resolve a selector to its transcript/API-log/meta/jobs/mutations paths
+  reconstruct stage a lost transcript from an AgentsView archive and surviving metadata (never changes live state)
   transcript  render a session's turns; --count <tool> prints the structural call count; --health prints mechanical per-session health metrics
   apilog      API-call diagnostics: per-call tokens/latency, empties, errors, cache spikes; --health prints a one-line API-health verdict
   jobs        job inspector: every job the session ran, with status, reason, exit code, output bytes, and timings

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -370,6 +370,9 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		if !ok || c.ID != r.ID || r.Source != "tool_result" {
 			return fail(errors.New("invalid or unlinked archived tool result"))
 		}
+		if !validArchivedResultStatus(c.Name, r.Status) {
+			return fail(fmt.Errorf("unsupported archived tool result status %q for %s", r.Status, c.Name))
+		}
 		if resultCalls[key] {
 			return fail(fmt.Errorf("duplicate archived tool result at call ordinal %d index %d", r.CallOrdinal, r.CallIndex))
 		}
@@ -389,8 +392,13 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 	}
 	firstAssistant := true
 	toolRoundOrdinal := -1
+	headerFields := map[string]bool{}
 	for _, m := range source.Messages {
 		if m.SourceType == "header" {
+			if headerFields[m.Kind] {
+				return fail(fmt.Errorf("duplicate archived header field %q", m.Kind))
+			}
+			headerFields[m.Kind] = true
 			switch m.Kind {
 			case "system_prompt":
 				h.SystemPrompt = m.Content
@@ -532,4 +540,17 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 	note := fmt.Sprintf("[SESSION RECONSTRUCTION]\nThis session was reconstructed from the AgentsView archive through %s. Later conversation may be missing; metadata was last updated %s. %d tool-result bodies were not retained and carry explicit unavailable notices. The original live processes were interrupted; archived claims about running processes, jobs, delegates, or test status are historical evidence only. Recheck the working tree and current state before continuing. Media and provider replay signatures were not retained. Full recovery provenance is in the staged report.json.", source.EndedAt, meta.UpdatedAt.Format(time.RFC3339Nano), report.MissingToolOutputs)
 	entries = append(entries, transcript.Entry{Kind: "entry", Seq: len(entries), Turn: schema.Turn{Kind: schema.TurnSteering, Message: llm.User(note), Timestamp: time.Now().UTC()}})
 	return h, entries, nil
+}
+
+func validArchivedResultStatus(toolName, status string) bool {
+	switch status {
+	case "completed", "error":
+		return true
+	case "running", "idle", "failed", "cancelled", "stopped", "exhausted":
+		// AgentsView uses delegate lifecycle as the status of successful calls
+		// to these tools. A failed delegate is not a failed status query.
+		return toolName == "delegate" || toolName == "delegate_send" || toolName == "job_status"
+	default:
+		return false
+	}
 }

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -18,6 +18,7 @@ import (
 
 	_ "modernc.org/sqlite" // Register the driver used to open the external archive read-only.
 
+	"primeradiant.com/evener/agent"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/identifier"
@@ -281,28 +282,8 @@ func reconstructionMutationIDs(path, sid string) (map[string]string, []byte, err
 	if err != nil {
 		return nil, nil, err
 	}
-	var journal struct {
-		SessionID string `json:"session_id"`
-		Journal   map[string]struct {
-			Method   string `json:"method"`
-			StableID string `json:"stable_turn_id"`
-		} `json:"journal"`
-	}
-	if err := json.Unmarshal(data, &journal); err != nil {
-		return nil, nil, err
-	}
-	if journal.SessionID != sid {
-		return nil, nil, errors.New("mutation journal session identity differs")
-	}
-	for id, entry := range journal.Journal {
-		if entry.StableID != "" && (entry.Method == "turn/start" || entry.Method == "turn/steer" || entry.Method == "turn/promoteQueuedAsSteer" || entry.Method == "turn/drainAsSteer" || entry.Method == "turn/queue") {
-			if previous := ids[entry.StableID]; previous != "" && previous != id {
-				return nil, nil, fmt.Errorf("ambiguous mutation identity for %s", entry.StableID)
-			}
-			ids[entry.StableID] = id
-		}
-	}
-	return ids, data, nil
+	ids, err = agent.ClientMutationInputIdentities(data, sid)
+	return ids, data, err
 }
 
 func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mutations map[string]string, report *reconstructionReport) (transcript.Header, []transcript.Entry, error) {
@@ -388,6 +369,7 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		return fail(errors.New("archive has tool calls without recoverable result events"))
 	}
 	firstAssistant := true
+	toolRoundOrdinal := -1
 	for _, m := range source.Messages {
 		if m.SourceType == "header" {
 			switch m.Kind {
@@ -413,8 +395,11 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		}
 		turn := schema.Turn{Kind: schema.TurnKind(m.Kind), Timestamp: stamp, StableTurnID: m.StableID, SteeringSource: m.PromptSource}
 		content := m.Content
-		if content == "["+m.Kind+"]" {
-			content = ""
+		switch turn.Kind {
+		case schema.TurnTool, schema.TurnToolResults, schema.TurnHookCompleted, schema.TurnAttentionResolution, schema.TurnSteering:
+			// Native history permits these records inside a pending tool round.
+		default:
+			toolRoundOrdinal = m.Ordinal
 		}
 		switch turn.Kind {
 		case schema.TurnUserInput, schema.TurnSteering, schema.TurnEnvironment, schema.TurnCheckpoint, schema.TurnSummary:
@@ -467,14 +452,19 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 				return fail(fmt.Errorf("archived tool-result message at ordinal %d has no recoverable results", m.Ordinal))
 			}
 			for _, r := range results[m.Ordinal] {
+				if r.CallOrdinal != toolRoundOrdinal {
+					return fail(fmt.Errorf("archived tool result at ordinal %d crosses a tool-round boundary", m.Ordinal))
+				}
 				c := callLocations[[2]int{r.CallOrdinal, r.CallIndex}]
 				text := r.Content
 				if text == "" && r.ContentLength > 0 {
 					report.MissingToolOutputs++
 					text = fmt.Sprintf("[Session reconstruction: this tool result body (%d bytes) was not retained by the archive. Its contents are unavailable; verify current state before relying on it.]", r.ContentLength)
 				}
-				isError := r.Status == "error" || strings.HasPrefix(text, "[tool error] ")
-				text = strings.TrimPrefix(text, "[tool error] ")
+				isError := r.Status == "error"
+				if isError {
+					text = strings.TrimPrefix(text, "[tool error] ")
+				}
 				turn.Message.Content = append(turn.Message.Content, llm.ContentPart{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: r.ID, Name: c.Name, Content: text, IsError: isError}})
 			}
 		case schema.TurnAttentionResolution:
@@ -485,6 +475,9 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 			continue
 		case schema.TurnSystem, schema.TurnModelSwitch, schema.TurnFailure, schema.TurnHookCompleted:
 			turn.Message.Role = llm.RoleSystem
+			if turn.Kind == schema.TurnFailure {
+				turn.ClientMutationID = mutations[m.StableID]
+			}
 			detail, prefix := content, ""
 			if n := strings.LastIndex(content, "\n{"); n >= 0 {
 				detail, prefix = content[n+1:], content[:n]

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -262,7 +262,7 @@ func readReconstructionSource(ctx context.Context, dbPath, sid string) (reconstr
 	if len(source.Messages) != source.MessageCount || source.MessageCount == 0 {
 		return source, errors.New("archive message count is incomplete or empty")
 	}
-	rows, err = tx.QueryContext(ctx, `SELECT message_id, tool_name, COALESCE(tool_use_id,''), COALESCE(input_json,''), COALESCE(call_index,0) FROM tool_calls WHERE session_id=? ORDER BY message_id, call_index`, archiveID)
+	rows, err = tx.QueryContext(ctx, `SELECT message_id, tool_name, COALESCE(tool_use_id,''), COALESCE(input_json,''), call_index FROM tool_calls WHERE session_id=? ORDER BY message_id, call_index`, archiveID)
 	if err != nil {
 		return source, err
 	}
@@ -467,11 +467,14 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 					}
 				}
 			}
+			var markers []string
 			for _, c := range calls[m.ID] {
-				marker := "[Tool: " + c.Name + "]"
-				if n := strings.LastIndex(content, marker); n >= 0 {
-					content = content[:n] + content[n+len(marker):]
-				}
+				markers = append(markers, "[Tool: "+c.Name+"]")
+			}
+			// Only a canonical tool-only block has unambiguous provenance.
+			// In mixed content a matching marker may be literal assistant text.
+			if content == strings.Join(markers, "\n\n") {
+				content = ""
 			}
 		case schema.TurnTool, schema.TurnToolResults:
 			turn.Message.Role = llm.RoleTool

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -120,7 +120,7 @@ func reconstructSession(ctx context.Context, sid, dbPath, metaPath, mutationsPat
 		"Media bytes, provider replay identifiers/signatures, message phases, and some private runtime fields are unavailable. Archived reasoning is retained as readable text.",
 		"Tool outputs omitted by the archive are replaced with explicit unavailable-content notices. Those notices do not prove the tool succeeded or failed.",
 		"Process, job, delegate, attention, queue, and task state are not reconstructed. Verify current files and process state before continuing work.",
-		"Attention-resolution records are preserved as historical steering notices. Their missing originating delivery IDs make them unsuitable for runtime attention replay.",
+		"Attention-resolution records are preserved only in source-snapshot.json and counted as historical_attention_records. Their missing originating delivery IDs make them unsuitable for runtime replay, and they must not enter model history.",
 	}}
 	header, entries, err := reconstructEntries(source, meta, mutationIDs, &report)
 	if err != nil {
@@ -470,14 +470,11 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 				turn.Message.Content = append(turn.Message.Content, llm.ContentPart{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: r.ID, Name: c.Name, Content: text, IsError: isError}})
 			}
 		case schema.TurnAttentionResolution:
-			// The archive omits originating steering AttentionIDs. Replaying only
-			// the resolution half would claim a delivery that cannot be verified.
-			// Steering can occur inside a tool round without making resume insert
-			// a synthetic interrupted-call result before the archived real result.
-			turn.Kind = schema.TurnSteering
-			turn.Message.Role = llm.RoleUser
-			content = "[Archived runtime record; original attention delivery state unavailable]\n" + m.Content
+			// The source snapshot retains this evidence. Native resolutions need
+			// originating delivery IDs that the archive omits; converting them to
+			// another turn kind would expose private bookkeeping to the model.
 			report.HistoricalAttentionRecords++
+			continue
 		case schema.TurnSystem, schema.TurnModelSwitch, schema.TurnFailure, schema.TurnHookCompleted:
 			turn.Message.Role = llm.RoleSystem
 			detail, prefix := content, ""

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -138,15 +139,8 @@ func reconstructSession(ctx context.Context, sid, dbPath, metaPath, mutationsPat
 			return report, err
 		}
 	}
-	// Use the runtime's strict schema boundary before publishing a staged file.
-	lines := bytes.Split(bytes.TrimSuffix(transcriptBytes.Bytes(), []byte("\n")), []byte("\n"))
-	if _, err := transcript.DecodeHeader(lines[0]); err != nil {
+	if err := validateReconstructionTranscript(transcriptBytes.Bytes(), transcript.DefaultMaxLineBytes); err != nil {
 		return report, err
-	}
-	for _, line := range lines[1:] {
-		if _, err := transcript.DecodeEntry(line); err != nil {
-			return report, err
-		}
 	}
 	sourceBytes, err := json.MarshalIndent(source, "", "  ")
 	if err != nil {
@@ -187,6 +181,31 @@ func reconstructSession(ctx context.Context, sid, dbPath, metaPath, mutationsPat
 	}
 	complete = true
 	return report, nil
+}
+
+func validateReconstructionTranscript(data []byte, maxLineBytes int) error {
+	// Match native restore's bounded framing as well as its record schema.
+	reader := bufio.NewReader(bytes.NewReader(data))
+	for i := 0; ; i++ {
+		line, complete, consumed, err := transcript.ReadLine(reader, maxLineBytes)
+		if err != nil {
+			return err
+		}
+		if !complete {
+			if i == 0 || consumed > 0 {
+				return io.ErrUnexpectedEOF
+			}
+			return nil
+		}
+		if i == 0 {
+			_, err = transcript.DecodeHeader(line)
+		} else {
+			_, err = transcript.DecodeEntry(line)
+		}
+		if err != nil {
+			return err
+		}
+	}
 }
 
 func writeReconstructionFile(name string, data []byte) error {

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -362,6 +362,9 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		if !ok || c.ID != r.ID || r.Source != "tool_result" {
 			return fail(errors.New("invalid or unlinked archived tool result"))
 		}
+		if resultCalls[key] {
+			return fail(fmt.Errorf("duplicate archived tool result at call ordinal %d index %d", r.CallOrdinal, r.CallIndex))
+		}
 		stamp, err := time.Parse(time.RFC3339Nano, r.Timestamp)
 		if err != nil {
 			return fail(err)

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -311,6 +311,7 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 	fail := func(err error) (transcript.Header, []transcript.Entry, error) { return h, nil, err }
 	calls := map[int][]archivedCall{}
 	callLocations := map[[2]int]archivedCall{}
+	callIDs := map[string]bool{}
 	messages := map[int]archivedMessage{}
 	toolOrdinals := map[time.Time]int{}
 	for i, m := range source.Messages {
@@ -344,6 +345,13 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		if _, exists := callLocations[key]; exists {
 			return fail(fmt.Errorf("duplicate archived tool call at ordinal %d index %d", m.Ordinal, c.Index))
 		}
+		if c.Index != len(calls[c.MessageID]) {
+			return fail(fmt.Errorf("non-contiguous archived tool call indices at ordinal %d", m.Ordinal))
+		}
+		if callIDs[c.ID] {
+			return fail(fmt.Errorf("duplicate archived tool call ID %s", c.ID))
+		}
+		callIDs[c.ID] = true
 		if c.Arguments == "" {
 			c.Arguments = "{}"
 		}

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -452,7 +452,8 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 					Output        int  `json:"output_tokens"`
 					Reasoning     *int `json:"reasoning_tokens"`
 					CacheRead     *int `json:"cache_read_input_tokens"`
-					CacheCreation struct {
+					CacheWrite    *int `json:"cache_creation_input_tokens"`
+					CacheCreation *struct {
 						FiveMinute *int `json:"ephemeral_5m_input_tokens"`
 						OneHour    *int `json:"ephemeral_1h_input_tokens"`
 					} `json:"cache_creation"`
@@ -460,7 +461,11 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 				if err := json.Unmarshal([]byte(m.TokenUsage), &usage); err != nil {
 					return fail(err)
 				}
-				turn.Usage = llm.Usage{InputTokens: usage.Input, OutputTokens: usage.Output, TotalTokens: usage.Input + usage.Output, ReasoningTokens: usage.Reasoning, CacheReadTokens: usage.CacheRead, CacheWriteTokens: usage.CacheCreation.FiveMinute, CacheWrite1hTokens: usage.CacheCreation.OneHour}
+				turn.Usage = llm.Usage{InputTokens: usage.Input, OutputTokens: usage.Output, TotalTokens: usage.Input + usage.Output, ReasoningTokens: usage.Reasoning, CacheReadTokens: usage.CacheRead, CacheWriteTokens: usage.CacheWrite}
+				if usage.CacheCreation != nil {
+					turn.Usage.CacheWriteTokens = usage.CacheCreation.FiveMinute
+					turn.Usage.CacheWrite1hTokens = usage.CacheCreation.OneHour
+				}
 				for _, cached := range []*int{turn.Usage.CacheReadTokens, turn.Usage.CacheWriteTokens, turn.Usage.CacheWrite1hTokens} {
 					if cached != nil {
 						turn.Usage.TotalTokens += *cached
@@ -524,6 +529,13 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 				}
 				if turn.Error != nil || turn.Hook != nil {
 					content = prefix
+					if strings.TrimSpace(content) == "" {
+						if turn.Error != nil {
+							content = turn.Error.Message
+						} else {
+							content = turn.Hook.Announcement()
+						}
+					}
 				}
 			}
 		default:

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -1,0 +1,469 @@
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite" // Register the driver used to open the external archive read-only.
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/identifier"
+	"primeradiant.com/evener/llm"
+)
+
+type reconstructionReport struct {
+	SessionID                  string    `json:"session_id"`
+	SourceDatabase             string    `json:"source_database"`
+	SourceSnapshotSHA256       string    `json:"source_snapshot_sha256"`
+	RecoveredThrough           string    `json:"recovered_through"`
+	MetadataUpdatedAt          time.Time `json:"metadata_updated_at"`
+	TranscriptPath             string    `json:"transcript_path"`
+	TranscriptSHA256           string    `json:"transcript_sha256"`
+	Entries                    int       `json:"entries"`
+	ArchivedMessages           int       `json:"archived_messages"`
+	ToolCalls                  int       `json:"tool_calls"`
+	ToolResults                int       `json:"tool_results"`
+	MissingToolOutputs         int       `json:"missing_tool_outputs"`
+	HistoricalAttentionRecords int       `json:"historical_attention_records"`
+	Limitations                []string  `json:"limitations"`
+}
+
+type archivedMessage struct {
+	ID, Ordinal                                                                               int
+	Content, Timestamp, SourceType, Kind, PromptSource, StableID, Model, Provider, TokenUsage string
+}
+
+type archivedCall struct {
+	MessageID, Index    int
+	Name, ID, Arguments string
+}
+
+type archivedResult struct {
+	CallOrdinal, CallIndex, ContentLength, EventIndex int
+	ID, Source, Status, Content, Timestamp            string
+}
+
+type reconstructionSource struct {
+	StartedAt, EndedAt, WorkingDir, Version string
+	MessageCount                            int
+	Messages                                []archivedMessage
+	Calls                                   []archivedCall
+	Results                                 []archivedResult
+}
+
+func cmdReconstruct(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("reconstruct", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dbPath := fs.String("agentsview-db", "", "AgentsView sessions.db (opened read-only)")
+	metaPath := fs.String("meta", "", "surviving session .meta.json")
+	mutationsPath := fs.String("mutations", "", "optional surviving mutation journal, to restore client input identities")
+	output := fs.String("output-dir", "", "new staging directory; must not exist")
+	asJSON := fs.Bool("json", false, "emit the recovery report as JSON")
+	sid, code := parseSelectorAndFlags(fs, args)
+	if code != 0 {
+		return code
+	}
+	sid = strings.TrimPrefix(sid, "local:")
+	if err := identifier.ValidateSessionID(sid); err != nil {
+		return fail(stderr, "reconstruct", err)
+	}
+	if *dbPath == "" || *metaPath == "" || *output == "" {
+		return fail(stderr, "reconstruct", errors.New("--agentsview-db, --meta, and --output-dir are required"))
+	}
+	report, err := reconstructSession(context.Background(), sid, *dbPath, *metaPath, *mutationsPath, *output)
+	if err != nil {
+		return fail(stderr, "reconstruct", err)
+	}
+	if *asJSON {
+		return emitJSON(stdout, report)
+	}
+	return writef(stdout, "%s: staged %d entries through %s; %d tool outputs unavailable\nTranscript: %s\nReport and preserved source: %s\nThis is reconstructed history, not the original transcript. Review report.json before installing.\n", sid, report.Entries, report.RecoveredThrough, report.MissingToolOutputs, report.TranscriptPath, filepath.Dir(filepath.Dir(report.TranscriptPath)))
+}
+
+func reconstructSession(ctx context.Context, sid, dbPath, metaPath, mutationsPath, output string) (reconstructionReport, error) {
+	var report reconstructionReport
+	metaBytes, err := os.ReadFile(metaPath)
+	if err != nil {
+		return report, err
+	}
+	var meta schema.SessionMeta
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		return report, err
+	}
+	if meta.ID != sid || meta.IsSubagent || meta.ParentSessionID != "" {
+		return report, errors.New("reconstruction requires matching metadata for a root session; forked and delegated histories are not supported")
+	}
+	source, err := readReconstructionSource(ctx, dbPath, sid)
+	if err != nil {
+		return report, err
+	}
+	mutationIDs, mutationBytes, err := reconstructionMutationIDs(mutationsPath, sid)
+	if err != nil {
+		return report, err
+	}
+	report = reconstructionReport{SessionID: sid, SourceDatabase: dbPath, RecoveredThrough: source.EndedAt, MetadataUpdatedAt: meta.UpdatedAt, ArchivedMessages: len(source.Messages), ToolCalls: len(source.Calls), ToolResults: len(source.Results), Limitations: []string{
+		"Reconstructed from normalized AgentsView records, not original transcript bytes. Content-part boundaries and whitespace may differ.",
+		"Archive coverage ends at recovered_through; surviving metadata may describe later work whose conversation is unavailable.",
+		"Media bytes, provider replay identifiers/signatures, message phases, and some private runtime fields are unavailable. Archived reasoning is retained as readable text.",
+		"Tool outputs omitted by the archive are replaced with explicit unavailable-content notices. Those notices do not prove the tool succeeded or failed.",
+		"Process, job, delegate, attention, queue, and task state are not reconstructed. Verify current files and process state before continuing work.",
+		"Attention-resolution records are preserved as historical system messages. Their missing originating delivery IDs make them unsuitable for runtime attention replay.",
+	}}
+	header, entries, err := reconstructEntries(source, meta, mutationIDs, &report)
+	if err != nil {
+		return report, err
+	}
+	report.Entries = len(entries)
+	var transcriptBytes bytes.Buffer
+	encoder := json.NewEncoder(&transcriptBytes)
+	if err := encoder.Encode(header); err != nil {
+		return report, err
+	}
+	for _, entry := range entries {
+		if err := encoder.Encode(entry); err != nil {
+			return report, err
+		}
+	}
+	// Use the runtime's strict schema boundary before publishing a staged file.
+	lines := bytes.Split(bytes.TrimSuffix(transcriptBytes.Bytes(), []byte("\n")), []byte("\n"))
+	if _, err := transcript.DecodeHeader(lines[0]); err != nil {
+		return report, err
+	}
+	for _, line := range lines[1:] {
+		if _, err := transcript.DecodeEntry(line); err != nil {
+			return report, err
+		}
+	}
+	sourceBytes, err := json.MarshalIndent(source, "", "  ")
+	if err != nil {
+		return report, err
+	}
+	report.SourceSnapshotSHA256 = fmt.Sprintf("%x", sha256.Sum256(sourceBytes))
+	report.TranscriptSHA256 = fmt.Sprintf("%x", sha256.Sum256(transcriptBytes.Bytes()))
+	output, err = filepath.Abs(output)
+	if err != nil {
+		return report, err
+	}
+	report.TranscriptPath = filepath.Join(output, "sessions", sid+".transcript.jsonl")
+	if err := os.Mkdir(output, 0o700); err != nil {
+		return report, fmt.Errorf("create new staging directory: %w", err)
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			_ = os.RemoveAll(output)
+		}
+	}()
+	if err := os.Mkdir(filepath.Join(output, "sessions"), 0o700); err != nil {
+		return report, err
+	}
+	files := map[string][]byte{report.TranscriptPath: transcriptBytes.Bytes(), filepath.Join(output, "sessions", sid+".meta.json"): metaBytes, filepath.Join(output, "source-snapshot.json"): sourceBytes}
+	if mutationBytes != nil {
+		files[filepath.Join(output, "source-mutations.json")] = mutationBytes
+	}
+	reportBytes, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return report, err
+	}
+	files[filepath.Join(output, "report.json")] = reportBytes
+	for name, data := range files {
+		if err := writeReconstructionFile(name, data); err != nil {
+			return report, err
+		}
+	}
+	complete = true
+	return report, nil
+}
+
+func writeReconstructionFile(name string, data []byte) error {
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	_, writeErr := f.Write(data)
+	syncErr := f.Sync()
+	return errors.Join(writeErr, syncErr, f.Close())
+}
+
+func readReconstructionSource(ctx context.Context, dbPath, sid string) (reconstructionSource, error) {
+	var source reconstructionSource
+	absolute, err := filepath.Abs(dbPath)
+	if err != nil {
+		return source, err
+	}
+	u := url.URL{Scheme: "file", Path: absolute, RawQuery: "mode=ro"}
+	db, err := sql.Open("sqlite", u.String())
+	if err != nil {
+		return source, err
+	}
+	defer db.Close() //nolint:errcheck // read-only database
+	tx, err := db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return source, err
+	}
+	defer tx.Rollback() //nolint:errcheck // preserve one read snapshot, never commit changes
+	archiveID := "evener:" + sid
+	var provider, parent string
+	err = tx.QueryRowContext(ctx, `SELECT agent, COALESCE(parent_session_id,''), COALESCE(started_at,''), COALESCE(ended_at,''), message_count, COALESCE(cwd,''), COALESCE(source_version,'') FROM sessions WHERE id=?`, archiveID).Scan(&provider, &parent, &source.StartedAt, &source.EndedAt, &source.MessageCount, &source.WorkingDir, &source.Version)
+	if err != nil {
+		return source, err
+	}
+	if provider != "evener" || parent != "" {
+		return source, errors.New("archive must be an Evener root session")
+	}
+	rows, err := tx.QueryContext(ctx, `SELECT id, ordinal, COALESCE(content,''), COALESCE(timestamp,''), COALESCE(source_type,''), COALESCE(source_subtype,''), COALESCE(prompt_source,''), COALESCE(source_uuid,''), COALESCE(model,''), COALESCE(provider_id,''), COALESCE(token_usage,'') FROM messages WHERE session_id=? ORDER BY ordinal`, archiveID)
+	if err != nil {
+		return source, err
+	}
+	for rows.Next() {
+		var m archivedMessage
+		if err := rows.Scan(&m.ID, &m.Ordinal, &m.Content, &m.Timestamp, &m.SourceType, &m.Kind, &m.PromptSource, &m.StableID, &m.Model, &m.Provider, &m.TokenUsage); err != nil {
+			_ = rows.Close()
+			return source, err
+		}
+		source.Messages = append(source.Messages, m)
+	}
+	if err := errors.Join(rows.Err(), rows.Close()); err != nil {
+		return source, err
+	}
+	if len(source.Messages) != source.MessageCount || source.MessageCount == 0 {
+		return source, errors.New("archive message count is incomplete or empty")
+	}
+	rows, err = tx.QueryContext(ctx, `SELECT message_id, tool_name, COALESCE(tool_use_id,''), COALESCE(input_json,''), COALESCE(call_index,0) FROM tool_calls WHERE session_id=? ORDER BY message_id, call_index`, archiveID)
+	if err != nil {
+		return source, err
+	}
+	for rows.Next() {
+		var c archivedCall
+		if err := rows.Scan(&c.MessageID, &c.Name, &c.ID, &c.Arguments, &c.Index); err != nil {
+			_ = rows.Close()
+			return source, err
+		}
+		source.Calls = append(source.Calls, c)
+	}
+	if err := errors.Join(rows.Err(), rows.Close()); err != nil {
+		return source, err
+	}
+	rows, err = tx.QueryContext(ctx, `SELECT tool_call_message_ordinal, call_index, tool_use_id, source, status, COALESCE(content,''), content_length, COALESCE(timestamp,''), event_index FROM tool_result_events WHERE session_id=? ORDER BY tool_call_message_ordinal, call_index, event_index`, archiveID)
+	if err != nil {
+		return source, err
+	}
+	for rows.Next() {
+		var r archivedResult
+		if err := rows.Scan(&r.CallOrdinal, &r.CallIndex, &r.ID, &r.Source, &r.Status, &r.Content, &r.ContentLength, &r.Timestamp, &r.EventIndex); err != nil {
+			_ = rows.Close()
+			return source, err
+		}
+		source.Results = append(source.Results, r)
+	}
+	return source, errors.Join(rows.Err(), rows.Close())
+}
+
+func reconstructionMutationIDs(path, sid string) (map[string]string, []byte, error) {
+	ids := map[string]string{}
+	if path == "" {
+		return ids, nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	var journal struct {
+		SessionID string `json:"session_id"`
+		Journal   map[string]struct {
+			Method   string `json:"method"`
+			StableID string `json:"stable_turn_id"`
+		} `json:"journal"`
+	}
+	if err := json.Unmarshal(data, &journal); err != nil {
+		return nil, nil, err
+	}
+	if journal.SessionID != sid {
+		return nil, nil, errors.New("mutation journal session identity differs")
+	}
+	for id, entry := range journal.Journal {
+		if entry.StableID != "" && (entry.Method == "turn/start" || entry.Method == "turn/steer" || entry.Method == "turn/promoteQueuedAsSteer" || entry.Method == "turn/queue") {
+			if previous := ids[entry.StableID]; previous != "" && previous != id {
+				return nil, nil, fmt.Errorf("ambiguous mutation identity for %s", entry.StableID)
+			}
+			ids[entry.StableID] = id
+		}
+	}
+	return ids, data, nil
+}
+
+func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mutations map[string]string, report *reconstructionReport) (transcript.Header, []transcript.Entry, error) {
+	h := transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion, SessionID: meta.ID, CreatedAt: meta.CreatedAt, ProfileID: meta.ProfileID, Model: meta.Model, WorkingDir: source.WorkingDir, BuildVersion: source.Version}
+	var entries []transcript.Entry
+	fail := func(err error) (transcript.Header, []transcript.Entry, error) { return h, nil, err }
+	calls := map[int][]archivedCall{}
+	callLocations := map[[2]int]archivedCall{}
+	messageOrdinals := map[int]int{}
+	for _, m := range source.Messages {
+		messageOrdinals[m.ID] = m.Ordinal
+	}
+	for _, c := range source.Calls {
+		ordinal, ok := messageOrdinals[c.MessageID]
+		if !ok || c.ID == "" || c.Name == "" || (c.Arguments != "" && !json.Valid([]byte(c.Arguments))) {
+			return fail(errors.New("invalid or unlinked archived tool call"))
+		}
+		calls[c.MessageID] = append(calls[c.MessageID], c)
+		callLocations[[2]int{ordinal, c.Index}] = c
+	}
+	results := map[string][]archivedResult{}
+	resultCalls := map[[2]int]bool{}
+	for _, r := range source.Results {
+		key := [2]int{r.CallOrdinal, r.CallIndex}
+		c, ok := callLocations[key]
+		if !ok || c.ID != r.ID || r.Source != "tool_result" {
+			return fail(errors.New("invalid or unlinked archived tool result"))
+		}
+		results[r.Timestamp] = append(results[r.Timestamp], r)
+		resultCalls[key] = true
+	}
+	if len(resultCalls) != len(callLocations) {
+		return fail(errors.New("archive has tool calls without recoverable result events"))
+	}
+	firstAssistant := true
+	for i, m := range source.Messages {
+		if m.Ordinal != i {
+			return fail(errors.New("archive ordinals contain gaps or duplicates"))
+		}
+		if m.SourceType == "header" {
+			switch m.Kind {
+			case "system_prompt":
+				h.SystemPrompt = m.Content
+			case "initial_task":
+				h.Task = m.Content
+			case "agent_tasks":
+				if err := json.Unmarshal([]byte(m.Content), &h.AgentTasks); err != nil {
+					return fail(err)
+				}
+			default:
+				return fail(fmt.Errorf("unknown archived header field %q", m.Kind))
+			}
+			continue
+		}
+		if m.SourceType != "entry" {
+			return fail(fmt.Errorf("unknown archive source type %q", m.SourceType))
+		}
+		stamp, err := time.Parse(time.RFC3339Nano, m.Timestamp)
+		if err != nil {
+			return fail(err)
+		}
+		turn := schema.Turn{Kind: schema.TurnKind(m.Kind), Timestamp: stamp, StableTurnID: m.StableID, SteeringSource: m.PromptSource}
+		content := m.Content
+		if content == "["+m.Kind+"]" {
+			content = ""
+		}
+		switch turn.Kind {
+		case schema.TurnUserInput, schema.TurnSteering, schema.TurnEnvironment, schema.TurnCheckpoint, schema.TurnSummary:
+			turn.Message.Role = llm.RoleUser
+			if turn.Kind == schema.TurnUserInput || (turn.Kind == schema.TurnSteering && m.PromptSource == "user") {
+				turn.ClientMutationID = mutations[m.StableID]
+			}
+		case schema.TurnAssistant:
+			turn.Message.Role = llm.RoleAssistant
+			turn.ResponseModel, turn.ResponseProvider = m.Model, m.Provider
+			if firstAssistant {
+				if m.Model != "" {
+					h.Model = m.Model
+				}
+				if m.Provider != "" {
+					h.ProfileID = m.Provider
+				}
+				firstAssistant = false
+			}
+			if m.TokenUsage != "" {
+				var usage struct {
+					Input     int  `json:"input_tokens"`
+					Output    int  `json:"output_tokens"`
+					Reasoning *int `json:"reasoning_tokens"`
+					CacheRead *int `json:"cache_read_input_tokens"`
+				}
+				if err := json.Unmarshal([]byte(m.TokenUsage), &usage); err != nil {
+					return fail(err)
+				}
+				turn.Usage = llm.Usage{InputTokens: usage.Input, OutputTokens: usage.Output, TotalTokens: usage.Input + usage.Output, ReasoningTokens: usage.Reasoning, CacheReadTokens: usage.CacheRead}
+			}
+			for _, c := range calls[m.ID] {
+				marker := "[Tool: " + c.Name + "]"
+				if n := strings.LastIndex(content, marker); n >= 0 {
+					content = content[:n] + content[n+len(marker):]
+				}
+			}
+		case schema.TurnTool, schema.TurnToolResults:
+			turn.Message.Role = llm.RoleTool
+			for _, r := range results[m.Timestamp] {
+				c := callLocations[[2]int{r.CallOrdinal, r.CallIndex}]
+				text := r.Content
+				if text == "" && r.ContentLength > 0 {
+					report.MissingToolOutputs++
+					text = fmt.Sprintf("[Session reconstruction: this tool result body (%d bytes) was not retained by the archive. Its contents are unavailable; verify current state before relying on it.]", r.ContentLength)
+				}
+				isError := r.Status == "error" || strings.HasPrefix(text, "[tool error] ")
+				text = strings.TrimPrefix(text, "[tool error] ")
+				turn.Message.Content = append(turn.Message.Content, llm.ContentPart{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: r.ID, Name: c.Name, Content: text, IsError: isError}})
+			}
+			delete(results, m.Timestamp)
+		case schema.TurnAttentionResolution:
+			// The archive omits originating steering AttentionIDs. Replaying only
+			// the resolution half would claim a delivery that cannot be verified.
+			turn.Kind = schema.TurnSystem
+			turn.Message.Role = llm.RoleUser
+			content = "[Archived runtime record; original attention delivery state unavailable]\n" + m.Content
+			report.HistoricalAttentionRecords++
+		case schema.TurnSystem, schema.TurnModelSwitch, schema.TurnFailure, schema.TurnHookCompleted:
+			turn.Message.Role = llm.RoleSystem
+			detail, prefix := content, ""
+			if n := strings.LastIndex(content, "\n{"); n >= 0 {
+				detail, prefix = content[n+1:], content[:n]
+			}
+			if json.Valid([]byte(detail)) {
+				switch turn.Kind {
+				case schema.TurnFailure:
+					err = json.Unmarshal([]byte(detail), &turn.Error)
+				case schema.TurnHookCompleted:
+					err = json.Unmarshal([]byte(detail), &turn.Hook)
+				}
+				if err != nil {
+					return fail(err)
+				}
+				if turn.Error != nil || turn.Hook != nil {
+					content = prefix
+				}
+			}
+		default:
+			return fail(fmt.Errorf("unsupported archived turn kind %q", m.Kind))
+		}
+		if strings.TrimSpace(content) != "" {
+			turn.Message.Content = append([]llm.ContentPart{{Kind: llm.ContentText, Text: strings.TrimSpace(content)}}, turn.Message.Content...)
+		}
+		for _, c := range calls[m.ID] {
+			turn.Message.Content = append(turn.Message.Content, llm.ContentPart{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: c.ID, Name: c.Name, Arguments: json.RawMessage(c.Arguments)}})
+		}
+		entries = append(entries, transcript.Entry{Kind: "entry", Seq: len(entries) + 1, Turn: turn})
+	}
+	if len(results) > 0 {
+		return fail(errors.New("archive has tool result events without matching transcript timestamps"))
+	}
+	if len(entries) == 0 || h.SystemPrompt == "" {
+		return fail(errors.New("archive lacks conversation entries or initial system prompt"))
+	}
+	note := fmt.Sprintf("[SESSION RECONSTRUCTION]\nThis session was reconstructed from the AgentsView archive through %s. Later conversation may be missing; metadata was last updated %s. %d tool-result bodies were not retained and carry explicit unavailable notices. The original live processes were interrupted; archived claims about running processes, jobs, delegates, or test status are historical evidence only. Recheck the working tree and current state before continuing. Media and provider replay signatures were not retained. Full recovery provenance is in the staged report.json.", source.EndedAt, meta.UpdatedAt.Format(time.RFC3339Nano), report.MissingToolOutputs)
+	entries = append(entries, transcript.Entry{Kind: "entry", Seq: len(entries) + 1, Turn: schema.Turn{Kind: schema.TurnSteering, Message: llm.User(note), Timestamp: time.Now().UTC()}})
+	return h, entries, nil
+}

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -311,19 +311,50 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 	fail := func(err error) (transcript.Header, []transcript.Entry, error) { return h, nil, err }
 	calls := map[int][]archivedCall{}
 	callLocations := map[[2]int]archivedCall{}
-	messageOrdinals := map[int]int{}
-	for _, m := range source.Messages {
-		messageOrdinals[m.ID] = m.Ordinal
+	messages := map[int]archivedMessage{}
+	toolOrdinals := map[time.Time]int{}
+	for i, m := range source.Messages {
+		if m.Ordinal != i {
+			return fail(errors.New("archive ordinals contain gaps or duplicates"))
+		}
+		if _, exists := messages[m.ID]; exists {
+			return fail(fmt.Errorf("duplicate archived message ID %d", m.ID))
+		}
+		messages[m.ID] = m
+		if m.SourceType == "entry" && (m.Kind == string(schema.TurnTool) || m.Kind == string(schema.TurnToolResults)) {
+			stamp, err := time.Parse(time.RFC3339Nano, m.Timestamp)
+			if err != nil {
+				return fail(err)
+			}
+			// The archive identifies result messages only by timestamp. Equal
+			// instants cannot be assigned to distinct messages without guessing.
+			stamp = stamp.UTC()
+			if _, exists := toolOrdinals[stamp]; exists {
+				return fail(fmt.Errorf("ambiguous archived tool-result timestamp %s", m.Timestamp))
+			}
+			toolOrdinals[stamp] = m.Ordinal
+		}
 	}
 	for _, c := range source.Calls {
-		ordinal, ok := messageOrdinals[c.MessageID]
-		if !ok || c.ID == "" || c.Name == "" || (c.Arguments != "" && !json.Valid([]byte(c.Arguments))) {
+		m, ok := messages[c.MessageID]
+		if !ok || m.SourceType != "entry" || m.Kind != string(schema.TurnAssistant) || c.Index < 0 || c.ID == "" || c.Name == "" {
 			return fail(errors.New("invalid or unlinked archived tool call"))
 		}
+		key := [2]int{m.Ordinal, c.Index}
+		if _, exists := callLocations[key]; exists {
+			return fail(fmt.Errorf("duplicate archived tool call at ordinal %d index %d", m.Ordinal, c.Index))
+		}
+		if c.Arguments == "" {
+			c.Arguments = "{}"
+		}
+		var arguments map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(c.Arguments), &arguments); err != nil || arguments == nil {
+			return fail(fmt.Errorf("archived tool call %s arguments must be a JSON object", c.ID))
+		}
 		calls[c.MessageID] = append(calls[c.MessageID], c)
-		callLocations[[2]int{ordinal, c.Index}] = c
+		callLocations[key] = c
 	}
-	results := map[string][]archivedResult{}
+	results := map[int][]archivedResult{}
 	resultCalls := map[[2]int]bool{}
 	for _, r := range source.Results {
 		key := [2]int{r.CallOrdinal, r.CallIndex}
@@ -331,17 +362,22 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		if !ok || c.ID != r.ID || r.Source != "tool_result" {
 			return fail(errors.New("invalid or unlinked archived tool result"))
 		}
-		results[r.Timestamp] = append(results[r.Timestamp], r)
+		stamp, err := time.Parse(time.RFC3339Nano, r.Timestamp)
+		if err != nil {
+			return fail(err)
+		}
+		ordinal, ok := toolOrdinals[stamp.UTC()]
+		if !ok || ordinal <= r.CallOrdinal {
+			return fail(errors.New("archive has tool result events without a matching message after their call"))
+		}
+		results[ordinal] = append(results[ordinal], r)
 		resultCalls[key] = true
 	}
 	if len(resultCalls) != len(callLocations) {
 		return fail(errors.New("archive has tool calls without recoverable result events"))
 	}
 	firstAssistant := true
-	for i, m := range source.Messages {
-		if m.Ordinal != i {
-			return fail(errors.New("archive ordinals contain gaps or duplicates"))
-		}
+	for _, m := range source.Messages {
 		if m.SourceType == "header" {
 			switch m.Kind {
 			case "system_prompt":
@@ -379,10 +415,10 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 			turn.Message.Role = llm.RoleAssistant
 			turn.ResponseModel, turn.ResponseProvider = m.Model, m.Provider
 			if firstAssistant {
-				if m.Model != "" {
+				if h.Model == "" {
 					h.Model = m.Model
 				}
-				if m.Provider != "" {
+				if h.ProfileID == "" {
 					h.ProfileID = m.Provider
 				}
 				firstAssistant = false
@@ -416,7 +452,10 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 			}
 		case schema.TurnTool, schema.TurnToolResults:
 			turn.Message.Role = llm.RoleTool
-			for _, r := range results[m.Timestamp] {
+			if len(results[m.Ordinal]) == 0 {
+				return fail(fmt.Errorf("archived tool-result message at ordinal %d has no recoverable results", m.Ordinal))
+			}
+			for _, r := range results[m.Ordinal] {
 				c := callLocations[[2]int{r.CallOrdinal, r.CallIndex}]
 				text := r.Content
 				if text == "" && r.ContentLength > 0 {
@@ -427,7 +466,6 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 				text = strings.TrimPrefix(text, "[tool error] ")
 				turn.Message.Content = append(turn.Message.Content, llm.ContentPart{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: r.ID, Name: c.Name, Content: text, IsError: isError}})
 			}
-			delete(results, m.Timestamp)
 		case schema.TurnAttentionResolution:
 			// The archive omits originating steering AttentionIDs. Replaying only
 			// the resolution half would claim a delivery that cannot be verified.
@@ -466,15 +504,12 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		for _, c := range calls[m.ID] {
 			turn.Message.Content = append(turn.Message.Content, llm.ContentPart{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: c.ID, Name: c.Name, Arguments: json.RawMessage(c.Arguments)}})
 		}
-		entries = append(entries, transcript.Entry{Kind: "entry", Seq: len(entries) + 1, Turn: turn})
-	}
-	if len(results) > 0 {
-		return fail(errors.New("archive has tool result events without matching transcript timestamps"))
+		entries = append(entries, transcript.Entry{Kind: "entry", Seq: len(entries), Turn: turn})
 	}
 	if len(entries) == 0 || h.SystemPrompt == "" {
 		return fail(errors.New("archive lacks conversation entries or initial system prompt"))
 	}
 	note := fmt.Sprintf("[SESSION RECONSTRUCTION]\nThis session was reconstructed from the AgentsView archive through %s. Later conversation may be missing; metadata was last updated %s. %d tool-result bodies were not retained and carry explicit unavailable notices. The original live processes were interrupted; archived claims about running processes, jobs, delegates, or test status are historical evidence only. Recheck the working tree and current state before continuing. Media and provider replay signatures were not retained. Full recovery provenance is in the staged report.json.", source.EndedAt, meta.UpdatedAt.Format(time.RFC3339Nano), report.MissingToolOutputs)
-	entries = append(entries, transcript.Entry{Kind: "entry", Seq: len(entries) + 1, Turn: schema.Turn{Kind: schema.TurnSteering, Message: llm.User(note), Timestamp: time.Now().UTC()}})
+	entries = append(entries, transcript.Entry{Kind: "entry", Seq: len(entries), Turn: schema.Turn{Kind: schema.TurnSteering, Message: llm.User(note), Timestamp: time.Now().UTC()}})
 	return h, entries, nil
 }

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -120,7 +120,7 @@ func reconstructSession(ctx context.Context, sid, dbPath, metaPath, mutationsPat
 		"Media bytes, provider replay identifiers/signatures, message phases, and some private runtime fields are unavailable. Archived reasoning is retained as readable text.",
 		"Tool outputs omitted by the archive are replaced with explicit unavailable-content notices. Those notices do not prove the tool succeeded or failed.",
 		"Process, job, delegate, attention, queue, and task state are not reconstructed. Verify current files and process state before continuing work.",
-		"Attention-resolution records are preserved as historical system messages. Their missing originating delivery IDs make them unsuitable for runtime attention replay.",
+		"Attention-resolution records are preserved as historical steering notices. Their missing originating delivery IDs make them unsuitable for runtime attention replay.",
 	}}
 	header, entries, err := reconstructEntries(source, meta, mutationIDs, &report)
 	if err != nil {
@@ -295,7 +295,7 @@ func reconstructionMutationIDs(path, sid string) (map[string]string, []byte, err
 		return nil, nil, errors.New("mutation journal session identity differs")
 	}
 	for id, entry := range journal.Journal {
-		if entry.StableID != "" && (entry.Method == "turn/start" || entry.Method == "turn/steer" || entry.Method == "turn/promoteQueuedAsSteer" || entry.Method == "turn/queue") {
+		if entry.StableID != "" && (entry.Method == "turn/start" || entry.Method == "turn/steer" || entry.Method == "turn/promoteQueuedAsSteer" || entry.Method == "turn/drainAsSteer" || entry.Method == "turn/queue") {
 			if previous := ids[entry.StableID]; previous != "" && previous != id {
 				return nil, nil, fmt.Errorf("ambiguous mutation identity for %s", entry.StableID)
 			}
@@ -389,15 +389,24 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 			}
 			if m.TokenUsage != "" {
 				var usage struct {
-					Input     int  `json:"input_tokens"`
-					Output    int  `json:"output_tokens"`
-					Reasoning *int `json:"reasoning_tokens"`
-					CacheRead *int `json:"cache_read_input_tokens"`
+					Input         int  `json:"input_tokens"`
+					Output        int  `json:"output_tokens"`
+					Reasoning     *int `json:"reasoning_tokens"`
+					CacheRead     *int `json:"cache_read_input_tokens"`
+					CacheCreation struct {
+						FiveMinute *int `json:"ephemeral_5m_input_tokens"`
+						OneHour    *int `json:"ephemeral_1h_input_tokens"`
+					} `json:"cache_creation"`
 				}
 				if err := json.Unmarshal([]byte(m.TokenUsage), &usage); err != nil {
 					return fail(err)
 				}
-				turn.Usage = llm.Usage{InputTokens: usage.Input, OutputTokens: usage.Output, TotalTokens: usage.Input + usage.Output, ReasoningTokens: usage.Reasoning, CacheReadTokens: usage.CacheRead}
+				turn.Usage = llm.Usage{InputTokens: usage.Input, OutputTokens: usage.Output, TotalTokens: usage.Input + usage.Output, ReasoningTokens: usage.Reasoning, CacheReadTokens: usage.CacheRead, CacheWriteTokens: usage.CacheCreation.FiveMinute, CacheWrite1hTokens: usage.CacheCreation.OneHour}
+				for _, cached := range []*int{turn.Usage.CacheReadTokens, turn.Usage.CacheWriteTokens, turn.Usage.CacheWrite1hTokens} {
+					if cached != nil {
+						turn.Usage.TotalTokens += *cached
+					}
+				}
 			}
 			for _, c := range calls[m.ID] {
 				marker := "[Tool: " + c.Name + "]"
@@ -422,7 +431,9 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		case schema.TurnAttentionResolution:
 			// The archive omits originating steering AttentionIDs. Replaying only
 			// the resolution half would claim a delivery that cannot be verified.
-			turn.Kind = schema.TurnSystem
+			// Steering can occur inside a tool round without making resume insert
+			// a synthetic interrupted-call result before the archived real result.
+			turn.Kind = schema.TurnSteering
 			turn.Message.Role = llm.RoleUser
 			content = "[Archived runtime record; original attention delivery state unavailable]\n" + m.Content
 			report.HistoricalAttentionRecords++

--- a/cmd/evener-doctor/reconstruct.go
+++ b/cmd/evener-doctor/reconstruct.go
@@ -420,7 +420,14 @@ func reconstructEntries(source reconstructionSource, meta schema.SessionMeta, mu
 		if err != nil {
 			return fail(err)
 		}
-		turn := schema.Turn{Kind: schema.TurnKind(m.Kind), Timestamp: stamp, StableTurnID: m.StableID, SteeringSource: m.PromptSource}
+		turn := schema.Turn{Kind: schema.TurnKind(m.Kind), Timestamp: stamp}
+		if turn.Kind == schema.TurnSteering {
+			turn.SteeringSource = m.PromptSource
+		}
+		switch turn.Kind {
+		case schema.TurnUserInput, schema.TurnSteering, schema.TurnFailure:
+			turn.StableTurnID = m.StableID
+		}
 		content := m.Content
 		switch turn.Kind {
 		case schema.TurnTool, schema.TurnToolResults, schema.TurnHookCompleted, schema.TurnAttentionResolution, schema.TurnSteering:

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -1,0 +1,241 @@
+package doctor
+
+import (
+	"bufio"
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/agent/execenv"
+	"primeradiant.com/evener/agent/provider"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/llm"
+)
+
+func reconstructionFixture(t *testing.T) (dbPath, metaPath, output string) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath, metaPath, output = filepath.Join(dir, "archive.db"), filepath.Join(dir, "session.meta.json"), filepath.Join(dir, "recovered")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	statements := []string{
+		`CREATE TABLE sessions (id TEXT, agent TEXT, parent_session_id TEXT, started_at TEXT, ended_at TEXT, message_count INTEGER, cwd TEXT, source_version TEXT)`,
+		`CREATE TABLE messages (id INTEGER, session_id TEXT, ordinal INTEGER, content TEXT, timestamp TEXT, source_type TEXT, source_subtype TEXT, prompt_source TEXT, source_uuid TEXT, model TEXT, provider_id TEXT, token_usage TEXT)`,
+		`CREATE TABLE tool_calls (message_id INTEGER, session_id TEXT, tool_name TEXT, tool_use_id TEXT, input_json TEXT, call_index INTEGER)`,
+		`CREATE TABLE tool_result_events (session_id TEXT, tool_call_message_ordinal INTEGER, call_index INTEGER, tool_use_id TEXT, source TEXT, status TEXT, content TEXT, content_length INTEGER, timestamp TEXT, event_index INTEGER)`,
+		`INSERT INTO sessions VALUES ('evener:02wLIRxqmq3AUo6vl2OW37','evener','','2026-09-09T01:00:00Z','2026-09-09T01:04:00Z',5,'/workspace','test')`,
+		`INSERT INTO messages VALUES (1,'evener:02wLIRxqmq3AUo6vl2OW37',0,'instructions','2026-09-09T01:00:00Z','header','system_prompt','','','','','')`,
+		`INSERT INTO messages VALUES (2,'evener:02wLIRxqmq3AUo6vl2OW37',1,'task sentinel','2026-09-09T01:01:00Z','entry','USER_INPUT','','turn_m1','','','')`,
+		`INSERT INTO messages VALUES (3,'evener:02wLIRxqmq3AUo6vl2OW37',2,'summary sentinel','2026-09-09T01:02:00Z','entry','SUMMARY','','','','','')`,
+		`INSERT INTO messages VALUES (4,'evener:02wLIRxqmq3AUo6vl2OW37',3,'[Tool: read_file]','2026-09-09T01:03:00Z','entry','ASSISTANT','','','model','provider','{"input_tokens":17,"output_tokens":4}')`,
+		`INSERT INTO messages VALUES (5,'evener:02wLIRxqmq3AUo6vl2OW37',4,'[TOOL_RESULTS]','2026-09-09T01:04:00Z','entry','TOOL_RESULTS','','','','','')`,
+		`INSERT INTO tool_calls VALUES (4,'evener:02wLIRxqmq3AUo6vl2OW37','read_file','call_1','{"file_path":"sentinel.txt"}',0)`,
+		`INSERT INTO tool_result_events VALUES ('evener:02wLIRxqmq3AUo6vl2OW37',3,0,'call_1','tool_result','completed','result sentinel',15,'2026-09-09T01:04:00Z',0)`,
+	}
+	for _, statement := range statements {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(t, metaPath, `{"id":"02wLIRxqmq3AUo6vl2OW37","profile_id":"provider","model":"model","created_at":"2026-09-09T01:00:00Z","updated_at":"2026-09-09T01:05:00Z","env_info":{"working_dir":"/workspace"},"config":{}}`)
+	return
+}
+
+func TestReconstructStagesNativeHistoryWithoutChangingSource(t *testing.T) {
+	db, meta, output := reconstructionFixture(t)
+	before, err := os.ReadFile(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	args := []string{"reconstruct", "02wLIRxqmq3AUo6vl2OW37", "--agentsview-db", db, "--meta", meta, "--output-dir", output, "--json"}
+	if code := run(args, &out, &errOut); code != 0 {
+		t.Fatalf("exit %d: %s", code, &errOut)
+	}
+	var report struct {
+		TranscriptPath     string `json:"transcript_path"`
+		Entries            int    `json:"entries"`
+		MissingToolOutputs int    `json:"missing_tool_outputs"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Entries != 5 || report.MissingToolOutputs != 0 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	f, err := os.Open(report.TranscriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	if !scanner.Scan() {
+		t.Fatal("missing header")
+	}
+	h, err := transcript.DecodeHeader(scanner.Bytes())
+	if err != nil || h.SessionID != "02wLIRxqmq3AUo6vl2OW37" || h.SystemPrompt != "instructions" {
+		t.Fatalf("header: %+v, %v", h, err)
+	}
+	var entries []transcript.Entry
+	for scanner.Scan() {
+		e, err := transcript.DecodeEntry(scanner.Bytes())
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries = append(entries, e)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if entries[0].Turn.Message.Text() != "task sentinel" || entries[0].Turn.StableTurnID != "turn_m1" {
+		t.Fatal("lost user input or stable identity")
+	}
+	history := agent.ResumeHistory(entries)
+	if len(history) != 4 || history[0].Kind != schema.TurnSummary {
+		t.Fatalf("resume compaction boundary: %+v", history)
+	}
+	call := history[1].Message.Content[0].ToolCall
+	result := history[2].Message.Content[0].ToolResult
+	if call == nil || result == nil || call.ID != result.ToolCallID || result.Content != "result sentinel" {
+		t.Fatal("tool exchange was not reconstructed")
+	}
+	after, err := os.ReadFile(db)
+	if err != nil || !bytes.Equal(before, after) {
+		t.Fatal("source archive changed")
+	}
+	transcriptBefore, err := os.ReadFile(report.TranscriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code := run(args, &out, &errOut); code == 0 {
+		t.Fatal("overwrote existing recovery output")
+	}
+	transcriptAfter, err := os.ReadFile(report.TranscriptPath)
+	if err != nil || !bytes.Equal(transcriptBefore, transcriptAfter) {
+		t.Fatal("existing transcript changed")
+	}
+}
+
+func TestReconstructReportsFilteredOutputs(t *testing.T) {
+	dbPath, meta, output := reconstructionFixture(t)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`UPDATE tool_result_events SET content=''`); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	if code := run([]string{"reconstruct", "02wLIRxqmq3AUo6vl2OW37", "--agentsview-db", dbPath, "--meta", meta, "--output-dir", output, "--json"}, &out, &errOut); code != 0 {
+		t.Fatalf("exit %d: %s", code, &errOut)
+	}
+	var report struct {
+		MissingToolOutputs int `json:"missing_tool_outputs"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.MissingToolOutputs != 1 {
+		t.Fatalf("missing output count: %d", report.MissingToolOutputs)
+	}
+}
+
+func TestReconstructRejectsIncompleteArchiveWithoutPublishing(t *testing.T) {
+	for _, damage := range []string{
+		`DELETE FROM tool_result_events`,
+		`UPDATE messages SET ordinal=99 WHERE id=5`,
+		`UPDATE sessions SET message_count=6`,
+		`UPDATE sessions SET parent_session_id='parent'`,
+		`UPDATE tool_calls SET input_json='{'`,
+		`UPDATE tool_result_events SET timestamp='2026-09-09T02:00:00Z'`,
+	} {
+		t.Run(damage, func(t *testing.T) {
+			dbPath, meta, output := reconstructionFixture(t)
+			db, err := sql.Open("sqlite", dbPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			if _, err := db.Exec(damage); err != nil {
+				t.Fatal(err)
+			}
+			var out, errOut bytes.Buffer
+			if code := run([]string{"reconstruct", "02wLIRxqmq3AUo6vl2OW37", "--agentsview-db", dbPath, "--meta", meta, "--output-dir", output}, &out, &errOut); code == 0 {
+				t.Fatal("accepted incomplete archive")
+			}
+			if _, err := os.Stat(output); !os.IsNotExist(err) {
+				t.Fatalf("published incomplete output: %v", err)
+			}
+		})
+	}
+}
+
+func TestReconstructRestoresClientMutationIdentity(t *testing.T) {
+	dbPath, meta, output := reconstructionFixture(t)
+	journal := filepath.Join(filepath.Dir(meta), "mutations.json")
+	mustWrite(t, journal, `{"session_id":"02wLIRxqmq3AUo6vl2OW37","journal":{"client-sentinel":{"method":"turn/start","stable_turn_id":"turn_m1"},"interrupt-sentinel":{"method":"turn/interrupt","stable_turn_id":"turn_m1"}}}`)
+	var out, errOut bytes.Buffer
+	if code := run([]string{"reconstruct", "02wLIRxqmq3AUo6vl2OW37", "--agentsview-db", dbPath, "--meta", meta, "--mutations", journal, "--output-dir", output}, &out, &errOut); code != 0 {
+		t.Fatalf("exit %d: %s", code, &errOut)
+	}
+	data, err := os.ReadFile(filepath.Join(output, "sessions", "02wLIRxqmq3AUo6vl2OW37.transcript.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := transcript.DecodeEntry(bytes.Split(data, []byte("\n"))[1])
+	if err != nil || entry.Turn.ClientMutationID != "client-sentinel" {
+		t.Fatalf("wrong mutation identity: %+v, %v", entry, err)
+	}
+}
+
+func TestReconstructPreservesAttentionEvidenceWithoutInventingDeliveryState(t *testing.T) {
+	dbPath, meta, output := reconstructionFixture(t)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`UPDATE messages SET source_subtype='ATTENTION_RESOLUTION',content=? WHERE id=3`, "opaque sentinel\n"+`{"attention_id":"attention-sentinel","disposition":"consumed"}`); err != nil {
+		t.Fatal(err)
+	}
+	var out, errOut bytes.Buffer
+	if code := run([]string{"reconstruct", "02wLIRxqmq3AUo6vl2OW37", "--agentsview-db", dbPath, "--meta", meta, "--output-dir", output}, &out, &errOut); code != 0 {
+		t.Fatalf("exit %d: %s", code, &errOut)
+	}
+	data, err := os.ReadFile(filepath.Join(output, "sessions", "02wLIRxqmq3AUo6vl2OW37.transcript.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, err := transcript.DecodeEntry(bytes.Split(data, []byte("\n"))[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var metadata schema.SessionMeta
+	metaBytes, err := os.ReadFile(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(metaBytes, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	metadata.EnvInfo.WorkingDir = output
+	restored, err := agent.RestoreSessionFromMeta(llm.NewClient(), provider.NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(output), metadata, output)
+	if err != nil {
+		t.Fatalf("reconstructed transcript cannot resume: %v", err)
+	}
+	defer restored.Close()
+	if entry.Turn.Kind != schema.TurnSystem || entry.Turn.AttentionResolution != nil || entry.Turn.Message.Text() == "" {
+		t.Fatalf("incomplete attention bookkeeping entered runtime replay: %+v", entry.Turn)
+	}
+}

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -209,6 +210,41 @@ func reconstructionSourceFixture(t *testing.T) reconstructionSource {
 		t.Fatal(err)
 	}
 	return source
+}
+
+func TestReconstructionValidationEnforcesNativeRecordSize(t *testing.T) {
+	for _, kind := range []string{"header", "entry"} {
+		t.Run(kind, func(t *testing.T) {
+			header := transcript.Header{Kind: "header", FormatVersion: transcript.FormatVersion}
+			entry := transcript.Entry{Kind: "entry", Turn: schema.Turn{Kind: schema.TurnUserInput, Message: llm.Message{Role: llm.RoleUser}}}
+			// Escaped content proves the bound applies to encoded record bytes.
+			text := strings.Repeat("<", 128)
+			if kind == "header" {
+				header.SystemPrompt = text
+			} else {
+				entry.Turn.Message.Content = []llm.ContentPart{{Kind: llm.ContentText, Text: text}}
+			}
+			var data bytes.Buffer
+			encoder := json.NewEncoder(&data)
+			if err := encoder.Encode(header); err != nil {
+				t.Fatal(err)
+			}
+			headerBytes := data.Len() - 1
+			if err := encoder.Encode(entry); err != nil {
+				t.Fatal(err)
+			}
+			limit := max(headerBytes, data.Len()-headerBytes-2)
+			if err := validateReconstructionTranscript(data.Bytes(), limit); err != nil {
+				t.Fatalf("rejected record at the payload limit: %v", err)
+			}
+			if err := validateReconstructionTranscript(data.Bytes(), limit-1); !errors.Is(err, transcript.ErrLineTooLong) {
+				t.Fatalf("oversized %s error = %v, want ErrLineTooLong", kind, err)
+			}
+			if err := validateReconstructionTranscript(data.Bytes()[:data.Len()-1], limit); !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("incomplete final record error = %v, want unexpected EOF", err)
+			}
+		})
+	}
 }
 
 func TestReconstructMatchesToolResultInstantsAndPreservesRounds(t *testing.T) {

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -255,7 +255,7 @@ func TestReconstructMatchesToolResultInstantsAndPreservesRounds(t *testing.T) {
 		archivedMessage{ID: 7, Ordinal: 6, SourceType: "entry", Kind: "TOOL_RESULTS", Timestamp: "2026-09-09T01:06:00Z"},
 	)
 	source.Calls = append(source.Calls, archivedCall{MessageID: 6, ID: "call_2", Name: "read_file", Arguments: `{}`})
-	source.Results = append(source.Results, archivedResult{CallOrdinal: 5, ID: "call_2", Source: "tool_result", Content: "second sentinel", Timestamp: "2026-09-09T01:06:00.000+00:00"})
+	source.Results = append(source.Results, archivedResult{CallOrdinal: 5, ID: "call_2", Source: "tool_result", Status: "completed", Content: "second sentinel", Timestamp: "2026-09-09T01:06:00.000+00:00"})
 	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
 	if err != nil {
 		t.Fatal(err)
@@ -391,6 +391,73 @@ func TestReconstructUsesRecordedToolErrorStatus(t *testing.T) {
 			result := entries[3].Turn.Message.Content[0].ToolResult
 			if result == nil || result.IsError != (status == "error") || result.Content != content {
 				t.Fatalf("changed literal tool output or error status: %+v", result)
+			}
+		})
+	}
+}
+
+func TestReconstructRejectsUnknownResultStatusBeforeStaging(t *testing.T) {
+	for _, status := range []string{"", "unknown-status", "ERROR", "running", "idle", "failed", "cancelled", "stopped", "exhausted"} {
+		t.Run(status, func(t *testing.T) {
+			dbPath, meta, output := reconstructionFixture(t)
+			db, err := sql.Open("sqlite", dbPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			if _, err := db.Exec(`UPDATE tool_result_events SET status=?`, status); err != nil {
+				t.Fatal(err)
+			}
+			_, err = reconstructSession(context.Background(), "02wLIRxqmq3AUo6vl2OW37", dbPath, meta, "", output)
+			if err == nil {
+				t.Fatal("accepted unknown result status")
+			}
+			if _, err := os.Stat(output); !os.IsNotExist(err) {
+				t.Fatalf("published output for unknown status: %v", err)
+			}
+		})
+	}
+}
+
+func TestReconstructPreservesSuccessfulDelegateLifecycleResults(t *testing.T) {
+	for _, tool := range []string{"delegate", "delegate_send", "job_status"} {
+		for _, status := range []string{"running", "idle", "failed", "cancelled", "stopped", "exhausted"} {
+			t.Run(tool+"/"+status, func(t *testing.T) {
+				source := reconstructionSourceFixture(t)
+				source.Calls[0].Name = tool
+				source.Results[0].Status = status
+				_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				history := agent.ResumeHistory(entries)
+				result := history[2].Message.Content[0].ToolResult
+				if result == nil || result.IsError || result.Content != source.Results[0].Content {
+					t.Fatalf("changed successful delegate lifecycle result: %+v", result)
+				}
+			})
+		}
+	}
+}
+
+func TestReconstructRejectsDuplicateHeaderFieldsBeforeStaging(t *testing.T) {
+	for _, kind := range []string{"system_prompt", "initial_task", "agent_tasks"} {
+		t.Run(kind, func(t *testing.T) {
+			dbPath, meta, output := reconstructionFixture(t)
+			db, err := sql.Open("sqlite", dbPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			if _, err := db.Exec(`UPDATE messages SET source_type='header', source_subtype=?, content='[]' WHERE id IN (2,3)`, kind); err != nil {
+				t.Fatal(err)
+			}
+			_, err = reconstructSession(context.Background(), "02wLIRxqmq3AUo6vl2OW37", dbPath, meta, "", output)
+			if err == nil {
+				t.Fatal("accepted duplicate header field")
+			}
+			if _, err := os.Stat(output); !os.IsNotExist(err) {
+				t.Fatalf("published output for duplicate header: %v", err)
 			}
 		})
 	}

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -305,7 +307,8 @@ func TestReconstructPreservesAttentionEvidenceWithoutInventingDeliveryState(t *t
 		t.Fatal(err)
 	}
 	defer db.Close()
-	if _, err := db.Exec(`UPDATE messages SET source_subtype='ATTENTION_RESOLUTION',content=? WHERE id=3`, "opaque sentinel\n"+`{"attention_id":"attention-sentinel","disposition":"consumed"}`); err != nil {
+	const evidence = "private-attention-sentinel\n" + `{"attention_id":"attention-sentinel","disposition":"consumed"}`
+	if _, err := db.Exec(`UPDATE messages SET source_subtype='ATTENTION_RESOLUTION',content=? WHERE id=3`, evidence); err != nil {
 		t.Fatal(err)
 	}
 	var out, errOut bytes.Buffer
@@ -316,9 +319,27 @@ func TestReconstructPreservesAttentionEvidenceWithoutInventingDeliveryState(t *t
 	if err != nil {
 		t.Fatal(err)
 	}
-	entry, err := transcript.DecodeEntry(bytes.Split(data, []byte("\n"))[2])
+	snapshot, err := os.ReadFile(filepath.Join(output, "source-snapshot.json"))
 	if err != nil {
 		t.Fatal(err)
+	}
+	var source reconstructionSource
+	if err := json.Unmarshal(snapshot, &source); err != nil {
+		t.Fatal(err)
+	}
+	if source.Messages[2].Kind != "ATTENTION_RESOLUTION" || source.Messages[2].Content != evidence {
+		t.Fatal("lost original attention evidence from source snapshot")
+	}
+	reportBytes, err := os.ReadFile(filepath.Join(output, "report.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var report reconstructionReport
+	if err := json.Unmarshal(reportBytes, &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.HistoricalAttentionRecords != 1 {
+		t.Fatal("report did not count the omitted attention record")
 	}
 	var metadata schema.SessionMeta
 	metaBytes, err := os.ReadFile(meta)
@@ -329,14 +350,56 @@ func TestReconstructPreservesAttentionEvidenceWithoutInventingDeliveryState(t *t
 		t.Fatal(err)
 	}
 	metadata.EnvInfo.WorkingDir = output
-	restored, err := agent.RestoreSessionFromMeta(llm.NewClient(), provider.NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(output), metadata, output)
+	requests := make(chan llm.Request, 16)
+	client := llm.NewClient()
+	client.Register(reconstructionRequestCapture{requests: requests})
+	restored, err := agent.RestoreSessionFromMeta(client, provider.NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(output), metadata, output)
 	if err != nil {
 		t.Fatalf("reconstructed transcript cannot resume: %v", err)
 	}
 	defer restored.Close()
-	if entry.Turn.Kind != schema.TurnSteering || entry.Turn.AttentionResolution != nil || entry.Turn.Message.Text() == "" {
-		t.Fatalf("incomplete attention bookkeeping entered runtime replay: %+v", entry.Turn)
+	if _, err := restored.ProcessInput(context.Background(), "resumed-input-sentinel", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected capture adapter to stop after receiving the request: %v", err)
 	}
+	foundInput := false
+	for len(requests) > 0 {
+		request := <-requests
+		for _, message := range request.Messages {
+			if strings.Contains(message.Text(), "private-attention-sentinel") {
+				t.Fatal("reconstruction sent internal attention evidence to the provider")
+			}
+			foundInput = foundInput || strings.Contains(message.Text(), "resumed-input-sentinel")
+		}
+	}
+	if !foundInput {
+		t.Fatal("did not capture the resumed model request")
+	}
+	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n"))[1:] {
+		entry, err := transcript.DecodeEntry(line)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if entry.Turn.Kind == schema.TurnAttentionResolution || entry.Turn.AttentionResolution != nil {
+			t.Fatalf("incomplete attention bookkeeping entered runtime replay: %+v", entry.Turn)
+		}
+	}
+}
+
+type reconstructionRequestCapture struct{ requests chan<- llm.Request }
+
+func (a reconstructionRequestCapture) Name() string { return "openai" }
+
+func (a reconstructionRequestCapture) Complete(_ context.Context, request llm.Request) (llm.Response, error) {
+	select {
+	case a.requests <- request:
+	default:
+	}
+	return llm.Response{}, context.Canceled
+}
+
+func (a reconstructionRequestCapture) Stream(ctx context.Context, request llm.Request) (llm.Stream, error) {
+	_, err := a.Complete(ctx, request)
+	return nil, err
 }
 
 func TestReconstructAttentionInsideToolRoundDoesNotInventAnotherResult(t *testing.T) {

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -16,6 +16,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"primeradiant.com/evener/agent"
+	agentdoctor "primeradiant.com/evener/agent/doctor"
 	"primeradiant.com/evener/agent/execenv"
 	"primeradiant.com/evener/agent/provider"
 	"primeradiant.com/evener/agent/schema"
@@ -580,6 +581,50 @@ func TestReconstructPreservesFailureMutationIdentityOnRestore(t *testing.T) {
 	}
 }
 
+func TestReconstructKeepsFailureAndHookMessagesReadable(t *testing.T) {
+	hook := schema.HookInfo{Event: "hook-event-sentinel", Matcher: "matcher-sentinel", ExitCode: 17}
+	for _, tc := range []struct {
+		kind    string
+		detail  any
+		message string
+	}{
+		{"TURN_FAILURE", schema.TurnFailureInfo{Message: "failure-readable-sentinel"}, "failure-readable-sentinel"},
+		{"HOOK_COMPLETED", hook, hook.Announcement()},
+	} {
+		for _, prefix := range []string{"", "prefix-sentinel"} {
+			t.Run(tc.kind+"/"+prefix, func(t *testing.T) {
+				dbPath, meta, output := reconstructionFixture(t)
+				db, err := sql.Open("sqlite", dbPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer db.Close()
+				detail, err := json.Marshal(tc.detail)
+				if err != nil {
+					t.Fatal(err)
+				}
+				content, want := string(detail), tc.message
+				if prefix != "" {
+					content, want = prefix+"\n"+content, prefix
+				}
+				if _, err := db.Exec(`UPDATE messages SET source_subtype=?,content=? WHERE id=3`, tc.kind, content); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := reconstructSession(context.Background(), "02wLIRxqmq3AUo6vl2OW37", dbPath, meta, "", output); err != nil {
+					t.Fatal(err)
+				}
+				view, err := agentdoctor.Transcript(output, "02wLIRxqmq3AUo6vl2OW37", agentdoctor.TranscriptOpts{})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if view.Turns[1].Text != want {
+					t.Fatalf("rendered diagnostic text = %q, want %q", view.Turns[1].Text, want)
+				}
+			})
+		}
+	}
+}
+
 func TestReconstructPreservesMetadataProfileAndModel(t *testing.T) {
 	for _, meta := range []schema.SessionMeta{
 		{ProfileID: "profile-sentinel", Model: "configured-model"},
@@ -856,7 +901,7 @@ func TestReconstructRejectsInvalidMutationJournalBeforeStaging(t *testing.T) {
 func TestReconstructRetainsArchivedCacheUsage(t *testing.T) {
 	source := reconstructionSource{Messages: []archivedMessage{
 		{ID: 1, Ordinal: 0, SourceType: "header", Kind: "system_prompt", Content: "sentinel"},
-		{ID: 2, Ordinal: 1, SourceType: "entry", Kind: "ASSISTANT", Timestamp: "2026-09-09T01:00:00Z", Content: "sentinel", TokenUsage: `{"input_tokens":17,"output_tokens":4,"cache_read_input_tokens":10,"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":30}}`},
+		{ID: 2, Ordinal: 1, SourceType: "entry", Kind: "ASSISTANT", Timestamp: "2026-09-09T01:00:00Z", Content: "sentinel", TokenUsage: `{"input_tokens":17,"output_tokens":4,"cache_read_input_tokens":10,"cache_creation_input_tokens":99,"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":30}}`},
 	}}
 	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
 	if err != nil {
@@ -865,5 +910,47 @@ func TestReconstructRetainsArchivedCacheUsage(t *testing.T) {
 	u := entries[0].Turn.Usage
 	if u.TotalTokens != 81 || u.CacheWriteTokens == nil || *u.CacheWriteTokens != 20 || u.CacheWrite1hTokens == nil || *u.CacheWrite1hTokens != 30 {
 		t.Fatalf("cache usage lost: %+v", u)
+	}
+}
+
+func TestReconstructRetainsAggregateCacheUsageWithoutBreakdown(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		aggregate    int
+		hasBreakdown bool
+		breakdown    any
+		wantWrite    bool
+	}{
+		{"aggregate only", 20, false, nil, true},
+		{"explicit zero", 0, false, nil, true},
+		{"null breakdown", 20, true, nil, true},
+		{"empty breakdown", 20, true, map[string]any{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := reconstructionSourceFixture(t)
+			usage := map[string]any{"input_tokens": 17, "output_tokens": 4, "cache_creation_input_tokens": tc.aggregate}
+			if tc.hasBreakdown {
+				usage["cache_creation"] = tc.breakdown
+			}
+			data, err := json.Marshal(usage)
+			if err != nil {
+				t.Fatal(err)
+			}
+			source.Messages[3].TokenUsage = string(data)
+			_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, total := entries[2].Turn.Usage, 21
+			if tc.wantWrite {
+				total += tc.aggregate
+			}
+			if got.TotalTokens != total || (got.CacheWriteTokens != nil) != tc.wantWrite || got.CacheWrite1hTokens != nil {
+				t.Fatalf("cache accounting = %+v, want write presence %t and total %d", got, tc.wantWrite, total)
+			}
+			if tc.wantWrite && *got.CacheWriteTokens != tc.aggregate {
+				t.Fatalf("cache writes = %d, want %d", *got.CacheWriteTokens, tc.aggregate)
+			}
+		})
 	}
 }

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -213,6 +213,61 @@ func reconstructionSourceFixture(t *testing.T) reconstructionSource {
 	return source
 }
 
+func TestReconstructScopesTurnIdentityAndSteeringProvenance(t *testing.T) {
+	for _, tc := range []struct {
+		kind         schema.TurnKind
+		ordinal      int
+		promptSource string
+		stableID     string
+		mutationID   string
+	}{
+		{schema.TurnUserInput, 1, "user", "turn-sentinel", "mutation-sentinel"},
+		{schema.TurnSteering, 2, "user", "turn-sentinel", "mutation-sentinel"},
+		{schema.TurnSteering, 2, "", "turn-sentinel", ""},
+		{schema.TurnFailure, 2, "user", "turn-sentinel", "mutation-sentinel"},
+		{schema.TurnAssistant, 3, "user", "", ""},
+		{schema.TurnTool, 4, "user", "", ""},
+		{schema.TurnToolResults, 4, "user", "", ""},
+		{schema.TurnEnvironment, 2, "user", "", ""},
+		{schema.TurnCheckpoint, 2, "user", "", ""},
+		{schema.TurnSummary, 2, "user", "", ""},
+		{schema.TurnSystem, 2, "user", "", ""},
+		{schema.TurnModelSwitch, 2, "user", "", ""},
+		{schema.TurnHookCompleted, 2, "user", "", ""},
+	} {
+		t.Run(string(tc.kind)+"/"+tc.promptSource, func(t *testing.T) {
+			source := reconstructionSourceFixture(t)
+			message := &source.Messages[tc.ordinal]
+			message.Kind = string(tc.kind)
+			message.StableID = "turn-sentinel"
+			message.PromptSource = tc.promptSource
+			_, entries, err := reconstructEntries(source, schema.SessionMeta{}, map[string]string{"turn-sentinel": "mutation-sentinel"}, &reconstructionReport{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := json.Marshal(entries[tc.ordinal-1])
+			if err != nil {
+				t.Fatal(err)
+			}
+			entry, err := transcript.DecodeEntry(data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			turn := entry.Turn
+			if turn.Kind != tc.kind || turn.StableTurnID != tc.stableID || turn.ClientMutationID != tc.mutationID {
+				t.Errorf("turn identity = (%s, %q, %q), want (%s, %q, %q)", turn.Kind, turn.StableTurnID, turn.ClientMutationID, tc.kind, tc.stableID, tc.mutationID)
+			}
+			steeringSource := ""
+			if tc.kind == schema.TurnSteering {
+				steeringSource = tc.promptSource
+			}
+			if turn.SteeringSource != steeringSource {
+				t.Errorf("steering source = %q, want %q", turn.SteeringSource, steeringSource)
+			}
+		})
+	}
+}
+
 func TestReconstructionValidationEnforcesNativeRecordSize(t *testing.T) {
 	for _, kind := range []string{"header", "entry"} {
 		t.Run(kind, func(t *testing.T) {

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"database/sql"
 	"encoding/json"
 	"os"
@@ -92,6 +93,9 @@ func TestReconstructStagesNativeHistoryWithoutChangingSource(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		if e.Seq != len(entries) {
+			t.Fatalf("entry sequence = %d, want %d", e.Seq, len(entries))
+		}
 		entries = append(entries, e)
 	}
 	if err := scanner.Err(); err != nil {
@@ -158,6 +162,18 @@ func TestReconstructRejectsIncompleteArchiveWithoutPublishing(t *testing.T) {
 		`UPDATE sessions SET message_count=6`,
 		`UPDATE sessions SET parent_session_id='parent'`,
 		`UPDATE tool_calls SET input_json='{'`,
+		`UPDATE tool_calls SET input_json='null'`,
+		`UPDATE tool_calls SET input_json='[]'`,
+		`UPDATE tool_calls SET input_json='42'`,
+		`UPDATE tool_calls SET input_json='"value"'`,
+		`INSERT INTO tool_calls SELECT * FROM tool_calls`,
+		`INSERT INTO messages SELECT 6,session_id,5,content,timestamp,source_type,source_subtype,prompt_source,source_uuid,model,provider_id,token_usage FROM messages WHERE id=5; UPDATE sessions SET message_count=6`,
+		`INSERT INTO messages SELECT 6,session_id,5,content,'2026-09-09T01:04:00+00:00',source_type,source_subtype,prompt_source,source_uuid,model,provider_id,token_usage FROM messages WHERE id=5; UPDATE sessions SET message_count=6`,
+		`UPDATE messages SET source_subtype='USER_INPUT' WHERE id=4`,
+		`UPDATE messages SET source_subtype='TOOL_RESULTS' WHERE id=3`,
+		`UPDATE messages SET id=1 WHERE id=2`,
+		`UPDATE tool_calls SET call_index=-1`,
+		`UPDATE messages SET timestamp='2026-09-09T01:02:00Z' WHERE id=3; UPDATE messages SET source_subtype='TOOL_RESULTS' WHERE id=3; UPDATE messages SET source_subtype='SUMMARY' WHERE id=5; UPDATE tool_result_events SET timestamp='2026-09-09T01:02:00Z'`,
 		`UPDATE tool_result_events SET timestamp='2026-09-09T02:00:00Z'`,
 	} {
 		t.Run(damage, func(t *testing.T) {
@@ -178,6 +194,87 @@ func TestReconstructRejectsIncompleteArchiveWithoutPublishing(t *testing.T) {
 				t.Fatalf("published incomplete output: %v", err)
 			}
 		})
+	}
+}
+
+func reconstructionSourceFixture(t *testing.T) reconstructionSource {
+	t.Helper()
+	dbPath, _, _ := reconstructionFixture(t)
+	source, err := readReconstructionSource(context.Background(), dbPath, "02wLIRxqmq3AUo6vl2OW37")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return source
+}
+
+func TestReconstructMatchesToolResultInstantsAndPreservesRounds(t *testing.T) {
+	source := reconstructionSourceFixture(t)
+	source.Results[0].Timestamp = "2026-09-08T18:04:00.000-07:00"
+	source.Messages = append(source.Messages,
+		archivedMessage{ID: 6, Ordinal: 5, SourceType: "entry", Kind: "ASSISTANT", Timestamp: "2026-09-09T01:05:00Z"},
+		archivedMessage{ID: 7, Ordinal: 6, SourceType: "entry", Kind: "TOOL_RESULTS", Timestamp: "2026-09-09T01:06:00Z"},
+	)
+	source.Calls = append(source.Calls, archivedCall{MessageID: 6, ID: "call_2", Name: "read_file", Arguments: `{}`})
+	source.Results = append(source.Results, archivedResult{CallOrdinal: 5, ID: "call_2", Source: "tool_result", Content: "second sentinel", Timestamp: "2026-09-09T01:06:00.000+00:00"})
+	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history := agent.ResumeHistory(entries)
+	if len(history) != 6 {
+		t.Fatalf("got %d resumed turns, want summary, two tool rounds and notice", len(history))
+	}
+	for i, want := range []struct{ id, content string }{{"call_1", "result sentinel"}, {"call_2", "second sentinel"}} {
+		call := history[1+2*i].Message.Content[0].ToolCall
+		parts := history[2+2*i].Message.Content
+		if call == nil || call.ID != want.id || len(parts) != 1 || parts[0].ToolResult == nil {
+			t.Fatalf("invalid tool round %d", i)
+		}
+		result := parts[0].ToolResult
+		if result.ToolCallID != want.id || result.Content != want.content || result.IsError {
+			t.Fatalf("misplaced or synthesized tool result: %+v", result)
+		}
+	}
+}
+
+func TestReconstructNormalizesMissingArgumentsToObject(t *testing.T) {
+	source := reconstructionSourceFixture(t)
+	source.Calls[0].Arguments = ""
+	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var args map[string]json.RawMessage
+	if err := json.Unmarshal(entries[2].Turn.Message.Content[0].ToolCall.Arguments, &args); err != nil || args == nil || len(args) != 0 {
+		t.Fatalf("missing arguments did not become an empty object: %v, %v", args, err)
+	}
+}
+
+func TestReconstructPreservesMetadataProfileAndModel(t *testing.T) {
+	for _, meta := range []schema.SessionMeta{
+		{ProfileID: "profile-sentinel", Model: "configured-model"},
+		{ProfileID: "profile-sentinel"},
+		{Model: "configured-model"},
+		{},
+	} {
+		source := reconstructionSourceFixture(t)
+		h, entries, err := reconstructEntries(source, meta, nil, &reconstructionReport{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantProfile, wantModel := meta.ProfileID, meta.Model
+		if wantProfile == "" {
+			wantProfile = "provider"
+		}
+		if wantModel == "" {
+			wantModel = "model"
+		}
+		if h.ProfileID != wantProfile || h.Model != wantModel {
+			t.Fatalf("header identity: %s/%s, want %s/%s", h.ProfileID, h.Model, wantProfile, wantModel)
+		}
+		if entries[2].Turn.ResponseProvider != "provider" || entries[2].Turn.ResponseModel != "model" {
+			t.Fatal("lost per-turn response identity")
+		}
 	}
 }
 
@@ -302,8 +399,8 @@ func TestReconstructIncludesDrainedSteeringMutationIdentity(t *testing.T) {
 
 func TestReconstructRetainsArchivedCacheUsage(t *testing.T) {
 	source := reconstructionSource{Messages: []archivedMessage{
-		{Ordinal: 0, SourceType: "header", Kind: "system_prompt", Content: "sentinel"},
-		{Ordinal: 1, SourceType: "entry", Kind: "ASSISTANT", Timestamp: "2026-09-09T01:00:00Z", Content: "sentinel", TokenUsage: `{"input_tokens":17,"output_tokens":4,"cache_read_input_tokens":10,"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":30}}`},
+		{ID: 1, Ordinal: 0, SourceType: "header", Kind: "system_prompt", Content: "sentinel"},
+		{ID: 2, Ordinal: 1, SourceType: "entry", Kind: "ASSISTANT", Timestamp: "2026-09-09T01:00:00Z", Content: "sentinel", TokenUsage: `{"input_tokens":17,"output_tokens":4,"cache_read_input_tokens":10,"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":30}}`},
 	}}
 	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
 	if err != nil {

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -41,7 +41,7 @@ func reconstructionFixture(t *testing.T) (dbPath, metaPath, output string) {
 		`INSERT INTO messages VALUES (2,'evener:02wLIRxqmq3AUo6vl2OW37',1,'task sentinel','2026-09-09T01:01:00Z','entry','USER_INPUT','','turn_m1','','','')`,
 		`INSERT INTO messages VALUES (3,'evener:02wLIRxqmq3AUo6vl2OW37',2,'summary sentinel','2026-09-09T01:02:00Z','entry','SUMMARY','','','','','')`,
 		`INSERT INTO messages VALUES (4,'evener:02wLIRxqmq3AUo6vl2OW37',3,'[Tool: read_file]','2026-09-09T01:03:00Z','entry','ASSISTANT','','','model','provider','{"input_tokens":17,"output_tokens":4}')`,
-		`INSERT INTO messages VALUES (5,'evener:02wLIRxqmq3AUo6vl2OW37',4,'[TOOL_RESULTS]','2026-09-09T01:04:00Z','entry','TOOL_RESULTS','','','','','')`,
+		`INSERT INTO messages VALUES (5,'evener:02wLIRxqmq3AUo6vl2OW37',4,'','2026-09-09T01:04:00Z','entry','TOOL_RESULTS','','','','','')`,
 		`INSERT INTO tool_calls VALUES (4,'evener:02wLIRxqmq3AUo6vl2OW37','read_file','call_1','{"file_path":"sentinel.txt"}',0)`,
 		`INSERT INTO tool_result_events VALUES ('evener:02wLIRxqmq3AUo6vl2OW37',3,0,'call_1','tool_result','completed','result sentinel',15,'2026-09-09T01:04:00Z',0)`,
 	}
@@ -323,6 +323,123 @@ func TestReconstructPreservesMultipleCallsInOneRound(t *testing.T) {
 	}
 }
 
+func TestReconstructPreservesLiteralMessageText(t *testing.T) {
+	source := reconstructionSourceFixture(t)
+	source.Messages[1].Content = "[USER_INPUT]"
+	source.Messages[3].Content = "[ASSISTANT]"
+	source.Messages = source.Messages[:4]
+	source.Calls, source.Results = nil, nil
+	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entries[0].Turn.Message.Text() != "[USER_INPUT]" || entries[2].Turn.Message.Text() != "[ASSISTANT]" {
+		t.Fatal("discarded literal message text")
+	}
+}
+
+func TestReconstructUsesRecordedToolErrorStatus(t *testing.T) {
+	for _, status := range []string{"completed", "error"} {
+		t.Run(status, func(t *testing.T) {
+			source := reconstructionSourceFixture(t)
+			source.Results[0].Status = status
+			const content = "[tool error] literal-sentinel"
+			source.Results[0].Content = content
+			if status == "error" {
+				source.Results[0].Content = "[tool error] " + content
+			}
+			_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := entries[3].Turn.Message.Content[0].ToolResult
+			if result == nil || result.IsError != (status == "error") || result.Content != content {
+				t.Fatalf("changed literal tool output or error status: %+v", result)
+			}
+		})
+	}
+}
+
+func TestReconstructRejectsResultsCrossingToolRoundBoundaries(t *testing.T) {
+	for _, kind := range []schema.TurnKind{schema.TurnUserInput, schema.TurnEnvironment, schema.TurnCheckpoint, schema.TurnSummary, schema.TurnSystem, schema.TurnAssistant, schema.TurnModelSwitch, schema.TurnFailure} {
+		t.Run(string(kind), func(t *testing.T) {
+			source := reconstructionSourceFixture(t)
+			tool := source.Messages[4]
+			tool.Ordinal = 5
+			boundary := archivedMessage{ID: 6, Ordinal: 4, SourceType: "entry", Kind: string(kind), Content: "boundary-sentinel", Timestamp: "2026-09-09T01:03:30Z"}
+			source.Messages = append(source.Messages[:4], boundary, tool)
+			_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+			if err == nil || entries != nil {
+				t.Fatal("accepted a result from an interrupted tool round")
+			}
+		})
+	}
+}
+
+func TestReconstructPreservesFailureMutationIdentityOnRestore(t *testing.T) {
+	dbPath, metaPath, output := reconstructionFixture(t)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	for _, statement := range []string{
+		`UPDATE messages SET source_subtype='TURN_FAILURE',source_uuid='turn_m1',content='{"message":"failure-sentinel"}' WHERE id=3`,
+		`DELETE FROM messages WHERE id>=4`, `DELETE FROM tool_calls`, `DELETE FROM tool_result_events`, `UPDATE sessions SET message_count=3`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	journalPath := filepath.Join(filepath.Dir(metaPath), "journal.json")
+	const journal = `{"version":1,"session_id":"02wLIRxqmq3AUo6vl2OW37","journal":{"failed-client":{"client_mutation_id":"failed-client","method":"turn/start","payload":{},"payload_hash":"44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a","stable_turn_id":"turn_m1","operation_state":"applied","execution_state":"failureRecording","projection_state":"pending","attempt_generation":1,"failure":{"message":"failure-sentinel"}}},"pending_executions":{"failed-client":{"client_mutation_id":"failed-client","method":"turn/start","input":[{"type":"text","text":"task sentinel"}],"execution_state":"failureRecording","turn_id":"turn_m1","projection_state":"pending"}},"budget_reservations":{},"next_turn_sequence":1,"accepted_turns":1}`
+	mustWrite(t, journalPath, journal)
+	report, err := reconstructSession(context.Background(), "02wLIRxqmq3AUo6vl2OW37", dbPath, metaPath, journalPath, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(output, "mutations"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(output, "mutations", "02wLIRxqmq3AUo6vl2OW37.json"), journal)
+	metaBytes, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var meta schema.SessionMeta
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		t.Fatal(err)
+	}
+	meta.EnvInfo.WorkingDir = output
+	restored, err := agent.RestoreSessionFromMeta(llm.NewClient(), provider.NewOpenAIProfile("gpt-5.2"), execenv.NewLocalExecutionEnvironment(output), meta, output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored.Close()
+	data, err := os.ReadFile(report.TranscriptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failures := 0
+	var failure schema.Turn
+	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n"))[1:] {
+		entry, err := transcript.DecodeEntry(line)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if entry.Turn.Kind == schema.TurnFailure {
+			failures++
+			failure = entry.Turn
+		}
+	}
+	if failures != 1 {
+		t.Fatalf("restore appended a duplicate failure: got %d", failures)
+	}
+	if failure.ClientMutationID != "failed-client" || failure.StableTurnID != "turn_m1" {
+		t.Fatal("lost failure mutation identity")
+	}
+}
+
 func TestReconstructPreservesMetadataProfileAndModel(t *testing.T) {
 	for _, meta := range []schema.SessionMeta{
 		{ProfileID: "profile-sentinel", Model: "configured-model"},
@@ -354,7 +471,7 @@ func TestReconstructPreservesMetadataProfileAndModel(t *testing.T) {
 func TestReconstructRestoresClientMutationIdentity(t *testing.T) {
 	dbPath, meta, output := reconstructionFixture(t)
 	journal := filepath.Join(filepath.Dir(meta), "mutations.json")
-	mustWrite(t, journal, `{"session_id":"02wLIRxqmq3AUo6vl2OW37","journal":{"client-sentinel":{"method":"turn/start","stable_turn_id":"turn_m1"},"interrupt-sentinel":{"method":"turn/interrupt","stable_turn_id":"turn_m1"}}}`)
+	mustWrite(t, journal, reconstructionJournalFixture(t, map[string]string{"client-sentinel": "turn/start", "interrupt-sentinel": "turn/interrupt"}))
 	var out, errOut bytes.Buffer
 	if code := run([]string{"reconstruct", "02wLIRxqmq3AUo6vl2OW37", "--agentsview-db", dbPath, "--meta", meta, "--mutations", journal, "--output-dir", output}, &out, &errOut); code != 0 {
 		t.Fatalf("exit %d: %s", code, &errOut)
@@ -521,13 +638,78 @@ func TestReconstructAttentionInsideToolRoundDoesNotInventAnotherResult(t *testin
 
 func TestReconstructIncludesDrainedSteeringMutationIdentity(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "mutations.json")
-	mustWrite(t, p, `{"session_id":"02wLIRxqmq3AUo6vl2OW37","journal":{"drain-sentinel":{"method":"turn/drainAsSteer","stable_turn_id":"turn_m1"}}}`)
+	mustWrite(t, p, reconstructionJournalFixture(t, map[string]string{"drain-sentinel": "turn/drainAsSteer"}))
 	ids, _, err := reconstructionMutationIDs(p, "02wLIRxqmq3AUo6vl2OW37")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ids["turn_m1"] != "drain-sentinel" {
 		t.Fatal("lost drained input identity")
+	}
+}
+
+func reconstructionJournalFixture(t *testing.T, methods map[string]string) string {
+	t.Helper()
+	records := map[string]any{}
+	for id, method := range methods {
+		records[id] = map[string]any{
+			"client_mutation_id": id, "method": method, "stable_turn_id": "turn_m1",
+			"payload_hash": "retained-payload-hash", "operation_state": "terminal",
+			"execution_state": "completed", "projection_state": "reflected", "attempt_generation": 1,
+		}
+	}
+	data, err := json.Marshal(map[string]any{
+		"version": 1, "session_id": "02wLIRxqmq3AUo6vl2OW37", "journal": records,
+		"pending_executions": map[string]any{}, "budget_reservations": map[string]any{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}
+
+func TestReconstructRejectsInvalidMutationJournalBeforeStaging(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		damage func(map[string]any, map[string]any)
+	}{
+		{"missing journal", func(j, _ map[string]any) { delete(j, "journal") }},
+		{"null journal", func(j, _ map[string]any) { j["journal"] = nil }},
+		{"null record", func(j, _ map[string]any) { j["journal"].(map[string]any)["client-sentinel"] = nil }},
+		{"missing record identity", func(_, r map[string]any) { delete(r, "client_mutation_id") }},
+		{"mismatched record identity", func(_, r map[string]any) { r["client_mutation_id"] = "different-client" }},
+		{"missing method", func(_, r map[string]any) { delete(r, "method") }},
+		{"missing execution state", func(_, r map[string]any) { delete(r, "execution_state") }},
+		{"invalid operation state", func(_, r map[string]any) { r["operation_state"] = "invalid" }},
+		{"missing attempt generation", func(_, r map[string]any) { delete(r, "attempt_generation") }},
+		{"invalid payload hash", func(_, r map[string]any) { r["payload"] = map[string]any{} }},
+		{"unknown record field", func(_, r map[string]any) { r["stable_trun_id"] = "turn_m1" }},
+		{"unsupported version", func(j, _ map[string]any) { j["version"] = 2 }},
+		{"missing pending executions", func(j, _ map[string]any) { delete(j, "pending_executions") }},
+		{"missing reservations", func(j, _ map[string]any) { delete(j, "budget_reservations") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath, meta, output := reconstructionFixture(t)
+			var journal map[string]any
+			if err := json.Unmarshal([]byte(reconstructionJournalFixture(t, map[string]string{"client-sentinel": "turn/start"})), &journal); err != nil {
+				t.Fatal(err)
+			}
+			record := journal["journal"].(map[string]any)["client-sentinel"].(map[string]any)
+			tc.damage(journal, record)
+			data, err := json.Marshal(journal)
+			if err != nil {
+				t.Fatal(err)
+			}
+			journalPath := filepath.Join(filepath.Dir(meta), "journal.json")
+			mustWrite(t, journalPath, string(data))
+			var out, errOut bytes.Buffer
+			if code := run([]string{"reconstruct", "02wLIRxqmq3AUo6vl2OW37", "--agentsview-db", dbPath, "--meta", meta, "--mutations", journalPath, "--output-dir", output}, &out, &errOut); code == 0 {
+				t.Fatal("accepted invalid mutation journal")
+			}
+			if _, err := os.Stat(output); !os.IsNotExist(err) {
+				t.Fatalf("published output for invalid journal: %v", err)
+			}
+		})
 	}
 }
 

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -235,7 +235,82 @@ func TestReconstructPreservesAttentionEvidenceWithoutInventingDeliveryState(t *t
 		t.Fatalf("reconstructed transcript cannot resume: %v", err)
 	}
 	defer restored.Close()
-	if entry.Turn.Kind != schema.TurnSystem || entry.Turn.AttentionResolution != nil || entry.Turn.Message.Text() == "" {
+	if entry.Turn.Kind != schema.TurnSteering || entry.Turn.AttentionResolution != nil || entry.Turn.Message.Text() == "" {
 		t.Fatalf("incomplete attention bookkeeping entered runtime replay: %+v", entry.Turn)
+	}
+}
+
+func TestReconstructAttentionInsideToolRoundDoesNotInventAnotherResult(t *testing.T) {
+	dbPath, meta, output := reconstructionFixture(t)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	for _, statement := range []string{
+		`UPDATE sessions SET message_count=6`,
+		`UPDATE messages SET ordinal=5 WHERE id=5`,
+		`INSERT INTO messages VALUES (6,'evener:02wLIRxqmq3AUo6vl2OW37',4,'attention sentinel','2026-09-09T01:03:30Z','entry','ATTENTION_RESOLUTION','','','','','')`,
+	} {
+		if _, err := db.Exec(statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var out, errOut bytes.Buffer
+	if code := run([]string{"reconstruct", "02wLIRxqmq3AUo6vl2OW37", "--agentsview-db", dbPath, "--meta", meta, "--output-dir", output}, &out, &errOut); code != 0 {
+		t.Fatalf("exit %d: %s", code, &errOut)
+	}
+	data, err := os.ReadFile(filepath.Join(output, "sessions", "02wLIRxqmq3AUo6vl2OW37.transcript.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var entries []transcript.Entry
+	for _, line := range bytes.Split(bytes.TrimSpace(data), []byte("\n"))[1:] {
+		entry, err := transcript.DecodeEntry(line)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries = append(entries, entry)
+	}
+	var results int
+	for _, turn := range agent.ResumeHistory(entries) {
+		for _, part := range turn.Message.Content {
+			if part.ToolResult != nil {
+				results++
+				if part.ToolResult.IsError {
+					t.Fatal("resume invented an interrupted-tool error")
+				}
+			}
+		}
+	}
+	if results != 1 {
+		t.Fatalf("got %d results for one archived call", results)
+	}
+}
+
+func TestReconstructIncludesDrainedSteeringMutationIdentity(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "mutations.json")
+	mustWrite(t, p, `{"session_id":"02wLIRxqmq3AUo6vl2OW37","journal":{"drain-sentinel":{"method":"turn/drainAsSteer","stable_turn_id":"turn_m1"}}}`)
+	ids, _, err := reconstructionMutationIDs(p, "02wLIRxqmq3AUo6vl2OW37")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ids["turn_m1"] != "drain-sentinel" {
+		t.Fatal("lost drained input identity")
+	}
+}
+
+func TestReconstructRetainsArchivedCacheUsage(t *testing.T) {
+	source := reconstructionSource{Messages: []archivedMessage{
+		{Ordinal: 0, SourceType: "header", Kind: "system_prompt", Content: "sentinel"},
+		{Ordinal: 1, SourceType: "entry", Kind: "ASSISTANT", Timestamp: "2026-09-09T01:00:00Z", Content: "sentinel", TokenUsage: `{"input_tokens":17,"output_tokens":4,"cache_read_input_tokens":10,"cache_creation":{"ephemeral_5m_input_tokens":20,"ephemeral_1h_input_tokens":30}}`},
+	}}
+	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := entries[0].Turn.Usage
+	if u.TotalTokens != 81 || u.CacheWriteTokens == nil || *u.CacheWriteTokens != 20 || u.CacheWrite1hTokens == nil || *u.CacheWrite1hTokens != 30 {
+		t.Fatalf("cache usage lost: %+v", u)
 	}
 }

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -254,6 +254,75 @@ func TestReconstructNormalizesMissingArgumentsToObject(t *testing.T) {
 	}
 }
 
+func TestReconstructRejectsAmbiguousOrIncompleteToolCalls(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		damage func(*reconstructionSource)
+	}{
+		{"duplicate ID within assistant", func(source *reconstructionSource) {
+			call, result := source.Calls[0], source.Results[0]
+			call.Index, result.CallIndex = 1, 1
+			source.Calls = append(source.Calls, call)
+			source.Results = append(source.Results, result)
+		}},
+		{"duplicate ID across assistants", func(source *reconstructionSource) {
+			assistant, tool := source.Messages[3], source.Messages[4]
+			assistant.ID, assistant.Ordinal, assistant.Timestamp = 6, 5, "2026-09-09T01:05:00Z"
+			tool.ID, tool.Ordinal, tool.Timestamp = 7, 6, "2026-09-09T01:06:00Z"
+			source.Messages = append(source.Messages, assistant, tool)
+			call, result := source.Calls[0], source.Results[0]
+			call.MessageID, result.CallOrdinal, result.Timestamp = assistant.ID, assistant.Ordinal, tool.Timestamp
+			source.Calls = append(source.Calls, call)
+			source.Results = append(source.Results, result)
+		}},
+		{"missing first index", func(source *reconstructionSource) {
+			source.Calls[0].Index, source.Results[0].CallIndex = 1, 1
+		}},
+		{"missing middle index", func(source *reconstructionSource) {
+			call, result := source.Calls[0], source.Results[0]
+			call.ID, result.ID = "call_2", "call_2"
+			call.Index, result.CallIndex = 2, 2
+			source.Calls = append(source.Calls, call)
+			source.Results = append(source.Results, result)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			source := reconstructionSourceFixture(t)
+			test.damage(&source)
+			_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+			if err == nil || entries != nil {
+				t.Fatal("reconstructed ambiguous or incomplete tool calls")
+			}
+		})
+	}
+}
+
+func TestReconstructPreservesMultipleCallsInOneRound(t *testing.T) {
+	source := reconstructionSourceFixture(t)
+	call, result := source.Calls[0], source.Results[0]
+	call.ID, result.ID = "call_2", "call_2"
+	call.Index, result.CallIndex = 1, 1
+	result.Content = "second-result-sentinel"
+	source.Calls = append(source.Calls, call)
+	source.Results = append(source.Results, result)
+	source.Messages[3].Content += "\n[Tool: read_file]"
+	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history := agent.ResumeHistory(entries)
+	if len(history) != 4 || len(history[1].Message.Content) != 2 || len(history[2].Message.Content) != 2 {
+		t.Fatal("lost a call or inserted a synthetic result")
+	}
+	for i, want := range []struct{ id, content string }{{"call_1", "result sentinel"}, {"call_2", "second-result-sentinel"}} {
+		call := history[1].Message.Content[i].ToolCall
+		result := history[2].Message.Content[i].ToolResult
+		if call == nil || result == nil || call.ID != want.id || result.ToolCallID != want.id || result.Content != want.content || result.IsError {
+			t.Fatalf("lost tool exchange %d", i)
+		}
+	}
+}
+
 func TestReconstructPreservesMetadataProfileAndModel(t *testing.T) {
 	for _, meta := range []schema.SessionMeta{
 		{ProfileID: "profile-sentinel", Model: "configured-model"},

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -167,6 +167,8 @@ func TestReconstructRejectsIncompleteArchiveWithoutPublishing(t *testing.T) {
 		`UPDATE tool_calls SET input_json='42'`,
 		`UPDATE tool_calls SET input_json='"value"'`,
 		`INSERT INTO tool_calls SELECT * FROM tool_calls`,
+		`INSERT INTO tool_result_events SELECT session_id,tool_call_message_ordinal,call_index,tool_use_id,source,status,content,content_length,timestamp,event_index+1 FROM tool_result_events`,
+		`INSERT INTO tool_result_events SELECT session_id,tool_call_message_ordinal,call_index,tool_use_id,source,status,content,content_length,'2026-09-09T01:05:00Z',event_index+1 FROM tool_result_events; INSERT INTO messages SELECT 6,session_id,5,content,'2026-09-09T01:05:00Z',source_type,source_subtype,prompt_source,source_uuid,model,provider_id,token_usage FROM messages WHERE id=5; UPDATE sessions SET message_count=6`,
 		`INSERT INTO messages SELECT 6,session_id,5,content,timestamp,source_type,source_subtype,prompt_source,source_uuid,model,provider_id,token_usage FROM messages WHERE id=5; UPDATE sessions SET message_count=6`,
 		`INSERT INTO messages SELECT 6,session_id,5,content,'2026-09-09T01:04:00+00:00',source_type,source_subtype,prompt_source,source_uuid,model,provider_id,token_usage FROM messages WHERE id=5; UPDATE sessions SET message_count=6`,
 		`UPDATE messages SET source_subtype='USER_INPUT' WHERE id=4`,

--- a/cmd/evener-doctor/reconstruct_test.go
+++ b/cmd/evener-doctor/reconstruct_test.go
@@ -341,7 +341,7 @@ func TestReconstructPreservesMultipleCallsInOneRound(t *testing.T) {
 	result.Content = "second-result-sentinel"
 	source.Calls = append(source.Calls, call)
 	source.Results = append(source.Results, result)
-	source.Messages[3].Content += "\n[Tool: read_file]"
+	source.Messages[3].Content += "\n\n[Tool: read_file]"
 	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
 	if err != nil {
 		t.Fatal(err)
@@ -371,6 +371,43 @@ func TestReconstructPreservesLiteralMessageText(t *testing.T) {
 	}
 	if entries[0].Turn.Message.Text() != "[USER_INPUT]" || entries[2].Turn.Message.Text() != "[ASSISTANT]" {
 		t.Fatal("discarded literal message text")
+	}
+}
+
+func TestReconstructPreservesLiteralToolMarkerInAssistantText(t *testing.T) {
+	source := reconstructionSourceFixture(t)
+	const content = "[Tool: read_file]\n\nliteral-sentinel [Tool: read_file] tail-sentinel"
+	source.Messages[3].Content = content
+	_, entries, err := reconstructEntries(source, schema.SessionMeta{}, nil, &reconstructionReport{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	history := agent.ResumeHistory(entries)
+	if history[1].Message.Text() != content {
+		t.Fatalf("changed ambiguous assistant content: %q", history[1].Message.Text())
+	}
+	parts := history[1].Message.Content
+	if len(parts) != 2 || parts[1].ToolCall == nil || parts[1].ToolCall.ID != "call_1" {
+		t.Fatal("lost structured tool call while preserving assistant text")
+	}
+}
+
+func TestReconstructRejectsMissingCallIndexBeforeStaging(t *testing.T) {
+	dbPath, meta, output := reconstructionFixture(t)
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`UPDATE tool_calls SET call_index=NULL`); err != nil {
+		t.Fatal(err)
+	}
+	_, err = reconstructSession(context.Background(), "02wLIRxqmq3AUo6vl2OW37", dbPath, meta, "", output)
+	if err == nil {
+		t.Fatal("invented zero index for a call with an unknown position")
+	}
+	if _, err := os.Stat(output); !os.IsNotExist(err) {
+		t.Fatalf("published output with unknown call index: %v", err)
 	}
 }
 

--- a/cmd/evener/providers_test.go
+++ b/cmd/evener/providers_test.go
@@ -113,9 +113,11 @@ func openAIProbeServer(t *testing.T) *httptest.Server {
 }
 
 func TestProvidersListShowsInstancesCredentialSourcesAndStrayEntries(t *testing.T) {
-	root := providersTestEnv(t, map[string]string{"GROQ_API_KEY": "gk"})
+	const envKey = "credential-sentinel:groq:unprinted"
+	const storedKey = "credential-sentinel:work:unprinted"
+	root := providersTestEnv(t, map[string]string{"GROQ_API_KEY": envKey})
 	path := writeProvidersToml(t, root, "[providers.work]\nbase = \"openai\"\nbase_url = \"https://gw.example.com/v1\"\n")
-	creds := "schema = 1\n[providers.kimi]\napi_key = \"old\"\n[providers.work]\napi_key = \"w\"\n"
+	creds := "schema = 1\n[providers.kimi]\napi_key = \"old\"\n[providers.work]\napi_key = \"" + storedKey + "\"\n"
 	if err := os.WriteFile(filepath.Join(root, "credentials.toml"), []byte(creds), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +132,7 @@ func TestProvidersListShowsInstancesCredentialSourcesAndStrayEntries(t *testing.
 			t.Fatalf("missing %q in\n%s", want, out)
 		}
 	}
-	if strings.Contains(out, "gk") || strings.Contains(out, "\"w\"") {
+	if strings.Contains(out, envKey) || strings.Contains(out, storedKey) || strings.Contains(stderr.String(), envKey) || strings.Contains(stderr.String(), storedKey) {
 		t.Fatalf("list prints credential sources, never values (spec §11.2):\n%s", out)
 	}
 	if !strings.Contains(stderr.String(), `credentials.toml entry "kimi" names no instance`) {


### PR DESCRIPTION
When a session transcript is lost but its metadata and AgentsView archive survive, Evener cannot read or resume it. Add `evener doctor reconstruct` to rebuild a staged transcript from that archive and surviving metadata, with an optional mutation journal for stable input identities.

The command opens the archive read-only in one transaction and creates a new staging bundle containing the reconstructed transcript, original metadata, source records, hashes, recovery cutoff, and explicit omissions. It refuses existing output. Generated JSONL passes native bounded framing and strict header/entry decoding before any output is published. Installation and daemon resume remain separate operations.

Reconstruction rejects incomplete or ambiguous archive data: missing ordinals, duplicate header fields or call identities, missing positions or gaps in call indices, non-object arguments, unknown result statuses, and missing/duplicate/misplaced results. Results are paired by parsed timestamp instants and must stay within their owning native tool round. The header preserves surviving profile/model identity, and entries use native sequence numbers. Cache-write usage follows native aggregate/breakdown precedence, and failure/hook records retain their readable diagnostics. Supplied mutation journals use the native decoder and validator; input and failure turns retain identities needed to prevent duplicate replay. Stable turn IDs are limited to input, steering, and failures, and steering provenance is limited to steering turns, matching native writers. Known delegate lifecycle statuses remain successful tool results when the archive uses them for successful delegate-related calls.

Normalized archives cannot recover every original field. Omitted tool bodies receive unavailable-content notices; media and provider signatures remain absent. Literal conversation text and successful output with error-like prefixes are preserved. Assistant tool-marker annotations are removed only when the whole message is the canonical tool-only block; mixed text remains intact. Attention-resolution evidence remains in the source snapshot and is omitted from runtime history because its originating delivery IDs are unavailable; it must neither recreate invalid attention state nor enter model prompts as steering.

Also fixes the credential-output test that blocked this PR: its two-character fake key `gk` could match CI's random temporary directory. Opaque credential sentinels now check both output streams without mistaking a configuration path for a leaked key.

Validation:

- [RoboRev reviewed `6114c44ad`](https://github.com/prime-radiant-inc/evener/pull/1090#issuecomment-5614699985): both reviewers completed with no issues found.
- `make merge-approval-gate` passed on `6114c44ad`: repository lint, build, all Go modules, and the frontend gate. [GitHub CI](https://github.com/prime-radiant-inc/evener/actions/runs/34522332539) also passed every job on that revision, including race, fuzz, browser checks, and snapshot artifacts.
- The doctor race suite, vet, and focused lint pass. Regressions exercise CLI refusal before publication, native restore and provider requests, mutation identity, tool-round integrity, literal content, status semantics, and record-size boundaries. Independent review confirmed the fixes against the native runtime and actual AgentsView parser.
- Fresh staging of all six preserved real-session archives passed on `6114c44ad`. Native `ResumeHistory` added zero synthetic interruption turns for every session. Verification uses fresh staging copies.
- Independent production CLI checks accepted headers and entries at exactly 128 MiB of encoded payload and rejected each at one byte over without creating output. Source database hashes stayed unchanged; large temporary fixtures were reclaimed.
- The credential-test failure was reproduced with `TMPDIR=/tmp/evener-gk-repro`; the corrected test passed five runs using that same path.

Usage and recovery limits are documented in `cmd/evener-doctor/RECONSTRUCTION.md`.

