### PR TITLE
fix(tool): repair a missing final outer-object brace

### DIFF
--- a/agent/cov_intg_hooks_test.go
+++ b/agent/cov_intg_hooks_test.go
@@ -160,9 +160,9 @@ func TestIntg_ExecTool_PreToolUseInvalidUpdatedInputErrors(t *testing.T) {
 	}`)
 	collect := drainEvents(sess)
 
-	// Existing arguments are malformed JSON, so merging the hook's updatedInput
-	// into them fails and the tool call is rejected before it runs.
-	res := sess.execTool(context.Background(), intg_probeCall(`{"path":"original"`), "")
+	// An unfinished string cannot be repaired by appending an outer brace, so
+	// merging the hook's updatedInput fails before the tool runs.
+	res := sess.execTool(context.Background(), intg_probeCall(`{"path":"original`), "")
 
 	if !res.IsError {
 		t.Fatalf("malformed-args + updatedInput should error; got %+v", res)
@@ -172,6 +172,28 @@ func TestIntg_ExecTool_PreToolUseInvalidUpdatedInputErrors(t *testing.T) {
 	}
 	if got := ran.Load(); got != 0 {
 		t.Errorf("probe tool ran %d time(s) despite invalid updatedInput; want 0", got)
+	}
+	sess.Close()
+	collect()
+}
+
+func TestIntg_ExecTool_PreToolUseRepairsMissingOuterBrace(t *testing.T) {
+	t.Parallel()
+	sess, ran := intg_hookSession(t, `{
+		"hooks": {
+			"PreToolUse": [
+				{"matcher": "*", "hooks": [{"type": "command", "command": "echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"allow\",\"updatedInput\":{\"path\":\"rewritten\"}}}'"}]}
+			]
+		}
+	}`)
+	collect := drainEvents(sess)
+
+	res := sess.execTool(context.Background(), intg_probeCall(`{"path":"original"`), "")
+	if res.IsError || res.Output != "path=rewritten" {
+		t.Fatalf("repaired arguments should accept hook update: %+v", res)
+	}
+	if got := ran.Load(); got != 1 {
+		t.Errorf("probe tool ran %d times; want 1", got)
 	}
 	sess.Close()
 	collect()

--- a/agent/internal/tool/repair/json.go
+++ b/agent/internal/tool/repair/json.go
@@ -18,10 +18,22 @@ var (
 )
 
 // RepairJSON makes unparseable tool-argument bytes parseable by fixing broken
-// \u escapes and lone UTF-16 surrogates in string values. Deliberately narrow:
+// \u escapes and lone UTF-16 surrogates in string values, or appending a missing
+// outer-object brace. These repairs are never combined. Deliberately narrow:
 // it does not attempt general JSON slop repair (trailing commas, etc.). Returns
 // (raw, nil) when it changes nothing.
 func RepairJSON(raw []byte) ([]byte, []Change) {
+	// A nonempty object that becomes valid with exactly one appended brace
+	// already has complete members. Let the JSON parser reject unfinished
+	// values, trailing commas, and missing nested closers; never invent fields.
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) > 1 && trimmed[0] == '{' {
+		candidate := append(bytes.Clone(raw), '}')
+		if json.Valid(candidate) {
+			return candidate, []Change{{Kind: ChangeMissingOuterBrace, Detail: "appended missing outer-object }"}}
+		}
+	}
+
 	s := string(raw)
 	var changes []Change
 

--- a/agent/internal/tool/repair/json_outer_brace_test.go
+++ b/agent/internal/tool/repair/json_outer_brace_test.go
@@ -1,0 +1,45 @@
+package repair
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestRepairJSON_MissingOuterBrace(t *testing.T) {
+	for _, in := range []string{
+		`{"end_turn":true,"message":"OK","output":{"artifacts":[],"data":{},"message":""}`,
+		`{"s":"done"`, `{"n":12`, `{"b":false`, `{"v":null`, `{"a":[]`, `{"o":{}`,
+		" \n{\"a\":1\t\n", `{"s":"} [ \\"`, `{"s":"\uD800"`,
+	} {
+		t.Run(in, func(t *testing.T) {
+			raw := []byte(in)
+			out, changes := RepairJSON(raw)
+			if string(out) != in+"}" || !json.Valid(out) {
+				t.Fatalf("got %q; want sole appended brace", out)
+			}
+			if len(changes) != 1 || changes[0].Kind != ChangeKind("missing_outer_brace") {
+				t.Fatalf("changes = %+v", changes)
+			}
+			if string(raw) != in {
+				t.Fatalf("input mutated: %q", raw)
+			}
+		})
+	}
+}
+
+func TestRepairJSON_MissingOuterBraceRefused(t *testing.T) {
+	for _, in := range []string{
+		``, `{`, " { \n", `{}`, `{"a":1}`, `[]`, `[1`, `[{"a":1`, `null`,
+		`{"a"`, `{"a":`, `{"a":tru`, `{"a":1e`, `{"a":1,`,
+		`{"a":"unfinished`, `{"a":"escape\`, `{"a":{`, `{"a":{"b":1`, `{"a":[1`,
+		`{"a":"\u12"`, `{"a":"\q"`, `{"a":1} garbage`, `{"a":1} {`,
+	} {
+		t.Run(in, func(t *testing.T) {
+			out, changes := RepairJSON([]byte(in))
+			if !bytes.Equal(out, []byte(in)) || len(changes) != 0 {
+				t.Fatalf("got %q, %+v; want unchanged", out, changes)
+			}
+		})
+	}
+}

--- a/agent/internal/tool/repair/repair.go
+++ b/agent/internal/tool/repair/repair.go
@@ -19,6 +19,7 @@ const (
 	ChangeCoerceType        ChangeKind = "coerce_type"
 	ChangeDropUnknown       ChangeKind = "drop_unknown"
 	ChangeUnicodeRepair     ChangeKind = "unicode_repair"
+	ChangeMissingOuterBrace ChangeKind = "missing_outer_brace"
 	ChangeFillRequired      ChangeKind = "fill_required"
 	ChangeNormalizeDefault  ChangeKind = "normalize_default"
 	ChangeSynthesize        ChangeKind = "synthesize"

--- a/agent/session_tool_repair_outer_brace_test.go
+++ b/agent/session_tool_repair_outer_brace_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"primeradiant.com/evener/agent/internal/tool"
+	"primeradiant.com/evener/agent/internal/tool/repair"
+	"primeradiant.com/evener/llm"
+)
+
+func TestPrepareToolCall_MissingOuterBrace(t *testing.T) {
+	reg := tool.NewRegistry()
+	if err := reg.Register(regTool(tool.DefCommunicate())); err != nil {
+		t.Fatal(err)
+	}
+	raw := `{"end_turn":true,"message":"OK","output":{"artifacts":[],"data":{},"message":""}`
+	for _, tc := range []struct {
+		name, args, finish string
+		repaired           bool
+	}{
+		{"completed", raw, "", true},
+		{"length stopped", raw, llm.FinishReasonLength, false},
+		{"empty object", `{}`, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := prepareToolCall(llm.ToolCallData{ID: "c1", Name: "communicate", Arguments: json.RawMessage(tc.args)}, reg.Get("communicate"), []string{"communicate"}, "communicate", "communicate", tc.finish)
+			if !tc.repaired {
+				if res.PrevalErr == "" || len(res.Changes) != 0 || string(res.Call.Arguments) != tc.args {
+					t.Fatalf("expected unchanged rejected call: %+v", res)
+				}
+				return
+			}
+			if res.PrevalErr != "" {
+				t.Fatal(res.PrevalErr)
+			}
+			if len(res.Changes) != 1 || res.Changes[0].Kind != repair.ChangeMissingOuterBrace {
+				t.Fatalf("changes: %+v", res.Changes)
+			}
+			var got, want any
+			if err := json.Unmarshal(res.Call.Arguments, &got); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal([]byte(raw+"}"), &want); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("arguments changed: got %#v want %#v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Append exactly one final outer-object brace only when the original non-bare object becomes valid JSON with that sole append; emit a distinct `missing_outer_brace` repair kind.
- Do not combine brace repair with Unicode rewriting or fabricate fields. Preserve the length-stop bypass.
- Cover the observed communicate payload, completed value types, malformed-input rejection, empty-object rejection, and hook rewriting. Preserve the formerly rejected missing-brace hook fixture as explicit success coverage and independently retain rejection coverage for an unfinished string.

## Verification
- TDD: repair package baseline passed; new missing-brace regressions failed before implementation and passed afterward.
- `go test ./agent/internal/tool/repair` passed.
- `go test ./agent -run 'TestPrepareToolCall_|TestSession_.*Repair' -count=1` passed.
- `go test ./agent -run '^TestIntg_ExecTool_PreToolUse(InvalidUpdatedInputErrors|RepairsMissingOuterBrace)$' -count=1` passed.
- `make merge-approval-gate && make vet` passed (lint, build, full non-fuzz module suites and frontend gate).
- `git diff --check` passed; Go files formatted.
- Independent read-only review found no issues, including a second review of the hook fixture correction.

## Separate dependency advisory
Frontend setup reported three moderate audit entries in existing `@vitest/mocker`, `vitest`, and `@vitest/coverage-v8`, all installed at 4.1.10. Underlying advisory: [GHSA-82fw-gwwq-j7x9](https://github.com/advisories/GHSA-82fw-gwwq-j7x9), path traversal/arbitrary file read through redirect mocks. `npm audit` exits 1 for these entries; no dependencies or lockfiles changed in this narrowly scoped repair.

No merge performed.