### PR TITLE
fix(keybindings): reject shortcuts with no key

### DIFF
--- a/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.test.ts
@@ -46,6 +46,10 @@ describe("parseChord", () => {
     expect(() => parseChord("")).toThrow();
     expect(() => parseChord("   ")).toThrow();
   });
+
+  test("rejects a modifier-only keybinding", () => {
+    expect(() => parseChord("Meta+")).toThrow();
+  });
 });
 
 describe("serializeChord round-trips", () => {

--- a/cmd/evener-hub/frontend/src/keybindings/chord.ts
+++ b/cmd/evener-hub/frontend/src/keybindings/chord.ts
@@ -33,11 +33,14 @@ function byCanonicalOrder(a: string, b: string): number {
 /** Parses a tinykeys keybinding string ("$mod+K", "Shift+A b") into the canonical AST. */
 export function parseChord(input: string): KeySequence {
   if (input.trim() === "") throw new Error("cannot parse an empty keybinding");
-  return parseKeybinding(input).map(([required, optional, key]) => ({
-    modifiers: [...required].sort(byCanonicalOrder),
-    optionalModifiers: [...optional].sort(byCanonicalOrder),
-    key,
-  }));
+  return parseKeybinding(input).map(([required, optional, key]) => {
+    if (key === "") throw new Error("cannot parse a keybinding with an empty key");
+    return {
+      modifiers: [...required].sort(byCanonicalOrder),
+      optionalModifiers: [...optional].sort(byCanonicalOrder),
+      key,
+    };
+  });
 }
 
 /** Returns a copy of the sequence with `modifier` added as an OPTIONAL


### PR DESCRIPTION
A shortcut such as `Meta+` currently parses with an empty key and can replace a working custom binding with one that cannot be triggered. Reject empty parsed keys at the shared chord boundary so the existing override validator reports the incomplete shortcut.

Validation: the new modifier-only regression fails on main and passes with the fix; all 69 chord/override-validator tests pass, as does touched-source Biome. The same correction restores the existing native shortcut tests within the 718-test native suite. CI and RoboRev must pass on this focused two-file PR before merge.
