### PR TITLE
fix(transcript): preserve interrupted turns after reload

### DIFF
--- a/internal/apptranscript/logical_turn.go
+++ b/internal/apptranscript/logical_turn.go
@@ -1,6 +1,7 @@
 package apptranscript
 
 import (
+	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
@@ -188,8 +189,12 @@ func groupedAppTurnProjection(acc *logicalTurnAccumulator, header transcript.Hea
 func stampGroupedTurnFromEntries(turn *appwire.Turn, entries []schema.Turn) {
 	var startedAt *int64
 	var usage llm.Usage
+	interrupted := false
 	for _, entry := range entries {
 		StampTurnFailure(turn, entry)
+		if entry.SteeringKind == events.SteeringKindInterrupted {
+			interrupted = true
+		}
 		if startedAt == nil && !entry.Timestamp.IsZero() {
 			ms := entry.Timestamp.UnixMilli()
 			startedAt = &ms
@@ -197,6 +202,9 @@ func stampGroupedTurnFromEntries(turn *appwire.Turn, entries []schema.Turn) {
 		usage = usage.Add(entry.Usage)
 	}
 	turn.StartedAt = startedAt
+	if interrupted && turn.Status != appwire.TurnStatusFailed {
+		turn.Status = appwire.TurnStatusInterrupted
+	}
 	if u := appwire.EvenerUsageFromLLM(usage); u != nil {
 		turn.Usage = u
 	}

--- a/internal/apptranscript/logical_turn.go
+++ b/internal/apptranscript/logical_turn.go
@@ -192,7 +192,7 @@ func stampGroupedTurnFromEntries(turn *appwire.Turn, entries []schema.Turn) {
 	interrupted := false
 	for _, entry := range entries {
 		StampTurnFailure(turn, entry)
-		if entry.SteeringKind == events.SteeringKindInterrupted {
+		if entry.Kind == schema.TurnSteering && entry.SteeringKind == events.SteeringKindInterrupted {
 			interrupted = true
 		}
 		if startedAt == nil && !entry.Timestamp.IsZero() {

--- a/internal/apptranscript/logical_turn_grouping_test.go
+++ b/internal/apptranscript/logical_turn_grouping_test.go
@@ -56,9 +56,7 @@ func TestItemReadersGroupContinuationEntries(t *testing.T) {
 	}
 	path := writeEntries(t, entries...)
 
-	fromFile := requireItemTurnsFromFile(t, path, testMaxLineBytes, func(turn schema.Turn, turnID string, turnIndex int) []appwire.ThreadItem {
-		return ProjectTurn(turnID, turnIndex, turn, nil, nil, nil)
-	})
+	fromFile := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
 	fromEntries, err := ItemTurnsFromEntries(transcript.Header{}, entries, sequentialTestProjector())
 	if err != nil {
 		t.Fatalf("ItemTurnsFromEntries: %v", err)
@@ -77,47 +75,43 @@ func TestItemReadersGroupContinuationEntries(t *testing.T) {
 }
 
 func TestItemReadersStampInterruptedSteeringOnGroupedTurn(t *testing.T) {
-	entries := []transcript.Entry{
-		{Kind: "entry", Seq: 1, Turn: schema.Turn{
-			Kind:         schema.TurnUserInput,
-			Message:      llm.User("before stop"),
-			StableTurnID: "turn_m2",
-		}},
-		{Kind: "entry", Seq: 2, Turn: schema.Turn{
-			Kind:         schema.TurnSteering,
-			Message:      llm.User("interrupted"),
-			SteeringKind: events.SteeringKindInterrupted,
-		}},
-		{Kind: "entry", Seq: 3, Turn: schema.Turn{
-			Kind:    schema.TurnFailure,
-			Message: llm.System("provider failed"),
-			Error:   &schema.TurnFailureInfo{Message: "provider failed"},
-		}},
-	}
-	path := writeEntries(t, entries...)
-	full := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
-	page := requirePageFromFile(t, NewTurnCache(), path, testMaxLineBytes, "", 50, func(turn schema.Turn, turnID string, turnIndex int, toolNames map[string]string) []appwire.ThreadItem {
-		return ProjectTurn(turnID, turnIndex, turn, toolNames, nil, nil)
-	})
-	for name, turns := range map[string][]appwire.Turn{
-		"full":    full,
-		"indexed": page.Turns,
-	} {
-		if len(turns) != 1 {
-			t.Fatalf("%s grouped turns = %d, want one interrupted logical turn", name, len(turns))
+	for _, failed := range []bool{false, true} {
+		name := "interrupted"
+		want := appwire.TurnStatusInterrupted
+		if failed {
+			name, want = "failed after interruption", appwire.TurnStatusFailed
 		}
-		if turns[0].Status != appwire.TurnStatusFailed {
-			t.Fatalf("%s grouped turn status = %q, want failure to take precedence", name, turns[0].Status)
-		}
-		interrupted := false
-		for _, item := range turns[0].Items {
-			if item.SteeringKind == events.SteeringKindInterrupted {
-				interrupted = true
+		t.Run(name, func(t *testing.T) {
+			entries := []transcript.Entry{
+				{Kind: "entry", Seq: 1, Turn: schema.Turn{Kind: schema.TurnUserInput, Message: llm.User("input"), StableTurnID: "turn_m2"}},
+				{Kind: "entry", Seq: 2, Turn: schema.Turn{Kind: schema.TurnSteering, Message: llm.User("interrupted"), SteeringKind: events.SteeringKindInterrupted}},
 			}
-		}
-		if !interrupted {
-			t.Fatalf("%s grouped items lost interrupted steering metadata: %+v", name, turns[0].Items)
-		}
+			if failed {
+				entries = append(entries, transcript.Entry{Kind: "entry", Seq: 3, Turn: schema.Turn{Kind: schema.TurnFailure, Error: &schema.TurnFailureInfo{Message: "provider failed"}}})
+			}
+			path := writeEntries(t, entries...)
+			names := map[string]string{}
+			full := requireItemTurnsFromFile(t, path, testMaxLineBytes, func(turn schema.Turn, turnID string, turnIndex int) []appwire.ThreadItem {
+				return ProjectTurn(turnID, turnIndex, turn, names, nil, nil)
+			})
+			page := requirePageFromFile(t, NewTurnCache(), path, testMaxLineBytes, "", 50, func(turn schema.Turn, turnID string, turnIndex int, toolNames map[string]string) []appwire.ThreadItem {
+				return ProjectTurn(turnID, turnIndex, turn, toolNames, nil, nil)
+			})
+			for reader, turns := range map[string][]appwire.Turn{"full": full, "indexed": page.Turns} {
+				if len(turns) != 1 || turns[0].Status != want {
+					t.Fatalf("%s turns = %+v, want one %s turn", reader, turns, want)
+				}
+				found := false
+				for _, item := range turns[0].Items {
+					if item.SteeringKind == events.SteeringKindInterrupted {
+						found = true
+					}
+				}
+				if !found {
+					t.Fatalf("%s lost interrupted steering item", reader)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/apptranscript/logical_turn_grouping_test.go
+++ b/internal/apptranscript/logical_turn_grouping_test.go
@@ -4,10 +4,12 @@ import (
 	"reflect"
 	"testing"
 
+	"primeradiant.com/evener/agent/events"
 	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/internal/appitempaging"
+	"primeradiant.com/evener/llm"
 )
 
 // itemKey builds the canonical transcript key the way production does, so the
@@ -69,6 +71,28 @@ func TestItemReadersGroupContinuationEntries(t *testing.T) {
 		if got, want := turnIDs(read.turns), []string{"turn_1"}; !reflect.DeepEqual(got, want) {
 			t.Errorf("%s item turn ids = %v, want one logical turn %v", read.name, got, want)
 		}
+	}
+}
+
+func TestItemReadersStampInterruptedSteeringOnGroupedTurn(t *testing.T) {
+	entries := []transcript.Entry{
+		{Kind: "entry", Seq: 1, Turn: schema.Turn{
+			Kind:         schema.TurnUserInput,
+			Message:      llm.User("before stop"),
+			StableTurnID: "turn_m2",
+		}},
+		{Kind: "entry", Seq: 2, Turn: schema.Turn{
+			Kind:         schema.TurnSteering,
+			Message:      llm.User("interrupted"),
+			SteeringKind: events.SteeringKindInterrupted,
+		}},
+	}
+	turns := requireItemTurnsFromFile(t, writeEntries(t, entries...), testMaxLineBytes, sequentialTestProjector())
+	if len(turns) != 1 {
+		t.Fatalf("grouped turns = %d, want one interrupted logical turn", len(turns))
+	}
+	if turns[0].Status != appwire.TurnStatusInterrupted {
+		t.Fatalf("grouped turn status = %q, want interrupted", turns[0].Status)
 	}
 }
 

--- a/internal/apptranscript/logical_turn_grouping_test.go
+++ b/internal/apptranscript/logical_turn_grouping_test.go
@@ -56,7 +56,9 @@ func TestItemReadersGroupContinuationEntries(t *testing.T) {
 	}
 	path := writeEntries(t, entries...)
 
-	fromFile := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
+	fromFile := requireItemTurnsFromFile(t, path, testMaxLineBytes, func(turn schema.Turn, turnID string, turnIndex int) []appwire.ThreadItem {
+		return ProjectTurn(turnID, turnIndex, turn, nil, nil, nil)
+	})
 	fromEntries, err := ItemTurnsFromEntries(transcript.Header{}, entries, sequentialTestProjector())
 	if err != nil {
 		t.Fatalf("ItemTurnsFromEntries: %v", err)
@@ -86,10 +88,17 @@ func TestItemReadersStampInterruptedSteeringOnGroupedTurn(t *testing.T) {
 			Message:      llm.User("interrupted"),
 			SteeringKind: events.SteeringKindInterrupted,
 		}},
+		{Kind: "entry", Seq: 3, Turn: schema.Turn{
+			Kind:    schema.TurnFailure,
+			Message: llm.System("provider failed"),
+			Error:   &schema.TurnFailureInfo{Message: "provider failed"},
+		}},
 	}
 	path := writeEntries(t, entries...)
 	full := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
-	page := requirePageFromFile(t, NewTurnCache(), path, testMaxLineBytes, "", 50, boundedTestProjector)
+	page := requirePageFromFile(t, NewTurnCache(), path, testMaxLineBytes, "", 50, func(turn schema.Turn, turnID string, turnIndex int, toolNames map[string]string) []appwire.ThreadItem {
+		return ProjectTurn(turnID, turnIndex, turn, toolNames, nil, nil)
+	})
 	for name, turns := range map[string][]appwire.Turn{
 		"full":    full,
 		"indexed": page.Turns,
@@ -97,8 +106,17 @@ func TestItemReadersStampInterruptedSteeringOnGroupedTurn(t *testing.T) {
 		if len(turns) != 1 {
 			t.Fatalf("%s grouped turns = %d, want one interrupted logical turn", name, len(turns))
 		}
-		if turns[0].Status != appwire.TurnStatusInterrupted {
-			t.Fatalf("%s grouped turn status = %q, want interrupted", name, turns[0].Status)
+		if turns[0].Status != appwire.TurnStatusFailed {
+			t.Fatalf("%s grouped turn status = %q, want failure to take precedence", name, turns[0].Status)
+		}
+		interrupted := false
+		for _, item := range turns[0].Items {
+			if item.SteeringKind == events.SteeringKindInterrupted {
+				interrupted = true
+			}
+		}
+		if !interrupted {
+			t.Fatalf("%s grouped items lost interrupted steering metadata: %+v", name, turns[0].Items)
 		}
 	}
 }

--- a/internal/apptranscript/logical_turn_grouping_test.go
+++ b/internal/apptranscript/logical_turn_grouping_test.go
@@ -87,12 +87,19 @@ func TestItemReadersStampInterruptedSteeringOnGroupedTurn(t *testing.T) {
 			SteeringKind: events.SteeringKindInterrupted,
 		}},
 	}
-	turns := requireItemTurnsFromFile(t, writeEntries(t, entries...), testMaxLineBytes, sequentialTestProjector())
-	if len(turns) != 1 {
-		t.Fatalf("grouped turns = %d, want one interrupted logical turn", len(turns))
-	}
-	if turns[0].Status != appwire.TurnStatusInterrupted {
-		t.Fatalf("grouped turn status = %q, want interrupted", turns[0].Status)
+	path := writeEntries(t, entries...)
+	full := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
+	page := requirePageFromFile(t, NewTurnCache(), path, testMaxLineBytes, "", 50, boundedTestProjector)
+	for name, turns := range map[string][]appwire.Turn{
+		"full":    full,
+		"indexed": page.Turns,
+	} {
+		if len(turns) != 1 {
+			t.Fatalf("%s grouped turns = %d, want one interrupted logical turn", name, len(turns))
+		}
+		if turns[0].Status != appwire.TurnStatusInterrupted {
+			t.Fatalf("%s grouped turn status = %q, want interrupted", name, turns[0].Status)
+		}
 	}
 }
 


### PR DESCRIPTION
A stopped turn changes from `interrupted` to `completed` when an offline session is loaded from its saved transcript. The durable interruption is already present on a steering entry, but the grouped turn reader only stamps failures.

Stamp the enclosing logical turn as interrupted when it contains interrupted steering, while preserving failure precedence. The shared stamp runs in full, indexed and item-window reads.

Validation: the regression exercises the real item projector through full and indexed readers for interruption alone and interruption followed by a failure. The interruption case fails against main, then passes with this fix. Full `go test -race ./internal/apptranscript -count=1`, `go vet ./internal/apptranscript`, and diff checks pass.
