### PR TITLE
fix(appwire): preserve steering ownership through transcript replay

### DIFF
--- a/agent/notification_test.go
+++ b/agent/notification_test.go
@@ -15,7 +15,9 @@ import (
 	"primeradiant.com/evener/agent/internal/goal"
 	"primeradiant.com/evener/agent/internal/jobstore"
 	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
 	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/internal/apptranscript"
 	"primeradiant.com/evener/llm"
 )
 
@@ -267,6 +269,90 @@ func TestNotificationTurnOwnsDaemonSteeringAfterCompletedUserTurn(t *testing.T) 
 	if steeringOwner != starts[0].TurnID {
 		t.Fatalf("daemon steering owner=%q, want notification turn %q", steeringOwner, starts[0].TurnID)
 	}
+}
+
+func TestNotificationTurnOwnsDirectRetrySteering(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	adapter := &fakeAdapter{
+		name: "openai",
+		steps: []func(req llm.Request) llm.Response{
+			func(req llm.Request) llm.Response { return finalResponse("warmup") },
+			func(req llm.Request) llm.Response { return llm.Response{} },
+			func(req llm.Request) llm.Response { return finalResponse("notification handled") },
+		},
+	}
+	sess := newSession(t, withAdapter(adapter), withDir(dir), withConfig(SessionConfig{NoProjectPrompts: true, StateDir: dir}))
+	defer sess.Close()
+	if _, err := sess.ProcessInput(context.Background(), "completed user turn", nil); err != nil {
+		t.Fatalf("warmup ProcessInput: %v", err)
+	}
+	recorder := serveAndRecord(t, sess)
+	sess.SteerKind("daemon steering", events.SteeringKindLoopDetected)
+	if _, err := sess.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("ProcessInputKind(EntryNotification): %v", err)
+	}
+	sess.mu.Lock()
+	liveHistory := append([]schema.Turn(nil), sess.history...)
+	sess.mu.Unlock()
+	_, starts := recorder.snapshot()
+	if len(starts) != 1 || starts[0].TurnID == "" {
+		t.Fatalf("notification EventTurnStarted = %#v, want one named boundary", starts)
+	}
+
+	data, err := readTranscriptFull(sess.TranscriptPath())
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	var persistedOwner, priorTurnID string
+	for _, entry := range data.Entries {
+		if entry.Turn.Kind == schema.TurnUserInput && priorTurnID == "" {
+			priorTurnID = entry.Turn.StableTurnID
+		}
+		if entry.Turn.SteeringKind == events.SteeringKindNoToolCalls {
+			persistedOwner = entry.Turn.OwningTurnID
+		}
+	}
+	if persistedOwner != starts[0].TurnID || persistedOwner == priorTurnID {
+		t.Fatalf("direct steering owner=%q, want notification turn %q and not prior user turn %q", persistedOwner, starts[0].TurnID, priorTurnID)
+	}
+	project := func(turn schema.Turn, turnID string, turnIndex int) []appwire.ThreadItem {
+		return apptranscript.ProjectTurn(turnID, turnIndex, turn, nil, nil, nil)
+	}
+	liveEntries := make([]transcript.Entry, len(liveHistory))
+	for i, turn := range liveHistory {
+		liveEntries[i] = transcript.Entry{Kind: "entry", Seq: i + 1, Turn: turn}
+	}
+	liveTurns, err := apptranscript.ItemTurnsFromEntries(data.Header, liveEntries, project)
+	if err != nil {
+		t.Fatalf("live projection: %v", err)
+	}
+	coldTurns, err := apptranscript.ItemTurnsFromEntries(data.Header, data.Entries, project)
+	if err != nil {
+		t.Fatalf("cold projection: %v", err)
+	}
+	liveItem := findNotificationSteeringItem(liveTurns)
+	coldItem := findNotificationSteeringItem(coldTurns)
+	if liveItem == nil || coldItem == nil {
+		t.Fatalf("NoToolCalls item live=%#v cold=%#v", liveItem, coldItem)
+	}
+	if liveItem.TranscriptKey != coldItem.TranscriptKey || liveItem.TurnID != coldItem.TurnID || liveItem.Status != coldItem.Status {
+		t.Fatalf("live/cold NoToolCalls identity live=(key %q, turn %q, status %q) cold=(key %q, turn %q, status %q)", liveItem.TranscriptKey, liveItem.TurnID, liveItem.Status, coldItem.TranscriptKey, coldItem.TurnID, coldItem.Status)
+	}
+	if coldItem.TurnID != starts[0].TurnID {
+		t.Fatalf("cold NoToolCalls turn=%q, want notification turn %q", coldItem.TurnID, starts[0].TurnID)
+	}
+}
+
+func findNotificationSteeringItem(turns []appwire.Turn) *appwire.ThreadItem {
+	for i := range turns {
+		for j := range turns[i].Items {
+			if turns[i].Items[j].SteeringKind == events.SteeringKindNoToolCalls {
+				return &turns[i].Items[j]
+			}
+		}
+	}
+	return nil
 }
 
 func TestNotificationPendingAfterToolRunsBeforeAnotherNormalRound(t *testing.T) {

--- a/agent/notification_test.go
+++ b/agent/notification_test.go
@@ -163,34 +163,56 @@ func TestNotificationTurn_DrivesModelRequestWithReminder(t *testing.T) {
 // retain both items in one logical turn.
 func TestNotificationTurnOwnsDurableReminderAndPendingClientSteering(t *testing.T) {
 	t.Parallel()
-	s := newTestSession(t)
-	const notificationTurnID = "turn_notification_owner"
-	appendPendingJobNotificationRecord(t, s.jobManager, s.ID())
-	s.enqueueJobNotification(jobNotification{JobID: "job_X"})
-
-	if err := s.ensureClientMutationStore(); err != nil {
+	var sess *Session
+	steerAccepted := make(chan struct{})
+	adapter := &fakeAdapter{name: "openai"}
+	adapter.steps = []func(req llm.Request) llm.Response{
+		func(llm.Request) llm.Response { return finalResponse("warmup") },
+		func(llm.Request) llm.Response {
+			if _, err := sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+				ClientMutationID:   "steer_notification_owner",
+				ExpectedInstanceID: sess.ID(),
+				Input:              []appwire.InputItem{{Type: "text", Text: "steer during notification"}},
+			}); err != nil {
+				panic(fmt.Sprintf("accept client steering: %v", err))
+			}
+			close(steerAccepted)
+			return communicateResponse(false, "notification handled")
+		},
+		func(llm.Request) llm.Response { return finalResponse("steering handled") },
+	}
+	client := llm.NewClient()
+	client.Register(adapter)
+	dir := t.TempDir()
+	sess = newSession(t, withClient(client), withDir(dir), withConfig(SessionConfig{MaxSubagentDepth: 1, NoProjectPrompts: true, StateDir: dir}))
+	if _, err := sess.ProcessInput(context.Background(), "warm up", nil); err != nil {
+		t.Fatalf("warmup ProcessInput: %v", err)
+	}
+	if err := sess.ensureClientMutationStore(); err != nil {
 		t.Fatalf("ensureClientMutationStore: %v", err)
 	}
-	if err := s.clientMutations.mutate(func(snapshot *clientMutationSnapshot) error {
-		snapshot.ActiveTurnID = notificationTurnID
-		return nil
-	}); err != nil {
-		t.Fatalf("claim notification turn: %v", err)
+	recorder := serveAndRecord(t, sess)
+	enqueueCompletedJobNotification(t, sess, "job_X")
+	if _, err := sess.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("ProcessInputKind(EntryNotification): %v", err)
 	}
-	if _, err := s.AcceptClientMutationSteer(appwire.TurnSteerParams{
-		ClientMutationID:   "steer_notification_owner",
-		ExpectedInstanceID: s.ID(),
-		Input:              []appwire.InputItem{{Type: "text", Text: "steer during notification"}},
-	}); err != nil {
-		t.Fatalf("accept client steering: %v", err)
+	select {
+	case <-steerAccepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("notification provider call did not accept client steering")
 	}
-
-	if !s.acceptNotificationInput(context.Background(), notificationTurnID) {
-		t.Fatal("notification input should proceed")
+	_, starts := recorder.snapshot()
+	if len(starts) != 1 || starts[0].TurnID == "" {
+		t.Fatalf("notification EventTurnStarted = %#v, want one nonempty owner", starts)
 	}
-
+	owner := starts[0].TurnID
+	data, err := readTranscriptFull(transcriptPath(sess.stateDir, sess.id))
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
 	var reminderOwner, steeringOwner string
-	for _, turn := range s.history {
+	for _, entry := range data.Entries {
+		turn := entry.Turn
 		if turn.SteeringKind == events.SteeringKindNotification {
 			reminderOwner = turn.OwningTurnID
 		}
@@ -198,11 +220,8 @@ func TestNotificationTurnOwnsDurableReminderAndPendingClientSteering(t *testing.
 			steeringOwner = turn.OwningTurnID
 		}
 	}
-	if reminderOwner != notificationTurnID {
-		t.Fatalf("notification reminder owner=%q, want %q", reminderOwner, notificationTurnID)
-	}
-	if steeringOwner != notificationTurnID {
-		t.Fatalf("pending client steering owner=%q, want %q", steeringOwner, notificationTurnID)
+	if reminderOwner == "" || steeringOwner == "" || reminderOwner != steeringOwner || reminderOwner != owner {
+		t.Fatalf("durable owners reminder=%q steering=%q EventTurnStarted=%q", reminderOwner, steeringOwner, owner)
 	}
 }
 

--- a/agent/notification_test.go
+++ b/agent/notification_test.go
@@ -198,6 +198,8 @@ func TestNotificationTurnOwnsDurableReminderAndPendingClientSteering(t *testing.
 	}
 	select {
 	case <-steerAccepted:
+		// TRIPWIRE: scripted provider execution should accept steering promptly;
+		// this bound prevents a broken notification turn from hanging the suite.
 	case <-time.After(5 * time.Second):
 		t.Fatal("notification provider call did not accept client steering")
 	}
@@ -206,7 +208,7 @@ func TestNotificationTurnOwnsDurableReminderAndPendingClientSteering(t *testing.
 		t.Fatalf("notification EventTurnStarted = %#v, want one nonempty owner", starts)
 	}
 	owner := starts[0].TurnID
-	data, err := readTranscriptFull(transcriptPath(sess.stateDir, sess.id))
+	data, err := readTranscriptFull(sess.TranscriptPath())
 	if err != nil {
 		t.Fatalf("read transcript: %v", err)
 	}
@@ -222,6 +224,48 @@ func TestNotificationTurnOwnsDurableReminderAndPendingClientSteering(t *testing.
 	}
 	if reminderOwner == "" || steeringOwner == "" || reminderOwner != steeringOwner || reminderOwner != owner {
 		t.Fatalf("durable owners reminder=%q steering=%q EventTurnStarted=%q", reminderOwner, steeringOwner, owner)
+	}
+}
+
+// TestNotificationTurnOwnsDaemonSteeringAfterCompletedUserTurn pins the
+// notification-only steering boundary. A daemon steer drained by a named
+// EntryNotification turn must carry that turn's owner into the durable
+// transcript, or cold projection folds it into the preceding user turn.
+func TestNotificationTurnOwnsDaemonSteeringAfterCompletedUserTurn(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	adapter := &fakeAdapter{
+		name: "openai",
+		steps: []func(req llm.Request) llm.Response{
+			func(req llm.Request) llm.Response { return finalResponse("warmup") },
+			func(req llm.Request) llm.Response { return finalResponse("notification handled") },
+		},
+	}
+	sess := newSession(t, withAdapter(adapter), withDir(dir), withConfig(SessionConfig{NoProjectPrompts: true, StateDir: dir}))
+	if _, err := sess.ProcessInput(context.Background(), "completed user turn", nil); err != nil {
+		t.Fatalf("warmup ProcessInput: %v", err)
+	}
+	recorder := serveAndRecord(t, sess)
+	sess.SteerKind("daemon steering", events.SteeringKindLoopDetected)
+	if _, err := sess.ProcessInputKind(context.Background(), "", nil, EntryNotification); err != nil {
+		t.Fatalf("ProcessInputKind(EntryNotification): %v", err)
+	}
+	_, starts := recorder.snapshot()
+	if len(starts) != 1 || starts[0].TurnID == "" {
+		t.Fatalf("notification EventTurnStarted = %#v, want one nonempty owner", starts)
+	}
+	data, err := readTranscriptFull(sess.TranscriptPath())
+	if err != nil {
+		t.Fatalf("read transcript: %v", err)
+	}
+	var steeringOwner string
+	for _, entry := range data.Entries {
+		if entry.Turn.SteeringKind == events.SteeringKindLoopDetected {
+			steeringOwner = entry.Turn.OwningTurnID
+		}
+	}
+	if steeringOwner != starts[0].TurnID {
+		t.Fatalf("daemon steering owner=%q, want notification turn %q", steeringOwner, starts[0].TurnID)
 	}
 }
 

--- a/agent/notification_test.go
+++ b/agent/notification_test.go
@@ -15,6 +15,7 @@ import (
 	"primeradiant.com/evener/agent/internal/goal"
 	"primeradiant.com/evener/agent/internal/jobstore"
 	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/llm"
 )
 
@@ -152,6 +153,56 @@ func TestNotificationTurn_DrivesModelRequestWithReminder(t *testing.T) {
 	sess.mu.Unlock()
 	if !sawSteering {
 		t.Fatal("no TurnSteering entry carrying the <job-notification ...> block was appended to history")
+	}
+}
+
+// TestNotificationTurnOwnsDurableReminderAndPendingClientSteering pins the
+// grouping boundary shared by the notification opener and a client steer that
+// arrives while that opener is active. The reminder and the steer must carry
+// the same supplied notification turn owner so live and replay projections
+// retain both items in one logical turn.
+func TestNotificationTurnOwnsDurableReminderAndPendingClientSteering(t *testing.T) {
+	t.Parallel()
+	s := newTestSession(t)
+	const notificationTurnID = "turn_notification_owner"
+	appendPendingJobNotificationRecord(t, s.jobManager, s.ID())
+	s.enqueueJobNotification(jobNotification{JobID: "job_X"})
+
+	if err := s.ensureClientMutationStore(); err != nil {
+		t.Fatalf("ensureClientMutationStore: %v", err)
+	}
+	if err := s.clientMutations.mutate(func(snapshot *clientMutationSnapshot) error {
+		snapshot.ActiveTurnID = notificationTurnID
+		return nil
+	}); err != nil {
+		t.Fatalf("claim notification turn: %v", err)
+	}
+	if _, err := s.AcceptClientMutationSteer(appwire.TurnSteerParams{
+		ClientMutationID:   "steer_notification_owner",
+		ExpectedInstanceID: s.ID(),
+		Input:              []appwire.InputItem{{Type: "text", Text: "steer during notification"}},
+	}); err != nil {
+		t.Fatalf("accept client steering: %v", err)
+	}
+
+	if !s.acceptNotificationInput(context.Background(), notificationTurnID) {
+		t.Fatal("notification input should proceed")
+	}
+
+	var reminderOwner, steeringOwner string
+	for _, turn := range s.history {
+		if turn.SteeringKind == events.SteeringKindNotification {
+			reminderOwner = turn.OwningTurnID
+		}
+		if turn.ClientMutationID == "steer_notification_owner" {
+			steeringOwner = turn.OwningTurnID
+		}
+	}
+	if reminderOwner != notificationTurnID {
+		t.Fatalf("notification reminder owner=%q, want %q", reminderOwner, notificationTurnID)
+	}
+	if steeringOwner != notificationTurnID {
+		t.Fatalf("pending client steering owner=%q, want %q", steeringOwner, notificationTurnID)
 	}
 }
 

--- a/agent/schema/turn.go
+++ b/agent/schema/turn.go
@@ -195,6 +195,9 @@ type Turn struct {
 	// recovery for both client input and daemon goal continuations.
 	ClientMutationID string `json:"client_mutation_id,omitempty"`
 	StableTurnID     string `json:"stable_turn_id,omitempty"`
+	// OwningTurnID identifies the logical turn that owns an ordinary steering
+	// entry. It differs from StableTurnID, which identifies the client mutation.
+	OwningTurnID string `json:"owning_turn_id,omitempty"`
 	// Error carries the diagnostic of a terminally failed turn. Set only on
 	// TurnFailure turns; nil everywhere else.
 	Error *TurnFailureInfo `json:"error,omitempty"`

--- a/agent/session_lifecycle.go
+++ b/agent/session_lifecycle.go
@@ -2149,7 +2149,7 @@ func (s *Session) acceptNotificationInput(ctx context.Context, turnID string) (p
 	var reminder string
 	if len(jobNotifs) > 0 {
 		reminder = s.formatJobNotificationReminder(jobNotifs)
-		if err := errors.Join(s.appendSteeringTurnDurably(reminder, events.SteeringKindNotification), sessionLifecycleFault(ctx, "append_notification")); err != nil {
+		if err := errors.Join(s.appendSteeringTurnDurablyForOwner(reminder, events.SteeringKindNotification, turnID), sessionLifecycleFault(ctx, "append_notification")); err != nil {
 			s.requeueJobNotifications(jobNotifications(jobNotifs))
 			s.finishNotificationNoop()
 			return false

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -1040,8 +1040,16 @@ func (s *Session) returnClaimedSteering(clientMutationID string) error {
 func (s *Session) appendSteeringTurn(text, kind string) {
 	t := schema.NewTurn(schema.TurnSteering, llm.User(text))
 	t.SteeringKind = kind
+	t.OwningTurnID = s.activeTurnOwner()
 	s.recordTurn(t, t)
 	s.emit(events.EventSteeringInjected, events.SteeringInjectedData{Text: text, Kind: kind})
+}
+
+func (s *Session) activeTurnOwner() string {
+	if s.clientMutations == nil {
+		return ""
+	}
+	return s.clientMutations.snapshot().ActiveTurnID
 }
 
 // appendSteeringTurnDurably is appendSteeringTurn's durable counterpart for
@@ -1052,7 +1060,7 @@ func (s *Session) appendSteeringTurn(text, kind string) {
 // for a turn that never made it to disk. The durable write happens before the
 // in-memory history append, preserving the crash-window ordering.
 func (s *Session) appendSteeringTurnDurably(text, kind string) error {
-	return s.appendSteeringTurnDurablyForOwner(text, kind, "")
+	return s.appendSteeringTurnDurablyForOwner(text, kind, s.activeTurnOwner())
 }
 
 // appendSteeringTurnDurablyForOwner durably records a daemon steering turn

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -83,6 +83,7 @@ type steeringMessage struct {
 	Provenance       *provenance.Causal `json:"provenance,omitempty"`
 	ClientMutationID string             `json:"client_mutation_id,omitempty"`
 	StableTurnID     string             `json:"stable_turn_id,omitempty"`
+	OwningTurnID     string             `json:"owning_turn_id,omitempty"`
 	// Source marks who sent the steering: events.SteeringSourceUser for
 	// human-sent steering (the UI steer action, or queued user input
 	// drained as steering), empty for daemon/system nudges. Surfaced on the
@@ -984,6 +985,7 @@ func (s *Session) consumeSteeringMessage(msg steeringMessage) bool {
 	t.SteeringKind = msg.Kind
 	t.ClientMutationID = msg.ClientMutationID
 	t.StableTurnID = msg.StableTurnID
+	t.OwningTurnID = s.clientMutations.snapshot().ActiveTurnID
 	if msg.ClientMutationID != "" {
 		if err := s.appendTurnAfterTranscriptWrite(
 			t,

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -1051,8 +1051,17 @@ func (s *Session) appendSteeringTurn(text, kind string) {
 // for a turn that never made it to disk. The durable write happens before the
 // in-memory history append, preserving the crash-window ordering.
 func (s *Session) appendSteeringTurnDurably(text, kind string) error {
+	return s.appendSteeringTurnDurablyForOwner(text, kind, "")
+}
+
+// appendSteeringTurnDurablyForOwner durably records a daemon steering turn
+// with the logical turn that owns it. Notification reminders use the caller's
+// supplied turn id because client steering arriving during that notification
+// turn is grouped by the same durable owner.
+func (s *Session) appendSteeringTurnDurablyForOwner(text, kind, owningTurnID string) error {
 	t := schema.NewTurn(schema.TurnSteering, llm.User(text))
 	t.SteeringKind = kind
+	t.OwningTurnID = owningTurnID
 	err := s.appendTurnAfterTranscriptWrite(
 		t,
 		func() error { return s.writeTranscriptDurableLocked(t) },

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -83,6 +83,7 @@ type steeringMessage struct {
 	Provenance       *provenance.Causal `json:"provenance,omitempty"`
 	ClientMutationID string             `json:"client_mutation_id,omitempty"`
 	StableTurnID     string             `json:"stable_turn_id,omitempty"`
+	OwningTurnID     string             `json:"owning_turn_id,omitempty"`
 	// Source marks who sent the steering: events.SteeringSourceUser for
 	// human-sent steering (the UI steer action, or queued user input
 	// drained as steering), empty for daemon/system nudges. Surfaced on the
@@ -985,14 +986,11 @@ func (s *Session) consumeSteeringMessage(msg steeringMessage) bool {
 	t.ClientMutationID = msg.ClientMutationID
 	t.StableTurnID = msg.StableTurnID
 	if msg.ClientMutationID != "" && s.clientMutations != nil {
-		// A pending steer is owned by the turn already running when it is
-		// delivered inline. When the carrier claims the steer, ActiveTurnID is
-		// the steer's own StableTurnID; that identifies the carrier turn and
-		// must not be persisted as its logical owner.
-		owner := s.clientMutations.snapshot().ActiveTurnID
-		if owner != msg.StableTurnID {
-			t.OwningTurnID = owner
-		}
+		// ActiveTurnID is the actual logical owner at delivery time. For an
+		// inline steer it is the already-running turn; for a carrier it is the
+		// carrier's reserved mutation turn. Both identities must be durable so
+		// replay can distinguish the two boundaries.
+		t.OwningTurnID = s.clientMutations.snapshot().ActiveTurnID
 	}
 	if msg.ClientMutationID != "" {
 		if err := s.appendTurnAfterTranscriptWrite(

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -83,7 +83,6 @@ type steeringMessage struct {
 	Provenance       *provenance.Causal `json:"provenance,omitempty"`
 	ClientMutationID string             `json:"client_mutation_id,omitempty"`
 	StableTurnID     string             `json:"stable_turn_id,omitempty"`
-	OwningTurnID     string             `json:"owning_turn_id,omitempty"`
 	// Source marks who sent the steering: events.SteeringSourceUser for
 	// human-sent steering (the UI steer action, or queued user input
 	// drained as steering), empty for daemon/system nudges. Surfaced on the
@@ -985,7 +984,16 @@ func (s *Session) consumeSteeringMessage(msg steeringMessage) bool {
 	t.SteeringKind = msg.Kind
 	t.ClientMutationID = msg.ClientMutationID
 	t.StableTurnID = msg.StableTurnID
-	t.OwningTurnID = s.clientMutations.snapshot().ActiveTurnID
+	if msg.ClientMutationID != "" && s.clientMutations != nil {
+		// A pending steer is owned by the turn already running when it is
+		// delivered inline. When the carrier claims the steer, ActiveTurnID is
+		// the steer's own StableTurnID; that identifies the carrier turn and
+		// must not be persisted as its logical owner.
+		owner := s.clientMutations.snapshot().ActiveTurnID
+		if owner != msg.StableTurnID {
+			t.OwningTurnID = owner
+		}
+	}
 	if msg.ClientMutationID != "" {
 		if err := s.appendTurnAfterTranscriptWrite(
 			t,

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -83,7 +83,6 @@ type steeringMessage struct {
 	Provenance       *provenance.Causal `json:"provenance,omitempty"`
 	ClientMutationID string             `json:"client_mutation_id,omitempty"`
 	StableTurnID     string             `json:"stable_turn_id,omitempty"`
-	OwningTurnID     string             `json:"owning_turn_id,omitempty"`
 	// Source marks who sent the steering: events.SteeringSourceUser for
 	// human-sent steering (the UI steer action, or queued user input
 	// drained as steering), empty for daemon/system nudges. Surfaced on the

--- a/agent/session_queue.go
+++ b/agent/session_queue.go
@@ -984,11 +984,12 @@ func (s *Session) consumeSteeringMessage(msg steeringMessage) bool {
 	t.SteeringKind = msg.Kind
 	t.ClientMutationID = msg.ClientMutationID
 	t.StableTurnID = msg.StableTurnID
-	if msg.ClientMutationID != "" && s.clientMutations != nil {
+	if s.clientMutations != nil {
 		// ActiveTurnID is the actual logical owner at delivery time. For an
 		// inline steer it is the already-running turn; for a carrier it is the
 		// carrier's reserved mutation turn. Both identities must be durable so
-		// replay can distinguish the two boundaries.
+		// replay can distinguish the two boundaries. System steering uses the
+		// same active turn when it is drained by a named daemon turn.
 		t.OwningTurnID = s.clientMutations.snapshot().ActiveTurnID
 	}
 	if msg.ClientMutationID != "" {

--- a/agent/session_steering_wake_mid_turn_test.go
+++ b/agent/session_steering_wake_mid_turn_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"primeradiant.com/evener/agent/internal/agenttest"
+	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/llm"
 )
@@ -43,6 +44,7 @@ func TestSteeringArrivingMidTurnIsDeliveredByTheWakeAfterABareTextEnd(t *testing
 	calls := 0
 	var steerOnce sync.Once
 	var steerErr error
+	var steerStableTurnID string
 
 	adapter := &agenttest.ScriptedAdapter{
 		Provider: "openai",
@@ -59,6 +61,7 @@ func TestSteeringArrivingMidTurnIsDeliveredByTheWakeAfterABareTextEnd(t *testing
 						ClientMutationID: "cm-steer-mid-turn",
 						Input:            []appwire.InputItem{{Type: "text", Text: "steer mid turn"}},
 					})
+					steerStableTurnID = sess.clientMutations.snapshot().PendingExecutions["cm-steer-mid-turn"].TurnID
 				})
 			}
 			if calls <= maxBareTextRetries+1 {
@@ -75,7 +78,15 @@ func TestSteeringArrivingMidTurnIsDeliveredByTheWakeAfterABareTextEnd(t *testing
 	}
 	client := llm.NewClient()
 	client.Register(adapter)
-	sess = newSession(t, withClient(client))
+	sess = newSession(t, withClient(client), withConfig(SessionConfig{
+		StateDir:         t.TempDir(),
+		NoProjectPrompts: true,
+		testOnly: testConfig{
+			skipGitSnapshot:     true,
+			minimalSystemPrompt: true,
+			noSyncJobStore:      true,
+		},
+	}))
 	if err := sess.ensureClientMutationStore(); err != nil {
 		t.Fatalf("ensureClientMutationStore: %v", err)
 	}
@@ -139,5 +150,26 @@ func TestSteeringArrivingMidTurnIsDeliveredByTheWakeAfterABareTextEnd(t *testing
 	}
 	if got := countBudgetSteering(budgetHistory(sess), "steer mid turn"); got != 1 {
 		t.Fatalf("delivered steering count = %d, want 1", got)
+	}
+
+	data, err := readTranscriptFull(transcriptPath(sess.stateDir, sess.id))
+	if err != nil {
+		t.Fatalf("read persisted transcript: %v", err)
+	}
+	var steering *schema.Turn
+	for i := range data.Entries {
+		if data.Entries[i].Turn.ClientMutationID == "cm-steer-mid-turn" {
+			steering = &data.Entries[i].Turn
+			break
+		}
+	}
+	if steering == nil {
+		t.Fatal("persisted transcript has no delivered steering turn")
+	}
+	if steering.StableTurnID != steerStableTurnID {
+		t.Fatalf("steering StableTurnID = %q, want reserved mutation id %q", steering.StableTurnID, steerStableTurnID)
+	}
+	if steering.OwningTurnID != "" {
+		t.Fatalf("carrier steering OwningTurnID = %q, want empty because carrier owns a new logical turn", steering.OwningTurnID)
 	}
 }

--- a/agent/session_steering_wake_mid_turn_test.go
+++ b/agent/session_steering_wake_mid_turn_test.go
@@ -169,7 +169,7 @@ func TestSteeringArrivingMidTurnIsDeliveredByTheWakeAfterABareTextEnd(t *testing
 	if steering.StableTurnID != steerStableTurnID {
 		t.Fatalf("steering StableTurnID = %q, want reserved mutation id %q", steering.StableTurnID, steerStableTurnID)
 	}
-	if steering.OwningTurnID != "" {
-		t.Fatalf("carrier steering OwningTurnID = %q, want empty because carrier owns a new logical turn", steering.OwningTurnID)
+	if steering.OwningTurnID != steerStableTurnID {
+		t.Fatalf("carrier steering OwningTurnID = %q, want active carrier turn %q", steering.OwningTurnID, steerStableTurnID)
 	}
 }

--- a/internal/apptranscript/logical_turn.go
+++ b/internal/apptranscript/logical_turn.go
@@ -21,8 +21,8 @@ import (
 // The grouping rule reproduces the live allocation from the file alone:
 //
 //   - USER_INPUT and typed goal-continuation STEERING open a logical turn.
-//     Ordinary STEERING joins the open turn because live steering attaches
-//     to the active turn; with no open group it starts a group of its own.
+//     Ordinary STEERING follows its explicit OwningTurnID when present;
+//     otherwise it joins the open turn because live steering attaches there.
 //   - CONTINUATIONS extend the open logical turn: ASSISTANT, TOOL,
 //     TOOL_RESULTS, and TURN_FAILURE (a failure closes nothing — the daemon
 //     may retry after a failure, and grouping it into the opener's turn keeps
@@ -65,9 +65,12 @@ func groupOpenAfter(kind schema.TurnKind) bool {
 // there is none). Openers always start a group; continuations join the open
 // group (start one only when the previous record closed it); standalone kinds
 // always start — and close — their own group.
-func recordStartsGroup(kind, prevKind schema.TurnKind, goalContinuation bool) bool {
+func recordStartsGroup(kind, prevKind schema.TurnKind, goalContinuation bool, owningTurnID, openTurnID string) bool {
 	if opensLogicalTurn(kind, goalContinuation) {
 		return true
+	}
+	if kind == schema.TurnSteering && owningTurnID != "" {
+		return owningTurnID != openTurnID
 	}
 	if continuesLogicalTurn(kind) {
 		return !groupOpenAfter(prevKind)
@@ -104,9 +107,16 @@ type logicalTurnAccumulator struct {
 // group).
 func (a *logicalTurnAccumulator) appendEntry(entry schema.Turn, entryIndex int, items []appwire.ThreadItem) {
 	kind := entry.Kind
+	owner := entry.OwningTurnID
 	switch {
 	case opensLogicalTurn(kind, entry.GoalContinuation != nil):
 		a.turns = append(a.turns, groupedTurn{turnID: persistedTurnID(entry, entryIndex)})
+		a.open = true
+	case kind == schema.TurnSteering && owner != "":
+		if a.open && len(a.turns) > 0 && a.turns[len(a.turns)-1].turnID == owner {
+			break
+		}
+		a.turns = append(a.turns, groupedTurn{turnID: owner})
 		a.open = true
 	case continuesLogicalTurn(kind) && a.open && len(a.turns) > 0:
 		// Join the open group.

--- a/internal/apptranscript/logical_turn.go
+++ b/internal/apptranscript/logical_turn.go
@@ -70,7 +70,7 @@ func recordStartsGroup(kind, prevKind schema.TurnKind, goalContinuation bool, ow
 		return true
 	}
 	if kind == schema.TurnSteering && owningTurnID != "" {
-		return owningTurnID != openTurnID
+		return !groupOpenAfter(prevKind) || owningTurnID != openTurnID
 	}
 	if continuesLogicalTurn(kind) {
 		return !groupOpenAfter(prevKind)

--- a/internal/apptranscript/logical_turn_grouping_test.go
+++ b/internal/apptranscript/logical_turn_grouping_test.go
@@ -74,6 +74,39 @@ func TestItemReadersGroupContinuationEntries(t *testing.T) {
 	}
 }
 
+func TestItemReadersHonorSteeringOwner(t *testing.T) {
+	for name, owner := range map[string]string{"active": "turn_m10", "carrier": "turn_m11"} {
+		entries := []transcript.Entry{
+			{Kind: "entry", Seq: 1, Turn: schema.Turn{Kind: schema.TurnUserInput, Message: llm.User("first"), StableTurnID: "turn_m10"}},
+			{Kind: "entry", Seq: 2, Turn: schema.Turn{Kind: schema.TurnAssistant, Message: llm.Assistant("answer")}},
+			{Kind: "entry", Seq: 3, Turn: schema.Turn{Kind: schema.TurnSteering, Message: llm.User("steer"), StableTurnID: "mutation_m11", OwningTurnID: owner}},
+			{Kind: "entry", Seq: 4, Turn: schema.Turn{Kind: schema.TurnAssistant, Message: llm.Assistant("followup")}},
+		}
+		path := writeEntries(t, entries...)
+		full := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
+		page := requirePageFromFile(t, NewTurnCache(), path, testMaxLineBytes, "", 50, boundedTestProjector)
+		wantIDs := []string{"turn_m10"}
+		if name == "carrier" {
+			wantIDs = []string{"turn_m10", owner}
+		}
+		for reader, turns := range map[string][]appwire.Turn{"full": full, "indexed": page.Turns} {
+			if got := turnIDs(turns); !reflect.DeepEqual(got, wantIDs) {
+				t.Errorf("%s %s IDs = %v, want %v", name, reader, got, wantIDs)
+			}
+		}
+	}
+}
+
+// TestFileProjectionReproducesLiveLogicalTurnKeys is the differential oracle
+// for F3: the file projection of a persisted logical turn must yield the same
+// turn id, entry ordinal, and item ordinals the live snapshot would have
+// allocated for the same items.
+//
+// Live allocation (appTurnSnapshot semantics, reproduced from the projector's
+// notification stream): each logical turn consumes one entry ordinal; items
+// are numbered 0..n-1 in arrival order. With no prelude, turn 1 opens at entry
+// ordinal 0 (user item 0, assistant item 1); turn 2 opens at entry ordinal 1
+// (user item 0, merged tool item 1, final assistant item 2).
 func TestItemReadersStampInterruptedSteeringOnGroupedTurn(t *testing.T) {
 	for _, failed := range []bool{false, true} {
 		name := "interrupted"

--- a/internal/apptranscript/logical_turn_grouping_test.go
+++ b/internal/apptranscript/logical_turn_grouping_test.go
@@ -84,17 +84,65 @@ func TestItemReadersHonorSteeringOwner(t *testing.T) {
 		}
 		path := writeEntries(t, entries...)
 		full := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
-		page := requirePageFromFile(t, NewTurnCache(), path, testMaxLineBytes, "", 50, boundedTestProjector)
 		wantIDs := []string{"turn_m10"}
 		if name == "carrier" {
 			wantIDs = []string{"turn_m10", owner}
 		}
-		for reader, turns := range map[string][]appwire.Turn{"full": full, "indexed": page.Turns} {
-			if got := turnIDs(turns); !reflect.DeepEqual(got, wantIDs) {
-				t.Errorf("%s %s IDs = %v, want %v", name, reader, got, wantIDs)
+		if got := turnIDs(full); !reflect.DeepEqual(got, wantIDs) {
+			t.Fatalf("%s full IDs = %v, want %v", name, got, wantIDs)
+		}
+		var paged []appwire.Turn
+		cursor := ""
+		for {
+			page := requirePageFromFile(t, NewTurnCache(), path, testMaxLineBytes, cursor, 1, boundedTestProjector)
+			paged = append(page.Turns, paged...)
+			if page.NextCursor == "" {
+				break
 			}
+			cursor = page.NextCursor
+		}
+		if got := turnIDs(paged); !reflect.DeepEqual(got, wantIDs) {
+			t.Errorf("%s paged IDs = %v, want %v", name, got, wantIDs)
+		}
+		if got, want := keysForTurns(paged), keysForTurns(full); !reflect.DeepEqual(got, want) {
+			t.Errorf("%s paged keys = %v, want full keys %v", name, got, want)
+		}
+		cache := NewTurnCache()
+		window, _, err := cache.LatestItemWindowFromFile(path, testMaxLineBytes, ItemWindowOptions{ThreadRef: "local:" + name, Limit: 1}, boundedTestProjector)
+		if err != nil {
+			t.Fatalf("%s LatestItemWindowFromFile: %v", name, err)
+		}
+		var itemKeys []string
+		for _, candidate := range window.Candidates {
+			itemKeys = append(itemKeys, candidate.Item.TranscriptKey)
+		}
+		for window.OlderCursor != "" {
+			window, _, err = cache.PreviousItemWindowFromFile(path, testMaxLineBytes, ItemWindowOptions{ThreadRef: "local:" + name, Cursor: window.OlderCursor, Limit: 1}, boundedTestProjector)
+			if err != nil {
+				t.Fatalf("%s PreviousItemWindowFromFile: %v", name, err)
+			}
+			previousKeys := make([]string, 0, len(window.Candidates))
+			for _, candidate := range window.Candidates {
+				previousKeys = append(previousKeys, candidate.Item.TranscriptKey)
+			}
+			itemKeys = append(previousKeys, itemKeys...)
+		}
+		var wantKeys []string
+		for _, turn := range full {
+			wantKeys = append(wantKeys, keysFor(turn)...)
+		}
+		if !reflect.DeepEqual(itemKeys, wantKeys) {
+			t.Errorf("%s item-window keys = %v, want full keys %v", name, itemKeys, wantKeys)
 		}
 	}
+}
+
+func keysForTurns(turns []appwire.Turn) []string {
+	keys := make([]string, 0)
+	for _, turn := range turns {
+		keys = append(keys, keysFor(turn)...)
+	}
+	return keys
 }
 
 // TestFileProjectionReproducesLiveLogicalTurnKeys is the differential oracle

--- a/internal/apptranscript/logical_turn_grouping_test.go
+++ b/internal/apptranscript/logical_turn_grouping_test.go
@@ -145,16 +145,6 @@ func keysForTurns(turns []appwire.Turn) []string {
 	return keys
 }
 
-// TestFileProjectionReproducesLiveLogicalTurnKeys is the differential oracle
-// for F3: the file projection of a persisted logical turn must yield the same
-// turn id, entry ordinal, and item ordinals the live snapshot would have
-// allocated for the same items.
-//
-// Live allocation (appTurnSnapshot semantics, reproduced from the projector's
-// notification stream): each logical turn consumes one entry ordinal; items
-// are numbered 0..n-1 in arrival order. With no prelude, turn 1 opens at entry
-// ordinal 0 (user item 0, assistant item 1); turn 2 opens at entry ordinal 1
-// (user item 0, merged tool item 1, final assistant item 2).
 func TestItemReadersStampInterruptedSteeringOnGroupedTurn(t *testing.T) {
 	for _, failed := range []bool{false, true} {
 		name := "interrupted"

--- a/internal/apptranscript/steering_append_identity_test.go
+++ b/internal/apptranscript/steering_append_identity_test.go
@@ -1,0 +1,160 @@
+package apptranscript
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+// TestSteeringOwnerIncrementalIndexIdentity keeps one indexed cache alive while
+// a session grows through the same append sequence used by the daemon. The
+// steering entry may stay in the already-open m10 logical turn or open the
+// delayed m11 owner; either way, every warm indexed read must agree with the
+// full projection and with one-item/one-turn paging.
+func TestSteeringOwnerIncrementalIndexIdentity(t *testing.T) {
+	t.Run("inline_m10_then_delayed_m11", func(t *testing.T) {
+		path := t.TempDir() + "/session.transcript.jsonl"
+		writer, err := transcript.NewWriter(path, transcript.Header{SessionID: "steering-append"})
+		if err != nil {
+			t.Fatalf("NewWriter: %v", err)
+		}
+		defer func() {
+			if err := writer.Close(); err != nil {
+				t.Errorf("Close: %v", err)
+			}
+		}()
+
+		appendTurn := func(turn schema.Turn) {
+			t.Helper()
+			if err := writer.Append(turn); err != nil {
+				t.Fatalf("Append %s: %v", turn.Kind, err)
+			}
+		}
+
+		appendTurn(schema.Turn{
+			Kind:         schema.TurnUserInput,
+			StableTurnID: "turn_m10",
+			Message:      llm.User("prefix"),
+		})
+		appendTurn(steeringAppendAssistantToolCall("prefix-call", "prefix_tool"))
+
+		cache := NewTurnCache()
+		assertSteeringAppendReads(t, cache, path, "turn_m10")
+
+		appendTurn(schema.Turn{
+			Kind:         schema.TurnSteering,
+			StableTurnID: "mutation_m11",
+			OwningTurnID: "turn_m10",
+			Message:      llm.User("steer"),
+		})
+		assertSteeringAppendReads(t, cache, path, "turn_m10")
+
+		appendTurn(steeringAppendAssistantToolCall("followup-call", "followup_tool"))
+		assertSteeringAppendReads(t, cache, path, "turn_m10")
+
+		appendTurn(schema.Turn{
+			Kind: schema.TurnToolResults,
+			Message: llm.Message{Content: []llm.ContentPart{{
+				Kind:       llm.ContentToolResult,
+				ToolResult: &llm.ToolResultData{ToolCallID: "followup-call", Name: "followup_tool", Content: "result"},
+			}}},
+		})
+		assertSteeringAppendReads(t, cache, path, "turn_m10")
+
+		appendTurn(schema.Turn{Kind: schema.TurnSteering, StableTurnID: "mutation_m12", OwningTurnID: "turn_m11", Message: llm.User("delayed steer")})
+		assertSteeringAppendReads(t, cache, path, "turn_m11")
+		appendTurn(steeringAppendAssistantToolCall("delayed-call", "delayed_tool"))
+		assertSteeringAppendReads(t, cache, path, "turn_m11")
+		appendTurn(schema.Turn{Kind: schema.TurnToolResults, Message: llm.Message{Content: []llm.ContentPart{{Kind: llm.ContentToolResult, ToolResult: &llm.ToolResultData{ToolCallID: "delayed-call", Name: "delayed_tool", Content: "delayed result"}}}}})
+		assertSteeringAppendReads(t, cache, path, "turn_m11")
+	})
+}
+
+func steeringAppendAssistantToolCall(id, name string) schema.Turn {
+	return schema.Turn{
+		Kind: schema.TurnAssistant,
+		Message: llm.Message{Content: []llm.ContentPart{{
+			Kind:     llm.ContentToolCall,
+			ToolCall: &llm.ToolCallData{ID: id, Name: name, Arguments: []byte(`{"input":"value"}`)},
+		}}},
+	}
+}
+
+func assertSteeringAppendReads(t *testing.T, cache *TurnCache, path, owner string) {
+	t.Helper()
+	index, _, err := cache.loadTurnIndexContext(context.Background(), path, testMaxLineBytes, boundedTestProjector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := openGroupState(index); got != owner {
+		t.Fatalf("append owner = %q, want persisted logical owner %q", got, owner)
+	}
+	window, _, err := cache.LatestItemWindowFromFile(path, testMaxLineBytes, ItemWindowOptions{
+		ThreadRef: "local:steering-append-" + owner,
+		Limit:     1,
+	}, boundedTestProjector)
+	if err != nil {
+		t.Fatalf("%s LatestItemWindowFromFile: %v", owner, err)
+	}
+	if len(window.Candidates) != 1 {
+		t.Fatalf("%s latest candidate count=%d, want 1", owner, len(window.Candidates))
+	}
+	gotItems := append([]appwire.ThreadItem(nil), window.Candidates[0].Item)
+	for window.OlderCursor != "" {
+		window, _, err = cache.PreviousItemWindowFromFile(path, testMaxLineBytes, ItemWindowOptions{
+			ThreadRef: "local:steering-append-" + owner,
+			Cursor:    window.OlderCursor,
+			Limit:     1,
+		}, boundedTestProjector)
+		if err != nil {
+			t.Fatalf("%s PreviousItemWindowFromFile: %v", owner, err)
+		}
+		gotItems = append([]appwire.ThreadItem{window.Candidates[0].Item}, gotItems...)
+	}
+	full := requireItemTurnsFromFile(t, path, testMaxLineBytes, sequentialTestProjector())
+	wantIDs := []string{"turn_m10"}
+	if owner == "turn_m11" {
+		wantIDs = append(wantIDs, owner)
+	}
+	if got := turnIDs(full); !reflect.DeepEqual(got, wantIDs) {
+		t.Fatalf("%s full turn IDs=%v, want %v", owner, got, wantIDs)
+	}
+
+	wantItems := flattenSteeringAppendItems(full)
+	if len(gotItems) != len(wantItems) {
+		t.Fatalf("%s item count=%d, want %d (full turns=%d)", owner, len(gotItems), len(wantItems), len(full))
+	}
+	for i := range wantItems {
+		got, want := gotItems[i], wantItems[i]
+		if got.TranscriptKey != want.TranscriptKey || got.Position == nil || want.Position == nil || *got.Position != *want.Position {
+			t.Fatalf("%s item %d identity=(key %q, position %+v), want (key %q, position %+v)", owner, i, got.TranscriptKey, got.Position, want.TranscriptKey, want.Position)
+		}
+	}
+
+	var paged []appwire.Turn
+	cursor := ""
+	for {
+		page := requirePageFromFile(t, cache, path, testMaxLineBytes, cursor, 1, boundedTestProjector)
+		paged = append(page.Turns, paged...)
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	if !reflect.DeepEqual(paged, full) {
+		t.Fatalf("%s full/page projection differ: full=%#v paged=%#v", owner, full, paged)
+	}
+}
+
+func flattenSteeringAppendItems(turns []appwire.Turn) []appwire.ThreadItem {
+	items := make([]appwire.ThreadItem, 0)
+	for _, turn := range turns {
+		items = append(items, turn.Items...)
+	}
+	return items
+}

--- a/internal/apptranscript/turn_index.go
+++ b/internal/apptranscript/turn_index.go
@@ -257,15 +257,25 @@ func (d turnIndexDisk) logicalTurnCount() int {
 	}
 	n := d.recordCount()
 	groupItems := uint64(0)
+	openTurnID := ""
 	for i := range n {
 		record := d.recordAt(i)
-		if i > 0 && recordStartsGroup(record.TurnKind, d.recordAt(i-1).TurnKind, record.GoalContinuation, record.OwningTurnID, "") {
+		prevKind := schema.TurnKind("")
+		if i > 0 {
+			prevKind = d.recordAt(i - 1).TurnKind
+		}
+		starts := i == 0 || recordStartsGroup(record.TurnKind, prevKind, record.GoalContinuation, record.OwningTurnID, openTurnID)
+		if starts {
 			// The previous group just closed: count it when it projected
 			// items.
-			if groupItems > 0 {
+			if i > 0 && groupItems > 0 {
 				count++
 			}
 			groupItems = 0
+			openTurnID = record.TurnID
+			if record.OwningTurnID != "" {
+				openTurnID = record.OwningTurnID
+			}
 		}
 		groupItems += uint64(record.GroupItems)
 	}
@@ -305,8 +315,14 @@ func (d turnIndexDisk) indexedGroups() []indexedGroup {
 	for i := range n {
 		record := d.recordAt(i)
 		role := groupRoleFor(record.TurnKind, record.GoalContinuation)
-		join := role == groupContinuation && len(groups) > 0 && groups[len(groups)-1].open
-		if join {
+		prevKind := schema.TurnKind("")
+		openTurnID := ""
+		if len(groups) > 0 {
+			prevKind = d.recordAt(i - 1).TurnKind
+			openTurnID = groups[len(groups)-1].turnID
+		}
+		starts := i == 0 || recordStartsGroup(record.TurnKind, prevKind, record.GoalContinuation, record.OwningTurnID, openTurnID)
+		if !starts && role == groupContinuation && len(groups) > 0 && groups[len(groups)-1].open {
 			group := &groups[len(groups)-1]
 			group.end = i + 1
 			group.items += uint64(record.GroupItems)
@@ -1775,14 +1791,26 @@ func openGroupState(index turnIndexDisk) (string, map[string]bool) {
 		return "", calls
 	}
 	turnID := ""
-	for i := n - 1; i >= 0; i-- {
+	open := false
+	for i := 0; i < n; i++ {
 		record := index.recordAt(i)
+		prevKind := schema.TurnKind("")
+		if i > 0 {
+			prevKind = index.recordAt(i - 1).TurnKind
+		}
+		starts := i == 0 || recordStartsGroup(record.TurnKind, prevKind, record.GoalContinuation, record.OwningTurnID, turnID)
+		if starts {
+			turnID = record.TurnID
+			if record.OwningTurnID != "" {
+				turnID = record.OwningTurnID
+			}
+			calls = map[string]bool{}
+			open = groupRoleFor(record.TurnKind, record.GoalContinuation) != groupStandalone
+		} else if !open {
+			continue
+		}
 		for _, id := range record.GroupCalls {
 			calls[id] = true
-		}
-		turnID = record.TurnID
-		if i == 0 || recordStartsGroup(record.TurnKind, index.recordAt(i-1).TurnKind, record.GoalContinuation, record.OwningTurnID, turnID) {
-			break
 		}
 	}
 	if turnID == "" && n > 0 {

--- a/internal/apptranscript/turn_index.go
+++ b/internal/apptranscript/turn_index.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	turnIndexVersion        = 12
+	turnIndexVersion        = 13
 	turnIndexJournalVersion = 3
 	turnIndexAnchorBytes    = 256
 
@@ -168,6 +168,7 @@ type indexedTurn struct {
 	// GoalContinuation distinguishes a top-level goal opener from ordinary
 	// steering without retaining model or display text in the derived index.
 	GoalContinuation bool     `json:"goal_continuation,omitempty"`
+	OwningTurnID     string   `json:"owning_turn_id,omitempty"`
 	TurnID           string   `json:"turn_id,omitempty"`
 	GroupItems       uint32   `json:"group_items,omitempty"`
 	GroupCalls       []string `json:"group_calls,omitempty"`
@@ -258,7 +259,7 @@ func (d turnIndexDisk) logicalTurnCount() int {
 	groupItems := uint64(0)
 	for i := range n {
 		record := d.recordAt(i)
-		if i > 0 && recordStartsGroup(record.TurnKind, d.recordAt(i-1).TurnKind, record.GoalContinuation) {
+		if i > 0 && recordStartsGroup(record.TurnKind, d.recordAt(i-1).TurnKind, record.GoalContinuation, record.OwningTurnID, "") {
 			// The previous group just closed: count it when it projected
 			// items.
 			if groupItems > 0 {
@@ -889,20 +890,27 @@ func scanTurnIndexWithCommitContext(ctx context.Context, file *os.File, transcri
 			entryIndex++
 			record := indexedTurn{Offset: offset, Length: length, Index: entryIndex, Kind: entry.Kind, TurnKind: entry.Turn.Kind}
 			record.GoalContinuation = entry.Turn.Kind == schema.TurnSteering && entry.Turn.GoalContinuation != nil
+			record.OwningTurnID = entry.Turn.OwningTurnID
 			record.ToolSeed, record.ToolChanges = toolProjectionState(entry, projectNames)
 			// Logical-group bookkeeping runs BEFORE projection: the entry is
 			// projected under its group's turn id (the opener's), exactly
 			// the way the range reader names it, so the index scan and the
 			// projection cannot disagree (kata: one name per entry).
 			record.TurnID = persistedTurnID(entry.Turn, entryIndex)
+			if record.OwningTurnID != "" {
+				record.TurnID = record.OwningTurnID
+			}
 			prevKind := schema.TurnKind("")
 			if len(appended) > 0 {
 				prevKind = appended[len(appended)-1].TurnKind
 			} else if n := index.recordCount(); n > 0 {
 				prevKind = index.recordAt(n - 1).TurnKind
 			}
-			if recordStartsGroup(entry.Turn.Kind, prevKind, record.GoalContinuation) {
+			if recordStartsGroup(entry.Turn.Kind, prevKind, record.GoalContinuation, record.OwningTurnID, openTurnID) {
 				openTurnID = record.TurnID
+				if record.OwningTurnID != "" {
+					openTurnID = record.OwningTurnID
+				}
 				openCalls = map[string]bool{}
 			} else if openCalls == nil || openTurnID == "" {
 				// Continues a group whose opener lives in the previously
@@ -1162,7 +1170,7 @@ func projectIndexedRangeObservedContext(ctx context.Context, path string, index 
 		// groups: find where this group's span ends, then decide whether to
 		// project it.
 		spanEnd := i + 1
-		for spanEnd < n && !recordStartsGroup(index.recordAt(spanEnd).TurnKind, index.recordAt(spanEnd-1).TurnKind, index.recordAt(spanEnd).GoalContinuation) {
+		for spanEnd < n && !recordStartsGroup(index.recordAt(spanEnd).TurnKind, index.recordAt(spanEnd-1).TurnKind, index.recordAt(spanEnd).GoalContinuation, index.recordAt(spanEnd).OwningTurnID, index.recordAt(i).TurnID) {
 			spanEnd++
 		}
 		groupItems := uint64(0)
@@ -1773,7 +1781,7 @@ func openGroupState(index turnIndexDisk) (string, map[string]bool) {
 			calls[id] = true
 		}
 		turnID = record.TurnID
-		if i == 0 || recordStartsGroup(record.TurnKind, index.recordAt(i-1).TurnKind, record.GoalContinuation) {
+		if i == 0 || recordStartsGroup(record.TurnKind, index.recordAt(i-1).TurnKind, record.GoalContinuation, record.OwningTurnID, turnID) {
 			break
 		}
 	}

--- a/internal/apptranscript/turn_index.go
+++ b/internal/apptranscript/turn_index.go
@@ -167,11 +167,14 @@ type indexedTurn struct {
 	TurnKind schema.TurnKind `json:"turn_kind,omitempty"`
 	// GoalContinuation distinguishes a top-level goal opener from ordinary
 	// steering without retaining model or display text in the derived index.
-	GoalContinuation bool     `json:"goal_continuation,omitempty"`
-	OwningTurnID     string   `json:"owning_turn_id,omitempty"`
-	TurnID           string   `json:"turn_id,omitempty"`
-	GroupItems       uint32   `json:"group_items,omitempty"`
-	GroupCalls       []string `json:"group_calls,omitempty"`
+	GoalContinuation bool `json:"goal_continuation,omitempty"`
+	// StartsGroup is derived once with the owning turn in scope. Readers and
+	// append recovery reuse the same boundary instead of inferring ownership
+	// from a continuation record's per-entry identity.
+	StartsGroup bool     `json:"starts_group,omitempty"`
+	TurnID      string   `json:"turn_id,omitempty"`
+	GroupItems  uint32   `json:"group_items,omitempty"`
+	GroupCalls  []string `json:"group_calls,omitempty"`
 }
 
 // groupRole classifies a record within its logical turn group.
@@ -257,25 +260,15 @@ func (d turnIndexDisk) logicalTurnCount() int {
 	}
 	n := d.recordCount()
 	groupItems := uint64(0)
-	openTurnID := ""
 	for i := range n {
 		record := d.recordAt(i)
-		prevKind := schema.TurnKind("")
-		if i > 0 {
-			prevKind = d.recordAt(i - 1).TurnKind
-		}
-		starts := i == 0 || recordStartsGroup(record.TurnKind, prevKind, record.GoalContinuation, record.OwningTurnID, openTurnID)
-		if starts {
+		if i > 0 && record.StartsGroup {
 			// The previous group just closed: count it when it projected
 			// items.
-			if i > 0 && groupItems > 0 {
+			if groupItems > 0 {
 				count++
 			}
 			groupItems = 0
-			openTurnID = record.TurnID
-			if record.OwningTurnID != "" {
-				openTurnID = record.OwningTurnID
-			}
 		}
 		groupItems += uint64(record.GroupItems)
 	}
@@ -315,14 +308,8 @@ func (d turnIndexDisk) indexedGroups() []indexedGroup {
 	for i := range n {
 		record := d.recordAt(i)
 		role := groupRoleFor(record.TurnKind, record.GoalContinuation)
-		prevKind := schema.TurnKind("")
-		openTurnID := ""
-		if len(groups) > 0 {
-			prevKind = d.recordAt(i - 1).TurnKind
-			openTurnID = groups[len(groups)-1].turnID
-		}
-		starts := i == 0 || recordStartsGroup(record.TurnKind, prevKind, record.GoalContinuation, record.OwningTurnID, openTurnID)
-		if !starts && role == groupContinuation && len(groups) > 0 && groups[len(groups)-1].open {
+		join := !record.StartsGroup && role == groupContinuation && len(groups) > 0 && groups[len(groups)-1].open
+		if join {
 			group := &groups[len(groups)-1]
 			group.end = i + 1
 			group.items += uint64(record.GroupItems)
@@ -906,17 +893,21 @@ func scanTurnIndexWithCommitContext(ctx context.Context, file *os.File, transcri
 			entryIndex++
 			record := indexedTurn{Offset: offset, Length: length, Index: entryIndex, Kind: entry.Kind, TurnKind: entry.Turn.Kind}
 			record.GoalContinuation = entry.Turn.Kind == schema.TurnSteering && entry.Turn.GoalContinuation != nil
-			if entry.Turn.Kind == schema.TurnSteering {
-				record.OwningTurnID = entry.Turn.OwningTurnID
-			}
 			record.ToolSeed, record.ToolChanges = toolProjectionState(entry, projectNames)
 			// Logical-group bookkeeping runs BEFORE projection: the entry is
 			// projected under its group's turn id (the opener's), exactly
 			// the way the range reader names it, so the index scan and the
 			// projection cannot disagree (kata: one name per entry).
 			record.TurnID = persistedTurnID(entry.Turn, entryIndex)
-			if record.OwningTurnID != "" {
-				record.TurnID = record.OwningTurnID
+			owner := ""
+			if entry.Turn.Kind == schema.TurnSteering && !record.GoalContinuation {
+				owner = entry.Turn.OwningTurnID
+			}
+			if owner != "" {
+				record.TurnID = owner
+				if openTurnID == "" {
+					openTurnID, openCalls = openGroupState(*index)
+				}
 			}
 			prevKind := schema.TurnKind("")
 			if len(appended) > 0 {
@@ -924,11 +915,9 @@ func scanTurnIndexWithCommitContext(ctx context.Context, file *os.File, transcri
 			} else if n := index.recordCount(); n > 0 {
 				prevKind = index.recordAt(n - 1).TurnKind
 			}
-			if recordStartsGroup(entry.Turn.Kind, prevKind, record.GoalContinuation, record.OwningTurnID, openTurnID) {
+			record.StartsGroup = recordStartsGroup(entry.Turn.Kind, prevKind, record.GoalContinuation, owner, openTurnID)
+			if record.StartsGroup {
 				openTurnID = record.TurnID
-				if record.OwningTurnID != "" {
-					openTurnID = record.OwningTurnID
-				}
 				openCalls = map[string]bool{}
 			} else if openCalls == nil || openTurnID == "" {
 				// Continues a group whose opener lives in the previously
@@ -1188,7 +1177,7 @@ func projectIndexedRangeObservedContext(ctx context.Context, path string, index 
 		// groups: find where this group's span ends, then decide whether to
 		// project it.
 		spanEnd := i + 1
-		for spanEnd < n && !recordStartsGroup(index.recordAt(spanEnd).TurnKind, index.recordAt(spanEnd-1).TurnKind, index.recordAt(spanEnd).GoalContinuation, index.recordAt(spanEnd).OwningTurnID, index.recordAt(i).TurnID) {
+		for spanEnd < n && !index.recordAt(spanEnd).StartsGroup {
 			spanEnd++
 		}
 		groupItems := uint64(0)
@@ -1792,28 +1781,19 @@ func openGroupState(index turnIndexDisk) (string, map[string]bool) {
 	if n == 0 {
 		return "", calls
 	}
-	tail := index.recordAt(n - 1)
-	turnID := tail.TurnID
-	if tail.OwningTurnID != "" {
-		turnID = tail.OwningTurnID
-	}
-	open := groupRoleFor(tail.TurnKind, tail.GoalContinuation) != groupStandalone
+	turnID := ""
 	for i := n - 1; i >= 0; i-- {
 		record := index.recordAt(i)
 		for _, id := range record.GroupCalls {
 			calls[id] = true
 		}
-		if i == 0 || !open {
+		turnID = record.TurnID
+		if i == 0 || record.StartsGroup {
 			break
 		}
-		prevPrevKind := schema.TurnKind("")
-		if i > 1 {
-			prevPrevKind = index.recordAt(i - 2).TurnKind
-		}
-		prev := index.recordAt(i - 1)
-		if recordStartsGroup(prev.TurnKind, prevPrevKind, prev.GoalContinuation, prev.OwningTurnID, turnID) {
-			break
-		}
+	}
+	if turnID == "" && n > 0 {
+		turnID = persistedTurnID(recordAtKindTurn(index, n-1), index.recordAt(n-1).Index)
 	}
 	return turnID, calls
 }

--- a/internal/apptranscript/turn_index.go
+++ b/internal/apptranscript/turn_index.go
@@ -906,7 +906,9 @@ func scanTurnIndexWithCommitContext(ctx context.Context, file *os.File, transcri
 			entryIndex++
 			record := indexedTurn{Offset: offset, Length: length, Index: entryIndex, Kind: entry.Kind, TurnKind: entry.Turn.Kind}
 			record.GoalContinuation = entry.Turn.Kind == schema.TurnSteering && entry.Turn.GoalContinuation != nil
-			record.OwningTurnID = entry.Turn.OwningTurnID
+			if entry.Turn.Kind == schema.TurnSteering {
+				record.OwningTurnID = entry.Turn.OwningTurnID
+			}
 			record.ToolSeed, record.ToolChanges = toolProjectionState(entry, projectNames)
 			// Logical-group bookkeeping runs BEFORE projection: the entry is
 			// projected under its group's turn id (the opener's), exactly
@@ -1790,31 +1792,28 @@ func openGroupState(index turnIndexDisk) (string, map[string]bool) {
 	if n == 0 {
 		return "", calls
 	}
-	turnID := ""
-	open := false
-	for i := 0; i < n; i++ {
+	tail := index.recordAt(n - 1)
+	turnID := tail.TurnID
+	if tail.OwningTurnID != "" {
+		turnID = tail.OwningTurnID
+	}
+	open := groupRoleFor(tail.TurnKind, tail.GoalContinuation) != groupStandalone
+	for i := n - 1; i >= 0; i-- {
 		record := index.recordAt(i)
-		prevKind := schema.TurnKind("")
-		if i > 0 {
-			prevKind = index.recordAt(i - 1).TurnKind
-		}
-		starts := i == 0 || recordStartsGroup(record.TurnKind, prevKind, record.GoalContinuation, record.OwningTurnID, turnID)
-		if starts {
-			turnID = record.TurnID
-			if record.OwningTurnID != "" {
-				turnID = record.OwningTurnID
-			}
-			calls = map[string]bool{}
-			open = groupRoleFor(record.TurnKind, record.GoalContinuation) != groupStandalone
-		} else if !open {
-			continue
-		}
 		for _, id := range record.GroupCalls {
 			calls[id] = true
 		}
-	}
-	if turnID == "" && n > 0 {
-		turnID = persistedTurnID(recordAtKindTurn(index, n-1), index.recordAt(n-1).Index)
+		if i == 0 || !open {
+			break
+		}
+		prevPrevKind := schema.TurnKind("")
+		if i > 1 {
+			prevPrevKind = index.recordAt(i - 2).TurnKind
+		}
+		prev := index.recordAt(i - 1)
+		if recordStartsGroup(prev.TurnKind, prevPrevKind, prev.GoalContinuation, prev.OwningTurnID, turnID) {
+			break
+		}
 	}
 	return turnID, calls
 }

--- a/server/appwire_steering_owner_replay_test.go
+++ b/server/appwire_steering_owner_replay_test.go
@@ -189,8 +189,8 @@ func assertSteeringOwnerInTranscript(t *testing.T, path, startedID, steerStableI
 	for sc.Scan() {
 		entry, decodeErr := transcript.DecodeEntry(sc.Bytes())
 		if decodeErr == nil && entry.Turn.Kind == schema.TurnSteering && entry.Turn.ClientMutationID == "steer-stable" {
-			copy := entry.Turn
-			found = &copy
+			steering := entry.Turn
+			found = &steering
 		}
 	}
 	if err := sc.Err(); err != nil {

--- a/server/appwire_steering_owner_replay_test.go
+++ b/server/appwire_steering_owner_replay_test.go
@@ -1,0 +1,237 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+
+	"primeradiant.com/evener/agent"
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/agent/transcript"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/llm"
+)
+
+// TestLiveSteeringOwnerIdentityReplays exercises the real session event bridge
+// for both steering delivery sites. The warmup turn is persisted before the
+// server is installed, so environment setup and cold hydration cannot hide a
+// missing owner on a live steering append. This regression compares the
+// steering carrier itself; full multi-round diagnostic parity has a separate
+// failure because live round timings currently consume unsaved item ordinals.
+func TestLiveSteeringOwnerIdentityReplays(t *testing.T) {
+	for _, delayed := range []bool{false, true} {
+		name := "inline"
+		if delayed {
+			name = "delayed"
+		}
+		t.Run(name, func(t *testing.T) {
+			var sess *agent.Session
+			adapter := &steeringOwnerReplayAdapter{delayed: delayed}
+			sess = newMutationReplaySessionWithAdapter(t, adapter)
+			adapter.sess = sess
+
+			warmupDone := make(chan struct{})
+			turnDone := make(chan struct{}, 2)
+			var bridgeMu sync.Mutex
+			live := false
+			var srv *Server
+			go sess.ConsumeEventsLossless(func(ev events.SessionEvent) {
+				bridgeMu.Lock()
+				enabled, current := live, srv
+				bridgeMu.Unlock()
+				if !enabled {
+					if ev.Kind == events.EventSessionEnd {
+						close(warmupDone)
+					}
+					return
+				}
+				if current != nil {
+					current.RecordAppEvent(ev)
+					if ev.Kind == events.EventSessionEnd {
+						turnDone <- struct{}{}
+					}
+				}
+			}, func() {})
+
+			_, err := sess.AcceptClientMutationStart(appwire.TurnStartParams{
+				ClientMutationID:   "warmup",
+				ExpectedInstanceID: sess.ID(),
+				Input:              []appwire.InputItem{{Type: "text", Text: "warmup environment"}},
+			})
+			if err != nil {
+				t.Fatalf("warmup start: %v", err)
+			}
+			if _, _, err := sess.ProcessClientMutationStart(context.Background(), nil); err != nil {
+				t.Fatalf("warmup process: %v", err)
+			}
+			<-warmupDone
+
+			server := NewServer(ServerConfig{})
+			installTranscriptIdentity(t, server, sess.ID(), sess.TranscriptPath())
+			bridgeMu.Lock()
+			srv = server
+			live = true
+			bridgeMu.Unlock()
+			start, err := sess.AcceptClientMutationStart(appwire.TurnStartParams{
+				ClientMutationID:   "actual-start",
+				ExpectedInstanceID: sess.ID(),
+				Input:              []appwire.InputItem{{Type: "text", Text: "actual question"}},
+			})
+			if err != nil {
+				t.Fatalf("actual start: %v", err)
+			}
+			if _, _, err := sess.ProcessClientMutationStart(context.Background(), nil); err != nil {
+				t.Fatalf("actual process: %v", err)
+			}
+			<-turnDone
+			if delayed {
+				if _, ran, err := sess.ProcessPendingUserInput(context.Background(), nil); err != nil || !ran {
+					t.Fatalf("delayed carrier: ran=%v err=%v", ran, err)
+				}
+				<-turnDone
+			}
+
+			if adapter.steerStableID == "" {
+				t.Fatalf("adapter never accepted steering (calls=%d)", adapter.calls)
+			}
+			assertSteeringOwnerInTranscript(t, sess.TranscriptPath(), start.Turn.ID, adapter.steerStableID, delayed)
+			full, _, err := appTurnsFromTranscriptFile(sess.TranscriptPath())
+			if err != nil {
+				t.Fatalf("cold projection: %v", err)
+			}
+			if got := len(steeringReplayIdentities(full)); got != 1 {
+				t.Fatalf("projected steering items = %d, want one accepted mutation", got)
+			}
+			read, err := srv.handleAppThreadRead(context.Background(), appwire.ThreadReadParams{Ref: "local:" + sess.ID(), IncludeTurns: true})
+			if err != nil {
+				t.Fatalf("live read: %v", err)
+			}
+			if !reflect.DeepEqual(steeringReplayIdentities(read.Thread.Turns), steeringReplayIdentities(full)) {
+				t.Fatalf("live projection identities differ from cold projection:\nlive=%#v\ncold=%#v", steeringReplayIdentities(read.Thread.Turns), steeringReplayIdentities(full))
+			}
+
+			initial, err := srv.handleAppThreadRead(context.Background(), appwire.ThreadReadParams{Ref: "local:" + sess.ID(), IncludeTurns: true, ItemLimit: 1})
+			if err != nil {
+				t.Fatalf("tiny initial read: %v", err)
+			}
+			paged := initial.Thread.Turns
+			cursor := initial.OlderCursor
+			for cursor != "" {
+				page, err := srv.handleAppThreadTurnsList(context.Background(), appwire.ThreadTurnsListParams{Ref: "local:" + sess.ID(), Cursor: cursor, ItemLimit: 1})
+				if err != nil {
+					t.Fatalf("tiny page: %v", err)
+				}
+				paged = append(page.Data, paged...)
+				cursor = page.NextCursor
+			}
+			if !reflect.DeepEqual(steeringReplayIdentities(paged), steeringReplayIdentities(full)) {
+				t.Fatalf("tiny page identities differ from cold projection:\npaged=%#v\ncold=%#v", steeringReplayIdentities(paged), steeringReplayIdentities(full))
+			}
+		})
+	}
+}
+
+type steeringOwnerReplayAdapter struct {
+	sess          *agent.Session
+	delayed       bool
+	calls         int
+	steerStableID string
+}
+
+func (a *steeringOwnerReplayAdapter) Name() string { return "openai" }
+
+func (a *steeringOwnerReplayAdapter) Complete(_ context.Context, req llm.Request) (llm.Response, error) {
+	if !requestHasTool(req, "communicate") {
+		return llm.Response{Provider: a.Name(), Model: req.Model, Message: llm.Assistant("warmup")}, nil
+	}
+	a.calls++
+	if a.calls >= 2 && a.steerStableID == "" {
+		response, err := a.sess.AcceptClientMutationSteer(appwire.TurnSteerParams{
+			ClientMutationID:   "steer-stable",
+			ExpectedInstanceID: a.sess.ID(),
+			Input:              []appwire.InputItem{{Type: "text", Text: "steering input"}},
+		})
+		if err != nil {
+			return llm.Response{}, err
+		}
+		a.steerStableID = response.Receipt.TurnID
+	}
+	response := steeringOwnerCommunicateResponse(a.delayed || a.calls != 2, a.calls)
+	response.Provider = a.Name()
+	response.Model = req.Model
+	return response, nil
+}
+
+func (a *steeringOwnerReplayAdapter) Stream(context.Context, llm.Request) (llm.Stream, error) {
+	return nil, llm.ErrStreamUnsupported
+}
+
+func steeringOwnerCommunicateResponse(endTurn bool, call int) llm.Response {
+	args, _ := json.Marshal(map[string]any{"message": "done", "end_turn": endTurn, "output": map[string]any{"message": "", "data": map[string]any{}, "artifacts": []string{}}})
+	return llm.Response{Message: llm.Message{Role: llm.RoleAssistant, Content: []llm.ContentPart{{Kind: llm.ContentToolCall, ToolCall: &llm.ToolCallData{ID: fmt.Sprintf("steering-call-%d", call), Name: "communicate", Arguments: args, Type: "function"}}}}}
+}
+
+func assertSteeringOwnerInTranscript(t *testing.T, path, startedID, steerStableID string, delayed bool) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open transcript: %v", err)
+	}
+	defer f.Close()
+	var found *schema.Turn
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		entry, decodeErr := transcript.DecodeEntry(sc.Bytes())
+		if decodeErr == nil && entry.Turn.Kind == schema.TurnSteering && entry.Turn.ClientMutationID == "steer-stable" {
+			copy := entry.Turn
+			found = &copy
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan transcript: %v", err)
+	}
+	if found == nil {
+		t.Fatal("transcript has no steering entry")
+	}
+	wantOwner := startedID
+	if delayed {
+		wantOwner = steerStableID
+	}
+	if steerStableID == "" {
+		t.Fatal("steering receipt has no stable turn id")
+	}
+	if found.OwningTurnID != wantOwner {
+		t.Fatalf("steering owner=%q, want %q", found.OwningTurnID, wantOwner)
+	}
+	if found.StableTurnID != steerStableID {
+		t.Fatalf("steering stable id=%q, want %q", found.StableTurnID, steerStableID)
+	}
+}
+
+type steeringReplayIdentity struct {
+	TurnID, Type, Key string
+	Position          appwire.ThreadItemPosition
+}
+
+func steeringReplayIdentities(turns []appwire.Turn) []steeringReplayIdentity {
+	var result []steeringReplayIdentity
+	for _, turn := range turns {
+		for _, item := range turn.Items {
+			if item.Type != "steering" {
+				continue
+			}
+			position := appwire.ThreadItemPosition{}
+			if item.Position != nil {
+				position = *item.Position
+			}
+			result = append(result, steeringReplayIdentity{turn.ID, item.Type, item.TranscriptKey, position})
+		}
+	}
+	return result
+}


### PR DESCRIPTION
Client steering was saved with its mutation identity but without the logical turn that actually consumed it. A restart could group inline steering with a different turn and change its transcript key, producing duplicates in a retained mobile history.

Persist the active owner when steering is delivered, keeping the receipt identity distinct. Full replay and the derived index use that owner to retain inline steering in its running turn and open a separate group for a delayed carrier. Notification reminders persist the actual notification turn owner too, so a following client steer belongs to the same group. The index derives boundaries from the semantic owner rather than storing a second ownership copy.

Validation: real scripted Session and lossless bridge for inline/delayed steering; durable-file owner checks; full and indexed steering identity checks; a real notification turn after a completed user turn, with client steering accepted through the mutation API during the provider call, checking both durable owners against the real opening event; full server/transcript race suites and scoped lint. These steering assertions do not claim complete diagnostic-item parity: the separate timing-persistence PR adds that full oracle.

Current-head CI and an actual clean RoboRev verdict are required before merge; combined native/hub restart qualification remains separate.

All direct daemon steering append paths now preserve the active named turn owner as well. A public notification retry with no reminder exercises the real no-tool-calls steering append, compares its persisted owner to the lossless turn-start event and checks in-memory/saved projection identity. Full server and saved-transcript race suites, focused notification ownership race tests and scoped lint pass.
