### PR TITLE
test(web): retain Vite startup diagnostics in concurrent guard failures

### DIFF
--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -129,7 +129,14 @@ test("starts concurrent guards on Vite-owned ports and reaps their listeners", a
   };
   const results = await Promise.allSettled([start(), start()]);
   for (const result of results) {
-    if (result.status === "rejected") throw result.reason;
+    if (result.status === "rejected") {
+      context.diagnostic(
+        browserGuardProcess.describeBrowserStartupFailure({
+          error: result.reason,
+        }),
+      );
+      throw result.reason;
+    }
   }
   assert.equal(guards.length, 2);
   assert.notEqual(guards[0].vitePort, guards[1].vitePort);


### PR DESCRIPTION
A real concurrent Vite startup failure reaches the Node test reporter as only an exit code and stack, even though the browser guard already captured the child's stderr. Print the existing startup diagnostic before rethrowing so the failing test records the actual Vite cause.

Startup, cleanup, deadlines and assertions are unchanged. The original one-off integration failure did not reproduce in twenty serial repetitions, eight concurrent test processes, or all five canonical browser guards; this change does not claim to repair its unknown cause.

Validation: an actual missing-dependency startup failure now prints its captured Vite stderr in TAP, with the dependency restored afterwards. The focused real Vite test and all 64 Node harness tests pass. All five canonical browser guards passed during the investigation.
