### PR TITLE
fix(plugins): name every competing copy in duplicate diagnostics

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/spawn/PluginSelectionPanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/PluginSelectionPanel.test.tsx
@@ -33,7 +33,15 @@ const preview: PluginPreviewResponse = {
       mcpCount: 1,
     },
   ],
-  diagnostics: [{ name: "ignored", source: "directory", message: "could not be loaded" }],
+  diagnostics: [
+    { name: "ignored", source: "directory", message: "could not be loaded" },
+    {
+      name: "superpowers",
+      source: "installed",
+      path: "/cache/superpowers",
+      message: 'duplicate plugin name "superpowers"; keeping the first of: /dev/superpowers, /cache/superpowers',
+    },
+  ],
   selectionErrors: [{ name: "missing", reason: "no valid current winner" }],
 };
 
@@ -107,6 +115,26 @@ test("exposes diagnostics and blocking selection errors without relying on color
   const details = screen.getByText(/preview diagnostic/);
   await user.click(details);
   expect(screen.getByText("could not be loaded")).toBeTruthy();
+});
+
+test("diagnostics render above the plugin list", () => {
+  renderPanel();
+
+  const text = screen.getByTestId("plugin-selection-panel").textContent ?? "";
+  const diagnosticAt = text.indexOf("could not be loaded");
+  const firstRowAt = text.indexOf("2 skills · 1 agent · 1 command");
+  expect(diagnosticAt).toBeGreaterThanOrEqual(0);
+  expect(diagnosticAt).toBeLessThan(firstRowAt);
+});
+
+test("a diagnostic whose message already names its path does not repeat it in parentheses", () => {
+  renderPanel();
+
+  const item = screen.getByText(/duplicate plugin name/).closest("li");
+  if (item === null) throw new Error("duplicate diagnostic list item not found");
+  expect(item.textContent).toBe(
+    'superpowers: duplicate plugin name "superpowers"; keeping the first of: /dev/superpowers, /cache/superpowers',
+  );
 });
 
 test("uses explicit names over preview selected flags", () => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/PluginSelectionPanel.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/PluginSelectionPanel.tsx
@@ -97,6 +97,23 @@ export function PluginSelectionPanel({
         </div>
       </div>
 
+      {diagnostics.length > 0 && (
+        <details className={CLASS.diagnostics}>
+          <summary>
+            {diagnostics.length} preview diagnostic{diagnostics.length === 1 ? "" : "s"} · Show details
+          </summary>
+          <ul>
+            {diagnostics.map((diagnostic) => (
+              <li key={`${diagnostic.name ?? ""}:${diagnostic.path ?? ""}:${diagnostic.message}`}>
+                {diagnostic.name && <strong>{diagnostic.name}: </strong>}
+                {diagnostic.message}
+                {diagnostic.path && !diagnostic.message.includes(diagnostic.path) && <span> ({diagnostic.path})</span>}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
       <div className={CLASS.list} data-testid="plugin-selection-list">
         {preview.plugins.map((plugin) => {
           const selected = selectedNames?.has(plugin.name) ?? plugin.selected;
@@ -156,22 +173,6 @@ export function PluginSelectionPanel({
             Retry
           </Button>
         </div>
-      )}
-      {diagnostics.length > 0 && (
-        <details className={CLASS.diagnostics}>
-          <summary>
-            {diagnostics.length} preview diagnostic{diagnostics.length === 1 ? "" : "s"} · Show details
-          </summary>
-          <ul>
-            {diagnostics.map((diagnostic) => (
-              <li key={`${diagnostic.name ?? ""}:${diagnostic.path ?? ""}:${diagnostic.message}`}>
-                {diagnostic.name && <strong>{diagnostic.name}: </strong>}
-                {diagnostic.message}
-                {diagnostic.path && <span> ({diagnostic.path})</span>}
-              </li>
-            ))}
-          </ul>
-        </details>
       )}
     </section>
   );

--- a/internal/plugins/resolve.go
+++ b/internal/plugins/resolve.go
@@ -160,7 +160,10 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 		Candidates: []LaunchPluginCandidate{}, SelectedDirs: []string{},
 		Diagnostics: []LaunchPluginDiagnostic{}, SelectionErrors: []PluginSelectionError{},
 	}
-	seen := make(map[string]bool)
+	// competing maps each manifest name to the paths of every candidate that
+	// offered it, winner first, so a duplicate's diagnostic can name every
+	// competing copy rather than only the one it is rejecting.
+	competing := make(map[string][]string)
 
 	// An inventory is something a caller acts on: the hub validates plugins
 	// and then detaches from the request context to finish the spawn, so an
@@ -214,11 +217,13 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 		}
 
 		name := instance.Manifest.Name
-		if seen[name] {
+		if prior := competing[name]; len(prior) > 0 {
+			paths := append(slices.Clone(prior), path)
+			competing[name] = paths
 			resolution.Diagnostics = append(resolution.Diagnostics, LaunchPluginDiagnostic{
 				Name:    name,
 				Path:    path,
-				Message: fmt.Sprintf("duplicate plugin name %q; keeping the first", name),
+				Message: fmt.Sprintf("duplicate plugin name %q; keeping the first of: %s", name, strings.Join(paths, ", ")),
 				Source:  source,
 			})
 			return
@@ -228,7 +233,7 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 		// requested by its embedded directory name, and
 		// TestBundledPluginsAreNamedAfterTheirDirectory pins that the two are
 		// the same string for every plugin this ships.
-		seen[name] = true
+		competing[name] = append(competing[name], path)
 
 		version := instance.Manifest.Version
 		if source == LaunchPluginSourceInstalled && registryVersion != "" {
@@ -284,7 +289,7 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 				})
 				continue
 			}
-			if !seen[name] && rootErr == nil {
+			if len(competing[name]) == 0 && rootErr == nil {
 				// Bundled plugins join the inventory only by request, so an
 				// unremarkable launch never picks them up. The lookup is by
 				// embedded directory name while add keys the inventory by
@@ -316,7 +321,7 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 					})
 				}
 			}
-			if !seen[name] {
+			if len(competing[name]) == 0 {
 				resolution.SelectionErrors = append(resolution.SelectionErrors, PluginSelectionError{
 					Name: name, Reason: "no valid plugin candidate",
 				})

--- a/internal/plugins/resolve_test.go
+++ b/internal/plugins/resolve_test.go
@@ -83,8 +83,14 @@ func TestResolveForLaunch_Contract(t *testing.T) {
 				}
 				assertCandidateNames(t, got, []string{"same", "alpha", "zeta"})
 				assertStrings(t, got.SelectedDirs, []string{explicit, alpha, zeta})
-				if len(got.Diagnostics) != 1 || got.Diagnostics[0].Name != "same" || !strings.Contains(got.Diagnostics[0].Message, "duplicate") {
+				dup := got.Diagnostics[0]
+				if len(got.Diagnostics) != 1 || dup.Name != "same" || !strings.Contains(dup.Message, "duplicate") {
 					t.Fatalf("duplicate diagnostic = %+v", got.Diagnostics)
+				}
+				installed := filepath.Join(root, "same-installed")
+				explicitAt, installedAt := strings.Index(dup.Message, explicit), strings.Index(dup.Message, installed)
+				if explicitAt < 0 || installedAt < 0 || explicitAt > installedAt {
+					t.Fatalf("duplicate diagnostic = %+v, want every competing path with the winner first", dup)
 				}
 			},
 		},
@@ -131,8 +137,43 @@ func TestResolveForLaunch_Contract(t *testing.T) {
 				if got.Diagnostics[0].Path != invalid || !strings.Contains(got.Diagnostics[0].Message, "load") && !strings.Contains(got.Diagnostics[0].Message, "plugin") {
 					t.Fatalf("invalid diagnostic = %+v", got.Diagnostics[0])
 				}
-				if got.Diagnostics[1].Name != "dup" || got.Diagnostics[1].Path != second {
-					t.Fatalf("duplicate diagnostic = %+v", got.Diagnostics[1])
+				dup := got.Diagnostics[1]
+				if dup.Name != "dup" || dup.Path != second {
+					t.Fatalf("duplicate diagnostic = %+v", dup)
+				}
+				firstAt, secondAt := strings.Index(dup.Message, first), strings.Index(dup.Message, second)
+				if firstAt < 0 || secondAt < 0 || firstAt > secondAt {
+					t.Fatalf("duplicate diagnostic = %+v, want every competing path with the winner first", dup)
+				}
+			},
+		},
+		{
+			name: "third duplicate names every competing path",
+			check: func(t *testing.T, root string, m *Manager) {
+				first := filepath.Join(root, "d1")
+				second := filepath.Join(root, "d2")
+				third := filepath.Join(root, "d3")
+				writePlugin(t, first, "tri", nil)
+				writePlugin(t, second, "tri", nil)
+				writePlugin(t, third, "tri", nil)
+				got, err := m.ResolveForLaunch(context.Background(), []string{first, second, third}, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(got.Diagnostics) != 2 {
+					t.Fatalf("diagnostics = %+v", got.Diagnostics)
+				}
+				// The second copy's diagnostic names the winner and itself.
+				for _, path := range []string{first, second} {
+					if !strings.Contains(got.Diagnostics[0].Message, path) {
+						t.Fatalf("second copy's diagnostic = %q, missing competing path %s", got.Diagnostics[0].Message, path)
+					}
+				}
+				// The third copy's diagnostic names every competing path.
+				for _, path := range []string{first, second, third} {
+					if !strings.Contains(got.Diagnostics[1].Message, path) {
+						t.Fatalf("third copy's diagnostic = %q, missing competing path %s", got.Diagnostics[1].Message, path)
+					}
 				}
 			},
 		},


### PR DESCRIPTION
## What

A duplicate plugin name at session launch was reported as `duplicate plugin name "superpowers"; keeping the first` with only the *rejected* candidate's path attached. The copy that actually won was nowhere in the message, and the parenthesized path read as if it named the kept one.

- `resolveForLaunch` now tracks every path that offered a manifest name (winner first) and the diagnostic lists them all: `duplicate plugin name "superpowers"; keeping the first of: /home/jesse/git/superpowers, /home/jesse/.config/evener/plugins/cache/...`. A third competing copy lists all three.
- The web plugin selection panel rendered that diagnostics block below the plugin list, burying it behind every row. It now renders directly above the list, and the trailing `(path)` parenthetical is omitted when the message already names that path.

## Evidence

- TDD red→green for both sides: extended resolver contract tests (two existing duplicate cases now assert both competing paths, winner first; new three-copies case pins the accumulated list) and two new panel tests (diagnostics above the list; no repeated path parenthetical).
- `go test ./internal/plugins/ -count=1` — ok; `go test ./cmd/evener-hub/ -run 'PluginPreview|PluginSelection|Plugins'` and `go test ./cmd/evener/ -run 'Plugin'` — ok (only consumers of the message: hub preview RPC, CLI `plugin list --effective`, web panel; the TUI does not render preview diagnostics).
- `gofmt` clean, `go vet` on touched packages clean.
- `make test-web` — web-typecheck, web-test, web-lint all PASS.
- End-to-end against the real plugin store via a built CLI (`plugin list --effective --plugin-dir …`): the warning now names both the local checkout and the marketplace cache copy, winner first.