### PR TITLE
fix(appwire): return arrays for empty project deletion results

### DIFF
--- a/cmd/evener-hub/project_delete.go
+++ b/cmd/evener-hub/project_delete.go
@@ -28,7 +28,11 @@ func (s *WebServer) projectDeleteResult(ctx context.Context, deleted []string, s
 		hint := navigationChangeHint{Projects: []string{project}}
 		navigation = s.navigationAfterDeletion(ctx, hint)
 	}
-	return appwire.ProjectDeleteResponse{Deleted: deleted, Skipped: skipped, Navigation: navigation}, nil
+	return appwire.ProjectDeleteResponse{
+		Deleted:    append([]string{}, deleted...),
+		Skipped:    append([]projectDeleteSkip{}, skipped...),
+		Navigation: navigation,
+	}, nil
 }
 
 // Roster and navigation refreshes do not undo committed artifact removal.

--- a/cmd/evener-hub/project_delete_test.go
+++ b/cmd/evener-hub/project_delete_test.go
@@ -313,6 +313,9 @@ func TestProjectDeleteRemovesFilesAndScrubs(t *testing.T) {
 	if len(resp.Deleted) != 1 {
 		t.Fatalf("want 1 deleted ref, got %+v", resp)
 	}
+	if resp.Skipped == nil || len(resp.Skipped) != 0 {
+		t.Fatalf("successful deletion must return an empty skipped array, got %#v", resp.Skipped)
+	}
 	for _, suffix := range []string{".meta.json", ".transcript.jsonl", ".log.jsonl", ".api.jsonl", ".future-artifact"} {
 		if _, err := os.Stat(filepath.Join(stateDir, "sessions", webTestSessionID+suffix)); !os.IsNotExist(err) {
 			t.Fatalf("%s should be removed", suffix)
@@ -1631,8 +1634,8 @@ func TestProjectDeleteDoesNotBroadcastWhenNothingRemoved(t *testing.T) {
 	if err != nil {
 		t.Fatalf("project delete: %v", err)
 	}
-	if len(got.Deleted) != 0 {
-		t.Fatalf("expected nothing actually deleted (session skipped), got %+v", got.Deleted)
+	if got.Deleted == nil || len(got.Deleted) != 0 {
+		t.Fatalf("skipped deletion must return an empty deleted array, got %#v", got.Deleted)
 	}
 }
 


### PR DESCRIPTION
A successful project deletion can return `skipped: null`, although the AppWire client contract exposes an array. Normalize both `deleted` and `skipped` in the common result constructor so every successful response uses arrays, including empty and skipped-only outcomes.

Strengthen the existing real deletion and skipped/no-op RPC regressions. The successful-deletion regression fails before the fix because `skipped` is nil; all project-deletion tests pass afterward. Scoped vet, golangci-lint, independent review, and `git diff --check` pass. Deletion decisions and navigation behavior are unchanged.
