### PR TITLE
WIP: preserve empty navigation response normalization

### DIFF
--- a/cmd/evener-hub/navigation_empty_delta_test.go
+++ b/cmd/evener-hub/navigation_empty_delta_test.go
@@ -1,0 +1,64 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/hubapi"
+)
+
+func TestNavigationDeltaEmptyPinCatalog(t *testing.T) {
+	key := navigationResourceKey{Kind: navigationResourcePinCatalog, Limit: 50}
+	version := func(revision uint64) appwire.NavigationReadBase {
+		return appwire.NavigationReadBase{GenerationID: "g", Revision: revision, ETag: fmt.Sprintf("catalog-%d", revision)}
+	}
+	catalog := func(revision uint64, populated bool) hubapi.NavigationSnapshot {
+		t.Helper()
+		value := hubapi.NavigationPinSectionCatalog{GenerationID: "g", Revision: revision}
+		if populated {
+			value.PinSections = hubapi.NavigationArray[hubapi.NavigationPinSectionDescriptor]{{ID: "focus", Name: "Focus", Count: 1}}
+		}
+		snapshot, err := normalizeNavigationResource(key, value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !populated && snapshot.Entities == nil {
+			t.Fatal("empty catalog normalized to nil entities")
+		}
+		return snapshot
+	}
+	for _, tc := range []struct {
+		name      string
+		populated bool
+	}{
+		{"remove final section", true}, {"metadata-only empty catalog", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base, current := catalog(1, tc.populated), catalog(2, false)
+			delta, err := diffNavigationSnapshots(key, version(1), version(2), base, current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			applied, err := applyNavigationDelta(base, delta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if applied.Entities == nil || len(applied.Entities) != 0 || len(applied.Containers) != 1 {
+				t.Fatalf("empty catalog has %d entities and %d containers", len(applied.Entities), len(applied.Containers))
+			}
+			root := applied.Containers[0]
+			if root.Owner.Kind != "resource_root" || root.Owner.Slot != "pin_sections" || len(root.Children) != 0 {
+				t.Fatalf("empty catalog root = %+v", root)
+			}
+			var metadata navigationPagedMetadata
+			if err := json.Unmarshal(applied.Metadata, &metadata); err != nil {
+				t.Fatal(err)
+			}
+			if metadata.Revision != 2 {
+				t.Fatalf("metadata revision = %d, want 2", metadata.Revision)
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/navigation_normalize.go
+++ b/cmd/evener-hub/navigation_normalize.go
@@ -148,6 +148,11 @@ func (b *navigationDocumentBuilder) addSessions(owner, slot string, sessions hub
 	b.container(containerKey, ownerValue, children)
 }
 func (b *navigationDocumentBuilder) finish() (hubapi.NavigationSnapshot, error) {
+	// History and applied deltas use an empty array. Keep projected empty
+	// resources in that same form so reconstruction checks compare equal graphs.
+	if b.entities == nil {
+		b.entities = []hubapi.NavigationEntityRecord{}
+	}
 	snapshot := hubapi.NavigationSnapshot{Metadata: b.metadata, Entities: b.entities, Containers: b.containers}
 	hubapi.SortNavigationSnapshot(&snapshot)
 	if err := validateNavigationResourceSnapshot(b.key, b.generation, b.revision, snapshot); err != nil {


### PR DESCRIPTION
Preserves unfinished navigation normalization and its regression test from the mobile landing worktree before laptop repair. Original source worktree remains unchanged.

Snapshot head: `e7160ec0b9b64ac5cbc301a2af64a5a8178dde21`, based on `ab02d1cbbfd9f33b4e318105574caaa47c398e9a`. Files: `cmd/evener-hub/navigation_normalize.go` and `cmd/evener-hub/navigation_empty_delta_test.go`.

Remaining: compare the behavior with current main and merged normalization PRs; determine whether this is already superseded; rebase/selectively extract only missing behavior; review the behavioral test; run focused hub tests, canonical merge gate, current-head CI and RoboRev. Only diff/whitespace checking was completed for this preservation snapshot. No claim of build or runtime qualification.
