### PR TITLE
WIP: preserve bounded concurrent session list loading

### DIFF
--- a/cmd/evener-hub/app_threadlist.go
+++ b/cmd/evener-hub/app_threadlist.go
@@ -2,24 +2,69 @@ package hub
 
 import (
 	"context"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
+	"primeradiant.com/evener/agent/schema"
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
 	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
 	"primeradiant.com/evener/identifier"
 )
 
+// threadListSourceTimeout prevents one unavailable or busy source from
+// holding the Hub's roster RPC open forever. Sources are queried concurrently,
+// so the total wait is bounded by this duration rather than by the number of
+// configured sources.
+const threadListSourceTimeout = 3 * time.Second
+
 func hubThreadList(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	return hubThreadListWithSourceTimeout(ctx, cfg, sources, params, threadListSourceTimeout)
+}
+
+func hubThreadListWithSourceTimeout(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadListParams, sourceTimeout time.Duration) (appwire.ThreadListResponse, error) {
 	threads := make([]appwire.Thread, 0)
 	liveIDs := map[string]struct{}{}
-	for _, source := range sources.All() {
+	allSources := sources.All()
+	type sourceResult struct {
+		index int
+		resp  appwire.ThreadListResponse
+		err   error
+	}
+	results := make(chan sourceResult, len(allSources))
+	for index, source := range allSources {
 		if !sourceAllowedForList(source.ID(), params) {
 			continue
 		}
-		resp, err := source.ListThreads(ctx, params)
+		go func(index int, source appsource.Source) {
+			sourceCtx, cancel := context.WithTimeout(ctx, sourceTimeout)
+			defer cancel()
+			resp, err := source.ListThreads(sourceCtx, params)
+			results <- sourceResult{index: index, resp: resp, err: err}
+		}(index, source)
+	}
+	listed := make([]sourceResult, 0, len(allSources))
+	for _, source := range allSources {
+		if !sourceAllowedForList(source.ID(), params) {
+			continue
+		}
+		select {
+		case result := <-results:
+			listed = append(listed, result)
+		case <-ctx.Done():
+			return appwire.ThreadListResponse{}, ctx.Err()
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return appwire.ThreadListResponse{}, err
+	}
+	slices.SortFunc(listed, func(a, b sourceResult) int { return a.index - b.index })
+	for _, result := range listed {
+		source := allSources[result.index]
+		resp, err := result.resp, result.err
 		if err != nil {
 			if sourceExplicitlyRequestedForList(source.ID(), params) {
 				return appwire.ThreadListResponse{}, err
@@ -52,10 +97,7 @@ func hubThreadList(ctx context.Context, cfg hubcore.WebConfig, sources *appsourc
 			if _, ok := liveIDs[threadListSourceKey("local", entry.ID)]; ok {
 				continue
 			}
-			thread, err := pastEntryThread(ctx, cfg, entry, false)
-			if err != nil {
-				return appwire.ThreadListResponse{}, err
-			}
+			thread := pastEntryThreadForList(cfg, entry)
 			if appThreadMatches(thread, params) {
 				threads = append(threads, thread)
 			}
@@ -159,13 +201,10 @@ func mergePastMetadataForList(ctx context.Context, cfg hubcore.WebConfig, source
 	if !ok {
 		return live, nil
 	}
-	past, err := pastEntryThread(ctx, cfg, entry, false)
-	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return appwire.Thread{}, ctxErr
-		}
-		return live, nil
+	if err := ctx.Err(); err != nil {
+		return appwire.Thread{}, err
 	}
+	past := pastEntryThreadForList(cfg, entry)
 	if live.ID == "" {
 		live.ID = past.ID
 	}
@@ -203,6 +242,62 @@ func mergePastMetadataForList(ctx context.Context, cfg hubcore.WebConfig, source
 		live.Evener.Profile = past.Evener.Profile
 	}
 	return live, nil
+}
+
+// pastEntryThreadForList is deliberately metadata-only. pastEntryThread also
+// loads delegate history and persisted task state, which is appropriate for a
+// single thread/read but makes a roster request scale with every transcript's
+// event log. The list response only needs fields that can enrich a live row.
+func pastEntryThreadForList(cfg hubcore.WebConfig, entry hubcore.PastEntry) appwire.Thread {
+	title := schema.SessionDisplayName(entry.Meta)
+	if title == "" {
+		title = entry.Meta.ID
+	}
+	name := title
+	if name == "" || name == strings.TrimSpace(entry.Meta.ID) {
+		name = hubcore.ShortID(strings.TrimSpace(entry.Meta.ID))
+	}
+	cwd := entry.Meta.EnvInfo.WorkingDir
+	ref := appwire.Ref{SourceID: "local", ThreadID: entry.Meta.ID}.String()
+	parentRef := ""
+	if entry.Meta.ParentSessionID != "" {
+		parentRef = appwire.Ref{SourceID: "local", ThreadID: entry.Meta.ParentSessionID}.String()
+	}
+	kind := "session"
+	if entry.Meta.IsSubagent {
+		kind = "subagent"
+	} else if entry.Meta.ParentSessionID != "" {
+		kind = "fork"
+	}
+	status := appwire.ThreadStatusNotLoaded
+	if cfg.Roster != nil {
+		if subState, live := cfg.Roster.SubagentState(entry.Meta.ID); live {
+			subState = strings.TrimSpace(subState)
+			if subState == "" {
+				subState = appwire.ThreadStatusActive
+			}
+			status = subState
+		}
+	}
+	return appwire.Thread{
+		ID:            entry.Meta.ID,
+		SessionID:     entry.Meta.ID,
+		Preview:       title,
+		Name:          name,
+		ModelProvider: entry.Meta.Model,
+		CreatedAt:     hubcore.UnixSeconds(hubcore.OrderCreatedAt(entry.Meta.CreatedAt, entry.Meta.UpdatedAt)),
+		UpdatedAt:     hubcore.UnixSeconds(hubcore.OrderUpdatedAt(entry.Meta.UpdatedAt, entry.Meta.CreatedAt)),
+		Status:        appwire.ThreadStatus{Type: status},
+		Path:          filepath.Base(cwd),
+		CWD:           cwd,
+		Source:        "local",
+		Evener: appwire.EvenerThread{
+			Ref:       ref,
+			ParentRef: parentRef,
+			Kind:      kind,
+			Profile:   entry.Meta.ProfileID,
+		},
+	}
 }
 
 func appThreadMatches(thread appwire.Thread, params appwire.ThreadListParams) bool {

--- a/cmd/evener-hub/app_threadlist_bounded_test.go
+++ b/cmd/evener-hub/app_threadlist_bounded_test.go
@@ -1,0 +1,81 @@
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+type barrierThreadListSource struct {
+	*scriptedAppSource
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (s *barrierThreadListSource) ListThreads(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	s.started <- struct{}{}
+	<-s.release
+	return appwire.ThreadListResponse{Data: []appwire.Thread{s.thread}}, nil
+}
+
+type cancelableThreadListSource struct{ *scriptedAppSource }
+
+func (s *cancelableThreadListSource) ListThreads(ctx context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	<-ctx.Done()
+	return appwire.ThreadListResponse{}, ctx.Err()
+}
+
+func TestHubThreadListQueriesSourcesInParallelAndPreservesOrder(t *testing.T) {
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	sources := appsource.NewRegistry()
+	sources.Add(&barrierThreadListSource{scriptedAppSource: &scriptedAppSource{id: "first", thread: appwire.Thread{ID: "first-thread", Source: "first"}}, started: started, release: release})
+	sources.Add(&barrierThreadListSource{scriptedAppSource: &scriptedAppSource{id: "second", thread: appwire.Thread{ID: "second-thread", Source: "second"}}, started: started, release: release})
+
+	result := make(chan appwire.ThreadListResponse, 1)
+	errors := make(chan error, 1)
+	go func() {
+		response, err := hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, time.Hour)
+		result <- response
+		errors <- err
+	}()
+	for range 2 {
+		<-started
+	}
+	close(release)
+	if err := <-errors; err != nil {
+		t.Fatal(err)
+	}
+	response := <-result
+	if len(response.Data) != 2 || response.Data[0].ID != "first-thread" || response.Data[1].ID != "second-thread" {
+		t.Fatalf("threads=%+v, want source order", response.Data)
+	}
+}
+
+func TestHubThreadListCancellationReleasesSourceWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sources := appsource.NewRegistry()
+	sources.Add(&cancelableThreadListSource{scriptedAppSource: &scriptedAppSource{id: "blocked"}})
+	result := make(chan error, 1)
+	go func() {
+		_, err := hubThreadListWithSourceTimeout(ctx, hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, time.Hour)
+		result <- err
+	}()
+	cancel()
+	if err := <-result; err != context.Canceled {
+		t.Fatalf("hubThreadList error=%v, want context cancellation", err)
+	}
+}
+
+func TestPastEntryThreadForListUsesMetadataOnly(t *testing.T) {
+	entry := hubcore.PastEntry{StateDir: "/path-that-must-not-be-opened", Meta: schema.SessionMeta{ID: "session-1", EnvInfo: schema.EnvironmentInfo{WorkingDir: "/project"}}}
+	thread := pastEntryThreadForList(hubcore.WebConfig{}, entry)
+	if thread.ID != entry.Meta.ID || thread.CWD != entry.Meta.EnvInfo.WorkingDir {
+		t.Fatalf("metadata projection=%+v, want session metadata", thread)
+	}
+}


### PR DESCRIPTION
Preserves unfinished bounded roster loading and its test from the mobile landing worktree before laptop repair. The original dirty worktree remains unchanged.

Snapshot head: `956a0ea6dd5aea40df9d5e86aed3c664f3640937`, based on `50565eb465981d4b5a8fbbc939ad0bfb245aec68`. Files: `cmd/evener-hub/app_threadlist.go` and `cmd/evener-hub/app_threadlist_bounded_test.go`.

Remaining: compare with current main and merged metadata-only roster optimization #1078; keep only the still-missing bounded per-source concurrency behavior. Confirm deterministic ordering, bounded fanout, cancellation, partial source failures and complete pagination. Review/run the behavioral tests, the hub race suite and canonical merge gate; obtain current-head CI and clean RoboRev. Measure representative session-opening/list latency on a physical iPhone. This recovery snapshot has only diff/whitespace verification, not a passing build or product gate.
