### PR TITLE
WIP: preserve activity continuation regression before repair

### DIFF
--- a/agent/jobs_activity.go
+++ b/agent/jobs_activity.go
@@ -1055,6 +1055,7 @@ func trimActivityTrailingEntry(session *appwire.JobActivitySession, rootID strin
 		RootID:    rootID,
 		SessionID: session.SessionID,
 		Path:      append([]string(nil), path...),
+		After:     activityPositionAfterEntries(session.Entries),
 	})
 	return true
 }

--- a/agent/jobs_activity.go
+++ b/agent/jobs_activity.go
@@ -890,7 +890,10 @@ func activityPositionAfterEntries(entries []appwire.JobActivityEntry) *activityE
 	if len(entries) == 0 {
 		return nil
 	}
-	entry := entries[len(entries)-1]
+	return activityEntryPositionFor(entries[len(entries)-1])
+}
+
+func activityEntryPositionFor(entry appwire.JobActivityEntry) *activityEntryPosition {
 	if entry.Job != nil {
 		return &activityEntryPosition{Kind: "shell", ID: entry.Job.JobID}
 	}
@@ -1048,14 +1051,25 @@ func trimActivityTrailingEntry(session *appwire.JobActivitySession, rootID strin
 			return true
 		}
 	}
+	removed := *entry
 	session.Entries = session.Entries[:i]
 	session.Branch.Truncated = true
+	after := activityPositionAfterEntries(session.Entries)
+	if raw, err := json.Marshal(removed); err == nil && len(raw) > activityMaxEncodedBytes {
+		after = activityEntryPositionFor(removed)
+		if after != nil {
+			appendActivityBranchError(
+				&session.Branch,
+				fmt.Sprintf("activity entry %q exceeds the %d-byte page limit and was omitted", after.ID, activityMaxEncodedBytes),
+			)
+		}
+	}
 	session.Branch.Continuation = encodeActivityContinuation(activityContinuation{
 		Version:   activityContinuationV1,
 		RootID:    rootID,
 		SessionID: session.SessionID,
 		Path:      append([]string(nil), path...),
-		After:     activityPositionAfterEntries(session.Entries),
+		After:     after,
 	})
 	return true
 }

--- a/agent/jobs_activity.go
+++ b/agent/jobs_activity.go
@@ -1034,10 +1034,28 @@ func trimActivityTreeToFit(tree appwire.JobActivityTree, rootID string) (appwire
 		if len(raw) <= activityMaxEncodedBytes {
 			return tree, nil
 		}
+		if omitUnrepresentableActivityEntry(&tree.Root, rootID, nil) {
+			continue
+		}
 		if !trimActivityTrailingEntry(&tree.Root, rootID, nil) {
 			return tree, nil
 		}
 	}
+}
+
+func omitUnrepresentableActivityEntry(session *appwire.JobActivitySession, rootID string, path []string) bool {
+	if session == nil || len(session.Entries) != 1 {
+		return false
+	}
+	entry := &session.Entries[0]
+	if entry.Delegate != nil && entry.Delegate.Child != nil && len(entry.Delegate.Child.Entries) > 0 {
+		return omitUnrepresentableActivityEntry(
+			entry.Delegate.Child,
+			rootID,
+			appendActivityPath(path, entry.Delegate.DelegateID),
+		)
+	}
+	return removeActivityEntry(session, 0, rootID, path, true)
 }
 
 func trimActivityTrailingEntry(session *appwire.JobActivitySession, rootID string, path []string) bool {
@@ -1051,16 +1069,26 @@ func trimActivityTrailingEntry(session *appwire.JobActivitySession, rootID strin
 			return true
 		}
 	}
-	removed := *entry
-	session.Entries = session.Entries[:i]
+	return removeActivityEntry(session, i, rootID, path, false)
+}
+
+func removeActivityEntry(
+	session *appwire.JobActivitySession,
+	i int,
+	rootID string,
+	path []string,
+	omitted bool,
+) bool {
+	removed := session.Entries[i]
+	session.Entries = append(session.Entries[:i], session.Entries[i+1:]...)
 	session.Branch.Truncated = true
 	after := activityPositionAfterEntries(session.Entries)
-	if raw, err := json.Marshal(removed); err == nil && len(raw) > activityMaxEncodedBytes {
+	if omitted {
 		after = activityEntryPositionFor(removed)
 		if after != nil {
 			appendActivityBranchError(
 				&session.Branch,
-				fmt.Sprintf("activity entry %q exceeds the %d-byte page limit and was omitted", after.ID, activityMaxEncodedBytes),
+				fmt.Sprintf("activity entry %q cannot fit within the %d-byte page limit and was omitted", after.ID, activityMaxEncodedBytes),
 			)
 		}
 	}

--- a/agent/jobs_activity.go
+++ b/agent/jobs_activity.go
@@ -25,10 +25,16 @@ const (
 )
 
 type activityContinuation struct {
-	Version   int      `json:"v"`
-	RootID    string   `json:"root"`
-	SessionID string   `json:"session"`
-	Path      []string `json:"path"`
+	Version   int                    `json:"v"`
+	RootID    string                 `json:"root"`
+	SessionID string                 `json:"session"`
+	Path      []string               `json:"path"`
+	After     *activityEntryPosition `json:"after,omitempty"`
+}
+
+type activityEntryPosition struct {
+	Kind string `json:"kind"`
+	ID   string `json:"id"`
 }
 
 // activitySessionSnapshot is the lock-free input to the activity projection.
@@ -46,6 +52,7 @@ type activitySessionSnapshot struct {
 	Diagnostics     []string
 	Children        map[string]*activitySessionSnapshot // child session ID
 	Errors          map[string]error                    // child session ID
+	ResumeAfter     *activityEntryPosition
 }
 
 type activitySessionLocator struct {
@@ -134,6 +141,16 @@ func decodeActivityContinuation(token, expectedRoot string) (activityContinuatio
 			return activityContinuation{}, fmt.Errorf("duplicate continuation path hop %q", hop)
 		}
 		seen[hop] = true
+	}
+	if cont.After != nil {
+		if cont.After.Kind != "shell" && cont.After.Kind != "delegate" {
+			return activityContinuation{}, fmt.Errorf("invalid continuation entry kind %q", cont.After.Kind)
+		}
+		if cont.After.ID == "" {
+			return activityContinuation{}, errors.New("continuation entry position is missing an ID")
+		}
+		position := *cont.After
+		cont.After = &position
 	}
 	cont.Path = append([]string(nil), cont.Path...)
 	return cont, nil
@@ -261,7 +278,7 @@ func buildActivityContinuationSnapshot(loc activitySessionLocator, cont activity
 		if loc.sessionID != cont.SessionID {
 			return nil, fmt.Errorf("continuation session %q does not match root %q", cont.SessionID, loc.sessionID)
 		}
-		return buildActivityFullSnapshot(loc, visited, required)
+		return buildActivityContinuationTarget(loc, cont, visited, required)
 	}
 	return buildActivityContinuationAt(loc, cont, 0, visited, required)
 }
@@ -271,7 +288,7 @@ func buildActivityContinuationAt(loc activitySessionLocator, cont activityContin
 		if loc.sessionID != cont.SessionID {
 			return nil, fmt.Errorf("continuation session %q does not match resolved path %q", cont.SessionID, loc.sessionID)
 		}
-		return buildActivityFullSnapshot(loc, visited, required)
+		return buildActivityContinuationTarget(loc, cont, visited, required)
 	}
 	loaded, err := loadActivityBase(loc, required)
 	if err != nil {
@@ -300,6 +317,16 @@ func buildActivityContinuationAt(loc activitySessionLocator, cont activityContin
 		return &filtered, nil
 	}
 	return nil, fmt.Errorf("continuation path hop %q not found", delegateID)
+}
+
+func buildActivityContinuationTarget(loc activitySessionLocator, cont activityContinuation, visited map[string]bool, required bool) (*activitySessionSnapshot, error) {
+	snapshot, err := buildActivityFullSnapshot(loc, visited, required)
+	if err != nil || snapshot == nil || cont.After == nil {
+		return snapshot, err
+	}
+	position := *cont.After
+	snapshot.ResumeAfter = &position
+	return snapshot, nil
 }
 
 func loadActivityBase(loc activitySessionLocator, required bool) (activityLoadedBase, error) {
@@ -633,8 +660,15 @@ func projectActivitySessionAt(snapshot activitySessionSnapshot, budget *activity
 	defer delete(budget.visiting, cycleKey)
 
 	records := activityOwnedRecords(snapshot.SessionID, mergeActivityRecords(snapshot.Jobs, snapshot.LiveJobs))
+	resumed := snapshot.ResumeAfter == nil
 	for _, rec := range records {
 		if rec == nil {
+			continue
+		}
+		if !resumed {
+			if activityEntryPositionMatches(snapshot.ResumeAfter, "shell", rec.JobID) {
+				resumed = true
+			}
 			continue
 		}
 		switch rec.Type {
@@ -651,6 +685,12 @@ func projectActivitySessionAt(snapshot activitySessionSnapshot, budget *activity
 		}
 	}
 	for _, delegateID := range sortedStableActivityDelegateIDs(snapshot.StableDelegates) {
+		if !resumed {
+			if activityEntryPositionMatches(snapshot.ResumeAfter, "delegate", delegateID) {
+				resumed = true
+			}
+			continue
+		}
 		if !activityConsumeWorkUnit(budget, 1) {
 			markActivitySessionTruncated(&projected, budget, snapshot.SessionID, path)
 			projected.Counts, projected.Aggregate = aggregateActivity(projected.Entries, projected.Branch)
@@ -658,6 +698,9 @@ func projectActivitySessionAt(snapshot activitySessionSnapshot, budget *activity
 		}
 		delegate := projectStableActivityDelegate(snapshot, snapshot.StableDelegates[delegateID], budget, depth, path)
 		projected.Entries = append(projected.Entries, appwire.JobActivityEntry{Kind: "delegate", Delegate: &delegate})
+	}
+	if !resumed {
+		appendActivityBranchError(&projected.Branch, fmt.Sprintf("continuation entry %q was not found in session %q", snapshot.ResumeAfter.ID, snapshot.SessionID))
 	}
 
 	projected.Counts, projected.Aggregate = aggregateActivity(projected.Entries, projected.Branch)
@@ -834,8 +877,27 @@ func markActivitySessionTruncated(session *appwire.JobActivitySession, budget *a
 			RootID:    budget.rootID,
 			SessionID: sessionID,
 			Path:      append([]string(nil), path...),
+			After:     activityPositionAfterEntries(session.Entries),
 		})
 	}
+}
+
+func activityEntryPositionMatches(position *activityEntryPosition, kind, id string) bool {
+	return position != nil && position.Kind == kind && position.ID == id
+}
+
+func activityPositionAfterEntries(entries []appwire.JobActivityEntry) *activityEntryPosition {
+	if len(entries) == 0 {
+		return nil
+	}
+	entry := entries[len(entries)-1]
+	if entry.Job != nil {
+		return &activityEntryPosition{Kind: "shell", ID: entry.Job.JobID}
+	}
+	if entry.Delegate != nil {
+		return &activityEntryPosition{Kind: "delegate", ID: entry.Delegate.DelegateID}
+	}
+	return nil
 }
 
 func markActivityDelegateTruncated(delegate *appwire.JobActivityDelegate, budget *activityBudget, sessionID string, path []string) {

--- a/agent/jobs_activity_continuation_progress_test.go
+++ b/agent/jobs_activity_continuation_progress_test.go
@@ -80,6 +80,68 @@ func TestLoadSessionJobActivityTree_SizeContinuationWalksRetainedJobsOnce(t *tes
 	}
 }
 
+func TestLoadSessionJobActivityTree_SizeContinuationSkipsUnrepresentableEntry(t *testing.T) {
+	stateDir := t.TempDir()
+	const rootID = "rootoversizedpage"
+	started := time.Unix(3_000, 0).UTC()
+	normalStarted := started.Add(time.Second)
+	s1cov_writeJobLog(t, stateDir, rootID,
+		jobstore.Event{
+			Kind:             jobstore.EventJobStarted,
+			TS:               started,
+			JobID:            "oversized_job",
+			Type:             jobstore.JobShell,
+			OwnerSessionID:   rootID,
+			VisibleToSession: rootID,
+			StartedAt:        &started,
+			Description:      strings.Repeat("x", activityMaxEncodedBytes+(256<<10)),
+		},
+		jobstore.Event{
+			Kind:             jobstore.EventJobStarted,
+			TS:               normalStarted,
+			JobID:            "normal_job",
+			Type:             jobstore.JobShell,
+			OwnerSessionID:   rootID,
+			VisibleToSession: rootID,
+			StartedAt:        &normalStarted,
+			Description:      "reachable after oversized job",
+		},
+	)
+	savePastActivityMeta(t, stateDir, rootID, "Oversized continuation")
+
+	first, err := LoadSessionJobActivityTree(stateDir, rootID, appwire.JobsListParams{})
+	if err != nil {
+		t.Fatalf("load omission page: %v", err)
+	}
+	assertActivityPageBound(t, 1, first)
+	if len(first.Root.Entries) != 0 {
+		t.Fatalf("omission page entries = %+v, want no representable entries", first.Root.Entries)
+	}
+	if first.Root.Branch.Error == "" {
+		t.Fatal("omission page branch error is empty")
+	}
+	if first.Root.Branch.Continuation == "" || !first.Root.Branch.Truncated {
+		t.Fatalf("omission page branch = %+v, want a continuation", first.Root.Branch)
+	}
+
+	second, err := LoadSessionJobActivityTree(stateDir, rootID, appwire.JobsListParams{
+		Continuation: first.Root.Branch.Continuation,
+	})
+	if err != nil {
+		t.Fatalf("load page after omission: %v", err)
+	}
+	assertActivityPageBound(t, 2, second)
+	if len(second.Root.Entries) != 1 || second.Root.Entries[0].Job == nil {
+		t.Fatalf("page after omission entries = %+v, want one shell job", second.Root.Entries)
+	}
+	if second.Root.Entries[0].Job.JobID != "normal_job" {
+		t.Fatalf("page after omission job = %q, want normal_job", second.Root.Entries[0].Job.JobID)
+	}
+	if second.Root.Branch.Truncated || second.Root.Branch.Continuation != "" {
+		t.Fatalf("page after omission branch = %+v, want terminal completion", second.Root.Branch)
+	}
+}
+
 func TestLoadSessionJobActivityTree_DepthContinuationStartsAtOmittedBranch(t *testing.T) {
 	stateDir := t.TempDir()
 	const delegateCount = activityMaxNewDepth*2 + 6

--- a/agent/jobs_activity_continuation_progress_test.go
+++ b/agent/jobs_activity_continuation_progress_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -33,9 +35,57 @@ func TestLoadSessionJobActivityTree_WorkContinuationWalksRetainedJobsOnce(t *tes
 	s1cov_writeJobLog(t, stateDir, rootID, events...)
 	savePastActivityMeta(t, stateDir, rootID, "Work continuation")
 
-	seen := make(map[string]bool, jobCount)
+	got, pages := walkRootActivityJobPages(t, stateDir, rootID, 3)
+	want := activityJobIDs("job", jobCount)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("walked job IDs differ: got %d IDs, want %d", len(got), len(want))
+	}
+	if pages != 2 {
+		t.Fatalf("walk used %d pages, want 2", pages)
+	}
+}
+
+func TestLoadSessionJobActivityTree_SizeContinuationWalksRetainedJobsOnce(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		rootID   = "rootsizepage"
+		jobCount = 6
+	)
+	started := time.Unix(2_000, 0).UTC()
+	description := strings.Repeat("x", 900<<10)
+	events := make([]jobstore.Event, 0, jobCount)
+	for i := range jobCount {
+		at := started.Add(time.Duration(i) * time.Second)
+		events = append(events, jobstore.Event{
+			Kind:             jobstore.EventJobStarted,
+			TS:               at,
+			JobID:            fmt.Sprintf("large_%04d", i),
+			Type:             jobstore.JobShell,
+			OwnerSessionID:   rootID,
+			VisibleToSession: rootID,
+			StartedAt:        &at,
+			Description:      description,
+		})
+	}
+	s1cov_writeJobLog(t, stateDir, rootID, events...)
+	savePastActivityMeta(t, stateDir, rootID, "Size continuation")
+
+	got, pages := walkRootActivityJobPages(t, stateDir, rootID, 4)
+	want := activityJobIDs("large", jobCount)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("walked job IDs differ: got %v, want %v", got, want)
+	}
+	if pages < 2 {
+		t.Fatalf("walk used %d page, want encoded-size continuation", pages)
+	}
+}
+
+func walkRootActivityJobPages(t *testing.T, stateDir, rootID string, maxPages int) ([]string, int) {
+	t.Helper()
+	seen := make(map[string]bool)
+	ordered := make([]string, 0)
 	continuation := ""
-	for pageNumber := 1; ; pageNumber++ {
+	for pageNumber := 1; pageNumber <= maxPages; pageNumber++ {
 		page, err := LoadSessionJobActivityTree(stateDir, rootID, appwire.JobsListParams{Continuation: continuation})
 		if err != nil {
 			t.Fatalf("load page %d: %v", pageNumber, err)
@@ -52,6 +102,7 @@ func TestLoadSessionJobActivityTree_WorkContinuationWalksRetainedJobsOnce(t *tes
 				t.Fatalf("page %d replayed retained job %q", pageNumber, entry.Job.JobID)
 			}
 			seen[entry.Job.JobID] = true
+			ordered = append(ordered, entry.Job.JobID)
 		}
 
 		next := page.Root.Branch.Continuation
@@ -59,26 +110,23 @@ func TestLoadSessionJobActivityTree_WorkContinuationWalksRetainedJobsOnce(t *tes
 			if page.Root.Branch.Truncated {
 				t.Fatalf("terminal page %d remains truncated: %+v", pageNumber, page.Root.Branch)
 			}
-			break
+			return ordered, pageNumber
 		}
 		if next == continuation {
 			t.Fatalf("page %d repeated continuation %q", pageNumber, next)
 		}
 		continuation = next
-		if pageNumber > 2 {
-			t.Fatalf("work continuation did not terminate after two pages")
-		}
 	}
+	t.Fatalf("continuation did not terminate within %d pages", maxPages)
+	return nil, 0
+}
 
-	if len(seen) != jobCount {
-		t.Fatalf("walk retained %d jobs, want %d", len(seen), jobCount)
+func activityJobIDs(prefix string, count int) []string {
+	ids := make([]string, count)
+	for i := range count {
+		ids[i] = fmt.Sprintf("%s_%04d", prefix, i)
 	}
-	for i := range jobCount {
-		jobID := fmt.Sprintf("job_%04d", i)
-		if !seen[jobID] {
-			t.Errorf("walk omitted retained job %q", jobID)
-		}
-	}
+	return ids
 }
 
 func assertActivityPageBound(t *testing.T, pageNumber int, page appwire.JobActivityTree) {

--- a/agent/jobs_activity_continuation_progress_test.go
+++ b/agent/jobs_activity_continuation_progress_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/internal/jobstore"
+	"primeradiant.com/evener/appwire"
+)
+
+func TestLoadSessionJobActivityTree_WorkContinuationWalksRetainedJobsOnce(t *testing.T) {
+	stateDir := t.TempDir()
+	const (
+		rootID   = "rootworkpage"
+		jobCount = activityMaxWorkUnits + 1
+	)
+	started := time.Unix(1_000, 0).UTC()
+	events := make([]jobstore.Event, 0, jobCount)
+	for i := range jobCount {
+		at := started.Add(time.Duration(i) * time.Second)
+		events = append(events, jobstore.Event{
+			Kind:             jobstore.EventJobStarted,
+			TS:               at,
+			JobID:            fmt.Sprintf("job_%04d", i),
+			Type:             jobstore.JobShell,
+			OwnerSessionID:   rootID,
+			VisibleToSession: rootID,
+			StartedAt:        &at,
+		})
+	}
+	s1cov_writeJobLog(t, stateDir, rootID, events...)
+	savePastActivityMeta(t, stateDir, rootID, "Work continuation")
+
+	seen := make(map[string]bool, jobCount)
+	continuation := ""
+	for pageNumber := 1; ; pageNumber++ {
+		page, err := LoadSessionJobActivityTree(stateDir, rootID, appwire.JobsListParams{Continuation: continuation})
+		if err != nil {
+			t.Fatalf("load page %d: %v", pageNumber, err)
+		}
+		assertActivityPageBound(t, pageNumber, page)
+		if len(page.Root.Entries) == 0 {
+			t.Fatalf("page %d made no progress", pageNumber)
+		}
+		for _, entry := range page.Root.Entries {
+			if entry.Job == nil {
+				t.Fatalf("page %d entry = %+v, want shell job", pageNumber, entry)
+			}
+			if seen[entry.Job.JobID] {
+				t.Fatalf("page %d replayed retained job %q", pageNumber, entry.Job.JobID)
+			}
+			seen[entry.Job.JobID] = true
+		}
+
+		next := page.Root.Branch.Continuation
+		if next == "" {
+			if page.Root.Branch.Truncated {
+				t.Fatalf("terminal page %d remains truncated: %+v", pageNumber, page.Root.Branch)
+			}
+			break
+		}
+		if next == continuation {
+			t.Fatalf("page %d repeated continuation %q", pageNumber, next)
+		}
+		continuation = next
+		if pageNumber > 2 {
+			t.Fatalf("work continuation did not terminate after two pages")
+		}
+	}
+
+	if len(seen) != jobCount {
+		t.Fatalf("walk retained %d jobs, want %d", len(seen), jobCount)
+	}
+	for i := range jobCount {
+		jobID := fmt.Sprintf("job_%04d", i)
+		if !seen[jobID] {
+			t.Errorf("walk omitted retained job %q", jobID)
+		}
+	}
+}
+
+func assertActivityPageBound(t *testing.T, pageNumber int, page appwire.JobActivityTree) {
+	t.Helper()
+	raw, err := json.Marshal(page)
+	if err != nil {
+		t.Fatalf("marshal page %d: %v", pageNumber, err)
+	}
+	if len(raw) > activityMaxEncodedBytes {
+		t.Fatalf("page %d encoded to %d bytes, limit %d", pageNumber, len(raw), activityMaxEncodedBytes)
+	}
+}

--- a/agent/jobs_activity_continuation_progress_test.go
+++ b/agent/jobs_activity_continuation_progress_test.go
@@ -80,6 +80,94 @@ func TestLoadSessionJobActivityTree_SizeContinuationWalksRetainedJobsOnce(t *tes
 	}
 }
 
+func TestLoadSessionJobActivityTree_DepthContinuationStartsAtOmittedBranch(t *testing.T) {
+	stateDir := t.TempDir()
+	const delegateCount = activityMaxNewDepth*2 + 6
+	sessionIDs := make([]string, delegateCount+1)
+	sessionIDs[0] = "rootdepthpage"
+	for i := 1; i <= delegateCount; i++ {
+		sessionIDs[i] = fmt.Sprintf("depth%03d", i)
+	}
+	for i := range delegateCount {
+		writePastStableDelegates(t, stateDir, sessionIDs[i], pastStableDescriptor(sessionIDs[i], sessionIDs[i+1], fmt.Sprintf("depth task %d", i)))
+	}
+	for i, sessionID := range sessionIDs {
+		s1cov_writeJobLog(t, stateDir, sessionID)
+		savePastActivityMeta(t, stateDir, sessionID, fmt.Sprintf("Depth %d", i))
+	}
+
+	seen := make(map[string]bool, delegateCount)
+	continuation := ""
+	targetSessionID := sessionIDs[0]
+	nextDelegate := 0
+	for pageNumber := 1; pageNumber <= 4; pageNumber++ {
+		page, err := LoadSessionJobActivityTree(stateDir, sessionIDs[0], appwire.JobsListParams{Continuation: continuation})
+		if err != nil {
+			t.Fatalf("load page %d: %v", pageNumber, err)
+		}
+		assertActivityPageBound(t, pageNumber, page)
+		target := findActivitySession(t, &page.Root, targetSessionID)
+		next := ""
+		for current := target; len(current.Entries) > 0; {
+			if len(current.Entries) != 1 || current.Entries[0].Delegate == nil {
+				t.Fatalf("page %d session %q entries = %+v, want one chain delegate", pageNumber, current.SessionID, current.Entries)
+			}
+			delegate := current.Entries[0].Delegate
+			wantID := "dlg_" + sessionIDs[nextDelegate+1]
+			if delegate.DelegateID != wantID {
+				t.Fatalf("page %d delegate %d = %q, want %q", pageNumber, nextDelegate, delegate.DelegateID, wantID)
+			}
+			if seen[delegate.DelegateID] {
+				t.Fatalf("page %d replayed retained delegate %q below continuation target", pageNumber, delegate.DelegateID)
+			}
+			seen[delegate.DelegateID] = true
+			nextDelegate++
+			if delegate.Branch.Continuation != "" {
+				if delegate.Child != nil {
+					t.Fatalf("page %d truncated delegate %q unexpectedly included its omitted child", pageNumber, delegate.DelegateID)
+				}
+				next = delegate.Branch.Continuation
+				targetSessionID = delegate.ChildSessionID
+				break
+			}
+			if delegate.Child == nil {
+				t.Fatalf("page %d delegate %q omitted child without continuation: branch=%+v diagnostics=%v", pageNumber, delegate.DelegateID, delegate.Branch, delegate.Diagnostics)
+			}
+			current = delegate.Child
+		}
+
+		if next == "" {
+			if nextDelegate != delegateCount {
+				t.Fatalf("depth walk ended after %d delegates, want %d", nextDelegate, delegateCount)
+			}
+			if len(seen) != delegateCount {
+				t.Fatalf("depth walk retained %d unique delegates, want %d", len(seen), delegateCount)
+			}
+			return
+		}
+		if next == continuation {
+			t.Fatalf("page %d repeated continuation %q", pageNumber, next)
+		}
+		continuation = next
+	}
+	t.Fatalf("depth continuation did not terminate within four pages")
+}
+
+func findActivitySession(t *testing.T, root *appwire.JobActivitySession, sessionID string) *appwire.JobActivitySession {
+	t.Helper()
+	for current := root; current != nil; {
+		if current.SessionID == sessionID {
+			return current
+		}
+		if len(current.Entries) != 1 || current.Entries[0].Delegate == nil {
+			t.Fatalf("continuation path ended before target session %q", sessionID)
+		}
+		current = current.Entries[0].Delegate.Child
+	}
+	t.Fatalf("continuation omitted target session %q", sessionID)
+	return nil
+}
+
 func walkRootActivityJobPages(t *testing.T, stateDir, rootID string, maxPages int) ([]string, int) {
 	t.Helper()
 	seen := make(map[string]bool)

--- a/agent/jobs_activity_continuation_progress_test.go
+++ b/agent/jobs_activity_continuation_progress_test.go
@@ -81,6 +81,64 @@ func TestLoadSessionJobActivityTree_SizeContinuationWalksRetainedJobsOnce(t *tes
 }
 
 func TestLoadSessionJobActivityTree_SizeContinuationSkipsUnrepresentableEntry(t *testing.T) {
+	assertUnrepresentableActivityEntryWalk(t, strings.Repeat("x", activityMaxEncodedBytes+(256<<10)))
+}
+
+func TestLoadSessionJobActivityTree_SizeContinuationAccountsForResponseEnvelope(t *testing.T) {
+	assertUnrepresentableActivityEntryWalk(t, activityBoundaryDescription(t))
+}
+
+func activityBoundaryDescription(t *testing.T) string {
+	t.Helper()
+	stateDir := t.TempDir()
+	const rootID = "rootoversizedpage"
+	started := time.Unix(3_000, 0).UTC()
+	s1cov_writeJobLog(t, stateDir, rootID, jobstore.Event{
+		Kind:             jobstore.EventJobStarted,
+		TS:               started,
+		JobID:            "oversized_job",
+		Type:             jobstore.JobShell,
+		OwnerSessionID:   rootID,
+		VisibleToSession: rootID,
+		StartedAt:        &started,
+		Description:      "x",
+	})
+	savePastActivityMeta(t, stateDir, rootID, "Oversized continuation")
+	probe, err := LoadSessionJobActivityTree(stateDir, rootID, appwire.JobsListParams{})
+	if err != nil {
+		t.Fatalf("load boundary probe: %v", err)
+	}
+	if len(probe.Root.Entries) != 1 || probe.Root.Entries[0].Job == nil {
+		t.Fatalf("boundary probe entries = %+v, want one shell job", probe.Root.Entries)
+	}
+	entry := probe.Root.Entries[0]
+	entry.Job.Description = ""
+	base, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal boundary entry base: %v", err)
+	}
+	description := strings.Repeat("x", activityMaxEncodedBytes-len(base)-1)
+	entry.Job.Description = description
+	encodedEntry, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal boundary entry: %v", err)
+	}
+	if len(encodedEntry) != activityMaxEncodedBytes-1 {
+		t.Fatalf("boundary entry encoded to %d bytes, want %d", len(encodedEntry), activityMaxEncodedBytes-1)
+	}
+	probe.Root.Entries[0] = entry
+	encodedTree, err := json.Marshal(probe)
+	if err != nil {
+		t.Fatalf("marshal boundary tree: %v", err)
+	}
+	if len(encodedTree) <= activityMaxEncodedBytes {
+		t.Fatalf("boundary tree encoded to %d bytes, want more than %d", len(encodedTree), activityMaxEncodedBytes)
+	}
+	return description
+}
+
+func assertUnrepresentableActivityEntryWalk(t *testing.T, description string) {
+	t.Helper()
 	stateDir := t.TempDir()
 	const rootID = "rootoversizedpage"
 	started := time.Unix(3_000, 0).UTC()
@@ -94,7 +152,7 @@ func TestLoadSessionJobActivityTree_SizeContinuationSkipsUnrepresentableEntry(t 
 			OwnerSessionID:   rootID,
 			VisibleToSession: rootID,
 			StartedAt:        &started,
-			Description:      strings.Repeat("x", activityMaxEncodedBytes+(256<<10)),
+			Description:      description,
 		},
 		jobstore.Event{
 			Kind:             jobstore.EventJobStarted,

--- a/agent/jobs_activity_continuation_progress_test.go
+++ b/agent/jobs_activity_continuation_progress_test.go
@@ -88,6 +88,19 @@ func TestLoadSessionJobActivityTree_SizeContinuationAccountsForResponseEnvelope(
 	assertUnrepresentableActivityEntryWalk(t, activityBoundaryDescription(t))
 }
 
+func TestLoadSessionJobActivityTree_EmptySessionLabelStaysBounded(t *testing.T) {
+	stateDir := t.TempDir()
+	const rootID = "rootoversizedlabel"
+	s1cov_writeJobLog(t, stateDir, rootID)
+	savePastActivityMeta(t, stateDir, rootID, strings.Repeat("x", activityMaxEncodedBytes+1024))
+
+	page, err := LoadSessionJobActivityTree(stateDir, rootID, appwire.JobsListParams{})
+	if err != nil {
+		t.Fatalf("load empty session with oversized label: %v", err)
+	}
+	assertActivityPageBound(t, 1, page)
+}
+
 func activityBoundaryDescription(t *testing.T) string {
 	t.Helper()
 	stateDir := t.TempDir()

--- a/appwire/protocol.go
+++ b/appwire/protocol.go
@@ -113,7 +113,7 @@ var Methods = []MethodSpec{
 	{MethodTurnCancelQueued, TurnCancelQueuedParams{}, TurnCancelQueuedResponse{}, ScopeBoth, "Removes one queued message by index so it is never consumed (cancel; also the removal half of edit-and-recompose)."},
 	{MethodGoalSet, GoalSetParams{}, GoalSetResponse{}, ScopeBoth, "Sets or clears the session's /goal objective."},
 	{MethodEvenerTasksList, TaskListParams{}, TaskListResponse{}, ScopeBoth, "Lists the session's tasks."},
-	{MethodEvenerJobsList, JobsListParams{}, JobsListResponse{}, ScopeBoth, "Returns the current-session activity tree. Hub-served for exited sessions via the persisted jobs.jsonl fallback; older daemons may still return a flat array in JobsListResponse.Data."},
+	{MethodEvenerJobsList, JobsListParams{}, JobsListResponse{}, ScopeBoth, "Returns one bounded page of the current-session activity tree; truncated branches carry continuations for later pages. Hub-served for exited sessions via the persisted jobs.jsonl fallback; older daemons may still return a flat array in JobsListResponse.Data."},
 	{MethodEvenerJobsOutput, JobsOutputParams{}, JobsOutputResponse{}, ScopeBoth, "Reads a byte tail of one job's output. Hub-served for exited sessions via the persisted jobs.jsonl fallback."},
 	{MethodEvenerThreadTranscriptsList, ThreadTranscriptListParams{}, ThreadTranscriptListResponse{}, ScopeHub, "Lists transcript targets (subagents/related threads) for a ref."},
 	{MethodEvenerSubagentPreview, EvenerSubagentPreviewParams{}, EvenerSubagentPreviewResponse{}, ScopeHub, "Reads a bounded lazy preview of a subagent transcript's latest direct items."},

--- a/appwire/types.go
+++ b/appwire/types.go
@@ -1406,6 +1406,8 @@ type JobActivitySession struct {
 	Branch      JobActivityBranchState `json:"branch"`
 }
 
+// JobActivityTree is one bounded page of retained activity. Truncated branches
+// carry continuations that request later pages of that branch.
 type JobActivityTree struct {
 	Revision uint64             `json:"revision"`
 	Root     JobActivitySession `json:"root"`

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.test.tsx
@@ -210,9 +210,9 @@ function activityTree(revision = 1) {
   };
 }
 
-function continuedPartialTree() {
+function continuedPartialTree(revision = 1) {
   return {
-    revision: 2,
+    revision,
     root: {
       sessionId: "sess_root",
       ref: "ref_root",
@@ -682,6 +682,35 @@ describe("ActivityPanel", () => {
       ref: "ref_root",
       continuation: "partial-page-2",
     });
+  });
+
+  test("a continuation from another revision is discarded and restarts from the root", async () => {
+    const user = userEvent.setup();
+    const fake = connectFakeClient();
+    let rootCalls = 0;
+    fake.on("evener/jobs/list", ({ continuation }) => {
+      if (continuation) return { data: continuedPartialTree(2) };
+      rootCalls++;
+      return { data: activityTree(rootCalls) };
+    });
+
+    render(<ActivityPanel sessionRef="ref_root" model={testModel()} now={0} />);
+    await user.click(screen.getByRole("button", { name: "Activity" }));
+    await screen.findByRole("tree");
+    await user.click(screen.getByRole("treeitem", { name: "2 inactive" }));
+    await user.click(screen.getByRole("button", { name: /load more/i }));
+
+    await waitFor(() => expect(fake.calls.filter((call) => call.method === "evener/jobs/list")).toHaveLength(3));
+    expect(fake.calls.filter((call) => call.method === "evener/jobs/list").map((call) => call.params)).toEqual([
+      { ref: "ref_root" },
+      { ref: "ref_root", continuation: "partial-page-2" },
+      { ref: "ref_root" },
+    ]);
+    expect(activityPanelStore.getState().entries.get("ref_root")?.load).toMatchObject({
+      kind: "ready",
+      tree: { revision: 2 },
+    });
+    expect(screen.queryByRole("treeitem", { name: /continued shell/i })).toBeNull();
   });
 
   test("a malformed continuation response stays local to the targeted branch and preserves retry affordance", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.test.tsx
@@ -274,6 +274,21 @@ function continuedPartialTree(revision = 1) {
   };
 }
 
+function partialContinuationPage(jobId: string, description: string, continuation?: string) {
+  const page = cloneFixture(continuedPartialTree());
+  const entry = page.root.entries[0];
+  if (entry?.kind !== "delegate" || !entry.delegate.child) {
+    throw new Error("partial continuation fixture is missing its delegate child");
+  }
+  entry.delegate.projectionRevision = 1;
+  const job = entry.delegate.child.entries[0];
+  if (job?.kind !== "shell") throw new Error("partial continuation fixture is missing its shell job");
+  job.job.jobId = jobId;
+  job.job.description = description;
+  entry.delegate.child.branch = continuation ? { truncated: true, continuation } : {};
+  return page;
+}
+
 function emptyTree() {
   return {
     revision: 1,
@@ -682,6 +697,45 @@ describe("ActivityPanel", () => {
       ref: "ref_root",
       continuation: "partial-page-2",
     });
+  });
+
+  test("same-revision nested continuation deltas append exactly once and advance to completion", async () => {
+    const user = userEvent.setup();
+    const fake = connectFakeClient();
+    fake.on("evener/jobs/list", ({ continuation }) => {
+      if (!continuation) {
+        return { data: partialContinuationPage("job_partial_page_1", "first page shell", "partial-page-2") };
+      }
+      if (continuation === "partial-page-2") {
+        return { data: partialContinuationPage("job_partial_page_2", "second page shell", "partial-page-3") };
+      }
+      if (continuation === "partial-page-3") {
+        return { data: partialContinuationPage("job_partial_page_3", "third page shell") };
+      }
+      throw new Error(`unexpected continuation ${continuation}`);
+    });
+
+    render(<ActivityPanel sessionRef="ref_root" model={testModel()} now={0} />);
+    await user.click(screen.getByRole("button", { name: "Activity" }));
+    await screen.findByRole("tree");
+    expect(screen.getByRole("treeitem", { name: /first page shell/i })).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /load more/i }));
+    expect(await screen.findByRole("treeitem", { name: /second page shell/i })).toBeTruthy();
+    expect(screen.getAllByRole("treeitem", { name: /first page shell/i })).toHaveLength(1);
+    expect(screen.getAllByRole("treeitem", { name: /second page shell/i })).toHaveLength(1);
+
+    await user.click(screen.getByRole("button", { name: /load more/i }));
+    expect(await screen.findByRole("treeitem", { name: /third page shell/i })).toBeTruthy();
+    expect(screen.getAllByRole("treeitem", { name: /first page shell/i })).toHaveLength(1);
+    expect(screen.getAllByRole("treeitem", { name: /second page shell/i })).toHaveLength(1);
+    expect(screen.getAllByRole("treeitem", { name: /third page shell/i })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: /load more/i })).toBeNull();
+    expect(fake.calls.filter((call) => call.method === "evener/jobs/list").map((call) => call.params)).toEqual([
+      { ref: "ref_root" },
+      { ref: "ref_root", continuation: "partial-page-2" },
+      { ref: "ref_root", continuation: "partial-page-3" },
+    ]);
   });
 
   test("a continuation from another revision is discarded and restarts from the root", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.test.tsx
@@ -454,6 +454,32 @@ describe("ActivityPanel", () => {
     expect(await screen.findByText("This session has ended")).toBeTruthy();
   });
 
+  test("an empty omission page exposes its error and continuation", async () => {
+    const user = userEvent.setup();
+    const fake = connectFakeClient();
+    const omitted = emptyTree();
+    omitted.root.branch = {
+      truncated: true,
+      continuation: "after-oversized-job",
+      error: "One retained activity entry was omitted because it exceeds the page limit.",
+    };
+    const next = activityTree();
+    next.root.entries = next.root.entries.slice(0, 1);
+    next.root.branch = {};
+    fake.on("evener/jobs/list", ({ continuation }) => ({ data: continuation ? next : omitted }));
+
+    render(<ActivityPanel sessionRef="ref_root" model={testModel()} now={0} />);
+    await user.click(screen.getByRole("button", { name: "Activity" }));
+
+    expect(await screen.findByText(/entry was omitted because it exceeds the page limit/i)).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: /load more/i }));
+    expect(await screen.findByRole("treeitem", { name: /compile root shell/i })).toBeTruthy();
+    expect(fake.calls.filter((call) => call.method === "evener/jobs/list").map((call) => call.params)).toEqual([
+      { ref: "ref_root" },
+      { ref: "ref_root", continuation: "after-oversized-job" },
+    ]);
+  });
+
   test("renders live rows plus a fold row for inactive entries, and an expanded fold survives refresh", async () => {
     const user = userEvent.setup();
     const fake = connectFakeClient();

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.tsx
@@ -11,7 +11,12 @@ import { threadsStore, useThreadsStore } from "../../../stores/threads";
 import { Button, EmptyState, Sheet, useToasts } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import { ActivityTree, type ActivityTreeHandle } from "./ActivityTree";
-import { type ActivityCounts, type ActivityTree as ActivityTreeData, parseActivityTree } from "./activityData";
+import {
+  type ActivityCounts,
+  type ActivityTree as ActivityTreeData,
+  activityNodeID,
+  parseActivityTree,
+} from "./activityData";
 import styles from "./activitypanel.module.css";
 
 export interface ActivityPanelProps {
@@ -208,6 +213,8 @@ export function ActivityPanelBody({ sessionRef, model }: ActivityPanelBodyProps)
     const currentTree = retainedTree(entry.load);
     const staleError = entry.load.kind === "ready" ? entry.load.staleError : undefined;
     const ended = entry.load.kind === "ended";
+    const emptyRootID = currentTree?.root.entries.length === 0 ? activityNodeID(currentTree.root) : undefined;
+    const emptyBranch = emptyRootID ? currentTree?.root.branch : undefined;
     return (
       <div className={CLASS.panel}>
         {ended && !currentTree && (
@@ -235,7 +242,27 @@ export function ActivityPanelBody({ sessionRef, model }: ActivityPanelBodyProps)
             </Button>
           </div>
         )}
-        {currentTree && currentTree.root.entries.length === 0 ? (
+        {currentTree && emptyRootID && (emptyBranch?.error || emptyBranch?.continuation) ? (
+          <EmptyState
+            title="Retained activity is incomplete"
+            hint={
+              entry.continuationFailures[emptyRootID] ??
+              emptyBranch.error ??
+              "More retained activity is available on the next page."
+            }
+            action={
+              emptyBranch.continuation ? (
+                <Button
+                  variant="quiet"
+                  size="sm"
+                  onClick={() => handleContinue(emptyRootID, emptyBranch.continuation ?? "")}
+                >
+                  Load more
+                </Button>
+              ) : undefined
+            }
+          />
+        ) : currentTree && currentTree.root.entries.length === 0 ? (
           <EmptyState
             title="No retained activity yet"
             hint="No shell or delegate activity has been retained for this session."

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityPanel.tsx
@@ -97,24 +97,31 @@ export function ActivityPanelBody({ sessionRef, model }: ActivityPanelBodyProps)
     };
   }, [sessionRef]);
 
+  const fetchFreshRoot = useCallback(
+    (forceRoot = false) => {
+      const bodyGeneration = bodyGenerationRef.current;
+      refreshRoot(
+        sessionRef,
+        model.jobsUpdatedAt,
+        (sentence) => {
+          if (
+            mountedRef.current &&
+            currentSessionRef.current === sessionRef &&
+            bodyGenerationRef.current === bodyGeneration
+          ) {
+            toasts.push("error", sentence);
+          }
+        },
+        forceRoot,
+      );
+    },
+    [model.jobsUpdatedAt, sessionRef, toasts],
+  );
+
   const fetchRoot = useCallback(
     (continuation?: { nodeID: string; token: string }, forceRoot = false) => {
       if (!continuation) {
-        const bodyGeneration = bodyGenerationRef.current;
-        refreshRoot(
-          sessionRef,
-          model.jobsUpdatedAt,
-          (sentence) => {
-            if (
-              mountedRef.current &&
-              currentSessionRef.current === sessionRef &&
-              bodyGenerationRef.current === bodyGeneration
-            ) {
-              toasts.push("error", sentence);
-            }
-          },
-          forceRoot,
-        );
+        fetchFreshRoot(forceRoot);
         return;
       }
       const requestID = activityPanelStore.getState().beginFetch(sessionRef, { nodeID: continuation.nodeID });
@@ -131,7 +138,10 @@ export function ActivityPanelBody({ sessionRef, model }: ActivityPanelBodyProps)
             });
             return;
           }
-          activityPanelStore.getState().publishFetch(sessionRef, requestID, { kind: "ready", tree: parsed });
+          const restartRoot = activityPanelStore
+            .getState()
+            .publishFetch(sessionRef, requestID, { kind: "ready", tree: parsed });
+          if (restartRoot) fetchFreshRoot(true);
         })
         .catch((err) => {
           activityPanelStore.getState().publishFetch(sessionRef, requestID, {
@@ -141,7 +151,7 @@ export function ActivityPanelBody({ sessionRef, model }: ActivityPanelBodyProps)
           });
         });
     },
-    [model.jobsUpdatedAt, sessionRef, toasts],
+    [fetchFreshRoot, sessionRef],
   );
 
   // The mount fetch preserves the old visible-fetch contract exactly: a

--- a/cmd/evener-hub/frontend/src/panes/sessionPanels/sessionPanelPane.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/sessionPanels/sessionPanelPane.test.tsx
@@ -242,7 +242,7 @@ function activityRootTree(): ActivityTree {
 
 function continuedActivityTree(): ActivityTree {
   return {
-    revision: 2,
+    revision: 1,
     root: {
       kind: "session",
       sessionId: "session_a",
@@ -556,6 +556,12 @@ test("retains Activity continuation failure, retry, and graft across remounts", 
     retriedContinuation.resolve({ data: continuedActivityTree() });
     await Promise.resolve();
   });
+  const resolvedEntry = activityPanelStore.getState().entries.get(model.ref);
+  expect(resolvedEntry?.pending).toBeUndefined();
+  if (resolvedEntry?.load.kind !== "ready") throw new Error("expected retained activity after continuation retry");
+  const resolvedDelegate = resolvedEntry.load.tree.root.entries[0];
+  if (resolvedDelegate?.kind !== "delegate") throw new Error("expected retained delegate after continuation retry");
+  expect(resolvedDelegate.delegate.child?.entries).toHaveLength(1);
 
   seedModel(model);
   render(<SessionPanelPane params={{ ref: model.ref }} paneId="panel-activity-grafted" focused kind="activity" />);

--- a/cmd/evener-hub/frontend/src/stores/activityPanel.edge.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/activityPanel.edge.test.ts
@@ -125,6 +125,7 @@ describe("activityPanelStore continuation paths", () => {
   test("continuation fetch with ready result grafts the tree", () => {
     resetActivityPanelStoreForTests();
     const current = makeTreeWithDelegate();
+    current.revision = 2;
     current.root.entries.push({
       kind: "shell",
       job: {

--- a/cmd/evener-hub/frontend/src/stores/activityPanel.edge.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/activityPanel.edge.test.ts
@@ -126,6 +126,20 @@ describe("activityPanelStore continuation paths", () => {
     resetActivityPanelStoreForTests();
     const current = makeTreeWithDelegate();
     current.revision = 2;
+    current.root.branch = {
+      truncated: true,
+      continuation: "root-page-2",
+      error: "root branch remains incomplete",
+    };
+    const currentDelegate = current.root.entries[0];
+    if (currentDelegate?.kind !== "delegate" || !currentDelegate.delegate.child) {
+      throw new Error("current fixture is missing its delegate child");
+    }
+    currentDelegate.delegate.child.branch = {
+      truncated: true,
+      continuation: "child-page-2",
+      error: "child page omitted",
+    };
     current.root.entries.push({
       kind: "shell",
       job: {
@@ -157,6 +171,7 @@ describe("activityPanelStore continuation paths", () => {
       throw new Error("continuation fixture is missing its delegate child");
     }
     patchDelegate.delegate.projectionRevision = 2;
+    patchDelegate.delegate.child.branch = { truncated: true, continuation: "child-page-3" };
     patchDelegate.delegate.child.entries = [
       {
         kind: "shell",
@@ -182,9 +197,15 @@ describe("activityPanelStore continuation paths", () => {
     if (entry?.load.kind === "ready") {
       const delegate = entry.load.tree.root.entries[0];
       expect(entry.load.tree.revision).toBe(2);
+      expect(entry.load.tree.root.branch).toEqual({
+        truncated: true,
+        continuation: "root-page-2",
+        error: "root branch remains incomplete",
+      });
       expect(delegate?.kind).toBe("delegate");
       if (delegate?.kind === "delegate") {
         expect(delegate.delegate.projectionRevision).toBe(2);
+        expect(delegate.delegate.child?.branch).toEqual({ truncated: true, continuation: "child-page-3" });
         expect(delegate.delegate.child?.entries).toEqual([
           {
             kind: "shell",

--- a/cmd/evener-hub/frontend/src/stores/activityPanel.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/activityPanel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import type { ActivityTree } from "../panes/session/chrome/activityData";
+import { type ActivityEntry, type ActivityTree, activityNodeID } from "../panes/session/chrome/activityData";
 import { resetWorkspaceStoreForTests } from "../shell/workspace";
 import { activityPanelStore, resetActivityPanelStoreForTests } from "./activityPanel";
 import { schedulePanelStoreEviction } from "./panelStoreEviction";
@@ -18,6 +18,32 @@ function tree(revision = 1): ActivityTree {
       branch: {},
     },
   };
+}
+
+function shell(jobId: string): ActivityEntry {
+  return {
+    kind: "shell",
+    job: {
+      jobId,
+      ownerSessionId: "sess_a",
+      ownerRef: "ref_a",
+      type: "shell",
+      status: "completed",
+      terminal: true,
+      background: false,
+      hasOutput: false,
+      description: jobId,
+      startedAt: "2026-01-01T00:00:00Z",
+      outputBytes: 0,
+    },
+  };
+}
+
+function rootPage(jobId: string, continuation?: string): ActivityTree {
+  const page = tree();
+  page.root.entries = [shell(jobId)];
+  page.root.branch = continuation ? { truncated: true, continuation } : {};
+  return page;
 }
 
 describe("activityPanelStore", () => {
@@ -109,6 +135,39 @@ describe("activityPanelStore", () => {
       kind: "ready",
       tree: { root: { counts: { active: 1, failed: 0, completed: 0, complete: true } } },
     });
+  });
+
+  test("appends same-revision root continuation deltas exactly once until the branch completes", () => {
+    resetActivityPanelStoreForTests();
+    const first = activityPanelStore.getState().beginFetch("ref_a");
+    activityPanelStore
+      .getState()
+      .publishFetch("ref_a", first, { kind: "ready", tree: rootPage("job_page_1", "page-2") });
+
+    const second = activityPanelStore.getState().beginFetch("ref_a", { nodeID: "session:sess_a" });
+    activityPanelStore
+      .getState()
+      .publishFetch("ref_a", second, { kind: "ready", tree: rootPage("job_page_2", "page-3") });
+
+    let entry = activityPanelStore.getState().entries.get("ref_a");
+    if (entry?.load.kind !== "ready") throw new Error("expected ready activity tree after page two");
+    expect(entry.load.tree.root.entries.map((activity) => activityNodeID(activity))).toEqual([
+      "job:job_page_1",
+      "job:job_page_2",
+    ]);
+    expect(entry.load.tree.root.branch.continuation).toBe("page-3");
+
+    const third = activityPanelStore.getState().beginFetch("ref_a", { nodeID: "session:sess_a" });
+    activityPanelStore.getState().publishFetch("ref_a", third, { kind: "ready", tree: rootPage("job_page_3") });
+
+    entry = activityPanelStore.getState().entries.get("ref_a");
+    if (entry?.load.kind !== "ready") throw new Error("expected ready activity tree after page three");
+    expect(entry.load.tree.root.entries.map((activity) => activityNodeID(activity))).toEqual([
+      "job:job_page_1",
+      "job:job_page_2",
+      "job:job_page_3",
+    ]);
+    expect(entry.load.tree.root.branch.continuation).toBeUndefined();
   });
 
   test("rejects a continuation from another revision and requests a root restart", () => {

--- a/cmd/evener-hub/frontend/src/stores/activityPanel.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/activityPanel.test.ts
@@ -4,7 +4,7 @@ import { resetWorkspaceStoreForTests } from "../shell/workspace";
 import { activityPanelStore, resetActivityPanelStoreForTests } from "./activityPanel";
 import { schedulePanelStoreEviction } from "./panelStoreEviction";
 
-function tree(revision = 1) {
+function tree(revision = 1): ActivityTree {
   return {
     revision,
     root: {
@@ -114,7 +114,6 @@ describe("activityPanelStore", () => {
   test("rejects a continuation from another revision and requests a root restart", () => {
     resetActivityPanelStoreForTests();
     const retained = tree(1);
-    retained.root.diagnostics = ["retained diagnostic"];
     retained.root.branch = { truncated: true, continuation: "page-2", error: "retained branch error" };
     const first = activityPanelStore.getState().beginFetch("ref_a");
     activityPanelStore.getState().publishFetch("ref_a", first, { kind: "ready", tree: retained });
@@ -131,7 +130,6 @@ describe("activityPanelStore", () => {
       tree: {
         revision: 1,
         root: {
-          diagnostics: ["retained diagnostic"],
           branch: { truncated: true, continuation: "page-2", error: "retained branch error" },
         },
       },

--- a/cmd/evener-hub/frontend/src/stores/activityPanel.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/activityPanel.test.ts
@@ -102,13 +102,42 @@ describe("activityPanelStore", () => {
     const first = activityPanelStore.getState().beginFetch("ref_a");
     activityPanelStore.getState().publishFetch("ref_a", first, { kind: "ready", tree: tree() });
     const continuation = activityPanelStore.getState().beginFetch("ref_a", { nodeID: "session:sess_a" });
-    const patch = tree(2);
+    const patch = tree();
     patch.root.counts = { active: 99, failed: 99, completed: 99, complete: false };
     activityPanelStore.getState().publishFetch("ref_a", continuation, { kind: "ready", tree: patch });
     expect(activityPanelStore.getState().entries.get("ref_a")?.load).toMatchObject({
       kind: "ready",
       tree: { root: { counts: { active: 1, failed: 0, completed: 0, complete: true } } },
     });
+  });
+
+  test("rejects a continuation from another revision and requests a root restart", () => {
+    resetActivityPanelStoreForTests();
+    const retained = tree(1);
+    retained.root.diagnostics = ["retained diagnostic"];
+    retained.root.branch = { truncated: true, continuation: "page-2", error: "retained branch error" };
+    const first = activityPanelStore.getState().beginFetch("ref_a");
+    activityPanelStore.getState().publishFetch("ref_a", first, { kind: "ready", tree: retained });
+    const continuation = activityPanelStore.getState().beginFetch("ref_a", { nodeID: "session:sess_a" });
+
+    const restartRoot = activityPanelStore
+      .getState()
+      .publishFetch("ref_a", continuation, { kind: "ready", tree: tree(2) });
+
+    expect(restartRoot).toBe(true);
+    const entry = activityPanelStore.getState().entries.get("ref_a");
+    expect(entry?.load).toMatchObject({
+      kind: "ready",
+      tree: {
+        revision: 1,
+        root: {
+          diagnostics: ["retained diagnostic"],
+          branch: { truncated: true, continuation: "page-2", error: "retained branch error" },
+        },
+      },
+    });
+    expect(entry?.continuationLoadingID).toBeUndefined();
+    expect(entry?.pending).toBeUndefined();
   });
 
   test("retains a continuation failure and clears it after retry", () => {
@@ -125,7 +154,7 @@ describe("activityPanelStore", () => {
       "session:sess_a": "branch failed",
     });
     const retry = activityPanelStore.getState().beginFetch("ref_a", { nodeID: "session:sess_a" });
-    activityPanelStore.getState().publishFetch("ref_a", retry, { kind: "ready", tree: tree(2) });
+    activityPanelStore.getState().publishFetch("ref_a", retry, { kind: "ready", tree: tree() });
     expect(activityPanelStore.getState().entries.get("ref_a")?.continuationFailures).toEqual({});
   });
 
@@ -136,7 +165,7 @@ describe("activityPanelStore", () => {
     activityPanelStore.getState().setSelected("ref_a", "session:sess_a");
     activityPanelStore.getState().setExpanded("ref_a", ["session:sess_a"]);
     const continuation = activityPanelStore.getState().beginFetch("ref_a", { nodeID: "session:sess_a" });
-    activityPanelStore.getState().publishFetch("ref_a", continuation, { kind: "ready", tree: tree(2) });
+    activityPanelStore.getState().publishFetch("ref_a", continuation, { kind: "ready", tree: tree() });
     const remounted = activityPanelStore.getState().entries.get("ref_a");
     expect(remounted?.disclosure.selectedID).toBe("session:sess_a");
     expect(remounted?.disclosure.expandedIDs).toEqual(["session:sess_a"]);

--- a/cmd/evener-hub/frontend/src/stores/activityPanel.ts
+++ b/cmd/evener-hub/frontend/src/stores/activityPanel.ts
@@ -42,7 +42,7 @@ export type ActivityFetchResult =
 export interface ActivityPanelStoreState {
   entries: Map<string, ActivityPanelEntry>;
   beginFetch(ref: string, continuation?: { nodeID: string }): number;
-  publishFetch(ref: string, requestID: number, result: ActivityFetchResult): void;
+  publishFetch(ref: string, requestID: number, result: ActivityFetchResult): boolean;
   setExpanded(ref: string, expandedIDs: string[]): void;
   setSelected(ref: string, selectedID?: string): void;
   toggleFold(ref: string, foldID: string): void;
@@ -226,7 +226,7 @@ export function graftContinuationTree(current: ActivityTree, targetID: string, p
   // for that partial window. The root counts are the badge's authoritative
   // summary, so a continuation must never replace them.
   return {
-    revision: Math.max(current.revision, patch.revision),
+    revision: current.revision,
     root: {
       ...root,
       aggregate: current.root.aggregate,
@@ -280,6 +280,7 @@ export const activityPanelStore = createStore<ActivityPanelStoreState>((set) => 
   },
 
   publishFetch(ref, requestID, result) {
+    let restartRoot = false;
     set((state) => {
       const current = state.entries.get(ref);
       if (!current || current.requestID !== requestID) return state;
@@ -298,18 +299,23 @@ export const activityPanelStore = createStore<ActivityPanelStoreState>((set) => 
         } else if (result.kind === "ready") {
           const previousTree = retainedTree(current.load);
           if (previousTree) {
-            const tree = graftContinuationTree(previousTree, pending.nodeID, result.tree);
-            const disclosure = reconcileActivityState({ ...current.disclosure, tree: previousTree }, tree);
-            const continuationFailures = { ...current.continuationFailures };
-            delete continuationFailures[pending.nodeID];
-            next = {
-              ...current,
-              load: { kind: "ready", tree },
-              disclosure: { ...disclosure, tree },
-              continuationLoadingID: undefined,
-              continuationFailures,
-              pending: undefined,
-            };
+            if (previousTree.revision !== result.tree.revision) {
+              restartRoot = true;
+              next = { ...current, continuationLoadingID: undefined, pending: undefined };
+            } else {
+              const tree = graftContinuationTree(previousTree, pending.nodeID, result.tree);
+              const disclosure = reconcileActivityState({ ...current.disclosure, tree: previousTree }, tree);
+              const continuationFailures = { ...current.continuationFailures };
+              delete continuationFailures[pending.nodeID];
+              next = {
+                ...current,
+                load: { kind: "ready", tree },
+                disclosure: { ...disclosure, tree },
+                continuationLoadingID: undefined,
+                continuationFailures,
+                pending: undefined,
+              };
+            }
           } else {
             next = readyRoot(current, result.tree);
           }
@@ -385,6 +391,7 @@ export const activityPanelStore = createStore<ActivityPanelStoreState>((set) => 
       entries.set(ref, next);
       return { entries };
     });
+    return restartRoot;
   },
 
   setExpanded(ref, expandedIDs) {

--- a/cmd/evener-hub/frontend/src/stores/activityPanel.ts
+++ b/cmd/evener-hub/frontend/src/stores/activityPanel.ts
@@ -150,14 +150,20 @@ function revisionFencedDelegate(current: ActivityDelegate, patch: ActivityDelega
   return state;
 }
 
-function mergeDelegate(current: ActivityDelegate, patch: ActivityDelegate): ActivityDelegate {
+function mergeDelegate(
+  current: ActivityDelegate,
+  patch: ActivityDelegate,
+  targetID: string,
+  insideTarget: boolean,
+): ActivityDelegate {
   const state = revisionFencedDelegate(current, patch);
+  const patchBranch = insideTarget || activityNodeID({ kind: "delegate", delegateId: current.delegateId }) === targetID;
   return {
     ...state,
-    branch: { ...patch.branch },
+    branch: { ...(patchBranch ? patch.branch : current.branch) },
     child:
       current.child && patch.child && current.child.sessionId === patch.child.sessionId
-        ? mergeSession(current.child, patch.child)
+        ? mergeSession(current.child, patch.child, targetID, patchBranch)
         : patch.child
           ? cloneSession(patch.child)
           : current.child
@@ -190,7 +196,13 @@ function fenceRootSession(current: ActivitySessionNode, incoming: ActivitySessio
   };
 }
 
-function mergeSession(current: ActivitySessionNode, patch: ActivitySessionNode): ActivitySessionNode {
+function mergeSession(
+  current: ActivitySessionNode,
+  patch: ActivitySessionNode,
+  targetID: string,
+  insideTarget = false,
+): ActivitySessionNode {
+  const patchBranch = insideTarget || activityNodeID(current) === targetID;
   const patchByID = new Map<string, ActivityEntry>();
   for (const entry of patch.entries) patchByID.set(activityNodeID(entry), entry);
   const mergedEntries = current.entries.map((entry) => {
@@ -198,7 +210,10 @@ function mergeSession(current: ActivitySessionNode, patch: ActivitySessionNode):
     const patchEntry = patchByID.get(id);
     if (!patchEntry) return cloneEntry(entry);
     if (entry.kind === "delegate" && patchEntry.kind === "delegate") {
-      return { kind: "delegate", delegate: mergeDelegate(entry.delegate, patchEntry.delegate) };
+      return {
+        kind: "delegate",
+        delegate: mergeDelegate(entry.delegate, patchEntry.delegate, targetID, patchBranch),
+      };
     }
     return cloneEntry(patchEntry);
   }) as ActivityEntry[];
@@ -212,13 +227,13 @@ function mergeSession(current: ActivitySessionNode, patch: ActivitySessionNode):
     label: patch.label,
     aggregate: patch.aggregate,
     counts: { ...patch.counts },
-    branch: { ...patch.branch },
+    branch: { ...(patchBranch ? patch.branch : current.branch) },
     entries: mergedEntries,
   };
 }
 
-export function graftContinuationTree(current: ActivityTree, patch: ActivityTree): ActivityTree {
-  const root = mergeSession(current.root, patch.root);
+export function graftContinuationTree(current: ActivityTree, targetID: string, patch: ActivityTree): ActivityTree {
+  const root = mergeSession(current.root, patch.root, targetID);
   // A continuation response describes one retained branch and can carry counts
   // for that partial window. The root counts are the badge's authoritative
   // summary, so a continuation must never replace them.
@@ -300,7 +315,7 @@ export const activityPanelStore = createStore<ActivityPanelStoreState>((set) => 
               restartRoot = true;
               next = { ...current, continuationLoadingID: undefined, pending: undefined };
             } else {
-              const tree = graftContinuationTree(previousTree, result.tree);
+              const tree = graftContinuationTree(previousTree, pending.nodeID, result.tree);
               const disclosure = reconcileActivityState({ ...current.disclosure, tree: previousTree }, tree);
               const continuationFailures = { ...current.continuationFailures };
               delete continuationFailures[pending.nodeID];

--- a/cmd/evener-hub/frontend/src/stores/activityPanel.ts
+++ b/cmd/evener-hub/frontend/src/stores/activityPanel.ts
@@ -150,16 +150,14 @@ function revisionFencedDelegate(current: ActivityDelegate, patch: ActivityDelega
   return state;
 }
 
-function mergeDelegate(current: ActivityDelegate, patch: ActivityDelegate, targetID: string): ActivityDelegate {
-  const delegateID = activityNodeID({ kind: "delegate", delegateId: current.delegateId });
+function mergeDelegate(current: ActivityDelegate, patch: ActivityDelegate): ActivityDelegate {
   const state = revisionFencedDelegate(current, patch);
-  if (delegateID === targetID) return state;
   return {
     ...state,
     branch: { ...patch.branch },
     child:
       current.child && patch.child && current.child.sessionId === patch.child.sessionId
-        ? mergeSession(current.child, patch.child, targetID)
+        ? mergeSession(current.child, patch.child)
         : patch.child
           ? cloneSession(patch.child)
           : current.child
@@ -192,8 +190,7 @@ function fenceRootSession(current: ActivitySessionNode, incoming: ActivitySessio
   };
 }
 
-function mergeSession(current: ActivitySessionNode, patch: ActivitySessionNode, targetID: string): ActivitySessionNode {
-  if (activityNodeID(current) === targetID) return cloneSession(patch);
+function mergeSession(current: ActivitySessionNode, patch: ActivitySessionNode): ActivitySessionNode {
   const patchByID = new Map<string, ActivityEntry>();
   for (const entry of patch.entries) patchByID.set(activityNodeID(entry), entry);
   const mergedEntries = current.entries.map((entry) => {
@@ -201,7 +198,7 @@ function mergeSession(current: ActivitySessionNode, patch: ActivitySessionNode, 
     const patchEntry = patchByID.get(id);
     if (!patchEntry) return cloneEntry(entry);
     if (entry.kind === "delegate" && patchEntry.kind === "delegate") {
-      return { kind: "delegate", delegate: mergeDelegate(entry.delegate, patchEntry.delegate, targetID) };
+      return { kind: "delegate", delegate: mergeDelegate(entry.delegate, patchEntry.delegate) };
     }
     return cloneEntry(patchEntry);
   }) as ActivityEntry[];
@@ -220,8 +217,8 @@ function mergeSession(current: ActivitySessionNode, patch: ActivitySessionNode, 
   };
 }
 
-export function graftContinuationTree(current: ActivityTree, targetID: string, patch: ActivityTree): ActivityTree {
-  const root = mergeSession(current.root, patch.root, targetID);
+export function graftContinuationTree(current: ActivityTree, patch: ActivityTree): ActivityTree {
+  const root = mergeSession(current.root, patch.root);
   // A continuation response describes one retained branch and can carry counts
   // for that partial window. The root counts are the badge's authoritative
   // summary, so a continuation must never replace them.
@@ -303,7 +300,7 @@ export const activityPanelStore = createStore<ActivityPanelStoreState>((set) => 
               restartRoot = true;
               next = { ...current, continuationLoadingID: undefined, pending: undefined };
             } else {
-              const tree = graftContinuationTree(previousTree, pending.nodeID, result.tree);
+              const tree = graftContinuationTree(previousTree, result.tree);
               const disclosure = reconcileActivityState({ ...current.disclosure, tree: previousTree }, tree);
               const continuationFailures = { ...current.continuationFailures };
               delete continuationFailures[pending.nodeID];

--- a/docs/appwire-protocol.md
+++ b/docs/appwire-protocol.md
@@ -109,7 +109,7 @@ no router (reserved).
 | `turn/cancelQueued` | both | `TurnCancelQueuedParams` | `TurnCancelQueuedResponse` | Removes one queued message by index so it is never consumed (cancel; also the removal half of edit-and-recompose). |
 | `goal/set` | both | `GoalSetParams` | `GoalSetResponse` | Sets or clears the session's /goal objective. |
 | `evener/tasks/list` | both | `TaskListParams` | `TaskListResponse` | Lists the session's tasks. |
-| `evener/jobs/list` | both | `JobsListParams` | `JobsListResponse` | Returns the current-session activity tree. Hub-served for exited sessions via the persisted jobs.jsonl fallback; older daemons may still return a flat array in JobsListResponse.Data. |
+| `evener/jobs/list` | both | `JobsListParams` | `JobsListResponse` | Returns one bounded page of the current-session activity tree; truncated branches carry continuations for later pages. Hub-served for exited sessions via the persisted jobs.jsonl fallback; older daemons may still return a flat array in JobsListResponse.Data. |
 | `evener/jobs/output` | both | `JobsOutputParams` | `JobsOutputResponse` | Reads a byte tail of one job's output. Hub-served for exited sessions via the persisted jobs.jsonl fallback. |
 | `evener/thread/transcripts/list` | hub | `ThreadTranscriptListParams` | `ThreadTranscriptListResponse` | Lists transcript targets (subagents/related threads) for a ref. |
 | `evener/subagentPreview` | hub | `EvenerSubagentPreviewParams` | `EvenerSubagentPreviewResponse` | Reads a bounded lazy preview of a subagent transcript's latest direct items. |


### PR DESCRIPTION
Full continuation checklist: #1116.

Recovery-only draft preserving unpublished mobile work before the development laptop goes for repair. Exact snapshot: `6f103518f4d8d55b10323498fcfbf177570cb01f`, branch `codex/mobile-repair-activity-regression`. Original subject: fix(hub): keep ancestor activity branch state.

Disposition: preserved in new branch codex/mobile-repair-activity-regression at 6f103518f4d8; original dirty worktree untouched. This assessment is provisional; compare with current #1091/#1096 and merged #1039/#1102 before deciding whether anything still needs landing. Do not merge this historical branch wholesale or roll current main backward. The original worktree was left unchanged.

Remaining: identify any unique useful behavior/evidence, extract only that into a focused current-main PR, test the actual contract, and obtain current-head CI and a clean actual RoboRev verdict. If fully superseded, document which PR preserves the behavior and close this archival draft without merging. This snapshot was checked with the repository secret scanner before publishing; no current build, runtime or release qualification is claimed.

Includes the previously uncommitted `agent/jobs_activity_continuation_progress_test.go` copied without changing the original worktree. Run and review the test before using it as evidence.
