### PR TITLE
ARCHIVE: preserve superseded discovery prototype files

### DIFF
--- a/cmd/evener-hub/frontend/src/protocol/examples/README-recovery.md
+++ b/cmd/evener-hub/frontend/src/protocol/examples/README-recovery.md
@@ -1,0 +1,5 @@
+# Recovery-only discovery prototypes
+
+These five files were recovered from the default checkout as authored prototype source. They are preserved for provenance and future reference only.
+
+The discovery implementation was superseded by the merged #1108 SDK discovery work. This recovery branch is not a qualification result and must not be merged or used as a release gate. The prototypes use historical assumptions and may depend on private fixtures or checkout-local state; review and adapt them before any future use.

--- a/cmd/evener-hub/frontend/src/protocol/examples/discovery-cli.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/discovery-cli.mjs
@@ -17,3 +17,4 @@ export async function runDiscoveryCLI(environment, hub) {
   console.log(JSON.stringify(summarizeDiscovery(result)));
   return result;
 }
+

--- a/cmd/evener-hub/frontend/src/protocol/examples/discovery-cli.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/discovery-cli.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { runDiscovery, summarizeDiscovery } from "./discovery-logic.mjs";
+import { withPrivateOutput } from "./private-output.mjs";
+
+export async function runDiscoveryCLI(environment, hub) {
+  const action = environment.EVENER_DISCOVERY_ACTION;
+  assert.ok(typeof action === "string" && action !== "", "Set EVENER_DISCOVERY_ACTION.");
+  const params = environment.EVENER_DISCOVERY_PARAMS_FILE
+    ? JSON.parse(await readFile(environment.EVENER_DISCOVERY_PARAMS_FILE, "utf8"))
+    : {};
+  const result = await withPrivateOutput(environment.EVENER_DISCOVERY_OUTPUT_FILE, async (output) => {
+    const result = await runDiscovery(hub, { action, params });
+    if (output) await output.writeFile(`${JSON.stringify(result.readback)}\n`);
+    return result;
+  });
+  console.log(JSON.stringify(summarizeDiscovery(result)));
+  return result;
+}

--- a/cmd/evener-hub/frontend/src/protocol/examples/discovery-logic.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/discovery-logic.mjs
@@ -123,3 +123,4 @@ export function summarizeDiscovery(result) {
   else if (result.action === "settings") count = value ? Object.keys(value).length : 0;
   return { outcome: result.outcome, action: result.action, ...(count === undefined ? {} : { count }) };
 }
+

--- a/cmd/evener-hub/frontend/src/protocol/examples/discovery-logic.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/discovery-logic.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+
+const METHODS = {
+  paths: ["evener/paths/complete", ["prefix", "limit", "includeFiles"]],
+  projects: ["evener/projects/recent", ["limit"]],
+  validatePath: ["evener/path/validate", ["path", "kind"]],
+  gitHead: ["evener/git/head", ["cwd"]],
+  search: ["evener/search", ["query"]],
+  harnesses: ["evener/harnesses/list", []],
+  settings: ["evener/settings/overview", []],
+};
+const isRecord = (v) => v !== null && typeof v === "object" && !Array.isArray(v);
+const nonempty = (v) => typeof v === "string" && v.trim() !== "";
+const optionalString = (v) => v === undefined || typeof v === "string";
+function inputFor(action, params) {
+  assert.ok(Object.hasOwn(METHODS, action), "Invalid discovery action.");
+  assert.ok(isRecord(params), "Invalid discovery parameters.");
+  const allowed = METHODS[action][1];
+  assert.ok(
+    Object.keys(params).every((key) => allowed.includes(key)),
+    "Unknown discovery parameter.",
+  );
+  if (action === "gitHead") assert.ok(nonempty(params.cwd), "Required path parameter.");
+  if (action === "paths" || action === "validatePath")
+    assert.ok(optionalString(params[action === "paths" ? "prefix" : "path"]), "Invalid path parameter.");
+  if (action === "projects" && params.limit !== undefined)
+    assert.ok(Number.isSafeInteger(params.limit), "Invalid project limit.");
+  if (action === "paths") {
+    if (params.limit !== undefined) assert.ok(Number.isSafeInteger(params.limit), "Invalid path limit.");
+    assert.ok(params.includeFiles === undefined || typeof params.includeFiles === "boolean", "Invalid includeFiles.");
+  }
+  if (action === "validatePath") assert.ok(optionalString(params.kind), "Invalid path kind.");
+  if (action === "search") assert.ok(optionalString(params.query), "Invalid search query.");
+  return structuredClone(params);
+}
+function stringArray(value, name) {
+  assert.ok(Array.isArray(value) && value.every((v) => typeof v === "string"), `Invalid ${name}.`);
+}
+function decode(action, value) {
+  assert.ok(isRecord(value), "Invalid discovery response.");
+  if (["paths", "projects", "harnesses"].includes(action)) {
+    assert.ok(Array.isArray(value.data), "Invalid discovery data.");
+    if (action === "harnesses")
+      for (const row of value.data)
+        assert.ok(
+          isRecord(row) &&
+            nonempty(row.id) &&
+            nonempty(row.label) &&
+            ["kind", "emptyTaskUnsupportedReason", "emptyTaskUnsupportedNextAction"].every((key) =>
+              optionalString(row[key]),
+            ),
+          "Invalid harness descriptor.",
+        );
+    else stringArray(value.data, "discovery data");
+  } else if (action === "validatePath") {
+    assert.ok(typeof value.path === "string" && typeof value.valid === "boolean", "Invalid path validation response.");
+    assert.ok(optionalString(value.error), "Invalid path validation error.");
+  } else if (action === "gitHead") assert.ok(typeof value.head === "string", "Invalid git head response.");
+  else if (action === "search") {
+    for (const key of ["live", "past"]) {
+      assert.ok(Array.isArray(value[key]), `Invalid search ${key} results.`);
+      for (const row of value[key]) {
+        assert.ok(
+          isRecord(row) && ["id", "title", "project", "state", "age", "ref"].every((k) => typeof row[k] === "string"),
+          "Invalid search result.",
+        );
+      }
+    }
+  } else if (action === "settings") {
+    const optionalStrings = (object, keys) => {
+      if (object === undefined) return;
+      assert.ok(isRecord(object), "Invalid settings section.");
+      for (const key of keys) assert.ok(optionalString(object[key]), "Invalid settings field.");
+    };
+    optionalStrings(value.hub, ["version", "commit", "listenAddr", "runDir", "spawnTimeout", "bearerTokenAge"]);
+    optionalStrings(value.storage, ["stateDir"]);
+    if (value.hub?.pastIndex !== undefined) {
+      assert.ok(isRecord(value.hub.pastIndex), "Invalid settings past index.");
+      optionalStrings(value.hub.pastIndex, ["path", "size"]);
+      for (const key of ["perPage", "count"])
+        assert.ok(
+          value.hub.pastIndex[key] === undefined || Number.isSafeInteger(value.hub.pastIndex[key]),
+          "Invalid settings count.",
+        );
+    }
+    assert.ok(
+      value.agents === undefined ||
+        (Array.isArray(value.agents) &&
+          value.agents.every((a) => isRecord(a) && nonempty(a.name) && optionalString(a.editPath))),
+      "Invalid settings agents.",
+    );
+    if (value.mcpDiscovered !== undefined) {
+      assert.ok(isRecord(value.mcpDiscovered), "Invalid MCP settings.");
+      assert.ok(optionalString(value.mcpDiscovered.error), "Invalid MCP settings error.");
+      if (value.mcpDiscovered.servers !== undefined)
+        assert.ok(
+          Array.isArray(value.mcpDiscovered.servers) &&
+            value.mcpDiscovered.servers.every((server) => {
+              if (!isRecord(server) || !nonempty(server.name)) return false;
+              return ["transport", "status", "error"].every((key) => optionalString(server[key]));
+            }),
+          "Invalid MCP settings servers.",
+        );
+    }
+  }
+  return structuredClone(value);
+}
+
+/** Run exactly one explicitly selected, read-only hub method. */
+export async function runDiscovery(hub, { action, params = {} } = {}) {
+  const [method] = METHODS[action] ?? [];
+  const captured = inputFor(action, params);
+  await hub.connect();
+  const response = await hub.request(method, captured);
+  return { outcome: "read", action, readback: decode(action, response) };
+}
+
+export function summarizeDiscovery(result) {
+  const value = result.readback;
+  let count;
+  if (Array.isArray(value?.data)) count = value.data.length;
+  else if (Array.isArray(value?.live) && Array.isArray(value?.past)) count = value.live.length + value.past.length;
+  else if (result.action === "settings") count = value ? Object.keys(value).length : 0;
+  return { outcome: result.outcome, action: result.action, ...(count === undefined ? {} : { count }) };
+}

--- a/cmd/evener-hub/frontend/src/protocol/examples/discovery.contract.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/discovery.contract.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, readFile, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { runDiscoveryCLI } from "./discovery-cli.mjs";
+import { runDiscovery, summarizeDiscovery } from "./discovery-logic.mjs";
+
+function fixture(response) {
+  const calls = [];
+  return {
+    calls,
+    hub: {
+      connect: async () => calls.push("connect"),
+      request: async (method, params) => {
+        calls.push({ method, params });
+        return response;
+      },
+    },
+  };
+}
+test("discovery dispatches one selected read with captured params and preserves future fields", async () => {
+  const params = { prefix: "/tmp", limit: 2, includeFiles: true };
+  const source = { data: ["/tmp/a"], future: { value: 1 } };
+  const f = fixture(source);
+  const pending = runDiscovery(f.hub, { action: "paths", params });
+  params.prefix = "/changed";
+  const result = await pending;
+  assert.deepEqual(f.calls, [
+    "connect",
+    { method: "evener/paths/complete", params: { prefix: "/tmp", limit: 2, includeFiles: true } },
+  ]);
+  assert.deepEqual(result.readback, source);
+  assert.deepEqual(summarizeDiscovery(result), { outcome: "read", action: "paths", count: 1 });
+});
+test("discovery validates real response contracts and does not call on bad input", async () => {
+  const f = fixture({ data: [] });
+  await assert.rejects(runDiscovery(f.hub, { action: "paths", params: { prefix: "", extra: true } }));
+  assert.deepEqual(f.calls, []);
+  for (const [action, response] of [
+    ["gitHead", { head: 4 }],
+    ["search", { live: [], past: [{}] }],
+    ["harnesses", { data: [{ id: "x" }] }],
+  ]) {
+    const bad = fixture(response);
+    await assert.rejects(runDiscovery(bad.hub, { action, params: action === "gitHead" ? { cwd: "/tmp" } : {} }));
+  }
+});
+test("discovery propagates transport errors", async () => {
+  const error = new Error("transport");
+  const f = fixture(error);
+  f.hub.request = async () => {
+    throw error;
+  };
+  await assert.rejects(runDiscovery(f.hub, { action: "settings", params: {} }), (actual) => actual === error);
+});
+test("paths accepts omitted and empty prefixes, and path validation reports empty input", async () => {
+  await runDiscovery(fixture({ data: [] }).hub, { action: "paths" });
+  await runDiscovery(fixture({ data: [] }).hub, { action: "paths", params: { prefix: "" } });
+  const result = await runDiscovery(fixture({ path: "", valid: false, error: "path is required" }).hub, {
+    action: "validatePath",
+    params: { path: "" },
+  });
+  assert.equal(result.readback.valid, false);
+});
+test("harness optional descriptor strings are type checked", async () => {
+  for (const key of ["kind", "emptyTaskUnsupportedReason", "emptyTaskUnsupportedNextAction"])
+    await assert.rejects(
+      runDiscovery(fixture({ data: [{ id: "x", label: "X", [key]: 1 }] }).hub, { action: "harnesses" }),
+    );
+});
+test("CLI keeps stdout metadata-only and writes private full output exclusively", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "evener-discovery-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const output = join(directory, "readback.json");
+  const params = join(directory, "params.json");
+  await writeFile(params, JSON.stringify({ query: "needle" }));
+  const f = fixture({
+    live: [],
+    past: [{ id: "id", title: "private", project: "/secret", state: "ended", age: "now", ref: "local:id" }],
+  });
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (line) => lines.push(line);
+  try {
+    await runDiscoveryCLI(
+      { EVENER_DISCOVERY_ACTION: "search", EVENER_DISCOVERY_PARAMS_FILE: params, EVENER_DISCOVERY_OUTPUT_FILE: output },
+      f.hub,
+    );
+  } finally {
+    console.log = originalLog;
+  }
+  assert.deepEqual(JSON.parse(lines[0]), { outcome: "read", action: "search", count: 1 });
+  assert.match(await readFile(output, "utf8"), /private/);
+  assert.equal((await stat(output)).mode & 0o777, 0o600);
+  await assert.rejects(
+    runDiscoveryCLI({ EVENER_DISCOVERY_ACTION: "search", EVENER_DISCOVERY_OUTPUT_FILE: output }, f.hub),
+  );
+  await assert.rejects(
+    runDiscoveryCLI({ EVENER_DISCOVERY_ACTION: "search", EVENER_DISCOVERY_OUTPUT_FILE: "relative.json" }, f.hub),
+  );
+});
+test("CLI removes only its incomplete private output after a failed read", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "evener-discovery-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const output = join(directory, "failed.json");
+  const f = fixture(new Error("read failed"));
+  f.hub.request = async () => {
+    throw new Error("read failed");
+  };
+  await assert.rejects(
+    runDiscoveryCLI({ EVENER_DISCOVERY_ACTION: "settings", EVENER_DISCOVERY_OUTPUT_FILE: output }, f.hub),
+  );
+  await assert.rejects(access(output));
+});
+test("CLI does not remove a replacement at the reserved output path", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "evener-discovery-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const output = join(directory, "replaced.json");
+  const f = fixture({});
+  f.hub.request = async () => {
+    await unlink(output);
+    await writeFile(output, "replacement");
+    throw new Error("read failed");
+  };
+  await assert.rejects(
+    runDiscoveryCLI({ EVENER_DISCOVERY_ACTION: "settings", EVENER_DISCOVERY_OUTPUT_FILE: output }, f.hub),
+  );
+  assert.equal(await readFile(output, "utf8"), "replacement");
+});
+
+test("settings validates known optional fields while preserving omissions and future data", async () => {
+  const valid = {
+    hub: { version: "0.1.0", pastIndex: {} },
+    storage: {},
+    agents: [{ name: "default", editPath: "", future: 1 }],
+    mcpDiscovered: {},
+    future: { opaque: true },
+  };
+  const result = await runDiscovery(fixture(valid).hub, { action: "settings" });
+  assert.deepEqual(result.readback, valid);
+  for (const response of [
+    { agents: [{ name: "default", editPath: 4 }] },
+    { hub: { commit: 4 } },
+    { hub: { pastIndex: { count: "1" } } },
+    { mcpDiscovered: { servers: [{ name: "x", transport: 4 }] } },
+  ]) {
+    await assert.rejects(runDiscovery(fixture(response).hub, { action: "settings" }));
+  }
+});

--- a/cmd/evener-hub/frontend/src/protocol/examples/discovery.contract.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/discovery.contract.mjs
@@ -148,3 +148,4 @@ test("settings validates known optional fields while preserving omissions and fu
     await assert.rejects(runDiscovery(fixture(response).hub, { action: "settings" }));
   }
 });
+

--- a/cmd/evener-hub/frontend/src/protocol/examples/discovery.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/discovery.mjs
@@ -1,0 +1,13 @@
+import { clientFromEnvironment } from "./connection.mjs";
+import { runDiscoveryCLI } from "./discovery-cli.mjs";
+
+let hub;
+try {
+  ({ hub } = clientFromEnvironment());
+  await runDiscoveryCLI(process.env, hub);
+} catch {
+  console.error("Discovery could not be read.");
+  process.exitCode = 1;
+} finally {
+  hub?.close();
+}

--- a/cmd/evener-hub/frontend/src/protocol/examples/discovery.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/discovery.mjs
@@ -11,3 +11,4 @@ try {
 } finally {
   hub?.close();
 }
+

--- a/cmd/evener-hub/frontend/src/protocol/examples/private-output.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/private-output.mjs
@@ -26,3 +26,4 @@ export async function withPrivateOutput(outputPath, operation) {
     }
   }
 }
+

--- a/cmd/evener-hub/frontend/src/protocol/examples/private-output.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/examples/private-output.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { lstat, open, unlink } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+
+// Reserve private output before connecting; never remove a replaced pathname.
+export async function withPrivateOutput(outputPath, operation) {
+  assert.ok(outputPath === undefined || isAbsolute(outputPath), "Use an absolute private output path.");
+  let output;
+  let reservation;
+  let ownsOutput = false;
+  try {
+    if (outputPath !== undefined) {
+      output = await open(outputPath, "wx", 0o600);
+      reservation = await output.stat();
+      ownsOutput = true;
+    }
+    const result = await operation(output);
+    ownsOutput = false;
+    return result;
+  } finally {
+    await output?.close();
+    if (ownsOutput && outputPath !== undefined) {
+      const current = await lstat(outputPath).catch(() => undefined);
+      if (current && reservation && current.dev === reservation.dev && current.ino === reservation.ino)
+        await unlink(outputPath).catch(() => {});
+    }
+  }
+}


### PR DESCRIPTION
Full continuation checklist: #1116.

Recovery-only archive of five previously untracked SDK discovery prototype files from the default checkout at e8059456206079ff99276bd5e14a77a6bdeba4f3, preserved byte-for-byte before laptop repair. Includes the original trailing blank lines; no default-checkout files were changed.

**Do not merge this branch.** These prototypes are superseded by merged #1108, whose tested discovery/private-output behavior remains authoritative. This draft preserves authored code for provenance and comparison; it does not undo the reviewed implementation.

Remaining: compare any historically useful contracts/ideas with #1108/#1114, record supersession and close this archival draft without merging. No build or package qualification is claimed. The original files were inspected for credentials; only synthetic fixture token-like data was present. README-recovery.md records the source and exclusions.
