### PR TITLE
fix(navigation): normalize empty graphs before delta comparison

### DIFF
--- a/cmd/evener-hub/navigation_delta_test.go
+++ b/cmd/evener-hub/navigation_delta_test.go
@@ -139,8 +139,8 @@ func TestNavigationDeltaReconstructsResourcesWithoutEntities(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if current.Entities != nil {
-				t.Fatalf("test setup: current snapshot has entities %+v, want an entity-less resource", current.Entities)
+			if len(current.Entities) != 0 {
+				t.Fatalf("test setup: current snapshot has %d entities, want an entity-less resource", len(current.Entities))
 			}
 			baseVersion := appwire.NavigationReadBase{GenerationID: "g", Revision: 1, ETag: "tag-1"}
 			currentVersion := appwire.NavigationReadBase{GenerationID: "g", Revision: 2, ETag: "tag-2"}

--- a/cmd/evener-hub/navigation_empty_delta_test.go
+++ b/cmd/evener-hub/navigation_empty_delta_test.go
@@ -1,0 +1,61 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/hubapi"
+)
+
+func TestNavigationDeltaEmptyPinCatalog(t *testing.T) {
+	key := navigationResourceKey{Kind: navigationResourcePinCatalog, Limit: 50}
+	version := func(revision uint64) appwire.NavigationReadBase {
+		return appwire.NavigationReadBase{GenerationID: "g", Revision: revision, ETag: fmt.Sprintf("catalog-%d", revision)}
+	}
+	catalog := func(revision uint64, populated bool) hubapi.NavigationSnapshot {
+		t.Helper()
+		value := hubapi.NavigationPinSectionCatalog{GenerationID: "g", Revision: revision}
+		if populated {
+			value.PinSections = hubapi.NavigationArray[hubapi.NavigationPinSectionDescriptor]{{ID: "focus", Name: "Focus", Count: 1}}
+		}
+		snapshot, err := normalizeNavigationResource(key, value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return snapshot
+	}
+	for _, tc := range []struct {
+		name      string
+		populated bool
+	}{
+		{"remove final section", true}, {"metadata-only empty catalog", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base, current := catalog(1, tc.populated), catalog(2, false)
+			delta, err := diffNavigationSnapshots(key, version(1), version(2), base, current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			applied, err := applyNavigationDelta(base, delta)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(applied.Entities) != 0 || len(applied.Containers) != 1 {
+				t.Fatalf("empty catalog has %d entities and %d containers", len(applied.Entities), len(applied.Containers))
+			}
+			root := applied.Containers[0]
+			if root.Owner.Kind != "resource_root" || root.Owner.Slot != "pin_sections" || len(root.Children) != 0 {
+				t.Fatalf("empty catalog root = %+v", root)
+			}
+			var metadata navigationPagedMetadata
+			if err := json.Unmarshal(applied.Metadata, &metadata); err != nil {
+				t.Fatal(err)
+			}
+			if metadata.Revision != 2 {
+				t.Fatalf("metadata revision = %d, want 2", metadata.Revision)
+			}
+		})
+	}
+}

--- a/cmd/evener-hub/navigation_normalize.go
+++ b/cmd/evener-hub/navigation_normalize.go
@@ -148,6 +148,11 @@ func (b *navigationDocumentBuilder) addSessions(owner, slot string, sessions hub
 	b.container(containerKey, ownerValue, children)
 }
 func (b *navigationDocumentBuilder) finish() (hubapi.NavigationSnapshot, error) {
+	// History and applied deltas use an empty array. Keep projected empty
+	// resources in that same form so reconstruction checks compare equal graphs.
+	if b.entities == nil {
+		b.entities = []hubapi.NavigationEntityRecord{}
+	}
 	snapshot := hubapi.NavigationSnapshot{Metadata: b.metadata, Entities: b.entities, Containers: b.containers}
 	hubapi.SortNavigationSnapshot(&snapshot)
 	if err := validateNavigationResourceSnapshot(b.key, b.generation, b.revision, snapshot); err != nil {


### PR DESCRIPTION
Removing the final pinned section can leave navigation projection with a nil entity list while applied delta/history uses an empty list. Reconstruction compares unequal representations of the same empty graph and rejects the navigation read.

Normalize empty projected entity lists in the document builder. Cover final-section removal and metadata-only empty catalog updates through the real snapshot diff/apply path; update the existing entity-less-resource fixture to assert semantic emptiness.

This is the focused current-main replacement for recovery draft #1111. Base source: 942b9dc727e37b358c95ee673f66258f330a9aff. The old dirty source worktree remains untouched. Only three implementation/test files change.

Validation: the affected delta/reconstruction tests pass. Full hub tests, canonical gate and independent causal regression checking are running; fresh CI and actual clean RoboRev are required before merge. Master continuation checklist: #1116. No native UI or Tauri code is included.
