### PR TITLE
Bound parallel session-list source loading

### DIFF
--- a/cmd/evener-hub/app_threadlist.go
+++ b/cmd/evener-hub/app_threadlist.go
@@ -15,6 +15,8 @@ import (
 
 const threadListSourceTimeout = 3 * time.Second
 
+const threadListSourceWorkers = 4
+
 func hubThreadList(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
 	return hubThreadListWithSourceTimeout(ctx, cfg, sources, params, threadListSourceTimeout)
 }
@@ -28,23 +30,47 @@ func hubThreadListWithSourceTimeout(ctx context.Context, cfg hubcore.WebConfig, 
 		resp  appwire.ThreadListResponse
 		err   error
 	}
-	results := make(chan sourceResult, len(allSources))
+	allowed := make([]int, 0, len(allSources))
 	for index, source := range allSources {
 		if !sourceAllowedForList(source.ID(), params) {
 			continue
 		}
-		go func(index int, source appsource.Source) {
-			sourceCtx, cancel := context.WithTimeout(ctx, sourceTimeout)
-			defer cancel()
-			resp, err := source.ListThreads(sourceCtx, params)
-			results <- sourceResult{index: index, resp: resp, err: err}
-		}(index, source)
+		allowed = append(allowed, index)
 	}
-	listed := make([]sourceResult, 0, len(allSources))
-	for _, source := range allSources {
-		if !sourceAllowedForList(source.ID(), params) {
-			continue
+	results := make(chan sourceResult, len(allowed))
+	jobs := make(chan int)
+	workerCount := min(threadListSourceWorkers, len(allowed))
+	for worker := 0; worker < workerCount; worker++ {
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case index, ok := <-jobs:
+					if !ok {
+						return
+					}
+					source := allSources[index]
+					sourceCtx, cancel := context.WithTimeout(ctx, sourceTimeout)
+					resp, err := source.ListThreads(sourceCtx, params)
+					cancel()
+					results <- sourceResult{index: index, resp: resp, err: err}
+				}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, index := range allowed {
+			select {
+			case jobs <- index:
+			case <-ctx.Done():
+				return
+			}
 		}
+	}()
+	listed := make([]sourceResult, 0, len(allowed))
+	for range allowed {
 		select {
 		case result := <-results:
 			listed = append(listed, result)

--- a/cmd/evener-hub/app_threadlist.go
+++ b/cmd/evener-hub/app_threadlist.go
@@ -40,7 +40,7 @@ func hubThreadListWithSourceTimeout(ctx context.Context, cfg hubcore.WebConfig, 
 	results := make(chan sourceResult, len(allowed))
 	jobs := make(chan int)
 	workerCount := min(threadListSourceWorkers, len(allowed))
-	for worker := 0; worker < workerCount; worker++ {
+	for range workerCount {
 		go func() {
 			for {
 				select {

--- a/cmd/evener-hub/app_threadlist.go
+++ b/cmd/evener-hub/app_threadlist.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"primeradiant.com/evener/appwire"
 	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
@@ -12,14 +13,52 @@ import (
 	"primeradiant.com/evener/identifier"
 )
 
+const threadListSourceTimeout = 3 * time.Second
+
 func hubThreadList(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	return hubThreadListWithSourceTimeout(ctx, cfg, sources, params, threadListSourceTimeout)
+}
+
+func hubThreadListWithSourceTimeout(ctx context.Context, cfg hubcore.WebConfig, sources *appsource.Registry, params appwire.ThreadListParams, sourceTimeout time.Duration) (appwire.ThreadListResponse, error) {
 	threads := make([]appwire.Thread, 0)
 	liveIDs := map[string]struct{}{}
-	for _, source := range sources.All() {
+	allSources := sources.All()
+	type sourceResult struct {
+		index int
+		resp  appwire.ThreadListResponse
+		err   error
+	}
+	results := make(chan sourceResult, len(allSources))
+	for index, source := range allSources {
 		if !sourceAllowedForList(source.ID(), params) {
 			continue
 		}
-		resp, err := source.ListThreads(ctx, params)
+		go func(index int, source appsource.Source) {
+			sourceCtx, cancel := context.WithTimeout(ctx, sourceTimeout)
+			defer cancel()
+			resp, err := source.ListThreads(sourceCtx, params)
+			results <- sourceResult{index: index, resp: resp, err: err}
+		}(index, source)
+	}
+	listed := make([]sourceResult, 0, len(allSources))
+	for _, source := range allSources {
+		if !sourceAllowedForList(source.ID(), params) {
+			continue
+		}
+		select {
+		case result := <-results:
+			listed = append(listed, result)
+		case <-ctx.Done():
+			return appwire.ThreadListResponse{}, ctx.Err()
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return appwire.ThreadListResponse{}, err
+	}
+	slices.SortFunc(listed, func(a, b sourceResult) int { return a.index - b.index })
+	for _, result := range listed {
+		source := allSources[result.index]
+		resp, err := result.resp, result.err
 		if err != nil {
 			if sourceExplicitlyRequestedForList(source.ID(), params) {
 				return appwire.ThreadListResponse{}, err

--- a/cmd/evener-hub/app_threadlist_bounded_test.go
+++ b/cmd/evener-hub/app_threadlist_bounded_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,10 +24,25 @@ func (s *barrierThreadListSource) ListThreads(context.Context, appwire.ThreadLis
 	return appwire.ThreadListResponse{Data: []appwire.Thread{s.thread}}, nil
 }
 
-type cancelableThreadListSource struct{ *scriptedAppSource }
+type cancelableThreadListSource struct {
+	*scriptedAppSource
+	started chan<- struct{}
+	done    chan<- struct{}
+}
+
+type failingThreadListSource struct {
+	*scriptedAppSource
+	err error
+}
+
+func (s *failingThreadListSource) ListThreads(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	return appwire.ThreadListResponse{}, s.err
+}
 
 func (s *cancelableThreadListSource) ListThreads(ctx context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	s.started <- struct{}{}
 	<-ctx.Done()
+	s.done <- struct{}{}
 	return appwire.ThreadListResponse{}, ctx.Err()
 }
 
@@ -59,16 +75,59 @@ func TestHubThreadListQueriesSourcesInParallelAndPreservesOrder(t *testing.T) {
 
 func TestHubThreadListCancellationReleasesSourceWait(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
+	entered := make(chan struct{}, 1)
+	done := make(chan struct{}, 1)
 	sources := appsource.NewRegistry()
-	sources.Add(&cancelableThreadListSource{scriptedAppSource: &scriptedAppSource{id: "blocked"}})
+	sources.Add(&cancelableThreadListSource{scriptedAppSource: &scriptedAppSource{id: "blocked"}, started: entered, done: done})
 	result := make(chan error, 1)
 	go func() {
 		_, err := hubThreadListWithSourceTimeout(ctx, hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, time.Hour)
 		result <- err
 	}()
+	<-entered
 	cancel()
 	if err := <-result; err != context.Canceled {
 		t.Fatalf("hubThreadList error=%v, want context cancellation", err)
+	}
+	<-done
+}
+
+func TestHubThreadListBoundsConcurrentSourcesAndKeepsOptionalErrors(t *testing.T) {
+	started := make(chan struct{}, 8)
+	release := make(chan struct{})
+	sources := appsource.NewRegistry()
+	for i := 0; i < 6; i++ {
+		sources.Add(&barrierThreadListSource{scriptedAppSource: &scriptedAppSource{id: fmt.Sprintf("source-%d", i), thread: appwire.Thread{ID: fmt.Sprintf("thread-%d", i)}}, started: started, release: release})
+	}
+	result := make(chan appwire.ThreadListResponse, 1)
+	go func() {
+		response, _ := hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, time.Hour)
+		result <- response
+	}()
+	for range threadListSourceWorkers {
+		<-started
+	}
+	select {
+	case <-started:
+		t.Fatal("started more sources than worker cap")
+	default:
+	}
+	close(release)
+	response := <-result
+	if len(response.Data) != 6 {
+		t.Fatalf("threads=%d, want 6", len(response.Data))
+	}
+}
+
+func TestHubThreadListOptionalAndExplicitSourceErrors(t *testing.T) {
+	sources := appsource.NewRegistry()
+	sources.Add(&failingThreadListSource{scriptedAppSource: &scriptedAppSource{id: "optional"}, err: context.DeadlineExceeded})
+	if response, err := hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, time.Second); err != nil || len(response.Data) != 0 {
+		t.Fatalf("optional error response=%+v err=%v", response, err)
+	}
+	params := appwire.ThreadListParams{SourceIDs: []string{"optional"}}
+	if _, err := hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, params, time.Second); err == nil {
+		t.Fatal("explicit source error was swallowed")
 	}
 }
 

--- a/cmd/evener-hub/app_threadlist_bounded_test.go
+++ b/cmd/evener-hub/app_threadlist_bounded_test.go
@@ -74,7 +74,10 @@ func TestHubThreadListCancellationReleasesSourceWait(t *testing.T) {
 
 func TestPastEntryThreadForListUsesMetadataOnly(t *testing.T) {
 	entry := hubcore.PastEntry{StateDir: "/path-that-must-not-be-opened", Meta: schema.SessionMeta{ID: "session-1", EnvInfo: schema.EnvironmentInfo{WorkingDir: "/project"}}}
-	thread := pastEntryThreadForList(hubcore.WebConfig{}, entry)
+	thread, err := pastEntryThreadForList(context.Background(), hubcore.WebConfig{}, entry)
+	if err != nil {
+		t.Fatalf("metadata projection: %v", err)
+	}
 	if thread.ID != entry.Meta.ID || thread.CWD != entry.Meta.EnvInfo.WorkingDir {
 		t.Fatalf("metadata projection=%+v, want session metadata", thread)
 	}

--- a/cmd/evener-hub/app_threadlist_bounded_test.go
+++ b/cmd/evener-hub/app_threadlist_bounded_test.go
@@ -3,6 +3,8 @@ package hub
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,9 +18,21 @@ type barrierThreadListSource struct {
 	*scriptedAppSource
 	started chan<- struct{}
 	release <-chan struct{}
+	current *int32
+	maximum *int32
 }
 
 func (s *barrierThreadListSource) ListThreads(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	if s.current != nil {
+		current := atomic.AddInt32(s.current, 1)
+		defer atomic.AddInt32(s.current, -1)
+		for {
+			maximum := atomic.LoadInt32(s.maximum)
+			if current <= maximum || atomic.CompareAndSwapInt32(s.maximum, maximum, current) {
+				break
+			}
+		}
+	}
 	s.started <- struct{}{}
 	<-s.release
 	return appwire.ThreadListResponse{Data: []appwire.Thread{s.thread}}, nil
@@ -95,9 +109,12 @@ func TestHubThreadListCancellationReleasesSourceWait(t *testing.T) {
 func TestHubThreadListBoundsConcurrentSourcesAndKeepsOptionalErrors(t *testing.T) {
 	started := make(chan struct{}, 8)
 	release := make(chan struct{})
+	var current, maximum int32
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
 	sources := appsource.NewRegistry()
 	for i := 0; i < 6; i++ {
-		sources.Add(&barrierThreadListSource{scriptedAppSource: &scriptedAppSource{id: fmt.Sprintf("source-%d", i), thread: appwire.Thread{ID: fmt.Sprintf("thread-%d", i)}}, started: started, release: release})
+		sources.Add(&barrierThreadListSource{scriptedAppSource: &scriptedAppSource{id: fmt.Sprintf("source-%d", i), thread: appwire.Thread{ID: fmt.Sprintf("thread-%d", i)}}, started: started, release: release, current: &current, maximum: &maximum})
 	}
 	result := make(chan appwire.ThreadListResponse, 1)
 	go func() {
@@ -107,15 +124,13 @@ func TestHubThreadListBoundsConcurrentSourcesAndKeepsOptionalErrors(t *testing.T
 	for range threadListSourceWorkers {
 		<-started
 	}
-	select {
-	case <-started:
-		t.Fatal("started more sources than worker cap")
-	default:
-	}
-	close(release)
+	releaseOnce.Do(func() { close(release) })
 	response := <-result
 	if len(response.Data) != 6 {
 		t.Fatalf("threads=%d, want 6", len(response.Data))
+	}
+	if maximum > threadListSourceWorkers {
+		t.Fatalf("maximum concurrent sources=%d, want <=%d", maximum, threadListSourceWorkers)
 	}
 }
 

--- a/cmd/evener-hub/app_threadlist_bounded_test.go
+++ b/cmd/evener-hub/app_threadlist_bounded_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -100,7 +101,7 @@ func TestHubThreadListCancellationReleasesSourceWait(t *testing.T) {
 	}()
 	<-entered
 	cancel()
-	if err := <-result; err != context.Canceled {
+	if err := <-result; !errors.Is(err, context.Canceled) {
 		t.Fatalf("hubThreadList error=%v, want context cancellation", err)
 	}
 	<-done
@@ -113,7 +114,7 @@ func TestHubThreadListBoundsConcurrentSourcesAndKeepsOptionalErrors(t *testing.T
 	var releaseOnce sync.Once
 	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
 	sources := appsource.NewRegistry()
-	for i := 0; i < 6; i++ {
+	for i := range 6 {
 		sources.Add(&barrierThreadListSource{scriptedAppSource: &scriptedAppSource{id: fmt.Sprintf("source-%d", i), thread: appwire.Thread{ID: fmt.Sprintf("thread-%d", i)}}, started: started, release: release, current: &current, maximum: &maximum})
 	}
 	result := make(chan appwire.ThreadListResponse, 1)
@@ -131,6 +132,20 @@ func TestHubThreadListBoundsConcurrentSourcesAndKeepsOptionalErrors(t *testing.T
 	}
 	if maximum > threadListSourceWorkers {
 		t.Fatalf("maximum concurrent sources=%d, want <=%d", maximum, threadListSourceWorkers)
+	}
+}
+
+func TestHubThreadListZeroSourceTimeoutPreservesOptionalAndExplicitErrors(t *testing.T) {
+	sources := appsource.NewRegistry()
+	sources.Add(&failingThreadListSource{scriptedAppSource: &scriptedAppSource{id: "optional-expired"}, err: context.DeadlineExceeded})
+	response, err := hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, 0)
+	if err != nil || len(response.Data) != 0 {
+		t.Fatalf("optional expired source response=%+v err=%v, want empty success", response, err)
+	}
+	params := appwire.ThreadListParams{SourceIDs: []string{"optional-expired"}}
+	_, err = hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, params, 0)
+	if err == nil {
+		t.Fatal("explicit expired source unexpectedly succeeded")
 	}
 }
 

--- a/cmd/evener-hub/app_threadlist_bounded_test.go
+++ b/cmd/evener-hub/app_threadlist_bounded_test.go
@@ -137,15 +137,19 @@ func TestHubThreadListBoundsConcurrentSourcesAndKeepsOptionalErrors(t *testing.T
 
 func TestHubThreadListZeroSourceTimeoutPreservesOptionalAndExplicitErrors(t *testing.T) {
 	sources := appsource.NewRegistry()
-	sources.Add(&failingThreadListSource{scriptedAppSource: &scriptedAppSource{id: "optional-expired"}, err: context.DeadlineExceeded})
+	sources.Add(&cancelableThreadListSource{
+		scriptedAppSource: &scriptedAppSource{id: "optional-expired"},
+		started:           make(chan struct{}, 2),
+		done:              make(chan struct{}, 2),
+	})
 	response, err := hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, 0)
 	if err != nil || len(response.Data) != 0 {
 		t.Fatalf("optional expired source response=%+v err=%v, want empty success", response, err)
 	}
 	params := appwire.ThreadListParams{SourceIDs: []string{"optional-expired"}}
 	_, err = hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, params, 0)
-	if err == nil {
-		t.Fatal("explicit expired source unexpectedly succeeded")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("explicit expired source error=%v, want deadline exceeded", err)
 	}
 }
 

--- a/cmd/evener-hub/app_threadlist_bounded_test.go
+++ b/cmd/evener-hub/app_threadlist_bounded_test.go
@@ -1,0 +1,81 @@
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/appwire"
+	"primeradiant.com/evener/cmd/evener-hub/internal/appsource"
+	"primeradiant.com/evener/cmd/evener-hub/internal/hubcore"
+)
+
+type barrierThreadListSource struct {
+	*scriptedAppSource
+	started chan<- struct{}
+	release <-chan struct{}
+}
+
+func (s *barrierThreadListSource) ListThreads(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	s.started <- struct{}{}
+	<-s.release
+	return appwire.ThreadListResponse{Data: []appwire.Thread{s.thread}}, nil
+}
+
+type cancelableThreadListSource struct{ *scriptedAppSource }
+
+func (s *cancelableThreadListSource) ListThreads(ctx context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	<-ctx.Done()
+	return appwire.ThreadListResponse{}, ctx.Err()
+}
+
+func TestHubThreadListQueriesSourcesInParallelAndPreservesOrder(t *testing.T) {
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	sources := appsource.NewRegistry()
+	sources.Add(&barrierThreadListSource{scriptedAppSource: &scriptedAppSource{id: "first", thread: appwire.Thread{ID: "first-thread", Source: "first"}}, started: started, release: release})
+	sources.Add(&barrierThreadListSource{scriptedAppSource: &scriptedAppSource{id: "second", thread: appwire.Thread{ID: "second-thread", Source: "second"}}, started: started, release: release})
+
+	result := make(chan appwire.ThreadListResponse, 1)
+	errors := make(chan error, 1)
+	go func() {
+		response, err := hubThreadListWithSourceTimeout(context.Background(), hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, time.Hour)
+		result <- response
+		errors <- err
+	}()
+	for range 2 {
+		<-started
+	}
+	close(release)
+	if err := <-errors; err != nil {
+		t.Fatal(err)
+	}
+	response := <-result
+	if len(response.Data) != 2 || response.Data[0].ID != "first-thread" || response.Data[1].ID != "second-thread" {
+		t.Fatalf("threads=%+v, want source order", response.Data)
+	}
+}
+
+func TestHubThreadListCancellationReleasesSourceWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	sources := appsource.NewRegistry()
+	sources.Add(&cancelableThreadListSource{scriptedAppSource: &scriptedAppSource{id: "blocked"}})
+	result := make(chan error, 1)
+	go func() {
+		_, err := hubThreadListWithSourceTimeout(ctx, hubcore.WebConfig{}, sources, appwire.ThreadListParams{}, time.Hour)
+		result <- err
+	}()
+	cancel()
+	if err := <-result; err != context.Canceled {
+		t.Fatalf("hubThreadList error=%v, want context cancellation", err)
+	}
+}
+
+func TestPastEntryThreadForListUsesMetadataOnly(t *testing.T) {
+	entry := hubcore.PastEntry{StateDir: "/path-that-must-not-be-opened", Meta: schema.SessionMeta{ID: "session-1", EnvInfo: schema.EnvironmentInfo{WorkingDir: "/project"}}}
+	thread := pastEntryThreadForList(hubcore.WebConfig{}, entry)
+	if thread.ID != entry.Meta.ID || thread.CWD != entry.Meta.EnvInfo.WorkingDir {
+		t.Fatalf("metadata projection=%+v, want session metadata", thread)
+	}
+}

--- a/cmd/evener-hub/internal/appsource/local_daemon.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon.go
@@ -243,14 +243,26 @@ func (s *LocalDaemonSource) acquireRelaySession(params appwire.ThreadReadParams)
 	return s.AcquireRelaySession(ref)
 }
 
-func (s *LocalDaemonSource) ListThreads(context.Context, appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+func (s *LocalDaemonSource) ListThreads(ctx context.Context, _ appwire.ThreadListParams) (appwire.ThreadListResponse, error) {
+	if err := ctx.Err(); err != nil {
+		return appwire.ThreadListResponse{}, err
+	}
 	out := appwire.ThreadListResponse{}
 	for _, entry := range s.listedEntries() {
+		if err := ctx.Err(); err != nil {
+			return appwire.ThreadListResponse{}, err
+		}
 		out.Data = append(out.Data, s.threadFromEntry(entry))
+	}
+	if err := ctx.Err(); err != nil {
+		return appwire.ThreadListResponse{}, err
 	}
 	sort.SliceStable(out.Data, func(i, j int) bool {
 		return localThreadLess(out.Data[i], out.Data[j])
 	})
+	if err := ctx.Err(); err != nil {
+		return appwire.ThreadListResponse{}, err
+	}
 	return out, nil
 }
 

--- a/cmd/evener-hub/internal/appsource/local_daemon_test.go
+++ b/cmd/evener-hub/internal/appsource/local_daemon_test.go
@@ -1180,3 +1180,15 @@ func TestLocalDaemonListKeepsChildReferencesDistinctFromOwnerWorkspace(t *testin
 		})
 	}
 }
+
+func TestLocalDaemonSourceListThreadsHonorsCanceledContext(t *testing.T) {
+	source := NewLocalDaemonSourceWithEntries("local", func() []LocalDaemonEntry {
+		return []LocalDaemonEntry{{Entry: rendezvous.Entry{Protocol: appwire.ProtocolVersion, ThreadID: "thread-1", SessionID: "session-1"}}}
+	}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := source.ListThreads(ctx, appwire.ThreadListParams{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("ListThreads error=%v, want context cancellation", err)
+	}
+}


### PR DESCRIPTION
Session-list loading waits for sources in sequence, so a slow source delays later sources. Query eligible sources with up to four concurrent workers and a three-second context deadline per source, then assemble responses in registry order. Parent cancellation stops the request and cancels source work. Optional source failures stay optional; explicitly requested source errors remain visible. Local metadata enumeration now checks cancellation while constructing its result.

Behavioral tests measure actual maximum concurrency, exercise parent cancellation, stable ordering, explicit/optional errors and a source waiting for its real context deadline. Focused race tests pass. The full canonical gate passed at 71d6b90150699566e2321864ddd5e1d533789685, and its actual RoboRev review found no issues.

Current head 647d44311697442af98c6ec8625546490b541063 integrates #1127's qualified main navigation fix. Fresh CI/RoboRev and the full local gate are running for this head. Context deadlines rely on sources honoring cancellation; no hard preemption of arbitrary noncooperating future sources is claimed.

This is the qualified candidate extracted from recovery-only #1112. Keep draft until current gates complete. Representative iPhone loading measurements remain a product acceptance task. Tracked in #1116.
