### PR TITLE
Test late compaction-owner paging fragments

### DIFF
--- a/internal/apptranscript/compaction_grouping_test.go
+++ b/internal/apptranscript/compaction_grouping_test.go
@@ -72,6 +72,10 @@ func TestCompactionOwnershipAcrossIncrementalItemReaders(t *testing.T) {
 			record(schema.TurnSummary, "summary", ""),
 			record(schema.TurnContextCompaction, "layer", "turn_active"),
 		}, []string{"turn_active", "summary", "turn_active"}},
+		{"late owner after next input is a paging fragment", []schema.Turn{
+			record(schema.TurnUserInput, "turn_next", ""),
+			record(schema.TurnContextCompaction, "layer", "turn_active"),
+		}, []string{"turn_active", "turn_next", "turn_active"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Exercise a late compaction record owned by an earlier logical turn after the next user input has already appeared. The existing behavioral test compares full projection, warm/cold indexed grouping and one-item paging so non-contiguous owner fragments retain the same identities across readers.

This is a small additional regression on top of #1100. It did not reveal a new production defect; the expected fragmented paging representation agrees across reader paths. Keep draft while #1100 and its environment prerequisite finish qualification. The test will be incorporated into the compaction branch after the current unchanged-head canonical gate finishes.

Repair and remaining work: #1116.
