### PR TITLE
fix(webui): open agent file links in a side pane

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMarkdown.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMarkdown.tsx
@@ -1,0 +1,75 @@
+import { type ReactPortal, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { docFileRawURL, docImageURL } from "../../../../protocol/docContent";
+import * as paneActions from "../../../../shell/paneActions";
+import { useTranscriptRenderContext } from "../../../../transcriptDisplay/renderContext";
+import { Markdown } from "../../../../widgets/markdown";
+import { OpenButton } from "../../../../widgets/openbutton";
+import { fileDocParams } from "../fileOpenBeside";
+
+function fileLinkPath(href: string): string | undefined {
+  // URL references are not filesystem paths. Decode only the pathname, once,
+  // before applying the same cwd boundary used by file tool cards.
+  if (/^(?:[a-z][a-z\d+.-]*:|\/\/|[?#])/i.test(href)) return undefined;
+  try {
+    const path = decodeURIComponent(href.split(/[?#]/, 1)[0] ?? "");
+    if (path.startsWith("//") || /[\\\p{Cc}]/u.test(path) || path.split("/").includes("..")) return undefined;
+    return path;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Adds session file actions to sanitized agent prose without changing the
+ * shared Markdown renderer's URL policy or admitting authored HTML. */
+export function AgentMarkdown({ source, live = false }: { source: string; live?: boolean }) {
+  const { thread } = useTranscriptRenderContext();
+  const sessionRef = thread?.ref;
+  const cwd = thread?.cwd;
+  const root = useRef<HTMLDivElement>(null);
+  const [affordances, setAffordances] = useState<ReactPortal[]>([]);
+  // Portal updates must not replace the innerHTML that owns their mount points.
+  const markdown = useMemo(() => <Markdown ref={root} source={source} live={live} />, [source, live]);
+
+  // source/live determine when Markdown replaces its sanitized DOM. Rebind even
+  // when the session is unchanged, including streamed and settled transitions.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: source/live invalidate the child Markdown DOM
+  useLayoutEffect(() => {
+    const portals: ReactPortal[] = [];
+    const cleanups: Array<() => void> = [];
+    for (const link of root.current?.querySelectorAll<HTMLAnchorElement>("a[href]") ?? []) {
+      const href = link.getAttribute("href") ?? "";
+      const params = fileDocParams(fileLinkPath(href), sessionRef, cwd);
+      if (params === undefined) continue;
+      const open = () => paneActions.openBeside({ type: "doc", params });
+      const onClick = (event: MouseEvent) => {
+        if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) return;
+        event.preventDefault();
+        event.stopPropagation();
+        open();
+      };
+      link.href =
+        params.kind === "image" ? docImageURL(params.session, params.path) : docFileRawURL(params.session, params.path);
+      link.addEventListener("click", onClick);
+      const slot = document.createElement("span");
+      link.after(slot);
+      portals.push(createPortal(<OpenButton label={`Open beside: ${params.path}`} onClick={open} />, slot));
+      cleanups.push(() => {
+        link.setAttribute("href", href);
+        link.removeEventListener("click", onClick);
+        slot.remove();
+      });
+    }
+    setAffordances(portals);
+    return () => {
+      for (const cleanup of cleanups) cleanup();
+    };
+  }, [source, live, sessionRef, cwd]);
+
+  return (
+    <>
+      {markdown}
+      {affordances}
+    </>
+  );
+}

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMarkdown.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMarkdown.tsx
@@ -6,6 +6,7 @@ import { useTranscriptRenderContext } from "../../../../transcriptDisplay/render
 import { Markdown } from "../../../../widgets/markdown";
 import { OpenButton } from "../../../../widgets/openbutton";
 import { fileDocParams } from "../fileOpenBeside";
+import { isValidTranscriptRef } from "./steeringClassify";
 
 function fileLinkPath(href: string): string | undefined {
   // URL references are not filesystem paths. Decode only the pathname, once,
@@ -24,7 +25,10 @@ function fileLinkPath(href: string): string | undefined {
  * shared Markdown renderer's URL policy or admitting authored HTML. */
 export function AgentMarkdown({ source, live = false }: { source: string; live?: boolean }) {
   const { thread } = useTranscriptRenderContext();
-  const sessionRef = thread?.ref;
+  const ref = thread?.ref;
+  // Document endpoints serve local sessions only, addressed by bare ID or local:ID.
+  const sessionRef =
+    ref && (!ref.includes(":") || (ref.startsWith("local:") && isValidTranscriptRef(ref))) ? ref : undefined;
   const cwd = thread?.cwd;
   const root = useRef<HTMLDivElement>(null);
   const [affordances, setAffordances] = useState<ReactPortal[]>([]);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/AgentMessageItem.tsx
@@ -28,12 +28,12 @@
 
 import { memo, type ReactNode } from "react";
 import { pendingTextJoined } from "../../../../protocol/reducer";
-import { Markdown } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 // Direct widget path, NOT the controller-owned widgets barrel: this pane
 // must not take a dependency on the barrel's ownership boundary.
 import { SpeakerAvatar } from "../../../../widgets/speakeravatar";
 import { type ItemRenderProps, ignoringTurn, registerItemRenderer } from "../types";
+import { AgentMarkdown } from "./AgentMarkdown";
 import styles from "./agentmessageitem.module.css";
 import { MessageTimestamp } from "./MessageTimestamp";
 
@@ -142,7 +142,7 @@ export const AgentMessageItem = memo(function AgentMessageItem({
     // stream's tail truncates, so formatting renders while streaming.
     return wrap(
       <div className={CLASS.stream} data-testid="agent-message-stream">
-        <Markdown source={pendingTextJoined(chunks)} live />
+        <AgentMarkdown source={pendingTextJoined(chunks)} live />
       </div>,
       "true",
     );
@@ -153,7 +153,7 @@ export const AgentMessageItem = memo(function AgentMessageItem({
   // one - mirrors legacy's own "empty finalize" rule (parity-m4-
   // transcript.md #6, renderer.js:2810-2816).
   if (!item.text) return null;
-  return wrap(<Markdown source={item.text} />, "false");
+  return wrap(<AgentMarkdown source={item.text} />, "false");
 }, ignoringTurn);
 
 registerItemRenderer("agentMessage", AgentMessageItem);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentFileLinks.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentFileLinks.test.tsx
@@ -95,6 +95,56 @@ test("file hyperlink has the standard open-beside affordance", () => {
 });
 
 test.each([
+  ["remote:034MXwo6BpPH0QQCgdICSf", false],
+  ["remote:034MXwo6BpPH0QQCgdICSf", true],
+  ["agentsview:034MXwo6BpPH0QQCgdICSf", false],
+  ["agentsview:034MXwo6BpPH0QQCgdICSf", true],
+  ["localhost:034MXwo6BpPH0QQCgdICSf", false],
+  ["LOCAL:034MXwo6BpPH0QQCgdICSf", false],
+  ["local:remote:034MXwo6BpPH0QQCgdICSf", false],
+] as const)("non-local session %s keeps ordinary file links (live=%s)", (ref, live) => {
+  render(message("[file](docs/design.md) [image](images/diagram.png)", live, { ...thread, ref }));
+  const link = screen.getByRole("link", { name: "file" });
+  expect(link.getAttribute("href")).toBe("docs/design.md");
+  expect(screen.getByRole("link", { name: "image" }).getAttribute("href")).toBe("images/diagram.png");
+  expect(link.getAttribute("target")).toBe("_blank");
+  expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  expect(screen.queryByRole("button")).toBeNull();
+  let prevented = true;
+  document.addEventListener(
+    "click",
+    (event) => {
+      prevented = event.defaultPrevented;
+      event.preventDefault(); // Observe ordinary navigation without asking jsdom to navigate.
+    },
+    { once: true },
+  );
+  fireEvent.click(link);
+  expect(prevented).toBe(false);
+  expect(workspaceStore.getState().panes).toEqual([]);
+});
+
+test.each(["034MXwo6BpPH0QQCgdICSf", "local:034MXwo6BpPH0QQCgdICSf"])(
+  "local session ref %s retains file actions",
+  (ref) => {
+    render(message(source, false, { ...thread, ref }));
+    fireEvent.click(screen.getByRole("button"));
+    expect(workspaceStore.getState().panes).toMatchObject([{ type: "doc", params: { session: ref, path } }]);
+  },
+);
+
+test("switching to a non-local snapshot removes existing file actions", () => {
+  const { rerender } = render(message(source));
+  expect(screen.getAllByRole("button")).toHaveLength(1);
+  rerender(message(source, false, { ...thread, ref: "remote:034MXwo6BpPH0QQCgdICSf" }));
+  expect(screen.getByRole("link").getAttribute("href")).toBe(path);
+  expect(screen.queryByRole("button")).toBeNull();
+  rerender(message(source));
+  fireEvent.click(screen.getByRole("button"));
+  expect(workspaceStore.getState().panes).toMatchObject([{ type: "doc", params: { session: thread.ref, path } }]);
+});
+
+test.each([
   ["docs/design%20notes.md", "docs/design notes.md", "file"],
   ["docs/notes%23one%3Ftwo%26three.md#section", "docs/notes#one?two&three.md", "file"],
   ["docs/100%25.md", "docs/100%.md", "file"],

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentFileLinks.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/agentFileLinks.test.tsx
@@ -1,0 +1,222 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { StrictMode } from "react";
+import { afterEach, expect, test } from "vitest";
+import type { ThreadModel } from "../../../../protocol/model";
+import { resetWorkspaceStoreForTests, workspaceStore } from "../../../../shell/workspace";
+import { TranscriptRenderProvider } from "../../../../transcriptDisplay/renderContext";
+import "../../../doc";
+import "../../index";
+import { AgentMessageItem } from "./AgentMessageItem";
+
+const thread: ThreadModel = {
+  ref: "local:034MXwo6BpPH0QQCgdICSf",
+  threadId: "034MXwo6BpPH0QQCgdICSf",
+  name: "File links",
+  status: { type: "idle" },
+  modelProvider: "",
+  model: "",
+  visionModel: "",
+  askPending: false,
+  pendingEscalations: [],
+  turns: [],
+  queue: null,
+  tasks: null,
+  jobsUpdatedAt: null,
+  jobsTreeRevision: null,
+  lastFrameAt: 0,
+  capabilities: {
+    send: false,
+    steer: false,
+    interrupt: false,
+    compact: false,
+    clear: false,
+    forkFromTurn: false,
+    shutdown: false,
+    changeModel: false,
+    changeVisionModel: false,
+    queue: false,
+    goal: false,
+    rename: false,
+  },
+  goal: null,
+  contextUsed: 0,
+  contextWindow: 0,
+  contextPressure: 0,
+  usage: null,
+  workMillis: 0,
+  reasoningEffortLevels: [],
+  supportsReasoning: false,
+  cwd: "/workspace/project",
+};
+const path = "docs/superpowers/specs/2026-09-10-daemon-idle-retirement-design.md";
+const source = `[written **design**](${path})`;
+
+function message(markdown: string, live = false, snapshot: ThreadModel | null = thread) {
+  return (
+    <TranscriptRenderProvider thread={snapshot ?? undefined}>
+      <AgentMessageItem
+        item={{ id: "message", turnId: "turn", type: "agentMessage", text: markdown, pendingText: [markdown] }}
+        turn={{ id: "turn", status: "completed", items: [] }}
+        sessionRef={snapshot?.ref}
+        live={live}
+      />
+    </TranscriptRenderProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  resetWorkspaceStoreForTests();
+});
+
+test.each([false, true])("agent file hyperlink opens the session-scoped document pane (live=%s)", (live) => {
+  render(message(source, live));
+  const link = screen.getByRole("link", { name: "written design" });
+  const url = new URL(link.getAttribute("href") ?? "", "https://hub.example");
+  expect(url.pathname).toBe("/doc/file");
+  expect(url.searchParams.get("session")).toBe("local:034MXwo6BpPH0QQCgdICSf");
+  expect(url.searchParams.get("path")).toBe(path);
+  expect(link.querySelector("strong")?.textContent).toBe("design");
+  expect(fireEvent.click(link)).toBe(false);
+  expect(workspaceStore.getState().panes).toMatchObject([
+    { type: "doc", params: { session: "local:034MXwo6BpPH0QQCgdICSf", path, kind: "file" } },
+  ]);
+});
+
+test("file hyperlink has the standard open-beside affordance", () => {
+  render(message(source));
+  const open = screen.getByRole("button", { name: `Open beside: ${path}` });
+  expect(open.getAttribute("title")).toBe("Open");
+  expect(open.querySelector("svg")).not.toBeNull();
+  fireEvent.click(open);
+  expect(workspaceStore.getState().panes).toMatchObject([
+    { type: "doc", params: { session: "local:034MXwo6BpPH0QQCgdICSf", path, kind: "file" } },
+  ]);
+});
+
+test.each([
+  ["docs/design%20notes.md", "docs/design notes.md", "file"],
+  ["docs/notes%23one%3Ftwo%26three.md#section", "docs/notes#one?two&three.md", "file"],
+  ["docs/100%25.md", "docs/100%.md", "file"],
+  ["docs/caf%C3%A9.md?download=1#section", "docs/café.md", "file"],
+  ["./docs/design.md", "./docs/design.md", "file"],
+  ["README", "README", "file"],
+  ["/workspace/project/docs/design.md", "docs/design.md", "file"],
+  ["images/screen%20shot.png", "images/screen shot.png", "image"],
+  ["images/diagram.svg", "images/diagram.svg", "file"],
+])("file link %s resolves to the actual file path", (href, expectedPath, kind) => {
+  render(message(`[file](${href})`));
+  const link = screen.getByRole("link", { name: "file" });
+  const url = new URL(link.getAttribute("href") ?? "", "https://hub.example");
+  expect(url.pathname).toBe(kind === "image" ? "/doc/image" : "/doc/file");
+  expect(url.searchParams.get("path")).toBe(expectedPath);
+  fireEvent.click(link);
+  expect(workspaceStore.getState().panes).toMatchObject([
+    { type: "doc", params: { session: thread.ref, path: expectedPath, kind } },
+  ]);
+});
+
+test.each([
+  "https://example.com/docs/design.md",
+  "http://example.com/docs/design.md",
+  "//example.com/docs/design.md",
+  "mailto:person@example.com",
+  "#section",
+  "?view=files",
+  "/settings",
+  "/workspace/project-other/design.md",
+  "../outside.md",
+  "docs/../../outside.md",
+  "docs/%2e%2e/outside.md",
+  "/workspace/project/../outside.md",
+  "%2f%2fexample.com/design.md",
+  "docs%5coutside.md",
+  "docs/%00invalid.md",
+  "docs/bad%ZZ.md",
+])("non-file or unsafe link %s keeps its original navigation without an affordance", (href) => {
+  render(message(`[link](${href})`));
+  const link = screen.getByRole("link", { name: "link" });
+  expect(link.getAttribute("href")).toBe(href);
+  expect(link.getAttribute("target")).toBe("_blank");
+  expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  expect(screen.queryByRole("button")).toBeNull();
+  expect(workspaceStore.getState().panes).toEqual([]);
+});
+
+test("file enhancement leaves raw HTML and dangerous schemes neutralized", () => {
+  const { container } = render(message('[bad](javascript:alert%281%29) <a href="docs/raw.md">raw</a>'));
+  expect(container.querySelector("a")?.hasAttribute("href")).toBe(false);
+  expect(container.querySelectorAll("a")).toHaveLength(1);
+  expect(screen.queryByRole("button")).toBeNull();
+});
+
+test.each(["ctrlKey", "metaKey", "shiftKey", "altKey"])("%s clicks preserve browser navigation", (modifier) => {
+  render(message(source));
+  let prevented = true;
+  const observeNavigation = (event: MouseEvent) => {
+    prevented = event.defaultPrevented;
+    event.preventDefault(); // jsdom has no browser navigation; observe before suppressing it.
+  };
+  document.addEventListener("click", observeNavigation, { once: true });
+  fireEvent.click(screen.getByRole("link"), { [modifier]: true });
+  expect(prevented).toBe(false);
+  expect(workspaceStore.getState().panes).toEqual([]);
+});
+
+test("stream updates and settlement keep one working affordance per file link", () => {
+  const { rerender } = render(<StrictMode>{message(source, true)}</StrictMode>);
+  expect(screen.getAllByRole("button")).toHaveLength(1);
+  const next = `${source}\n\n[second](docs/second.md)`;
+  rerender(<StrictMode>{message(next, true)}</StrictMode>);
+  expect(screen.getAllByRole("button")).toHaveLength(2);
+  fireEvent.click(screen.getByRole("link", { name: "second" }));
+  expect(workspaceStore.getState().panes).toMatchObject([{ type: "doc", params: { path: "docs/second.md" } }]);
+  rerender(<StrictMode>{message(next)}</StrictMode>);
+  expect(screen.getAllByRole("button")).toHaveLength(2);
+  fireEvent.click(screen.getByRole("button", { name: "Open beside: docs/second.md" }));
+  expect(workspaceStore.getState().panes).toHaveLength(1);
+  rerender(<StrictMode>{message("no links")}</StrictMode>);
+  expect(screen.queryByRole("button")).toBeNull();
+});
+
+test("missing context fails closed and hydrated snapshot changes rebind existing links", () => {
+  const { rerender } = render(message(source, false, null));
+  expect(screen.getByRole("link").getAttribute("href")).toBe(path);
+  expect(screen.queryByRole("button")).toBeNull();
+  rerender(message(source));
+  expect(screen.getAllByRole("button")).toHaveLength(1);
+  rerender(message(source, false, { ...thread, ref: "local:other", cwd: "/other/worktree" }));
+  fireEvent.click(screen.getByRole("link"));
+  expect(workspaceStore.getState().panes).toMatchObject([
+    { type: "doc", params: { session: "local:other", path, kind: "file" } },
+  ]);
+  rerender(message(source, false, { ...thread, cwd: "" }));
+  expect(screen.queryByRole("button")).toBeNull();
+  expect(screen.getByRole("link").getAttribute("href")).toBe(path);
+});
+
+test("reference links in long streaming Markdown receive the same file action", () => {
+  const text = `${"A paragraph of context.\n\n".repeat(120)}[design][spec]\n\n[spec]: docs/design.md`;
+  render(message(text, true));
+  fireEvent.click(screen.getByRole("link", { name: "design" }));
+  expect(workspaceStore.getState().panes).toMatchObject([
+    { type: "doc", params: { session: thread.ref, path: "docs/design.md", kind: "file" } },
+  ]);
+});
+
+test("streaming caret stays attached to the final prose block", () => {
+  render(message(source, true));
+  const stream = screen.getByTestId("agent-message-stream");
+  // Matches agentmessageitem.module.css's live caret selector.
+  expect(stream.querySelector(":scope > div > :last-child")).toBe(screen.getByRole("link").closest("p"));
+});
+
+test("opening a file keeps the session in the main pane and places the document beside it", () => {
+  workspaceStore.getState().openPane("session", { ref: thread.ref });
+  render(message(source));
+  fireEvent.click(screen.getByRole("button"));
+  expect(workspaceStore.getState().panes).toMatchObject([
+    { type: "session", params: { ref: thread.ref }, slot: "main" },
+    { type: "doc", params: { session: thread.ref, path, kind: "file" }, slot: "secondary" },
+  ]);
+});

--- a/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/markdown/index.tsx
@@ -1,6 +1,6 @@
 import DOMPurify from "dompurify";
 import { Marked, type RendererObject, type Token, type Tokens } from "marked";
-import { useMemo, useRef } from "react";
+import { type Ref, useMemo, useRef } from "react";
 import codeblockStyles from "../codeblock/codeblock.module.css";
 import { requireClass } from "../internal/requireClass";
 import { markdownLexer } from "./lexer";
@@ -9,6 +9,8 @@ import { closeOpenMarkdown } from "./streaming";
 
 export interface MarkdownProps {
   source: string;
+  /** Lets a caller attach actions to sanitized content without a layout wrapper. */
+  ref?: Ref<HTMLDivElement>;
   /** True while `source` is a possibly-truncated stream still in flight:
    * constructs left open at the tail (unterminated `**`/`*`/`~~`, inline
    * code, fenced code blocks) are closed before parsing via
@@ -328,7 +330,7 @@ function tailStartsIndented(tail: string): boolean {
  * source is treated as a truncated stream and its open constructs are
  * closed before parsing (see streaming.ts).
  */
-export function Markdown({ source, live = false }: MarkdownProps) {
+export function Markdown({ source, live = false, ref }: MarkdownProps) {
   // Live streams re-render per streamed token, and each render re-parses the
   // whole message (marked + DOMPurify) - O(n^2) over a long stream. Past the
   // window above, the settled head is served from a cache keyed on its own
@@ -415,5 +417,5 @@ export function Markdown({ source, live = false }: MarkdownProps) {
   // filtering for href/src is untouched - SANITIZE_CONFIG never sets
   // ALLOWED_URI_REGEXP). See this file's own comments above for the rest.
   // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized via DOMPurify + escaped renderer overrides, see above
-  return <div className={CLASS.root} dangerouslySetInnerHTML={{ __html: html }} />;
+  return <div ref={ref} className={CLASS.root} dangerouslySetInnerHTML={{ __html: html }} />;
 }


### PR DESCRIPTION
## Summary

- Resolve file hyperlinks in agent output using the session's cwd and existing document routes, so clicking opens the file beside the transcript.
- Add the existing open-beside affordance to eligible links in both streaming and settled messages.
- Preserve external URLs, unsafe/out-of-workspace references, Markdown sanitization, modified-click behavior, and the streaming caret.
- Add 38 regression cases using real transcript rendering and workspace state, including the path reported in session `034MXwo6BpPH0QQCgdICSf`: `docs/superpowers/specs/2026-09-10-daemon-idle-retirement-design.md`.

## Verification

- [x] `make lint`
- [x] `make vet`
- [x] `make test` (all modules and frontend gate)
- [x] `make build-web`
- [x] `TMPDIR=/tmp make test-web-browser` (all five guards)
- [x] Native Chrome component smoke: rewritten href, visible open affordance, final-paragraph streaming caret, and native anchor/button clicks retaining the session in the main slot and opening the document in the secondary slot.
- [x] Independent code review, including a regression test and fix for streaming-caret placement.

## Environment notes

The browser guards initially failed before DevTools readiness with Chrome `SIGTRAP` under the session's nested scratch `TMPDIR`. All five passed with `TMPDIR=/tmp`; no harness assertions or Chrome security flags were changed. The component smoke verified navigation state rather than fetching the archived session's actual document bytes.

Dependency installation also reported three existing moderate Vitest-related advisories (`GHSA-82fw-gwwq-j7x9`). Dependency manifests and lockfiles are unchanged by this fix.
