### PR TITLE
fix(webui): update Vitest and clean test diagnostics

### DIFF
--- a/cmd/evener-hub/frontend/package-lock.json
+++ b/cmd/evener-hub/frontend/package-lock.json
@@ -33,12 +33,12 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
-        "@vitest/coverage-v8": "^4.1.10",
+        "@vitest/coverage-v8": "^4.1.11",
         "fake-indexeddb": "6.2.5",
         "jsdom": "^29.1.1",
         "typescript": "^6.0.3",
         "vite": "^8.1.5",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1152,14 +1152,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
-      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1173,8 +1173,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.10",
-        "vitest": "4.1.10"
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1183,16 +1183,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1201,13 +1201,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1228,9 +1228,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1241,13 +1241,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1255,14 +1255,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1271,9 +1271,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1281,13 +1281,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2069,9 +2069,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
-      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+      "integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -2361,9 +2361,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2397,9 +2397,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
-      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2563,19 +2563,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -2603,12 +2603,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/cmd/evener-hub/frontend/package.json
+++ b/cmd/evener-hub/frontend/package.json
@@ -45,11 +45,11 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/coverage-v8": "^4.1.11",
     "fake-indexeddb": "6.2.5",
     "jsdom": "^29.1.1",
     "typescript": "^6.0.3",
     "vite": "^8.1.5",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.11"
   }
 }

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.js
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // The WIRE half of the guards' plumbing (browserGuardCdp.mjs). Everything here
 // runs against a fake `send` and a fake socket: the module's contract with
 // Chrome is CDP request/response shapes, and none of these cases needs a
@@ -14,7 +16,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test } from "node:test";
+import { afterEach, test, vi } from "vitest";
 
 import {
   applyViewport,
@@ -26,6 +28,10 @@ import {
   navigateTo,
   waitForHttp,
 } from "./browserGuardCdp.mjs";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 test("preserves the announced endpoint host when building HTTP URLs", () => {
   assert.equal(
@@ -42,14 +48,14 @@ test("preserves the announced endpoint host when building HTTP URLs", () => {
   );
 });
 
-test("one startup deadline aborts the pending HTTP readiness phase", async (context) => {
-  context.mock.timers.enable({ apis: ["setTimeout"] });
+test("one startup deadline aborts the pending HTTP readiness phase", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
   const deadline = createStartupDeadline();
   const pending = waitForHttp("http://127.0.0.1:1/json/version", "chrome", () => null, {
     signal: deadline.signal,
   });
 
-  context.mock.timers.tick(30_000);
+  vi.advanceTimersByTime(30_000);
   await assert.rejects(pending, /browser startup deadline exceeded after 30000ms/);
   deadline.clear();
 });
@@ -144,9 +150,11 @@ test("no CDP call leaves a timeout timer holding the event loop", async () => {
 // this script took 30.044 seconds; spawnguard took 31.102 against 1.451
 // seconds of work. The bound is deliberately loose: it is here to catch a
 // 30-second hang, not to police startup jitter.
-test("a guard-shaped script exits as soon as its work is done", async (context) => {
+// Let the elapsed-time assertion judge the child after it exits, including
+// the 30-second timer-leak case, without a shorter runner deadline.
+test("a guard-shaped script exits as soon as its work is done", { timeout: 0 }, async (context) => {
   const dir = mkdtempSync(path.join(tmpdir(), "browser-guard-cdp-test-"));
-  context.after(() => rmSync(dir, { recursive: true, force: true }));
+  context.onTestFinished(() => rmSync(dir, { recursive: true, force: true }));
   const script = path.join(dir, "guardShaped.mjs");
   writeFileSync(
     script,
@@ -186,14 +194,14 @@ test("navigateTo stops listening for the load event once the page has loaded", a
 // a socket the guards reuse for every later case -- parsing every CDP message
 // that arrives for the rest of the run. Mock timers stand in for the 30 seconds
 // so this stays a millisecond test.
-test("navigateTo stops listening when the load event never arrives", async (context) => {
+test("navigateTo stops listening when the load event never arrives", async () => {
   const socket = fakeSocket();
   let announceNavigate;
   const navigateIssued = new Promise((resolve) => {
     announceNavigate = resolve;
   });
   const send = fakeSend(socket, { onNavigate: announceNavigate });
-  context.mock.timers.enable({ apis: ["setTimeout"] });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 
   const navigation = navigateTo({ ws: socket, send }, "http://127.0.0.1:65535/");
   const rejected = assert.rejects(navigation, /timeout calling navigateTo after 30000ms/);
@@ -203,7 +211,7 @@ test("navigateTo stops listening when the load event never arrives", async (cont
   // even armed is worse: nothing would ever fire it and this would hang.
   await navigateIssued;
   await drainMicrotasks();
-  context.mock.timers.tick(30_000);
+  vi.advanceTimersByTime(30_000);
   await rejected;
 
   assert.equal(socket.listenerCount("message"), 0);

--- a/cmd/evener-hub/frontend/src/App.test.tsx
+++ b/cmd/evener-hub/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { initNotifications, resetNotificationsForTests } from "./notifications";
 import { AppwireClient } from "./protocol/client";
@@ -298,9 +298,11 @@ test("initiates and settles the welcome navigation load without an error", async
   }));
   const navRead = stubDeferredNavigationRead(client);
   render(<AppShell client={client} />);
-  await navRead.requested;
-  navRead.release();
-  await navigationStore.getState().loadManifest();
+  await act(async () => {
+    await navRead.requested;
+    navRead.release();
+    await navigationStore.getState().loadManifest();
+  });
   const manifest = navigationStore.getState().manifest;
   expect(manifest).not.toBeNull();
   expect(manifest?.error).toBeNull();
@@ -322,11 +324,28 @@ test("AppShell's injected v2 handshake selects navigation through AppWire", asyn
     return { ...navigationReadResponse("app-generation"), etag: '"app-manifest"' };
   });
 
-  render(<AppShell client={client} />);
-  await vi.waitFor(() => expect(calls).toEqual([{ resource: "manifest", representationVersion: 2 }]));
+  const connect = vi.spyOn(client, "connect");
+  const loadManifest = vi.spyOn(navigationStore.getState(), "loadManifest");
+  try {
+    render(<AppShell client={client} />);
+    expect(connect).toHaveBeenCalled();
+    const connectionResult = connect.mock.results[0];
+    if (connectionResult?.type !== "return") throw new Error("AppShell did not start the handshake");
+    await act(async () => {
+      await connectionResult.value;
+      expect(loadManifest).toHaveBeenCalled();
+      const manifestResult = loadManifest.mock.results[0];
+      if (manifestResult?.type !== "return") throw new Error("AppShell did not start the manifest load");
+      await manifestResult.value;
+    });
+    await vi.waitFor(() => expect(calls).toEqual([{ resource: "manifest", representationVersion: 2 }]));
 
-  expect(navigationStore.getState().mode).toBe("v2");
-  expect(calls).toEqual([{ resource: "manifest", representationVersion: 2 }]);
+    expect(navigationStore.getState().mode).toBe("v2");
+    expect(calls).toEqual([{ resource: "manifest", representationVersion: 2 }]);
+  } finally {
+    connect.mockRestore();
+    loadManifest.mockRestore();
+  }
 });
 
 test("does not escape a navigation request before the test fake is installed", () => {

--- a/cmd/evener-hub/frontend/src/dev/SurfaceGallery.test.tsx
+++ b/cmd/evener-hub/frontend/src/dev/SurfaceGallery.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, expect, test } from "vitest";
 import { resetAskDockStoreForTests } from "../panes/session/composer/askDock/askDockStore";
 import { resetNavigationStoreForTests } from "../stores/navigation/store";
@@ -19,8 +19,10 @@ test("renders without throwing, with the intro note", () => {
   expect(screen.getByText(/surface gallery/i)).toBeTruthy();
 });
 
-test.each(SURFACE_GALLERY_SECTIONS)("mounts discovered section $path without throwing", (section) => {
-  render(<SurfaceGallery sections={[section]} />);
+test.each(SURFACE_GALLERY_SECTIONS)("mounts discovered section $path without throwing", async (section) => {
+  await act(async () => {
+    render(<SurfaceGallery sections={[section]} />);
+  });
   expect(screen.getAllByRole("heading", { level: 2 }).length).toBeGreaterThan(0);
 });
 

--- a/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/Session.test.tsx
@@ -5,7 +5,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testi
 import userEvent from "@testing-library/user-event";
 import { IDBFactory, IDBObjectStore } from "fake-indexeddb";
 import { StrictMode, useSyncExternalStore } from "react";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, onTestFinished, test, vi } from "vitest";
 import { AppwireClient } from "../../protocol/client";
 import { WireError } from "../../protocol/errors";
 import { FakeClient } from "../../protocol/testing/fakeClient";
@@ -15,6 +15,7 @@ import { ClientProvider } from "../../shell/clientContext";
 import { urlToPane } from "../../shell/routing";
 import { resetWorkspaceStoreForTests, workspaceStore } from "../../shell/workspace";
 import { connectionStore } from "../../stores/connection";
+import { MutationOutbox } from "../../stores/mutationOutbox";
 import { MutationOutboxIndexedDB } from "../../stores/mutationOutboxIndexedDB";
 import { navigationStore, resetNavigationStoreForTests } from "../../stores/navigation/store";
 import { keyID } from "../../stores/navigation/types";
@@ -377,19 +378,27 @@ test("omits the old live Detail toolbar while transcript and older-history conte
   expect(screen.getByTestId("load-older-row")).toBeTruthy();
   expect(screen.getByTestId("load-older-sentinel")).toBeTruthy();
   expect(screen.queryByRole("button", { name: /^Detail:/ })).toBeNull();
-  transcriptDisplayStore.setState({ viewport: "desktop" });
-  transcriptDisplayStore.getState().setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }));
+  act(() => {
+    transcriptDisplayStore.setState({ viewport: "desktop" });
+    transcriptDisplayStore
+      .getState()
+      .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }));
+  });
   await waitFor(() =>
     expect(screen.getByTestId("transcript-view-announcement").textContent).toContain("Transcript detail: Full detail"),
   );
   const status = screen.getByTestId("transcript-view-announcement");
-  transcriptDisplayStore
-    .getState()
-    .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }, { roundTimings: true }));
+  act(() => {
+    transcriptDisplayStore
+      .getState()
+      .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }, { roundTimings: true }));
+  });
   await waitFor(() => expect(status.textContent).toContain("Transcript detail: Full detail · 1 advanced"));
-  transcriptDisplayStore
-    .getState()
-    .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }, { tokenCounts: true }));
+  act(() => {
+    transcriptDisplayStore
+      .getState()
+      .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }, { tokenCounts: true }));
+  });
   await waitFor(() => expect(status.textContent).toContain("Transcript detail: Full detail · 1 advanced"));
   expect(screen.getByTestId("transcript-view-announcement")).toBe(status);
 });
@@ -589,7 +598,7 @@ test("cold-start skeleton stays through durable outbox settlement after an ident
   );
   await waitFor(() => expect(screen.getByText(/send the first message/i)).toBeTruthy());
 
-  const clientMutationId = await seedPendingSend();
+  const clientMutationId = await act(async () => seedPendingSend());
   expect(screen.getByTestId("cold-start-skeleton")).toBeTruthy();
 
   act(() => {
@@ -624,8 +633,10 @@ test("cold-start skeleton stays through durable outbox settlement after an ident
   expect(screen.queryByTestId("pending-chips")).toBeNull();
   expect(userMessage.compareDocumentPosition(skeleton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
-  await mutationStorage.settleApplied(clientMutationId);
-  await refreshPendingTurnsProjection("ref_a");
+  await act(async () => {
+    await mutationStorage.settleApplied(clientMutationId);
+    await refreshPendingTurnsProjection("ref_a");
+  });
   expect(screen.getByTestId("cold-start-skeleton")).toBeTruthy();
 
   act(() => {
@@ -683,11 +694,13 @@ test("an explicitly rejected first send leaves cold-start state for durable reco
   );
   await waitFor(() => expect(screen.getByText(/send the first message/i)).toBeTruthy());
 
-  const clientMutationId = await seedPendingSend();
+  const clientMutationId = await act(async () => seedPendingSend());
   await waitFor(() => expect(screen.getByTestId("cold-start-skeleton")).toBeTruthy());
 
-  await mutationStorage.transferToRecovery(clientMutationId, "rejected");
-  await refreshPendingTurnsProjection("ref_a");
+  await act(async () => {
+    await mutationStorage.transferToRecovery(clientMutationId, "rejected");
+    await refreshPendingTurnsProjection("ref_a");
+  });
   await waitFor(() => expect(screen.queryByTestId("cold-start-skeleton")).toBeNull());
   expect((await mutationStorage.getRecovery(clientMutationId))?.recoveryKind).toBe("rejected");
 });
@@ -2110,13 +2123,19 @@ test.each([false, true])("restart-required empty transcript suppresses first-sen
     </ClientProvider>,
   );
   await screen.findByRole("alert");
-  if (pending) await seedPendingSend();
+  if (pending) await act(async () => seedPendingSend());
   expect(screen.queryByText(/send the first message/i)).toBeNull();
   expect(screen.queryByTestId("cold-start-skeleton")).toBeNull();
   expect(screen.getByText("Session unavailable until restart")).toBeTruthy();
 });
 
 test("explicit Resume follows the returned identity through transcript and new sends", async ({ onTestFinished }) => {
+  const hydration = vi.spyOn(threadsStore.getState(), "ensureThread");
+  const refresh = vi.spyOn(threadsStore.getState(), "refreshThread");
+  onTestFinished(() => {
+    hydration.mockRestore();
+    refresh.mockRestore();
+  });
   onTestFinished(stubSessionSlots);
   vi.mocked(ComposerModule.Composer).mockRestore();
   vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
@@ -2210,12 +2229,36 @@ test("explicit Resume follows the returned identity through transcript and new s
   await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
   await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
   expect(resumed).toBe(false);
+  // Reconnect starts discovery after hydration. Observe that original promise
+  // when it starts; a snapshot of spy results here would miss the pending scan.
+  let observeDiscovery!: (completion: Promise<void>) => void;
+  const readyDiscovery = new Promise<void>((resolve) => {
+    observeDiscovery = resolve;
+  });
+  const connectionReady = MutationOutbox.prototype.connectionReady;
+  const discovery = vi.spyOn(MutationOutbox.prototype, "connectionReady").mockImplementation(function (
+    this: MutationOutbox,
+  ) {
+    const completion = connectionReady.call(this);
+    observeDiscovery(completion);
+    return completion;
+  });
+  onTestFinished(() => discovery.mockRestore());
   await user.click(screen.getByRole("button", { name: "Resume session" }));
   await screen.findByText("Current transcript after clear");
   expect(window.location.pathname).toBe("/s/local%3Acurrent-b");
   expect(screen.queryByText("Saved transcript before clear")).toBeNull();
   expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
   expect(requests.filter(({ method }) => method === "turn/start")).toHaveLength(0);
+  expect(hydration).toHaveBeenCalledWith(stableRef);
+  expect(hydration).toHaveBeenCalledWith(currentRef);
+  expect(refresh).toHaveBeenCalledWith(currentRef);
+  await act(async () => {
+    await Promise.all(hydration.mock.results.map((result) => result.value));
+    await Promise.all(refresh.mock.results.map((result) => result.value));
+    await readyDiscovery;
+    await flushPendingTurnsProjectionForTests();
+  });
   expect(await mutationStorage.listOutbox(stableRef)).toEqual([
     expect.objectContaining({ clientMutationId: uncertain, state: "blockedUnknown" }),
   ]);
@@ -2226,6 +2269,7 @@ test("explicit Resume follows the returned identity through transcript and new s
   expect(requests.find(({ method }) => method === "turn/start")?.params).toEqual(
     expect.objectContaining({ ref: currentRef }),
   );
+  await flushPendingTurnsProjectionForTests();
 });
 
 test("offers explicit resume after restart even without pending messages", async () => {
@@ -2459,8 +2503,10 @@ test.each(["notLoaded", "active", "idle"])(
     };
     try {
       status = recoveryStatus;
-      fireEvent.click(screen.getByRole("button", { name: "Refresh session" }));
-      await readHeld;
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Refresh session" }));
+        await readHeld;
+      });
       const resume = await screen.findByRole("button", { name: "Resume session" });
       expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
       expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
@@ -2527,10 +2573,12 @@ test.each(["active", "idle"])("retained %s child preserves uncertainty until its
   expect(screen.getByRole("link", { name: "Open owning session" }).getAttribute("href")).toContain("parent");
   expect(threadsStore.getState().restartBlockingObligations.size).toBe(0);
   expect(threadsStore.getState().mutationAuthorityRefs.has("local:retained-child")).toBe(false);
+  await flushPendingTurnsProjectionForTests();
   expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
   expect(fake.calls.filter((call) => call.method === "thread/resume" || call.method === "turn/start")).toHaveLength(0);
   fireEvent.click(refresh);
   await waitFor(() => expect((refresh as HTMLButtonElement).disabled).toBe(false));
+  await flushPendingTurnsProjectionForTests();
   expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown");
   expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
   // A session retained by its owner offers no force stop anywhere in the
@@ -2687,6 +2735,21 @@ test("recovery rejection blocks durable dispatch and refreshes the Resume contro
   try {
     const fake = connectFakeClient();
     const ref = "local:failed-stop-recovery";
+    // Advancing the discovery clock does not finish its IndexedDB-backed
+    // hydration. This store publication is the reconciliation completion edge.
+    const nextReconciliation = () =>
+      new Promise<void>((resolve) => {
+        const unsubscribe = threadsStore.subscribe((state, previous) => {
+          if (
+            state.mutationReconciliationFailures !== previous.mutationReconciliationFailures &&
+            !state.mutationReconciliationFailures.has(ref)
+          ) {
+            unsubscribe();
+            resolve();
+          }
+        });
+        onTestFinished(unsubscribe);
+      });
     let fenced = false;
     let reads = 0;
     let mutationId = "";
@@ -2720,16 +2783,21 @@ test("recovery rejection blocks durable dispatch and refreshes the Resume contro
     });
     await act(async () => {
       await threadsStore.getState().queue(ref, "preserve this uncertain message");
+      await flushPendingTurnsProjectionForTests();
     });
     await waitFor(async () => expect((await mutationStorage.getOutbox(mutationId))?.state).toBe("blockedUnknown"));
     expect(threadsStore.getState().mutationAuthorityRefs.has(ref)).toBe(false);
+    const reconciled = nextReconciliation();
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
+      await reconciled;
+      await flushPendingTurnsProjectionForTests();
     });
     expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
     expect(reads).toBeGreaterThan(1);
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4000);
+      await flushPendingTurnsProjectionForTests();
     });
     expect((await mutationStorage.getOutbox(mutationId))?.composerText).toBe("preserve this uncertain message");
     expect(threadsStore.getState().restartBlockingObligations.has(ref)).toBe(true);
@@ -2745,6 +2813,8 @@ test.each(["pending", "failed"])(
   async (outcome) => {
     vi.mocked(SessionChromeModule.SessionChrome).mockRestore();
     const fake = connectFakeClient();
+    const refresh = vi.spyOn(threadsStore.getState(), "refreshThread");
+    onTestFinished(() => refresh.mockRestore());
     const ref = "local:saved-auto-resume";
     let daemonStarted = false;
     let stopped = false;
@@ -2796,6 +2866,7 @@ test.each(["pending", "failed"])(
       await user.keyboard("{Escape}");
       await act(async () => {
         await threadsStore.getState().send(ref, "continue the saved conversation");
+        await flushPendingTurnsProjectionForTests();
       });
       await waitFor(() => expect(daemonStarted).toBe(true));
       if (outcome === "failed") {
@@ -2805,6 +2876,7 @@ test.each(["pending", "failed"])(
       expect(threadsStore.getState().threads.get(ref)?.status.type).toBe("notLoaded");
       await openForceStopDialog(user);
       expect(fake.calls.filter((call) => call.method === "evener/thread/forceStop")).toHaveLength(0);
+      refresh.mockClear();
       await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Force stop" }));
       await waitFor(() => expect(stopped).toBe(true));
       expect(await screen.findByRole("button", { name: "Resume session" })).toBeTruthy();
@@ -2813,6 +2885,11 @@ test.each(["pending", "failed"])(
       ]);
       expect(fake.calls.filter((call) => call.method === "turn/start")).toHaveLength(1);
       expect(fake.calls.filter((call) => call.method === "thread/resume")).toHaveLength(0);
+      expect(refresh).toHaveBeenCalledWith(ref);
+      await act(async () => {
+        await Promise.all(refresh.mock.results.map((result) => result.value));
+        await flushPendingTurnsProjectionForTests();
+      });
       expect((await mutationStorage.getOutbox(mutationId))?.composerText).toBe("continue the saved conversation");
     } finally {
       await act(async () => rejectRead(blocked()));

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.test.tsx
@@ -581,7 +581,7 @@ describe("ActivityTree", () => {
     const delegateRow = screen.getByRole("treeitem", { name: "Inspect the repo" });
     const foldRow = screen.getByRole("treeitem", { name: FOLD_NAME });
 
-    shellRow.focus();
+    act(() => shellRow.focus());
     await user.keyboard("{ArrowDown}");
     expect(document.activeElement).toBe(delegateRow);
     await user.keyboard("{ArrowDown}");
@@ -606,7 +606,7 @@ describe("ActivityTree", () => {
     expect(screen.getByText("npm test")).toBeTruthy();
 
     // Enter on the fold row toggles the fold.
-    foldRow.focus();
+    act(() => foldRow.focus());
     await user.keyboard("{Enter}");
     expect(onToggleFold).toHaveBeenCalledWith(FOLD_ID);
     expect(openTranscript).not.toHaveBeenCalled();
@@ -624,7 +624,7 @@ describe("ActivityTree", () => {
     // #884 round 3). Modified arrows must neither move row focus nor be
     // preventDefaulted here.
     const shellRow = screen.getByRole("treeitem", { name: "run tests" });
-    shellRow.focus();
+    act(() => shellRow.focus());
     for (const event of [
       { key: "ArrowDown", altKey: true },
       { key: "ArrowUp", ctrlKey: true },
@@ -655,7 +655,7 @@ describe("ActivityTree", () => {
 
     // Enter on the chevron remains the chevron's own activation (the detail
     // strip), never the row's transcript activation.
-    chevron.focus();
+    act(() => chevron.focus());
     await user.keyboard("{Enter}");
     expect(openTranscript).not.toHaveBeenCalled();
   });

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/SessionChrome.test.tsx
@@ -768,7 +768,9 @@ test("desktop Activity waits for the body's first root attempt before owning lat
 
   const current = threadsStore.getState().threads.get("ref_activity_fresh");
   if (!current) throw new Error("missing activity freshness model");
-  threadsStore.setState({ threads: new Map([[current.ref, { ...current, jobsUpdatedAt: 2 }]]) });
+  act(() => {
+    threadsStore.setState({ threads: new Map([[current.ref, { ...current, jobsUpdatedAt: 2 }]]) });
+  });
   // Two more fetches, not one: the unmount hands refresh ownership back to
   // the chrome, which first catches up on bump 1 (the body's attempt ran at
   // a null bump), and bump 2 - arriving while that catch-up is in flight -

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
@@ -177,6 +177,9 @@ async function mountComposer(ref: string, overrides: Partial<Thread> = {}): Prom
       <Composer ref={ref} />
     </ClientProvider>,
   );
+  await act(async () => {
+    await flushPendingTurnsProjectionForTests();
+  });
   return fake;
 }
 
@@ -490,7 +493,13 @@ test.each(["storage", "composer"] as const)(
   async (source) => {
     const subscribe = source === "storage" ? subscribeMutationPersistence : subscribeComposerSubmissionCommitted;
     const failure = new Error("subscriber failed");
-    const report = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const expectedMessage =
+      source === "storage" ? "Mutation persistence listener failed" : "Composer submission listener failed";
+    const realConsoleError = console.error.bind(console);
+    const report = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      if (args.length === 2 && args[0] === expectedMessage && args[1] === failure) return;
+      realConsoleError(...args);
+    });
     const unsubscribeFailure = subscribe(() => {
       throw failure;
     });
@@ -512,6 +521,7 @@ test.each(["storage", "composer"] as const)(
     } finally {
       unsubscribeFailure();
       unsubscribeObserved();
+      report.mockRestore();
     }
   },
 );
@@ -563,9 +573,11 @@ function askArgs(questions: Array<Record<string, unknown>>): string {
 const ONE_QUESTION = [{ header: "Deploy?", question: "Ship now?", options: [{ label: "Yes", detail: "" }] }];
 
 function startTurn(fake: FakeClient, ref: string, turnId: string): void {
-  fake.emitNotification({
-    method: "turn/started",
-    params: { threadId: `thr_${ref}`, ref, turn: { id: turnId, status: "inProgress", itemsView: "" } },
+  act(() => {
+    fake.emitNotification({
+      method: "turn/started",
+      params: { threadId: `thr_${ref}`, ref, turn: { id: turnId, status: "inProgress", itemsView: "" } },
+    });
   });
 }
 
@@ -590,13 +602,17 @@ function ackAskUserCall(
       argumentsJson: askArgs(questions),
     },
   };
-  fake.emitNotification({
-    method: "item/started",
-    params: { ...base, item: { ...base.item, status: "inProgress" } },
+  act(() => {
+    fake.emitNotification({
+      method: "item/started",
+      params: { ...base, item: { ...base.item, status: "inProgress" } },
+    });
   });
-  fake.emitNotification({
-    method: "item/completed",
-    params: { ...base, item: { ...base.item, status: "completed" } },
+  act(() => {
+    fake.emitNotification({
+      method: "item/completed",
+      params: { ...base, item: { ...base.item, status: "completed" } },
+    });
   });
 }
 
@@ -1039,6 +1055,8 @@ test("the composer un-hides once the pending ask resolves through the normal sen
 
   await act(async () => {
     await askDockStore.getState().sendBatch("ref_a", batchId);
+    await turnStarted;
+    await flushPendingTurnsProjectionForTests();
   });
 
   await expect(turnStarted).resolves.toMatchObject({

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.liveCapabilities.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.liveCapabilities.test.tsx
@@ -296,14 +296,14 @@ test("a working session offers Stop before its turn has announced a name", async
 // This state is not reachable from a correct daemon any more, which is why the
 // frame is hand-built here. That is the point of the breadcrumb: it exists for
 // the trigger nobody has found yet.
-test("a working session drawn with no Stop leaves a sighting naming the frame that did it", () => {
+test("a working session drawn with no Stop leaves a sighting naming the frame that did it", async () => {
   resetStoplessComposerSightingsForTests();
   const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
   try {
     const fake = new FakeClient("ready");
     connectionStore.getState().connect(fake);
     fake.on("thread/read", () => ({ thread: thread("idle", daemonCapabilities(false)) }) as ThreadReadResponse);
-    return threadsStore
+    await threadsStore
       .getState()
       .ensureThread(REF)
       .then(() => {
@@ -327,6 +327,23 @@ test("a working session drawn with no Stop leaves a sighting naming the frame th
         expect(screen.queryByTestId("composer-stop")).toBeNull();
         const sightings = stoplessComposerSightings();
         expect(sightings).toHaveLength(1);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls).toStrictEqual([
+          [
+            "[evener 5gdv] composer is showing a working session with no Stop. Please attach this to kata 5gdv:",
+            {
+              ref: REF,
+              status: "active",
+              activeTurnId: undefined,
+              capabilities: { ...daemonCapabilities(true), interrupt: false },
+              capabilitySource: "statusFrame",
+              // This frame names no in-flight turn, so there is nothing to steer.
+              showSteer: false,
+              ended: false,
+            },
+          ],
+        ]);
+        expect(warn).toHaveBeenCalledWith(expect.any(String), sightings[0]);
         expect(sightings[0]).toMatchObject({
           ref: REF,
           status: "active",

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.test.tsx
@@ -38,6 +38,7 @@ import {
   resetPendingTurnsStoreForTests,
 } from "./queue/pendingTurnsStore";
 import { requestQuoteInsert, resetQuoteInsertStoreForTests } from "./quoteInsert";
+import { resetStoplessComposerSightingsForTests } from "./stoplessComposer";
 
 function Composer(props: React.ComponentProps<typeof ComposerView>) {
   const client = connectionStore.getState().client;
@@ -843,7 +844,9 @@ test("a quote-insert request for a DIFFERENT ref never reaches this composer", a
   act(() => {
     requestQuoteInsert("ref_other", "> quoted line\n\n");
   });
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await act(async () => {
+    await flushPendingTurnsProjectionForTests();
+  });
   expect(textarea().value).toBe("");
 });
 
@@ -911,7 +914,9 @@ test("a composer-focus request for a DIFFERENT ref never focuses this composer",
   act(() => {
     requestComposerFocus("ref_other");
   });
-  await new Promise((resolve) => setTimeout(resolve, 0));
+  await act(async () => {
+    await flushPendingTurnsProjectionForTests();
+  });
   expect(document.activeElement).not.toBe(textarea());
 });
 
@@ -1230,7 +1235,8 @@ test("a local outbox failure leaves the composer untouched and sends no RPC", as
   // @ts-expect-error this test exercises the explicit unavailable-storage boundary
   globalThis.indexedDB = undefined;
   const user = userEvent.setup();
-  const fake = await mountComposer("ref_a");
+  const fake = await act(async () => mountComposer("ref_a"));
+  await flushPendingTurnsProjectionForTests();
 
   await user.type(textarea(), "hello");
   await user.click(submitButton());
@@ -2055,8 +2061,10 @@ test("editing a rejected queue row merges it through the normal Composer", async
   const user = userEvent.setup();
   await mountComposer("ref_a", { status: { type: "idle" } });
   await user.type(textarea(), "current work");
-  await seedRejectedRecovery(storage, "ref_a", "rejected draft");
-  await refreshPendingTurnsProjection("ref_a");
+  await act(async () => {
+    await seedRejectedRecovery(storage, "ref_a", "rejected draft");
+    await refreshPendingTurnsProjection("ref_a");
+  });
 
   const row = screen.getByText("rejected draft").closest("li");
   if (!row) throw new Error("missing rejected queue row");
@@ -2312,7 +2320,11 @@ test("draining an active recovery consumes its owner before the next submission"
       queue: { revision: 1, depth: 1, ids: ["q1"], texts: ["queued"], preview: ["queued"] },
     },
   });
-  fake.on("turn/drainAsSteer", () => new Promise<never>(() => undefined));
+  const dispatched = deferred<void>();
+  fake.on("turn/drainAsSteer", () => {
+    dispatched.resolve();
+    return new Promise<never>(() => undefined);
+  });
   await flushPendingTurnsProjectionForTests();
   expect(textarea().value).toBe("retry me");
   const transact = IDBDatabase.prototype.transaction;
@@ -2327,13 +2339,18 @@ test("draining an active recovery consumes its owner before the next submission"
     return transaction;
   });
   try {
-    fireEvent.click(screen.getByRole("button", { name: "Steer queue now" }));
-    await committed.promise;
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Steer queue now" }));
+      await committed.promise;
+    });
     // Recovery ownership must be consumed by the same durable write, before
     // the mounted composer's success callback can clear or autosave its draft.
     expect(await storage.getRecovery(recovery.clientMutationId)).toBeUndefined();
   } finally {
-    await act(async () => hold?.release());
+    await act(async () => {
+      hold?.release();
+      await dispatched.promise;
+    });
     await flushPendingTurnsProjectionForTests();
   }
   expect(await storage.getRecovery(recovery.clientMutationId)).toBeUndefined();
@@ -2432,17 +2449,46 @@ test("a busy session renders both steer and stop, enabled", async () => {
 });
 
 test("a busy session on a harness that can't interrupt renders steer but not stop", async () => {
-  await mountComposer("ref_a", {
-    status: { type: "active" },
-    evener: {
-      ref: "ref_a",
-      capabilities: { ...FULL_CAPABILITIES, interrupt: false },
-      queue: { revision: 0 },
-      activeTurnId: "turn_1",
-    },
-  });
-  expect(steerButton()).toBeTruthy();
-  expect(screen.queryByTestId("composer-stop")).toBeNull();
+  resetStoplessComposerSightingsForTests();
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    await mountComposer("ref_a", {
+      status: { type: "active" },
+      evener: {
+        ref: "ref_a",
+        capabilities: { ...FULL_CAPABILITIES, interrupt: false },
+        queue: { revision: 0 },
+        activeTurnId: "turn_1",
+      },
+    });
+    expect(steerButton()).toBeTruthy();
+    expect(screen.queryByTestId("composer-stop")).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls).toStrictEqual([
+      [
+        "[evener 5gdv] composer is showing a working session with no Stop. Please attach this to kata 5gdv:",
+        {
+          ref: "ref_a",
+          status: "active",
+          activeTurnId: "turn_1",
+          capabilities: { ...FULL_CAPABILITIES, interrupt: false },
+          capabilitySource: "read",
+          showSteer: true,
+          ended: false,
+        },
+      ],
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        ref: "ref_a",
+        status: "active",
+        capabilities: expect.objectContaining({ interrupt: false, steer: true }),
+      }),
+    );
+  } finally {
+    warn.mockRestore();
+  }
 });
 
 test("a busy session on a harness that can't steer renders stop but not steer", async () => {
@@ -2636,7 +2682,7 @@ function pastePngInto(el: HTMLElement, name = "shot.png"): void {
   Object.defineProperty(event, "clipboardData", {
     value: { items: [{ kind: "file", type: "image/png", getAsFile: () => file }] },
   });
-  el.dispatchEvent(event);
+  fireEvent(el, event);
 }
 
 function installCanvasStubs(): void {
@@ -2815,8 +2861,10 @@ test.each(["keep marker", "delete marker", "add attachment", "replace attachment
       return transaction;
     });
     try {
-      fireEvent.click(submitButton());
-      await committed;
+      await act(async () => {
+        fireEvent.click(submitButton());
+        await committed;
+      });
       if (edit === "replace attachment") {
         fireEvent.click(screen.getByRole("button", { name: "Edit goal: Keep the session focused" }));
         fireEvent.click(screen.getByRole("button", { name: "Replace draft" }));

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
@@ -264,21 +264,32 @@ test("Send is enabled even with nothing answered - an unresolved question compos
 });
 
 test("clicking Send composes and submits through the plain send() path, then the settled batch disappears", async () => {
-  const user = userEvent.setup();
   const fake = connectFakeClient();
   await hydrateWithOneAsk(fake);
   fake.on("turn/start", () => new Promise(() => {}));
   render(<AskDock ref="ref_a" />);
 
   const persisted = nextMutationPersistence("ref_a");
-  await user.click(screen.getByRole("button", { name: /send answers/i }));
-  await persisted;
+  const sendBatch = vi.spyOn(askDockStore.getState(), "sendBatch");
+  try {
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /send answers/i }));
+      await persisted;
 
-  const [record] = (await readMutationPersistence("ref_a")).outbox;
-  expect(record?.payload).toMatchObject({
-    ref: "ref_a",
-    input: [{ type: "text", text: "[answers]\n1. [Deploy?] → skipped (no answer)" }],
-  });
+      const [record] = (await readMutationPersistence("ref_a")).outbox;
+      expect(record?.payload).toMatchObject({
+        ref: "ref_a",
+        input: [{ type: "text", text: "[answers]\n1. [Deploy?] → skipped (no answer)" }],
+      });
+      // Persistence is announced before sendBatch removes the submitted batch.
+      // Observe the click's real completion, without issuing another send.
+      const result = sendBatch.mock.results[0];
+      if (result?.type !== "return") throw new Error("Send did not return a batch submission");
+      await result.value;
+    });
+  } finally {
+    sendBatch.mockRestore();
+  }
   await waitFor(() => expect(askDockStore.getState().byRef.get("ref_a")?.batches ?? []).toEqual([]));
   expect(screen.queryByText("Deploy?")).toBeNull();
 });
@@ -649,8 +660,10 @@ test("Mod+Enter on the batch invokes the primary action (send) for a single-ques
   render(<AskDock ref="ref_a" />);
 
   const persisted = nextMutationPersistence("ref_a");
-  fireEvent.keyDown(screen.getByRole("radio", { name: "Yes" }), { key: "Enter", metaKey: true });
-  await persisted;
+  await act(async () => {
+    fireEvent.keyDown(screen.getByRole("radio", { name: "Yes" }), { key: "Enter", metaKey: true });
+    await persisted;
+  });
 
   const [record] = (await readMutationPersistence("ref_a")).outbox;
   expect(record?.payload).toMatchObject({ ref: "ref_a" });
@@ -663,8 +676,10 @@ test("Mod+Enter with ctrlKey also invokes the primary action", async () => {
   render(<AskDock ref="ref_a" />);
 
   const persisted = nextMutationPersistence("ref_a");
-  fireEvent.keyDown(screen.getByRole("radio", { name: "Yes" }), { key: "Enter", ctrlKey: true });
-  await persisted;
+  await act(async () => {
+    fireEvent.keyDown(screen.getByRole("radio", { name: "Yes" }), { key: "Enter", ctrlKey: true });
+    await persisted;
+  });
 
   const [record] = (await readMutationPersistence("ref_a")).outbox;
   expect(record?.payload).toMatchObject({ ref: "ref_a" });
@@ -804,8 +819,10 @@ test("plain Enter in the free-text answer input invokes the primary action", asy
   await user.type(screen.getByPlaceholderText(/type your answer/i), "custom answer");
 
   const persisted = nextMutationPersistence("ref_a");
-  fireEvent.keyDown(screen.getByPlaceholderText(/type your answer/i), { key: "Enter" });
-  await persisted;
+  await act(async () => {
+    fireEvent.keyDown(screen.getByPlaceholderText(/type your answer/i), { key: "Enter" });
+    await persisted;
+  });
 
   const [record] = (await readMutationPersistence("ref_a")).outbox;
   expect(record?.payload).toMatchObject({ ref: "ref_a" });
@@ -925,7 +942,7 @@ test("activation focus waits for visibility, then lets the browser reveal the co
     observer.report(false);
     expect(focusSpy).not.toHaveBeenCalled();
 
-    observer.report(true);
+    act(() => observer.report(true));
     const dock = document.querySelector("[data-ask-response-dock]");
     await waitFor(() => expect(dock?.contains(document.activeElement)).toBe(true));
     expect(focusSpy).toHaveBeenCalled();
@@ -979,7 +996,7 @@ test("activation while off-screen steals no focus; becoming visible focuses the 
     expect(document.activeElement).toBe(document.body);
     expect(askDockStore.getState().byRef.get("ref_a")?.pendingGreeted ?? false).toBe(false);
 
-    observer.report(true);
+    act(() => observer.report(true));
     const dock = document.querySelector("[data-ask-response-dock]");
     await waitFor(() => expect(dock?.contains(document.activeElement)).toBe(true));
     expect(askDockStore.getState().byRef.get("ref_a")?.pendingGreeted).toBe(true);
@@ -1264,7 +1281,7 @@ test("a mid-send batch's editing controls are disabled while the open batch stay
   askDockStore.getState().setNote("ref_a", sendingKey, "mid-flight edit");
   expect(askDockStore.getState().byRef.get("ref_a")?.answers[sendingKey]?.resolution ?? null).toBeNull();
   expect(askDockStore.getState().byRef.get("ref_a")?.answers[sendingKey]?.note ?? "").toBe("");
-  askDockStore.getState().setNote("ref_a", openKey, "fine here");
+  act(() => askDockStore.getState().setNote("ref_a", openKey, "fine here"));
   expect(askDockStore.getState().byRef.get("ref_a")?.answers[openKey]?.note).toBe("fine here");
 });
 

--- a/cmd/evener-hub/frontend/src/panes/session/composer/attachments/useAttachments.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/attachments/useAttachments.test.ts
@@ -11,8 +11,10 @@ let originalToBlob: typeof HTMLCanvasElement.prototype.toBlob;
 let originalImage: typeof Image;
 let originalCreateObjectURL: typeof URL.createObjectURL;
 let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+let decodes: Promise<void>[];
 
 beforeEach(() => {
+  decodes = [];
   originalGetContext = HTMLCanvasElement.prototype.getContext;
   originalToBlob = HTMLCanvasElement.prototype.toBlob;
   originalImage = globalThis.Image;
@@ -33,7 +35,7 @@ beforeEach(() => {
     private _src = "";
     set src(value: string) {
       this._src = value;
-      Promise.resolve().then(() => this.onload?.());
+      decodes.push(Promise.resolve().then(() => this.onload?.()));
     }
     get src(): string {
       return this._src;
@@ -209,6 +211,9 @@ test("reset clears settled items and restarts markers at one", async () => {
 
   expect(result.current.items).toHaveLength(1);
   expect(result.current.items[0]).toMatchObject({ marker: 1, name: "new.png" });
+  await act(async () => {
+    await Promise.all(decodes);
+  });
 });
 
 test("reset invalidates a pending encode success", async () => {
@@ -248,7 +253,7 @@ test("reset invalidates a pending encode failure without stripping replacement t
   expect(onRejected).not.toHaveBeenCalled();
 });
 
-test("ingesting an image synchronously splices its marker into the editor text and flags the item pending", () => {
+test("ingesting an image synchronously splices its marker into the editor text and flags the item pending", async () => {
   const editor = makeFakeEditor("hello", 5);
   const { result } = renderHook(() => useAttachments(editor));
 
@@ -261,6 +266,9 @@ test("ingesting an image synchronously splices its marker into the editor text a
   expect(result.current.items).toHaveLength(1);
   expect(result.current.items[0]).toMatchObject({ marker: 1, pending: true, name: "a.png" });
   expect(result.current.hasPending).toBe(true);
+  await act(async () => {
+    await Promise.all(decodes);
+  });
 });
 
 test("after the async re-encode resolves, the item flips to settled with data/width/height", async () => {
@@ -319,7 +327,7 @@ test("an oversized image is rejected before decode, naming the 8 MB limit", () =
   expect(onRejected.mock.calls[0]?.[0]).toContain("maximum 8 MB");
 });
 
-test("a mixed accept+reject batch combines all rejections into one onRejected call while still accepting the good file", () => {
+test("a mixed accept+reject batch combines all rejections into one onRejected call while still accepting the good file", async () => {
   const editor = makeFakeEditor("", 0);
   const { result } = renderHook(() => useAttachments(editor));
   const onRejected = vi.fn();
@@ -336,9 +344,12 @@ test("a mixed accept+reject batch combines all rejections into one onRejected ca
   const message = onRejected.mock.calls[0]?.[0] as string;
   expect(message).toContain("a.txt");
   expect(message).toContain("b.pdf");
+  await act(async () => {
+    await Promise.all(decodes);
+  });
 });
 
-test("the 9th image in one session is rejected on the count cap, naming the 8-image limit", () => {
+test("the 9th image in one session is rejected on the count cap, naming the 8-image limit", async () => {
   const editor = makeFakeEditor("", 0);
   const { result } = renderHook(() => useAttachments(editor));
 
@@ -356,6 +367,9 @@ test("the 9th image in one session is rejected on the count cap, naming the 8-im
   });
   expect(result.current.items).toHaveLength(8);
   expect(onRejected.mock.calls[0]?.[0]).toContain("maximum 8 images");
+  await act(async () => {
+    await Promise.all(decodes);
+  });
 });
 
 test("a decode failure strips the marker from the editor text, drops the item, and reports via onRejected", async () => {
@@ -436,6 +450,9 @@ test("marker numbering never reuses a number removed via removeItem", async () =
     result.current.ingestFiles([makeFile("b.png")], () => {});
   });
   expect(result.current.items[0]?.marker).toBe(2);
+  await act(async () => {
+    await Promise.all(decodes);
+  });
 });
 
 test("clearSubmitted removes exactly the submitted markers, leaving items added mid-flight intact", async () => {
@@ -517,6 +534,9 @@ test("clearSubmitted resets the marker counter to restart at 1 once the result i
     result.current.ingestFiles([makeFile("fresh.png")], () => {});
   });
   expect(result.current.items[0]?.marker).toBe(1);
+  await act(async () => {
+    await Promise.all(decodes);
+  });
 });
 
 test("clearSubmitted does NOT reset the counter when surviving (mid-flight) items remain", async () => {
@@ -544,6 +564,9 @@ test("clearSubmitted does NOT reset the counter when surviving (mid-flight) item
   });
   // b.png kept marker 2; c.png must be 3, never reusing 1.
   expect(result.current.items.map((i) => i.marker)).toEqual([2, 3]);
+  await act(async () => {
+    await Promise.all(decodes);
+  });
 });
 
 test("toInputAttachments maps settled items to the {marker, mediaType, data, name} shape only", async () => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/composerFocus.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/composerFocus.test.ts
@@ -51,5 +51,5 @@ test("a focus request remains pending across subscriber remounts until a textare
   expect(second.result.current?.id).toBe(requestId);
   act(() => consumeComposerFocus("ref-pending"));
   expect(second.result.current).toBeUndefined();
-  resetComposerFocusStoreForTests();
+  act(() => resetComposerFocusStoreForTests());
 });

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/QueueStrip.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/QueueStrip.test.tsx
@@ -413,6 +413,9 @@ describe("dismiss a rejected Stop", () => {
 
   test("a record already discarded elsewhere still leaves the strip", async () => {
     const { record, row } = await renderRejectedStop();
+    // The seeded row is visible before the mount's projection reads settle.
+    // Finish those existing reads before another surface deletes their record.
+    await flushPendingTurnsProjectionForTests();
     // Discarded by another surface (a second tab, or this session's own
     // Composer) after this projection last read: the durable record is gone,
     // the row on screen is not, and the discard below reports "nothing to do".
@@ -924,8 +927,10 @@ describe("drain-as-steer affordance", () => {
       defaultProps({ getComposerText: () => ({ text: "my current draft", hasPending: false }), onDrainSuccess }),
     );
 
+    const drainButton = await screen.findByRole("button", { name: "Steer queue now" });
     await act(async () => {
-      fireEvent.click(await screen.findByRole("button", { name: "Steer queue now" }));
+      fireEvent.click(drainButton);
+      await flushPendingTurnsProjectionForTests();
     });
 
     await waitFor(() => {
@@ -949,8 +954,10 @@ describe("drain-as-steer affordance", () => {
     });
     renderStrip(defaultProps());
 
+    const drainButton = await screen.findByRole("button", { name: "Steer queue now" });
     await act(async () => {
-      fireEvent.click(await screen.findByRole("button", { name: "Steer queue now" }));
+      fireEvent.click(drainButton);
+      await flushPendingTurnsProjectionForTests();
     });
     expect(getToasts()).toHaveLength(0);
     expect(screen.queryByText(/reload/i)).toBeNull();
@@ -982,8 +989,10 @@ describe("drain-as-steer affordance", () => {
     }));
     renderStrip(defaultProps({ getComposerText: () => ({ text: "my current draft", hasPending: true }) }));
 
+    const drainButton = await screen.findByRole("button", { name: "Steer queue now" });
     await act(async () => {
-      fireEvent.click(await screen.findByRole("button", { name: "Steer queue now" }));
+      fireEvent.click(drainButton);
+      await flushPendingTurnsProjectionForTests();
     });
 
     await screen.findByText(/image attachment is still processing/i);

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
@@ -68,24 +68,7 @@ async function connect(overrides: Partial<Thread> = {}): Promise<FakeClient> {
   return fake;
 }
 
-// Suppress React's "not configured to support act(...)" warnings. These fire
-// because zustand store updates trigger async re-renders that settle after
-// act() returns in jsdom. The tests are correct; the warning is a known
-// limitation of the jsdom + zustand + testing-library interaction. Matched
-// on its exact, stable one-arg text rather than blanket-silenced, so any
-// *other* console.error a regression here might produce still reaches real
-// console.error and stays visible in test output.
-const ACT_ENVIRONMENT_WARNING = "The current testing environment is not configured to support act(...)";
-const realConsoleError = console.error.bind(console);
-let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
-
 beforeEach(() => {
-  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-    if (args.length === 1 && args[0] === ACT_ENVIRONMENT_WARNING) {
-      return;
-    }
-    realConsoleError(...args);
-  });
   globalThis.indexedDB = new IDBFactory();
   connectionStore.setState({ state: "idle", client: null, serverInfo: undefined });
   resetThreadsStoreForTests();
@@ -93,7 +76,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  consoleErrorSpy.mockRestore();
   cleanup();
   vi.restoreAllMocks();
   // Every test here calls ensureThread(ref)/connect(fake) directly for
@@ -514,9 +496,9 @@ test("a replayed pending receipt keeps a long-running steer until its authoritat
     if (clientMutationId === mutationId) signalReceiptSettled();
     return settled;
   });
-  replayReceipt();
-  await receiptSettled;
   await act(async () => {
+    replayReceipt();
+    await receiptSettled;
     await refreshPendingTurnsProjection("ref_a");
   });
   expect(await storage.listOutbox("ref_a")).toEqual([]);
@@ -551,8 +533,8 @@ test("a replayed pending receipt keeps a long-running steer until its authoritat
       },
     });
   });
-  await identitySettled;
   await act(async () => {
+    await identitySettled;
     await refreshPendingTurnsProjection("ref_a");
   });
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/jobTools.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { act, cleanup, render, screen, within } from "@testing-library/react";
 import { afterEach, expect, test, vi } from "vitest";
 import { toolRendererFor } from "../toolRenderers";
 import "./jobTools";
@@ -236,7 +236,7 @@ test("job_status: copy button writes the normalized structured state, not item.o
   try {
     render(<Body item={item({ toolName: "job_status", output: outputWithJunk, raw })} live={false} />);
     const btn = screen.getByRole("button", { name: "Copy raw JSON" });
-    btn.click();
+    act(() => btn.click());
     expect(writeText).toHaveBeenCalledTimes(1);
     // The copied text must be valid JSON of the structured state, not the
     // raw output string (which has trailing junk). Compare parsed values
@@ -244,6 +244,11 @@ test("job_status: copy button writes the normalized structured state, not item.o
     const copied = writeText.mock.calls[0]![0] as string;
     expect(JSON.parse(copied)).toEqual(raw);
     expect(copied).not.toContain("--- breaker ---");
+    await act(async () => {
+      const completion = writeText.mock.results[0];
+      if (completion?.type !== "return") throw new Error("clipboard write did not return a promise");
+      await completion.value;
+    });
   } finally {
     Object.defineProperty(navigator, "clipboard", {
       value: originalClipboard,

--- a/cmd/evener-hub/frontend/src/panes/sessionPanels/sessionPanelPane.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/sessionPanels/sessionPanelPane.test.tsx
@@ -315,7 +315,7 @@ test("renders a scaffold loading state before the session model hydrates", () =>
   expect(screen.getByText("Loading session panel…")).toBeTruthy();
 });
 
-test("keeps the scaffold heading consistent with the registered title after rename", () => {
+test("keeps the scaffold heading consistent with the registered title after rename", async () => {
   const model = testModel({ name: "Initial name" });
   seedModel(model);
   const { rerender } = render(
@@ -324,7 +324,9 @@ test("keeps the scaffold heading consistent with the registered title after rena
   expect(screen.getByRole("heading", { name: sessionPanelTitle("details", model.ref, model.name) })).toBeTruthy();
 
   const renamed = testModel({ name: "Renamed session" });
-  seedModel(renamed);
+  await act(async () => {
+    seedModel(renamed);
+  });
   rerender(<SessionPanelPane params={{ ref: renamed.ref }} paneId="panel-title" focused kind="details" />);
   expect(screen.getByRole("heading", { name: sessionPanelTitle("details", renamed.ref, renamed.name) })).toBeTruthy();
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/ConnectProviderDialog.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/ConnectProviderDialog.test.tsx
@@ -44,8 +44,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   cleanup();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   vi.useRealTimers();
   vi.restoreAllMocks();
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.edge.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.edge.test.tsx
@@ -64,8 +64,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   cleanup();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   vi.useRealTimers();
   vi.restoreAllMocks();
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/CredentialsSection.test.tsx
@@ -73,8 +73,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   cleanup();
+  connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   vi.useRealTimers();
 });
 
@@ -511,13 +511,28 @@ describe("OAuth start branches", () => {
     const user = userEvent.setup();
     const inspector = await openSheet(user, "personal");
     vi.useFakeTimers();
-    fireEvent.click(within(inspector).getByRole("button", { name: "Sign in…" }));
+    const request = vi.spyOn(fake, "request");
+    await act(async () => {
+      const requestIndex = request.mock.calls.length;
+      fireEvent.click(within(inspector).getByRole("button", { name: "Sign in…" }));
+      const started = request.mock.results[requestIndex];
+      if (started?.type !== "return") throw new Error("Sign in did not start the device flow request");
+      expect(request.mock.calls[requestIndex]?.[0]).toBe("evener/auth/device/start");
+      await started.value;
+    });
     await vi.waitFor(() => expect(screen.getByText("AAAA-1111")).toBeTruthy());
 
     // Flow A expires.
     await advanceTime(1000);
     expect(screen.getByText(/Code expired/)).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Start again" }));
+    await act(async () => {
+      const requestIndex = request.mock.calls.length;
+      fireEvent.click(screen.getByRole("button", { name: "Start again" }));
+      const started = request.mock.results[requestIndex];
+      if (started?.type !== "return") throw new Error("Start again did not start a new device flow request");
+      expect(request.mock.calls[requestIndex]?.[0]).toBe("evener/auth/device/start");
+      await started.value;
+    });
 
     // Flow B starts fresh: its own code, NOT flow A's leftover expired state.
     await vi.waitFor(() => expect(screen.getByText("BBBB-2222")).toBeTruthy());

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceSheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/credentials/InstanceSheet.test.tsx
@@ -109,7 +109,7 @@ describe("visibility", () => {
   test("closes itself when the instance disappears from the store", async () => {
     const { onClose } = renderSheet(instance({ name: "a", providerId: "x" }));
     expect(screen.getByRole("dialog", { name: "a" })).toBeTruthy();
-    credentialsStore.setState({ instances: [] });
+    act(() => credentialsStore.setState({ instances: [] }));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/hubUpdates.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { WireError } from "../../../protocol/errors";
@@ -122,10 +122,10 @@ test("restarting and timed-out states render their messages", async () => {
   await screen.findByText(/Up to date on snapshot/);
 
   const { hubUpdateStore } = await import("../../../stores/hubUpdate");
-  hubUpdateStore.setState({ restarting: true });
+  act(() => hubUpdateStore.setState({ restarting: true }));
   expect(await screen.findByText(/Restarting hub/)).toBeTruthy();
 
-  hubUpdateStore.setState({ restarting: false, restartTimedOut: true });
+  act(() => hubUpdateStore.setState({ restarting: false, restartTimedOut: true }));
   expect(await screen.findByText(/didn't come back within 30s/)).toBeTruthy();
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/keybindings.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
 import { ACTIONS } from "../../../keybindings/actions";
@@ -721,13 +721,10 @@ test("a stale save's error does not surface into a reopened capture", async () =
   const client = new FakeClient("ready");
   client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
   let rejectPatch: ((error: Error) => void) | undefined;
-  client.on(
-    "evener/settings/keybindings/patch",
-    () =>
-      new Promise<KeybindingsOverrides>((_resolve, reject) => {
-        rejectPatch = reject;
-      }),
-  );
+  const pendingPatch = new Promise<KeybindingsOverrides>((_resolve, reject) => {
+    rejectPatch = reject;
+  });
+  client.on("evener/settings/keybindings/patch", () => pendingPatch);
   await wireClient(client, true);
   render(<KeybindingsSection />);
 
@@ -745,9 +742,9 @@ test("a stale save's error does not surface into a reopened capture", async () =
   // hubError - the section-level alert is the store's contract for any
   // failed patch, capture or not; what the generation token guards is the
   // row/capture continuation.)
-  rejectPatch?.(new Error("hub exploded"));
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
+  await act(async () => {
+    rejectPatch?.(new Error("hub exploded"));
+    await expect(pendingPatch).rejects.toThrow("hub exploded");
   });
   expect(within(rowFor("Open the command palette")).queryByRole("alert")).toBeNull();
   // hubError also makes the whole section read-only (editable includes
@@ -999,7 +996,7 @@ test("a confirmed hub payload clears a stale row error - and leaves an unrelated
   // inline error clears WITH it - the bindings it described are no longer
   // the truth (the palette was never unbound).
   failPatch = false;
-  await keybindingsStore.getState().refreshOverrides();
+  await act(() => keybindingsStore.getState().refreshOverrides());
   expect(keybindingsStore.getState().hubError).toBeNull();
   await waitFor(() => expect(within(row).queryByRole("alert")).toBeNull());
 
@@ -1009,9 +1006,11 @@ test("a confirmed hub payload clears a stale row error - and leaves an unrelated
   // read-only for the flight and cancels captures by design (finding 18) -
   // the notification path confirms a payload without the loading gate.
   const box = await enterCapture("Focus the composer");
-  client.emitNotification({
-    method: "evener/settings/keybindings/changed",
-    params: overridesPayload(1, []),
+  act(() => {
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(1, []),
+    });
   });
   expect(screen.getByRole("textbox", { name: /Press the new shortcut/ })).toBe(box);
 });
@@ -1127,13 +1126,10 @@ test("editable flipping false mid-capture closes the box and a resolving in-flig
   const client = new FakeClient("ready");
   client.on("evener/settings/keybindings/get", () => overridesPayload(1, []));
   let resolvePatch: ((value: KeybindingsOverrides) => void) | undefined;
-  client.on(
-    "evener/settings/keybindings/patch",
-    () =>
-      new Promise<KeybindingsOverrides>((resolve) => {
-        resolvePatch = resolve;
-      }),
-  );
+  const pendingPatch = new Promise<KeybindingsOverrides>((resolve) => {
+    resolvePatch = resolve;
+  });
+  client.on("evener/settings/keybindings/patch", () => pendingPatch);
   await wireClient(client, true);
   render(<KeybindingsSection />);
 
@@ -1145,16 +1141,18 @@ test("editable flipping false mid-capture closes the box and a resolving in-flig
 
   // Support drops while the save is in flight: the row goes read-only and
   // the capture must close with it.
-  connectionStore.setState({
-    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  await act(async () => {
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
   });
   await waitFor(() => expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull());
   expect(screen.queryByRole("button", { name: /shortcut for Open the command palette/ })).toBeNull();
 
   // The stale save resolves: no capture reopens, no row-level error.
-  resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
+  await act(async () => {
+    resolvePatch?.(overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]));
+    await pendingPatch;
   });
   expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull();
   expect(within(rowFor("Open the command palette")).queryByRole("alert")).toBeNull();
@@ -1167,16 +1165,20 @@ test("editable true → false → true leaves the row read-only then editable ag
   await enterCapture("Open the command palette");
 
   // Support drops: capture cancelled, editing affordance gone.
-  connectionStore.setState({
-    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  await act(async () => {
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
   });
   await waitFor(() => expect(screen.queryByRole("textbox", { name: /Press the new shortcut/ })).toBeNull());
   expect(screen.queryByRole("button", { name: /shortcut for Open the command palette/ })).toBeNull();
 
   // Support returns (the store re-refreshes the hub payload on its own):
   // the chord button comes back and opens a NEW capture.
-  connectionStore.setState({
-    features: { ...(await client.connect()).features, keybindingsSettings: true },
+  await act(async () => {
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
   });
   const chordButton = await screen.findByRole("button", { name: "Change the shortcut for Open the command palette" });
   await userEvent.setup().click(chordButton);
@@ -1253,9 +1255,11 @@ test("a Reset preflight rejection's row error clears on the next confirmed paylo
   // Nothing hub-sourced follows on its own: the error persists until a
   // confirmed payload lands (the composer rule was removed through another
   // client), then clears with the apply.
-  client.emitNotification({
-    method: "evener/settings/keybindings/changed",
-    params: overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+  act(() => {
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(2, [{ action: ACTIONS.paletteOpen, chord: "Control+P" }]),
+    });
   });
   await waitFor(() => expect(within(row).queryByRole("alert")).toBeNull());
   expect(keybindingsStore.getState().hubError).toBeNull();
@@ -1290,11 +1294,15 @@ test("a generation-fenced queued write's row error clears on the next confirmed 
   // A support flap ends the ready generation: the flap-back begins a NEW
   // generation and re-refreshes (revision 3 again), confirming state - that
   // apply-serial bump happens BEFORE either row error exists.
-  connectionStore.setState({
-    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  await act(async () => {
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
   });
-  connectionStore.setState({
-    features: { ...(await client.connect()).features, keybindingsSettings: true },
+  await act(async () => {
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: true },
+    });
   });
   await waitFor(() => expect(keybindingsStore.getState().loaded).toBe(true));
 
@@ -1310,9 +1318,11 @@ test("a generation-fenced queued write's row error clears on the next confirmed 
 
   // A confirmed payload for the NEW generation supersedes the bindings the
   // error described: the row error clears.
-  client.emitNotification({
-    method: "evener/settings/keybindings/changed",
-    params: overridesPayload(5, []),
+  act(() => {
+    client.emitNotification({
+      method: "evener/settings/keybindings/changed",
+      params: overridesPayload(5, []),
+    });
   });
   await waitFor(() => expect(within(composerRow).queryByRole("alert")).toBeNull());
 });
@@ -1330,13 +1340,17 @@ test("a wedged support loss keeps the overrides firing and the status does not c
   // the support drop's un-apply restore exact-matches, throws, and rolls
   // back. palette.open's default is $mod+K with legacyEitherMod, so the
   // restored base serializes "Control+[Meta]+K" (Meta OPTIONAL).
-  keybindingsRegistry.getState().registerBinding({
-    id: "foreign.squatter",
-    actionId: "foreign.action",
-    chord: "Control+[Meta]+K",
+  act(() => {
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
   });
-  connectionStore.setState({
-    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  await act(async () => {
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
   });
 
   const alert = await screen.findByRole("alert");
@@ -1406,13 +1420,17 @@ test("Retry does not appear on an unsupported hub, even with the rollback alert 
   render(<KeybindingsSection />);
   // The wedge rolls the support drop's un-apply back (finding-35 staging):
   // the rollback alert shows, but the hub is unsupported - no Retry.
-  keybindingsRegistry.getState().registerBinding({
-    id: "foreign.squatter",
-    actionId: "foreign.action",
-    chord: "Control+[Meta]+K",
+  act(() => {
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
   });
-  connectionStore.setState({
-    features: { ...(await client.connect()).features, keybindingsSettings: false },
+  await act(async () => {
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: false },
+    });
   });
   const alert = await screen.findByRole("alert");
   expect(alert.textContent).toContain("still in effect");
@@ -1434,10 +1452,12 @@ test("Retry is disabled while a refresh is in flight through the rollback window
 
   // The wedge: a foreign binding squatting palette.open's default chord, so
   // the rewire's un-apply restore throws and rolls back.
-  keybindingsRegistry.getState().registerBinding({
-    id: "foreign.squatter",
-    actionId: "foreign.action",
-    chord: "Control+[Meta]+K",
+  act(() => {
+    keybindingsRegistry.getState().registerBinding({
+      id: "foreign.squatter",
+      actionId: "foreign.action",
+      chord: "Control+[Meta]+K",
+    });
   });
   const clientB = new FakeClient("ready");
   let resolveGet: ((p: KeybindingsOverrides) => void) | undefined;
@@ -1448,9 +1468,11 @@ test("Retry is disabled while a refresh is in flight through the rollback window
         resolveGet = resolve;
       }),
   );
-  connectionStore.getState().connect(clientB);
-  connectionStore.setState({
-    features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+  act(() => connectionStore.getState().connect(clientB));
+  await act(async () => {
+    connectionStore.setState({
+      features: { ...(await clientB.connect()).features, keybindingsSettings: true },
+    });
   });
   await waitFor(() => expect(keybindingsStore.getState().hubLoading).toBe(true));
   expect(keybindingsStore.getState().hubError).toContain("still in effect");
@@ -1466,7 +1488,7 @@ test("Retry is disabled while a refresh is in flight through the rollback window
 
   // Unwedge; the refresh lands, clears the rollback error, and the control
   // unmounts.
-  keybindingsRegistry.getState().unregisterBinding("foreign.squatter");
+  act(() => keybindingsRegistry.getState().unregisterBinding("foreign.squatter"));
   resolveGet?.(overridesPayload(1, []));
   await waitFor(() => expect(keybindingsStore.getState().hubError).toBeNull());
   expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/BrowseSection.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/BrowseSection.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
@@ -105,11 +105,15 @@ test("an expanded marketplace whose catalog was retired re-browses; a collapsed 
   });
   const browseSpy = vi.fn(() => ({ name: "acme-plugins", plugins: [{ name: "fresh-linter" }] }));
   fake.on("evener/marketplace/browse", browseSpy);
+  const browseMarketplace = vi.spyOn(extensionsStore.getState(), "browseMarketplace");
   render(<Harness initialExpanded={new Set(["acme-plugins"])} />);
   expect(screen.getByText("linter")).toBeTruthy();
   expect(browseSpy).not.toHaveBeenCalled();
 
-  fake.emitNotification({ method: "evener/marketplace/updated", params: {} });
+  act(() => fake.emitNotification({ method: "evener/marketplace/updated", params: {} }));
+  const browse = browseMarketplace.mock.results[0];
+  if (browse?.type !== "return") throw new Error("Expanded marketplace did not start its replacement browse");
+  await act(() => browse.value);
 
   expect(await screen.findByText("fresh-linter")).toBeTruthy();
   const browseCalls = fake.calls.filter((c) => c.method === "evener/marketplace/browse");
@@ -271,7 +275,7 @@ test("typing a filter query auto-expands (after the debounce) a marketplace with
   );
   render(<Harness />);
   await user.type(screen.getByPlaceholderText("Filter plugins…"), "lint");
-  await vi.advanceTimersByTimeAsync(150);
+  await act(() => vi.advanceTimersByTimeAsync(150));
   await waitFor(() =>
     expect(screen.getByRole("button", { name: /acme-plugins/ }).getAttribute("aria-expanded")).toBe("true"),
   );
@@ -316,13 +320,16 @@ test("a filter query outrun by a newer one leaves the tree loading no longer tha
   render(<Harness />);
   const filter = screen.getByPlaceholderText("Filter plugins…");
   await user.type(filter, "li");
-  await vi.advanceTimersByTimeAsync(150);
+  await act(() => vi.advanceTimersByTimeAsync(150));
   expect(screen.getByText("Loading marketplaces…")).toBeTruthy();
 
   // The next keystroke, while that catalog is still in flight.
   await user.type(filter, "n");
-  await vi.advanceTimersByTimeAsync(150);
-  release();
+  await act(() => vi.advanceTimersByTimeAsync(150));
+  await act(async () => {
+    release();
+    await gate;
+  });
 
   await waitFor(() => expect(screen.queryByText("Loading marketplaces…")).toBeNull());
   const toggle = screen.getByRole("button", { name: /acme-plugins/ });
@@ -352,12 +359,15 @@ test("the filter waits for a catalog that was already loading when the query ran
   render(<Harness />);
   await user.click(screen.getByRole("button", { name: /acme-plugins/ }));
   await user.type(screen.getByPlaceholderText("Filter plugins…"), "lin");
-  await vi.advanceTimersByTimeAsync(150);
+  await act(() => vi.advanceTimersByTimeAsync(150));
   // findByText, not getByText: this query starts no request of its own, so
   // no store update comes along to flush the filterLoading render with it.
   expect(await screen.findByText("Loading marketplaces…")).toBeTruthy();
 
-  release();
+  await act(async () => {
+    release();
+    await gate;
+  });
 
   await waitFor(() => expect(screen.queryByText("Loading marketplaces…")).toBeNull());
   expect(screen.getByRole("button", { name: /acme-plugins/ }).getAttribute("aria-expanded")).toBe("true");
@@ -372,6 +382,6 @@ test("zero matches anywhere shows a not-found message quoting the query", async 
   fake.on("evener/marketplace/browse", () => ({ name: "acme-plugins", plugins: [{ name: "linter" }] }));
   render(<Harness />);
   await user.type(screen.getByPlaceholderText("Filter plugins…"), "zzz");
-  await vi.advanceTimersByTimeAsync(150);
+  await act(() => vi.advanceTimersByTimeAsync(150));
   expect(await screen.findByText('No plugins match "zzz".')).toBeTruthy();
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/MarketplaceSheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/MarketplaceSheet.test.tsx
@@ -662,13 +662,10 @@ test("a pending Remove confirm does not follow a selection change", async () => 
 test("a remove still in flight does not leave the next marketplace's confirm busy", async () => {
   const fake = connectionStore.getState().client as FakeClient;
   let release: (() => void) | undefined;
-  fake.on(
-    "evener/marketplace/remove",
-    () =>
-      new Promise((resolve) => {
-        release = () => resolve({ marketplaces: [OTHER] });
-      }),
-  );
+  const removal = new Promise<{ marketplaces: MarketplaceEntry[] }>((resolve) => {
+    release = () => resolve({ marketplaces: [OTHER] });
+  });
+  fake.on("evener/marketplace/remove", () => removal);
   const { select } = renderSheet(ACME);
   act(() => extensionsStore.setState({ marketplaces: [ACME, OTHER] }));
   const user = userEvent.setup();
@@ -683,7 +680,10 @@ test("a remove still in flight does not leave the next marketplace's confirm bus
   const confirm = screen.getByRole("dialog", { name: "Remove marketplace" });
   expect(within(confirm).getByText(/"other"/)).toBeTruthy();
   expect((within(confirm).getByRole("button", { name: "Remove" }) as HTMLButtonElement).disabled).toBe(false);
-  act(() => release?.());
+  await act(async () => {
+    release?.();
+    await removal;
+  });
 });
 
 // The removal names the marketplace it was confirmed for, and so does the

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { FakeClient } from "../../../../protocol/testing/fakeClient";
@@ -52,12 +52,13 @@ test("renders nothing when target is null", () => {
   expect(screen.queryByRole("dialog")).toBeNull();
 });
 
-test("renders name, state chips, version, marketplace, and source", () => {
+test("renders name, state chips, version, marketplace, and source", async () => {
   connectFakeClient();
   extensionsStore.setState({
     plugins: [{ ...LINTER, broken: true, enabled: false, autoUpgrade: true }],
     marketplaces: [ACME],
   });
+  const browseMarketplace = vi.spyOn(extensionsStore.getState(), "browseMarketplace");
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
   expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
   expect(screen.getByText("broken")).toBeTruthy();
@@ -66,22 +67,33 @@ test("renders name, state chips, version, marketplace, and source", () => {
   expect(screen.getByText("v1.2.0")).toBeTruthy();
   expect(screen.getByText("acme-plugins")).toBeTruthy();
   expect(screen.getByText("github: acme/plugins")).toBeTruthy();
+  const browse = browseMarketplace.mock.results[0];
+  if (browse?.type !== "return") throw new Error("Plugin detail sheet did not start its catalog browse");
+  await act(() => browse.value);
 });
 
-test("omits the source row when the marketplace is not registered", () => {
+test("omits the source row when the marketplace is not registered", async () => {
   connectFakeClient();
   extensionsStore.setState({ plugins: [LINTER], marketplaces: [] });
+  const browseMarketplace = vi.spyOn(extensionsStore.getState(), "browseMarketplace");
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
   expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
   expect(screen.queryByText("github: acme/plugins")).toBeNull();
+  const browse = browseMarketplace.mock.results[0];
+  if (browse?.type !== "return") throw new Error("Plugin detail sheet did not start its catalog browse");
+  await act(() => browse.value);
 });
 
-test("the Enabled and Auto-upgrade switches reflect the entry's state", () => {
+test("the Enabled and Auto-upgrade switches reflect the entry's state", async () => {
   connectFakeClient();
   extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
+  const browseMarketplace = vi.spyOn(extensionsStore.getState(), "browseMarketplace");
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
   expect(screen.getByRole("switch", { name: "Enabled" }).getAttribute("aria-checked")).toBe("true");
   expect(screen.getByRole("switch", { name: "Auto-upgrade" }).getAttribute("aria-checked")).toBe("false");
+  const browse = browseMarketplace.mock.results[0];
+  if (browse?.type !== "return") throw new Error("Plugin detail sheet did not start its catalog browse");
+  await act(() => browse.value);
 });
 
 test("the Enabled switch calls pluginDisable on an enabled plugin, pluginEnable on a disabled one", async () => {
@@ -339,8 +351,12 @@ test("closes itself when the entry disappears from the store (removed elsewhere)
   connectFakeClient();
   extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
   const onClose = vi.fn();
+  const browseMarketplace = vi.spyOn(extensionsStore.getState(), "browseMarketplace");
   render(<PluginDetailSheet target={TARGET} onClose={onClose} />);
   expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
-  extensionsStore.setState({ plugins: [] });
+  const browse = browseMarketplace.mock.results[0];
+  if (browse?.type !== "return") throw new Error("Plugin detail sheet did not start its catalog browse");
+  act(() => extensionsStore.setState({ plugins: [] }));
+  await act(() => browse.value);
   await waitFor(() => expect(onClose).toHaveBeenCalled());
 });

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/mcp.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/mcp.test.tsx
@@ -1,10 +1,10 @@
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
 import type { SettingsOverviewResponse } from "../../../protocol/types.gen";
 import { connectionStore } from "../../../stores/connection";
-import { resetExtensionsStoreForTests } from "../../../stores/extensions";
+import { extensionsStore, resetExtensionsStoreForTests } from "../../../stores/extensions";
 import { getToasts, resetToastStoreForTests } from "../../../widgets/toast/store";
 import { McpSection, type SettingsOverviewLike } from "./mcp";
 
@@ -36,14 +36,18 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-test("calls the injected overview hook's fetch on mount", () => {
+test("calls the injected overview hook's fetch on mount", async () => {
   connectFakeClient();
   const fetchFn = vi.fn(async () => {});
+  const fetchLaunchLayer = vi.spyOn(extensionsStore.getState(), "fetchLaunchLayer");
   render(<McpSection useOverviewStore={overviewHook({ fetch: fetchFn })} />);
   expect(fetchFn).toHaveBeenCalledOnce();
+  const fetch = fetchLaunchLayer.mock.results[0];
+  if (fetch?.type !== "return") throw new Error("MCP section did not start its launch-layer fetch");
+  await act(() => fetch.value);
 });
 
-test("renders discovered servers from the injected overview data with a status per row", () => {
+test("renders discovered servers from the injected overview data with a status per row", async () => {
   connectFakeClient();
   const data: SettingsOverviewResponse = {
     mcpDiscovered: {
@@ -53,31 +57,47 @@ test("renders discovered servers from the injected overview data with a status p
       ],
     },
   };
+  const fetchLaunchLayer = vi.spyOn(extensionsStore.getState(), "fetchLaunchLayer");
   render(<McpSection useOverviewStore={overviewHook({ data })} />);
   expect(screen.getByText(/local-tool/)).toBeTruthy();
   expect(screen.getByText("available")).toBeTruthy();
   expect(screen.getByText(/remote-api/)).toBeTruthy();
   expect(screen.getByText("unreachable")).toBeTruthy();
   expect(screen.getByText("connection refused")).toBeTruthy();
+  const fetch = fetchLaunchLayer.mock.results[0];
+  if (fetch?.type !== "return") throw new Error("MCP section did not start its launch-layer fetch");
+  await act(() => fetch.value);
 });
 
-test("shows the discovered-servers empty state", () => {
+test("shows the discovered-servers empty state", async () => {
   connectFakeClient();
+  const fetchLaunchLayer = vi.spyOn(extensionsStore.getState(), "fetchLaunchLayer");
   render(<McpSection useOverviewStore={overviewHook({ data: { mcpDiscovered: { servers: [] } } })} />);
   expect(screen.getByText("No MCP servers configured.")).toBeTruthy();
+  const fetch = fetchLaunchLayer.mock.results[0];
+  if (fetch?.type !== "return") throw new Error("MCP section did not start its launch-layer fetch");
+  await act(() => fetch.value);
 });
 
-test("shows a loading state for discovered servers before the overview resolves", () => {
+test("shows a loading state for discovered servers before the overview resolves", async () => {
   connectFakeClient();
+  const fetchLaunchLayer = vi.spyOn(extensionsStore.getState(), "fetchLaunchLayer");
   render(<McpSection useOverviewStore={overviewHook({ loading: true, data: null })} />);
   expect(screen.getAllByRole("status", { name: "Loading" }).length).toBeGreaterThan(0);
+  const fetch = fetchLaunchLayer.mock.results[0];
+  if (fetch?.type !== "return") throw new Error("MCP section did not start its launch-layer fetch");
+  await act(() => fetch.value);
 });
 
-test("a top-level probe failure replaces the discovered-servers list with one message", () => {
+test("a top-level probe failure replaces the discovered-servers list with one message", async () => {
   connectFakeClient();
+  const fetchLaunchLayer = vi.spyOn(extensionsStore.getState(), "fetchLaunchLayer");
   render(<McpSection useOverviewStore={overviewHook({ data: { mcpDiscovered: { error: "probe timed out" } } })} />);
   expect(screen.getByText("Failed to load")).toBeTruthy();
   expect(screen.getByText("probe timed out")).toBeTruthy();
+  const fetch = fetchLaunchLayer.mock.results[0];
+  if (fetch?.type !== "return") throw new Error("MCP section did not start its launch-layer fetch");
+  await act(() => fetch.value);
 });
 
 test("renders the mcpConfigs entries from the launch layer", async () => {

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/mobile.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, type RenderOptions, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { WireError } from "../../../protocol/errors";
 import { FakeClient } from "../../../protocol/testing/fakeClient";
@@ -9,11 +9,14 @@ import { MobileSection } from "./mobile";
 // Lets one test simulate a rejected `import("qrcode.react")` chunk load: the
 // mock only throws while the flag is set, so every other test imports the
 // real renderer untouched.
-const qrChunkControl = vi.hoisted(() => ({ failChunkLoad: false }));
+const qrChunkControl = vi.hoisted(() => ({
+  failChunkLoad: false,
+  error: new Error("Simulated QR chunk load failure"),
+}));
 
 vi.mock("qrcode.react", async (importOriginal) => {
   if (qrChunkControl.failChunkLoad) {
-    throw new Error("Simulated QR chunk load failure");
+    throw qrChunkControl.error;
   }
   return importOriginal();
 });
@@ -39,6 +42,15 @@ function renderMobileSection() {
 }
 
 test("keeps the pairing link usable when the QR chunk fails to load", async () => {
+  // Vitest wraps the rejected mock factory; assert both that wrapper and the
+  // original failure instead of accepting an arbitrary QR rendering error.
+  const mockErrorMessage =
+    '[vitest] There was an error when mocking a module. If you are using "vi.mock" factory, make sure there are no top level variables inside, since this call is hoisted to top of the file. Read more: https://vitest.dev/api/vi.html#vi-mock';
+  const onCaughtError = vi.fn<NonNullable<RenderOptions["onCaughtError"]>>((error, info) => {
+    if (!(error instanceof Error) || error.message !== mockErrorMessage || error.cause !== qrChunkControl.error) {
+      console.error(error, info);
+    }
+  });
   const authURL = "https://hub.example.test/auth/mobile-secret";
   client.on("evener/mobile/pairing", () => ({ authUrl: authURL }));
 
@@ -63,6 +75,7 @@ test("keeps the pairing link usable when the QR chunk fails to load", async () =
       <FreshClientProvider client={client}>
         <FreshMobileSection />
       </FreshClientProvider>,
+      { onCaughtError },
     );
 
     // The failure stays scoped to the QR slot: an error fallback instead of
@@ -72,6 +85,11 @@ test("keeps the pairing link usable when the QR chunk fails to load", async () =
     expect(screen.getByRole("button", { name: "Copy pairing link" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Mobile app" })).toBeTruthy();
     expect(screen.queryByRole("img", { name: "Mobile app pairing QR code" })).toBeNull();
+    expect(onCaughtError).toHaveBeenCalledTimes(1);
+    const caughtError = onCaughtError.mock.calls[0]?.[0];
+    expect(caughtError).toBeInstanceOf(Error);
+    expect(caughtError).toHaveProperty("message", mockErrorMessage);
+    expect((caughtError as Error).cause).toBe(qrChunkControl.error);
   } finally {
     qrChunkControl.failChunkLoad = false;
   }

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/transcript.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/transcript.test.tsx
@@ -205,7 +205,11 @@ test("keeps browser-storage failure inline without a failure notification", asyn
   transcriptDisplayStore.setState({ hubSupport: "supported" });
   renderWithToasts();
   vi.stubGlobal("localStorage", new FailingStorage());
-  transcriptDisplayStore.getState().setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }));
+  act(() => {
+    transcriptDisplayStore
+      .getState()
+      .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "full" }));
+  });
 
   expect(transcriptDisplayStore.getState().storageWarning).toMatch(/may not survive restart/);
   await waitFor(() => expect(screen.getAllByRole("alert")).toHaveLength(1));
@@ -400,11 +404,16 @@ test("acknowledges a notification received before its matching save response", a
   client.on("evener/settings/transcriptDisplay/patch", () => response.promise);
   await mountReadySection(client);
   await userEvent.setup().click(screen.getAllByRole("radio", { name: "Full detail" })[0]!);
-  client.emitNotification({
-    method: "evener/settings/transcriptDisplay/changed",
-    params: { layout: "desktop", revision: 2, config: toWireConfig(draft) },
-  } as AnyNotification);
-  response.resolve({ layout: "desktop", revision: 2, config: toWireConfig(draft) });
+  act(() => {
+    client.emitNotification({
+      method: "evener/settings/transcriptDisplay/changed",
+      params: { layout: "desktop", revision: 2, config: toWireConfig(draft) },
+    } as AnyNotification);
+  });
+  await act(async () => {
+    response.resolve({ layout: "desktop", revision: 2, config: toWireConfig(draft) });
+    await response.promise;
+  });
 
   expect(await screen.findByText("Settings saved")).toBeTruthy();
   expect(screen.getAllByText("Settings saved")).toHaveLength(1);
@@ -434,8 +443,12 @@ test("does not acknowledge a save from a stale client generation", async () => {
   await userEvent.setup().click(screen.getAllByRole("radio", { name: "Full detail" })[0]!);
   const refreshCountBeforeReconnect = refreshes;
   reconnecting = true;
-  client.emitStateChange("idle");
-  client.emitReady();
+  const request = vi.spyOn(client, "request");
+  await act(async () => {
+    client.emitStateChange("idle");
+    client.emitReady();
+    await Promise.all(request.mock.results.map((result) => result.value));
+  });
   await waitFor(() =>
     expect(
       client.calls.filter((call) => call.method === "evener/settings/transcriptDisplay/get").length,
@@ -509,7 +522,10 @@ test("does not toast when an overlapping PATCH conflicts with the committed winn
 
   await userEvent.setup().click(screen.getAllByRole("radio", { name: "Full detail" })[0]!);
   await waitFor(() => expect(responses).toHaveLength(1));
-  const competingPatch = transcriptDisplayStore.getState().patchHubDefault("desktop", newerDraft);
+  let competingPatch!: ReturnType<ReturnType<typeof transcriptDisplayStore.getState>["patchHubDefault"]>;
+  act(() => {
+    competingPatch = transcriptDisplayStore.getState().patchHubDefault("desktop", newerDraft);
+  });
   await waitFor(() => expect(responses).toHaveLength(2));
 
   responses[0]?.resolve({ layout: "desktop", revision: 2, config: toWireConfig(firstDraft) });
@@ -517,14 +533,16 @@ test("does not toast when an overlapping PATCH conflicts with the committed winn
   expect(screen.queryByText("Settings saved")).toBeNull();
   expect(transcriptDisplayStore.getState().drafts.desktop).toEqual(newerDraft);
 
-  responses[1]?.reject(
-    new WireError("revision conflict", -32013, {
-      evenerErrorInfo: "conflict",
-      layout: "desktop",
-      current: { revision: 2, config: toWireConfig(firstDraft) },
-    }),
-  );
-  await expect(competingPatch).rejects.toThrow("revision conflict");
+  await act(async () => {
+    responses[1]?.reject(
+      new WireError("revision conflict", -32013, {
+        evenerErrorInfo: "conflict",
+        layout: "desktop",
+        current: { revision: 2, config: toWireConfig(firstDraft) },
+      }),
+    );
+    await expect(competingPatch).rejects.toThrow("revision conflict");
+  });
   expect(transcriptDisplayStore.getState().hub.desktop).toEqual({ revision: 2, config: firstDraft });
   expect(transcriptDisplayStore.getState().drafts.desktop).toBeUndefined();
   expect(screen.queryByText("Settings saved")).toBeNull();

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.test.tsx
@@ -336,8 +336,8 @@ test("successful keyless testing refreshes availability without an auth notifica
   const connectProvider = await screen.findByRole("button", { name: "Connect provider" });
   // Finish the lazy dialog's mount and catalog refresh before retaining a button
   // reference: the refresh replaces the initially cached instance rows.
+  await user.click(connectProvider);
   await act(async () => {
-    await user.click(connectProvider);
     await vi.dynamicImportSettled();
   });
   const testConnection = await screen.findByRole("button", { name: "Test connection" });
@@ -2251,7 +2251,9 @@ test("resets the prompt and attachments after a successful spawn, but keeps stic
   const prompt = screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
   await setWorkingDir(user, "/tmp/project");
   await user.type(prompt, "do the thing");
-  pastePngInto(prompt);
+  await act(async () => {
+    pastePngInto(prompt);
+  });
   await waitFor(() => expect(prompt.value).toBe("do the thing[image 1]"));
   await waitFor(() => expect(screen.getByRole("button", { name: /remove/i })).toBeTruthy());
 
@@ -2279,7 +2281,9 @@ test("a failed spawn leaves the prompt and attachment staged (failure paths keep
 
   const prompt = screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
   await user.type(prompt, "do the thing");
-  pastePngInto(prompt);
+  await act(async () => {
+    pastePngInto(prompt);
+  });
   await waitFor(() => expect(prompt.value).toBe("do the thing[image 1]"));
   await waitFor(() => expect(screen.getByRole("button", { name: /remove/i })).toBeTruthy());
 
@@ -2443,7 +2447,9 @@ test("a settled attachment renders as a thumbnail tile, not a text chip (kata kb
   await settled();
 
   const prompt = screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
-  pastePngInto(prompt, "shot.png");
+  await act(async () => {
+    pastePngInto(prompt, "shot.png");
+  });
   await waitFor(() => expect(prompt.value).toBe("[image 1]"));
 
   // The whole thumbnail is the control that opens the lightbox, named for the
@@ -2460,7 +2466,9 @@ test("a pending attachment is the same tile, and says nothing about its progress
   await settled();
 
   const prompt = screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
-  pastePngInto(prompt, "shot.png");
+  await act(async () => {
+    pastePngInto(prompt, "shot.png");
+  });
   await waitFor(() => expect(prompt.value).toBe("[image 1]"));
 
   // An empty slot the thumbnail will fill, named so a screen reader hears
@@ -2489,11 +2497,13 @@ test("focus on a staged attachment's remove button survives its decode settling 
   await settled();
 
   const prompt = screen.getByRole("textbox", { name: "Prompt" }) as HTMLTextAreaElement;
-  act(() => {
+  await act(async () => {
     pastePngInto(prompt, "shot.png");
   });
   const removeButton = screen.getByRole("button", { name: "Remove shot.png" });
-  removeButton.focus();
+  await act(async () => {
+    removeButton.focus();
+  });
   expect(document.activeElement).toBe(removeButton);
 
   await act(async () => {

--- a/cmd/evener-hub/frontend/src/panes/spawn/SpawnChunk.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/SpawnChunk.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, type RenderOptions, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Component, type ReactNode } from "react";
 import { afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
@@ -90,12 +90,13 @@ function missingCredentialsClient(): FakeClient {
   return fake;
 }
 
-function renderSpawn(client: FakeClient) {
+function renderSpawn(client: FakeClient, options: RenderOptions) {
   return render(
     <ClientProvider client={client}>
       <Spawn params={{}} paneId="spawn-1" focused={true} />
       <Toast />
     </ClientProvider>,
+    options,
   );
 }
 
@@ -103,29 +104,21 @@ async function openConnectDialog(user: ReturnType<typeof userEvent.setup>): Prom
   await user.click(await screen.findByRole("button", { name: "Connect provider" }));
 }
 
-// Suppress console.error noise from React's error-boundary logging during
-// tests that deliberately trigger chunk-load failures. The errors are
-// expected; the boundary catches them. Matched on React's own stable
-// componentDidCatch format string plus its fixed boundary-recovery
-// sentence, rather than blanket-silenced, so any *other* console.error a
-// regression here might produce still reaches real console.error and
-// stays visible in test output (DockRegion.test.tsx's own recipe).
-const REACT_ERROR_BOUNDARY_FORMAT = "%o\n\n%s\n\n%s\n";
-const REACT_ERROR_BOUNDARY_PREFACE = "The above error occurred in one of your React components.";
 const realConsoleError = console.error.bind(console);
-let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+// Capture only this render's injected failure; every test also asserts the
+// complete callback count and error identity, including repeated retries.
+function captureExpectedError(expectedError: Error) {
+  return vi.fn<NonNullable<RenderOptions["onCaughtError"]>>((error, info) => {
+    if (error !== expectedError) realConsoleError(error, info);
+  });
+}
 
 beforeAll(() => {
   globalThis.localStorage = new MemoryStorage() as unknown as Storage;
 });
 
 beforeEach(() => {
-  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-    if (args[0] === REACT_ERROR_BOUNDARY_FORMAT && args[2] === REACT_ERROR_BOUNDARY_PREFACE) {
-      return;
-    }
-    realConsoleError(...args);
-  });
   localStorage.clear();
   resetCredentialsStoreForTests();
   loadConnectDialog.mockReset();
@@ -138,7 +131,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  consoleErrorSpy.mockRestore();
   cleanup();
   connectionStore.setState({ state: "idle", serverInfo: undefined, client: null });
   resetExtensionsStoreForTests();
@@ -154,27 +146,33 @@ afterEach(() => {
 });
 
 test("a rejected dialog chunk shows the failure message with a Retry", async () => {
-  vi.mocked(loadConnectDialog).mockRejectedValue(new Error(CHUNK_ERROR));
+  const chunkError = new Error(CHUNK_ERROR);
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadConnectDialog).mockRejectedValue(chunkError);
   const user = userEvent.setup();
   const client = missingCredentialsClient();
   connectionStore.getState().connect(client);
-  renderSpawn(client);
+  renderSpawn(client, { onCaughtError });
 
   await openConnectDialog(user);
 
   expect(await screen.findByText("Couldn't load the connect dialog")).toBeTruthy();
   expect(screen.getByText(CHUNK_ERROR)).toBeTruthy();
   expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
 });
 
 test("Retry fetches the chunk again and mounts the dialog on the second attempt", async () => {
+  const chunkError = new Error(CHUNK_ERROR);
+  const onCaughtError = captureExpectedError(chunkError);
   vi.mocked(loadConnectDialog)
-    .mockRejectedValueOnce(new Error(CHUNK_ERROR))
+    .mockRejectedValueOnce(chunkError)
     .mockResolvedValueOnce({ ConnectProviderDialog: StubConnectDialog } as never);
   const user = userEvent.setup();
   const client = missingCredentialsClient();
   connectionStore.getState().connect(client);
-  renderSpawn(client);
+  renderSpawn(client, { onCaughtError });
 
   await openConnectDialog(user);
   await screen.findByText("Couldn't load the connect dialog");
@@ -187,16 +185,20 @@ test("Retry fetches the chunk again and mounts the dialog on the second attempt"
   expect(await screen.findByText("connect dialog mounted")).toBeTruthy();
   expect(vi.mocked(loadConnectDialog).mock.calls).toEqual([[false], [true]]);
   expect(screen.queryByText("Couldn't load the connect dialog")).toBeNull();
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
 });
 
 test("a retry that fails again offers a page reload instead of stranding the provider flow", async () => {
-  vi.mocked(loadConnectDialog).mockRejectedValue(new Error(CHUNK_ERROR));
+  const chunkError = new Error(CHUNK_ERROR);
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadConnectDialog).mockRejectedValue(chunkError);
   const reload = vi.fn();
   vi.stubGlobal("location", { ...window.location, reload });
   const user = userEvent.setup();
   const client = missingCredentialsClient();
   connectionStore.getState().connect(client);
-  renderSpawn(client);
+  renderSpawn(client, { onCaughtError });
 
   await openConnectDialog(user);
   await screen.findByText("Couldn't load the connect dialog");
@@ -210,6 +212,9 @@ test("a retry that fails again offers a page reload instead of stranding the pro
 
   expect(reload).toHaveBeenCalledTimes(1);
   expect(vi.mocked(loadConnectDialog).mock.calls).toEqual([[false], [true]]);
+  expect(onCaughtError).toHaveBeenCalledTimes(2);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
+  expect(onCaughtError.mock.calls[1]?.[0]).toBe(chunkError);
 });
 
 test("an ordinary retry failure does not prescribe a page reload", async () => {
@@ -218,7 +223,9 @@ test("an ordinary retry failure does not prescribe a page reload", async () => {
   // failure: the dialog boundary declines it, so it lands on the next
   // boundary above - never the dialog failure state, and so never the
   // Retry/Reload pair that could misreport it as a stale deploy.
-  vi.mocked(loadConnectDialog).mockRejectedValue(new Error("ConnectProviderDialog chunk request failed with 500"));
+  const chunkError = new Error("ConnectProviderDialog chunk request failed with 500");
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadConnectDialog).mockRejectedValue(chunkError);
   const client = missingCredentialsClient();
   connectionStore.getState().connect(client);
   const user = userEvent.setup();
@@ -229,6 +236,7 @@ test("an ordinary retry failure does not prescribe a page reload", async () => {
       </DialogTestOuterBoundary>
       <Toast />
     </ClientProvider>,
+    { onCaughtError },
   );
 
   await openConnectDialog(user);
@@ -238,6 +246,9 @@ test("an ordinary retry failure does not prescribe a page reload", async () => {
   ).toBeTruthy();
   expect(screen.queryByText("Couldn't load the connect dialog")).toBeNull();
   expect(screen.queryByRole("button", { name: "Reload page" })).toBeNull();
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
+  expect(onCaughtError.mock.calls[0]?.[1].errorBoundary).toBeInstanceOf(DialogTestOuterBoundary);
 });
 
 // A logic bug thrown by the RESOLVED dialog's own render is not a chunk-load
@@ -255,8 +266,14 @@ class DialogTestOuterBoundary extends Component<{ children: ReactNode }, { failu
 }
 
 test("a logic bug in the resolved dialog keeps unwinding past the dialog boundary", async () => {
+  const renderError = new Error("ConnectProviderDialog render logic bug");
+  const onCaughtError = vi.fn<NonNullable<RenderOptions["onCaughtError"]>>((error, info) => {
+    if (error !== renderError || !(info.errorBoundary instanceof DialogTestOuterBoundary)) {
+      realConsoleError(error, info);
+    }
+  });
   function BuggyDialog() {
-    throw new Error("ConnectProviderDialog render logic bug");
+    throw renderError;
   }
   vi.mocked(loadConnectDialog).mockResolvedValue({ ConnectProviderDialog: BuggyDialog } as never);
   const user = userEvent.setup();
@@ -269,10 +286,14 @@ test("a logic bug in the resolved dialog keeps unwinding past the dialog boundar
       </DialogTestOuterBoundary>
       <Toast />
     </ClientProvider>,
+    { onCaughtError },
   );
 
   await openConnectDialog(user);
 
   expect(await screen.findByText("outer boundary caught: ConnectProviderDialog render logic bug")).toBeTruthy();
   expect(screen.queryByText("Couldn't load the connect dialog")).toBeNull();
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(renderError);
+  expect(onCaughtError.mock.calls[0]?.[1].errorBoundary).toBeInstanceOf(DialogTestOuterBoundary);
 });

--- a/cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/transcript/Transcript.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { lazy } from "react";
 import { afterAll, afterEach, beforeEach, expect, test, vi } from "vitest";
 import { FakeClient } from "../../protocol/testing/fakeClient";
@@ -235,21 +235,27 @@ test("keeps transcript/history and projection announcements without standalone D
   expect(screen.getByTestId("load-older-sentinel")).toBeTruthy();
   expect(screen.queryByRole("button", { name: /^Detail:/ })).toBeNull();
   expect(screen.queryByRole("menuitem", { name: "Verbosity…" })).toBeNull();
-  transcriptDisplayStore.setState({ viewport: "desktop" });
-  transcriptDisplayStore
-    .getState()
-    .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "activity" }));
+  await act(async () => {
+    transcriptDisplayStore.setState({ viewport: "desktop" });
+    transcriptDisplayStore
+      .getState()
+      .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "activity" }));
+  });
   await waitFor(() =>
     expect(screen.getByTestId("transcript-view-announcement").textContent).toContain("Transcript detail: Activity"),
   );
   const status = screen.getByTestId("transcript-view-announcement");
-  transcriptDisplayStore
-    .getState()
-    .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "activity" }, { roundTimings: true }));
+  await act(async () => {
+    transcriptDisplayStore
+      .getState()
+      .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "activity" }, { roundTimings: true }));
+  });
   await waitFor(() => expect(status.textContent).toContain("Transcript detail: Activity · 1 advanced"));
-  transcriptDisplayStore
-    .getState()
-    .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "activity" }, { tokenCounts: true }));
+  await act(async () => {
+    transcriptDisplayStore
+      .getState()
+      .setLocal("desktop", makeTranscriptDisplayConfig({ kind: "preset", level: "activity" }, { tokenCounts: true }));
+  });
   await waitFor(() => expect(status.textContent).toContain("Transcript detail: Activity · 1 advanced"));
   expect(screen.getByTestId("transcript-view-announcement")).toBe(status);
 });

--- a/cmd/evener-hub/frontend/src/protocol/tokenFlood.test.tsx
+++ b/cmd/evener-hub/frontend/src/protocol/tokenFlood.test.tsx
@@ -10,6 +10,7 @@
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { memo } from "react";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { flushPendingTurnsProjectionForTests } from "../panes/session/composer/queue/pendingTurnsStore";
 import Session from "../panes/session/Session";
 import { type ItemRenderProps, ignoringTurn, registerItemRenderer } from "../panes/session/transcript/types";
 import { ClientProvider } from "../shell/clientContext";
@@ -241,12 +242,15 @@ describe("token-flood: 100-delta streaming fast path through a mounted Session",
     const ref = "ref_flood_session";
     fake.on("thread/read", () => ({ thread: floodThread(ref) }) as ThreadReadResponse);
 
-    render(
-      <ClientProvider client={fake}>
-        <Session params={{ ref }} paneId="p1" focused={true} />
-      </ClientProvider>,
-    );
+    await act(async () => {
+      render(
+        <ClientProvider client={fake}>
+          <Session params={{ ref }} paneId="p1" focused={true} />
+        </ClientProvider>,
+      );
+    });
 
+    await flushPendingTurnsProjectionForTests();
     await waitFor(() => expect(document.querySelector('[data-testid="settled-probe"]')).toBeTruthy());
     const renderCountAfterMount = renderCount;
     expect(renderCountAfterMount).toBeGreaterThan(0);
@@ -259,12 +263,15 @@ describe("token-flood: 100-delta streaming fast path through a mounted Session",
     // one call stack into a single render pass (which would silently hide
     // exactly the per-delta re-render cost this probe exists to measure).
     for (const delta of chunks) {
-      act(() => {
+      await act(async () => {
         fake.emitNotification({
           method: "item/agentMessage/delta",
           params: { ref, turnId: "turn_flood_settled", itemId: "item_flood_live", delta },
         } as AnyNotification);
       });
+      // Notification subscribers also start durable projection reads. Await
+      // those real completions before delivering the next wire frame.
+      await flushPendingTurnsProjectionForTests();
     }
 
     // Asserted synchronously, NOT polled: the live agent message renders its

--- a/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/AppShell.test.tsx
@@ -549,11 +549,22 @@ test("mounts and renders the welcome pane", async () => {
   expect(await screen.findByText("No session open")).toBeTruthy();
 });
 
-test("wires the injected client into connectionStore (connects on mount)", () => {
+test("wires the injected client into connectionStore (connects on mount)", async () => {
   const fake = new FakeClient("ready");
-  render(<AppShell client={fake} />);
-  expect(connectionStore.getState().client).toBe(fake);
-  expect(connectionStore.getState().state).toBe("ready");
+  const connect = vi.spyOn(fake, "connect");
+  try {
+    render(<AppShell client={fake} />);
+    expect(connectionStore.getState().client).toBe(fake);
+    expect(connectionStore.getState().state).toBe("ready");
+    expect(connect).toHaveBeenCalled();
+    const connectionResult = connect.mock.results[0];
+    if (connectionResult?.type !== "return") throw new Error("AppShell did not start the handshake");
+    await act(async () => {
+      await connectionResult.value;
+    });
+  } finally {
+    connect.mockRestore();
+  }
 });
 
 test("shows no banner while the injected client is ready", async () => {
@@ -913,19 +924,21 @@ function seedColdModJPage(ref = "local:late") {
 }
 
 function setColdModJState(loadSection: NavigationStoreState["loadSection"]) {
-  navigationStore.setState({
-    mode: "v2",
-    manifest: {
-      data: {
-        generation_id: "generation_test",
-        revision: 1,
-        sources: [],
-        attentionSummary: { needsYou: 1, error: 0, working: 0 },
-        catalogs: { projects: { count: 0 }, archived_projects: { count: 0 }, test_runs: { count: 0 } },
-        sections: { live: { count: 0 }, needs_you: { count: 1 }, pin_sections: { count: 0 } },
-      },
-    } as never,
-    loadSection,
+  act(() => {
+    navigationStore.setState({
+      mode: "v2",
+      manifest: {
+        data: {
+          generation_id: "generation_test",
+          revision: 1,
+          sources: [],
+          attentionSummary: { needsYou: 1, error: 0, working: 0 },
+          catalogs: { projects: { count: 0 }, archived_projects: { count: 0 }, test_runs: { count: 0 } },
+          sections: { live: { count: 0 }, needs_you: { count: 1 }, pin_sections: { count: 0 } },
+        },
+      } as never,
+      loadSection,
+    });
   });
 }
 
@@ -938,10 +951,13 @@ test("late Mod-J page success does not navigate after focus moves to Settings", 
   fireEvent.keyDown(window, { key: "j", metaKey: true });
   await waitFor(() => expect(loadSection).toHaveBeenCalledTimes(1));
   act(() => workspaceStore.getState().replacePrimary("settings", {}));
-  seedColdModJPage();
-  resolveLoad(undefined as never);
-  await Promise.resolve();
-  await Promise.resolve();
+  await act(async () => {
+    seedColdModJPage();
+    resolveLoad(undefined as never);
+    const loadResult = loadSection.mock.results[0];
+    if (loadResult?.type !== "return") throw new Error("needs-you page load did not start");
+    await loadResult.value;
+  });
   expect(window.location.pathname).toBe("/");
   expect(workspaceStore.getState().mainPane()?.type).toBe("settings");
 });
@@ -957,10 +973,13 @@ test("late Mod-J page success does not navigate after a modal opens", async () =
   const modal = document.createElement("div");
   modal.setAttribute("aria-modal", "true");
   document.body.appendChild(modal);
-  seedColdModJPage("local:modal-late");
-  resolveLoad(undefined as never);
-  await Promise.resolve();
-  await Promise.resolve();
+  await act(async () => {
+    seedColdModJPage("local:modal-late");
+    resolveLoad(undefined as never);
+    const loadResult = loadSection.mock.results[0];
+    if (loadResult?.type !== "return") throw new Error("needs-you page load did not start");
+    await loadResult.value;
+  });
   expect(window.location.pathname).toBe("/");
   modal.remove();
 });
@@ -975,8 +994,12 @@ test("v1 Mod-J does not re-request an in-flight needs-you page", async () => {
   fireEvent.keyDown(window, { key: "j", metaKey: true });
   fireEvent.keyDown(window, { key: "j", metaKey: true });
   await waitFor(() => expect(loadSection).toHaveBeenCalledTimes(1));
-  resolveLoad(undefined as never);
-  await Promise.resolve();
+  await act(async () => {
+    resolveLoad(undefined as never);
+    const loadResult = loadSection.mock.results[0];
+    if (loadResult?.type !== "return") throw new Error("needs-you page load did not start");
+    await loadResult.value;
+  });
   expect(loadSection).toHaveBeenCalledTimes(1);
 });
 
@@ -989,8 +1012,11 @@ test("v1 Mod-J does not re-request a failed needs-you page", async () => {
   await waitFor(() => expect(loadSection).toHaveBeenCalledTimes(1));
   fireEvent.keyDown(window, { key: "j", metaKey: true });
   fireEvent.keyDown(window, { key: "j", metaKey: true });
-  await Promise.resolve();
-  await Promise.resolve();
+  await act(async () => {
+    const loadResult = loadSection.mock.results[0];
+    if (loadResult?.type !== "return") throw new Error("needs-you page load did not start");
+    await expect(loadResult.value).rejects.toThrow("network failed");
+  });
   expect(loadSection).toHaveBeenCalledTimes(1);
 });
 
@@ -1020,8 +1046,11 @@ test("v1 Mod-J does not re-request an empty needs-you page", async () => {
   await waitFor(() => expect(loadSection).toHaveBeenCalledTimes(1));
   fireEvent.keyDown(window, { key: "j", metaKey: true });
   fireEvent.keyDown(window, { key: "j", metaKey: true });
-  await Promise.resolve();
-  await Promise.resolve();
+  await act(async () => {
+    const loadResult = loadSection.mock.results[0];
+    if (loadResult?.type !== "return") throw new Error("needs-you page load did not start");
+    await loadResult.value;
+  });
   expect(loadSection).toHaveBeenCalledTimes(1);
 });
 
@@ -1864,7 +1893,7 @@ test("a deferred deep link beats a restored active session panel", async () => {
   render(<AppShell client={new FakeClient("ready")} />);
 
   expect(paneFor("local:child")).toBeUndefined();
-  installLocationForRoute("local:child");
+  act(() => installLocationForRoute("local:child"));
   await waitFor(() => expect(paneFor("local:child")?.slot).toBe("secondary"));
   await waitFor(() => expect(workspaceStore.getState().focusedPaneId).toBe(paneFor("local:child")?.id));
 });
@@ -2443,7 +2472,7 @@ test("mobile: a /s/{ref} deep link still opens once the tree lands, instead of b
   await screen.findByText("No session open");
   expect(window.location.pathname).toBe("/s/local%3As1");
 
-  installLocationForRoute("local:s1");
+  act(() => installLocationForRoute("local:s1"));
 
   await waitFor(() => expect(workspaceStore.getState().mainPane()?.params).toMatchObject({ ref: "local:s1" }));
   // And the address bar now names it in paneToURL's own canonical form.
@@ -2465,7 +2494,7 @@ test("crossing desktop → mobile → desktop preserves a focused panel and its 
   await screen.findByText("Loading session panel…");
   await waitFor(() => expect(getDockviewApi()?.panels.some((panel) => panel.id === panelId)).toBe(true));
 
-  setMobile(true);
+  act(() => setMobile(true));
   expect(await screen.findByText("Loading session panel…")).toBeTruthy();
   expect(workspaceStore.getState().focusedPaneId).toBe(panelId);
   // The scaffold header is display:none below 900px - StackHost's top-bar
@@ -2473,13 +2502,17 @@ test("crossing desktop → mobile → desktop preserves a focused panel and its 
   // panel panes.
   expect(screen.getByRole("button", { name: "Back" })).toBeTruthy();
 
-  setMobile(false);
-  await waitFor(() => expect(getDockviewApi()).toBeNull());
+  act(() => {
+    setMobile(false);
+    // Still the mobile host, after the event but before React commits it.
+    // DockRegion's shared lazy payload mounts DockHost immediately at commit.
+    expect(getDockviewApi()).toBeNull();
+  });
   await waitFor(() => expect(getDockviewApi()?.panels.some((panel) => panel.id === panelId)).toBe(true));
   expect(workspaceStore.getState().focusedPaneId).toBe(panelId);
   expect(getDockviewApi()).not.toBeNull();
 
-  setMobile(true);
+  act(() => setMobile(true));
   await screen.findByText("Loading session panel…");
   await userEvent.setup().click(screen.getByRole("button", { name: "Back" }));
   await waitFor(() => expect(workspaceStore.getState().focusedPaneId).not.toBe(panelId));
@@ -3556,7 +3589,7 @@ test("an in-flight live demand-load goes inert after leaving the session and ret
   // The route-placement effect re-focuses the session pane on the return
   // leg only when the location resource is present, so the test installs
   // it exactly as the app's own location lookup would have.
-  installLocationForRoute("local:live-a");
+  act(() => installLocationForRoute("local:live-a"));
 
   // Demand in flight from A (the last loaded live row). The leave/return
   // must be a round trip the OLD guards cannot see: going to "/" opens the
@@ -3630,7 +3663,7 @@ test("a second press adopts an in-flight demand whose guards went stale", async 
   // The route-placement effect re-focuses the session pane on the return
   // leg only when the location resource is present, so the test installs it
   // exactly as the app's own location lookup would have.
-  installLocationForRoute("local:live-a");
+  act(() => installLocationForRoute("local:live-a"));
 
   // Press one: demand in flight from A (the last loaded live row).
   await user.keyboard("{Alt>}{Shift>}{ArrowRight}{/Shift}{/Alt}");

--- a/cmd/evener-hub/frontend/src/shell/ConnectionBanner.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/ConnectionBanner.test.tsx
@@ -132,8 +132,11 @@ describe('state "reconnecting"', () => {
     const { rerender } = render(<ConnectionBanner state="closed" delayMs={0} />);
 
     const fresh = new FakeClient("reconnecting");
-    connectionStore.getState().connect(fresh);
-    rerender(<ConnectionBanner state="reconnecting" delayMs={0} />);
+    await act(async () => {
+      connectionStore.getState().connect(fresh);
+      rerender(<ConnectionBanner state="reconnecting" delayMs={0} />);
+      await Promise.all(vi.mocked(fetch).mock.results.map((result) => result.value));
+    });
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Retry now" }));
@@ -151,9 +154,12 @@ describe('state "closed" - generic (neither probe matches)', () => {
     expect(screen.getByText("Connection closed.")).toBeTruthy();
   });
 
-  test('offers a "Retry" action', () => {
+  test('offers a "Retry" action', async () => {
     render(<ConnectionBanner state="closed" delayMs={0} />);
     expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    await act(async () => {
+      await Promise.all(vi.mocked(fetch).mock.results.map((result) => result.value));
+    });
   });
 });
 
@@ -406,7 +412,7 @@ describe("reveal delay", () => {
     expect(screen.queryByText(/reconnecting to the server/i)).toBeNull();
   });
 
-  test("re-arms the delay on a fresh attention state after recovery", () => {
+  test("re-arms the delay on a fresh attention state after recovery", async () => {
     vi.useFakeTimers();
     const { rerender } = render(<ConnectionBanner state="reconnecting" delayMs={10_000} />);
     // Recover before the first delay fires - no banner.
@@ -416,7 +422,10 @@ describe("reveal delay", () => {
     // Drop again: the delay clock starts fresh.
     rerender(<ConnectionBanner state="closed" delayMs={10_000} />);
     expect(screen.queryByText("Connection closed.")).toBeNull();
-    act(() => vi.advanceTimersByTime(10_000));
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.all(vi.mocked(fetch).mock.results.map((result) => result.value));
+    });
     expect(screen.getByText("Connection closed.")).toBeTruthy();
   });
 });

--- a/cmd/evener-hub/frontend/src/shell/DockHost.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/DockHost.test.tsx
@@ -207,9 +207,13 @@ test("wires the 'Pop out' group-header affordance into the live dockview host", 
   workspaceStore.getState().openPane("doc", { ref: "ref_main" });
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_main/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  });
   await screen.findByText(/doc pane: ref_a/); // secondary group's header is already visible with just this one pane
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  });
   await screen.findByText(/doc pane: ref_b/);
 
   // The affordance is a dockview right-header action rendered by the real
@@ -269,17 +273,23 @@ test("cancels toggle-open focus when a panel deactivates before its lazy pane mo
     render(<DockHost />);
     await screen.findByText(/doc pane: ref_main/);
 
-    const delayed = workspaceStore.getState().togglePane("sessionDetails", { ref: "ref_delayed" }).paneId;
+    const delayed = await act(
+      async () => workspaceStore.getState().togglePane("sessionDetails", { ref: "ref_delayed" }).paneId,
+    );
     expect(await screen.findByText("Loading…")).toBeTruthy();
     expect(screen.queryByText("delayed details body")).toBeNull();
 
-    workspaceStore.getState().focusPane(main);
+    act(() => {
+      workspaceStore.getState().focusPane(main);
+    });
     await vi.waitFor(() => expect(tabIsActive("Doc ref_main")).toBe(true));
 
     const previousFocus = document.createElement("button");
     document.body.append(previousFocus);
     previousFocus.focus();
-    workspaceStore.getState().focusPane(delayed);
+    act(() => {
+      workspaceStore.getState().focusPane(delayed);
+    });
     expect(await screen.findByText("Loading…")).toBeTruthy();
     await act(async () => {
       resolveChunk();
@@ -309,7 +319,9 @@ test("a host teardown preserves the still-focused pane's pending focus marker", 
     const view = render(<DockHost />);
     await screen.findByText(/doc pane: ref_main/);
 
-    const delayed = workspaceStore.getState().togglePane("sessionDetails", { ref: "ref_swap" }).paneId;
+    const delayed = await act(
+      async () => workspaceStore.getState().togglePane("sessionDetails", { ref: "ref_swap" }).paneId,
+    );
     expect(await screen.findByText("Loading…")).toBeTruthy();
     expect(workspaceStore.getState().focusedPaneId).toBe(delayed);
 
@@ -368,7 +380,9 @@ test("a second pane opens in a group to the RIGHT of the main pane, not stacked 
   await screen.findByText(/doc pane: ref_a/);
   expect(document.querySelectorAll(".dv-groupview")).toHaveLength(1);
 
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  });
 
   await screen.findByText(/doc pane: ref_b/);
   // Two groups side by side, so both panes are visible at once - the main pane
@@ -382,9 +396,13 @@ test("a third pane joins the existing right-hand group rather than making a thir
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_a/);
 
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  });
   await screen.findByText(/doc pane: ref_b/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_c" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_c" });
+  });
   await screen.findByText(/doc pane: ref_c/);
 
   expect(document.querySelectorAll(".dv-groupview")).toHaveLength(2); // still two columns
@@ -407,13 +425,17 @@ test("the main group's header is always hidden; the secondary group's is always 
   // The lone main pane: dockview's own per-group header, hidden.
   expect(headerHiddenFlags()).toEqual([true]);
 
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  });
   await screen.findByText(/doc pane: ref_b/);
   // The lone SECONDARY pane's header is visible - this is the fix for 65zj,
   // not a lingering bare group.
   expect(headerHiddenFlags()).toEqual([true, false]);
 
-  workspaceStore.getState().openPane("doc", { ref: "ref_c" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_c" });
+  });
   await screen.findByText(/doc pane: ref_c/);
   // The right-hand group now stacks two panes; still visible, main still bare.
   expect(headerHiddenFlags()).toEqual([true, false]);
@@ -433,7 +455,7 @@ test("a lone secondary pane has a reachable native close control, and closing it
   await screen.findByText(/doc pane: ref_main/);
   expect(document.querySelectorAll(".dv-groupview")).toHaveLength(1); // no right-hand column yet
 
-  const beside = workspaceStore.getState().openPane("doc", { ref: "ref_a" }); // e.g. a file's "Open beside"
+  const beside = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_a" })); // e.g. a file's "Open beside"
   await screen.findByText(/doc pane: ref_a/);
   expect(document.querySelectorAll(".dv-groupview")).toHaveLength(2);
 
@@ -478,7 +500,9 @@ test("the main pane offers no way to close it - it is replaceable, not closeable
   // And the main slot is never empty: closing it programmatically (the only
   // route left, since no affordance does) puts welcome back rather than
   // leaving a hole.
-  workspaceStore.getState().closePane(workspaceStore.getState().mainPane()!.id);
+  act(() => {
+    workspaceStore.getState().closePane(workspaceStore.getState().mainPane()!.id);
+  });
   await screen.findByText("No session open");
   expect(workspaceStore.getState().mainPane()?.type).toBe("welcome");
 });
@@ -502,7 +526,9 @@ test("navigating from the boot welcome pane to a real pane replaces it in the ma
   render(<DockHost />);
   await screen.findByText("No session open"); // the boot fallback's welcome pane
 
-  workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  });
 
   await screen.findByText(/doc pane: ref_a/);
   expect(screen.queryByText("No session open")).toBeNull();
@@ -515,7 +541,9 @@ test("closing the only main pane relaunches welcome in the main slot", async () 
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_a/);
 
-  workspaceStore.getState().closePane(main);
+  act(() => {
+    workspaceStore.getState().closePane(main);
+  });
 
   expect(await screen.findByText("No session open")).toBeTruthy();
   expect(workspaceStore.getState().mainPane()?.type).toBe("welcome");
@@ -525,10 +553,14 @@ test("closing the main pane relaunches welcome there without promoting a right-h
   const main = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // secondary group
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // secondary group
   await screen.findByText(/doc pane: ref_b/);
 
-  workspaceStore.getState().closePane(main);
+  act(() => {
+    workspaceStore.getState().closePane(main);
+  });
 
   expect(await screen.findByText("No session open")).toBeTruthy();
   expect(workspaceStore.getState().mainPane()?.type).toBe("welcome");
@@ -541,10 +573,12 @@ test("closing a secondary pane does NOT relaunch welcome - the main slot is stil
   workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_a/);
-  const secondary = workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  const secondary = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_b" }));
   await screen.findByText(/doc pane: ref_b/);
 
-  workspaceStore.getState().closePane(secondary);
+  act(() => {
+    workspaceStore.getState().closePane(secondary);
+  });
 
   await vi.waitFor(() => {
     expect(document.querySelectorAll(".dv-groupview")).toHaveLength(1);
@@ -567,7 +601,9 @@ test("reopening a singleton pane focuses the existing tab instead of duplicating
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_a/);
 
-  workspaceStore.getState().openPane("settings", { section: "appearance" });
+  act(() => {
+    workspaceStore.getState().openPane("settings", { section: "appearance" });
+  });
 
   await screen.findByText(/settings pane: appearance/);
   expect(workspaceStore.getState().panes).toHaveLength(2); // still just the two panes, not three
@@ -578,7 +614,9 @@ test("reopening a singleton pane with different params updates the existing tab'
   render(<DockHost />);
   await screen.findByText(/settings pane: appearance/);
 
-  workspaceStore.getState().openPane("settings", { section: "credentials" });
+  act(() => {
+    workspaceStore.getState().openPane("settings", { section: "credentials" });
+  });
 
   expect(await screen.findByText(/settings pane: credentials/)).toBeTruthy();
   expect(workspaceStore.getState().panes).toHaveLength(1);
@@ -592,10 +630,12 @@ test("a primary replacement removes stale panels from the live DockHost", async 
   workspace.openPane("session", { ref: "local:session-a" });
   render(<DockHost />);
   await screen.findAllByText("local:session-a");
-  workspace.openPane("doc", { ref: "secondary" });
+  act(() => {
+    workspace.openPane("doc", { ref: "secondary" });
+  });
   await screen.findByText(/doc pane: secondary/);
 
-  const replacementId = workspace.replacePrimary("session", { ref: "local:session-b" });
+  const replacementId = await act(async () => workspace.replacePrimary("session", { ref: "local:session-b" }));
 
   expect(workspaceStore.getState().panes).toEqual([
     { id: replacementId, type: "session", params: { ref: "local:session-b" }, slot: "main" },
@@ -614,9 +654,11 @@ test("clicking a different tab updates workspaceStore.focusedPaneId", async () =
   workspaceStore.getState().openPane("doc", { ref: "ref_main" });
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_main/);
-  const second = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  const second = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_a" }));
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks on ref_a, focused
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // stacks on ref_a, focused
   await screen.findByText(/doc pane: ref_b/);
 
   const user = userEvent.setup();
@@ -635,9 +677,11 @@ test("clicking a secondary tab's native close button updates workspaceStore.pane
   workspaceStore.getState().openPane("doc", { ref: "ref_main" });
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_main/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  });
   await screen.findByText(/doc pane: ref_a/);
-  const closing = workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  const closing = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_b" }));
   await screen.findByText(/doc pane: ref_b/);
 
   const user = userEvent.setup();
@@ -657,7 +701,7 @@ test("clicking a secondary tab's native close button updates workspaceStore.pane
   // Reopening the same ref proves the id was actually released, not just
   // hidden - a still-tracked "closed" pane would come back focused instead
   // of minting a fresh one.
-  const reopened = workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  const reopened = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_b" }));
   expect(reopened).not.toBe(closing);
 });
 
@@ -667,13 +711,17 @@ test("workspace.closePane removes the dockview tab", async () => {
   workspaceStore.getState().openPane("doc", { ref: "ref_main" });
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_main/);
-  const first = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  const first = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_a" }));
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks on ref_a
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // stacks on ref_a
   await screen.findByText(/doc pane: ref_b/);
   expect(visibleTabTexts()).toEqual(["Doc ref_a", "Doc ref_b"]);
 
-  workspaceStore.getState().closePane(first);
+  act(() => {
+    workspaceStore.getState().closePane(first);
+  });
 
   // dockview announces "<title> closed" via an off-screen aria-live region
   // (a nice a11y feature it ships with by default - see this task's
@@ -691,12 +739,16 @@ test("workspace.focusPane activates the corresponding dockview tab", async () =>
   workspaceStore.getState().openPane("doc", { ref: "ref_main" });
   render(<DockHost />);
   await screen.findByText(/doc pane: ref_main/);
-  const first = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
+  const first = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_a" }));
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // focused initially
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // focused initially
   await screen.findByText(/doc pane: ref_b/);
 
-  workspaceStore.getState().focusPane(first);
+  act(() => {
+    workspaceStore.getState().focusPane(first);
+  });
 
   expect(await screen.findByText(/doc pane: ref_a \(focused=true\)/)).toBeTruthy();
   expect(tabIsActive("Doc ref_a")).toBe(true);
@@ -861,10 +913,12 @@ test("a session pane's tab title live-updates when the thread is renamed, with n
   await screen.findByTestId("empty-state");
   expect(document.querySelector(".dv-tab")?.textContent).toBe("Original name");
 
-  threadsStore.setState((s) => {
-    const next = new Map(s.threads);
-    next.set("ref_x", { ...next.get("ref_x")!, name: "Renamed" });
-    return { threads: next };
+  await act(async () => {
+    threadsStore.setState((s) => {
+      const next = new Map(s.threads);
+      next.set("ref_x", { ...next.get("ref_x")!, name: "Renamed" });
+      return { threads: next };
+    });
   });
 
   await vi.waitFor(() => {
@@ -912,10 +966,12 @@ test("a session pane's tab shows a live status dot wired to the real dockview ho
   // Idle (this fixture's default status): no dot at all.
   expect(within(sessionTab()).queryByRole("img")).toBeNull();
 
-  threadsStore.setState((s) => {
-    const next = new Map(s.threads);
-    next.set("ref_x", { ...next.get("ref_x")!, status: { type: "awaiting" } });
-    return { threads: next };
+  act(() => {
+    threadsStore.setState((s) => {
+      const next = new Map(s.threads);
+      next.set("ref_x", { ...next.get("ref_x")!, status: { type: "awaiting" } });
+      return { threads: next };
+    });
   });
   expect(await within(sessionTab()).findByRole("img", { name: "Needs you" })).toBeTruthy();
 

--- a/cmd/evener-hub/frontend/src/shell/PaneTab.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/PaneTab.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import type { IDockviewPanelHeaderProps } from "dockview-core";
 import { afterEach, beforeEach, expect, test } from "vitest";
 import type { ThreadModel } from "../protocol/model";
@@ -127,10 +127,12 @@ test("the dot re-renders when the thread's status changes, with no remount", asy
   render(<PaneTab {...tabProps({ paneType: "session", paneParams: { ref: "ref_a" } })} />);
   expect(screen.queryByRole("img")).toBeNull();
 
-  threadsStore.setState((s) => {
-    const next = new Map(s.threads);
-    next.set("ref_a", { ...next.get("ref_a")!, status: { type: "awaiting" } });
-    return { threads: next };
+  act(() => {
+    threadsStore.setState((s) => {
+      const next = new Map(s.threads);
+      next.set("ref_a", { ...next.get("ref_a")!, status: { type: "awaiting" } });
+      return { threads: next };
+    });
   });
   expect(await screen.findByRole("img", { name: "Needs you" })).toBeTruthy();
 });

--- a/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/cheatsheet/CheatsheetOverlay.test.tsx
@@ -85,11 +85,13 @@ function overridesPayload(revision: number, rules: KeybindingsRule[]): Keybindin
 }
 
 async function wireClient(client: FakeClient, supported: boolean): Promise<void> {
-  connectionStore.getState().connect(client);
-  connectionStore.setState({
-    features: { ...(await client.connect()).features, keybindingsSettings: supported },
+  await act(async () => {
+    connectionStore.getState().connect(client);
+    connectionStore.setState({
+      features: { ...(await client.connect()).features, keybindingsSettings: supported },
+    });
+    await keybindingsStore.getState().refreshOverrides();
   });
-  await keybindingsStore.getState().refreshOverrides();
 }
 
 function questionTriggerRegistered(): boolean {
@@ -319,7 +321,9 @@ test("override removal with the pref OFF restores the defaults and strips the ? 
   // with no knowledge of the pref - and the reconcile strips it again
   // without throwing (a rollback would surface as hubError).
   payload = overridesPayload(4, []);
-  await keybindingsStore.getState().refreshOverrides();
+  await act(async () => {
+    await keybindingsStore.getState().refreshOverrides();
+  });
   expect(keybindingsStore.getState().hubError).toBeNull();
   expect(questionTriggerRegistered()).toBe(false);
   expect(
@@ -344,7 +348,9 @@ test("override removal with the pref ON restores the defaults with exactly one ?
   // The restore re-registers "?" itself; the reconcile must be a no-op here -
   // re-registering the same id would throw into the store's rollback path.
   payload = overridesPayload(4, []);
-  await keybindingsStore.getState().refreshOverrides();
+  await act(async () => {
+    await keybindingsStore.getState().refreshOverrides();
+  });
   expect(keybindingsStore.getState().hubError).toBeNull();
   expect(keybindingsRegistry.getState().bindings.filter((b) => b.id === CHARACTER_KEY_TRIGGER_BINDING_ID)).toHaveLength(
     1,

--- a/cmd/evener-hub/frontend/src/shell/mobile/StackHost.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/mobile/StackHost.test.tsx
@@ -188,7 +188,9 @@ test("switching the focused pane (workspace.focusPane) swaps which one is render
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_b/);
 
-  workspaceStore.getState().focusPane(first);
+  act(() => {
+    workspaceStore.getState().focusPane(first);
+  });
 
   expect(await screen.findByText(/doc pane: ref_a \(focused=true\)/)).toBeTruthy();
   expect(screen.queryByText(/doc pane: ref_b/)).toBeNull();
@@ -228,14 +230,20 @@ test("switching away from a pane and back remounts it fresh - local state does n
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_b/);
 
-  workspaceStore.getState().focusPane(first);
+  act(() => {
+    workspaceStore.getState().focusPane(first);
+  });
   await screen.findByText(/doc pane: ref_a/);
   await user.click(screen.getByRole("button", { name: /clicks: 0/ }));
   expect(screen.getByRole("button", { name: /clicks: 1/ })).toBeTruthy();
 
-  workspaceStore.getState().focusPane(second);
+  act(() => {
+    workspaceStore.getState().focusPane(second);
+  });
   await screen.findByText(/doc pane: ref_b/);
-  workspaceStore.getState().focusPane(first);
+  act(() => {
+    workspaceStore.getState().focusPane(first);
+  });
 
   expect(await screen.findByText(/doc pane: ref_a/)).toBeTruthy();
   expect(screen.getByRole("button", { name: /clicks: 0/ })).toBeTruthy(); // reset, not preserved
@@ -273,7 +281,9 @@ test("a session panel pane's top-bar Back returns to the parent session, not the
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_before/);
 
-  workspaceStore.getState().openPane("sessionDetails", { ref: "local:ref_panel" });
+  act(() => {
+    workspaceStore.getState().openPane("sessionDetails", { ref: "local:ref_panel" });
+  });
   expect(await screen.findByText("Loading session panel…")).toBeTruthy();
 
   await user.click(screen.getByRole("button", { name: "Back" }));
@@ -291,7 +301,9 @@ test("back returns to the pane that was focused before the current one", async (
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
 
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // a forward navigation, observed live
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // a forward navigation, observed live
   await screen.findByText(/doc pane: ref_b/);
 
   const user = userEvent.setup();
@@ -321,9 +333,13 @@ test("back walks multiple levels deep, one pane per tap", async () => {
   workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  });
   await screen.findByText(/doc pane: ref_b/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_c" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_c" });
+  });
   await screen.findByText(/doc pane: ref_c/);
 
   const user = userEvent.setup();
@@ -342,7 +358,9 @@ test("a back tap does not push the pane it left onto the stack (no ping-pong)", 
   workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  });
   await screen.findByText(/doc pane: ref_b/);
 
   const user = userEvent.setup();
@@ -379,7 +397,9 @@ test("a REAL back/forward gesture does not stack the pane it left, unlike an ord
   const first = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // ordinary forward nav: stacks ref_a
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // ordinary forward nav: stacks ref_a
   await screen.findByText(/doc pane: ref_b/);
 
   // Simulates a real browser back landing on ref_a.
@@ -407,7 +427,9 @@ test("an ORDINARY (untrusted) synthetic popstate - routing.ts's own navigate() -
   const first = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks ref_a
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // stacks ref_a
   await screen.findByText(/doc pane: ref_b/);
 
   act(() => {
@@ -428,7 +450,7 @@ test("a REAL back/forward gesture landing back on the stack's own top does not r
   const first = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  const second = workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks ref_a
+  const second = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_b" })); // stacks ref_a
   await screen.findByText(/doc pane: ref_b/);
 
   // Real back to ref_a, then real FORWARD back to ref_b - both real, both
@@ -463,9 +485,11 @@ test("KNOWN, DISCLOSED LIMITATION: two consecutive real back gestures still conf
   const a = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  const b = workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks ref_a
+  const b = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_b" })); // stacks ref_a
   await screen.findByText(/doc pane: ref_b/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_c" }); // stacks ref_b
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_c" });
+  }); // stacks ref_b
   await screen.findByText(/doc pane: ref_c/);
 
   act(() => {
@@ -489,7 +513,9 @@ test("back skips a stacked pane that has since been closed, falling to welcome w
   const first = workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks ref_a as the back target
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // stacks ref_a as the back target
   await screen.findByText(/doc pane: ref_b/);
 
   // Closing the NON-focused, stacked pane (ref_a) does not change
@@ -511,9 +537,11 @@ test("back skips a stale MIDDLE stack entry and lands on the next valid one behi
   workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  const second = workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks ref_a
+  const second = await act(async () => workspaceStore.getState().openPane("doc", { ref: "ref_b" })); // stacks ref_a
   await screen.findByText(/doc pane: ref_b/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_c" }); // stacks ref_b
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_c" });
+  }); // stacks ref_b
   await screen.findByText(/doc pane: ref_c/);
 
   // ref_b sits BETWEEN ref_a and ref_c on the stack ([ref_a, ref_b]) - closing
@@ -546,7 +574,9 @@ test("a published paneBack handler takes over the top-bar Back button instead of
   workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks ref_a
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // stacks ref_a
   await screen.findByText(/doc pane: ref_b/);
 
   const paneBack = vi.fn();
@@ -566,7 +596,9 @@ test("clearing paneBack hands the Back button back to the ordinary stack walk", 
   workspaceStore.getState().openPane("doc", { ref: "ref_a" });
   render(<StackHost />);
   await screen.findByText(/doc pane: ref_a/);
-  workspaceStore.getState().openPane("doc", { ref: "ref_b" }); // stacks ref_a
+  act(() => {
+    workspaceStore.getState().openPane("doc", { ref: "ref_b" });
+  }); // stacks ref_a
   await screen.findByText(/doc pane: ref_b/);
 
   act(() => {
@@ -601,7 +633,9 @@ test("the URL updates to a deep-linked pane's URL once it becomes focused", asyn
   render(<StackHost />);
   await screen.findByText("No session open");
 
-  workspaceStore.getState().openPane("session", { ref: "local:ref_x" });
+  act(() => {
+    workspaceStore.getState().openPane("session", { ref: "local:ref_x" });
+  });
   await screen.findByRole("heading", { name: "local:ref_x" });
 
   expect(window.location.pathname).toBe("/s/local%3Aref_x");
@@ -613,7 +647,9 @@ test("switching between two deep-linked panes updates the URL each time", async 
   await screen.findByRole("heading", { name: "local:ref_x" });
   expect(window.location.pathname).toBe("/s/local%3Aref_x");
 
-  workspaceStore.getState().openPane("session", { ref: "local:ref_y" });
+  act(() => {
+    workspaceStore.getState().openPane("session", { ref: "local:ref_y" });
+  });
   await screen.findByRole("heading", { name: "local:ref_y" });
 
   expect(window.location.pathname).toBe("/s/local%3Aref_y");
@@ -633,7 +669,9 @@ test("back navigation updates the URL to match the pane it returns to", async ()
   workspaceStore.getState().openPane("session", { ref: "local:ref_x" });
   render(<StackHost />);
   await screen.findByRole("heading", { name: "local:ref_x" });
-  workspaceStore.getState().openPane("session", { ref: "local:ref_y" });
+  act(() => {
+    workspaceStore.getState().openPane("session", { ref: "local:ref_y" });
+  });
   await screen.findByRole("heading", { name: "local:ref_y" });
   expect(window.location.pathname).toBe("/s/local%3Aref_y");
 
@@ -665,7 +703,9 @@ test("the sync resumes on the pane that lands once the route is no longer deferr
   const { rerender } = render(<StackHost routeDeferred />);
   await screen.findByText("No session open");
 
-  workspaceStore.getState().openPane("session", { ref: "local:ref_placed" });
+  act(() => {
+    workspaceStore.getState().openPane("session", { ref: "local:ref_placed" });
+  });
   rerender(<StackHost />);
 
   await screen.findByRole("heading", { name: "local:ref_placed" });
@@ -701,7 +741,9 @@ test("kata 098n: focusing a different session from a /thread route still publish
   render(<StackHost />);
   await screen.findByRole("heading", { name: "local:ref_shared" });
 
-  workspaceStore.getState().openPane("session", { ref: "local:ref_other" });
+  act(() => {
+    workspaceStore.getState().openPane("session", { ref: "local:ref_other" });
+  });
   await screen.findByRole("heading", { name: "local:ref_other" });
 
   expect(window.location.pathname).toBe("/s/local%3Aref_other");
@@ -770,7 +812,9 @@ test("the top bar title is empty when no pane has published one", async () => {
 
 test("a real session pane's scaffold-published title lands in the top bar", async () => {
   workspaceStore.getState().openPane("session", { ref: "local:ref_titled" });
-  render(<StackHost />);
+  await act(async () => {
+    render(<StackHost />);
+  });
   // The session pane's own PaneScaffold publishes its title (model.name ||
   // ref fallback, Session.tsx) through the channel on mount.
   await vi.waitFor(() => expect(screen.getByTestId("topbar-title").textContent).toBe("local:ref_titled"));

--- a/cmd/evener-hub/frontend/src/shell/palette/CommandPalette.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/palette/CommandPalette.test.tsx
@@ -290,8 +290,10 @@ test("the palette scopes catalog commands to active diagnostics without mutating
   await user.type(screen.getByRole("combobox"), "/whoami");
   expect(screen.getByRole("option", { name: /Continue in the composer/ })).toBeTruthy();
 
-  threadsStore.setState({
-    threads: new Map([["ref_a", testModel({ ref: "ref_a" })]]),
+  act(() => {
+    threadsStore.setState({
+      threads: new Map([["ref_a", testModel({ ref: "ref_a" })]]),
+    });
   });
   await waitFor(() => expect(screen.getByRole("option", { name: /Continue in the composer/ })).toBeTruthy());
   await user.clear(screen.getByRole("combobox"));
@@ -346,7 +348,7 @@ test("a session-scoped built-in (/interrupt) is never listed as a runnable comma
   connectionStore.getState().connect(fake);
   focusSession("ref_a", { status: { type: "idle" }, activeTurnId: undefined });
   render(<CommandPalette />);
-  act(() => openPalette("/interrupt"));
+  await act(async () => openPalette("/interrupt"));
 
   expect(screen.queryByRole("option", { name: /Interrupt agent/ })).toBeNull();
   expect(screen.getByRole("option", { name: /Continue in the composer/ })).toBeTruthy();

--- a/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/Rail.test.tsx
@@ -1045,10 +1045,12 @@ describe("resource-backed Rail", () => {
         [keyID(location.key), location],
         [keyID(live.key), live],
       ]);
-      navigationStore.setState({ resources: nextResources });
-      await act(async () => undefined);
-      navigationStore.setState({ attention: { changed: [], summary: { needsYou: 0, error: 0, working: 0 } } });
-      await act(async () => undefined);
+      await act(async () => {
+        navigationStore.setState({ resources: nextResources });
+      });
+      await act(async () => {
+        navigationStore.setState({ attention: { changed: [], summary: { needsYou: 0, error: 0, working: 0 } } });
+      });
       expect(scroll).toHaveBeenCalledTimes(1);
       expect(consumed).toHaveBeenCalledTimes(1);
       view.rerender(<Rail revealTarget="target" onRevealConsumed={consumed} />);

--- a/cmd/evener-hub/frontend/src/shell/rail/index.test.tsx
+++ b/cmd/evener-hub/frontend/src/shell/rail/index.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, type RenderOptions, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Component, type ReactNode } from "react";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
@@ -32,25 +32,17 @@ function StubRailHost() {
   return <p>rail host mounted</p>;
 }
 
-// Suppress console.error noise from React's error-boundary logging during
-// tests that deliberately trigger chunk-load failures. The errors are
-// expected; the boundary catches them. Matched on React's own stable
-// componentDidCatch format string plus its fixed boundary-recovery
-// sentence, rather than blanket-silenced, so any *other* console.error a
-// regression here might produce still reaches real console.error and
-// stays visible in test output (DockRegion.test.tsx's own recipe).
-const REACT_ERROR_BOUNDARY_FORMAT = "%o\n\n%s\n\n%s\n";
-const REACT_ERROR_BOUNDARY_PREFACE = "The above error occurred in one of your React components.";
 const realConsoleError = console.error.bind(console);
-let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+// Capture only this render's injected failure; every test also asserts the
+// complete callback count and error identity, including repeated retries.
+function captureExpectedError(expectedError: Error) {
+  return vi.fn<NonNullable<RenderOptions["onCaughtError"]>>((error, info) => {
+    if (error !== expectedError) realConsoleError(error, info);
+  });
+}
 
 beforeEach(() => {
-  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
-    if (args[0] === REACT_ERROR_BOUNDARY_FORMAT && args[2] === REACT_ERROR_BOUNDARY_PREFACE) {
-      return;
-    }
-    realConsoleError(...args);
-  });
   loadRailHost.mockReset();
   loadRailHost.mockImplementation(realLoadRailHost);
   // The chunk is one shared lazy() payload per page load, so each test needs
@@ -61,7 +53,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  consoleErrorSpy.mockRestore();
   cleanup();
   // Whichever override the LAST test set (mockRejectedValue/mockResolvedValue/
   // mockResolvedValueOnce...) would otherwise still be armed on this shared
@@ -73,19 +64,25 @@ afterEach(() => {
 });
 
 test("a rejected RailHost chunk shows the failure message with a Retry", async () => {
-  vi.mocked(loadRailHost).mockRejectedValue(new Error(CHUNK_ERROR));
+  const chunkError = new Error(CHUNK_ERROR);
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadRailHost).mockRejectedValue(chunkError);
 
-  render(<RailHost />);
+  render(<RailHost />, { onCaughtError });
 
   expect(await screen.findByText("Couldn't load the sidebar")).toBeTruthy();
   expect(screen.getByText(CHUNK_ERROR)).toBeTruthy();
   expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
 });
 
 test("the failure stands in a rail-sized shell holding the row's width", async () => {
-  vi.mocked(loadRailHost).mockRejectedValue(new Error(CHUNK_ERROR));
+  const chunkError = new Error(CHUNK_ERROR);
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadRailHost).mockRejectedValue(chunkError);
 
-  render(<RailHost />);
+  render(<RailHost />, { onCaughtError });
 
   const failure = await screen.findByTestId("rail-chunk-failure");
   // The same flex:none + width + background + right-border the live rail
@@ -94,15 +91,17 @@ test("the failure stands in a rail-sized shell holding the row's width", async (
   expect(failure.className).toMatch(/rail/);
   const style = getComputedStyle(failure);
   expect(style.getPropertyValue("--rail-width").trim()).not.toBe("");
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
 });
 
 test("Retry fetches the chunk again and mounts the host on the second attempt", async () => {
-  vi.mocked(loadRailHost)
-    .mockRejectedValueOnce(new Error(CHUNK_ERROR))
-    .mockResolvedValueOnce({ RailHost: StubRailHost });
+  const chunkError = new Error(CHUNK_ERROR);
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadRailHost).mockRejectedValueOnce(chunkError).mockResolvedValueOnce({ RailHost: StubRailHost });
   const user = userEvent.setup();
 
-  render(<RailHost />);
+  render(<RailHost />, { onCaughtError });
   await screen.findByText("Couldn't load the sidebar");
   await user.click(screen.getByRole("button", { name: "Retry" }));
 
@@ -113,33 +112,39 @@ test("Retry fetches the chunk again and mounts the host on the second attempt", 
   expect(await screen.findByText("rail host mounted")).toBeTruthy();
   expect(vi.mocked(loadRailHost).mock.calls).toEqual([[false], [true]]);
   expect(screen.queryByText("Couldn't load the sidebar")).toBeNull();
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
 });
 
 test("a successful retry is reused after the wrapper unmounts and remounts", async () => {
-  vi.mocked(loadRailHost)
-    .mockRejectedValueOnce(new Error(CHUNK_ERROR))
-    .mockResolvedValueOnce({ RailHost: StubRailHost });
+  const chunkError = new Error(CHUNK_ERROR);
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadRailHost).mockRejectedValueOnce(chunkError).mockResolvedValueOnce({ RailHost: StubRailHost });
   const user = userEvent.setup();
 
-  const first = render(<RailHost />);
+  const first = render(<RailHost />, { onCaughtError });
   await screen.findByText("Couldn't load the sidebar");
   await user.click(screen.getByRole("button", { name: "Retry" }));
   expect(await screen.findByText("rail host mounted")).toBeTruthy();
 
   first.unmount();
-  render(<RailHost />);
+  render(<RailHost />, { onCaughtError });
 
   expect(await screen.findByText("rail host mounted")).toBeTruthy();
   expect(vi.mocked(loadRailHost).mock.calls).toEqual([[false], [true]]);
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
 });
 
 test("a retry that fails again offers a page reload instead of stranding the sidebar", async () => {
-  vi.mocked(loadRailHost).mockRejectedValue(new Error(CHUNK_ERROR));
+  const chunkError = new Error(CHUNK_ERROR);
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadRailHost).mockRejectedValue(chunkError);
   const reload = vi.fn();
   vi.stubGlobal("location", { ...window.location, reload });
   const user = userEvent.setup();
 
-  render(<RailHost />);
+  render(<RailHost />, { onCaughtError });
   await screen.findByText("Couldn't load the sidebar");
   // The first failure offers only the cache-busted retry: a deploy that
   // removed the hashed chunk is still only one hypothesis among transient
@@ -151,6 +156,9 @@ test("a retry that fails again offers a page reload instead of stranding the sid
 
   expect(reload).toHaveBeenCalledTimes(1);
   expect(vi.mocked(loadRailHost).mock.calls).toEqual([[false], [true]]);
+  expect(onCaughtError).toHaveBeenCalledTimes(2);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
+  expect(onCaughtError.mock.calls[1]?.[0]).toBe(chunkError);
 });
 
 test("an ordinary retry failure does not prescribe a page reload", async () => {
@@ -159,17 +167,23 @@ test("an ordinary retry failure does not prescribe a page reload", async () => {
   // a chunk-load failure: the rail boundary declines it, so it lands on the
   // next boundary above - never the rail failure state, and so never the
   // Retry/Reload pair that could misreport it as a stale deploy.
-  vi.mocked(loadRailHost).mockRejectedValue(new Error("RailHost chunk request failed with status 500"));
+  const chunkError = new Error("RailHost chunk request failed with status 500");
+  const onCaughtError = captureExpectedError(chunkError);
+  vi.mocked(loadRailHost).mockRejectedValue(chunkError);
 
   render(
     <RailTestOuterBoundary>
       <RailHost />
     </RailTestOuterBoundary>,
+    { onCaughtError },
   );
 
   expect(await screen.findByText("outer boundary caught: RailHost chunk request failed with status 500")).toBeTruthy();
   expect(screen.queryByText("Couldn't load the sidebar")).toBeNull();
   expect(screen.queryByRole("button", { name: "Reload page" })).toBeNull();
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(chunkError);
+  expect(onCaughtError.mock.calls[0]?.[1].errorBoundary).toBeInstanceOf(RailTestOuterBoundary);
 });
 
 // A logic bug thrown by the RESOLVED chunk's own render is not a chunk-load
@@ -187,9 +201,15 @@ class RailTestOuterBoundary extends Component<{ children: ReactNode }, { failure
 }
 
 test("a logic bug in the resolved chunk keeps unwinding past the rail boundary", async () => {
+  const renderError = new Error("RailHost render logic bug");
+  const onCaughtError = vi.fn<NonNullable<RenderOptions["onCaughtError"]>>((error, info) => {
+    if (error !== renderError || !(info.errorBoundary instanceof RailTestOuterBoundary)) {
+      realConsoleError(error, info);
+    }
+  });
   vi.mocked(loadRailHost).mockResolvedValue({
     RailHost: () => {
-      throw new Error("RailHost render logic bug");
+      throw renderError;
     },
   });
 
@@ -197,8 +217,12 @@ test("a logic bug in the resolved chunk keeps unwinding past the rail boundary",
     <RailTestOuterBoundary>
       <RailHost />
     </RailTestOuterBoundary>,
+    { onCaughtError },
   );
 
   expect(await screen.findByText("outer boundary caught: RailHost render logic bug")).toBeTruthy();
   expect(screen.queryByText("Couldn't load the sidebar")).toBeNull();
+  expect(onCaughtError).toHaveBeenCalledTimes(1);
+  expect(onCaughtError.mock.calls[0]?.[0]).toBe(renderError);
+  expect(onCaughtError.mock.calls[0]?.[1].errorBoundary).toBeInstanceOf(RailTestOuterBoundary);
 });

--- a/cmd/evener-hub/frontend/src/stores/credentials.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/credentials.test.ts
@@ -1,4 +1,4 @@
-import { cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { FakeClient } from "../protocol/testing/fakeClient";
 import { threadStartedNotification } from "../protocol/testing/notifications";
@@ -440,7 +440,9 @@ describe("useCredentialsStore", () => {
     fake.on("evener/instance/list", () => LIST_RESPONSE);
     const { result } = renderHook(() => useCredentialsStore((s) => s.instances.length));
     expect(result.current).toBe(0);
-    await credentialsStore.getState().fetch();
+    await act(async () => {
+      await credentialsStore.getState().fetch();
+    });
     expect(result.current).toBe(1);
   });
 

--- a/cmd/evener-hub/frontend/src/stores/threads.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.test.ts
@@ -3361,22 +3361,60 @@ describe("notification routing differential (randomized: index vs scan reference
 
     let clock = 10_000;
     const history: AnyNotification[] = [];
+    let duplicateStarts = 0;
     for (let i = 0; i < 200; i += 1) {
       const n = pick(generators)();
       history.push(n);
       clock += 7;
+      // The small, deliberately shared turn-id space generates repeated
+      // starts. Derive the expected diagnostics from the independent scan
+      // state BEFORE either fold, never from what the indexed store logs.
+      const expectedDiagnostics =
+        n.method === "turn/started"
+          ? [...reference.threads.values(), ...reference.watchedThreads.values()]
+              .filter(
+                (model) =>
+                  notificationTargetsThread(n, model) && model.turns.some((turn) => turn.id === n.params.turn.id),
+              )
+              .map(() => [
+                `applyNotification: turn/started turnId ${n.params.turn.id} already exists in model.turns — replacing it in place instead of appending a duplicate row (turn-id-uniqueness invariant violated)`,
+              ])
+          : [];
+      duplicateStarts += expectedDiagnostics.length;
+      const checkDiagnostics = (fold: () => void): void => {
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        try {
+          fold();
+          expect(errorSpy.mock.calls, `diagnostics for notification ${i}: ${n.method}`).toEqual(expectedDiagnostics);
+        } finally {
+          errorSpy.mockRestore();
+        }
+      };
       const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(clock);
       try {
-        fake.emitNotification(n);
+        checkDiagnostics(() => fake.emitNotification(n));
       } finally {
         dateNowSpy.mockRestore();
       }
-      scanFold(reference, n, clock, new Set());
+      checkDiagnostics(() => scanFold(reference, n, clock, new Set()));
+      for (const map of [
+        threadsStore.getState().threads,
+        threadsStore.getState().watchedThreads,
+        reference.threads,
+        reference.watchedThreads,
+      ]) {
+        for (const model of map.values()) {
+          expect(new Set(model.turns.map((turn) => turn.id)).size, `unique turn ids after notification ${i}`).toBe(
+            model.turns.length,
+          );
+        }
+      }
       // The index must stay in lockstep with the maps after every fold, not
       // just at the end: a skipped re-index must fail at the frame that
       // skipped it, not only if a later random frame observes the staleness.
       assertIndexesConsistent();
     }
+    expect(duplicateStarts).toBeGreaterThan(0);
 
     const actual = snapshotFor({
       threads: threadsStore.getState().threads,

--- a/cmd/evener-hub/frontend/src/testSetup.test.tsx
+++ b/cmd/evener-hub/frontend/src/testSetup.test.tsx
@@ -1,0 +1,32 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, test, vi } from "vitest";
+import { Button } from "./widgets/button";
+
+test("the test environment supports React act through render, update, and unmount", async () => {
+  const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+  const warnings = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  try {
+    await act(async () => {
+      root.render(<Button>Run</Button>);
+    });
+    expect(container.querySelector("button")?.disabled).toBe(false);
+    await act(async () => {
+      root.render(<Button disabled>Run</Button>);
+    });
+    expect(container.querySelector("button")?.disabled).toBe(true);
+  } finally {
+    await act(async () => root.unmount());
+    container.remove();
+    try {
+      expect(errors.mock.calls).toEqual([]);
+      expect(warnings.mock.calls).toEqual([]);
+    } finally {
+      errors.mockRestore();
+      warnings.mockRestore();
+    }
+  }
+});

--- a/cmd/evener-hub/frontend/src/testSetup.ts
+++ b/cmd/evener-hub/frontend/src/testSetup.ts
@@ -1,0 +1,19 @@
+import { afterAll, beforeAll } from "vitest";
+
+const reactEnvironment = globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean };
+let previousActEnvironment: boolean | undefined;
+
+// Testing Library cannot register its suite-wide act setup without global
+// beforeAll/afterAll hooks. Our tests import their Vitest hooks explicitly.
+beforeAll(() => {
+  previousActEnvironment = reactEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  reactEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  if (previousActEnvironment === undefined) {
+    delete reactEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  } else {
+    reactEnvironment.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+});

--- a/cmd/evener-hub/frontend/src/widgets/disclosure/disclosureStore.test.ts
+++ b/cmd/evener-hub/frontend/src/widgets/disclosure/disclosureStore.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, expect, test } from "vitest";
 import {
   beginDisclosureBaseline,
@@ -10,13 +10,16 @@ import {
   toggleDisclosure,
 } from "./disclosureStore";
 
-afterEach(() => resetDisclosureStoreForTests());
+afterEach(() => {
+  cleanup();
+  resetDisclosureStoreForTests();
+});
 
 // isDisclosureOpen is a reactive hook (it rides useStore, mirroring
 // subagentModuleStore.ts's useSubagentRows), so it must be read inside a
 // render context - renderHook is exactly how that sibling store's own test
-// reads its reactive selector. setDisclosureOpen/toggleDisclosure are plain
-// getState/setState mutators and are called directly.
+// reads its reactive selector. Mutations after a read need act because those
+// hook subscribers remain mounted until cleanup.
 const readOpen = (id: string, fallback: boolean): boolean =>
   renderHook(() => isDisclosureOpen(id, fallback)).result.current;
 
@@ -25,17 +28,21 @@ test("unset id reports the fallback", () => {
   expect(readOpen("a", true)).toBe(true);
 });
 
-test("setDisclosureOpen overrides the fallback and persists", () => {
+test("setDisclosureOpen overrides the fallback and persists", async () => {
   setDisclosureOpen("a", true);
   expect(readOpen("a", false)).toBe(true);
-  setDisclosureOpen("a", false);
+  await act(async () => {
+    setDisclosureOpen("a", false);
+  });
   expect(readOpen("a", true)).toBe(false);
 });
 
-test("toggle flips from the fallback then from stored state", () => {
+test("toggle flips from the fallback then from stored state", async () => {
   toggleDisclosure("a", false); // fallback false -> true
   expect(readOpen("a", false)).toBe(true);
-  toggleDisclosure("a", false); // stored true -> false
+  await act(async () => {
+    toggleDisclosure("a", false); // stored true -> false
+  });
   expect(readOpen("a", false)).toBe(false);
 });
 

--- a/cmd/evener-hub/frontend/src/widgets/popover/popover.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/popover/popover.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, expect, test, vi } from "vitest";
 import { Popover } from "./index";
 
@@ -116,7 +116,9 @@ test("re-measures placement when the panel's own size changes after opening", as
 
     const grow = callbacks[0];
     if (!grow) throw new Error("expected Popover to observe its panel for size changes");
-    grow([], {} as ResizeObserver);
+    await act(async () => {
+      grow([], {} as ResizeObserver);
+    });
 
     expect(panel.style.top).not.toBe("");
     expect(panel.style.left).not.toBe("");

--- a/cmd/evener-hub/frontend/vite.config.ts
+++ b/cmd/evener-hub/frontend/vite.config.ts
@@ -87,7 +87,7 @@ export default defineConfig({
     // Vitest use on many-core hosts; the canonical npm test command tightens
     // it to four workers so the root gate retains capacity for its Go streams.
     maxWorkers: Math.max(1, Math.min(os.availableParallelism(), 12)),
-    setupFiles: [],
+    setupFiles: ["./src/testSetup.ts"],
     // A handful of shell suites must import the real pane modules from inside
     // beforeAll rather than statically: those modules transitively pull in
     // stores/prefs, whose createStore initializer reads localStorage at module
@@ -116,6 +116,7 @@ export default defineConfig({
         // the fake client, fake socket and stream harnesses the suites drive.
         "src/protocol/fixtures/**",
         "src/protocol/testing/**",
+        "src/testSetup.ts",
         // A benchmark is not run by `vitest run`, so counting it only ever
         // reports 0% for code no test was ever meant to execute.
         "src/**/*.bench.ts",


### PR DESCRIPTION
## Summary

- Update Vitest and `@vitest/coverage-v8` to 4.1.11, fixing GHSA-82fw-gwwq-j7x9 (`@vitest/mocker` path traversal). `npm audit` reports zero vulnerabilities.
- Install the React act-environment setup explicitly and await the actual asynchronous work in affected tests. Capture and assert intentional diagnostics precisely, without globally suppressing warnings or weakening existing assertions.
- Move the seven CDP helper tests to Vitest's Node environment and stable fake timers, removing Node 22's experimental MockTimers warning. Retain real-timer leak checks and the original wall-clock acceptance bound.

The lockfile update refreshes nine Vitest-family entries plus four transitives: `es-module-lexer` 2.3.2, `obug` 2.2.1, `tinyexec` 1.3.1, and `tinyrainbow` 3.1.1. No new dependency was introduced for the harness fixes. No production application behavior changes.

## Verification

- `npm ci` and `npm audit`: pass, zero vulnerabilities
- `make test-web`: typecheck, unit tests, and Biome pass
- Raw `npm test`: 439 Vitest files / 9,915 tests plus 57 Node tests pass; zero uncaptured diagnostics, including Node warnings
- `TMPDIR=/tmp make test-web-browser`: all five browser guards pass
- `make build-web`: pass
- `npm run test:coverage`: 9,915 tests pass; zero uncaptured diagnostics
- Coverage: statements 94.25%, branches 88.4%, functions 95.44%, lines 96.72%
- Independent review approved all repairs. Existing assertion preservation and targeted mutation checks verified triggering behavior, exact diagnostic oracles, timer/listener leak detection, and the wall-clock acceptance boundary.

Browser checks use `/tmp` because Chrome startup traps with this environment's deeply nested default temporary directory.
