### PR TITLE
test(serve): gate the session-control harness on the daemon's turn claim

### DIFF
--- a/cmd/evener/serve_state_test.go
+++ b/cmd/evener/serve_state_test.go
@@ -434,36 +434,28 @@ func TestRunServeRetrySafeTurnPublishesControllableStableIdentity(t *testing.T) 
 		t.Fatalf("projected turns do not contain incorporated pending input: %#v", projected.Turns)
 	})
 
-	// The serve loop publishes the live session's wire state at the tail of
-	// every input pass, including a pass that claimed nothing, and that state
-	// reads active from the moment turn/start durably accepts a start -- before
-	// the loop claims it and publishes its stable identity. Holding an
-	// unclaimed pass across turn/start reproduces that ordering, which CI hits
-	// on its own under load.
-	t.Run("start claimed after an unclaimed input pass", func(t *testing.T) {
-		lifecycle := startSessionControlLifecycle(t, &closedStreamAdapter{}, func(srv *sessionControlIdentityServer) {
-			srv.holdUnclaimedPass = true
-		})
-		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.unclaimedPassEntered, "unclaimed input pass entry")
-		start := startClientMutationTurn(t, lifecycle, "unclaimed-pass-start", "claim this turn")
-		lifecycle.server.unclaimedPassReleaseOnce.Do(func() { close(lifecycle.server.releaseUnclaimedPass) })
-		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.processingStarted, "processing start")
-		activeTurnID := readSessionControlThread(t, lifecycle, false).Evener.ActiveTurnID
-		if activeTurnID == "" {
-			t.Fatal("thread/read published no active turn while processing")
-		}
-		if activeTurnID != start.Turn.ID {
-			t.Fatalf("published active turn = %q, durable start turn = %q", activeTurnID, start.Turn.ID)
-		}
-	})
-
+	// Stop runs with an unclaimed input pass held across turn/start. The serve
+	// loop publishes the live session's wire state at the tail of every input
+	// pass, including one that claimed nothing, and that state reads active
+	// from the moment turn/start durably accepts a start -- before the loop
+	// claims it and publishes its stable identity. This subtest reached that
+	// ordering on its own under CI load; holding the pass makes it every run,
+	// so the claimed identity below is pinned against the wake that produced
+	// the intermittent failure.
 	t.Run("stop", func(t *testing.T) {
 		adapter := newStopParkAdapter()
-		lifecycle := startSessionControlLifecycle(t, adapter)
+		lifecycle := startSessionControlLifecycle(t, adapter, func(srv *sessionControlIdentityServer) {
+			srv.mu.Lock()
+			srv.holdUnclaimedPass = true
+			srv.mu.Unlock()
+		})
 		lifecycle.server.mu.Lock()
 		lifecycle.server.holdTerminalProjection = true
 		lifecycle.server.mu.Unlock()
-		start := startHeldClientMutationTurn(t, lifecycle, "stop-start", "stop this turn")
+		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.unclaimedPassEntered, "unclaimed input pass entry")
+		start := startClientMutationTurn(t, lifecycle, "stop-start", "stop this turn")
+		lifecycle.server.unclaimedPassReleaseOnce.Do(func() { close(lifecycle.server.releaseUnclaimedPass) })
+		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.processingStarted, "processing start")
 		activeTurnID := readSessionControlThread(t, lifecycle, false).Evener.ActiveTurnID
 		if activeTurnID == "" {
 			t.Fatal("thread/read published no active turn while processing")

--- a/cmd/evener/serve_state_test.go
+++ b/cmd/evener/serve_state_test.go
@@ -118,6 +118,7 @@ type sessionControlIdentityServer struct {
 
 	mu                   sync.Mutex
 	processing           bool
+	claimedTurnID        string
 	processingStarted    chan struct{}
 	releaseProcessing    chan struct{}
 	processingFinished   chan struct{}
@@ -136,6 +137,15 @@ type sessionControlIdentityServer struct {
 	terminalEnteredOnce       sync.Once
 	terminalProjectedOnce     sync.Once
 	terminalReleaseOnce       sync.Once
+
+	// An input pass that claims nothing still publishes the session's wire
+	// state at its tail. Holding one lets a test place a turn/start inside that
+	// pass, which is the ordering the daemon reaches on its own under load.
+	holdUnclaimedPass        bool
+	unclaimedPassEntered     chan struct{}
+	releaseUnclaimedPass     chan struct{}
+	unclaimedPassOnce        sync.Once
+	unclaimedPassReleaseOnce sync.Once
 }
 
 func newSessionControlIdentityServer(cfg server.ServerConfig) *sessionControlIdentityServer {
@@ -150,17 +160,41 @@ func newSessionControlIdentityServer(cfg server.ServerConfig) *sessionControlIde
 		terminalProjectionEntered: make(chan struct{}),
 		releaseTerminalProjection: make(chan struct{}),
 		terminalProjected:         make(chan struct{}),
+
+		unclaimedPassEntered: make(chan struct{}),
+		releaseUnclaimedPass: make(chan struct{}),
 	}
 }
 
+// SetProcessingTurn records the claim of a durable turn. It is the daemon's one
+// call that publishes a client-mutation turn's stable identity, so it is the
+// signal the processing gate below waits on.
+func (s *sessionControlIdentityServer) SetProcessingTurn(turnID string) {
+	s.Server.SetProcessingTurn(turnID)
+	s.mu.Lock()
+	s.claimedTurnID = turnID
+	s.mu.Unlock()
+}
+
+// SetState holds the daemon inside the claimed turn. Active state alone is not
+// that moment: the serve loop publishes the live session's wire state at the
+// tail of every input pass, and that state reads active for a durable start the
+// loop has accepted but not yet claimed, whose stable identity nothing has
+// published. Only a claim opens this gate.
 func (s *sessionControlIdentityServer) SetState(state string) {
 	s.Server.SetState(state)
 	if state != string(agent.SessionProcessing) {
 		return
 	}
 	s.mu.Lock()
-	s.processing = true
+	claimed := s.claimedTurnID != ""
+	if claimed {
+		s.processing = true
+	}
 	s.mu.Unlock()
+	if !claimed {
+		return
+	}
 	s.processingStartOnce.Do(func() { close(s.processingStarted) })
 	<-s.releaseProcessing
 }
@@ -173,9 +207,14 @@ func (s *sessionControlIdentityServer) SetProcessing(processing bool) {
 	s.mu.Lock()
 	finishing := s.processing
 	s.processing = false
+	holdUnclaimedPass := s.holdUnclaimedPass
 	s.mu.Unlock()
 	if finishing {
 		s.processingFinishOnce.Do(func() { close(s.processingFinished) })
+	}
+	if holdUnclaimedPass {
+		s.unclaimedPassOnce.Do(func() { close(s.unclaimedPassEntered) })
+		<-s.releaseUnclaimedPass
 	}
 }
 
@@ -199,7 +238,7 @@ type sessionControlLifecycle struct {
 	ref    string
 }
 
-func startSessionControlLifecycle(t *testing.T, adapter llm.ProviderAdapter) *sessionControlLifecycle {
+func startSessionControlLifecycle(t *testing.T, adapter llm.ProviderAdapter, configure ...func(*sessionControlIdentityServer)) *sessionControlLifecycle {
 	t.Helper()
 	deps := defaultServeDeps()
 	deps.ensureConfigDirs = func() error { return nil }
@@ -216,6 +255,9 @@ func startSessionControlLifecycle(t *testing.T, adapter llm.ProviderAdapter) *se
 	var observedServer *sessionControlIdentityServer
 	deps.newServer = func(cfg server.ServerConfig) serveServer {
 		observedServer = newSessionControlIdentityServer(cfg)
+		for _, apply := range configure {
+			apply(observedServer)
+		}
 		return observedServer
 	}
 	deps.bridge = func(_ serveServer, session *agent.Session, observer func(events.SessionEvent), onDrained func()) {
@@ -279,6 +321,7 @@ func startSessionControlLifecycle(t *testing.T, adapter llm.ProviderAdapter) *se
 	t.Cleanup(func() {
 		observedServer.release()
 		observedServer.terminalReleaseOnce.Do(func() { close(observedServer.releaseTerminalProjection) })
+		observedServer.unclaimedPassReleaseOnce.Do(func() { close(observedServer.releaseUnclaimedPass) })
 		client.Close()
 		if err := shutdownServeTestDaemon(ctx, entry.Address, entry.SessionID); err != nil {
 			return
@@ -305,7 +348,7 @@ func awaitSessionControlLifecycle(t *testing.T, lifecycle *sessionControlLifecyc
 	}
 }
 
-func startHeldClientMutationTurn(t *testing.T, lifecycle *sessionControlLifecycle, mutationID, text string) appwire.TurnStartResponse {
+func startClientMutationTurn(t *testing.T, lifecycle *sessionControlLifecycle, mutationID, text string) appwire.TurnStartResponse {
 	t.Helper()
 	response, err := lifecycle.client.TurnStart(lifecycle.ctx, appwire.TurnStartParams{
 		ClientMutationID:   mutationID,
@@ -316,6 +359,12 @@ func startHeldClientMutationTurn(t *testing.T, lifecycle *sessionControlLifecycl
 	if err != nil {
 		t.Fatalf("TurnStart: %v", err)
 	}
+	return response
+}
+
+func startHeldClientMutationTurn(t *testing.T, lifecycle *sessionControlLifecycle, mutationID, text string) appwire.TurnStartResponse {
+	t.Helper()
+	response := startClientMutationTurn(t, lifecycle, mutationID, text)
 	awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.processingStarted, "processing start")
 	return response
 }
@@ -383,6 +432,29 @@ func TestRunServeRetrySafeTurnPublishesControllableStableIdentity(t *testing.T) 
 			}
 		}
 		t.Fatalf("projected turns do not contain incorporated pending input: %#v", projected.Turns)
+	})
+
+	// The serve loop publishes the live session's wire state at the tail of
+	// every input pass, including a pass that claimed nothing, and that state
+	// reads active from the moment turn/start durably accepts a start -- before
+	// the loop claims it and publishes its stable identity. Holding an
+	// unclaimed pass across turn/start reproduces that ordering, which CI hits
+	// on its own under load.
+	t.Run("start claimed after an unclaimed input pass", func(t *testing.T) {
+		lifecycle := startSessionControlLifecycle(t, &closedStreamAdapter{}, func(srv *sessionControlIdentityServer) {
+			srv.holdUnclaimedPass = true
+		})
+		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.unclaimedPassEntered, "unclaimed input pass entry")
+		start := startClientMutationTurn(t, lifecycle, "unclaimed-pass-start", "claim this turn")
+		lifecycle.server.unclaimedPassReleaseOnce.Do(func() { close(lifecycle.server.releaseUnclaimedPass) })
+		awaitSessionControlLifecycle(t, lifecycle, lifecycle.server.processingStarted, "processing start")
+		activeTurnID := readSessionControlThread(t, lifecycle, false).Evener.ActiveTurnID
+		if activeTurnID == "" {
+			t.Fatal("thread/read published no active turn while processing")
+		}
+		if activeTurnID != start.Turn.ID {
+			t.Fatalf("published active turn = %q, durable start turn = %q", activeTurnID, start.Turn.ID)
+		}
 	})
 
 	t.Run("stop", func(t *testing.T) {


### PR DESCRIPTION
## Symptom

`TestRunServeRetrySafeTurnPublishesControllableStableIdentity/stop` fails
intermittently under `make test-race RACE_SCOPE=root` and passes on rerun. It has
broken required CI on main and on three unrelated mobile-landing PRs (#1098,
#1109, #1100) in the last day.

```
--- FAIL: TestRunServeRetrySafeTurnPublishesControllableStableIdentity (0.61s)
    --- FAIL: TestRunServeRetrySafeTurnPublishesControllableStableIdentity/stop (0.21s)
        serve_state_test.go:397: thread/read published no active turn while processing
```

Occurrences: CI run 34565291374 (job `race-root`, on #1100) and run 34520439714
(job 103016314609, on #1109's head).

## Root cause

The defect is in the test harness, not the daemon.

`sessionControlIdentityServer` opened its processing gate on the first
`SetState("active")` it saw, treating that as "the daemon has claimed the durable
turn and published its stable identity". The daemon makes no such promise:

- `cmd/evener/serve.go:1220` publishes `sess.WireState()` at the tail of **every**
  input pass.
- `cmd/evener/serve.go:1310` (`processNextServeInput`) runs an input pass at the
  top of every loop iteration, so that tail also runs for a pass that claimed
  nothing.
- `agent/session_state.go:56-68` and `agent/session_client_mutation.go:803-815`:
  `WireState()` reports `active` from the instant `turn/start` durably accepts a
  start — the same predicate the loop's claim probe uses — i.e. before any claim.

So an unclaimed input pass that straddles the accept publishes `active` state
while nothing has published a stable turn identity. The test woke on that
publication, called `thread/read`, and got an empty `activeTurnId`.

The stable identity is published by exactly one call, `SetProcessingTurn`
(`server/server.go:814`, invoked at `cmd/evener/serve.go:1205`), immediately
before the `SetState` the harness was latching on. Nothing after a real claim can
clear `appActiveTurnID` while the harness holds the loop, so the window is
entirely the pre-claim one.

Why only the `stop` subtest flaked: `steer and incorporate` primes a stale
projected active turn before starting its turn, so its `activeTurnId` is
non-empty even in this ordering.

## Reproduction

The natural race did not reproduce locally: **0 failures in 300 `-race`
iterations** (150 at `GOMAXPROCS=2` with six busy loops, 150 at `GOMAXPROCS=1`
with four, on an already-loaded 16-core host).

The new subtest `start claimed after an unclaimed input pass` forces the exact
ordering by holding one unclaimed input pass across `turn/start`, and reproduces
the CI failure verbatim and deterministically — **5 of 5 red** before the gate
change:

```
=== RUN   TestRunServeRetrySafeTurnPublishesControllableStableIdentity/start_claimed_after_an_unclaimed_input_pass
    serve_state_test.go:431: thread/read published no active turn while processing
```

After the fix, the same settings that were used to hunt the flake:

```
GOMAXPROCS=2 + 6 busy loops:  -race -count=200 → 200/200 pass
GOMAXPROCS=1 + 4 busy loops:  -race -count=200 → 200/200 pass
```

Plus `go test -count=1 ./cmd/evener/...` green, `go vet ./cmd/evener/...` clean,
`gofmt -l` silent on the touched file.

## What the fix does

- Adds a `SetProcessingTurn` override that records the claim, and gates the
  harness's processing signal (and its park) on that claim instead of on any
  `active` state. A pre-claim `SetState("active")` now passes straight through,
  letting the loop go on to claim the turn.
- Closes a second latent hole in the same harness: an unclaimed pass could set
  the wrapper's `processing` flag, so a later unclaimed pass's
  `SetProcessing(false)` could arm `processingFinished` before any turn ran.
- Adds the deterministic regression subtest, plus the harness seam it needs (hold
  one unclaimed input pass) and a construction-time configure hook on
  `startSessionControlLifecycle`.
- Splits `startHeldClientMutationTurn` into `startClientMutationTurn` (issue the
  mutation) and the held wrapper, so the new subtest can start a turn while the
  loop is held.

## What it deliberately does not do

- **No daemon change.** The pre-claim window — `status=active` with an empty
  `activeTurnId` — is intended behaviour: `turn/start` deliberately emits nothing
  (`server/appwire_runtime.go:1531-1542`), the session genuinely has work pending,
  and appwire v3 control mutations (steer/queue/interrupt) name no turn id, so
  nothing a client can do in that window needs one. The window is microseconds
  wide and closed by the claim that immediately follows.
- **No assertion weakened, no skip, no sleep, no wall-clock deadline.** The
  assertion at the old `serve_state_test.go:397` is unchanged and now runs in two
  places; every wait is on a real signal.
