### PR TITLE
test(appserver): order the unsubscribe-registration assertion on the capture handoff

### DIFF
--- a/internal/appserver/websocket_dispatch_test.go
+++ b/internal/appserver/websocket_dispatch_test.go
@@ -603,6 +603,7 @@ func TestServeWebSocketUnsubscribeWaitsThroughSubscriptionRegistration(t *testin
 	entered := make(chan struct{})
 	release := make(chan struct{})
 	unsubStarted := make(chan struct{})
+	captureResolved := make(chan error, 1)
 	server := NewServer(ServerConfig{
 		ServerName: "test-server", SourceID: "local",
 		SubscriptionAdmissionResolver: func(msg appwire.Message) (string, bool) {
@@ -621,7 +622,17 @@ func TestServeWebSocketUnsubscribeWaitsThroughSubscriptionRegistration(t *testin
 		<-release
 	}
 	HandleTyped(server.Router(), appwire.MethodThreadRead, func(ctx context.Context, params appwire.ThreadReadParams) (appwire.ThreadReadResponse, error) {
-		if !CaptureSubscription(ctx, false, func() string { return params.ThreadID }, func() uint64 { return 0 }, func() bool { return true }) {
+		if !CaptureSubscriptionWithHandoff(
+			ctx,
+			false,
+			func() string { return params.ThreadID },
+			func() uint64 { return 0 },
+			func() bool { return true },
+			CaptureSubscriptionHandoff{
+				Commit: func() { captureResolved <- nil },
+				Abort:  func() { captureResolved <- errors.New("the read capture was withdrawn") },
+			},
+		) {
 			return appwire.ThreadReadResponse{}, nil
 		}
 		return appwire.ThreadReadResponse{Thread: appwire.Thread{ID: params.ThreadID}}, nil
@@ -656,6 +667,14 @@ func TestServeWebSocketUnsubscribeWaitsThroughSubscriptionRegistration(t *testin
 	}
 	if err := waitFor(t, "read after registration", readDone); err != nil {
 		t.Fatalf("read failed: %v", err)
+	}
+	// An unsubscribe that lands while the read's generation is still buffering
+	// marks that entry withdrawn and leaves the capture to drop it (see
+	// subscription.withdrawn). The capture resolves after its response reaches
+	// the send queue, so the client's read response is not an ordering signal
+	// for the registry; the capture handoff is.
+	if err := waitFor(t, "read capture resolution", captureResolved); err != nil {
+		t.Fatalf("read capture failed: %v", err)
 	}
 	server.subs.mu.RLock()
 	defer server.subs.mu.RUnlock()


### PR DESCRIPTION
## Symptom

`TestServeWebSocketUnsubscribeWaitsThroughSubscriptionRegistration` fails
intermittently in required CI (`race-root`, `make test-race RACE_SCOPE=root`)
and passes on rerun. Seen on two unrelated branches within a day:

```
--- FAIL: TestServeWebSocketUnsubscribeWaitsThroughSubscriptionRegistration (0.01s)
    websocket_dispatch_test.go:663: unsubscribe left a stale registered subscription
```

- run `34541625455` on `fix/web-relative-file-links` (b430f67b4)
- run `34529896590` on `codex/mobile-repair-handoff-20260910` (0d30ea35f)

## Root cause

A test ordering assumption, not a server defect.

When the unsubscribe lands while the read's capture generation is still
buffering, `Subscriptions.Unsubscribe` marks that registry entry `withdrawn`
and deliberately leaves it in `byThread` — removing it there would strand the
capture's rollback snapshot (`internal/appserver/subscriptions.go:59-74`,
`:95-116`). The capture's own resolution is what drops it
(`subscriptions.go:228-251`, the `sub.withdrawn` branch of `Release`).

That resolution runs inside `enqueueResponse` **after** the response has
already entered `conn.send` (`internal/appserver/server.go:631-641`: `case
c.send <- msg:` then `finalizer.commit()`). The send loop can therefore write
the read response and the client's `ThreadRead` can return while the withdrawn
entry is still in `server.subs.byThread`.

The test used the client's receipt of the read response as its ordering signal
and then read the raw map (`websocket_dispatch_test.go:657-663`), so a
scheduling delay between those two points produced the failure.

Nothing leaks to the client in that window: `Route`, `IsSubscribed`, `Threads`,
`Connections` and `ConnectionCount` all skip `withdrawn` entries, so the
unsubscribed connection receives no events. Only the raw map length is
transiently non-zero.

Traced interleaving from the failing runs (instrumented build):

```
beginBuffered       thread=th_registration_barrier gen=1
unsubscribeMatching thread=th_registration_barrier withdrawn=true buffering=true
enqueueResponse     queued id=3        <- unsubscribe response: unsubDone fires
enqueueResponse     queued id=2        <- read response queued: readDone can fire
    websocket_dispatch_test.go:663: unsubscribe left a stale registered subscription
                                       <- assertion runs before commit/Release
```

## Reproduction

The flake did not surface in 2,400 focused iterations or 120 full-package
`-race` runs under concurrent load on an unmodified tree. Widening the two
scheduling windows it depends on makes it deterministic:

1. a delay after `captureSubscription` releases `admissionMu`, so the parked
   unsubscribe worker reaches `enqueueResponse` before the read handler does;
2. a delay between a response entering `conn.send` and its hydration finalizer
   committing.

```
go test -race -count=30 -cpu 4 -v \
  -run 'TestServeWebSocketUnsubscribeWaitsThroughSubscriptionRegistration' \
  ./internal/appserver/
```

| build | iterations | failures |
| --- | --- | --- |
| before, both windows widened | 30 | 16 |
| after, both windows widened | 500 | 0 |
| after, unmodified, `-cpu 1,2,4` | 750 | 0 |
| after, unmodified, full package under 6-way concurrent load | 60 | 0 |

The widening patch is a throwaway diagnostic; it is not part of this change.

## What the fix does

The read handler captures through `CaptureSubscriptionWithHandoff` — the entry
point `cmd/evener-hub/app_relay.go:1235` already uses in production — and the
test waits for that handoff's `Commit`/`Abort` before asserting. Those run
after `finalizer.commit()` / `finalizer.abort()`, i.e. after the generation has
been released or withdrawn, so they are the registry's real ordering signal.
An `Abort` is reported as a test failure rather than silently satisfying the
assertion.

## What it deliberately does not do

- No server change. The withdrawn-entry handoff is the documented design and
  it is correct; nothing observable by a client changes.
- No sleep, no wall-clock deadline, no polling loop, no `t.Skip`.
- The assertion is unchanged: still `len(server.subs.byThread[threadID]) != 0`
  against the raw registry, not a softer query helper.
- No change to the earlier barrier assertion that unsubscribe cannot complete
  before the registration release, which is what this test exists to pin.

## Verification

- `go test -count=1 ./internal/appserver/...` — ok
- `go test -race -count=1 ./internal/appserver/...` — ok
- `go vet ./internal/appserver/...` — clean
- `gofmt -l internal/appserver/websocket_dispatch_test.go` — silent
