### PR TITLE
fix(web): bound each browser-guard readiness probe attempt

### DIFF
--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
@@ -110,7 +110,7 @@ function raceWithAbort(promise, signal) {
  * answers, and the caller's deadline still decides how long the phase may take.
  * Measured announcement-to-answer on a warm local Chrome: 138ms to 1.6s.
  */
-const PROBE_ATTEMPT_TIMEOUT_MS = 2000;
+export const PROBE_ATTEMPT_TIMEOUT_MS = 2000;
 
 /**
  * Bound ONE attempt without losing the caller's deadline.
@@ -130,22 +130,29 @@ function boundAttempt(signal, ms) {
 }
 
 /**
- * Name the phase a startup deadline died in, and what its attempts were doing.
+ * What the poll actually did, for whichever way it ended.
  *
- * Waiting for Chrome's stderr announcement and waiting for the announced
- * endpoint to answer share one deadline, and both used to report the same bare
- * "browser startup deadline exceeded" - so a failed CI run could not say which
- * of the two had stalled. The deadline's own message stays the prefix, because
- * that is what run.mjs frames as an environment problem.
+ * A phase that ran out of budget and a phase that ran out of attempts are both
+ * unreadable without it: waiting for Chrome's stderr announcement and waiting
+ * for the announced endpoint to answer share one deadline and used to report
+ * the same bare "browser startup deadline exceeded", and the attempt-cap
+ * message named neither how many attempts there had been nor what the last one
+ * was doing.
  */
-function describePollAbort(reason, label, url, attempts, lastAttempt) {
-  return new Error(
-    `${reason.message} while waiting for ${label} after ${attempts} attempt${attempts === 1 ? "" : "s"} ` +
-      `polling ${url}: last attempt ${lastAttempt}`,
-  );
+function describeAttempts(attempts, lastAttempt) {
+  return `after ${attempts} attempt${attempts === 1 ? "" : "s"}, last attempt ${lastAttempt}`;
 }
 
-export function createStartupDeadline(ms = 30000) {
+/**
+ * The budget one startup PHASE gets - the wait for Chrome's DevTools
+ * announcement, or a poll for an endpoint to answer. Each phase's caller arms
+ * one of these and hands its signal down, and for a poll that signal is the
+ * ONLY thing bounding total wall time: the attempt cap inside waitForHttp is a
+ * backstop, not a clock.
+ */
+export const STARTUP_DEADLINE_MS = 30000;
+
+export function createStartupDeadline(ms = STARTUP_DEADLINE_MS) {
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(new Error(`browser startup deadline exceeded after ${ms}ms`)),
@@ -171,7 +178,10 @@ export function createStartupDeadline(ms = 30000) {
  *
  * Every attempt carries its own bound (PROBE_ATTEMPT_TIMEOUT_MS) so that one
  * request the endpoint accepts and never answers cannot stand in for the whole
- * poll; the caller's signal remains the only thing that ends the wait.
+ * poll. THE CALLER OWNS THE TOTAL BUDGET and must pass a signal: the attempt
+ * cap below is a backstop against an endless loop, not a wall-clock bound, and
+ * with per-attempt bounds it no longer approximates one. A phase polled without
+ * a deadline can sit here for minutes.
  */
 export async function waitForHttp(
   url,
@@ -204,12 +214,14 @@ export async function waitForHttp(
       await raceWithFailure(delay(100, signal), failure);
     }
   } catch (error) {
+    // The deadline's own message stays the prefix: that is what the runners
+    // frame as an environment problem rather than a test case failure.
     if (attempts > 0 && signal && error === abortReason(signal)) {
-      throw describePollAbort(error, label, url, attempts, lastAttempt);
+      throw new Error(`${error.message} while polling ${url} for ${label} ${describeAttempts(attempts, lastAttempt)}`);
     }
     throw error;
   }
-  throw new Error(`${label} never came up at ${url}`);
+  throw new Error(`${label} never came up at ${url} ${describeAttempts(attempts, lastAttempt)}`);
 }
 
 /**

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
@@ -119,13 +119,28 @@ export const PROBE_ATTEMPT_TIMEOUT_MS = 2000;
  * running, and the loser here is a live socket. Composing with the caller's
  * signal is what still lets the startup deadline cancel the request in flight
  * instead of leaving it holding the guard's event loop open.
+ *
+ * Which is also why clear() ABORTS an unsettled request rather than only
+ * clearing the timer. The attempt is not always what ends the race: a Chrome
+ * that exits mid-probe settles the failure promise instead, and the request it
+ * was racing stays connected to an endpoint nobody is waiting for any more -
+ * a live socket outliving the wait that owned it, until its own bound expires
+ * seconds later. A request that already answered is left alone; aborting that
+ * would only tear down a response the caller has in hand.
  */
 function boundAttempt(signal, ms) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error(`probe attempt exceeded ${ms}ms`)), ms);
+  let settled = false;
   return {
     signal: signal ? AbortSignal.any([signal, controller.signal]) : controller.signal,
-    clear: () => clearTimeout(timer),
+    settle: () => {
+      settled = true;
+    },
+    clear: () => {
+      clearTimeout(timer);
+      if (!settled) controller.abort(new Error("probe attempt abandoned before it answered"));
+    },
   };
 }
 
@@ -178,10 +193,11 @@ export function createStartupDeadline(ms = STARTUP_DEADLINE_MS) {
  *
  * Every attempt carries its own bound (PROBE_ATTEMPT_TIMEOUT_MS) so that one
  * request the endpoint accepts and never answers cannot stand in for the whole
- * poll. THE CALLER OWNS THE TOTAL BUDGET and must pass a signal: the attempt
- * cap below is a backstop against an endless loop, not a wall-clock bound, and
- * with per-attempt bounds it no longer approximates one. A phase polled without
- * a deadline can sit here for minutes.
+ * poll. The total bound is the caller's deadline, and a caller that does not
+ * pass one gets STARTUP_DEADLINE_MS of its own: the attempt cap below is a
+ * backstop against an endless loop, not a wall-clock bound, and with
+ * per-attempt bounds it no longer approximates one - 300 silent attempts would
+ * otherwise be ten minutes of polling nobody asked for.
  */
 export async function waitForHttp(
   url,
@@ -189,39 +205,45 @@ export async function waitForHttp(
   launchFailed = () => null,
   { signal, failure = null, fetchImpl = fetch, attemptTimeoutMs = PROBE_ATTEMPT_TIMEOUT_MS } = {},
 ) {
+  const ownDeadline = signal ? null : createStartupDeadline();
+  const deadline = signal ?? ownDeadline.signal;
   let attempts = 0;
   let lastAttempt = "none";
   try {
     for (let attempt = 0; attempt < 300; attempt++) {
-      if (signal?.aborted) throw abortReason(signal);
+      if (deadline.aborted) throw abortReason(deadline);
       const launchError = launchFailed();
       if (launchError) throw launchError;
-      const bound = boundAttempt(signal, attemptTimeoutMs);
+      const bound = boundAttempt(deadline, attemptTimeoutMs);
       attempts++;
       lastAttempt = "still in flight";
       try {
-        const response = await raceWithFailure(raceWithAbort(fetchImpl(url, { signal: bound.signal }), signal), failure);
+        const request = fetchImpl(url, { signal: bound.signal });
+        request.then(bound.settle, bound.settle);
+        const response = await raceWithFailure(raceWithAbort(request, deadline), failure);
         if (response.ok) return;
         lastAttempt = `answered HTTP ${response.status}`;
       } catch (error) {
-        if (startupFailures.has(error) || signal?.aborted) throw startupFailures.has(error) ? error : abortReason(signal);
+        if (startupFailures.has(error) || deadline.aborted) throw startupFailures.has(error) ? error : abortReason(deadline);
         // The child process is still starting, or this attempt outlasted its
         // own bound and the next one gets a fresh connection.
         lastAttempt = error.message;
       } finally {
         bound.clear();
       }
-      await raceWithFailure(delay(100, signal), failure);
+      await raceWithFailure(delay(100, deadline), failure);
     }
+    throw new Error(`${label} never came up at ${url} ${describeAttempts(attempts, lastAttempt)}`);
   } catch (error) {
     // The deadline's own message stays the prefix: that is what the runners
     // frame as an environment problem rather than a test case failure.
-    if (attempts > 0 && signal && error === abortReason(signal)) {
+    if (attempts > 0 && error === abortReason(deadline)) {
       throw new Error(`${error.message} while polling ${url} for ${label} ${describeAttempts(attempts, lastAttempt)}`);
     }
     throw error;
+  } finally {
+    ownDeadline?.clear();
   }
-  throw new Error(`${label} never came up at ${url} ${describeAttempts(attempts, lastAttempt)}`);
 }
 
 /**

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.mjs
@@ -94,6 +94,57 @@ function raceWithAbort(promise, signal) {
   });
 }
 
+/**
+ * One probe attempt's own tripwire bound.
+ *
+ * Once Chrome has announced its DevTools endpoint the port is BOUND, so a probe
+ * can no longer fail fast: the connection is accepted and, while the browser
+ * thread behind it is still busy, simply ignored. fetch never gives up on a
+ * connected socket of its own accord, so a single attempt that lands in that
+ * window used to hold the caller's whole startup deadline open while the
+ * poll-every-100ms loop below waited on it - one attempt, then the deadline
+ * (run 34257184696: "deadline exceeded after 30000ms" printed underneath the
+ * DevTools announcement it had already received).
+ *
+ * This is a tripwire, not the mechanism: the wait still ends when the endpoint
+ * answers, and the caller's deadline still decides how long the phase may take.
+ * Measured announcement-to-answer on a warm local Chrome: 138ms to 1.6s.
+ */
+const PROBE_ATTEMPT_TIMEOUT_MS = 2000;
+
+/**
+ * Bound ONE attempt without losing the caller's deadline.
+ *
+ * An AbortController rather than withTimeout's race: the race's loser keeps
+ * running, and the loser here is a live socket. Composing with the caller's
+ * signal is what still lets the startup deadline cancel the request in flight
+ * instead of leaving it holding the guard's event loop open.
+ */
+function boundAttempt(signal, ms) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(`probe attempt exceeded ${ms}ms`)), ms);
+  return {
+    signal: signal ? AbortSignal.any([signal, controller.signal]) : controller.signal,
+    clear: () => clearTimeout(timer),
+  };
+}
+
+/**
+ * Name the phase a startup deadline died in, and what its attempts were doing.
+ *
+ * Waiting for Chrome's stderr announcement and waiting for the announced
+ * endpoint to answer share one deadline, and both used to report the same bare
+ * "browser startup deadline exceeded" - so a failed CI run could not say which
+ * of the two had stalled. The deadline's own message stays the prefix, because
+ * that is what run.mjs frames as an environment problem.
+ */
+function describePollAbort(reason, label, url, attempts, lastAttempt) {
+  return new Error(
+    `${reason.message} while waiting for ${label} after ${attempts} attempt${attempts === 1 ? "" : "s"} ` +
+      `polling ${url}: last attempt ${lastAttempt}`,
+  );
+}
+
 export function createStartupDeadline(ms = 30000) {
   const controller = new AbortController();
   const timer = setTimeout(
@@ -117,19 +168,46 @@ export function createStartupDeadline(ms = 30000) {
  * the endpoint instead of the reason. It is deliberately per-subsystem: a
  * Chrome that could not launch must not abort - or be blamed for - the wait on
  * a Vite that is coming up fine.
+ *
+ * Every attempt carries its own bound (PROBE_ATTEMPT_TIMEOUT_MS) so that one
+ * request the endpoint accepts and never answers cannot stand in for the whole
+ * poll; the caller's signal remains the only thing that ends the wait.
  */
-export async function waitForHttp(url, label, launchFailed = () => null, { signal, failure = null, fetchImpl = fetch } = {}) {
-  for (let attempt = 0; attempt < 300; attempt++) {
-    if (signal?.aborted) throw abortReason(signal);
-    const launchError = launchFailed();
-    if (launchError) throw launchError;
-    try {
-      if ((await raceWithFailure(raceWithAbort(fetchImpl(url, signal ? { signal } : undefined), signal), failure)).ok) return;
-    } catch (error) {
-      if (startupFailures.has(error) || signal?.aborted) throw startupFailures.has(error) ? error : abortReason(signal);
-      // The child process is still starting.
+export async function waitForHttp(
+  url,
+  label,
+  launchFailed = () => null,
+  { signal, failure = null, fetchImpl = fetch, attemptTimeoutMs = PROBE_ATTEMPT_TIMEOUT_MS } = {},
+) {
+  let attempts = 0;
+  let lastAttempt = "none";
+  try {
+    for (let attempt = 0; attempt < 300; attempt++) {
+      if (signal?.aborted) throw abortReason(signal);
+      const launchError = launchFailed();
+      if (launchError) throw launchError;
+      const bound = boundAttempt(signal, attemptTimeoutMs);
+      attempts++;
+      lastAttempt = "still in flight";
+      try {
+        const response = await raceWithFailure(raceWithAbort(fetchImpl(url, { signal: bound.signal }), signal), failure);
+        if (response.ok) return;
+        lastAttempt = `answered HTTP ${response.status}`;
+      } catch (error) {
+        if (startupFailures.has(error) || signal?.aborted) throw startupFailures.has(error) ? error : abortReason(signal);
+        // The child process is still starting, or this attempt outlasted its
+        // own bound and the next one gets a fresh connection.
+        lastAttempt = error.message;
+      } finally {
+        bound.clear();
+      }
+      await raceWithFailure(delay(100, signal), failure);
     }
-    await raceWithFailure(delay(100, signal), failure);
+  } catch (error) {
+    if (attempts > 0 && signal && error === abortReason(signal)) {
+      throw describePollAbort(error, label, url, attempts, lastAttempt);
+    }
+    throw error;
   }
   throw new Error(`${label} never came up at ${url}`);
 }

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.js
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.js
@@ -27,6 +27,8 @@ import {
   evaluate,
   forcePseudoStates,
   navigateTo,
+  PROBE_ATTEMPT_TIMEOUT_MS,
+  STARTUP_DEADLINE_MS,
   waitForHttp,
 } from "./browserGuardCdp.mjs";
 
@@ -62,38 +64,47 @@ test("one startup deadline aborts the pending HTTP readiness phase", async () =>
 });
 
 /**
- * A loopback endpoint that ACCEPTS connections and answers nothing until
- * `silentMs` have passed since it started listening, then answers every
- * request. That is the shape of a Chrome which has bound - and therefore
- * announced - its DevTools port while the browser thread behind it is still
- * too busy to serve /json/version.
+ * A loopback endpoint that ACCEPTS connections and answers nothing for its
+ * first `ignoredRequests` requests, then answers every request after them.
+ * That is the shape of a Chrome which has bound - and therefore announced -
+ * its DevTools port while the browser thread behind it is still too busy to
+ * serve /json/version.
+ *
+ * What it answers is decided by that COUNT and never by a clock, so the retry
+ * these tests pin does not ride on scheduler timing. Requests are counted by
+ * parsing complete request heads rather than by counting "data" events or
+ * accepted connections: one request split across two TCP reads, or a
+ * connection undici opens without sending on, must not read as two attempts
+ * and let a poll that never retried pass.
  */
-function silentEndpoint(silentMs) {
-  let listeningAt = 0;
+function silentEndpoint(ignoredRequests) {
   let requests = 0;
-  // An abandoned attempt leaves its socket behind on this side too. They are
-  // destroyed by hand at the end of the test: a net.Server stays a live handle
-  // on the event loop until every connection it accepted is gone, and a test
-  // file that never drains is a hang, not a failure.
+  // A net.Server stays a live handle on the event loop until every connection
+  // it accepted is gone, and an abandoned attempt leaves its socket on this
+  // side too - so they are destroyed by hand when the test ends.
   const sockets = new Set();
   const server = createServer((socket) => {
     sockets.add(socket);
     socket.on("close", () => sockets.delete(socket));
     socket.on("error", () => {});
-    socket.on("data", () => {
-      requests++;
-      if (Date.now() - listeningAt < silentMs) return;
-      socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}");
+    let received = "";
+    socket.on("data", (chunk) => {
+      received += chunk;
+      // Every probe is a GET with no body, so the blank line ends the request.
+      for (let head = received.indexOf("\r\n\r\n"); head >= 0; head = received.indexOf("\r\n\r\n")) {
+        received = received.slice(head + 4);
+        requests++;
+        if (requests > ignoredRequests) {
+          socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}");
+        }
+      }
     });
   });
   return {
     requestCount: () => requests,
     listen: () =>
       new Promise((resolve) => {
-        server.listen(0, "127.0.0.1", () => {
-          listeningAt = Date.now();
-          resolve(`http://127.0.0.1:${server.address().port}/json/version`);
-        });
+        server.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${server.address().port}/json/version`));
       }),
     close: () => {
       for (const socket of sockets) socket.destroy();
@@ -110,24 +121,40 @@ function silentEndpoint(silentMs) {
 // poll-every-100ms loop below it never ran a second time. The loop only ever
 // advanced when an attempt failed FAST, which after the announcement it cannot:
 // the port is bound, so the connection is accepted and then simply ignored.
+//
+// The endpoint is a real socket on purpose: what has to hold is that fetch
+// honours the abort and the NEXT request goes out, which no fake transport can
+// stand in for. Nothing here is timed, though - the endpoint ignores its first
+// request and answers the second, so a slow machine changes when this test
+// finishes and never whether it passes.
 test("a probe attempt that never answers is abandoned so the poll keeps going", async (context) => {
-  const endpoint = silentEndpoint(400);
-  context.after(() => endpoint.close());
+  const endpoint = silentEndpoint(1);
+  context.onTestFinished(() => endpoint.close());
   const url = await endpoint.listen();
   const deadline = createStartupDeadline(3_000);
-  context.after(() => deadline.clear());
+  context.onTestFinished(() => deadline.clear());
   const before = liveTimers();
-  const started = Date.now();
 
+  // Before the fix this rejected with the deadline, having spent all 3000ms
+  // of it inside the first attempt.
   await waitForHttp(url, "chrome devtools endpoint", () => null, {
     signal: deadline.signal,
     attemptTimeoutMs: 150,
   });
 
-  const elapsed = Date.now() - started;
-  assert.ok(elapsed < 3_000, `the wait took ${elapsed}ms: it spent the whole startup deadline inside one attempt`);
-  assert.ok(endpoint.requestCount() > 1, `only ${endpoint.requestCount()} request was ever sent: the poll never retried`);
-  assert.equal(liveTimers(), before, "an attempt's own timer outlived the attempt it was bounding");
+  assert.equal(deadline.signal.aborted, false, "the poll did not finish inside its own startup budget");
+  assert.ok(
+    endpoint.requestCount() >= 2,
+    `the endpoint parsed ${endpoint.requestCount()} request(s): the poll never retried after the first went unanswered`,
+  );
+  // A leak here shows up as GROWTH - one armed timer per abandoned attempt.
+  // The count is not asserted equal because it is process-wide: unrelated
+  // timers belonging to the runner expire while this test is running, and a
+  // test that fails when one of those happens to fire is not a test.
+  assert.ok(
+    liveTimers() <= before,
+    `live timers went from ${before} to ${liveTimers()}: an attempt's own timer outlived the attempt it was bounding`,
+  );
 });
 
 // A startup deadline that names neither the phase it died in nor what its
@@ -136,10 +163,10 @@ test("a probe attempt that never answers is abandoned so the poll keeps going", 
 // budget and, until now, one indistinguishable message.
 test("the startup deadline says which endpoint it was polling and how often", async (context) => {
   const endpoint = silentEndpoint(Number.MAX_SAFE_INTEGER);
-  context.after(() => endpoint.close());
+  context.onTestFinished(() => endpoint.close());
   const url = await endpoint.listen();
   const deadline = createStartupDeadline(600);
-  context.after(() => deadline.clear());
+  context.onTestFinished(() => deadline.clear());
 
   await assert.rejects(
     waitForHttp(url, "chrome devtools endpoint", () => null, { signal: deadline.signal, attemptTimeoutMs: 100 }),
@@ -150,6 +177,18 @@ test("the startup deadline says which endpoint it was polling and how often", as
       assert.match(error.message, /after \d+ attempts?/);
       return true;
     },
+  );
+});
+
+// Every test above hands waitForHttp its own attemptTimeoutMs so it can run in
+// milliseconds, which means none of them would notice an edit that put the
+// PRODUCTION bound back above the deadline it has to retry inside - restoring
+// the flake with this whole file still green. This is the only thing holding
+// the two constants in a workable relationship.
+test("the shipped attempt bound leaves room to retry inside the startup deadline", () => {
+  assert.ok(
+    PROBE_ATTEMPT_TIMEOUT_MS * 5 <= STARTUP_DEADLINE_MS,
+    `one attempt may hold ${PROBE_ATTEMPT_TIMEOUT_MS}ms of a ${STARTUP_DEADLINE_MS}ms phase: too few fit for a poll to be a poll`,
   );
 });
 

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.js
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.js
@@ -79,13 +79,24 @@ test("one startup deadline aborts the pending HTTP readiness phase", async () =>
  */
 function silentEndpoint(ignoredRequests) {
   let requests = 0;
+  let announceRequest;
+  let announceClose;
+  const firstRequest = new Promise((resolve) => {
+    announceRequest = resolve;
+  });
+  const firstConnectionClosed = new Promise((resolve) => {
+    announceClose = resolve;
+  });
   // A net.Server stays a live handle on the event loop until every connection
   // it accepted is gone, and an abandoned attempt leaves its socket on this
   // side too - so they are destroyed by hand when the test ends.
   const sockets = new Set();
   const server = createServer((socket) => {
     sockets.add(socket);
-    socket.on("close", () => sockets.delete(socket));
+    socket.on("close", () => {
+      sockets.delete(socket);
+      announceClose();
+    });
     socket.on("error", () => {});
     let received = "";
     socket.on("data", (chunk) => {
@@ -94,6 +105,7 @@ function silentEndpoint(ignoredRequests) {
       for (let head = received.indexOf("\r\n\r\n"); head >= 0; head = received.indexOf("\r\n\r\n")) {
         received = received.slice(head + 4);
         requests++;
+        announceRequest();
         if (requests > ignoredRequests) {
           socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}");
         }
@@ -102,6 +114,8 @@ function silentEndpoint(ignoredRequests) {
   });
   return {
     requestCount: () => requests,
+    firstRequest: () => firstRequest,
+    firstConnectionClosed: () => firstConnectionClosed,
     listen: () =>
       new Promise((resolve) => {
         server.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${server.address().port}/json/version`));
@@ -190,6 +204,59 @@ test("the shipped attempt bound leaves room to retry inside the startup deadline
     PROBE_ATTEMPT_TIMEOUT_MS * 5 <= STARTUP_DEADLINE_MS,
     `one attempt may hold ${PROBE_ATTEMPT_TIMEOUT_MS}ms of a ${STARTUP_DEADLINE_MS}ms phase: too few fit for a poll to be a poll`,
   );
+});
+
+// An attempt is not always what ends its own race. A Chrome that exits
+// mid-probe settles the failure promise, waitForHttp rejects with it, and the
+// request that was racing is still connected - to an endpoint nobody is waiting
+// on any more. Clearing the attempt's timer on the way out does not take that
+// socket down; only aborting its controller does.
+test("a probe abandoned because the browser died does not leave its request running", async (context) => {
+  const endpoint = silentEndpoint(Number.MAX_SAFE_INTEGER);
+  context.onTestFinished(() => endpoint.close());
+  const url = await endpoint.listen();
+  const deadline = createStartupDeadline(30_000);
+  context.onTestFinished(() => deadline.clear());
+  const died = new Error("Chrome exited before DevTools readiness (code 1, signal none)");
+
+  await assert.rejects(
+    waitForHttp(url, "chrome devtools endpoint", () => null, {
+      signal: deadline.signal,
+      // Chrome dies only once its request is on the wire, so this pins the
+      // abandoned-mid-flight case and not a race with connection setup.
+      failure: endpoint.firstRequest().then(() => died),
+      // Far longer than this test can run: the attempt's own bound must not be
+      // what eventually closes the socket, or it would pass without the fix.
+      attemptTimeoutMs: 600_000,
+    }),
+    /Chrome exited before DevTools readiness/,
+  );
+
+  // Without the abort this never resolves and the test dies of its own timeout.
+  await endpoint.firstConnectionClosed();
+});
+
+// waitForHttp's total bound is the caller's deadline, and for most of this
+// module's life a caller could simply not pass one - 300 attempts at their own
+// bound apiece, ten minutes of polling, with nothing to stop it. Callers now
+// get a deadline whether they bring one or not.
+test("a poll with no caller deadline arms one of its own", async () => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  const before = liveTimers();
+  const pending = waitForHttp("http://127.0.0.1:1/json/version", "vite dev server", () => null, {
+    fetchImpl: () => new Promise(() => {}),
+  });
+  const rejected = assert.rejects(pending, (error) => {
+    assert.match(error.message, new RegExp(`browser startup deadline exceeded after ${STARTUP_DEADLINE_MS}ms`));
+    assert.match(error.message, /vite dev server/);
+    return true;
+  });
+
+  await vi.advanceTimersByTimeAsync(STARTUP_DEADLINE_MS);
+  await rejected;
+  // The fallback is a timer this module armed itself; leaving it behind would
+  // hold a guard's event loop open for the rest of its budget.
+  assert.ok(liveTimers() <= before, `live timers went from ${before} to ${liveTimers()}: the fallback deadline outlived its poll`);
 });
 
 const cdpModuleUrl = new URL("./browserGuardCdp.mjs", import.meta.url).href;

--- a/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardCdp.test.mjs
@@ -12,6 +12,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -52,6 +53,98 @@ test("one startup deadline aborts the pending HTTP readiness phase", async (cont
   context.mock.timers.tick(30_000);
   await assert.rejects(pending, /browser startup deadline exceeded after 30000ms/);
   deadline.clear();
+});
+
+/**
+ * A loopback endpoint that ACCEPTS connections and answers nothing until
+ * `silentMs` have passed since it started listening, then answers every
+ * request. That is the shape of a Chrome which has bound - and therefore
+ * announced - its DevTools port while the browser thread behind it is still
+ * too busy to serve /json/version.
+ */
+function silentEndpoint(silentMs) {
+  let listeningAt = 0;
+  let requests = 0;
+  // An abandoned attempt leaves its socket behind on this side too. They are
+  // destroyed by hand at the end of the test: a net.Server stays a live handle
+  // on the event loop until every connection it accepted is gone, and a test
+  // file that never drains is a hang, not a failure.
+  const sockets = new Set();
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => {});
+    socket.on("data", () => {
+      requests++;
+      if (Date.now() - listeningAt < silentMs) return;
+      socket.end("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}");
+    });
+  });
+  return {
+    requestCount: () => requests,
+    listen: () =>
+      new Promise((resolve) => {
+        server.listen(0, "127.0.0.1", () => {
+          listeningAt = Date.now();
+          resolve(`http://127.0.0.1:${server.address().port}/json/version`);
+        });
+      }),
+    close: () => {
+      for (const socket of sockets) socket.destroy();
+      server.close();
+    },
+  };
+}
+
+// The flake this pins (run 34257184696): Chrome announced its DevTools endpoint
+// and the guard still died on "browser startup deadline exceeded after
+// 30000ms". A probe attempt had no bound of its own, so the ONE request that
+// landed while the browser was still unresponsive held the whole startup
+// budget open - fetch does not give up on a connected socket - and the
+// poll-every-100ms loop below it never ran a second time. The loop only ever
+// advanced when an attempt failed FAST, which after the announcement it cannot:
+// the port is bound, so the connection is accepted and then simply ignored.
+test("a probe attempt that never answers is abandoned so the poll keeps going", async (context) => {
+  const endpoint = silentEndpoint(400);
+  context.after(() => endpoint.close());
+  const url = await endpoint.listen();
+  const deadline = createStartupDeadline(3_000);
+  context.after(() => deadline.clear());
+  const before = liveTimers();
+  const started = Date.now();
+
+  await waitForHttp(url, "chrome devtools endpoint", () => null, {
+    signal: deadline.signal,
+    attemptTimeoutMs: 150,
+  });
+
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed < 3_000, `the wait took ${elapsed}ms: it spent the whole startup deadline inside one attempt`);
+  assert.ok(endpoint.requestCount() > 1, `only ${endpoint.requestCount()} request was ever sent: the poll never retried`);
+  assert.equal(liveTimers(), before, "an attempt's own timer outlived the attempt it was bounding");
+});
+
+// A startup deadline that names neither the phase it died in nor what its
+// attempts were doing is why the CI log above could not be read: waiting for
+// the stderr announcement and waiting for the endpoint to answer share one
+// budget and, until now, one indistinguishable message.
+test("the startup deadline says which endpoint it was polling and how often", async (context) => {
+  const endpoint = silentEndpoint(Number.MAX_SAFE_INTEGER);
+  context.after(() => endpoint.close());
+  const url = await endpoint.listen();
+  const deadline = createStartupDeadline(600);
+  context.after(() => deadline.clear());
+
+  await assert.rejects(
+    waitForHttp(url, "chrome devtools endpoint", () => null, { signal: deadline.signal, attemptTimeoutMs: 100 }),
+    (error) => {
+      assert.match(error.message, /browser startup deadline exceeded after 600ms/);
+      assert.match(error.message, /chrome devtools endpoint/);
+      assert.match(error.message, new RegExp(`polling ${url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+      assert.match(error.message, /after \d+ attempts?/);
+      return true;
+    },
+  );
 });
 
 const cdpModuleUrl = new URL("./browserGuardCdp.mjs", import.meta.url).href;

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 
+import { createStartupDeadline, devtoolsHttpURL, waitForHttp } from "./browserGuardCdp.mjs";
+
 const CHROME_CANDIDATES = [
   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
   "/usr/bin/google-chrome",
@@ -16,6 +18,25 @@ const CHILD_EXIT_GRACE_MS = 2_000;
 const SIGNAL_EXIT_CODES = { SIGINT: 130, SIGTERM: 143 };
 const DEVTOOLS_ANNOUNCEMENT_PREFIX = "DevTools listening on ";
 const VITE_READY_TIMEOUT_MS = 30_000;
+
+/**
+ * How long Chrome gets to print "DevTools listening" before the guard calls it
+ * an environment failure. Deliberately FAR larger than the 30s an endpoint gets
+ * to answer once announced, because the two waits fail for different reasons.
+ *
+ * Measured on the GitHub runner that failed run 34570447477: Chrome's first
+ * stderr byte arrived 21s after launch and it still had not announced at 30s,
+ * with its dbus retries running to 27s - a browser making progress, on a cold
+ * page cache, on a loaded two-core VM. The four guards after it on the SAME
+ * runner came up in seconds. 30s was simply under the cold-start floor.
+ *
+ * This is a tripwire and nothing else depends on its value: a Chrome that
+ * CANNOT start never reaches it, because the exit and spawn-error handlers
+ * below reject the readiness promise the moment either fires. What it bounds is
+ * the one case where the process is alive and silent, and four times the
+ * observed floor is the margin chosen for it.
+ */
+const CHROME_ANNOUNCEMENT_DEADLINE_MS = 120_000;
 const VITE_LOCAL_ANNOUNCEMENT = /Local:\s+http:\/\/(\[[^\]]+\]|[^/:\s]+):(\d+)(?:\/\s*)?$/;
 
 function isLoopbackHost(hostname) {
@@ -148,6 +169,66 @@ export function describeBrowserStartupFailure({
     "     library, a sandbox denial and an unwritable profile all report there.",
   );
   return lines.join("\n");
+}
+
+/**
+ * Take a started guard from "processes are running" to "there is a browser to
+ * drive", and frame anything that goes wrong as the environment problem it is.
+ *
+ * Every guard runner had a verbatim copy of this. It is one function because
+ * the two waits inside it have to be reasoned about together: the announcement
+ * and the endpoint answering are different failures with different causes, so
+ * they get SEPARATE budgets. Sharing one, as the copies did, let a cold Chrome
+ * that took 25 seconds to announce hand the endpoint wait five - the poll would
+ * then die of a deadline that had already been spent by the phase before it.
+ */
+export async function waitForBrowserReady(guard, { announcementTimeoutMs = CHROME_ANNOUNCEMENT_DEADLINE_MS } = {}) {
+  const announcement = createStartupDeadline(announcementTimeoutMs);
+  let endpointAnswer = null;
+  try {
+    let endpoint;
+    try {
+      endpoint = await guard.waitForChrome({ signal: announcement.signal });
+    } catch (error) {
+      // Name the phase, and say what the browser had managed to do. Run
+      // 34570447477 printed "browser startup deadline exceeded after 30000ms"
+      // and nothing else - the same sentence the endpoint poll after it would
+      // have printed - and which of the two had stalled had to be argued out
+      // of microtask ordering rather than read.
+      if (error !== announcement.signal.reason) throw error;
+      const firstStderr = guard.getChromeFirstStderrDelay();
+      throw new Error(
+        `${error.message} while waiting for Chrome's DevTools announcement on stderr ` +
+          `(${
+            firstStderr === null
+              ? "Chrome had written nothing to stderr"
+              : `Chrome's first stderr byte arrived ${firstStderr}ms after launch`
+          })`,
+      );
+    }
+    endpointAnswer = createStartupDeadline();
+    await waitForHttp(
+      devtoolsHttpURL(endpoint, "/json/version"),
+      "chrome devtools endpoint",
+      guard.getChromeLaunchError,
+      { signal: endpointAnswer.signal, failure: guard.getChromeFailure() },
+    );
+    return endpoint;
+  } catch (error) {
+    throw new Error(
+      describeBrowserStartupFailure({
+        error,
+        subsystem: "chrome",
+        chromeBinary: guard.chromeBinary,
+        chromeArgv: guard.getChromeArgv(),
+        chromeStderr: guard.getChromeError(),
+        viteStderr: guard.getViteError(),
+      }),
+    );
+  } finally {
+    announcement.clear();
+    endpointAnswer?.clear();
+  }
 }
 
 export function chromeProfileIsolationArgs(platform = process.platform) {
@@ -735,6 +816,8 @@ export async function startBrowserGuard({
   let viteLineBuffer = "";
   let chromeLaunchError = null;
   let chromeArgv = [];
+  let chromeSpawnedAt = 0;
+  let chromeFirstStderrAfterMs = null;
   let chromeEndpoint = null;
   let chromeLineBuffer = "";
   let resolveChromeReady;
@@ -860,6 +943,7 @@ export async function startBrowserGuard({
       ...chromeArgs,
       "about:blank",
     ];
+    chromeSpawnedAt = Date.now();
     chrome = spawnProcess(resolvedChrome, chromeArgv, {
       // Chrome's stderr is the only thing that says WHY it would not start (a
       // missing dylib, a sandbox denial, a profile it cannot write).
@@ -873,6 +957,7 @@ export async function startBrowserGuard({
       failChrome(error);
     });
     chrome.stderr?.on("data", (chunk) => {
+      chromeFirstStderrAfterMs ??= Date.now() - chromeSpawnedAt;
       chromeErr += chunk;
       chromeLineBuffer += chunk.toString();
       const lines = chromeLineBuffer.split(/\r\n|\r|\n/);
@@ -931,10 +1016,15 @@ export async function startBrowserGuard({
     getChromeFailure: () => chromeFailure,
     chromeBinary: resolvedChrome,
     getChromeArgv: () => chromeArgv,
-    // This promise is the process/devtools readiness handoff. The runner owns
-    // its single startup deadline and passes its abort signal through both the
-    // announcement and /json/version phases.
+    // This promise is the process/devtools readiness handoff. It rejects with
+    // the caller's own abort reason; waitForBrowserReady, which arms the
+    // announcement budget, is what says which phase that reason belongs to.
     waitForChrome: ({ signal } = {}) => withAbort(chromeReady, signal, chromeFailure),
+    // How long after launch Chrome first wrote ANYTHING, or null if it never
+    // did. The number that separates a browser which is slow from one which is
+    // not running: 21000ms of silence and then dbus retries, in run
+    // 34570447477, is a cold page cache, not a broken install.
+    getChromeFirstStderrDelay: () => chromeFirstStderrAfterMs,
     cleanup: lifecycle.cleanup,
   };
 }

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { waitForHttp } from "./browserGuardCdp.mjs";
+import { createStartupDeadline, waitForHttp } from "./browserGuardCdp.mjs";
 import * as browserGuardProcess from "./browserGuardProcess.mjs";
 
 const { createBrowserProcessCleanup, findAvailablePort, startBrowserGuard } = browserGuardProcess;
@@ -1030,6 +1030,34 @@ test("the diagnostic blames vite for a vite failure and does not send the reader
   });
 
   assert.match(message, /Port 5173 is already in use/);
+  assert.match(message, /Chrome is not implicated/);
+  assert.doesNotMatch(message, /install Chrome/);
+});
+
+// The Vite readiness poll only recently got a deadline of its own (every guard
+// runner arms one beside the Chrome phase's). What it produces when that
+// deadline fires has to keep reading as an environment problem and has to keep
+// pointing at Vite: a guard that told the reader to install Chrome because its
+// dev server never answered would send them to the wrong place with an
+// authoritative-looking checklist.
+test("a vite readiness poll that runs out of deadline still frames as a vite environment problem", async () => {
+  const deadline = createStartupDeadline(300);
+  const error = await waitForHttp("http://127.0.0.1:1/", "vite dev server", () => null, {
+    signal: deadline.signal,
+  }).then(
+    () => null,
+    (rejection) => rejection,
+  );
+  deadline.clear();
+
+  assert.match(error.message, /browser startup deadline exceeded after 300ms/);
+  assert.match(error.message, /vite dev server/);
+  const message = browserGuardProcess.describeBrowserStartupFailure({
+    error,
+    subsystem: "vite",
+    viteStderr: "",
+  });
+  assert.match(message, /environment problem, not a test case failure/);
   assert.match(message, /Chrome is not implicated/);
   assert.doesNotMatch(message, /install Chrome/);
 });

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import { existsSync, mkdtempSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -1040,6 +1041,110 @@ test("the diagnostic blames vite for a vite failure and does not send the reader
 // pointing at Vite: a guard that told the reader to install Chrome because its
 // dev server never answered would send them to the wrong place with an
 // authoritative-looking checklist.
+/** A guard whose Chrome never announces, for the announcement-deadline path. */
+function silentChromeGuard(firstStderrDelay) {
+  return {
+    waitForChrome: ({ signal }) =>
+      new Promise((_, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+    getChromeFirstStderrDelay: () => firstStderrDelay,
+    getChromeLaunchError: () => null,
+    getChromeFailure: () => new Promise(() => {}),
+    chromeBinary: "/usr/bin/google-chrome",
+    getChromeArgv: () => ["--headless=new"],
+    getChromeError: () => "[3036:3072:0911/063804.935306:ERROR:dbus/bus.cc:405] Failed to connect to the bus",
+    getViteError: () => "",
+  };
+}
+
+// Run 34570447477 died here and could not say so: no DevTools announcement
+// came, and the only thing the guard printed was "browser startup deadline
+// exceeded after 30000ms" - the same sentence the /json/version poll after it
+// would have printed. The phase has to name itself, and it has to say what
+// Chrome had managed to do, because "first stderr byte at 21s" is the number
+// that told us the browser was slow rather than broken.
+test("an announcement that never arrives names its phase and what Chrome had done", async () => {
+  const failure = await browserGuardProcess
+    .waitForBrowserReady(silentChromeGuard(21_004), { announcementTimeoutMs: 50 })
+    .then(
+      () => null,
+      (error) => error.message,
+    );
+
+  assert.match(failure, /environment problem, not a test case failure/);
+  assert.match(failure, /browser startup deadline exceeded after 50ms/);
+  assert.match(failure, /while waiting for Chrome's DevTools announcement on stderr/);
+  assert.match(failure, /Chrome's first stderr byte arrived 21004ms after launch/);
+});
+
+test("an announcement deadline on a Chrome that never said anything reports the silence", async () => {
+  const failure = await browserGuardProcess
+    .waitForBrowserReady(silentChromeGuard(null), { announcementTimeoutMs: 50 })
+    .then(
+      () => null,
+      (error) => error.message,
+    );
+
+  assert.match(failure, /Chrome had written nothing to stderr/);
+});
+
+// The delay above is only worth reporting if it is really measured off Chrome's
+// own output, so this takes it from a started guard rather than a stub.
+test("the first-stderr delay is measured from Chrome's own output", async (context) => {
+  const { guard, children } = await startFakeGuard();
+  reapOnTeardown(context, guard, children);
+
+  assert.equal(guard.getChromeFirstStderrDelay(), null);
+  children[1].stderr.emit("data", "[3036:3072:0911/063804.935306:ERROR:dbus/bus.cc:405] Failed to connect to the bus\n");
+  assert.ok(
+    Number.isInteger(guard.getChromeFirstStderrDelay()) && guard.getChromeFirstStderrDelay() >= 0,
+    `expected a measured delay, got ${guard.getChromeFirstStderrDelay()}`,
+  );
+});
+
+// The readiness handoff every guard runner used to carry a verbatim copy of.
+// All five now call this, so it holds the shape they depend on: the announced
+// endpoint comes back, and neither of its two deadlines is left armed - a guard
+// ends by setting process.exitCode, so a live timer is a guard that will not
+// exit until it fires.
+test("waitForBrowserReady returns the announced endpoint and leaves no deadline armed", async (context) => {
+  const answered = [];
+  const server = createServer((request, response) => {
+    answered.push(request.url);
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end("{}");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  context.after(() => new Promise((resolve) => server.close(resolve)));
+  const endpoint = { url: `ws://127.0.0.1:${server.address().port}/devtools/browser/fixture` };
+  const announcementSignals = [];
+  const guard = {
+    waitForChrome: ({ signal }) => {
+      announcementSignals.push(signal);
+      return Promise.resolve(endpoint);
+    },
+    getChromeFirstStderrDelay: () => 12,
+    getChromeLaunchError: () => null,
+    getChromeFailure: () => new Promise(() => {}),
+    chromeBinary: "/fake/chrome",
+    getChromeArgv: () => [],
+    getChromeError: () => "",
+    getViteError: () => "",
+  };
+  const before = process.getActiveResourcesInfo().filter((resource) => resource === "Timeout").length;
+
+  assert.equal(await browserGuardProcess.waitForBrowserReady(guard), endpoint);
+
+  assert.deepEqual(answered, ["/json/version"]);
+  assert.equal(announcementSignals.length, 1);
+  assert.equal(announcementSignals[0].aborted, false);
+  assert.ok(
+    process.getActiveResourcesInfo().filter((resource) => resource === "Timeout").length <= before,
+    "a startup deadline outlived the phase it was bounding",
+  );
+});
+
 test("a vite readiness poll that runs out of deadline still frames as a vite environment problem", async () => {
   const deadline = createStartupDeadline(300);
   const error = await waitForHttp("http://127.0.0.1:1/", "vite dev server", () => null, {

--- a/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
@@ -226,12 +226,17 @@ async function main() {
   let failed = 0;
   const warnings = [];
   try {
+    const viteDeadline = createStartupDeadline();
     try {
-      await waitForHttp(`http://127.0.0.1:${vitePort}/`, "vite dev server", guard.getViteLaunchError);
+      await waitForHttp(`http://127.0.0.1:${vitePort}/`, "vite dev server", guard.getViteLaunchError, {
+        signal: viteDeadline.signal,
+      });
     } catch (err) {
       throw new Error(
         describeBrowserStartupFailure({ error: err, subsystem: "vite", viteStderr: guard.getViteError() }),
       );
+    } finally {
+      viteDeadline.clear();
     }
     const startupDeadline = createStartupDeadline();
     try {

--- a/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/layoutguard/run.mjs
@@ -76,11 +76,10 @@ import {
   navigateTo,
   realizedViewport,
   createStartupDeadline,
-  devtoolsHttpURL,
   waitForFonts,
   waitForHttp,
 } from "../browserGuardCdp.mjs";
-import { describeBrowserStartupFailure, startBrowserGuard } from "../browserGuardProcess.mjs";
+import { describeBrowserStartupFailure, startBrowserGuard, waitForBrowserReady } from "../browserGuardProcess.mjs";
 import { resolveComposes } from "./resolve-composes.mjs";
 import { diagnoseRealizedViewport, normalizeViewportSpec } from "./viewport.mjs";
 import { injectWidthMatrix } from "./widthMatrix.mjs";
@@ -238,29 +237,7 @@ async function main() {
     } finally {
       viteDeadline.clear();
     }
-    const startupDeadline = createStartupDeadline();
-    try {
-      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
-      await waitForHttp(
-        devtoolsHttpURL(cdpEndpoint, "/json/version"),
-        "chrome devtools endpoint",
-        guard.getChromeLaunchError,
-        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
-      );
-    } catch (err) {
-      throw new Error(
-        describeBrowserStartupFailure({
-          error: err,
-          subsystem: "chrome",
-          chromeBinary: guard.chromeBinary,
-          chromeArgv: guard.getChromeArgv(),
-          chromeStderr: guard.getChromeError(),
-          viteStderr: guard.getViteError(),
-        }),
-      );
-    } finally {
-      startupDeadline.clear();
-    }
+    cdpEndpoint = await waitForBrowserReady(guard);
 
     const page = await connectPage(cdpEndpoint);
     const emulation = { viewportApplied: false };

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -43,14 +43,13 @@ import {
   clearViewportOverride,
   connectPage,
   createStartupDeadline,
-  devtoolsHttpURL,
   evaluate,
   navigateTo,
   realizedViewport,
   waitForFonts,
   waitForHttp,
 } from "../browserGuardCdp.mjs";
-import { describeBrowserStartupFailure, startBrowserGuard } from "../browserGuardProcess.mjs";
+import { describeBrowserStartupFailure, startBrowserGuard, waitForBrowserReady } from "../browserGuardProcess.mjs";
 
 const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -1025,29 +1024,7 @@ async function main() {
     } finally {
       viteDeadline.clear();
     }
-    const startupDeadline = createStartupDeadline();
-    try {
-      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
-      await waitForHttp(
-        devtoolsHttpURL(cdpEndpoint, "/json/version"),
-        "chrome devtools endpoint",
-        guard.getChromeLaunchError,
-        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
-      );
-    } catch (err) {
-      throw new Error(
-        describeBrowserStartupFailure({
-          error: err,
-          subsystem: "chrome",
-          chromeBinary: guard.chromeBinary,
-          chromeArgv: guard.getChromeArgv(),
-          chromeStderr: guard.getChromeError(),
-          viteStderr: guard.getViteError(),
-        }),
-      );
-    } finally {
-      startupDeadline.clear();
-    }
+    cdpEndpoint = await waitForBrowserReady(guard);
 
     for (const width of sweep.filter((candidate) => candidate < 900 || candidate === 900)) {
       const sendMeasurements = await measureComposerSend(

--- a/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/overflowguard/run.mjs
@@ -1010,16 +1010,20 @@ async function main() {
 
   let failed = 0;
   try {
+    const viteDeadline = createStartupDeadline();
     try {
       await waitForHttp(
         `http://127.0.0.1:${vitePort}/overflowharness.html`,
         "vite dev server",
         guard.getViteLaunchError,
+        { signal: viteDeadline.signal },
       );
     } catch (err) {
       throw new Error(
         describeBrowserStartupFailure({ error: err, subsystem: "vite", viteStderr: guard.getViteError() }),
       );
+    } finally {
+      viteDeadline.clear();
     }
     const startupDeadline = createStartupDeadline();
     try {

--- a/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
@@ -235,10 +235,15 @@ async function main() {
   let cdpEndpoint;
 
   try {
+    const viteDeadline = createStartupDeadline();
     try {
-      await waitForHttp(`http://127.0.0.1:${vitePort}/shellguard.html`, "vite dev server", guard.getViteLaunchError);
+      await waitForHttp(`http://127.0.0.1:${vitePort}/shellguard.html`, "vite dev server", guard.getViteLaunchError, {
+        signal: viteDeadline.signal,
+      });
     } catch (error) {
       throw new Error(describeBrowserStartupFailure({ error, subsystem: "vite", viteStderr: guard.getViteError() }));
+    } finally {
+      viteDeadline.clear();
     }
     const startupDeadline = createStartupDeadline();
     try {

--- a/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/shellguard/run.mjs
@@ -17,13 +17,12 @@ import {
   clearViewportOverride,
   connectPage,
   createStartupDeadline,
-  devtoolsHttpURL,
   evaluate,
   navigateTo,
   waitForFonts,
   waitForHttp,
 } from "../browserGuardCdp.mjs";
-import { describeBrowserStartupFailure, startBrowserGuard } from "../browserGuardProcess.mjs";
+import { describeBrowserStartupFailure, startBrowserGuard, waitForBrowserReady } from "../browserGuardProcess.mjs";
 
 const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -245,29 +244,7 @@ async function main() {
     } finally {
       viteDeadline.clear();
     }
-    const startupDeadline = createStartupDeadline();
-    try {
-      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
-      await waitForHttp(
-        devtoolsHttpURL(cdpEndpoint, "/json/version"),
-        "chrome devtools endpoint",
-        guard.getChromeLaunchError,
-        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
-      );
-    } catch (error) {
-      throw new Error(
-        describeBrowserStartupFailure({
-          error,
-          subsystem: "chrome",
-          chromeBinary: guard.chromeBinary,
-          chromeArgv: guard.getChromeArgv(),
-          chromeStderr: guard.getChromeError(),
-          viteStderr: guard.getViteError(),
-        }),
-      );
-    } finally {
-      startupDeadline.clear();
-    }
+    cdpEndpoint = await waitForBrowserReady(guard);
     const result = await measureOnPage(
       cdpEndpoint,
       vitePort,

--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -352,12 +352,17 @@ async function main() {
 
   let failed = 0;
   try {
+    const viteDeadline = createStartupDeadline();
     try {
-      await waitForHttp(`http://127.0.0.1:${vitePort}/spawnguard.html`, "vite dev server", guard.getViteLaunchError);
+      await waitForHttp(`http://127.0.0.1:${vitePort}/spawnguard.html`, "vite dev server", guard.getViteLaunchError, {
+        signal: viteDeadline.signal,
+      });
     } catch (error) {
       throw new Error(
         describeBrowserStartupFailure({ error: error, subsystem: "vite", viteStderr: guard.getViteError() }),
       );
+    } finally {
+      viteDeadline.clear();
     }
     const startupDeadline = createStartupDeadline();
     try {

--- a/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/spawnguard/run.mjs
@@ -13,13 +13,12 @@ import {
   clearViewportOverride,
   connectPage,
   createStartupDeadline,
-  devtoolsHttpURL,
   evaluate,
   navigateTo,
   waitForFonts,
   waitForHttp,
 } from "../browserGuardCdp.mjs";
-import { describeBrowserStartupFailure, startBrowserGuard } from "../browserGuardProcess.mjs";
+import { describeBrowserStartupFailure, startBrowserGuard, waitForBrowserReady } from "../browserGuardProcess.mjs";
 
 const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const WIDTHS = [320, 390, 899, 900, 1440];
@@ -364,29 +363,7 @@ async function main() {
     } finally {
       viteDeadline.clear();
     }
-    const startupDeadline = createStartupDeadline();
-    try {
-      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
-      await waitForHttp(
-        devtoolsHttpURL(cdpEndpoint, "/json/version"),
-        "chrome devtools endpoint",
-        guard.getChromeLaunchError,
-        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
-      );
-    } catch (error) {
-      throw new Error(
-        describeBrowserStartupFailure({
-          error: error,
-          subsystem: "chrome",
-          chromeBinary: guard.chromeBinary,
-          chromeArgv: guard.getChromeArgv(),
-          chromeStderr: guard.getChromeError(),
-          viteStderr: guard.getViteError(),
-        }),
-      );
-    } finally {
-      startupDeadline.clear();
-    }
+    cdpEndpoint = await waitForBrowserReady(guard);
     for (const width of WIDTHS) {
       const result = await measureAt(cdpEndpoint, vitePort, width);
       const failures = assertResult(result, width);

--- a/cmd/evener-hub/frontend/scripts/transcriptscrollguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/transcriptscrollguard/run.mjs
@@ -55,12 +55,20 @@ async function main() {
   let cdpEndpoint;
 
   try {
+    const viteDeadline = createStartupDeadline();
     try {
-      await waitForHttp(`http://127.0.0.1:${vitePort}/transcriptscrollguard.html`, "vite dev server", guard.getViteLaunchError);
+      await waitForHttp(
+        `http://127.0.0.1:${vitePort}/transcriptscrollguard.html`,
+        "vite dev server",
+        guard.getViteLaunchError,
+        { signal: viteDeadline.signal },
+      );
     } catch (error) {
       throw new Error(
         describeBrowserStartupFailure({ error, subsystem: "vite", viteStderr: guard.getViteError() }),
       );
+    } finally {
+      viteDeadline.clear();
     }
     const startupDeadline = createStartupDeadline();
     try {

--- a/cmd/evener-hub/frontend/scripts/transcriptscrollguard/run.mjs
+++ b/cmd/evener-hub/frontend/scripts/transcriptscrollguard/run.mjs
@@ -21,13 +21,12 @@ import {
   clearViewportOverride,
   connectPage,
   createStartupDeadline,
-  devtoolsHttpURL,
   evaluate,
   navigateTo,
   waitForFonts,
   waitForHttp,
 } from "../browserGuardCdp.mjs";
-import { describeBrowserStartupFailure, startBrowserGuard } from "../browserGuardProcess.mjs";
+import { describeBrowserStartupFailure, startBrowserGuard, waitForBrowserReady } from "../browserGuardProcess.mjs";
 
 const FRONTEND = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 
@@ -70,29 +69,7 @@ async function main() {
     } finally {
       viteDeadline.clear();
     }
-    const startupDeadline = createStartupDeadline();
-    try {
-      cdpEndpoint = await guard.waitForChrome({ signal: startupDeadline.signal });
-      await waitForHttp(
-        devtoolsHttpURL(cdpEndpoint, "/json/version"),
-        "chrome devtools endpoint",
-        guard.getChromeLaunchError,
-        { signal: startupDeadline.signal, failure: guard.getChromeFailure() },
-      );
-    } catch (error) {
-      throw new Error(
-        describeBrowserStartupFailure({
-          error,
-          subsystem: "chrome",
-          chromeBinary: guard.chromeBinary,
-          chromeArgv: guard.getChromeArgv(),
-          chromeStderr: guard.getChromeError(),
-          viteStderr: guard.getViteError(),
-        }),
-      );
-    } finally {
-      startupDeadline.clear();
-    }
+    cdpEndpoint = await waitForBrowserReady(guard);
 
     const page = await connectPage(cdpEndpoint);
     const { send } = page;


### PR DESCRIPTION
## Symptom

Run [34257184696](https://github.com/prime-radiant-inc/evener/actions/runs/34257184696) (main push `91d1d6356`, 2026-09-08) failed the required `web` job:

```
FAIL  web-layoutguard (exit 2)
browser guard startup failed (environment problem, not a test case failure): browser startup deadline exceeded after 30000ms
...
DevTools listening on ws://127.0.0.1:44767/devtools/browser/7d93ae34-...
```

Chrome had announced its DevTools endpoint, and the guard still died on the startup deadline. The other four guards, which run after it with a warm Chrome, passed.

## Cause

`waitForHttp` (`browserGuardCdp.mjs`) polls the endpoint every 100 ms, but an attempt had no bound of its own — `fetch` never gives up on a connected socket. Once Chrome announces its endpoint the port is **bound**, so a probe can no longer fail fast: the connection is accepted and, while the browser thread behind it is still busy, simply ignored. The first request to land in that window held the entire 30 s budget, and the retry loop below it never ran a second time. The retry only ever advanced on a fast failure (connection refused), which after the announcement cannot happen.

The log pins the phase: the Chrome stderr capture is read in the same microtask drain as the deadline's abort, so the announcement can only appear in it if it arrived *before* the deadline fired. Chrome was up; the budget went to waiting for its endpoint to answer.

Reproduced deterministically against a loopback socket that accepts connections and stays silent for 5 s: `waitForHttp` sent exactly one request and failed at its 20 s deadline, 15 s after the endpoint started answering. With this change it retries and returns at 6.3 s.

## What the fix does

- Each probe attempt gets its own 2 s tripwire bound, composed with the caller's signal via `AbortSignal.any`, so the startup deadline still cancels the in-flight request instead of leaving a socket holding the guard's event loop open. The attempt timer is cleared in a `finally`, the discipline the rest of this module is built on.
- The deadline error now names the phase it died in, the endpoint it was polling, the attempt count, and what the last attempt was doing. The announcement wait and the endpoint wait share one deadline and previously reported the same bare message — which is why the CI log above could not say which had stalled.

## What it does not do

- It does not raise any deadline. The overall 30 s startup budget is unchanged; per `docs/developing-evener/testing.md`, the per-attempt bound is a tripwire on a poll, not the mechanism.
- It does not retry anything a test case does. The change is confined to startup readiness polling, which runs before the first case; case execution over CDP is untouched, so no real failure can be retried or hidden.
- It does not change the environment-vs-test-failure classification: the error still flows through `describeBrowserStartupFailure` as "environment problem, not a test case failure".
- It cannot make a browser that is genuinely unresponsive for 30 s pass. It removes the case where a browser that *was* ready spent the budget inside one abandoned-nowhere request.

## Tests

Two regression tests in `browserGuardCdp.test.mjs`, both against a real loopback socket:

- *a probe attempt that never answers is abandoned so the poll keeps going* — RED: failed at 3008 ms with "browser startup deadline exceeded after 3000ms" (the whole deadline inside one attempt). GREEN: 515 ms, more than one request sent, no attempt timer outliving its attempt.
- *the startup deadline says which endpoint it was polling and how often* — RED: message was the bare `browser startup deadline exceeded after 600ms`. GREEN: names the label, URL and attempt count.

`node --test scripts/*.test.mjs`: 66/66 pass. `make test-web`: PASS (typecheck, test, lint). `make test-web-browser`: all five guards PASS, twice (32.4 s, 27.6 s).