### PR TITLE
test(web): own the last two act-diagnostics residuals

### DIFF
--- a/cmd/evener-hub/frontend/src/dev/surface-sections/composer.test.tsx
+++ b/cmd/evener-hub/frontend/src/dev/surface-sections/composer.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, within } from "@testing-library/react";
 import { afterEach, expect, test } from "vitest";
 import { resetAskDockStoreForTests } from "../../panes/session/composer/askDock/askDockStore";
+import { flushPendingTurnsProjectionForTests } from "../../panes/session/composer/queue/pendingTurnsStore";
 import { resetThreadsStoreForTests } from "../../stores/threads";
 import ComposerSurfaceSection from "./composer";
 
@@ -11,8 +12,12 @@ afterEach(() => {
   localStorage.clear();
 });
 
-test("each themed composer has a dedicated pane-width fixture and retains editable drafts and question selection", () => {
+test("each themed composer has a dedicated pane-width fixture and retains editable drafts and question selection", async () => {
   const { container } = render(<ComposerSurfaceSection />);
+  // The section's mount effect seeds threadsStore with three real composer
+  // fixtures; that schedules the pending-turns projection, which publishes
+  // asynchronously. Own its tracked completion before the test body ends.
+  await flushPendingTurnsProjectionForTests();
   const panes = container.querySelectorAll("[data-theme]");
   expect(panes).toHaveLength(2);
   for (const pane of panes) {
@@ -25,7 +30,10 @@ test("each themed composer has a dedicated pane-width fixture and retains editab
     if (!drafted || !pending) throw new Error("missing gallery fixture");
     const input = within(drafted).getByRole("textbox") as HTMLTextAreaElement;
     expect(input.value).toContain("CHANGELOG");
-    input.focus();
+    // focus() blurs the previously focused pane's textarea; the Composer's
+    // blur handler (handleTextareaBlur) updates state in response, so the
+    // raw DOM focus call must be owned.
+    act(() => input.focus());
     fireEvent.change(input, { target: { value: "Keep this editable" } });
     expect(input.value).toBe("Keep this editable");
     expect(document.activeElement).toBe(input);

--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.integration.test.tsx
@@ -397,7 +397,9 @@ test.each(["other control", "sibling Composer", "replacement Composer"] as const
       } else {
         if (destination === "replacement Composer") cleanup();
         fake.on("thread/read", () => readResponse("ref_b", idleFocusThread("ref_b")));
-        await threadsStore.getState().ensureThread("ref_b");
+        await act(async () => {
+          await threadsStore.getState().ensureThread("ref_b");
+        });
         const second = render(<Composer ref="ref_b" />);
         destinationElement = second
           .getAllByRole("textbox", { name: "Message" })


### PR DESCRIPTION
## What

Two test-only residuals left after #1132's diagnostics cleanup, found by a full raw frontend run at e812703f (442 files / 10,035 tests green, but 767 act warnings in exactly two files). Each fix owns the actual update boundary; no production code, no assertion changes, no suppression.

1. **`src/dev/surface-sections/composer.test.tsx` (760 warnings → 0)**: the section's mount effect seeds threadsStore with three real composer fixtures, scheduling the pending-turns projection that publishes asynchronously after the sync test body ended. The test now awaits the existing `flushPendingTurnsProjectionForTests()` after render, and the raw `input.focus()` is wrapped in `act` — a stack capture showed the blur it triggers on the previous pane's textarea reaches `Composer.tsx:1245 handleTextareaBlur`'s state update outside act.
2. **`src/panes/session/composer/Composer.integration.test.tsx` (7 warnings → 0)**: "ordinary Send does not steal focus from sibling/replacement Composer after a delayed commit" hydrated the sibling thread with a bare `await threadsStore.getState().ensureThread("ref_b")`, publishing to the mounted composer outside act. The call is now inside `await act(async () => ...)`.

## Evidence

- Red (at e812703f, focused): gallery 760 warnings; focus test 7 warnings (`main-residual-gallery-red.log`, `main-residual-focus-red.log`).
- Green (focused): both zero warnings (`main-residual-gallery-green2.log`, `main-residual-focus-green.log`).
- Full suite on this branch: typecheck exit 0; `npm run test` 442 files / 10,035 Vitest + 81 Node tests pass with **zero** stderr blocks, zero act warnings, zero ExperimentalWarning (`main-residual-final-full.log`).

## Notes

- Follow-up to #1132; the no-Stop sighting and duplicate-turn captures it landed remain untouched and clean.
- Relates to the PR #1070 delivery work (the notes branch integrates current main next); this PR is independent of that feature and can land alone.