### PR TITLE
test(serve): gate the idle-publication harness on the bridge's terminal projection

### DIFF
--- a/cmd/evener/serve_state_test.go
+++ b/cmd/evener/serve_state_test.go
@@ -65,12 +65,52 @@ type idlePublicationServer struct {
 	idlePublished  chan struct{}
 	publishedState string
 	publishOnce    sync.Once
+
+	// One turn writes the status thread/read returns from two goroutines. The
+	// serve loop writes it synchronously at the tail of every input pass; the
+	// event bridge writes it again as it projects that turn's carriers --
+	// active when the user-input carrier lands
+	// (server/appwire_runtime.go:439), idle again when the session-end carrier
+	// does (server/bridge.go:223-228). The bridge drains a buffered feed on its
+	// own goroutine, so the loop's idle write is not the end of the publication
+	// a reader observes.
+	turnProjected     chan struct{}
+	turnProjectedOnce sync.Once
+
+	// Parking the turn's carrier until the loop has published idle makes the
+	// lagging-bridge ordering happen every run instead of only under load.
+	releaseCarrier     chan struct{}
+	releaseCarrierOnce sync.Once
 }
 
 func newIdlePublicationServer(cfg server.ServerConfig) *idlePublicationServer {
 	return &idlePublicationServer{
-		Server:        server.NewServer(cfg),
-		idlePublished: make(chan struct{}),
+		Server:         server.NewServer(cfg),
+		idlePublished:  make(chan struct{}),
+		turnProjected:  make(chan struct{}),
+		releaseCarrier: make(chan struct{}),
+	}
+}
+
+// holdTurnCarrier parks the bridge on the turn's opening carrier until the serve
+// loop has published its post-turn state, which is the ordering CI reached on
+// its own: the carrier's projection republishes active after the loop wrote
+// idle.
+func (s *idlePublicationServer) holdTurnCarrier(ev events.SessionEvent) {
+	if ev.Kind != events.EventUserInput {
+		return
+	}
+	select {
+	case <-s.idlePublished:
+	case <-s.releaseCarrier:
+	}
+}
+
+// noteTurnProjected opens the gate on the session-end carrier: it is the last
+// write the bridge makes to the status this turn publishes.
+func (s *idlePublicationServer) noteTurnProjected(ev events.SessionEvent) {
+	if ev.Kind == events.EventSessionEnd {
+		s.turnProjectedOnce.Do(func() { close(s.turnProjected) })
 	}
 }
 
@@ -530,10 +570,11 @@ func TestRunServe_StreamErrorPublishesIdleStatus(t *testing.T) {
 	// The dep must return once attached and drain on its own goroutine; see
 	// serveDeps.bridge.
 	deps.bridge = func(_ serveServer, session *agent.Session, observer func(events.SessionEvent), onDrained func()) {
-		go func() {
-			defer onDrained()
-			server.BridgeWithObserver(observedServer.Server, session.Events(), observer)
-		}()
+		session.ConsumeEventsLossless(func(ev events.SessionEvent) {
+			observedServer.holdTurnCarrier(ev)
+			server.BridgeEvent(observedServer.Server, ev, observer)
+			observedServer.noteTurnProjected(ev)
+		}, onDrained)
 	}
 	deps.subscriberCount = func(_ serveServer, id string) int {
 		return observedServer.AppServer().SubscriberCount(id)
@@ -552,6 +593,9 @@ func TestRunServe_StreamErrorPublishesIdleStatus(t *testing.T) {
 	}()
 
 	entry := waitForServeTestRendezvous(t, runDir)
+	t.Cleanup(func() {
+		observedServer.releaseCarrierOnce.Do(func() { close(observedServer.releaseCarrier) })
+	})
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	transport, err := appwire.DialWebSocket(ctx, "ws://"+entry.Address+"/rpc", http.DefaultClient)
@@ -585,6 +629,17 @@ func TestRunServe_StreamErrorPublishesIdleStatus(t *testing.T) {
 	if got := observedServer.postTurnState(); got != string(agent.SessionIdle) {
 		t.Fatalf("published post-turn state = %q, want %q", got, agent.SessionIdle)
 	}
+	// Everything below reads the server's published status, which the loop's
+	// write above does not settle: the bridge projects the same turn's carriers
+	// on its own goroutine, republishing active for the user-input carrier and
+	// idle again only for the session-end one. Wait for that last write rather
+	// than for the loop's.
+	select {
+	case <-observedServer.turnProjected:
+	case <-ctx.Done():
+		t.Fatalf("post-turn terminal projection: %v", ctx.Err())
+	}
+
 	if got := observedServer.GetStatus().State; got != string(agent.SessionIdle) {
 		t.Fatalf("stored server state = %q, want %q", got, agent.SessionIdle)
 	}


### PR DESCRIPTION
## Signature

`TestRunServe_StreamErrorPublishesIdleStatus` failed in CI on PR #1137 (head `87f4944`, a
frontend-only change that cannot touch this code), `tests` job, and passed on rerun:

```
--- FAIL: TestRunServe_StreamErrorPublishesIdleStatus (0.22s)
    serve_state_test.go:601: thread/read = status "active", capabilities {Send:false Steer:true
    Interrupt:true Compact:true Clear:false ForkFromTurn:false Shutdown:true ChangeModel:true
    ChangeVisionModel:true Queue:true Goal:true Rename:true}; want idle, send enabled, queue and
    interrupt disabled
```

## Root cause

In the harness, not the daemon.

One turn writes the status `thread/read` returns from **two goroutines**:

- the serve input loop writes it synchronously at the tail of every input pass —
  `cmd/evener/serve.go:1320-1322` (`srv.SetProcessing(false)` then `srv.SetState(sess.WireState())`);
- the event bridge writes it again as it projects that same turn's carriers — `active` when the
  user-input carrier lands (`server/appwire_runtime.go:437-440`, whose comment names this
  reconciliation: "A carrier can arrive after processing cleanup ... Reconcile the pull state
  before publishing the carrier's active notification so thread/read agrees with it"), and `idle`
  again when the session-end carrier does (`server/bridge.go:215-229` via
  `applySessionEventStatus`).

`thread/read` reads exactly that field: `appStatus(status.State, processing, turnReserved)` at
`server/appwire_runtime.go:2266` and `:2557`, with the whole capability set derived from the same
status (`server/appwire_runtime.go:2419-2432`) — which is why the reported set is the full active
one.

The bridge drains a buffered feed (256-deep, `agent/session_init.go:295`) on its own goroutine, so
the loop's idle write is **not** the end of the publication a reader observes.
`idlePublicationServer.SetState` (`cmd/evener/serve_state_test.go:97-107`, pre-fix) opened its gate
on that loop write. A bridge still holding the turn's carrier therefore republished `active` after
the test had already been released, and `thread/read` at `:601` — and the stored-state assertion
beside it at `:588` — read the carrier's `active`.

This is the same class as #1133 (`bf67c454f`): the gate stopped at a proxy signal instead of the
publication the assertion reads.

## Fix

- The gate now waits on the projection of the **session-end carrier** — the bridge's last write to
  this turn's status — before the assertions that read that status. No assertion is weakened,
  deleted or re-pointed.
- The bridge dep moves to `ConsumeEventsLossless` + `BridgeEvent`, matching the daemon's own dep
  (`cmd/evener/serve.go:220-225`) and the sibling harness in this file; the channel form it used is
  the one `server/bridge.go:18-20` documents as not the daemon's path.
- The harness holds the turn's opening carrier until the loop has published idle, so the
  lagging-bridge ordering happens **every run** rather than only under load — the same pinning
  #1133 applied to its unclaimed pass.

## Reproduction evidence

The natural race did not reproduce locally in 190 `-race` iterations (50 at `GOMAXPROCS=2` idle, 60
at `GOMAXPROCS=2` with six busy loops, 80 at `GOMAXPROCS=1` with eight), nor across four full
`cmd/evener` package runs under the same pressure. Instrumenting the harness showed why: locally the
bridge always drains the turn's carrier well before the loop's tail (traced
`bridge projected USER_INPUT state=active` ~14ms ahead of `SetState(idle)`).

Constructing the ordering makes it deterministic:

- Pre-fix gate + carrier held until the loop's idle publication: **5 of 5 red**, at the stored-state
  assertion (`stored server state = "active", want "idle"`) — the same window, one statement earlier.
- Pre-fix gate + bridge additionally parked between the carrier and the terminal event: **5 of 5
  red** at the CI assertion, reproducing the CI message exactly, capability set included.
- With the gate: **50 of 50** green under `-race` at `GOMAXPROCS=2` with six busy loops, **50 of 50**
  at `GOMAXPROCS=1` with eight, and 50 of 50 with `-count=50` unpressured.

## Gates

- `go test -race -count=50` focused: PASS
- `go test -count=1 ./cmd/evener/...`: ok (4 packages)
- `go test -race -count=1 ./cmd/evener/`: ok
- `go test -run TestNoBareWallClockDeadlineInAgentTests ./agent/`: ok (no wall-clock bound added; the
  new wait uses the test's existing context)
- `gofmt -l cmd/evener/`: clean
- `go vet ./cmd/evener/...`: clean
- `golangci-lint run ./cmd/evener/...` (pinned 2.13.1): 0 issues
