### PR TITLE
fix(web): honor the Reasoning flag with a content-free Thinking… placeholder

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -87,6 +87,20 @@ test("wires a content-free thinking entry through TurnBlock to the placeholder (
   expect(screen.queryByText("abcdefghijklmnop")).toBeNull();
 });
 
+test("redacts a critical reasoning row on a terminal turn", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+  const projected = turn(
+    [item({ type: "reasoning", status: "failed", reasoningSummaries: [["abcdefghijklmnop"]] })],
+    { status: "interrupted" },
+    config,
+  );
+  render(withConfig(config, <TurnBlock turn={projected} />));
+  expect(screen.getByTestId("think-block-redacted").textContent).toContain("Thought failed");
+  expect(screen.queryByText("abcdefghijklmnop")).toBeNull();
+  expect(screen.queryByTestId("think-block-live-body")).toBeNull();
+  expect(document.querySelector("details")).toBeNull();
+});
+
 test("the turn root remains a centered, shrinkable reading column", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "turnblock.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.test.tsx
@@ -73,6 +73,20 @@ test("tags the root with the turn id", () => {
   expect(container.querySelector('[data-turn-id="turn_42"]')).toBeTruthy();
 });
 
+test("wires a content-free thinking entry through TurnBlock to the placeholder (never the thought body)", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "tools" });
+  const projected = turn(
+    [item({ type: "reasoning", status: "inProgress", reasoningSummaries: [["abcdefghijklmnop"]] })],
+    {},
+    config,
+  );
+  render(withConfig(config, <TurnBlock turn={projected} />));
+  expect(screen.getByText(/Thinking…/)).toBeTruthy();
+  expect(screen.getByTestId("loader-grid")).toBeTruthy();
+  expect(screen.queryByTestId("think-block-live-body")).toBeNull();
+  expect(screen.queryByText("abcdefghijklmnop")).toBeNull();
+});
+
 test("the turn root remains a centered, shrinkable reading column", () => {
   const here = dirname(fileURLToPath(import.meta.url));
   const css = readFileSync(join(here, "turnblock.module.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
@@ -288,6 +288,7 @@ export function TurnBlock({
         opensExchange={exchangeOpeners?.has(item.id)}
         agentLabel={agentLabel}
         projectedSummary={entry.kind === "critical" ? entry.summary : undefined}
+        contentFree={entry.kind === "thinking"}
         renderContext={itemRenderContext}
         thread={thread}
         threadFingerprint={threadFingerprintForItem(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/TurnBlock.tsx
@@ -289,6 +289,7 @@ export function TurnBlock({
         agentLabel={agentLabel}
         projectedSummary={entry.kind === "critical" ? entry.summary : undefined}
         contentFree={entry.kind === "thinking"}
+        redacted={entry.kind === "critical" && entry.redacted}
         renderContext={itemRenderContext}
         thread={thread}
         threadFingerprint={threadFingerprintForItem(

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx
@@ -113,6 +113,32 @@ test("contentFree with no chunks yet shows the label alone, never a fabricated t
   expect(screen.queryByText(/tokens/)).toBeNull();
 });
 
+// --- redacted: critical reasoning on a broken turn, no thought text ---------
+
+test("redacted renders a neutral failure summary and none of the thought text, preview, or body", () => {
+  render(
+    <ThinkBlock
+      item={item({ status: "failed", reasoningSummaries: [["abcdefghijklmnop"]] })}
+      turn={turn}
+      live={false}
+      redacted={true}
+    />,
+  );
+  expect(screen.getByTestId("think-block-redacted").textContent).toContain("Thought failed");
+  expect(screen.queryByText("abcdefghijklmnop")).toBeNull();
+  expect(screen.queryByTestId("think-block-live-body")).toBeNull();
+  expect(document.querySelector("details")).toBeNull();
+});
+
+test("redacted without a failed item status uses the neutral label", () => {
+  render(
+    <ThinkBlock item={item({ reasoningSummaries: [["abcdefghijklmnop"]] })} turn={turn} live={false} redacted={true} />,
+  );
+  expect(screen.getByTestId("think-block-redacted").textContent).toContain("Thought not shown");
+  expect(screen.queryByText("abcdefghijklmnop")).toBeNull();
+  expect(document.querySelector("details")).toBeNull();
+});
+
 // Jesse's review call: a blinking caret inside a read-only reasoning view
 // reads as an edit cursor. Liveness is carried by the "Thinking…" eyebrow
 // and the visibly growing text, so the live view mounts no StreamingText at

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx
@@ -86,6 +86,33 @@ test("live shows a Thinking label and renders the reasoning text open (not colla
   expect(document.querySelector("details")).toBeNull();
 });
 
+// --- content-free: Loader placeholder, no thought text ----------------------
+
+test("contentFree renders only the Loader placeholder and an approximate token count, never the thought text", () => {
+  render(
+    <ThinkBlock
+      item={item({ reasoningSummaries: [["abcdefghijklmnop"]] })}
+      turn={turn}
+      live={true}
+      contentFree={true}
+    />,
+  );
+  expect(screen.getByText(/Thinking…/)).toBeTruthy();
+  // 16 characters -> characters/4 -> 4, marked approximate.
+  expect(screen.getByText(/~4 tokens/)).toBeTruthy();
+  expect(screen.getByTestId("loader-grid")).toBeTruthy();
+  // No body, no settled disclosure, and above all no thought text.
+  expect(screen.queryByTestId("think-block-live-body")).toBeNull();
+  expect(screen.queryByText("abcdefghijklmnop")).toBeNull();
+  expect(document.querySelector("details")).toBeNull();
+});
+
+test("contentFree with no chunks yet shows the label alone, never a fabricated token count", () => {
+  render(<ThinkBlock item={item({ reasoningSummaries: [] })} turn={turn} live={true} contentFree={true} />);
+  expect(screen.getByText("Thinking…")).toBeTruthy();
+  expect(screen.queryByText(/tokens/)).toBeNull();
+});
+
 // Jesse's review call: a blinking caret inside a read-only reasoning view
 // reads as an edit cursor. Liveness is carried by the "Thinking…" eyebrow
 // and the visibly growing text, so the live view mounts no StreamingText at

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.test.tsx
@@ -115,13 +115,14 @@ test("contentFree with no chunks yet shows the label alone, never a fabricated t
 
 // --- redacted: critical reasoning on a broken turn, no thought text ---------
 
-test("redacted renders a neutral failure summary and none of the thought text, preview, or body", () => {
+test("redacted renders the projector's summary and none of the thought text, preview, or body", () => {
   render(
     <ThinkBlock
       item={item({ status: "failed", reasoningSummaries: [["abcdefghijklmnop"]] })}
       turn={turn}
       live={false}
       redacted={true}
+      projectedSummary="Thought failed"
     />,
   );
   expect(screen.getByTestId("think-block-redacted").textContent).toContain("Thought failed");
@@ -130,9 +131,15 @@ test("redacted renders a neutral failure summary and none of the thought text, p
   expect(document.querySelector("details")).toBeNull();
 });
 
-test("redacted without a failed item status uses the neutral label", () => {
+test("redacted renders the neutral label the projector supplies", () => {
   render(
-    <ThinkBlock item={item({ reasoningSummaries: [["abcdefghijklmnop"]] })} turn={turn} live={false} redacted={true} />,
+    <ThinkBlock
+      item={item({ reasoningSummaries: [["abcdefghijklmnop"]] })}
+      turn={turn}
+      live={false}
+      redacted={true}
+      projectedSummary="Thought not shown"
+    />,
   );
   expect(screen.getByTestId("think-block-redacted").textContent).toContain("Thought not shown");
   expect(screen.queryByText("abcdefghijklmnop")).toBeNull();

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
@@ -212,13 +212,16 @@ function thinkBlockPropsEqual(prev: ItemRenderProps, next: ItemRenderProps): boo
 export const ThinkBlock = memo(function ThinkBlock({ item, turn, live, sessionRef, contentFree }: ItemRenderProps) {
   const context = useTranscriptRenderContext();
   const { config } = context;
-  // The content-free projection never renders the thought's text, so it short
-  // circuits before any disclosure state is read.
-  if (contentFree) return <ContentFreeThinkBlock item={item} />;
   const disclosureScope = disclosureScopeForSession(context, sessionRef);
   const disclosureKey = scopedDisclosureId(disclosureScope, item.id);
   const disclosureFallback = expandDetailsByDefault(config) || disclosureDefault(disclosureScope, item.id, false);
+  // isDisclosureOpen IS a custom hook (it wraps zustand's useStore - see
+  // disclosureStore's own note), so it must be called unconditionally before
+  // any early return: an entry that toggles contentFree on a mounted row would
+  // otherwise change the hook order between renders.
   const open = isDisclosureOpen(disclosureKey, disclosureFallback);
+  // The content-free projection never renders the thought's text.
+  if (contentFree) return <ContentFreeThinkBlock item={item} />;
   const isLive = (live || item.status === "inProgress") && isCurrentThought(item, turn);
   if (isLive) return <LiveThinkBlock item={item} />;
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
@@ -182,6 +182,22 @@ function ContentFreeThinkBlock({ item }: { item: ItemModel }) {
   );
 }
 
+// The redacted counterpart for a critical reasoning row while the reasoning
+// content flag is off: a failed or interrupted turn still explains itself, but
+// never by showing the thought. Only the icon and a neutral failure summary
+// render - no preview, no disclosure, and no body.
+function RedactedThinkBlock({ item }: { item: ItemModel }) {
+  const failed = item.status === "failed" || item.status === "interrupted";
+  return (
+    <div className={CLASS.block} data-testid="think-block" data-redacted="true">
+      <span className={CLASS.label} data-testid="think-block-redacted">
+        {thoughtIcon}
+        {failed ? "Thought failed" : "Thought not shown"}
+      </span>
+    </div>
+  );
+}
+
 // isCurrentThought: whether this reasoning item is still the turn's CURRENT
 // activity - the tail of turn.items. The wire never emits item/completed for
 // a reasoning item (only turn/completed settles it; TurnBlock's isItemLive
@@ -209,7 +225,14 @@ function thinkBlockPropsEqual(prev: ItemRenderProps, next: ItemRenderProps): boo
   return ignoringTurn(prev, next) && isCurrentThought(prev.item, prev.turn) === isCurrentThought(next.item, next.turn);
 }
 
-export const ThinkBlock = memo(function ThinkBlock({ item, turn, live, sessionRef, contentFree }: ItemRenderProps) {
+export const ThinkBlock = memo(function ThinkBlock({
+  item,
+  turn,
+  live,
+  sessionRef,
+  contentFree,
+  redacted,
+}: ItemRenderProps) {
   const context = useTranscriptRenderContext();
   const { config } = context;
   const disclosureScope = disclosureScopeForSession(context, sessionRef);
@@ -220,8 +243,9 @@ export const ThinkBlock = memo(function ThinkBlock({ item, turn, live, sessionRe
   // any early return: an entry that toggles contentFree on a mounted row would
   // otherwise change the hook order between renders.
   const open = isDisclosureOpen(disclosureKey, disclosureFallback);
-  // The content-free projection never renders the thought's text.
+  // Neither content-free state reads the thought's text.
   if (contentFree) return <ContentFreeThinkBlock item={item} />;
+  if (redacted) return <RedactedThinkBlock item={item} />;
   const isLive = (live || item.status === "inProgress") && isCurrentThought(item, turn);
   if (isLive) return <LiveThinkBlock item={item} />;
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
@@ -184,15 +184,16 @@ function ContentFreeThinkBlock({ item }: { item: ItemModel }) {
 
 // The redacted counterpart for a critical reasoning row while the reasoning
 // content flag is off: a failed or interrupted turn still explains itself, but
-// never by showing the thought. Only the icon and a neutral failure summary
-// render - no preview, no disclosure, and no body.
-function RedactedThinkBlock({ item }: { item: ItemModel }) {
-  const failed = item.status === "failed" || item.status === "interrupted";
+// never by showing the thought. Only the icon and the projector's neutral
+// summary render - no preview, no disclosure, and no body. The summary text is
+// owned by the projector (criticalEntry), not re-derived here, so there is one
+// source of truth for it.
+function RedactedThinkBlock({ summary }: { summary: string }) {
   return (
     <div className={CLASS.block} data-testid="think-block" data-redacted="true">
       <span className={CLASS.label} data-testid="think-block-redacted">
         {thoughtIcon}
-        {failed ? "Thought failed" : "Thought not shown"}
+        {summary}
       </span>
     </div>
   );
@@ -232,6 +233,7 @@ export const ThinkBlock = memo(function ThinkBlock({
   sessionRef,
   contentFree,
   redacted,
+  projectedSummary,
 }: ItemRenderProps) {
   const context = useTranscriptRenderContext();
   const { config } = context;
@@ -243,9 +245,11 @@ export const ThinkBlock = memo(function ThinkBlock({
   // any early return: an entry that toggles contentFree on a mounted row would
   // otherwise change the hook order between renders.
   const open = isDisclosureOpen(disclosureKey, disclosureFallback);
-  // Neither content-free state reads the thought's text.
+  // Neither content-free state RENDERS the thought's text. The placeholder
+  // reads it only to estimate a length for its "~N tokens" label; the redacted
+  // state renders the projector's neutral summary and nothing else.
   if (contentFree) return <ContentFreeThinkBlock item={item} />;
-  if (redacted) return <RedactedThinkBlock item={item} />;
+  if (redacted) return <RedactedThinkBlock summary={projectedSummary ?? "Thought not shown"} />;
   const isLive = (live || item.status === "inProgress") && isCurrentThought(item, turn);
   if (isLive) return <LiveThinkBlock item={item} />;
 

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
@@ -51,7 +51,7 @@ import {
   expandDetailsByDefault,
   useTranscriptRenderContext,
 } from "../../../../transcriptDisplay/renderContext";
-import { Chevron, Markdown, ToolIcon } from "../../../../widgets";
+import { Chevron, Loader, Markdown, ToolIcon } from "../../../../widgets";
 import {
   disclosureDefault,
   isDisclosureOpen,
@@ -60,6 +60,7 @@ import {
 } from "../../../../widgets/disclosure/disclosureStore";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { type ItemRenderProps, ignoringTurn, registerItemRenderer } from "../types";
+import { formatTokenCount } from "./format";
 import {
   formatThoughtDuration,
   joinedReasoningParagraphs,
@@ -157,6 +158,30 @@ function LiveThinkBlock({ item }: { item: ItemModel }) {
   );
 }
 
+// The content-free counterpart to LiveThinkBlock: shown when the reasoning
+// content flag is off, so the reader sees that the agent is thinking - through
+// the catalog Loader's pulsing grid - without any of the thought's text. The
+// brain glyph and body are deliberately absent; only the Loader and its label
+// render.
+//
+// The token figure is an ESTIMATE. The wire carries no live token accounting
+// for a reasoning stream (a turn's usage arrives only when the turn settles -
+// see turnMeta.ts), so this is the conventional characters/4 heuristic over
+// the same joined source the streaming body would have rendered, marked
+// approximate with "~". No count renders until the first chunk lands, so a
+// just-started thought shows the label alone rather than a fabricated "~0".
+function ContentFreeThinkBlock({ item }: { item: ItemModel }) {
+  const paragraphs = joinedReasoningParagraphs(item.reasoningSummaries);
+  const characters = paragraphs.reduce((total, paragraph) => total + paragraph.length, 0);
+  const estimatedTokens = Math.round(characters / 4);
+  const label = estimatedTokens > 0 ? `Thinking… · ~${formatTokenCount(estimatedTokens)} tokens` : "Thinking…";
+  return (
+    <div className={CLASS.block} data-testid="think-block" data-live="true" data-content-free="true">
+      <Loader label={label} />
+    </div>
+  );
+}
+
 // isCurrentThought: whether this reasoning item is still the turn's CURRENT
 // activity - the tail of turn.items. The wire never emits item/completed for
 // a reasoning item (only turn/completed settles it; TurnBlock's isItemLive
@@ -184,9 +209,12 @@ function thinkBlockPropsEqual(prev: ItemRenderProps, next: ItemRenderProps): boo
   return ignoringTurn(prev, next) && isCurrentThought(prev.item, prev.turn) === isCurrentThought(next.item, next.turn);
 }
 
-export const ThinkBlock = memo(function ThinkBlock({ item, turn, live, sessionRef }: ItemRenderProps) {
+export const ThinkBlock = memo(function ThinkBlock({ item, turn, live, sessionRef, contentFree }: ItemRenderProps) {
   const context = useTranscriptRenderContext();
   const { config } = context;
+  // The content-free projection never renders the thought's text, so it short
+  // circuits before any disclosure state is read.
+  if (contentFree) return <ContentFreeThinkBlock item={item} />;
   const disclosureScope = disclosureScopeForSession(context, sessionRef);
   const disclosureKey = scopedDisclosureId(disclosureScope, item.id);
   const disclosureFallback = expandDetailsByDefault(config) || disclosureDefault(disclosureScope, item.id, false);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/types.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/types.ts
@@ -28,6 +28,12 @@ export interface ItemRenderProps {
   // A projector-owned compact summary for a critical entry. When present,
   // renderers must not reconstruct a routine summary from raw tool fields.
   projectedSummary?: string;
+  // True when the projector chose a content-free entry for this item (the
+  // "thinking" projection of a live current reasoning item while the reasoning
+  // content flag is off). The renderer must render only a placeholder and must
+  // not read the item's own text. Set for every entry kind by TurnBlock, so a
+  // memoized renderer can compare it by value.
+  contentFree?: boolean;
   /** Snapshot inputs relevant to this item; stable when an unrelated delta lands. */
   threadFingerprint?: string;
   thread?: ThreadModel;
@@ -76,6 +82,7 @@ export function ignoringTurn(prev: ItemRenderProps, next: ItemRenderProps): bool
     prev.opensExchange === next.opensExchange &&
     prev.agentLabel === next.agentLabel &&
     prev.projectedSummary === next.projectedSummary &&
+    prev.contentFree === next.contentFree &&
     prev.renderContext === next.renderContext &&
     prev.threadFingerprint === next.threadFingerprint
   );

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/types.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/types.ts
@@ -34,6 +34,11 @@ export interface ItemRenderProps {
   // not read the item's own text. Set for every entry kind by TurnBlock, so a
   // memoized renderer can compare it by value.
   contentFree?: boolean;
+  // True when a critical reasoning row must render with no thought text at all
+  // (the content flag is off and the row is only on the failure path). The
+  // renderer shows a neutral failure summary instead of the thought's body,
+  // preview, or disclosure.
+  redacted?: boolean;
   /** Snapshot inputs relevant to this item; stable when an unrelated delta lands. */
   threadFingerprint?: string;
   thread?: ThreadModel;
@@ -83,6 +88,7 @@ export function ignoringTurn(prev: ItemRenderProps, next: ItemRenderProps): bool
     prev.agentLabel === next.agentLabel &&
     prev.projectedSummary === next.projectedSummary &&
     prev.contentFree === next.contentFree &&
+    prev.redacted === next.redacted &&
     prev.renderContext === next.renderContext &&
     prev.threadFingerprint === next.threadFingerprint
   );

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/types.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/types.ts
@@ -31,8 +31,9 @@ export interface ItemRenderProps {
   // True when the projector chose a content-free entry for this item (the
   // "thinking" projection of a live current reasoning item while the reasoning
   // content flag is off). The renderer must render only a placeholder and must
-  // not read the item's own text. Set for every entry kind by TurnBlock, so a
-  // memoized renderer can compare it by value.
+  // not render the item's own text (it may read it for a length estimate). Set
+  // for every entry kind by TurnBlock, so a memoized renderer can compare it by
+  // value.
   contentFree?: boolean;
   // True when a critical reasoning row must render with no thought text at all
   // (the content flag is off and the row is only on the failure path). The

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
@@ -350,21 +350,38 @@ describe("transcript projector", () => {
     ]);
   });
 
-  test("hides an in-progress reasoning item while the turn is live when reasoning is off", () => {
+  test("replaces a live current thought with a content-free placeholder when reasoning is off", () => {
     const liveTurn = turn([item("think", "reasoning", { status: "inProgress", text: "in-flight thought" })], {
       status: "inProgress",
     });
     const model = { ...threadWith(), turns: [liveTurn] } as ThreadModel;
 
-    expect(entriesFor(model, preset("chat"))).toEqual([]);
-    expect(entriesFor(model, preset("tools"))).toEqual([]);
+    const placeholder = [expect.objectContaining({ kind: "thinking", id: "think" })];
+    expect(entriesFor(model, preset("chat"))).toEqual(placeholder);
+    expect(entriesFor(model, preset("tools"))).toEqual(placeholder);
     expect(
       entriesFor(model, custom({ toolIntent: true, toolCalls: true, reasoning: false, expandByDefault: false })),
-    ).toEqual([]);
+    ).toEqual(placeholder);
+    // A content-free placeholder is not openable, so it contributes no
+    // disclosure id the Full-view baseline would have to reach.
+    expect(projectThread(model, preset("tools")).eligibleDisclosureIds).toEqual([]);
 
     // With reasoning on, the same live item is ordinary (streaming) content.
     expect(entriesFor(model, preset("full")).map((entry) => entry.id)).toEqual(["think"]);
     expect(entriesFor(model, preset("full")).map((entry) => entry.kind)).toEqual(["item"]);
+  });
+
+  test("hides an in-progress reasoning item that is no longer the turn's current thought when reasoning is off", () => {
+    const liveTurn = turn(
+      [
+        item("think", "reasoning", { status: "inProgress", text: "superseded thought" }),
+        item("agent", "agentMessage", { text: "answer" }),
+      ],
+      { status: "inProgress" },
+    );
+    const model = { ...threadWith(), turns: [liveTurn] } as ThreadModel;
+
+    expect(entriesFor(model, preset("tools")).map((entry) => entry.id)).toEqual(["agent"]);
   });
 
   test("keeps the typed failure marker for failed and interrupted turns", () => {

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
@@ -384,6 +384,15 @@ describe("transcript projector", () => {
     expect(entriesFor(model, preset("tools")).map((entry) => entry.id)).toEqual(["agent"]);
   });
 
+  test("does not show the content-free placeholder on a completed turn with a stale in-progress item", () => {
+    const completed = turn([item("think", "reasoning", { status: "inProgress", text: "stale" })], {
+      status: "completed",
+    });
+    const model = { ...threadWith(), turns: [completed] } as ThreadModel;
+
+    expect(entriesFor(model, preset("tools"))).toEqual([]);
+  });
+
   test("never shows the content-free placeholder on a terminal turn", () => {
     const interrupted = turn([item("think", "reasoning", { status: "inProgress", text: "cut short" })], {
       status: "interrupted",

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
@@ -350,6 +350,23 @@ describe("transcript projector", () => {
     ]);
   });
 
+  test("hides an in-progress reasoning item while the turn is live when reasoning is off", () => {
+    const liveTurn = turn([item("think", "reasoning", { status: "inProgress", text: "in-flight thought" })], {
+      status: "inProgress",
+    });
+    const model = { ...threadWith(), turns: [liveTurn] } as ThreadModel;
+
+    expect(entriesFor(model, preset("chat"))).toEqual([]);
+    expect(entriesFor(model, preset("tools"))).toEqual([]);
+    expect(
+      entriesFor(model, custom({ toolIntent: true, toolCalls: true, reasoning: false, expandByDefault: false })),
+    ).toEqual([]);
+
+    // With reasoning on, the same live item is ordinary (streaming) content.
+    expect(entriesFor(model, preset("full")).map((entry) => entry.id)).toEqual(["think"]);
+    expect(entriesFor(model, preset("full")).map((entry) => entry.kind)).toEqual(["item"]);
+  });
+
   test("keeps the typed failure marker for failed and interrupted turns", () => {
     const model = {
       ...threadWith(),

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
@@ -390,7 +390,16 @@ describe("transcript projector", () => {
     });
     const model = { ...threadWith(), turns: [interrupted] } as ThreadModel;
 
-    expect(entriesFor(model, preset("tools"))).toEqual([expect.objectContaining({ kind: "critical", id: "think" })]);
+    const entries = entriesFor(model, preset("tools"));
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "critical",
+      id: "think",
+      redacted: true,
+      // The summary must never be the thought's own text.
+      summary: "Thought not shown",
+    });
+    expect(entries[0]).not.toMatchObject({ summary: "cut short" });
   });
 
   test("keeps the typed failure marker for failed and interrupted turns", () => {

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.test.ts
@@ -384,6 +384,15 @@ describe("transcript projector", () => {
     expect(entriesFor(model, preset("tools")).map((entry) => entry.id)).toEqual(["agent"]);
   });
 
+  test("never shows the content-free placeholder on a terminal turn", () => {
+    const interrupted = turn([item("think", "reasoning", { status: "inProgress", text: "cut short" })], {
+      status: "interrupted",
+    });
+    const model = { ...threadWith(), turns: [interrupted] } as ThreadModel;
+
+    expect(entriesFor(model, preset("tools"))).toEqual([expect.objectContaining({ kind: "critical", id: "think" })]);
+  });
+
   test("keeps the typed failure marker for failed and interrupted turns", () => {
     const model = {
       ...threadWith(),

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -268,10 +268,12 @@ function decisionFor(
     if (vector.reasoning) return "item";
     // With reasoning off, a live current thought becomes a content-free
     // placeholder: the reader sees that the agent is thinking without the
-    // stream itself. An in-progress thought that is NOT the turn's tail is
-    // deliberately hidden (the renderer would not stream it either). Failure
-    // and terminal-turn visibility stay so a broken turn still explains itself.
-    if (isLiveCurrentReasoning(item, turn)) return "thinking";
+    // stream itself. A terminal turn never takes the placeholder - the agent
+    // is not thinking any more - and an in-progress thought that is NOT the
+    // turn's tail is hidden (the renderer would not stream it either).
+    // Failure and terminal-turn visibility stay so a broken turn still
+    // explains itself.
+    if (isLiveCurrentReasoning(item, turn) && !isTerminalTurn(turn)) return "thinking";
     return hasFailureStatus(item) || isTerminalTurn(turn) ? "critical" : "hidden";
   }
 

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -219,10 +219,10 @@ function criticalEntry(
   if (item.type === "commandExecution") {
     summary = toolSummary(item);
   } else if (item.type === "reasoning") {
-    // A reasoning item's summary must never be its own text: a critical
-    // reasoning row is only ever reached with the content flag off, where any
-    // thought text would defeat the setting.
-    summary = "Thought not shown";
+    // Neutral, and never the thought's own text. A failed or interrupted
+    // thought says so; the renderer renders this verbatim (one source of
+    // truth for the redacted label).
+    summary = hasFailureStatus(item) ? "Thought failed" : "Thought not shown";
   } else {
     summary = itemSummary(item);
   }

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -162,10 +162,12 @@ function isTerminalTurn(turn: TurnModel): boolean {
 // The renderer streams only the reasoning item that is still the turn's current
 // activity - the tail of turn.items (see ThinkBlock's isCurrentThought). The
 // content-free placeholder must match that exactly: a superseded thought must
-// not wear a "Thinking…" label, and a thought that is no longer the current one
-// has nothing content-free left to say.
+// not wear a "Thinking…" label, and neither must a thought on a turn that has
+// settled. The `turn.status` guard matters because a completed turn can still
+// carry a stale `inProgress` reasoning item in a snapshot or a race, and the
+// loader must not pulse for an agent that is no longer thinking.
 function isLiveCurrentReasoning(item: ItemModel, turn: TurnModel): boolean {
-  return isActiveItem(item, turn) && turn.items[turn.items.length - 1] === item;
+  return turn.status === "inProgress" && isActiveItem(item, turn) && turn.items[turn.items.length - 1] === item;
 }
 
 function itemSummary(item: ItemModel): string {
@@ -291,12 +293,12 @@ function decisionFor(
     if (vector.reasoning) return "item";
     // With reasoning off, a live current thought becomes a content-free
     // placeholder: the reader sees that the agent is thinking without the
-    // stream itself. A terminal turn never takes the placeholder - the agent
-    // is not thinking any more - and an in-progress thought that is NOT the
-    // turn's tail is hidden (the renderer would not stream it either).
-    // Failure and terminal-turn visibility stay so a broken turn still
-    // explains itself.
-    if (isLiveCurrentReasoning(item, turn) && !isTerminalTurn(turn)) return "thinking";
+    // stream itself. Only an in-progress turn takes the placeholder - a
+    // terminal turn's agent is not thinking any more - and an in-progress
+    // thought that is NOT the turn's tail is hidden (the renderer would not
+    // stream it either). Failure and terminal-turn visibility stay so a broken
+    // turn still explains itself.
+    if (isLiveCurrentReasoning(item, turn)) return "thinking";
     return hasFailureStatus(item) || isTerminalTurn(turn) ? "critical" : "hidden";
   }
 

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -44,6 +44,12 @@ export type ProjectedEntry =
       sourceItemId?: string;
       item: ItemModel;
       summary: string;
+      /**
+       * A critical reasoning item whose text must not render because the
+       * `reasoning` content flag is off. The renderer shows a neutral failure
+       * summary instead of the thought's live body, preview, or disclosure.
+       */
+      redacted: boolean;
     };
 
 type ProjectedCriticalEntry = Extract<ProjectedEntry, { kind: "critical" }>;
@@ -203,7 +209,23 @@ function intentEntry(item: ItemModel, turnId: string, sourceIndex: number): Proj
   };
 }
 
-function criticalEntry(item: ItemModel, turnId: string, sourceIndex: number): ProjectedCriticalEntry {
+function criticalEntry(
+  item: ItemModel,
+  turnId: string,
+  sourceIndex: number,
+  redacted: boolean,
+): ProjectedCriticalEntry {
+  let summary: string;
+  if (item.type === "commandExecution") {
+    summary = toolSummary(item);
+  } else if (item.type === "reasoning") {
+    // A reasoning item's summary must never be its own text: a critical
+    // reasoning row is only ever reached with the content flag off, where any
+    // thought text would defeat the setting.
+    summary = "Thought not shown";
+  } else {
+    summary = itemSummary(item);
+  }
   return {
     kind: "critical",
     id: item.id,
@@ -211,7 +233,8 @@ function criticalEntry(item: ItemModel, turnId: string, sourceIndex: number): Pr
     sourceIndex,
     sourceItemId: item.id,
     item,
-    summary: item.type === "commandExecution" ? toolSummary(item) : itemSummary(item),
+    summary,
+    redacted,
   };
 }
 
@@ -295,6 +318,14 @@ function eligibleDisclosure(item: ItemModel): boolean {
   return item.type === "systemMessage" && item.eventKind !== undefined && item.eventKind !== "";
 }
 
+// A reasoning item projected as critical while the `reasoning` content flag is
+// off must render redacted: the reader asked not to see thoughts, and a broken
+// turn is no licence to show them. The renderer shows a neutral failure summary
+// instead (see ProjectedEntry's critical.redacted).
+function redactsReasoning(item: ItemModel, vector: ContentVector): boolean {
+  return item.type === "reasoning" && !vector.reasoning;
+}
+
 function addAnchor(anchors: ProjectedAnchor[], entry: ProjectedEntry, index: number): void {
   anchors.push({
     id: entry.id,
@@ -307,13 +338,14 @@ function addAnchor(anchors: ProjectedAnchor[], entry: ProjectedEntry, index: num
 function terminalFallbackEntry(
   turn: TurnModel,
   sourceIndexByItem: ReadonlyMap<ItemModel, number>,
+  vector: ContentVector,
 ): ProjectedCriticalEntry | undefined {
   if (!isTerminalTurn(turn)) return undefined;
   const sourceItem = turn.items.at(-1);
   if (!sourceItem) return undefined;
   const sourceIndex = sourceIndexByItem.get(sourceItem);
   if (sourceIndex === undefined) return undefined;
-  return criticalEntry(sourceItem, turn.id, sourceIndex);
+  return criticalEntry(sourceItem, turn.id, sourceIndex, redactsReasoning(sourceItem, vector));
 }
 
 export function projectThread(model: ThreadModel, config: TranscriptDisplayConfigV1): TranscriptProjection {
@@ -344,7 +376,7 @@ export function projectThread(model: ThreadModel, config: TranscriptDisplayConfi
       } else if (decision === "intent") {
         entry = intentEntry(item, turn.id, itemSourceIndex);
       } else {
-        entry = criticalEntry(item, turn.id, itemSourceIndex);
+        entry = criticalEntry(item, turn.id, itemSourceIndex, redactsReasoning(item, vector));
       }
       visibleItems.push(item);
       entries.push(entry);
@@ -361,7 +393,7 @@ export function projectThread(model: ThreadModel, config: TranscriptDisplayConfi
       }
     }
     if (entries.length === 0) {
-      const fallback = terminalFallbackEntry(turn, sourceIndexByItem);
+      const fallback = terminalFallbackEntry(turn, sourceIndexByItem, vector);
       if (fallback) {
         visibleItems.push(fallback.item);
         entries.push(fallback);

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -244,7 +244,12 @@ function decisionFor(
 
   if (item.type === "reasoning") {
     if (vector.reasoning) return "item";
-    return hasFailureStatus(item) || isActiveItem(item, turn) || isTerminalTurn(turn) ? "critical" : "hidden";
+    // An in-progress reasoning item is deliberately NOT escalated. Its renderer
+    // streams the thought open while it is the turn's current activity, so
+    // projecting an active thought here would show the full reasoning stream
+    // even with `reasoning` disabled. Failure and terminal-turn visibility stay
+    // so a broken turn still explains itself.
+    return hasFailureStatus(item) || isTerminalTurn(turn) ? "critical" : "hidden";
   }
 
   if (item.type === "systemMessage") return systemDecision(item, config);

--- a/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
+++ b/cmd/evener-hub/frontend/src/transcriptDisplay/projector.ts
@@ -12,6 +12,19 @@ export const ACTION_SUMMARY_UNAVAILABLE = "Action summary unavailable";
 export type ProjectedEntry =
   | { kind: "item"; id: string; turnId: string; sourceIndex: number; item: ItemModel; isMessage: boolean }
   | {
+      /**
+       * A content-free placeholder for a reasoning item that is the turn's
+       * live current thought while the `reasoning` content flag is off. It
+       * carries the source item only so the renderer can estimate a streaming
+       * token count; the thought's text is never rendered from this entry.
+       */
+      kind: "thinking";
+      id: string;
+      turnId: string;
+      sourceIndex: number;
+      item: ItemModel;
+    }
+  | {
       kind: "intent";
       id: `intent:${string}`;
       turnId: string;
@@ -140,6 +153,15 @@ function isTerminalTurn(turn: TurnModel): boolean {
   return turn.status === "failed" || turn.status === "interrupted";
 }
 
+// The renderer streams only the reasoning item that is still the turn's current
+// activity - the tail of turn.items (see ThinkBlock's isCurrentThought). The
+// content-free placeholder must match that exactly: a superseded thought must
+// not wear a "Thinking…" label, and a thought that is no longer the current one
+// has nothing content-free left to say.
+function isLiveCurrentReasoning(item: ItemModel, turn: TurnModel): boolean {
+  return isActiveItem(item, turn) && turn.items[turn.items.length - 1] === item;
+}
+
 function itemSummary(item: ItemModel): string {
   const description = item.description?.trim();
   if (description) return description;
@@ -193,7 +215,7 @@ function criticalEntry(item: ItemModel, turnId: string, sourceIndex: number): Pr
   };
 }
 
-type Decision = "item" | "intent" | "critical" | "hidden";
+type Decision = "item" | "intent" | "critical" | "thinking" | "hidden";
 
 function systemDecision(item: ItemModel, config: TranscriptDisplayConfigV1): Decision {
   const eventKind = item.eventKind;
@@ -244,11 +266,12 @@ function decisionFor(
 
   if (item.type === "reasoning") {
     if (vector.reasoning) return "item";
-    // An in-progress reasoning item is deliberately NOT escalated. Its renderer
-    // streams the thought open while it is the turn's current activity, so
-    // projecting an active thought here would show the full reasoning stream
-    // even with `reasoning` disabled. Failure and terminal-turn visibility stay
-    // so a broken turn still explains itself.
+    // With reasoning off, a live current thought becomes a content-free
+    // placeholder: the reader sees that the agent is thinking without the
+    // stream itself. An in-progress thought that is NOT the turn's tail is
+    // deliberately hidden (the renderer would not stream it either). Failure
+    // and terminal-turn visibility stay so a broken turn still explains itself.
+    if (isLiveCurrentReasoning(item, turn)) return "thinking";
     return hasFailureStatus(item) || isTerminalTurn(turn) ? "critical" : "hidden";
   }
 
@@ -314,6 +337,8 @@ export function projectThread(model: ThreadModel, config: TranscriptDisplayConfi
       let entry: ProjectedEntry;
       if (decision === "item") {
         entry = itemEntry(item, turn.id, itemSourceIndex);
+      } else if (decision === "thinking") {
+        entry = { kind: "thinking", id: item.id, turnId: turn.id, sourceIndex: itemSourceIndex, item };
       } else if (decision === "intent") {
         entry = intentEntry(item, turn.id, itemSourceIndex);
       } else {

--- a/cmd/evener-hub/frontend/src/widgets/loader/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/loader/index.tsx
@@ -36,11 +36,14 @@ function formatElapsed(startedAt: number, now: number): string {
 
 /**
  * A small pixel-grid glyph plus an optional mm:ss elapsed readout, for a
- * genuinely indeterminate, user-initiated wait (a network fetch, a spawn) -
- * NOT a stand-in for agent liveness. Cadence already owns that signal with
- * its own honest-liveness stance (pure render, decaying trace, no faked
- * motion); reusing Loader's shimmer for "the agent is working" would just
- * be a second, competing liveness indicator.
+ * genuinely indeterminate wait (a network fetch, a spawn). Loader is NOT a
+ * general agent-liveness stand-in: Cadence owns that signal with its own
+ * honest-liveness stance (pure render, decaying trace, no faked motion). The
+ * one scoped exception is the transcript's content-free "Thinking…"
+ * placeholder for a live reasoning item with the Reasoning content flag off
+ * (transcriptDisplay's projector emits it; ThinkBlock renders it) - a
+ * user-approved use of this grid as the only motion the transcript adds,
+ * recorded in docs/web-ui/design-system.md's motion budget.
  *
  * The grid's animation is the one deliberate exception to the app's ban on
  * idle animation (Direction, Global Constraints): it only exists at all

--- a/cmd/evener-hub/frontend/src/widgets/loader/loader.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/loader/loader.module.css
@@ -20,9 +20,10 @@
   opacity: 0.3;
 }
 
-/* The one deliberate exception to the app's ban on idle animation - see
- * this widget's index.tsx doc comment for why Loader (not Cadence) is where
- * it lives. Nine cells wave on a staggered diagonal at a slow ~1.4s period;
+/* The deliberate exception to the app's ban on idle animation - see this
+ * widget's index.tsx doc comment for why Loader (not Cadence) is where it
+ * lives, and for the scoped transcript placeholder use approved 2026-09-11.
+ * Nine cells wave on a staggered diagonal at a slow ~1.4s period;
  * under prefers-reduced-motion: no-preference only. With a reduced-motion
  * preference set, every cell just stays at its static, dim resting opacity
  * (0.3 above) - the elapsed readout keeps counting either way, since it's

--- a/docs/web-ui/decisions.md
+++ b/docs/web-ui/decisions.md
@@ -23,6 +23,14 @@ so the row cannot leak the thought. The renderer draws just
 reasoning stream, so a real count would be fabricated). The placeholder
 disappears the moment the thought stops being the turn's current activity.
 
+A critical reasoning row (a failed or interrupted turn, still projected as
+critical so the turn explains itself) renders redacted: a neutral "Thought
+failed" / "Thought not shown" summary, with no thought body, preview, or
+disclosure. This narrows the 2026-08-25 "preserve terminal transcript failures"
+behavior for reasoning specifically - a broken turn still explains itself, but
+not by showing content the reader disabled. The projector no longer derives a
+reasoning critical entry's summary from the item's own text.
+
 This is the one approved exception to the motion budget's ban on pulses and
 shimmer on live data (design-system.md §5). The grid pulses while the
 placeholder is shown and, unlike Cadence, is not gated on deltas actually

--- a/docs/web-ui/decisions.md
+++ b/docs/web-ui/decisions.md
@@ -5,6 +5,32 @@ alternatives, and what source review found at the time. The current
 [design system](design-system.md#design-model-an-editorial-instrument) governs new work;
 dated verdicts below are not a competing current mandate.
 
+## 2026-09-11 the reasoning placeholder is content-free, on Loader's grid
+
+Turning the Reasoning content flag off still streamed a live thought open and
+then folded it away: the projector escalated any in-progress reasoning item to
+a critical row regardless of the flag, and the reasoning renderer streams an
+in-progress item open as the turn's current thought. The escalation is gone.
+Jesse asked that a live thought instead show a content-free "Thinking…" and
+picked the catalog `Loader`'s pulsing pixel grid as its motion.
+
+The projector now emits a distinct `thinking` entry for the turn's live current
+reasoning item when the flag is off (transcriptDisplay/projector.ts). It
+carries the source item only for a length estimate and never any rendered text,
+so the row cannot leak the thought. The renderer draws just
+`<Loader label=…>`: the label plus an approximate token figure
+(characters/4, marked "~" - the wire carries no live token accounting for a
+reasoning stream, so a real count would be fabricated). The placeholder
+disappears the moment the thought stops being the turn's current activity.
+
+This is the one approved exception to the motion budget's ban on pulses and
+shimmer on live data (design-system.md §5). The grid pulses while the
+placeholder is shown and, unlike Cadence, is not gated on deltas actually
+arriving, so it keeps pulsing if the stream stalls; Cadence's decaying trace
+stays the honest liveness signal. Every other idle pulse or shimmer remains
+banned, and `widgets/loader`'s own doc note no longer claims its motion is
+reserved away from agent liveness.
+
 ## Editorial instrument (2026-09-09)
 
 The user approved a comprehensive Tufte-inspired editorial direction and the

--- a/docs/web-ui/design-system.md
+++ b/docs/web-ui/design-system.md
@@ -544,6 +544,13 @@ is streaming or hung is worse than no indicator). Every widget with motion of it
 `prefers-reduced-motion: reduce` (currently: Cadence, Dialog, Disclosure, Menu, SegmentedControl,
 SelectionQuote, Sheet, StatusDot, Switch) — collapses to instant, no exceptions.
 
+One approved exception (2026-09-11): the transcript's content-free "Thinking…" placeholder,
+shown for a live reasoning item while the Reasoning content flag is off, uses the catalog
+`Loader`'s pulsing pixel grid (Jesse's call). It renders no reasoning text, disappears once the
+thought is no longer the turn's current activity, and is the only animation the transcript itself
+adds. Unlike Cadence it is not activity-gated, so it keeps pulsing if the stream stalls; Cadence's
+decaying trace remains the honest liveness signal. Every other idle pulse or shimmer stays banned.
+
 ---
 
 ## 6. Copy rules
@@ -809,7 +816,9 @@ only until the first authoritative transcript item. It must disappear on an
 authoritative frame, terminal/error/cancel state, session change, or pending
 failure; it must never appear for an untouched empty session. Reuse the static
 `Skeleton` widget, keep its accessible loading status and decorative bars, and
-do not add shimmer, pulse, or other motion that implies live data.
+do not add shimmer, pulse, or other motion that implies live data (the one
+motion exception, the Reasoning placeholder's `Loader` grid, is recorded in the
+motion budget above).
 
 Below 700px both speaker rows become a grid rather than a flex row: the avatar
 and the speaker header share the first row and the prose spans the full pane


### PR DESCRIPTION
## Root cause

The verbosity setting's Reasoning flag is enforced by the transcript projector (`transcriptDisplay/projector.ts`). Its reasoning branch escalated **any** in-progress reasoning item to a `critical` row regardless of the flag:

```ts
if (item.type === "reasoning") {
  if (vector.reasoning) return "item";
  return hasFailureStatus(item) || isActiveItem(item, turn) || isTerminalTurn(turn) ? "critical" : "hidden";
}
```

The reasoning renderer (`ThinkBlock`) treats an in-progress item as the turn's current thought and streams it fully open, then folds it away once superseded. So with Reasoning off, the thinking stream still opened by default and folded away.

## What changed

- Stop escalating active reasoning in `decisionFor`, so the flag governs the stream.
- With Reasoning off, project a distinct content-free `thinking` entry for the turn's live current reasoning item. It carries no rendered text, so the row cannot leak the thought.
- `ThinkBlock` renders only the catalog `Loader` (its pulsing pixel grid) plus an **approximate** token figure (`Thinking… · ~1.2k tokens`), derived from the streamed text at characters/4 and marked with `~`. The wire carries no live token accounting for a reasoning stream (a turn's usage arrives only when the turn settles), so a real count would be fabricated. No count shows until the first chunk lands.
- A critical reasoning row (failed/interrupted turn) renders **redacted** — a neutral `Thought failed` / `Thought not shown` summary with no body, preview, or disclosure — and the projector no longer derives a reasoning critical entry's summary from the item's own text. This closes the RoboRev content-leak finding: a broken turn still explains itself, but not by showing content the reader disabled.
- `isDisclosureOpen` is a custom hook, so it is now called unconditionally before any early return (RoboRev Rules-of-Hooks finding).

## Design-system exception

The content-free placeholder is the one approved exception to the motion budget's ban on pulses/shimmer on live data. Recorded in `docs/web-ui/design-system.md` §5 and the loading rule, plus a dated `docs/web-ui/decisions.md` entry. `Loader`'s own doc note now reflects the scoped use rather than reserving its motion away from agent liveness.

## Verification

- TDD: projector and renderer tests added first (red), then implemented (green).
- `make test-web`: `web-typecheck`, `web-test`, `web-lint` all PASS, rebased on current `main`.
- Coverage: projector content-free projection (live current, non-tail, terminal), redacted critical summary; `ThinkBlock` content-free placeholder and redacted renderer (no body/preview/text); `TurnBlock` integration for both.

## Notes

- The estimate metric is characters/4 (Jesse approved).
- The terminal-turn redaction narrows the pre-existing "preserve terminal transcript failures" behavior for reasoning specifically, at Jesse's direction.
- The Rules-of-Hooks fix is structural; the test environment tolerates the original conditional call (React re-mounts the hook list when zero tracked hooks run), so there is no direct runtime regression test for it.
