### PR TITLE
fix(llm): never send a reasoning effort the model row cannot vouch for

### DIFF
--- a/agent/provider/profile.go
+++ b/agent/provider/profile.go
@@ -292,8 +292,10 @@ func (p *Profile) MaxOutputTokens() int {
 // SupportsReasoning is false only for an explicit reasoning = false row.
 func (p *Profile) SupportsReasoning() bool { return !p.res.Caps.ReasoningDisabled() }
 
-// ReasoningEffortLevels is the row's effort ladder; empty passes any
-// requested effort through unchanged (spec §7.4).
+// ReasoningEffortLevels is the row's effort ladder. An empty ladder vouches
+// for no level: a builder that spells the effort name omits it, while
+// budget-shaped thinking still sizes its budget from the requested effort
+// (see llm.VouchedEffort).
 func (p *Profile) ReasoningEffortLevels() []string {
 	if p.res.Caps.ReasoningDisabled() {
 		return nil

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -299,15 +299,15 @@ effort-capability rather than a separately configured
 
 | `thinking_format` | when an effort is set | with `ThinkingAlwaysOn` and no effort |
 |---|---|---|
-| `openai` (default) | `reasoning_effort: <wire>` if effort-capable, else nothing | `reasoning_effort: medium` clamped to `EffortValues`, if effort-capable, else nothing |
-| `openrouter` | `reasoning: {effort: <wire>}` unconditionally | `reasoning: {enabled: true}` |
-| `zai` | always `thinking: {type: enabled, clear_thinking: false}`; plus `reasoning_effort: <wire>` if effort-capable | `thinking: {type: enabled, clear_thinking: false}` |
-| `deepseek` | always `thinking: {type: enabled}`; plus `reasoning_effort: <wire>` if effort-capable | `thinking: {type: enabled}` |
-| `together` | always `reasoning: {enabled: true}`; plus `reasoning_effort: <wire>` if effort-capable | `reasoning: {enabled: true}` |
+| `openai` (default) | `reasoning_effort: <wire>` when the ladder vouches for the level, else nothing | `reasoning_effort: medium` clamped to `EffortValues` when the ladder lists a level, else nothing |
+| `openrouter` | `reasoning: {effort: <wire>}` unconditionally — the vouch-gate exception below | `reasoning: {enabled: true}` |
+| `zai` | always `thinking: {type: enabled, clear_thinking: false}`; plus `reasoning_effort: <wire>` when the ladder vouches | `thinking: {type: enabled, clear_thinking: false}` |
+| `deepseek` | always `thinking: {type: enabled}`; plus `reasoning_effort: <wire>` when the ladder vouches | `thinking: {type: enabled}` |
+| `together` | always `reasoning: {enabled: true}`; plus `reasoning_effort: <wire>` when the ladder vouches | `reasoning: {enabled: true}` |
 | `qwen` | `enable_thinking: true` | `enable_thinking: true` |
 | `qwen-chat-template` | `chat_template_kwargs: {enable_thinking: true, preserve_thinking: true}` | same |
 | `chat-template` | `chat_template_kwargs: <ChatTemplateKwargs>` (omitted when empty) | same |
-| `string-thinking` | `thinking: <wire>` | `thinking: "medium"` clamped to `EffortValues` |
+| `string-thinking` | `thinking: <wire>` when the ladder vouches, else nothing | `thinking: "medium"` when the ladder lists a level, else nothing |
 
 An explicit `none` is the user turning thinking off. The `openai` (and
 default) dialect sends `reasoning_effort: none`, `openrouter` sends
@@ -318,12 +318,24 @@ anthropic and google protocols have no value that says off, so they omit the
 control. An off never falls through to the `ThinkingAlwaysOn` column: those
 shapes switch thinking on, which would invert what the user asked for.
 
+**The vouch gate.** A field that spells the level is written only when the
+row's `effort_values` ladder lists a rankable level (`llm.VouchedEffort`); a
+level the ladder cannot vouch for is omitted, not sent, so an uncatalogued
+model cannot 400 a provider that rejects it. Two exemptions keep working:
+`openrouter` passes the requested effort through unconditionally because
+OpenRouter normalizes the level itself and its model listing often omits
+supported efforts; and rows that map the effort to a numeric budget (Anthropic
+`budget_tokens`/`budget+effort`, the Google `thinkingConfig`) still consume the
+effort even with an empty ladder, because the row declares that control. On
+the Responses protocol the encrypted-reasoning `include` and a configured
+summary survive an unvouched effort: no level is sent, but replay stays intact.
+
 **anthropic.** `ThinkingShape` picks one of three bodies: `adaptive` →
 `thinking: {type: adaptive}` plus `display`, sent whenever `ThinkingAlwaysOn`
-or an effort is set, plus `output_config.effort` only when the caller set
-one; `budget` → `thinking: {type: enabled, budget_tokens}`, only when an
-effort is set; `budget+effort` (Opus 4.5, Kimi K3) → both. An unset shape
-sends no thinking object at all.
+or an effort is set, plus `output_config.effort` only when the caller set one
+and the ladder vouches for it; `budget` → `thinking: {type: enabled,
+budget_tokens}`, only when an effort is set; `budget+effort` (Opus 4.5, Kimi
+K3) → both. An unset shape sends no thinking object at all.
 
 **Replay.** Prior thinking on the openai-chat protocol writes back to
 whichever field it arrived on — `reasoning_content`, `reasoning`, or
@@ -336,9 +348,9 @@ What changed structurally: `thinking_format` is now a `Caps` field set in
 `providers.toml`/the curated overlay (a provider- or model-level TOML key),
 not a `[instances.X.compat]` table entry. There's no separate `thinking_levels`
 per-model map anymore — a wire-spelled `effort_values` ladder on a model row
-under the existing clamp behavior reproduces it exactly: a below-range
-request raises to the lowest supported value, and the top tier resolves to
-the model's own spelling.
+drives the clamp-and-vouch behavior: a below-range request raises to the
+lowest supported value, the top tier resolves to the model's own spelling, and
+a level the ladder does not list sends no effort name at all.
 
 ## `providers.toml`
 
@@ -747,10 +759,13 @@ generation, the zai and qwen thinking toggles) do move to `medium`. Set
 the off level that reaches the wire, and on any other model it means no
 reasoning control at all, so the provider decides.
 
-**Per-model clamping.** Each resolved row advertises the levels it supports
-(`EffortValues` → `Profile.ReasoningEffortLevels()`), so an over-range
-request (e.g. `xhigh` to a model capped at `high`) is reduced rather than
-rejected. A row that states no ladder passes the effort through unchanged.
+**Per-model clamping and vouching.** Each resolved row advertises the levels
+it supports (`EffortValues` → `Profile.ReasoningEffortLevels()`), so an
+over-range request (e.g. `xhigh` to a model capped at `high`) is reduced rather
+than rejected. A row that states no ladder vouches for no level: the effort
+still sizes budget-shaped thinking, but a field that spells the level is
+omitted rather than sent (see
+[Reasoning and thinking dialects](#reasoning-and-thinking-dialects)).
 
 **Provider mapping.** The openai-chat dialects send the `reasoning_effort`
 enum (see [Reasoning and thinking dialects](#reasoning-and-thinking-dialects)

--- a/llm/providers/anthropic/protocol_request.go
+++ b/llm/providers/anthropic/protocol_request.go
@@ -122,8 +122,8 @@ func applyThinkingShape(body map[string]any, req llm.Request, res registry.Resol
 			thinking["display"] = display
 		}
 		body["thinking"] = thinking
-		if effort != "" {
-			body["output_config"] = map[string]any{"effort": effort}
+		if v := llm.VouchedEffort(effort, caps.EffortValues); v != "" {
+			body["output_config"] = map[string]any{"effort": v}
 		}
 	case "budget", "budget+effort":
 		if effort == "" {
@@ -137,7 +137,9 @@ func applyThinkingShape(body map[string]any, req llm.Request, res registry.Resol
 			body["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
 		}
 		if registry.StringValue(caps.ThinkingShape) == "budget+effort" {
-			body["output_config"] = map[string]any{"effort": effort}
+			if v := llm.VouchedEffort(effort, caps.EffortValues); v != "" {
+				body["output_config"] = map[string]any{"effort": v}
+			}
 		}
 	}
 }

--- a/llm/providers/anthropic/protocol_request.go
+++ b/llm/providers/anthropic/protocol_request.go
@@ -112,7 +112,9 @@ func applyThinkingShape(body map[string]any, req llm.Request, res registry.Resol
 	if req.ReasoningEffort != nil {
 		effort = *req.ReasoningEffort
 	}
-	switch registry.StringValue(caps.ThinkingShape) {
+	shape := registry.StringValue(caps.ThinkingShape)
+	vouched := llm.VouchedEffort(effort, caps.EffortValues)
+	switch shape {
 	case "adaptive":
 		if !registry.BoolValue(caps.ThinkingAlwaysOn) && effort == "" {
 			return
@@ -122,8 +124,8 @@ func applyThinkingShape(body map[string]any, req llm.Request, res registry.Resol
 			thinking["display"] = display
 		}
 		body["thinking"] = thinking
-		if v := llm.VouchedEffort(effort, caps.EffortValues); v != "" {
-			body["output_config"] = map[string]any{"effort": v}
+		if vouched != "" {
+			body["output_config"] = map[string]any{"effort": vouched}
 		}
 	case "budget", "budget+effort":
 		if effort == "" {
@@ -136,10 +138,8 @@ func applyThinkingShape(body map[string]any, req llm.Request, res registry.Resol
 		if budget > 0 {
 			body["thinking"] = map[string]any{"type": "enabled", "budget_tokens": budget}
 		}
-		if registry.StringValue(caps.ThinkingShape) == "budget+effort" {
-			if v := llm.VouchedEffort(effort, caps.EffortValues); v != "" {
-				body["output_config"] = map[string]any{"effort": v}
-			}
+		if shape == "budget+effort" && vouched != "" {
+			body["output_config"] = map[string]any{"effort": vouched}
 		}
 	}
 }

--- a/llm/providers/anthropic/protocol_test.go
+++ b/llm/providers/anthropic/protocol_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func protoRes(mutate func(c *registry.Caps)) registry.Resolved {
-	caps := registry.Caps{Fields: registry.Baseline(registry.ProtocolAnthropic), MaxOutputTokens: new(64000), Reasoning: new(true), ReasoningControls: []string{"effort"}}
+	caps := registry.Caps{Fields: registry.Baseline(registry.ProtocolAnthropic), MaxOutputTokens: new(64000), Reasoning: new(true), ReasoningControls: []string{"effort"}, EffortValues: []string{"minimal", "low", "medium", "high", "xhigh", "max"}}
 	if mutate != nil {
 		mutate(&caps)
 	}

--- a/llm/providers/anthropic/reasoning_vouch_test.go
+++ b/llm/providers/anthropic/reasoning_vouch_test.go
@@ -1,0 +1,55 @@
+package anthropic
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/llm/registry"
+)
+
+// The adaptive shape writes the effort NAME to output_config.effort. A row
+// with no ladder vouches for no name, so only the adaptive body survives — the
+// level is dropped rather than forced.
+func TestApplyThinkingShape_AdaptiveEmptyLadderDropsEffortName(t *testing.T) {
+	high := "high"
+	body := map[string]any{}
+	res := registry.Resolved{Caps: registry.Caps{ThinkingShape: new("adaptive"), ThinkingAlwaysOn: new(true)}}
+	applyThinkingShape(body, llm.Request{ReasoningEffort: &high}, res, false)
+	if _, has := body["output_config"]; has {
+		t.Fatalf("empty-ladder adaptive row wrote output_config: %v", body)
+	}
+	if body["thinking"] == nil {
+		t.Fatalf("adaptive body must survive the dropped effort: %v", body)
+	}
+}
+
+// A vouched adaptive effort is still written, clamped into the ladder.
+func TestApplyThinkingShape_AdaptiveVouchedEffortClamps(t *testing.T) {
+	xhigh := "xhigh"
+	body := map[string]any{}
+	res := registry.Resolved{Caps: registry.Caps{
+		ThinkingShape: new("adaptive"), ThinkingAlwaysOn: new(true),
+		EffortValues: []string{"low", "high"},
+	}}
+	applyThinkingShape(body, llm.Request{ReasoningEffort: &xhigh}, res, false)
+	cfg, _ := body["output_config"].(map[string]any)
+	if cfg == nil || cfg["effort"] != "high" {
+		t.Fatalf("output_config = %v, want effort high", body["output_config"])
+	}
+}
+
+// budget+effort still sizes its numeric budget from the effort, but only
+// writes the effort name when the row vouches for it.
+func TestApplyThinkingShape_BudgetPlusEffortEmptyLadderKeepsBudget(t *testing.T) {
+	high := "high"
+	body := map[string]any{}
+	res := registry.Resolved{Caps: registry.Caps{ThinkingShape: new("budget+effort")}}
+	applyThinkingShape(body, llm.Request{ReasoningEffort: &high}, res, false)
+	if _, has := body["output_config"]; has {
+		t.Fatalf("empty-ladder budget+effort row wrote an effort name: %v", body)
+	}
+	thinking, _ := body["thinking"].(map[string]any)
+	if thinking == nil || thinking["type"] != "enabled" {
+		t.Fatalf("budget body must survive the dropped effort name: %v", body)
+	}
+}

--- a/llm/providers/anthropic/reasoning_vouch_test.go
+++ b/llm/providers/anthropic/reasoning_vouch_test.go
@@ -12,8 +12,12 @@ import (
 // level is dropped rather than forced.
 func TestApplyThinkingShape_AdaptiveEmptyLadderDropsEffortName(t *testing.T) {
 	high := "high"
+	res := protoRes(func(c *registry.Caps) {
+		c.EffortValues = nil
+		c.ThinkingShape = new("adaptive")
+		c.ThinkingAlwaysOn = new(true)
+	})
 	body := map[string]any{}
-	res := registry.Resolved{Caps: registry.Caps{ThinkingShape: new("adaptive"), ThinkingAlwaysOn: new(true)}}
 	applyThinkingShape(body, llm.Request{ReasoningEffort: &high}, res, false)
 	if _, has := body["output_config"]; has {
 		t.Fatalf("empty-ladder adaptive row wrote output_config: %v", body)
@@ -26,11 +30,12 @@ func TestApplyThinkingShape_AdaptiveEmptyLadderDropsEffortName(t *testing.T) {
 // A vouched adaptive effort is still written, clamped into the ladder.
 func TestApplyThinkingShape_AdaptiveVouchedEffortClamps(t *testing.T) {
 	xhigh := "xhigh"
+	res := protoRes(func(c *registry.Caps) {
+		c.EffortValues = []string{"low", "high"}
+		c.ThinkingShape = new("adaptive")
+		c.ThinkingAlwaysOn = new(true)
+	})
 	body := map[string]any{}
-	res := registry.Resolved{Caps: registry.Caps{
-		ThinkingShape: new("adaptive"), ThinkingAlwaysOn: new(true),
-		EffortValues: []string{"low", "high"},
-	}}
 	applyThinkingShape(body, llm.Request{ReasoningEffort: &xhigh}, res, false)
 	cfg, _ := body["output_config"].(map[string]any)
 	if cfg == nil || cfg["effort"] != "high" {
@@ -42,8 +47,11 @@ func TestApplyThinkingShape_AdaptiveVouchedEffortClamps(t *testing.T) {
 // writes the effort name when the row vouches for it.
 func TestApplyThinkingShape_BudgetPlusEffortEmptyLadderKeepsBudget(t *testing.T) {
 	high := "high"
+	res := protoRes(func(c *registry.Caps) {
+		c.EffortValues = nil
+		c.ThinkingShape = new("budget+effort")
+	})
 	body := map[string]any{}
-	res := registry.Resolved{Caps: registry.Caps{ThinkingShape: new("budget+effort")}}
 	applyThinkingShape(body, llm.Request{ReasoningEffort: &high}, res, false)
 	if _, has := body["output_config"]; has {
 		t.Fatalf("empty-ladder budget+effort row wrote an effort name: %v", body)

--- a/llm/providers/chatcompletions/reasoning.go
+++ b/llm/providers/chatcompletions/reasoning.go
@@ -49,31 +49,39 @@ func applyThinkingFormat(body map[string]any, req llm.Request, caps registry.Cap
 		}
 		wire = llm.ClampReasoningEffort("medium", caps.EffortValues)
 	}
+	// A field that spells the level (reasoning_effort, reasoning.effort,
+	// thinking) is written only for a level the row's ladder vouches for. A
+	// row with no ladder — an uncatalogued model — gets no level rather than
+	// one a provider may reject. The dialects' non-level enable objects below
+	// still fire unconditionally, so a mandatory-thinking row keeps thinking
+	// on without being told a level it cannot accept.
+	level := llm.VouchedEffort(wire, caps.EffortValues)
 	switch format {
 	case "", "openai":
-		if capable {
-			body["reasoning_effort"] = wire
+		if capable && level != "" {
+			body["reasoning_effort"] = level
 		}
 	case "openrouter":
-		if explicit {
-			body["reasoning"] = map[string]any{"effort": wire}
-		} else {
+		switch {
+		case explicit && level != "":
+			body["reasoning"] = map[string]any{"effort": level}
+		case alwaysOn:
 			body["reasoning"] = map[string]any{"enabled": true}
 		}
 	case "zai":
 		body["thinking"] = map[string]any{"type": "enabled", "clear_thinking": false}
-		if explicit && capable {
-			body["reasoning_effort"] = wire
+		if explicit && capable && level != "" {
+			body["reasoning_effort"] = level
 		}
 	case "deepseek":
 		body["thinking"] = map[string]any{"type": "enabled"}
-		if explicit && capable {
-			body["reasoning_effort"] = wire
+		if explicit && capable && level != "" {
+			body["reasoning_effort"] = level
 		}
 	case "together":
 		body["reasoning"] = map[string]any{"enabled": true}
-		if explicit && capable {
-			body["reasoning_effort"] = wire
+		if explicit && capable && level != "" {
+			body["reasoning_effort"] = level
 		}
 	case "qwen":
 		body["enable_thinking"] = true
@@ -84,6 +92,8 @@ func applyThinkingFormat(body map[string]any, req llm.Request, caps registry.Cap
 			body["chat_template_kwargs"] = caps.ChatTemplateKwargs
 		}
 	case "string-thinking":
-		body["thinking"] = wire
+		if level != "" {
+			body["thinking"] = level
+		}
 	}
 }

--- a/llm/providers/chatcompletions/reasoning.go
+++ b/llm/providers/chatcompletions/reasoning.go
@@ -47,14 +47,12 @@ func applyThinkingFormat(body map[string]any, req llm.Request, caps registry.Cap
 		if !alwaysOn {
 			return
 		}
-		wire = llm.ClampReasoningEffort("medium", caps.EffortValues)
+		wire = "medium"
 	}
-	// A field that spells the level (reasoning_effort, reasoning.effort,
-	// thinking) is written only for a level the row's ladder vouches for. A
-	// row with no ladder — an uncatalogued model — gets no level rather than
-	// one a provider may reject. The dialects' non-level enable objects below
-	// still fire unconditionally, so a mandatory-thinking row keeps thinking
-	// on without being told a level it cannot accept.
+	// VouchedEffort clamps within the row's ladder and refuses a level the
+	// ladder does not list, so a row with no ladder writes no effort name.
+	// The non-level enable objects below still fire, keeping a
+	// mandatory-thinking row on without a level it cannot accept.
 	level := llm.VouchedEffort(wire, caps.EffortValues)
 	switch format {
 	case "", "openai":
@@ -62,10 +60,9 @@ func applyThinkingFormat(body map[string]any, req llm.Request, caps registry.Cap
 			body["reasoning_effort"] = level
 		}
 	case "openrouter":
-		switch {
-		case explicit && level != "":
+		if explicit && level != "" {
 			body["reasoning"] = map[string]any{"effort": level}
-		case alwaysOn:
+		} else if alwaysOn {
 			body["reasoning"] = map[string]any{"enabled": true}
 		}
 	case "zai":

--- a/llm/providers/chatcompletions/reasoning.go
+++ b/llm/providers/chatcompletions/reasoning.go
@@ -60,8 +60,12 @@ func applyThinkingFormat(body map[string]any, req llm.Request, caps registry.Cap
 			body["reasoning_effort"] = level
 		}
 	case "openrouter":
-		if explicit && level != "" {
-			body["reasoning"] = map[string]any{"effort": level}
+		// OpenRouter is the documented exception to the vouch gate: it
+		// normalizes reasoning.effort itself and its model listing often
+		// omits supported efforts, so the requested level is passed through
+		// unconditionally and the gateway maps it to a budget.
+		if explicit {
+			body["reasoning"] = map[string]any{"effort": wire}
 		} else if alwaysOn {
 			body["reasoning"] = map[string]any{"enabled": true}
 		}

--- a/llm/providers/chatcompletions/reasoning_none_test.go
+++ b/llm/providers/chatcompletions/reasoning_none_test.go
@@ -79,24 +79,28 @@ func TestApplyThinkingFormat_ExplicitOffNeverSwitchesThinkingOn(t *testing.T) {
 	}
 }
 
-// The mandatory-thinking backstop on the "openai" dialect still fires for a
-// request that reaches the adapter with no effort at all: the format emits its
-// medium default. When the row takes no effort control the backstop has no
-// field to ride and the body stays empty — a known gap pinned here so it
-// cannot change silently.
-func TestApplyThinkingFormat_MandatoryBackstopNeedsAnEffortField(t *testing.T) {
-	alwaysOn := func(controls ...string) registry.Resolved {
+// The mandatory-thinking backstop on the "openai" dialect fires for a request
+// that reaches the adapter with no effort at all, but only when the row's
+// ladder vouches for the default: evener never forces a level the row cannot
+// accept. A row that takes no effort control has no field to ride either, so
+// its body stays empty.
+func TestApplyThinkingFormat_MandatoryBackstopNeedsAVouchedEffort(t *testing.T) {
+	alwaysOn := func(controls []string, ladder []string) registry.Resolved {
 		return resolved(func(c *registry.Caps) {
 			c.Reasoning = new(true)
 			c.ReasoningControls = controls
+			c.EffortValues = ladder
 			c.ThinkingAlwaysOn = new(true)
 			c.ThinkingFormat = new("openai")
 		})
 	}
-	if body := build(t, userReq("hi"), alwaysOn("effort")); body["reasoning_effort"] != "medium" {
+	if body := build(t, userReq("hi"), alwaysOn([]string{"effort"}, []string{"low", "medium", "high"})); body["reasoning_effort"] != "medium" {
 		t.Fatalf("body = %#v, want the medium backstop on the openai dialect", body)
 	}
-	if got := reasoningKeys(build(t, userReq("hi"), alwaysOn("toggle"))); len(got) != 0 {
+	if body := build(t, userReq("hi"), alwaysOn([]string{"effort"}, nil)); body["reasoning_effort"] != nil {
+		t.Fatalf("an empty-ladder always-on row must not have a level forced on it: %#v", body)
+	}
+	if got := reasoningKeys(build(t, userReq("hi"), alwaysOn([]string{"toggle"}, nil))); len(got) != 0 {
 		t.Fatalf("a row that takes no effort has no field for the backstop to ride, got %s", jsonOf(t, got))
 	}
 }

--- a/llm/providers/chatcompletions/reasoning_vouch_test.go
+++ b/llm/providers/chatcompletions/reasoning_vouch_test.go
@@ -3,7 +3,6 @@ package chatcompletions
 import (
 	"testing"
 
-	"primeradiant.com/evener/llm"
 	"primeradiant.com/evener/llm/registry"
 )
 
@@ -20,8 +19,9 @@ func emptyLadderCaps(format string) registry.Resolved {
 }
 
 // A row that lists no effort ladder vouches for no level, so no name-carrying
-// reasoning field may reach the wire. A task override of "medium" on an
-// uncatalogued gateway model is exactly how the reported 400 happened.
+// reasoning field may reach the wire — the bug class that let a task override
+// of "medium" 400 on an uncatalogued gateway model. openrouter is the
+// documented exception and is covered separately.
 func TestBuildBody_EmptyLadderNeverWritesAnEffortName(t *testing.T) {
 	high := "high"
 	for _, format := range []string{"", "openai", "zai", "deepseek", "together", "string-thinking"} {
@@ -59,15 +59,18 @@ func TestBuildBody_EmptyLadderAlwaysOnBackstopWritesNothing(t *testing.T) {
 	}
 }
 
-// openrouter's enable object is its non-level way to keep thinking on. An
-// unvouched explicit level becomes no effort, not reasoning.effort; an
-// always-on row still keeps its enable object.
-func TestBuildBody_EmptyLadderOpenrouterDropsEffort(t *testing.T) {
+// openrouter is the documented exception to the vouch gate: it normalizes
+// reasoning.effort itself and its model listing often omits supported efforts,
+// so an explicit level passes through even with an empty ladder
+// (docs/llm-providers.md pins the dialect as "unconditionally"). With no
+// effort at all, an always-on row still gets its enable object.
+func TestBuildBody_OpenrouterKeepsExplicitEffortOnAnEmptyLadder(t *testing.T) {
 	high := "high"
-	notAlwaysOn := build(t, func() llm.Request { r := userReq("hi"); r.ReasoningEffort = &high; return r }(),
-		emptyLadderCaps("openrouter"))
-	if v, has := notAlwaysOn["reasoning"]; has {
-		t.Fatalf("unvouched effort wrote reasoning = %v, want nothing", v)
+	req := userReq("hi")
+	req.ReasoningEffort = &high
+	body := build(t, req, emptyLadderCaps("openrouter"))
+	if got := jsonOf(t, body["reasoning"]); got != jsonOf(t, map[string]any{"effort": "high"}) {
+		t.Fatalf("openrouter reasoning = %s, want the requested effort passed through", got)
 	}
 
 	alwaysOn := resolved(func(c *registry.Caps) {
@@ -76,9 +79,8 @@ func TestBuildBody_EmptyLadderOpenrouterDropsEffort(t *testing.T) {
 		c.ThinkingFormat = new("openrouter")
 		c.ThinkingAlwaysOn = new(true)
 	})
-	body := build(t, userReq("hi"), alwaysOn)
-	if got := jsonOf(t, body["reasoning"]); got != jsonOf(t, map[string]any{"enabled": true}) {
-		t.Fatalf("always-on empty-ladder row reasoning = %s, want the enable object", got)
+	if got := jsonOf(t, build(t, userReq("hi"), alwaysOn)["reasoning"]); got != jsonOf(t, map[string]any{"enabled": true}) {
+		t.Fatalf("always-on row with no effort reasoning = %s, want the enable object", got)
 	}
 }
 

--- a/llm/providers/chatcompletions/reasoning_vouch_test.go
+++ b/llm/providers/chatcompletions/reasoning_vouch_test.go
@@ -1,0 +1,99 @@
+package chatcompletions
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/llm/registry"
+)
+
+// emptyLadderCaps is the synthesized/uncatalogued shape that produced the
+// lunaroute 400: effort-capable, but no effort ladder to vouch for a level.
+func emptyLadderCaps(format string) registry.Resolved {
+	return resolved(func(c *registry.Caps) {
+		c.Reasoning = new(true)
+		c.ReasoningControls = []string{"effort"}
+		if format != "" {
+			c.ThinkingFormat = new(format)
+		}
+	})
+}
+
+// A row that lists no effort ladder vouches for no level, so no name-carrying
+// reasoning field may reach the wire. A task override of "medium" on an
+// uncatalogued gateway model is exactly how the reported 400 happened.
+func TestBuildBody_EmptyLadderNeverWritesAnEffortName(t *testing.T) {
+	high := "high"
+	for _, format := range []string{"", "openai", "zai", "deepseek", "together", "string-thinking"} {
+		t.Run(format, func(t *testing.T) {
+			req := userReq("hi")
+			req.ReasoningEffort = &high
+			body := build(t, req, emptyLadderCaps(format))
+			if v, has := body["reasoning_effort"]; has {
+				t.Fatalf("empty-ladder row wrote reasoning_effort = %v: %v", v, body)
+			}
+			// string-thinking spells the level on "thinking"; the other
+			// dialects write an enable OBJECT there (or on "reasoning"),
+			// which forces no level and is allowed.
+			if format == "string-thinking" {
+				if v, has := body["thinking"]; has {
+					t.Fatalf("empty-ladder string-thinking row wrote thinking = %v", v)
+				}
+			}
+		})
+	}
+}
+
+// The mandatory-thinking backstop must not force its default onto a row that
+// cannot accept a level: an empty-ladder always-on row gets no effort name.
+func TestBuildBody_EmptyLadderAlwaysOnBackstopWritesNothing(t *testing.T) {
+	res := resolved(func(c *registry.Caps) {
+		c.Reasoning = new(true)
+		c.ReasoningControls = []string{"effort"}
+		c.ThinkingFormat = new("openai")
+		c.ThinkingAlwaysOn = new(true)
+	})
+	body := build(t, userReq("hi"), res)
+	if v, has := body["reasoning_effort"]; has {
+		t.Fatalf("empty-ladder always-on row wrote reasoning_effort = %v", v)
+	}
+}
+
+// openrouter's enable object is its non-level way to keep thinking on. An
+// unvouched explicit level becomes no effort, not reasoning.effort; an
+// always-on row still keeps its enable object.
+func TestBuildBody_EmptyLadderOpenrouterDropsEffort(t *testing.T) {
+	high := "high"
+	notAlwaysOn := build(t, func() llm.Request { r := userReq("hi"); r.ReasoningEffort = &high; return r }(),
+		emptyLadderCaps("openrouter"))
+	if v, has := notAlwaysOn["reasoning"]; has {
+		t.Fatalf("unvouched effort wrote reasoning = %v, want nothing", v)
+	}
+
+	alwaysOn := resolved(func(c *registry.Caps) {
+		c.Reasoning = new(true)
+		c.ReasoningControls = []string{"effort"}
+		c.ThinkingFormat = new("openrouter")
+		c.ThinkingAlwaysOn = new(true)
+	})
+	body := build(t, userReq("hi"), alwaysOn)
+	if got := jsonOf(t, body["reasoning"]); got != jsonOf(t, map[string]any{"enabled": true}) {
+		t.Fatalf("always-on empty-ladder row reasoning = %s, want the enable object", got)
+	}
+}
+
+// A vouched level is still clamped within the row's ladder.
+func TestBuildBody_VouchedEffortClampsToTheLadder(t *testing.T) {
+	xhigh := "xhigh"
+	res := resolved(func(c *registry.Caps) {
+		c.Reasoning = new(true)
+		c.ReasoningControls = []string{"effort"}
+		c.EffortValues = []string{"low", "high"}
+	})
+	req := userReq("hi")
+	req.ReasoningEffort = &xhigh
+	body := build(t, req, res)
+	if body["reasoning_effort"] != "high" {
+		t.Fatalf("reasoning_effort = %v, want high (clamped into the ladder)", body["reasoning_effort"])
+	}
+}

--- a/llm/providers/chatcompletions/request_test.go
+++ b/llm/providers/chatcompletions/request_test.go
@@ -72,6 +72,7 @@ func TestBuildBody_ThinkingFormats(t *testing.T) {
 			res := resolved(func(caps *registry.Caps) {
 				caps.Reasoning = new(true)
 				caps.ReasoningControls = []string{"effort"}
+				caps.EffortValues = []string{"low", "medium", "high"}
 				if c.format != "" {
 					caps.ThinkingFormat = new(c.format)
 				}
@@ -142,10 +143,12 @@ func TestBuildBody_ReasoningGates(t *testing.T) {
 		t.Fatalf("none sends nothing: %v", body)
 	}
 
-	unknown := resolved(nil) // Reasoning nil, no controls: an explicit effort passes through
+	// A row with no verdict and no controls has no ladder either, so it
+	// vouches for no level: the effort is dropped rather than forced.
+	unknown := resolved(nil)
 	req.ReasoningEffort = &high
-	if body := build(t, req, unknown); body["reasoning_effort"] != "high" {
-		t.Fatalf("unknown row must pass an explicit effort through: %v", body)
+	if body := build(t, req, unknown); body["reasoning_effort"] != nil {
+		t.Fatalf("a row with no ladder must not get an effort name: %v", body)
 	}
 }
 

--- a/llm/providers/responses/reasoning_vouch_test.go
+++ b/llm/providers/responses/reasoning_vouch_test.go
@@ -1,0 +1,29 @@
+package responses
+
+import (
+	"testing"
+
+	"primeradiant.com/evener/llm"
+	"primeradiant.com/evener/llm/registry"
+)
+
+// An empty ladder vouches for no level, so the Responses reasoning object must
+// not spell one. This is the same bug class as the lunaroute 400 on the
+// chat-completions side.
+func TestReasoningObject_EmptyLadderWritesNoEffort(t *testing.T) {
+	high := "high"
+	if got := reasoningObject(llm.Request{ReasoningEffort: &high}, registry.Caps{Reasoning: new(true)}); got != nil {
+		t.Fatalf("empty-ladder row got reasoning = %v, want nil", got)
+	}
+}
+
+// A vouched level is clamped into the row's ladder and written by name.
+func TestReasoningObject_VouchedEffortClamps(t *testing.T) {
+	xhigh := "xhigh"
+	got := reasoningObject(llm.Request{ReasoningEffort: &xhigh}, registry.Caps{
+		Reasoning: new(true), ReasoningControls: []string{"effort"}, EffortValues: []string{"low", "high"},
+	})
+	if got == nil || got["effort"] != "high" {
+		t.Fatalf("reasoning = %v, want effort high", got)
+	}
+}

--- a/llm/providers/responses/reasoning_vouch_test.go
+++ b/llm/providers/responses/reasoning_vouch_test.go
@@ -29,3 +29,51 @@ func TestReasoningObject_VouchedEffortClamps(t *testing.T) {
 		t.Fatalf("reasoning = %v, want effort high", got)
 	}
 }
+
+// An effort-capable row whose ladder vouches for nothing still reasons: the
+// requested level sends no effort name, but the encrypted-reasoning include
+// must survive so a gateway that returns it can replay on later turns.
+func TestBuildBody_UnvouchedEffortKeepsEncryptedReasoningInclude(t *testing.T) {
+	high := "high"
+	req := userReq("hi")
+	req.ReasoningEffort = &high
+	res := resolved(func(c *registry.Caps) {
+		c.Reasoning = new(true)
+		c.ReasoningControls = []string{"effort"}
+	})
+	body := build(t, req, res)
+	if _, has := body["reasoning"]; has {
+		t.Fatalf("an unvouched effort must not send a reasoning object: %v", body)
+	}
+	inc, _ := body["include"].([]string)
+	found := false
+	for _, v := range inc {
+		if v == "reasoning.encrypted_content" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("include = %v, want reasoning.encrypted_content so replay keeps working", inc)
+	}
+}
+
+// A configured summary is a request for a summary, not an effort name, so it
+// still rides when the ladder cannot vouch for the requested level.
+func TestBuildBody_UnvouchedEffortKeepsConfiguredSummary(t *testing.T) {
+	high := "high"
+	req := userReq("hi")
+	req.ReasoningEffort = &high
+	res := resolved(func(c *registry.Caps) {
+		c.Reasoning = new(true)
+		c.ReasoningControls = []string{"effort"}
+		c.ReasoningSummary = new("auto")
+	})
+	body := build(t, req, res)
+	r, _ := body["reasoning"].(map[string]any)
+	if r == nil || r["summary"] != "auto" {
+		t.Fatalf("reasoning = %v, want the configured summary", body["reasoning"])
+	}
+	if _, has := r["effort"]; has {
+		t.Fatalf("summary-only object must not carry an unvouched effort: %v", r)
+	}
+}

--- a/llm/providers/responses/reasoning_vouch_test.go
+++ b/llm/providers/responses/reasoning_vouch_test.go
@@ -9,10 +9,12 @@ import (
 
 // An empty ladder vouches for no level, so the Responses reasoning object must
 // not spell one. This is the same bug class as the lunaroute 400 on the
-// chat-completions side.
+// chat-completions side. ReasoningControls must list "effort" so the row is
+// effort-capable and the vouch gate actually runs.
 func TestReasoningObject_EmptyLadderWritesNoEffort(t *testing.T) {
 	high := "high"
-	if got := reasoningObject(llm.Request{ReasoningEffort: &high}, registry.Caps{Reasoning: new(true)}); got != nil {
+	caps := registry.Caps{Reasoning: new(true), ReasoningControls: []string{"effort"}}
+	if got := reasoningObject(llm.Request{ReasoningEffort: &high}, caps); got != nil {
 		t.Fatalf("empty-ladder row got reasoning = %v, want nil", got)
 	}
 }

--- a/llm/providers/responses/request.go
+++ b/llm/providers/responses/request.go
@@ -171,7 +171,11 @@ func reasoningObject(req llm.Request, caps registry.Caps) map[string]any {
 	}
 	out := map[string]any{}
 	if req.ReasoningEffort != nil && caps.EffortCapable() {
-		out["effort"] = *req.ReasoningEffort
+		// A row that lists no ladder vouches for no level, so the object
+		// carries none rather than one the provider may reject.
+		if v := llm.VouchedEffort(*req.ReasoningEffort, caps.EffortValues); v != "" {
+			out["effort"] = v
+		}
 	}
 	summary := registry.StringValue(caps.ReasoningSummary)
 	if summary == "none" {

--- a/llm/providers/responses/request.go
+++ b/llm/providers/responses/request.go
@@ -107,12 +107,17 @@ func buildBody(req llm.Request, res registry.Resolved, stream bool) (out map[str
 		body["metadata"] = req.Metadata
 	}
 	reasoningOff := caps.Reasoning != nil && !*caps.Reasoning
-	if reasoning := reasoningObject(req, caps); reasoning != nil {
+	reasoning := reasoningObject(req, caps)
+	if reasoning != nil {
 		body["reasoning"] = reasoning
-		// The include rides an {effort: none} object too. It is inert when the
-		// model honors the off, and it is the only thing that keeps replay
-		// working on a gateway that reasons anyway — which is not knowable in
-		// advance, so we send it rather than guess, as tool_choice does.
+	}
+	// The include rides an {effort: none} object too. It is inert when the
+	// model honors the off, and it is the only thing that keeps replay
+	// working on a gateway that reasons anyway — which is not knowable in
+	// advance, so we send it rather than guess, as tool_choice does. It also
+	// rides a request whose effort the ladder cannot vouch for: no level is
+	// sent, but the model still reasons, so replay must keep working.
+	if reasoning != nil || reasoningRequested(req, caps) {
 		body["include"] = appendUnique(slices.Clone(req.Include), encryptedReasoning)
 	} else if len(req.Include) > 0 {
 		body["include"] = slices.Clone(req.Include)
@@ -181,13 +186,28 @@ func reasoningObject(req llm.Request, caps registry.Caps) map[string]any {
 	if summary == "none" {
 		summary = ""
 	}
-	if summary != "" && (len(out) > 0 || registry.BoolValue(caps.ThinkingAlwaysOn)) {
+	if summary != "" && (len(out) > 0 || registry.BoolValue(caps.ThinkingAlwaysOn) || reasoningRequested(req, caps)) {
 		out["summary"] = summary
 	}
 	if len(out) == 0 {
 		return nil
 	}
 	return out
+}
+
+// reasoningRequested reports whether the request asks the model to reason,
+// even when the row's ladder cannot vouch for the requested level. An
+// uncatalogued gateway row still reasons; keeping this true lets the
+// encrypted-reasoning include and a configured summary survive without
+// sending an effort name the row cannot accept.
+func reasoningRequested(req llm.Request, caps registry.Caps) bool {
+	if caps.Reasoning != nil && !*caps.Reasoning {
+		return false
+	}
+	if req.ReasoningEffort == nil || *req.ReasoningEffort == "none" {
+		return false
+	}
+	return caps.EffortCapable()
 }
 
 func appendUnique(values []string, value string) []string {

--- a/llm/providers/responses/request_test.go
+++ b/llm/providers/responses/request_test.go
@@ -20,6 +20,7 @@ func resolved(mutate func(c *registry.Caps)) registry.Resolved {
 func openaiCaps(c *registry.Caps) {
 	c.Reasoning = new(true)
 	c.ReasoningControls = []string{"effort"}
+	c.EffortValues = []string{"minimal", "low", "medium", "high", "xhigh", "max"}
 	c.StrictTools = new(true)
 	c.ReasoningSummary = new("auto")
 	c.WebSearch = new(true)
@@ -69,7 +70,11 @@ func TestBuildBody_GroqBaselineSendsOnlyTheSpecFields(t *testing.T) {
 	req.MaxTokens = new(100)
 	req.ResponseFormat = &llm.ResponseFormat{Type: "json_schema", JSONSchema: map[string]any{"type": "object"}}
 	req.StopSequences = []string{"x"}
-	res := resolved(func(c *registry.Caps) { c.Reasoning = new(true); c.ReasoningControls = []string{"effort"} })
+	res := resolved(func(c *registry.Caps) {
+		c.Reasoning = new(true)
+		c.ReasoningControls = []string{"effort"}
+		c.EffortValues = []string{"low", "medium", "high"}
+	})
 	res.Instance, res.ModelID, res.WireID = "groq", "openai/gpt-oss-120b", "openai/gpt-oss-120b"
 	body := build(t, req, res)
 	for _, k := range []string{"model", "instructions", "input", "tools", "max_output_tokens", "reasoning", "text", "include"} {

--- a/llm/reasoning_effort_test.go
+++ b/llm/reasoning_effort_test.go
@@ -70,6 +70,34 @@ func TestReasoningEffortRank(t *testing.T) {
 	}
 }
 
+// VouchedEffort is the gate for fields that spell the effort NAME. It is
+// distinct from ClampReasoningEffort: an empty ladder or unrankable vocabulary
+// yields "" (omit), because evener never writes an effort name the resolved
+// row cannot vouch for. Budget-shaped rows do not use it.
+func TestVouchedEffort(t *testing.T) {
+	cases := []struct {
+		name      string
+		requested string
+		levels    []string
+		want      string
+	}{
+		{"empty ladder vouches for nothing", "high", nil, ""},
+		{"empty ladder vouches for nothing even when unset", "", nil, ""},
+		{"listed level is returned", "high", []string{"low", "high"}, "high"},
+		{"unlisted level clamps into the ladder", "xhigh", []string{"low", "high"}, "high"},
+		{"unrankable vocabulary is dropped", "turbo", []string{"low", "high"}, ""},
+		{"case-insensitive match", "HIGH", []string{"low", "high"}, "high"},
+		{"the off sentinel is not an effort name", "none", []string{"low", "high"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := VouchedEffort(tc.requested, tc.levels); got != tc.want {
+				t.Errorf("VouchedEffort(%q, %v) = %q, want %q", tc.requested, tc.levels, got, tc.want)
+			}
+		})
+	}
+}
+
 // The disable aliases normalize to the canonical "none", not to "" — an
 // explicit off must stay distinguishable from "nothing configured" so the
 // session's default effort never overrides a user who turned thinking off.

--- a/llm/registry/derive.go
+++ b/llm/registry/derive.go
@@ -114,8 +114,9 @@ func (c Caps) EffortOffCapable() bool {
 // §8.4): effort ∈ ReasoningControls, which after derivation is every
 // reasoning row except one that lists controls without effort. A row with
 // no controls and no Reasoning verdict (an unknown model) is capable too,
-// so an explicit effort still reaches the wire as it did before the
-// registry.
+// so an explicit effort still reaches request shaping as it did before the
+// registry; the protocol builder then writes it only for a level an
+// EffortValues ladder vouches for (llm.VouchedEffort).
 func (c Caps) EffortCapable() bool {
 	if slices.Contains(c.ReasoningControls, "effort") {
 		return true

--- a/llm/registry_shape.go
+++ b/llm/registry_shape.go
@@ -62,9 +62,11 @@ func samplingPaths(protocol string) (temperature, topP, stop string) {
 
 // ShapeRequest is the single place request-level shaping happens (spec
 // §7.5), in this order: clear reasoning controls when the row has
-// Reasoning = false; clamp the effort to EffortValues (an empty ladder
-// passes it through; no effort is ever added here — §7.4's rule in agent is
-// what sets one); apply MaxOutputTokens when the request has none; drop
+// Reasoning = false; clamp the effort to EffortValues (an empty ladder leaves
+// the effort for the protocol builder, which drops a name it cannot vouch for
+// but still sizes budget-shaped thinking from it; no effort is ever added
+// here — §7.4's rule in agent is what sets one); apply MaxOutputTokens when
+// the request has none; drop
 // request-level sampling parameters the row's
 // Sampling or Fields say not to send; gate the prompt-cache fields; turn
 // store on for a planned Responses continuation. It returns a shaped copy

--- a/llm/types.go
+++ b/llm/types.go
@@ -756,9 +756,6 @@ func ClampReasoningEffort(requested string, supportedLevels []string) string {
 // use this: such a row legitimately states no effort ladder and still needs
 // the requested effort to size its budget.
 func VouchedEffort(requested string, levels []string) string {
-	if len(levels) == 0 {
-		return ""
-	}
 	v := ClampReasoningEffort(requested, levels)
 	if v == "" || v == ReasoningEffortNone {
 		return ""

--- a/llm/types.go
+++ b/llm/types.go
@@ -700,7 +700,9 @@ func ReasoningEffortRank(effort string) int {
 // e.g. "xhigh" against a wire-spelled ["high","max"] resolves to "max"); a
 // request above the model's top supported level is lowered to that level.
 // Empty, "none", unknown vocabulary, or an empty supported set pass through
-// unchanged so the provider can decide. This is the single guard that keeps
+// unchanged so the provider can decide; callers that spell the level on the
+// wire use VouchedEffort instead, which refuses a level the ladder does not
+// list. This is the single guard that keeps
 // loop-detector escalation, the --reasoning-effort flag, and the UI selector
 // from sending a level a model rejects (e.g. "max" to a model that only
 // supports minimal/low/medium/high).
@@ -738,6 +740,35 @@ func ClampReasoningEffort(requested string, supportedLevels []string) string {
 		return highest
 	}
 	return requested
+}
+
+// VouchedEffort returns the level to write onto a field that spells the effort
+// NAME — reasoning_effort, reasoning.effort, output_config.effort, or the
+// string-thinking "thinking" value — clamped within the row's listed
+// EffortValues. It returns "" when the row lists no ladder, or when the
+// requested value clamps to nothing the ladder lists: evener never forces an
+// effort name that the resolved row cannot vouch for. The explicit off
+// sentinel ("none") is handled by the adapters' thinking-format logic, not
+// here, so it also returns "".
+//
+// Rows that derive a numeric budget instead of spelling the level
+// (anthropic budget_tokens/budget+effort, the google thinkingConfig) do not
+// use this: such a row legitimately states no effort ladder and still needs
+// the requested effort to size its budget.
+func VouchedEffort(requested string, levels []string) string {
+	if len(levels) == 0 {
+		return ""
+	}
+	v := ClampReasoningEffort(requested, levels)
+	if v == "" || v == ReasoningEffortNone {
+		return ""
+	}
+	for _, l := range levels {
+		if strings.EqualFold(strings.TrimSpace(l), v) {
+			return v
+		}
+	}
+	return ""
 }
 
 // IntFromAny extracts an integer from a JSON-decoded value.


### PR DESCRIPTION
## Problem

An uncatalogued model row is synthesized with `reasoning_controls: ["effort"]` and an empty `effort_values`, so `ClampReasoningEffort` passed any requested level through unchanged.

A task-level override of `"medium"` against `lunaroute/deepseek-4.1-flash` was forwarded verbatim and the gateway rejected every round:

```
lunaroute error (status=400): ... "DeepSeek V4.1 reasoning_effort must be low, high, xhigh, max, or an integer within [1, 100] ..."
```

Because the in-progress task re-applied the override on every `continue`, the session stayed wedged.

## Fix

New `llm.VouchedEffort(requested, levels)`: returns a clamped level only when the row's ladder lists it, and `""` otherwise. It gates exactly the fields that spell the effort **name**:

- openai-chat: `reasoning_effort`, `reasoning.effort`, string `thinking`
- Responses: `reasoning.effort`
- Anthropic: `output_config.effort` (adaptive and budget+effort)

Budget-shaped thinking is deliberately untouched: Claude `budget_tokens` and the Google `thinkingConfig` convert the effort to a numeric budget for rows that declare that control, so an empty ladder does not silently disable them. Non-level enable objects still fire, so a mandatory-thinking row stays enabled.

An uncatalogued model now sends no effort instead of a guessed default; declare `effort_values` on the row to opt one in. Same philosophy as the #834 temperature gate.

## Verification

- `go test ./llm/... ./agent/provider/` and the focused provider packages: pass
- `go vet ./llm/... ./agent/provider/`: clean
- `make lint-golangci`: pass
- Full `go test ./llm/... ./agent/...` on the source branch passed except pre-existing `agent/sandbox` bwrap failures, which reproduce identically on a clean HEAD worktree (environmental)
- Live: `--reasoning-effort high` on uncatalogued `lunaroute/glm-5.3-flash` -> body carries no `reasoning_effort`, call succeeds; `--reasoning-effort medium` against a model with `effort_values = ["low","high","xhigh","max"]` -> clamps to `high`, call succeeds