### PR TITLE
fix(vertex,google): unblock Gemini models (global-only warnings, regional 404, MCP schema metadata)

### DIFF
--- a/appwire/types.go
+++ b/appwire/types.go
@@ -2187,6 +2187,10 @@ type ModelDescriptor struct {
 	InputCostPerMillion   *float64 `json:"inputCostPerMillion,omitempty"`
 	OutputCostPerMillion  *float64 `json:"outputCostPerMillion,omitempty"`
 	ReasoningEffortLevels []string `json:"reasoningEffortLevels,omitempty"`
+	// Warnings carries the registry's resolved-row notes (e.g. a global-only
+	// model under a regional Vertex location) so the model picker can flag a
+	// row the resolver itself warns about.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 type ModelListDiagnostic struct {

--- a/cmd/evener-hub/frontend/src/protocol/types.gen.ts
+++ b/cmd/evener-hub/frontend/src/protocol/types.gen.ts
@@ -959,6 +959,7 @@ export interface ModelDescriptor {
   inputCostPerMillion?: number;
   outputCostPerMillion?: number;
   reasoningEffortLevels?: string[];
+  warnings?: string[];
 }
 
 export interface ModelListDiagnostic {

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/index.tsx
@@ -42,6 +42,7 @@ const CLASS = {
   rowName: requireClass(styles.rowName, "modelCatalog.module.css", "rowName"),
   check: requireClass(styles.check, "modelCatalog.module.css", "check"),
   meta: requireClass(styles.meta, "modelCatalog.module.css", "meta"),
+  warning: requireClass(styles.warning, "modelCatalog.module.css", "warning"),
   unavailable: requireClass(styles.unavailable, "modelCatalog.module.css", "unavailable"),
   panelSheet: requireClass(styles.panelSheet, "modelCatalog.module.css", "panelSheet"),
   listSheet: requireClass(styles.listSheet, "modelCatalog.module.css", "listSheet"),
@@ -293,6 +294,14 @@ export function ModelCatalogPanel({
               return (
                 <li key={row.key} role="presentation" className={CLASS.groupRow}>
                   {row.label}
+                </li>
+              );
+            }
+            if (row.kind === "warning") {
+              return (
+                <li key={row.key} role="presentation" className={CLASS.warning} data-testid="model-warning">
+                  <span aria-hidden="true">⚠ </span>
+                  {row.text}
                 </li>
               );
             }

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.module.css
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.module.css
@@ -166,6 +166,16 @@
   font-size: var(--font-size-caption);
 }
 
+/* A resolved row the registry itself warns about (a global-only model under a
+ * regional Vertex location): one dim line under the row, not an option. Same
+ * passive ink as the rest of the catalog's metadata - it is information, not
+ * an alarm - and slightly indented so it reads as belonging to the row above. */
+.warning {
+  padding: 0 var(--space-2) var(--space-1) var(--space-4);
+  color: var(--ink-mid);
+  font-size: var(--font-size-caption);
+}
+
 /* --- sheet variant (mobile bottom Sheet) ---------------------------------
  * The design system's mobile-forms rule (docs/web-ui/design-system.md §11):
  * sheet options are at least 48px tall, use the existing tokens, and reuse

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.test.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/modelCatalog.test.tsx
@@ -237,6 +237,46 @@ describe("open state", () => {
 
 // --- the input replaces the previously-selected value ---------------------
 
+describe("model warnings", () => {
+  // A global-only model under a regional Vertex location: the registry warns
+  // on the resolved row, and the picker must flag it so the user doesn't pick
+  // a row that will 404 at launch.
+  const VERTEX_GEMINI: ModelCatalogEntry = {
+    provider: "vertex",
+    model: "gemini-3.5-flash",
+    displayName: "Gemini 3.5 Flash",
+    warnings: [
+      'regional Vertex location "us-central1" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.5-flash',
+    ],
+  };
+
+  test("a resolved row's warning renders as a visible note beside the model", async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      loadCatalog: vi.fn().mockResolvedValue({ models: [VERTEX_GEMINI], recent: [] }),
+    });
+
+    await openPicker(user);
+    await screen.findByRole("option", { name: /Gemini 3.5 Flash/ });
+
+    const note = screen.getByTestId("model-warning");
+    expect(note.textContent).toContain("regional Vertex location");
+    expect(note.textContent).toContain("gemini-3.5-flash");
+    // The note is informational, not a second option: the row stays pickable.
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+  });
+
+  test("a model with no warnings renders no note", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+
+    await openPicker(user);
+    await screen.findByRole("option", { name: /Claude Sonnet/ });
+
+    expect(screen.queryByTestId("model-warning")).toBeNull();
+  });
+});
+
 describe("input pre-fill", () => {
   test("opens pre-filled with the current qualified value, focused, and fully selected", async () => {
     const user = userEvent.setup();

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/pickerRows.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/pickerRows.ts
@@ -21,6 +21,7 @@ import type { ModelCatalog, ModelCatalogDiagnostic, ModelCatalogEntry } from "./
 export type PickerRow =
   | { kind: "group"; key: string; label: string }
   | { kind: "model"; key: string; option: CatalogOption; meta: string }
+  | { kind: "warning"; key: string; text: string }
   | { kind: "unavailable"; key: string; text: string };
 
 /** The pickable row kind - the only one that becomes a listbox option. */
@@ -85,6 +86,16 @@ export function buildPickerRows(catalog: ModelCatalog | null, query: string): Pi
   if (!catalog) return [];
   const rows: PickerRow[] = [];
 
+  // A model row's registry warnings render as their own dim in-place line
+  // directly beneath it, so an uncallable row is visibly flagged without the
+  // note becoming a second listbox option. Same shape as an unavailable line:
+  // informational text, skipped by pickableRows.
+  const pushWarnings = (option: CatalogOption, prefix: string) => {
+    for (const [i, text] of (option.entry.warnings ?? []).entries()) {
+      rows.push({ kind: "warning", key: `warning:${rows.length}:${prefix}:${option.qualified}:${i}`, text });
+    }
+  };
+
   const recent = filterCatalog(toCatalogOptions(catalog.recent), query);
   if (recent.length > 0) {
     rows.push({ kind: "group", key: `group:${rows.length}:${RECENT_GROUP}`, label: RECENT_GROUP });
@@ -95,6 +106,7 @@ export function buildPickerRows(catalog: ModelCatalog | null, query: string): Pi
         option,
         meta: rowMeta(option.entry, true),
       });
+      pushWarnings(option, "recent");
     }
   }
 
@@ -108,6 +120,7 @@ export function buildPickerRows(catalog: ModelCatalog | null, query: string): Pi
       option,
       meta: rowMeta(option.entry, false),
     });
+    pushWarnings(option, "model");
   }
 
   for (const diag of catalog.diagnostics ?? []) {

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
@@ -45,6 +45,35 @@ describe("catalog snapshot merging", () => {
     expect(mergeCatalogEntry(existing, richer).warnings).toEqual(richer.warnings);
   });
 
+  test("a later response without warnings clears the ones an earlier scope had", () => {
+    const warn =
+      'regional Vertex location "us-central1" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.8-flash';
+    const warned = { provider: "vertex", model: "gemini-3.8-flash", displayName: "Gemini 3.8 Flash", warnings: [warn] };
+    // The same model resolved under a global location: the registry has nothing
+    // to warn about, so the descriptor carries no warnings at all.
+    const quiet = { provider: "vertex", model: "gemini-3.8-flash", displayName: "Gemini 3.8 Flash" };
+
+    expect(mergeCatalogEntry(warned, quiet)).toEqual(quiet);
+  });
+
+  test("a merged snapshot warns about the models and recent rows alike", () => {
+    const warn =
+      'regional Vertex location "us-central1" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.8-flash';
+    const entry = (warnings?: string[]) => ({
+      provider: "vertex",
+      model: "gemini-3.8-flash",
+      displayName: "Gemini 3.8 Flash",
+      warnings,
+    });
+    const merged = mergeCatalogSnapshot(
+      { models: [entry([warn])], recent: [entry([warn])] },
+      { models: [entry()], recent: [entry()] },
+    );
+
+    expect(merged.models[0]?.warnings).toBeUndefined();
+    expect(merged.recent[0]?.warnings).toBeUndefined();
+  });
+
   test("does not merge entries with different providers or models", () => {
     const existing = {
       provider: "openai",

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
@@ -56,7 +56,7 @@ describe("catalog snapshot merging", () => {
     expect(mergeCatalogEntry(warned, quiet)).toEqual(quiet);
   });
 
-  test("a merged snapshot warns about the models and recent rows alike", () => {
+  test("a merged snapshot carries only the later snapshot's warnings", () => {
     const warn =
       'regional Vertex location "us-central1" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.8-flash';
     const entry = (warnings?: string[]) => ({
@@ -70,8 +70,9 @@ describe("catalog snapshot merging", () => {
       { models: [entry()], recent: [entry()] },
     );
 
+    // recent is passed through un-merged, so only the merged models list can
+    // pin that a later snapshot's silence beats an earlier scope's warning.
     expect(merged.models[0]?.warnings).toBeUndefined();
-    expect(merged.recent[0]?.warnings).toBeUndefined();
   });
 
   test("does not merge entries with different providers or models", () => {

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.test.ts
@@ -33,6 +33,18 @@ describe("catalog snapshot merging", () => {
     expect(mergeCatalogEntry(existing, richer)).toEqual(richer);
   });
 
+  test("a later response supplies warnings the visible entry lacked", () => {
+    const existing = { provider: "vertex", model: "gemini-3.8-flash", displayName: "Gemini 3.8 Flash" };
+    const richer = {
+      ...existing,
+      warnings: [
+        'regional Vertex location "us-central1" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.8-flash',
+      ],
+    };
+
+    expect(mergeCatalogEntry(existing, richer).warnings).toEqual(richer.warnings);
+  });
+
   test("does not merge entries with different providers or models", () => {
     const existing = {
       provider: "openai",

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.ts
@@ -32,11 +32,19 @@ export function mergeCatalogEntry(
     "inputCostPerMillion",
     "outputCostPerMillion",
     "reasoningEffortLevels",
-    "warnings",
   ] as const;
   for (const field of optionalFields) {
     const value = incoming[field];
     if (value !== undefined) Object.assign(merged, { [field]: value });
+  }
+  // Warnings are a finding about the resolution behind this snapshot, not a
+  // capability: the same model under a global location (or another project)
+  // arrives without them, and the later snapshot has its word. Keeping an
+  // earlier scope's warnings would warn about a location the pane has left.
+  if (incoming.warnings === undefined) {
+    delete merged.warnings;
+  } else {
+    merged.warnings = incoming.warnings;
   }
   if (incoming.supportsReasoning === false && incoming.reasoningEffortLevels === undefined) {
     merged.reasoningEffortLevels = [];

--- a/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.ts
+++ b/cmd/evener-hub/frontend/src/widgets/modelCatalog/scopedCatalog.ts
@@ -32,6 +32,7 @@ export function mergeCatalogEntry(
     "inputCostPerMillion",
     "outputCostPerMillion",
     "reasoningEffortLevels",
+    "warnings",
   ] as const;
   for (const field of optionalFields) {
     const value = incoming[field];

--- a/cmd/evener-hub/spawn.go
+++ b/cmd/evener-hub/spawn.go
@@ -845,7 +845,7 @@ func listEvenerLaunchModelContract(ctx context.Context, evenerBinary string, env
 		if provider == "" || name == "" {
 			continue
 		}
-		models = append(models, appwire.ModelDescriptor{Provider: provider, Model: name})
+		models = append(models, appwire.ModelDescriptor{Provider: provider, Model: name, Warnings: append([]string(nil), model.Warnings...)})
 	}
 	diagnostics := make([]appwire.ModelListDiagnostic, 0, len(resp.Diagnostics))
 	for _, diag := range resp.Diagnostics {

--- a/cmd/evener-hub/spawn_test.go
+++ b/cmd/evener-hub/spawn_test.go
@@ -808,6 +808,41 @@ exit 2
 	}
 }
 
+// TestListEvenerLaunchModelContractCarriesWarnings: the launch contract's
+// models are the picker's primary source, so a resolved row's registry warning
+// (a global-only model under a regional Vertex location) must survive the
+// parse instead of being flattened to provider/model.
+func TestListEvenerLaunchModelContractCarriesWarnings(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fake-evener")
+	script := `#!/bin/sh
+if [ "$1" = "launch-check" ]; then
+	  printf '{"protocol":"evener-appwire-v5","models":[{"provider":"vertex","model":"gemini-3.5-flash","warnings":["regional Vertex location \\"us-central1\\" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.5-flash"]}]}\n'
+  exit 0
+fi
+exit 2
+`
+	writeFakeEvener(t, bin, script)
+
+	resp, err := listEvenerLaunchModelContract(context.Background(), bin, nil)
+	if err != nil {
+		t.Fatalf("listEvenerLaunchModelContract: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("data=%+v, want one model", resp.Data)
+	}
+	got := resp.Data[0]
+	if got.Provider != "vertex" || got.Model != "gemini-3.5-flash" {
+		t.Fatalf("descriptor=%+v", got)
+	}
+	if !slices.ContainsFunc(got.Warnings, func(w string) bool {
+		return strings.Contains(w, "regional Vertex location")
+	}) {
+		t.Fatalf("warnings=%v, want the regional-location note", got.Warnings)
+	}
+}
+
 func TestValidateEvenerLaunchContractRejectsIncompatibleProtocolBinary(t *testing.T) {
 	evenerBinary := filepath.Join(t.TempDir(), "old-evener")
 	writeFakeEvener(t, evenerBinary, `#!/bin/sh

--- a/cmd/evener-tui/hub_commands.go
+++ b/cmd/evener-tui/hub_commands.go
@@ -774,7 +774,7 @@ func buildModelPickerItems(models []appwire.ModelDescriptor, rawModelID bool) []
 		if rawModelID {
 			id = model
 		}
-		items = append(items, tuipick.ModelPickerItem{ID: id, Display: display, Group: provider, Meta: modelInfoMetaTail(option)})
+		items = append(items, tuipick.ModelPickerItem{ID: id, Display: display, Group: provider, Meta: modelInfoMetaTail(option), Warnings: append([]string(nil), option.Warnings...)})
 	}
 	return items
 }

--- a/cmd/evener-tui/hub_model_picker_items_test.go
+++ b/cmd/evener-tui/hub_model_picker_items_test.go
@@ -178,6 +178,30 @@ func TestModelPickerItemsFromResponse_NoRecentOmitsGroup(t *testing.T) {
 	}
 }
 
+// The hub's model/list response carries the registry's resolved-row warnings
+// (a global-only model under a regional Vertex location); the TUI picker must
+// keep them so its rows can carry the same note the web and mobile pickers
+// show, instead of offering the row bare.
+func TestModelPickerItemsFromResponse_CarriesWarnings(t *testing.T) {
+	const note = `regional Vertex location "us-central1" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.8-flash`
+	resp := appwire.ModelListResponse{
+		Data: []appwire.ModelDescriptor{
+			{Provider: "vertex", Model: "gemini-3.8-flash", Warnings: []string{note}},
+			{Provider: "vertex", Model: "gemini-2.5-flash"},
+		},
+	}
+	items := modelPickerItemsFromResponse(resp, false)
+	if len(items) != 2 {
+		t.Fatalf("got %d items, want 2", len(items))
+	}
+	if len(items[0].Warnings) != 1 || items[0].Warnings[0] != note {
+		t.Errorf("warned row = %#v, want the registry warning carried", items[0])
+	}
+	if len(items[1].Warnings) != 0 {
+		t.Errorf("unwarned row = %#v, want no warnings", items[1])
+	}
+}
+
 func TestVisionModelPickerItemsPrependPseudoEntriesAndFilterDescriptors(t *testing.T) {
 	models := []appwire.ModelDescriptor{
 		{Provider: "openai", Model: "gpt-3.5-turbo", SupportsVision: new(false)},

--- a/cmd/evener-tui/internal/tuipick/model_picker.go
+++ b/cmd/evener-tui/internal/tuipick/model_picker.go
@@ -96,6 +96,9 @@ func (m ModelPicker) filtered() []ModelPickerItem {
 
 func (m ModelPicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if msg, ok := msg.(tea.KeyMsg); ok {
+		// Every key acts on the row the picker is showing, so a cursor left
+		// over a list a filter shortened is clamped before the key reads it.
+		m.cursor = m.cursorIndex(m.filtered())
 		switch msg.Type {
 		case tea.KeyEscape, tea.KeyCtrlC:
 			m.cancelled = true
@@ -103,7 +106,7 @@ func (m ModelPicker) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case tea.KeyEnter:
 			filtered := m.filtered()
-			if len(filtered) == 0 || m.cursor >= len(filtered) {
+			if len(filtered) == 0 {
 				return m, nil
 			}
 			item := filtered[m.cursor]
@@ -191,7 +194,7 @@ func (m ModelPicker) itemLines(filtered []ModelPickerItem, i int) []string {
 	cursor := "  "
 	style := tuitheme.MpNormalStyle
 	isActive := modelIDMatchesActive(item.ID, m.active)
-	if i == m.cursor {
+	if i == m.cursorIndex(filtered) {
 		cursor = "> "
 		style = tuitheme.MpCursorStyle
 	} else if isActive {
@@ -233,9 +236,7 @@ func (m ModelPicker) visibleRange(filtered []ModelPickerItem) (int, int) {
 	if len(filtered) == 0 {
 		return 0, 0
 	}
-	// A cursor can outlive the list it indexes (a filter narrowed the list, or
-	// a caller set it directly), so clamp it rather than trust it.
-	cursor := min(max(m.cursor, 0), len(filtered)-1)
+	cursor := m.cursorIndex(filtered)
 	start, end := cursor, cursor+1
 	used := m.renderedLines(filtered, cursor)
 	for {
@@ -279,6 +280,17 @@ func modelIDMatchesActive(id, active string) bool {
 
 // SetTitle overrides the picker's heading.
 func (m *ModelPicker) SetTitle(title string) { m.title = title }
+
+// cursorIndex is the cursor clamped into the filtered list. A cursor can
+// outlive the list it indexes (a filter narrowed the list, or a caller set it
+// directly), and the window, the highlight, and the selection must agree on
+// which row that is.
+func (m ModelPicker) cursorIndex(filtered []ModelPickerItem) int {
+	if len(filtered) == 0 {
+		return 0
+	}
+	return min(max(m.cursor, 0), len(filtered)-1)
+}
 
 // Done reports whether the picker has been dismissed.
 func (m ModelPicker) Done() bool { return m.done }

--- a/cmd/evener-tui/internal/tuipick/model_picker.go
+++ b/cmd/evener-tui/internal/tuipick/model_picker.go
@@ -156,15 +156,7 @@ func (m ModelPicker) renderBody() string {
 		b.WriteString(tuitheme.MpDimStyle.Render(emptyText))
 		b.WriteString("\n")
 	} else {
-		maxVisible := 15
-		start := 0
-		if len(filtered) > maxVisible {
-			start = max(m.cursor-maxVisible/2, 0)
-			if start+maxVisible > len(filtered) {
-				start = len(filtered) - maxVisible
-			}
-		}
-		end := min(start+maxVisible, len(filtered))
+		start, end := visibleRange(filtered, m.cursor)
 
 		for i := start; i < end; i++ {
 			item := filtered[i]
@@ -202,12 +194,64 @@ func (m ModelPicker) renderBody() string {
 			}
 		}
 
-		if len(filtered) > maxVisible {
+		if start > 0 || end < len(filtered) {
 			b.WriteString(tuitheme.MpDimStyle.Render(fmt.Sprintf("  ... %d items total", len(filtered))))
 			b.WriteString("\n")
 		}
 	}
 	return b.String()
+}
+
+// maxVisibleLines is the picker body's rendered-line budget. Items are not a
+// fixed height — each warning adds a line under its row, and a group's first
+// item adds a header — so the window is measured in rendered lines rather than
+// items; counting items let a few warned rows push the footer off the overlay.
+const maxVisibleLines = 15
+
+// renderedLines is how many body lines filtered[i] occupies: its own row, one
+// line per warning, and one for the group header when it starts a group (the
+// renderer writes a header at the first item and at every group change).
+func renderedLines(filtered []ModelPickerItem, i int) int {
+	n := 1 + len(filtered[i].Warnings)
+	if filtered[i].Group != "" && (i == 0 || filtered[i-1].Group != filtered[i].Group) {
+		n++
+	}
+	return n
+}
+
+// visibleRange is the [start, end) window of filtered items to render: the
+// cursor's item plus the neighbours that fit the budget, taken from both sides
+// so the cursor stays near the middle. An item that alone exceeds the budget
+// still renders, since a row cannot be shown in part.
+func visibleRange(filtered []ModelPickerItem, cursor int) (int, int) {
+	if len(filtered) == 0 {
+		return 0, 0
+	}
+	// A cursor can outlive the list it indexes (a filter narrowed the list, or
+	// a caller set it directly), so clamp it rather than trust it.
+	cursor = min(max(cursor, 0), len(filtered)-1)
+	start, end := cursor, cursor+1
+	used := renderedLines(filtered, cursor)
+	for {
+		grew := false
+		if end < len(filtered) {
+			if n := renderedLines(filtered, end); used+n <= maxVisibleLines {
+				used += n
+				end++
+				grew = true
+			}
+		}
+		if start > 0 {
+			if n := renderedLines(filtered, start-1); used+n <= maxVisibleLines {
+				start--
+				used += n
+				grew = true
+			}
+		}
+		if !grew {
+			return start, end
+		}
+	}
 }
 
 // modelIDMatchesActive reports whether a picker item ID names the same model

--- a/cmd/evener-tui/internal/tuipick/model_picker.go
+++ b/cmd/evener-tui/internal/tuipick/model_picker.go
@@ -21,6 +21,11 @@ type ModelPickerItem struct {
 	// Meta is a compact trailing tail (context window, price, capability
 	// flags) appended dim after the row. "" renders nothing extra.
 	Meta string
+	// Warnings are the registry's resolved-row notes (e.g. a global-only
+	// model under a regional Vertex location). Each renders as its own dim
+	// line under the row; the row stays selectable, matching the web and
+	// mobile pickers. Empty renders nothing extra.
+	Warnings []string
 }
 
 // ModelPicker is an inline Bubble Tea model for selecting from a filtered list.
@@ -191,6 +196,10 @@ func (m ModelPicker) renderBody() string {
 			}
 			b.WriteString(line)
 			b.WriteString("\n")
+			for _, warning := range item.Warnings {
+				b.WriteString("    " + tuitheme.MpDimStyle.Render("⚠ "+warning))
+				b.WriteString("\n")
+			}
 		}
 
 		if len(filtered) > maxVisible {

--- a/cmd/evener-tui/internal/tuipick/model_picker.go
+++ b/cmd/evener-tui/internal/tuipick/model_picker.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 	"primeradiant.com/evener/cmd/evener-tui/internal/tuiprim"
 	"primeradiant.com/evener/cmd/evener-tui/internal/tuitheme"
 )
@@ -156,40 +157,10 @@ func (m ModelPicker) renderBody() string {
 		b.WriteString(tuitheme.MpDimStyle.Render(emptyText))
 		b.WriteString("\n")
 	} else {
-		start, end := visibleRange(filtered, m.cursor)
-
+		start, end := m.visibleRange(filtered)
 		for i := start; i < end; i++ {
-			item := filtered[i]
-			if item.Group != "" && (i == 0 || filtered[i-1].Group != item.Group) {
-				b.WriteString(tuitheme.MpDimStyle.Render(strings.ToUpper(item.Group)))
-				b.WriteString("\n")
-			}
-			cursor := "  "
-			style := tuitheme.MpNormalStyle
-			isActive := modelIDMatchesActive(item.ID, m.active)
-			if i == m.cursor {
-				cursor = "> "
-				style = tuitheme.MpCursorStyle
-			} else if isActive {
-				style = tuitheme.MpActiveStyle
-			}
-			line := cursor + style.Render(item.Display)
-			if item.ID != item.Display && item.Display != "" {
-				line += "  " + tuitheme.MpDimStyle.Render(item.ID)
-			}
-			if item.Meta != "" {
-				line += "  " + tuitheme.MpDimStyle.Render(item.Meta)
-			}
-			if isActive {
-				line += "  " + tuitheme.MpActiveTag.Render("(active)")
-			}
-			if item.DisabledReason != "" {
-				line += "  " + tuitheme.MpDimStyle.Render("disabled: "+item.DisabledReason)
-			}
-			b.WriteString(line)
-			b.WriteString("\n")
-			for _, warning := range item.Warnings {
-				b.WriteString("    " + tuitheme.MpDimStyle.Render("⚠ "+warning))
+			for _, line := range m.itemLines(filtered, i) {
+				b.WriteString(line)
 				b.WriteString("\n")
 			}
 		}
@@ -203,46 +174,81 @@ func (m ModelPicker) renderBody() string {
 }
 
 // maxVisibleLines is the picker body's rendered-line budget. Items are not a
-// fixed height — each warning adds a line under its row, and a group's first
-// item adds a header — so the window is measured in rendered lines rather than
-// items; counting items let a few warned rows push the footer off the overlay.
+// fixed height — each warning adds a line under its row, a group's first item
+// adds a header, and the frame wraps anything longer than it is wide — so the
+// window is measured in terminal lines rather than items.
 const maxVisibleLines = 15
 
-// renderedLines is how many body lines filtered[i] occupies: its own row, one
-// line per warning, and one for the group header when it starts a group (the
-// renderer writes a header at the first item and at every group change).
-func renderedLines(filtered []ModelPickerItem, i int) int {
-	n := 1 + len(filtered[i].Warnings)
-	if filtered[i].Group != "" && (i == 0 || filtered[i-1].Group != filtered[i].Group) {
-		n++
+// itemLines is the body an item renders: the group header when it starts a
+// group, its row, then one line per warning. The window measurer and the
+// renderer share it, so what a row costs is stated once.
+func (m ModelPicker) itemLines(filtered []ModelPickerItem, i int) []string {
+	item := filtered[i]
+	var lines []string
+	if item.Group != "" && (i == 0 || filtered[i-1].Group != item.Group) {
+		lines = append(lines, tuitheme.MpDimStyle.Render(strings.ToUpper(item.Group)))
 	}
-	return n
+	cursor := "  "
+	style := tuitheme.MpNormalStyle
+	isActive := modelIDMatchesActive(item.ID, m.active)
+	if i == m.cursor {
+		cursor = "> "
+		style = tuitheme.MpCursorStyle
+	} else if isActive {
+		style = tuitheme.MpActiveStyle
+	}
+	line := cursor + style.Render(item.Display)
+	if item.ID != item.Display && item.Display != "" {
+		line += "  " + tuitheme.MpDimStyle.Render(item.ID)
+	}
+	if item.Meta != "" {
+		line += "  " + tuitheme.MpDimStyle.Render(item.Meta)
+	}
+	if isActive {
+		line += "  " + tuitheme.MpActiveTag.Render("(active)")
+	}
+	if item.DisabledReason != "" {
+		line += "  " + tuitheme.MpDimStyle.Render("disabled: "+item.DisabledReason)
+	}
+	lines = append(lines, line)
+	for _, warning := range item.Warnings {
+		lines = append(lines, "    "+tuitheme.MpDimStyle.Render("⚠ "+warning))
+	}
+	return lines
+}
+
+// renderedLines is how many terminal lines filtered[i] takes on screen: the
+// lines it renders, wrapped the way the overlay's frame wraps the body, since
+// a row or warning longer than the frame occupies more than one.
+func (m ModelPicker) renderedLines(filtered []ModelPickerItem, i int) int {
+	block := strings.Join(m.itemLines(filtered, i), "\n")
+	return strings.Count(ansi.Wrap(block, tuiprim.OverlayContentWidth(m.overlayWidth()), ""), "\n") + 1
 }
 
 // visibleRange is the [start, end) window of filtered items to render: the
 // cursor's item plus the neighbours that fit the budget, taken from both sides
 // so the cursor stays near the middle. An item that alone exceeds the budget
 // still renders, since a row cannot be shown in part.
-func visibleRange(filtered []ModelPickerItem, cursor int) (int, int) {
+func (m ModelPicker) visibleRange(filtered []ModelPickerItem) (int, int) {
 	if len(filtered) == 0 {
 		return 0, 0
 	}
 	// A cursor can outlive the list it indexes (a filter narrowed the list, or
 	// a caller set it directly), so clamp it rather than trust it.
-	cursor = min(max(cursor, 0), len(filtered)-1)
+	cursor := min(max(m.cursor, 0), len(filtered)-1)
 	start, end := cursor, cursor+1
-	used := renderedLines(filtered, cursor)
+	used := m.renderedLines(filtered, cursor)
 	for {
 		grew := false
 		if end < len(filtered) {
-			if n := renderedLines(filtered, end); used+n <= maxVisibleLines {
+			if n := m.renderedLines(filtered, end); used+n <= maxVisibleLines {
 				used += n
 				end++
 				grew = true
 			}
 		}
 		if start > 0 {
-			if n := renderedLines(filtered, start-1); used+n <= maxVisibleLines {
+			if n := m.renderedLines(filtered, start-1); used+n <= maxVisibleLines {
 				start--
 				used += n
 				grew = true
@@ -288,13 +294,7 @@ func (m ModelPicker) View() string {
 	if title == "" {
 		title = "Select model"
 	}
-	// Match old tuiprim.RenderPopupPane width logic: popup is min(max(termWidth,44),96)
-	// so content at 90 chars won't be word-wrapped by the Overlay frame.
-	w := m.width
-	if w <= 0 {
-		w = 96
-	}
-	w = min(max(w, 44), 96)
+	w := m.overlayWidth()
 	body := m.renderBody()
 	footer := tuiprim.ActionBarForWidth(w, tuiprim.KbdHint("↑↓", "navigate"), tuiprim.KbdHint("enter", "select"), tuiprim.KbdHint("esc", "cancel"))
 	return tuiprim.Overlay(tuiprim.OverlayOpts{
@@ -303,4 +303,15 @@ func (m ModelPicker) View() string {
 		Body:   body,
 		Footer: footer,
 	})
+}
+
+// overlayWidth is the width of the frame the picker renders into: the old
+// tuiprim.RenderPopupPane logic, min(max(termWidth, 44), 96), so content at 90
+// chars is not word-wrapped by the Overlay frame.
+func (m ModelPicker) overlayWidth() int {
+	w := m.width
+	if w <= 0 {
+		w = 96
+	}
+	return min(max(w, 44), 96)
 }

--- a/cmd/evener-tui/internal/tuipick/model_picker_test.go
+++ b/cmd/evener-tui/internal/tuipick/model_picker_test.go
@@ -161,12 +161,49 @@ func TestModelPicker_DisabledItemRendersReasonAndCannotSelect(t *testing.T) {
 	if mp.done || mp.selected != "" {
 		t.Fatalf("disabled row should keep picker open without selection: done=%v selected=%q", mp.done, mp.selected)
 	}
-
 	tm, _ = mp.Update(tea.KeyMsg{Type: tea.KeyDown})
 	tm, _ = tm.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	mp = tm.(ModelPicker)
 	if !mp.done || mp.selected != "ollama/llama3" {
 		t.Fatalf("enabled row selection done=%v selected=%q, want ollama/llama3", mp.done, mp.selected)
+	}
+}
+
+// A registry warning (e.g. a global-only model under a regional Vertex
+// location) renders as a dim note under the row while the row stays
+// selectable: it is information, not a disabled or removed option.
+func TestModelPicker_WarningRendersUnderRowAndStaysSelectable(t *testing.T) {
+	const note = `regional location cannot serve this model`
+	items := []ModelPickerItem{
+		{ID: "vertex/gemini-3.8-flash", Display: "gemini-3.8-flash", Warnings: []string{note}},
+	}
+	p := NewModelPicker(items, "", 80)
+
+	plain := ansiPattern.ReplaceAllString(p.View(), "")
+	lines := strings.Split(plain, "\n")
+	var row, warningLine string
+	for _, line := range lines {
+		if strings.Contains(line, "gemini-3.8-flash") {
+			row = line
+		}
+		if strings.Contains(line, note) {
+			warningLine = line
+		}
+	}
+	if row == "" {
+		t.Fatal("no row for the model in view")
+	}
+	if strings.Contains(row, note) {
+		t.Fatalf("the warning must render on its own line, not on the row: %q", row)
+	}
+	if warningLine == "" {
+		t.Fatalf("picker did not render the warning as its own line:\n%s", plain)
+	}
+
+	selectedModel, _ := p.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	selected := selectedModel.(ModelPicker)
+	if !selected.Done() || selected.Selected() != "vertex/gemini-3.8-flash" {
+		t.Fatalf("a warned row must stay selectable: done:%v selected:%q", selected.Done(), selected.Selected())
 	}
 }
 

--- a/cmd/evener-tui/internal/tuipick/model_picker_test.go
+++ b/cmd/evener-tui/internal/tuipick/model_picker_test.go
@@ -6,6 +6,9 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
+
+	"primeradiant.com/evener/cmd/evener-tui/internal/tuiprim"
 )
 
 func TestModelPicker_FilterAndSelect(t *testing.T) {
@@ -208,11 +211,13 @@ func TestModelPicker_WarningRendersUnderRowAndStaysSelectable(t *testing.T) {
 	}
 }
 
-// windowLines is renderBody's rendered model window: the filter line and its
-// blank separator, then every line up to the optional "N items total" trailer.
+// windowLines is renderBody's model window as the overlay frame renders it:
+// the body wrapped to the frame's content width, minus the filter line and its
+// blank separator and the optional "N items total" trailer. A warning longer
+// than the frame is wide occupies the terminal lines it really occupies.
 func windowLines(t *testing.T, m ModelPicker) (lines []string, trailer bool) {
 	t.Helper()
-	body := strings.TrimRight(m.renderBody(), "\n")
+	body := strings.TrimRight(ansi.Wrap(m.renderBody(), tuiprim.OverlayContentWidth(m.overlayWidth()), ""), "\n")
 	lines = strings.Split(body, "\n")
 	if len(lines) < 2 || !strings.HasPrefix(lines[0], "Filter:") || lines[1] != "" {
 		t.Fatalf("unexpected body preamble:\n%s", body)
@@ -264,6 +269,32 @@ func TestModelPicker_GroupHeadersCountTowardTheBodyBudget(t *testing.T) {
 	lines, _ := windowLines(t, p)
 	if len(lines) > maxVisibleLines {
 		t.Fatalf("body window = %d rendered lines, want <= %d:\n%s", len(lines), maxVisibleLines, p.renderBody())
+	}
+}
+
+// The warning a regional Vertex location actually emits is longer than the
+// overlay is wide, and the frame wraps it. The budget must count the terminal
+// lines an item really occupies, or a few warned rows still push the rows and
+// the footer off the screen.
+func TestModelPicker_WrappedWarningsStayWithinTheBodyBudget(t *testing.T) {
+	const note = `regional Vertex location "us-central1" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.8-flash`
+	items := make([]ModelPickerItem, 20)
+	for i := range items {
+		items[i] = ModelPickerItem{
+			ID:       fmt.Sprintf("m%d", i),
+			Display:  fmt.Sprintf("m%d", i),
+			Warnings: []string{note},
+		}
+	}
+	p := NewModelPicker(items, "", 80)
+	p.cursor = 10
+
+	lines, _ := windowLines(t, p)
+	if len(lines) > maxVisibleLines {
+		t.Fatalf("body window = %d rendered lines, want <= %d:\n%s", len(lines), maxVisibleLines, p.renderBody())
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), "> m10") {
+		t.Fatalf("the cursor's row must stay in the window:\n%s", p.renderBody())
 	}
 }
 

--- a/cmd/evener-tui/internal/tuipick/model_picker_test.go
+++ b/cmd/evener-tui/internal/tuipick/model_picker_test.go
@@ -320,6 +320,30 @@ func TestModelPicker_StaleCursorStillRendersABoundedWindow(t *testing.T) {
 	}
 }
 
+// The clamped cursor is the row the picker is on: it is highlighted, and Enter
+// selects it. A stale cursor that only the windowing clamped left no
+// highlighted row and made Enter a no-op.
+func TestModelPicker_StaleCursorHighlightsAndSelects(t *testing.T) {
+	items := make([]ModelPickerItem, 20)
+	for i := range items {
+		items[i] = ModelPickerItem{ID: fmt.Sprintf("m%d", i), Display: fmt.Sprintf("m%d", i)}
+	}
+	p := NewModelPicker(items, "", 80)
+	p.filter = "m1" // m1 and m10..m19: 11 items for a cursor at 15
+	p.cursor = 15
+
+	lines, _ := windowLines(t, p)
+	if !strings.Contains(strings.Join(lines, "\n"), "> m19") {
+		t.Fatalf("the clamped cursor's row must be highlighted:\n%s", p.renderBody())
+	}
+
+	tm, _ := p.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	selected := tm.(ModelPicker)
+	if !selected.Done() || selected.Selected() != "m19" {
+		t.Fatalf("Enter must select the highlighted row: done=%v selected=%q", selected.Done(), selected.Selected())
+	}
+}
+
 func TestModelPicker_Navigation(t *testing.T) {
 	items := []ModelPickerItem{
 		{ID: "a", Display: "a"},

--- a/cmd/evener-tui/internal/tuipick/model_picker_test.go
+++ b/cmd/evener-tui/internal/tuipick/model_picker_test.go
@@ -1,6 +1,7 @@
 package tuipick
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -204,6 +205,87 @@ func TestModelPicker_WarningRendersUnderRowAndStaysSelectable(t *testing.T) {
 	selected := selectedModel.(ModelPicker)
 	if !selected.Done() || selected.Selected() != "vertex/gemini-3.8-flash" {
 		t.Fatalf("a warned row must stay selectable: done:%v selected:%q", selected.Done(), selected.Selected())
+	}
+}
+
+// windowLines is renderBody's rendered model window: the filter line and its
+// blank separator, then every line up to the optional "N items total" trailer.
+func windowLines(t *testing.T, m ModelPicker) (lines []string, trailer bool) {
+	t.Helper()
+	body := strings.TrimRight(m.renderBody(), "\n")
+	lines = strings.Split(body, "\n")
+	if len(lines) < 2 || !strings.HasPrefix(lines[0], "Filter:") || lines[1] != "" {
+		t.Fatalf("unexpected body preamble:\n%s", body)
+	}
+	lines = lines[2:]
+	if n := len(lines); n > 0 && strings.Contains(lines[n-1], "items total") {
+		trailer = true
+		lines = lines[:n-1]
+	}
+	return lines, trailer
+}
+
+// A warned row is taller than a plain one, so the window is budgeted in
+// rendered lines: a list of warned models must not push the rows and the
+// footer past the overlay's intended height.
+func TestModelPicker_WarnedRowsStayWithinTheBodyBudget(t *testing.T) {
+	items := make([]ModelPickerItem, 20)
+	for i := range items {
+		items[i] = ModelPickerItem{
+			ID:       fmt.Sprintf("m%d", i),
+			Display:  fmt.Sprintf("m%d", i),
+			Warnings: []string{"regional location cannot serve this model"},
+		}
+	}
+	p := NewModelPicker(items, "", 80)
+	p.cursor = 10
+
+	lines, trailer := windowLines(t, p)
+	if len(lines) > maxVisibleLines {
+		t.Fatalf("body window = %d rendered lines, want <= %d:\n%s", len(lines), maxVisibleLines, p.renderBody())
+	}
+	if !trailer {
+		t.Fatalf("a windowed list must still say how many items it has:\n%s", p.renderBody())
+	}
+	if !strings.Contains(strings.Join(lines, "\n"), "> m10") {
+		t.Fatalf("the cursor's row must stay in the window:\n%s", p.renderBody())
+	}
+}
+
+// Group headers are rendered lines too: the budget counts them, not just rows.
+func TestModelPicker_GroupHeadersCountTowardTheBodyBudget(t *testing.T) {
+	items := make([]ModelPickerItem, 20)
+	for i := range items {
+		items[i] = ModelPickerItem{ID: fmt.Sprintf("m%d", i), Display: fmt.Sprintf("m%d", i), Group: fmt.Sprintf("g%d", i)}
+	}
+	p := NewModelPicker(items, "", 80)
+	p.cursor = 10
+
+	lines, _ := windowLines(t, p)
+	if len(lines) > maxVisibleLines {
+		t.Fatalf("body window = %d rendered lines, want <= %d:\n%s", len(lines), maxVisibleLines, p.renderBody())
+	}
+}
+
+// A cursor can outlive the list it indexes: a filter narrows the list under a
+// cursor that was set while the list was longer. The window clamps it instead
+// of indexing past the end.
+func TestModelPicker_StaleCursorStillRendersABoundedWindow(t *testing.T) {
+	items := make([]ModelPickerItem, 20)
+	for i := range items {
+		items[i] = ModelPickerItem{
+			ID:       fmt.Sprintf("m%d", i),
+			Display:  fmt.Sprintf("m%d", i),
+			Warnings: []string{"regional location cannot serve this model"},
+		}
+	}
+	p := NewModelPicker(items, "", 80)
+	p.filter = "m1" // matches m1 and m10..m19: 11 items for a cursor at 15
+	p.cursor = 15
+
+	lines, _ := windowLines(t, p)
+	if len(lines) > maxVisibleLines {
+		t.Fatalf("body window = %d rendered lines, want <= %d:\n%s", len(lines), maxVisibleLines, p.renderBody())
 	}
 }
 

--- a/cmd/evener-tui/internal/tuiprim/primitives.go
+++ b/cmd/evener-tui/internal/tuiprim/primitives.go
@@ -143,7 +143,7 @@ func Overlay(opts OverlayOpts) string {
 		Width(opts.Width)
 
 	// 4 = 2 padding columns on each side from Padding(1,2) above.
-	contentWidth := max(opts.Width-4, 1)
+	contentWidth := OverlayContentWidth(opts.Width)
 
 	titleLine := lipgloss.NewStyle().Bold(true).Foreground(accent).Render(opts.Title)
 	body := ansi.Wrap(opts.Body, contentWidth, "")
@@ -153,4 +153,12 @@ func Overlay(opts OverlayOpts) string {
 	}
 	content := titleLine + "\n\n" + body
 	return frame.Render(content)
+}
+
+// OverlayContentWidth is the width a body line occupies inside an overlay of
+// the given width: the frame pads two columns on each side. Callers that
+// measure their own body — a list window counting the lines a row renders —
+// use it to measure at the width the frame will wrap to.
+func OverlayContentWidth(width int) int {
+	return max(width-4, 1)
 }

--- a/cmd/evener/internal/launchcheck/launchcheck.go
+++ b/cmd/evener/internal/launchcheck/launchcheck.go
@@ -27,6 +27,10 @@ const launchCheckListTimeout = 8 * time.Second
 type launchCheckModel struct {
 	Provider string `json:"provider"`
 	Model    string `json:"model"`
+	// Warnings carries the resolved row's registry notes so the hub picker can
+	// flag rows the resolver itself warns about (e.g. a global-only model under
+	// a regional Vertex location).
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // supportedLaunchFlags advertises the serve/run flags this binary accepts
@@ -141,7 +145,7 @@ func launchCheckModels() ([]launchCheckModel, []appwire.ModelListDiagnostic, err
 			continue
 		}
 		for _, m := range listing.Models {
-			out = append(out, launchCheckModel{Provider: inst.Name, Model: m.ModelID})
+			out = append(out, launchCheckModel{Provider: inst.Name, Model: m.ModelID, Warnings: append([]string(nil), m.Warnings...)})
 		}
 	}
 	return out, diagnostics, nil

--- a/cmd/evener/internal/launchcheck/launchcheck_test.go
+++ b/cmd/evener/internal/launchcheck/launchcheck_test.go
@@ -308,3 +308,73 @@ func TestLaunchCheckSeesOnlyTheDeclaredInstances(t *testing.T) {
 		}
 	}
 }
+
+// TestLaunchCheckCarriesResolvedWarnings proves the resolved-row notes the
+// registry attaches (a global-only Gemini under a regional Vertex location)
+// survive into the launch contract's models, which is the hub picker's primary
+// source. A config built on the vertex preset with models_endpoint "-" makes
+// the listing registry-only: no network, but the rows resolve with warnings.
+func TestLaunchCheckCarriesResolvedWarnings(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "providers.toml")
+	if err := os.WriteFile(cfgPath, []byte(`
+[providers.vtx]
+base = "google-vertex"
+models_endpoint = "-"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stateRoot := t.TempDir()
+	env := map[string]string{
+		"GOOGLE_VERTEX_PROJECT":  "p",
+		"GOOGLE_VERTEX_LOCATION": "us-central1",
+		"OLLAMA_HOST":            "127.0.0.1:1",
+	}
+
+	old := launchCheckLoadClient
+	t.Cleanup(func() { launchCheckLoadClient = old })
+	launchCheckLoadClient = func(stateDir string) (*llm.Client, error) {
+		r, _, err := cmdutil.LoadRegistry(
+			registry.WithConfigPath(cfgPath),
+			registry.WithStateRoot(stateRoot),
+			registry.WithOffline(true), registry.WithoutCache(),
+			registry.WithEnv(func(k string) (string, bool) { v, ok := env[k]; return v, ok }),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return cmdutil.NewRegistryClient(r, stateDir), nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	err := RunLaunchCheck([]string{
+		"--protocol", appwire.ProtocolVersion,
+		"--models",
+		"--json",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runLaunchCheck: %v stderr=%s", err, stderr.String())
+	}
+	var out struct {
+		Models []struct {
+			Provider string   `json:"provider"`
+			Model    string   `json:"model"`
+			Warnings []string `json:"warnings"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode stdout %q: %v", stdout.String(), err)
+	}
+	for _, m := range out.Models {
+		if m.Provider != "vtx" || m.Model != "gemini-3.5-flash" {
+			continue
+		}
+		if !slices.ContainsFunc(m.Warnings, func(w string) bool {
+			return strings.Contains(w, "regional Vertex location")
+		}) {
+			t.Fatalf("gemini-3.5-flash warnings=%v, want the regional-location note", m.Warnings)
+		}
+		return
+	}
+	t.Fatalf("models=%+v, want vtx/gemini-3.5-flash", out.Models)
+}

--- a/cmdutil/cmdutil.go
+++ b/cmdutil/cmdutil.go
@@ -198,7 +198,12 @@ func ListModelsFunc(client *llm.Client, instance string) func(context.Context) (
 // ModelDescriptorFromResolved is the wire view of a resolved row (spec §11.3).
 func ModelDescriptorFromResolved(res registry.Resolved) appwire.ModelDescriptor {
 	caps := res.Caps
-	d := appwire.ModelDescriptor{Provider: res.Instance, Model: res.ModelID, ReasoningEffortLevels: append([]string(nil), caps.EffortValues...)}
+	d := appwire.ModelDescriptor{
+		Provider:              res.Instance,
+		Model:                 res.ModelID,
+		ReasoningEffortLevels: append([]string(nil), caps.EffortValues...),
+		Warnings:              append([]string(nil), res.Warnings...),
+	}
 	if caps.ContextWindow != nil {
 		d.ContextWindow = new(*caps.ContextWindow)
 	}

--- a/cmdutil/model_descriptor_warnings_test.go
+++ b/cmdutil/model_descriptor_warnings_test.go
@@ -1,0 +1,36 @@
+package cmdutil
+
+import (
+	"slices"
+	"testing"
+
+	"primeradiant.com/evener/llm/registry"
+)
+
+// A resolved row's warnings (e.g. Vertex's "regional location cannot call a
+// global-only model" note) must survive the mapping to the wire descriptor so
+// the web model picker can flag the row. Dropping them here is what kept the
+// note out of the hub UI.
+func TestModelDescriptorFromResolvedCarriesWarnings(t *testing.T) {
+	res := registry.Resolved{
+		Instance: "vertex",
+		ModelID:  "gemini-3.5-flash",
+		Warnings: []string{"model gemini-3.5-flash is served only from the global Vertex endpoint; the configured regional location us-central1 will 404"},
+	}
+
+	got := ModelDescriptorFromResolved(res)
+
+	if !slices.Equal(got.Warnings, res.Warnings) {
+		t.Fatalf("Warnings=%v, want %v", got.Warnings, res.Warnings)
+	}
+}
+
+// A row with no warnings must not fabricate any: the field stays nil so the
+// wire omits it and the picker renders an unadorned row.
+func TestModelDescriptorFromResolvedOmitsAbsentWarnings(t *testing.T) {
+	got := ModelDescriptorFromResolved(registry.Resolved{Instance: "openai", ModelID: "gpt-5.5"})
+
+	if len(got.Warnings) != 0 {
+		t.Fatalf("Warnings=%v, want none", got.Warnings)
+	}
+}

--- a/llm/providers/google/protocol_test.go
+++ b/llm/providers/google/protocol_test.go
@@ -125,6 +125,34 @@ func TestProtocolBuildBody_DropsGeminiSchemaMetaKeys(t *testing.T) {
 	}
 }
 
+// A property *name* is data, not a schema keyword. A tool may legitimately
+// declare an argument named "$id" or "$comment", and the sanitizer must keep
+// it while still stripping a keyword of the same name at a schema position
+// (otherwise the schema loses a parameter that "required" still names).
+func TestProtocolBuildBody_KeepsPropertyNamesThatLookLikeMetaKeys(t *testing.T) {
+	req := protoReq("")
+	req.Tools = []llm.ToolDefinition{{
+		Name: "t",
+		Parameters: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"$id":      map[string]any{"type": "string"},
+				"$comment": map[string]any{"type": "string"},
+				"ok":       map[string]any{"type": "string"},
+			},
+			"required": []any{"$id", "ok"},
+		},
+	}}
+
+	params := protoBuild(t, req, protoRes(nil))["tools"].([]map[string]any)[0]["functionDeclarations"].([]map[string]any)[0]["parameters"].(map[string]any)
+	props := params["properties"].(map[string]any)
+	for _, name := range []string{"$id", "$comment", "ok"} {
+		if _, ok := props[name]; !ok {
+			t.Fatalf("property %q must survive sanitizing: %#v", name, props)
+		}
+	}
+}
+
 func TestProtocolBuildBody_NullableSchemasOnGeminiWire(t *testing.T) {
 	req := protoReq("")
 	req.Tools = []llm.ToolDefinition{{

--- a/llm/providers/google/protocol_test.go
+++ b/llm/providers/google/protocol_test.go
@@ -86,6 +86,45 @@ func TestProtocolBuildBody(t *testing.T) {
 	}
 }
 
+// An MCP server's tool schema arrives as JSON Schema, and its document
+// metadata ($schema, $id, $comment) has no field in Gemini's restricted
+// Schema proto: Vertex rejects the whole request with "Unknown name
+// \"$schema\"". The sanitizer must drop those keys at every level while
+// keeping the validation keywords.
+func TestProtocolBuildBody_DropsGeminiSchemaMetaKeys(t *testing.T) {
+	req := protoReq("")
+	req.Tools = []llm.ToolDefinition{{
+		Name: "use_browser",
+		Parameters: map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"$id":     "https://example.test/use_browser.json",
+			"type":    "object",
+			"properties": map[string]any{
+				"action": map[string]any{
+					"$comment": "the action to run",
+					"type":     "string",
+				},
+			},
+			"required": []any{"action"},
+		},
+	}}
+
+	tools := protoBuild(t, req, protoRes(nil))["tools"].([]map[string]any)
+	params := tools[0]["functionDeclarations"].([]map[string]any)[0]["parameters"].(map[string]any)
+	for _, key := range []string{"$schema", "$id"} {
+		if _, ok := params[key]; ok {
+			t.Fatalf("Gemini parameters must not carry %q: %#v", key, params)
+		}
+	}
+	action := params["properties"].(map[string]any)["action"].(map[string]any)
+	if _, ok := action["$comment"]; ok {
+		t.Fatalf("nested $comment must be dropped: %#v", action)
+	}
+	if action["type"] != "string" || params["required"] == nil {
+		t.Fatalf("validation keywords must survive sanitizing: %#v", params)
+	}
+}
+
 func TestProtocolBuildBody_NullableSchemasOnGeminiWire(t *testing.T) {
 	req := protoReq("")
 	req.Tools = []llm.ToolDefinition{{

--- a/llm/providers/google/protocol_transport.go
+++ b/llm/providers/google/protocol_transport.go
@@ -41,7 +41,7 @@ func reclassifyGemini(res registry.Resolved) func(status int, body []byte, err e
 		}
 		out := llm.RewriteErrorProvider(classifyGeminiError(status, body, retryAfter, err), res.Instance)
 		if remedy, ok := regionalVertexGlobalOnlyRemedy(res, status, body); ok {
-			return &llm.ConfigurationError{Message: remedy, Cause: out}
+			return &llm.ConfigurationError{Message: fmt.Sprintf("%s; provider said: %s", remedy, out.Error()), Cause: out}
 		}
 		return out
 	}
@@ -53,13 +53,19 @@ func reclassifyGemini(res registry.Resolved) func(status int, body []byte, err e
 // models (Gemini 3 and later, recent Claude ids) only from its global
 // endpoint; the raw 404 says to check the region but not which one works.
 // Only a regional location gets a remedy — a request already addressed to
-// global/us/eu is not helped by moving endpoints.
+// global/us/eu is not helped by moving endpoints — and only for a model the
+// registry knows is global-only: Vertex returns this same 404 when the
+// project simply lacks access to a model that is valid there, and rewriting
+// that as an endpoint change would hide the real failure.
 func regionalVertexGlobalOnlyRemedy(res registry.Resolved, status int, body []byte) (string, bool) {
 	if status != http.StatusNotFound || !strings.Contains(string(body), "Publisher model") {
 		return "", false
 	}
 	loc := res.Transport.Vars["GOOGLE_VERTEX_LOCATION"]
 	if loc == "" || loc == "global" || loc == "us" || loc == "eu" {
+		return "", false
+	}
+	if !registry.IsVertexGlobalOnly(res.WireID) {
 		return "", false
 	}
 	return fmt.Sprintf("instance %q: Vertex location %q does not serve model %q; use global, us, or eu (set GOOGLE_VERTEX_LOCATION)", res.Instance, loc, res.WireID), true

--- a/llm/providers/google/protocol_transport.go
+++ b/llm/providers/google/protocol_transport.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (p *Protocol) call(operation, family, method, u string, body map[string]any, req llm.Request, res registry.Resolved) *protocolhttp.Call {
-	return &protocolhttp.Call{Operation: operation, EndpointFamily: family, Method: method, URL: u, Body: body, Req: req, Res: res, Client: p.Client, Reclassify: reclassifyGemini(res.Instance)}
+	return &protocolhttp.Call{Operation: operation, EndpointFamily: family, Method: method, URL: u, Body: body, Req: req, Res: res, Client: p.Client, Reclassify: reclassifyGemini(res)}
 }
 
 func (p *Protocol) completionCall(operation, family, method, u string, body map[string]any, req llm.Request, res registry.Resolved) *protocolhttp.Call {
@@ -30,15 +30,39 @@ func (p *Protocol) completionCall(operation, family, method, u string, body map[
 // reclassifyGemini applies the gRPC status remap of classifyGeminiError to
 // the runner's classified error (RESOURCE_EXHAUSTED on a 400 is a rate
 // limit, DEADLINE_EXCEEDED a timeout, UNAVAILABLE/INTERNAL a server error)
-// and keeps the instance name on the remapped error.
-func reclassifyGemini(instance string) func(status int, body []byte, err error) error {
+// and keeps the instance name on the remapped error. It then turns Vertex's
+// "Publisher model ... was not found" 404 on a regional location into an
+// actionable configuration error (regionalVertexGlobalOnlyRemedy).
+func reclassifyGemini(res registry.Resolved) func(status int, body []byte, err error) error {
 	return func(status int, body []byte, err error) error {
 		var retryAfter *time.Duration
 		if le, ok := errors.AsType[llm.Error](err); ok {
 			retryAfter = le.RetryAfter()
 		}
-		return llm.RewriteErrorProvider(classifyGeminiError(status, body, retryAfter, err), instance)
+		out := llm.RewriteErrorProvider(classifyGeminiError(status, body, retryAfter, err), res.Instance)
+		if remedy, ok := regionalVertexGlobalOnlyRemedy(res, status, body); ok {
+			return &llm.ConfigurationError{Message: remedy, Cause: out}
+		}
+		return out
 	}
+}
+
+// regionalVertexGlobalOnlyRemedy recognizes the 404 Vertex returns when a
+// publisher model is not served by the location the resolved transport was
+// built with, and returns the message naming the remedy. Vertex serves some
+// models (Gemini 3 and later, recent Claude ids) only from its global
+// endpoint; the raw 404 says to check the region but not which one works.
+// Only a regional location gets a remedy — a request already addressed to
+// global/us/eu is not helped by moving endpoints.
+func regionalVertexGlobalOnlyRemedy(res registry.Resolved, status int, body []byte) (string, bool) {
+	if status != http.StatusNotFound || !strings.Contains(string(body), "Publisher model") {
+		return "", false
+	}
+	loc := res.Transport.Vars["GOOGLE_VERTEX_LOCATION"]
+	if loc == "" || loc == "global" || loc == "us" || loc == "eu" {
+		return "", false
+	}
+	return fmt.Sprintf("instance %q: Vertex location %q does not serve model %q; use global, us, or eu (set GOOGLE_VERTEX_LOCATION)", res.Instance, loc, res.WireID), true
 }
 
 // Complete implements llm.Protocol.

--- a/llm/providers/google/protocol_transport.go
+++ b/llm/providers/google/protocol_transport.go
@@ -58,24 +58,19 @@ func reclassifyGemini(res registry.Resolved) func(status int, body []byte, err e
 // project simply lacks access to a model that is valid there, and rewriting
 // that as an endpoint change would hide the real failure.
 func regionalVertexGlobalOnlyRemedy(res registry.Resolved, status int, body []byte) (string, bool) {
-	// Only a transport whose host the vertex-location rule derived from the
-	// location reaches a Vertex regional endpoint; a custom transport that
-	// merely reads GOOGLE_VERTEX_LOCATION into its URL is talking to
-	// something else, and rewriting its 404 would misattribute the failure.
-	if res.Transport.HostRule != registry.HostRuleVertexLocation {
-		return "", false
-	}
-	// A directly supplied GOOGLE_VERTEX_HOST (exposed in Vars by buildTransport)
-	// sends the request to that host even when the path still names a regional
-	// location, so the 404 is the supplied host's own failure.
-	if res.Transport.Vars["GOOGLE_VERTEX_HOST"] != "" {
+	// Only a request addressed to the endpoint the vertex-location rule
+	// derived from the location reaches a Vertex regional endpoint; a
+	// transport that merely reads GOOGLE_VERTEX_LOCATION into its own URL is
+	// talking to something else, and rewriting its 404 would misattribute the
+	// failure.
+	loc, derived := res.Transport.VertexDerivedLocation()
+	if !derived {
 		return "", false
 	}
 	if status != http.StatusNotFound || !strings.Contains(string(body), "Publisher model") {
 		return "", false
 	}
-	loc := res.Transport.Vars["GOOGLE_VERTEX_LOCATION"]
-	if loc == "" || loc == "global" || loc == "us" || loc == "eu" {
+	if loc == "global" || loc == "us" || loc == "eu" {
 		return "", false
 	}
 	if !registry.IsVertexGlobalOnly(res.WireID) {

--- a/llm/providers/google/protocol_transport.go
+++ b/llm/providers/google/protocol_transport.go
@@ -63,7 +63,7 @@ func regionalVertexGlobalOnlyRemedy(res registry.Resolved, status int, body []by
 	// transport that merely reads GOOGLE_VERTEX_LOCATION into its own URL is
 	// talking to something else, and rewriting its 404 would misattribute the
 	// failure.
-	loc, derived := res.Transport.VertexDerivedLocation()
+	loc, derived := registry.VertexLocationDerived(res.Transport, res.HostDerivedByRule)
 	if !derived {
 		return "", false
 	}

--- a/llm/providers/google/protocol_transport.go
+++ b/llm/providers/google/protocol_transport.go
@@ -65,6 +65,12 @@ func regionalVertexGlobalOnlyRemedy(res registry.Resolved, status int, body []by
 	if res.Transport.HostRule != registry.HostRuleVertexLocation {
 		return "", false
 	}
+	// A directly supplied GOOGLE_VERTEX_HOST (exposed in Vars by buildTransport)
+	// sends the request to that host even when the path still names a regional
+	// location, so the 404 is the supplied host's own failure.
+	if res.Transport.Vars["GOOGLE_VERTEX_HOST"] != "" {
+		return "", false
+	}
 	if status != http.StatusNotFound || !strings.Contains(string(body), "Publisher model") {
 		return "", false
 	}

--- a/llm/providers/google/protocol_transport.go
+++ b/llm/providers/google/protocol_transport.go
@@ -67,7 +67,10 @@ func regionalVertexGlobalOnlyRemedy(res registry.Resolved, status int, body []by
 	if !derived {
 		return "", false
 	}
-	if status != http.StatusNotFound || !strings.Contains(string(body), "Publisher model") {
+	// The phrase is matched without regard to case: the regional body observed
+	// on 2026-09-12 reads "Publisher model", and the remedy should not depend
+	// on the provider's capitalization.
+	if status != http.StatusNotFound || !strings.Contains(strings.ToLower(string(body)), "publisher model") {
 		return "", false
 	}
 	if loc == "global" || loc == "us" || loc == "eu" {

--- a/llm/providers/google/protocol_transport.go
+++ b/llm/providers/google/protocol_transport.go
@@ -58,6 +58,13 @@ func reclassifyGemini(res registry.Resolved) func(status int, body []byte, err e
 // project simply lacks access to a model that is valid there, and rewriting
 // that as an endpoint change would hide the real failure.
 func regionalVertexGlobalOnlyRemedy(res registry.Resolved, status int, body []byte) (string, bool) {
+	// Only a transport whose host the vertex-location rule derived from the
+	// location reaches a Vertex regional endpoint; a custom transport that
+	// merely reads GOOGLE_VERTEX_LOCATION into its URL is talking to
+	// something else, and rewriting its 404 would misattribute the failure.
+	if res.Transport.HostRule != registry.HostRuleVertexLocation {
+		return "", false
+	}
 	if status != http.StatusNotFound || !strings.Contains(string(body), "Publisher model") {
 		return "", false
 	}

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -86,6 +87,59 @@ func protoLive(srv *httptest.Server) registry.Resolved {
 	res.Transport = registry.Transport{Auth: registry.AuthHeader, AuthHeader: "x-goog-api-key", BaseURL: srv.URL + "/v1beta", Endpoint: "/models/{model}:generateContent", StreamEndpoint: "/models/{model}:streamGenerateContent?alt=sse", ModelsEndpoint: "/models", CountTokensEndpoint: "/models/{model}:countTokens"}
 	res.Credential = registry.Credential{Value: "k-1", Source: "api_key"}
 	return res
+}
+
+// hostRewriteClient serves every request from srv whatever authority the URL
+// names. The remedy decides from Transport.BaseURL, so a fixture that asserts
+// something about the authority has to carry the authority production carries
+// while the request still lands on the test server.
+func hostRewriteClient(t *testing.T, srv *httptest.Server) *http.Client {
+	t.Helper()
+	target, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := srv.Client()
+	next := client.Transport
+	client.Transport = rewriteHostRoundTripper{target: target, next: next}
+	return client
+}
+
+type rewriteHostRoundTripper struct {
+	target *url.URL
+	next   http.RoundTripper
+}
+
+func (f rewriteHostRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme, req.URL.Host = f.target.Scheme, f.target.Host
+	return f.next.RoundTrip(req)
+}
+
+// vertexAuthorityRes is a resolved Vertex publisher-model transport on the
+// location-derived endpoint authority for loc: what the registry builds when
+// the vertex-location host rule derives the host. Callers pair it with
+// hostRewriteClient, since the authority it names is not the test server's.
+func vertexAuthorityRes(t *testing.T, srv *httptest.Server, loc string) registry.Resolved {
+	t.Helper()
+	res := protoLive(srv)
+	res.WireID = "gemini-3.8-flash"
+	res.Transport.HostRule = registry.HostRuleVertexLocation
+	res.Transport.BaseURL = vertexAuthority(loc) + "/v1/projects/p/locations/" + loc
+	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": loc, "GOOGLE_VERTEX_PROJECT": "p"}
+	return res
+}
+
+// vertexAuthority is the host the vertex-location rule derives for loc
+// (spec §9.4), restated here so the fixture is an independent statement of
+// the rule rather than a call into it.
+func vertexAuthority(loc string) string {
+	switch loc {
+	case "global":
+		return "https://aiplatform.googleapis.com"
+	case "us", "eu":
+		return "https://aiplatform." + loc + ".rep.googleapis.com"
+	}
+	return "https://" + loc + "-aiplatform.googleapis.com"
 }
 
 func TestProtocolCompleteUsesHeaderAuthAndModelInPath(t *testing.T) {
@@ -181,12 +235,9 @@ func TestProtocolReclassifiesGRPCStatus(t *testing.T) {
 func TestProtocolRegionalVertexPublisherModelNotFoundIsActionable(t *testing.T) {
 	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
 	srv, _ := protoServer(t, http.StatusNotFound, body)
-	res := protoLive(srv)
-	res.WireID = "gemini-3.8-flash"
-	res.Transport.HostRule = registry.HostRuleVertexLocation
-	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
+	res := vertexAuthorityRes(t, srv, "us-central1")
 
-	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
 	cfgErr, ok := errors.AsType[*llm.ConfigurationError](err)
 	if !ok || !strings.Contains(cfgErr.Message, "us-central1") || !strings.Contains(cfgErr.Message, "global") {
 		t.Fatalf("regional publisher-model 404 must be an actionable configuration error: %v", err)
@@ -204,12 +255,10 @@ func TestProtocolRegionalVertexPublisherModelNotFoundIsActionable(t *testing.T) 
 func TestProtocolRegionalNonGlobalOnly404StaysProviderError(t *testing.T) {
 	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-2.5-flash`" + ` was not found or your project does not have access to it."}}`
 	srv, _ := protoServer(t, http.StatusNotFound, body)
-	res := protoLive(srv)
+	res := vertexAuthorityRes(t, srv, "us-central1")
 	res.WireID = "gemini-2.5-flash"
-	res.Transport.HostRule = registry.HostRuleVertexLocation
-	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
 
-	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
 	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a model the registry does not know to be global-only must not claim a regional remedy: %v", err)
 	}
@@ -225,13 +274,12 @@ func TestProtocolRegionalNonGlobalOnly404StaysProviderError(t *testing.T) {
 func TestProtocolNonVertexTransport404StaysProviderError(t *testing.T) {
 	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
 	srv, _ := protoServer(t, http.StatusNotFound, body)
-	res := protoLive(srv)
-	res.WireID = "gemini-3.8-flash"
+	res := vertexAuthorityRes(t, srv, "us-central1")
 	// A custom gateway transport that happens to read GOOGLE_VERTEX_LOCATION
 	// into its path: no vertex-location host rule.
-	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
+	res.Transport.HostRule = ""
 
-	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
 	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a transport without the vertex-location host rule must not get the Vertex remedy: %v", err)
 	}
@@ -250,15 +298,38 @@ func TestProtocolDirectVertexHost404StaysProviderError(t *testing.T) {
 	res := protoLive(srv)
 	res.WireID = "gemini-3.8-flash"
 	res.Transport.HostRule = registry.HostRuleVertexLocation
+	res.Transport.BaseURL = "https://gw.example.test/v1/projects/p/locations/us-central1"
 	res.Transport.Vars = map[string]string{
 		"GOOGLE_VERTEX_LOCATION": "us-central1",
 		"GOOGLE_VERTEX_PROJECT":  "p",
 		"GOOGLE_VERTEX_HOST":     "https://gw.example.test",
 	}
 
-	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
 	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a directly supplied host must not get the location-derived remedy: %v", err)
+	}
+	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
+		t.Fatalf("the provider's 404 must survive: %v", err)
+	}
+}
+
+// A transport that inherits the vertex-location rule but points its base URL at
+// a literal host reaches that host, not a regional Vertex endpoint — even when
+// its path reads the location. The 404 is the host's own failure and must not
+// be rewritten as a Vertex location configuration error.
+func TestProtocolLiteralHostWithLocationPath404StaysProviderError(t *testing.T) {
+	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
+	srv, _ := protoServer(t, http.StatusNotFound, body)
+	res := protoLive(srv)
+	res.WireID = "gemini-3.8-flash"
+	res.Transport.HostRule = registry.HostRuleVertexLocation
+	res.Transport.BaseURL = "https://gw.example.test/v1/projects/p/locations/us-central1"
+	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
+
+	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
+	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
+		t.Fatalf("a literal host must not get the location-derived remedy: %v", err)
 	}
 	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
 		t.Fatalf("the provider's 404 must survive: %v", err)
@@ -270,12 +341,9 @@ func TestProtocolDirectVertexHost404StaysProviderError(t *testing.T) {
 func TestProtocolGlobalVertexPublisherModelNotFoundStaysProviderError(t *testing.T) {
 	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/global/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
 	srv, _ := protoServer(t, http.StatusNotFound, body)
-	res := protoLive(srv)
-	res.WireID = "gemini-3.8-flash"
-	res.Transport.HostRule = registry.HostRuleVertexLocation
-	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "global", "GOOGLE_VERTEX_PROJECT": "p"}
+	res := vertexAuthorityRes(t, srv, "global")
 
-	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
 	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a global-endpoint 404 must not claim a regional remedy: %v", err)
 	}

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -174,6 +174,45 @@ func TestProtocolReclassifiesGRPCStatus(t *testing.T) {
 	}
 }
 
+// A publisher model Vertex serves from its global endpoint only 404s on a
+// regional one. The raw message tells the user to check the region without
+// naming the remedy; the reclassifier turns it into a configuration error
+// that does (the same class the registry warns about at resolve time).
+func TestProtocolRegionalVertexPublisherModelNotFoundIsActionable(t *testing.T) {
+	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
+	srv, _ := protoServer(t, http.StatusNotFound, body)
+	res := protoLive(srv)
+	res.WireID = "gemini-3.8-flash"
+	res.Transport.HostRule = registry.HostRuleVertexLocation
+	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
+
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	var cfgErr *llm.ConfigurationError
+	if !errors.As(err, &cfgErr) || !strings.Contains(cfgErr.Message, "us-central1") || !strings.Contains(cfgErr.Message, "global") {
+		t.Fatalf("regional publisher-model 404 must be an actionable configuration error: %v", err)
+	}
+}
+
+// The same 404 against the global endpoint already names the endpoint that
+// serves the model, so it stays the provider's own error.
+func TestProtocolGlobalVertexPublisherModelNotFoundStaysProviderError(t *testing.T) {
+	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/global/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
+	srv, _ := protoServer(t, http.StatusNotFound, body)
+	res := protoLive(srv)
+	res.WireID = "gemini-3.8-flash"
+	res.Transport.HostRule = registry.HostRuleVertexLocation
+	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "global", "GOOGLE_VERTEX_PROJECT": "p"}
+
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	var cfgErr *llm.ConfigurationError
+	if errors.As(err, &cfgErr) {
+		t.Fatalf("a global-endpoint 404 must not claim a regional remedy: %v", err)
+	}
+	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
+		t.Fatalf("global 404 must stay the provider's 404: %v", err)
+	}
+}
+
 func TestProtocolListModelsAndCountTokens(t *testing.T) {
 	srv, got := protoServer(t, 200, `{"models":[{"name":"models/gemini-2.5-flash","inputTokenLimit":922000,"outputTokenLimit":128000,"supportedGenerationMethods":["generateContent"]},{"name":"models/embedding-001","supportedGenerationMethods":["embedContent"]}]}`)
 	res := protoLive(srv)

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -191,6 +191,31 @@ func TestProtocolRegionalVertexPublisherModelNotFoundIsActionable(t *testing.T) 
 	if !ok || !strings.Contains(cfgErr.Message, "us-central1") || !strings.Contains(cfgErr.Message, "global") {
 		t.Fatalf("regional publisher-model 404 must be an actionable configuration error: %v", err)
 	}
+	if !strings.Contains(cfgErr.Message, "not found or your project does not have access") {
+		t.Fatalf("the remedy must keep the provider's own detail visible: %q", cfgErr.Message)
+	}
+}
+
+// A regional publisher-model 404 for a model the registry does not know to be
+// global-only is ambiguous: Vertex uses the same body for "not found" and for
+// "your project does not have access to it". Rewriting it as a global-endpoint
+// remedy would hide a genuine permissions failure, so it stays the provider's
+// own error.
+func TestProtocolRegionalNonGlobalOnly404StaysProviderError(t *testing.T) {
+	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-2.5-flash`" + ` was not found or your project does not have access to it."}}`
+	srv, _ := protoServer(t, http.StatusNotFound, body)
+	res := protoLive(srv)
+	res.WireID = "gemini-2.5-flash"
+	res.Transport.HostRule = registry.HostRuleVertexLocation
+	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
+
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
+		t.Fatalf("a model the registry does not know to be global-only must not claim a regional remedy: %v", err)
+	}
+	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
+		t.Fatalf("the provider's 404 must survive: %v", err)
+	}
 }
 
 // The same 404 against the global endpoint already names the endpoint that

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -240,6 +240,31 @@ func TestProtocolNonVertexTransport404StaysProviderError(t *testing.T) {
 	}
 }
 
+// A vertex-location transport whose host was supplied directly still names a
+// location in its path, but the request reaches the supplied host, not the
+// location-derived endpoint — so its 404 is the host's own failure and must
+// not be rewritten as a Vertex regional-location configuration error.
+func TestProtocolDirectVertexHost404StaysProviderError(t *testing.T) {
+	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
+	srv, _ := protoServer(t, http.StatusNotFound, body)
+	res := protoLive(srv)
+	res.WireID = "gemini-3.8-flash"
+	res.Transport.HostRule = registry.HostRuleVertexLocation
+	res.Transport.Vars = map[string]string{
+		"GOOGLE_VERTEX_LOCATION": "us-central1",
+		"GOOGLE_VERTEX_PROJECT":  "p",
+		"GOOGLE_VERTEX_HOST":     "https://gw.example.test",
+	}
+
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
+		t.Fatalf("a directly supplied host must not get the location-derived remedy: %v", err)
+	}
+	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
+		t.Fatalf("the provider's 404 must survive: %v", err)
+	}
+}
+
 // The same 404 against the global endpoint already names the endpoint that
 // serves the model, so it stays the provider's own error.
 func TestProtocolGlobalVertexPublisherModelNotFoundStaysProviderError(t *testing.T) {

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -218,6 +218,28 @@ func TestProtocolRegionalNonGlobalOnly404StaysProviderError(t *testing.T) {
 	}
 }
 
+// The remedy is Vertex's: a transport whose host was not derived from a
+// Vertex location (no vertex-location host rule) is not talking to a Vertex
+// regional endpoint, whatever variables its URL templates read, so its 404
+// must not be rewritten into a Vertex location configuration error.
+func TestProtocolNonVertexTransport404StaysProviderError(t *testing.T) {
+	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
+	srv, _ := protoServer(t, http.StatusNotFound, body)
+	res := protoLive(srv)
+	res.WireID = "gemini-3.8-flash"
+	// A custom gateway transport that happens to read GOOGLE_VERTEX_LOCATION
+	// into its path: no vertex-location host rule.
+	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
+
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
+		t.Fatalf("a transport without the vertex-location host rule must not get the Vertex remedy: %v", err)
+	}
+	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
+		t.Fatalf("the provider's 404 must survive: %v", err)
+	}
+}
+
 // The same 404 against the global endpoint already names the endpoint that
 // serves the model, so it stays the provider's own error.
 func TestProtocolGlobalVertexPublisherModelNotFoundStaysProviderError(t *testing.T) {

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -89,57 +88,19 @@ func protoLive(srv *httptest.Server) registry.Resolved {
 	return res
 }
 
-// hostRewriteClient serves every request from srv whatever authority the URL
-// names. The remedy decides from Transport.BaseURL, so a fixture that asserts
-// something about the authority has to carry the authority production carries
-// while the request still lands on the test server.
-func hostRewriteClient(t *testing.T, srv *httptest.Server) *http.Client {
-	t.Helper()
-	target, err := url.Parse(srv.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client := srv.Client()
-	next := client.Transport
-	client.Transport = rewriteHostRoundTripper{target: target, next: next}
-	return client
-}
-
-type rewriteHostRoundTripper struct {
-	target *url.URL
-	next   http.RoundTripper
-}
-
-func (f rewriteHostRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.URL.Scheme, req.URL.Host = f.target.Scheme, f.target.Host
-	return f.next.RoundTrip(req)
-}
-
-// vertexAuthorityRes is a resolved Vertex publisher-model transport on the
-// location-derived endpoint authority for loc: what the registry builds when
-// the vertex-location host rule derives the host. Callers pair it with
-// hostRewriteClient, since the authority it names is not the test server's.
+// vertexAuthorityRes is a resolved Vertex publisher-model transport whose
+// authority the vertex-location host rule derived from loc: the provenance the
+// registry records (Resolved.HostDerivedByRule) when its base URL template
+// reads {GOOGLE_VERTEX_HOST}. What that derivation accepts and rejects is the
+// registry's own to prove; this fixture states the provenance the remedy reads.
 func vertexAuthorityRes(t *testing.T, srv *httptest.Server, loc string) registry.Resolved {
 	t.Helper()
 	res := protoLive(srv)
 	res.WireID = "gemini-3.8-flash"
 	res.Transport.HostRule = registry.HostRuleVertexLocation
-	res.Transport.BaseURL = vertexAuthority(loc) + "/v1/projects/p/locations/" + loc
 	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": loc, "GOOGLE_VERTEX_PROJECT": "p"}
+	res.HostDerivedByRule = true
 	return res
-}
-
-// vertexAuthority is the host the vertex-location rule derives for loc
-// (spec §9.4), restated here so the fixture is an independent statement of
-// the rule rather than a call into it.
-func vertexAuthority(loc string) string {
-	switch loc {
-	case "global":
-		return "https://aiplatform.googleapis.com"
-	case "us", "eu":
-		return "https://aiplatform." + loc + ".rep.googleapis.com"
-	}
-	return "https://" + loc + "-aiplatform.googleapis.com"
 }
 
 func TestProtocolCompleteUsesHeaderAuthAndModelInPath(t *testing.T) {
@@ -237,7 +198,7 @@ func TestProtocolRegionalVertexPublisherModelNotFoundIsActionable(t *testing.T) 
 	srv, _ := protoServer(t, http.StatusNotFound, body)
 	res := vertexAuthorityRes(t, srv, "us-central1")
 
-	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
 	cfgErr, ok := errors.AsType[*llm.ConfigurationError](err)
 	if !ok || !strings.Contains(cfgErr.Message, "us-central1") || !strings.Contains(cfgErr.Message, "global") {
 		t.Fatalf("regional publisher-model 404 must be an actionable configuration error: %v", err)
@@ -258,7 +219,7 @@ func TestProtocolRegionalNonGlobalOnly404StaysProviderError(t *testing.T) {
 	res := vertexAuthorityRes(t, srv, "us-central1")
 	res.WireID = "gemini-2.5-flash"
 
-	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
 	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a model the registry does not know to be global-only must not claim a regional remedy: %v", err)
 	}
@@ -279,7 +240,7 @@ func TestProtocolNonVertexTransport404StaysProviderError(t *testing.T) {
 	// into its path: no vertex-location host rule.
 	res.Transport.HostRule = ""
 
-	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
 	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a transport without the vertex-location host rule must not get the Vertex remedy: %v", err)
 	}
@@ -288,74 +249,29 @@ func TestProtocolNonVertexTransport404StaysProviderError(t *testing.T) {
 	}
 }
 
-// A vertex-location transport whose host was supplied directly still names a
-// location in its path, but the request reaches the supplied host, not the
-// location-derived endpoint — so its 404 is the host's own failure and must
-// not be rewritten as a Vertex regional-location configuration error.
-func TestProtocolDirectVertexHost404StaysProviderError(t *testing.T) {
+// A transport the host rule did not derive the authority for — a literal host
+// in the base URL (even one naming the location's own host with a path of its
+// own), or a GOOGLE_VERTEX_HOST supplied directly — is addressed to the route
+// the config built, so its 404 is that route's own failure and must not be
+// rewritten as a Vertex regional-location configuration error. Transport
+// resolution is where those shapes are told apart (registry's
+// TestResolve_LiteralHost* and TestResolve_DirectHost*); this covers the
+// remedy's side of the contract, and states the supplied-host shape.
+func TestProtocolUnderivedHost404StaysProviderError(t *testing.T) {
 	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
 	srv, _ := protoServer(t, http.StatusNotFound, body)
 	res := protoLive(srv)
 	res.WireID = "gemini-3.8-flash"
 	res.Transport.HostRule = registry.HostRuleVertexLocation
-	res.Transport.BaseURL = "https://gw.example.test/v1/projects/p/locations/us-central1"
 	res.Transport.Vars = map[string]string{
 		"GOOGLE_VERTEX_LOCATION": "us-central1",
 		"GOOGLE_VERTEX_PROJECT":  "p",
 		"GOOGLE_VERTEX_HOST":     "https://gw.example.test",
 	}
 
-	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
 	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
-		t.Fatalf("a directly supplied host must not get the location-derived remedy: %v", err)
-	}
-	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
-		t.Fatalf("the provider's 404 must survive: %v", err)
-	}
-}
-
-// A transport that inherits the vertex-location rule but points its base URL at
-// a literal host reaches that host, not a regional Vertex endpoint — even when
-// its path reads the location. The 404 is the host's own failure and must not
-// be rewritten as a Vertex location configuration error.
-func TestProtocolLiteralHostWithLocationPath404StaysProviderError(t *testing.T) {
-	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
-	srv, _ := protoServer(t, http.StatusNotFound, body)
-	res := protoLive(srv)
-	res.WireID = "gemini-3.8-flash"
-	res.Transport.HostRule = registry.HostRuleVertexLocation
-	res.Transport.BaseURL = "https://gw.example.test/v1/projects/p/locations/us-central1"
-	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
-
-	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
-	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
-		t.Fatalf("a literal host must not get the location-derived remedy: %v", err)
-	}
-	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
-		t.Fatalf("the provider's 404 must survive: %v", err)
-	}
-}
-
-// A GOOGLE_VERTEX_HOST supplied directly is the authority the user chose, even
-// when it names the location's own host: a path prefix puts something else in
-// front of the regional endpoint, so its 404 is that of the route the user
-// built, not of the location-derived endpoint.
-func TestProtocolDirectVertexHostWithPath404StaysProviderError(t *testing.T) {
-	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
-	srv, _ := protoServer(t, http.StatusNotFound, body)
-	res := protoLive(srv)
-	res.WireID = "gemini-3.8-flash"
-	res.Transport.HostRule = registry.HostRuleVertexLocation
-	res.Transport.BaseURL = "https://us-central1-aiplatform.googleapis.com/proxy/v1/projects/p/locations/us-central1"
-	res.Transport.Vars = map[string]string{
-		"GOOGLE_VERTEX_LOCATION": "us-central1",
-		"GOOGLE_VERTEX_PROJECT":  "p",
-		"GOOGLE_VERTEX_HOST":     "https://us-central1-aiplatform.googleapis.com/proxy",
-	}
-
-	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
-	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
-		t.Fatalf("a supplied host must not get the location-derived remedy: %v", err)
+		t.Fatalf("an underived authority must not get the location-derived remedy: %v", err)
 	}
 	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
 		t.Fatalf("the provider's 404 must survive: %v", err)
@@ -369,7 +285,7 @@ func TestProtocolGlobalVertexPublisherModelNotFoundStaysProviderError(t *testing
 	srv, _ := protoServer(t, http.StatusNotFound, body)
 	res := vertexAuthorityRes(t, srv, "global")
 
-	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
+	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
 	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a global-endpoint 404 must not claim a regional remedy: %v", err)
 	}

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -187,8 +187,8 @@ func TestProtocolRegionalVertexPublisherModelNotFoundIsActionable(t *testing.T) 
 	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "us-central1", "GOOGLE_VERTEX_PROJECT": "p"}
 
 	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
-	var cfgErr *llm.ConfigurationError
-	if !errors.As(err, &cfgErr) || !strings.Contains(cfgErr.Message, "us-central1") || !strings.Contains(cfgErr.Message, "global") {
+	cfgErr, ok := errors.AsType[*llm.ConfigurationError](err)
+	if !ok || !strings.Contains(cfgErr.Message, "us-central1") || !strings.Contains(cfgErr.Message, "global") {
 		t.Fatalf("regional publisher-model 404 must be an actionable configuration error: %v", err)
 	}
 }
@@ -204,8 +204,7 @@ func TestProtocolGlobalVertexPublisherModelNotFoundStaysProviderError(t *testing
 	res.Transport.Vars = map[string]string{"GOOGLE_VERTEX_LOCATION": "global", "GOOGLE_VERTEX_PROJECT": "p"}
 
 	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
-	var cfgErr *llm.ConfigurationError
-	if errors.As(err, &cfgErr) {
+	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a global-endpoint 404 must not claim a regional remedy: %v", err)
 	}
 	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -192,19 +192,26 @@ func TestProtocolReclassifiesGRPCStatus(t *testing.T) {
 // A publisher model Vertex serves from its global endpoint only 404s on a
 // regional one. The raw message tells the user to check the region without
 // naming the remedy; the reclassifier turns it into a configuration error
-// that does (the same class the registry warns about at resolve time).
+// that does (the same class the registry warns about at resolve time). The
+// match does not depend on the provider's casing: the regional body observed
+// on 2026-09-12 reads "Publisher model", and the same message with a capital M
+// takes the same path rather than dropping the guidance silently.
 func TestProtocolRegionalVertexPublisherModelNotFoundIsActionable(t *testing.T) {
-	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
-	srv, _ := protoServer(t, http.StatusNotFound, body)
-	res := vertexAuthorityRes(t, srv, "us-central1")
+	for _, phrase := range []string{"Publisher model", "Publisher Model"} {
+		t.Run(phrase, func(t *testing.T) {
+			body := `{"error":{"code":404,"message":"` + phrase + ` ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
+			srv, _ := protoServer(t, http.StatusNotFound, body)
+			res := vertexAuthorityRes(t, srv, "us-central1")
 
-	_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
-	cfgErr, ok := errors.AsType[*llm.ConfigurationError](err)
-	if !ok || !strings.Contains(cfgErr.Message, "us-central1") || !strings.Contains(cfgErr.Message, "global") {
-		t.Fatalf("regional publisher-model 404 must be an actionable configuration error: %v", err)
-	}
-	if !strings.Contains(cfgErr.Message, "not found or your project does not have access") {
-		t.Fatalf("the remedy must keep the provider's own detail visible: %q", cfgErr.Message)
+			_, err := (&Protocol{Client: srv.Client()}).Complete(context.Background(), protoReq(""), res)
+			cfgErr, ok := errors.AsType[*llm.ConfigurationError](err)
+			if !ok || !strings.Contains(cfgErr.Message, "us-central1") || !strings.Contains(cfgErr.Message, "global") {
+				t.Fatalf("regional publisher-model 404 must be an actionable configuration error: %v", err)
+			}
+			if !strings.Contains(cfgErr.Message, "not found or your project does not have access") {
+				t.Fatalf("the remedy must keep the provider's own detail visible: %q", cfgErr.Message)
+			}
+		})
 	}
 }
 

--- a/llm/providers/google/protocol_transport_test.go
+++ b/llm/providers/google/protocol_transport_test.go
@@ -336,6 +336,32 @@ func TestProtocolLiteralHostWithLocationPath404StaysProviderError(t *testing.T) 
 	}
 }
 
+// A GOOGLE_VERTEX_HOST supplied directly is the authority the user chose, even
+// when it names the location's own host: a path prefix puts something else in
+// front of the regional endpoint, so its 404 is that of the route the user
+// built, not of the location-derived endpoint.
+func TestProtocolDirectVertexHostWithPath404StaysProviderError(t *testing.T) {
+	body := `{"error":{"code":404,"message":"Publisher model ` + "`projects/p/locations/us-central1/publishers/google/models/gemini-3.8-flash`" + ` was not found or your project does not have access to it."}}`
+	srv, _ := protoServer(t, http.StatusNotFound, body)
+	res := protoLive(srv)
+	res.WireID = "gemini-3.8-flash"
+	res.Transport.HostRule = registry.HostRuleVertexLocation
+	res.Transport.BaseURL = "https://us-central1-aiplatform.googleapis.com/proxy/v1/projects/p/locations/us-central1"
+	res.Transport.Vars = map[string]string{
+		"GOOGLE_VERTEX_LOCATION": "us-central1",
+		"GOOGLE_VERTEX_PROJECT":  "p",
+		"GOOGLE_VERTEX_HOST":     "https://us-central1-aiplatform.googleapis.com/proxy",
+	}
+
+	_, err := (&Protocol{Client: hostRewriteClient(t, srv)}).Complete(context.Background(), protoReq(""), res)
+	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
+		t.Fatalf("a supplied host must not get the location-derived remedy: %v", err)
+	}
+	if le, ok := errors.AsType[llm.Error](err); !ok || le.StatusCode() != http.StatusNotFound {
+		t.Fatalf("the provider's 404 must survive: %v", err)
+	}
+}
+
 // The same 404 against the global endpoint already names the endpoint that
 // serves the model, so it stays the provider's own error.
 func TestProtocolGlobalVertexPublisherModelNotFoundStaysProviderError(t *testing.T) {

--- a/llm/providers/google/request.go
+++ b/llm/providers/google/request.go
@@ -174,6 +174,13 @@ func sanitizeGeminiSchema(v any) any {
 			if k == "additionalProperties" || geminiSchemaMetaKeys[k] {
 				continue
 			}
+			// A schema's "properties" maps property *names* to schemas, and a
+			// name is data: a tool may declare an argument called "$id". Only
+			// the schemas on the right are sanitized, never the names.
+			if k == "properties" {
+				out[k] = sanitizeGeminiNamedSchemas(vv)
+				continue
+			}
 			if k == "type" {
 				if typ, nullable, ok := geminiNullableType(vv); ok {
 					out[k] = typ
@@ -199,6 +206,22 @@ func sanitizeGeminiSchema(v any) any {
 	default:
 		return v
 	}
+}
+
+// sanitizeGeminiNamedSchemas sanitizes a map whose keys are names rather than
+// schema keywords (the value of a schema's "properties"): each value is
+// sanitized as a schema, but no key is filtered, so a property legitimately
+// named "$schema" or "additionalProperties" survives.
+func sanitizeGeminiNamedSchemas(v any) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return sanitizeGeminiSchema(v)
+	}
+	out := make(map[string]any, len(m))
+	for name, schema := range m {
+		out[name] = sanitizeGeminiSchema(schema)
+	}
+	return out
 }
 
 func geminiEnumWithoutNull(v any) any {

--- a/llm/providers/google/request.go
+++ b/llm/providers/google/request.go
@@ -148,14 +148,30 @@ func toGeminiFunctionDecls(tools []llm.ToolDefinition) []map[string]any {
 	return out
 }
 
+// geminiSchemaMetaKeys are JSON Schema's document-metadata keywords (draft-07
+// and 2020-12). They carry no validation semantics, but Gemini's Schema proto
+// has no field for them and rejects the request ("Unknown name \"$schema\"").
+// MCP servers emit them: a tool schema generated from a Zod shape starts with
+// $schema, so a single MCP tool otherwise fails every Gemini request.
+var geminiSchemaMetaKeys = map[string]bool{
+	"$schema":        true,
+	"$id":            true,
+	"$comment":       true,
+	"$anchor":        true,
+	"$dynamicAnchor": true,
+	"$vocabulary":    true,
+}
+
 func sanitizeGeminiSchema(v any) any {
 	switch x := v.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(x))
 		for k, vv := range x {
-			// The Gemini Schema proto does not accept JSON Schema's additionalProperties field.
-			// Omitting it preserves compatibility while keeping the rest of the schema useful.
-			if k == "additionalProperties" {
+			// The Gemini Schema proto accepts neither JSON Schema's
+			// additionalProperties field nor its $ document metadata.
+			// Omitting them preserves compatibility while keeping the rest
+			// of the schema useful.
+			if k == "additionalProperties" || geminiSchemaMetaKeys[k] {
 				continue
 			}
 			if k == "type" {

--- a/llm/registry/hostrules.go
+++ b/llm/registry/hostrules.go
@@ -159,39 +159,25 @@ func vertexHost(location string) string {
 	return "https://" + location + "-aiplatform.googleapis.com"
 }
 
-// VertexDerivedLocation reports the location whose endpoint the resolved
-// transport's base URL actually addresses, and false when the request is not
-// addressed to a location-derived Vertex endpoint at all.
+// VertexLocationDerived reports the location whose endpoint the resolved
+// transport addresses, when the vertex-location host rule derived that
+// endpoint's host from it; false when the request is not addressed to a
+// location-derived Vertex endpoint at all.
 //
-// The vertex-location rule derives the host from the location, but a transport
-// can inherit the rule and still point somewhere else: a literal host in the
-// base URL (even one whose path reads {GOOGLE_VERTEX_LOCATION}), or a
-// GOOGLE_VERTEX_HOST supplied directly (even one naming the location's own
-// host, since a path of its own puts something else on the route). Those
-// requests take the route the user built, so only the endpoint the rule itself
-// derived makes the location the endpoint's business.
-func (t Transport) VertexDerivedLocation() (string, bool) {
+// The rule derives a host from the location, but a transport can inherit the
+// rule and still point elsewhere: a literal host in the base URL (even one
+// naming the location's own host, with a path of its own), or a
+// GOOGLE_VERTEX_HOST supplied directly. Those requests take the route the
+// config built, so only the endpoint the rule produced makes the location the
+// endpoint's business. hostDerived is that provenance, recorded by
+// buildTransport when the base URL template's {GOOGLE_VERTEX_HOST} resolved
+// from the location (Resolved.HostDerivedByRule).
+func VertexLocationDerived(t Transport, hostDerived bool) (string, bool) {
 	if t.HostRule != HostRuleVertexLocation {
 		return "", false
 	}
-	// buildTransport exposes a supplied host in Vars; a derived one leaves it
-	// out. A supplied host is the user's authority whichever way it is shaped.
-	if t.Vars["GOOGLE_VERTEX_HOST"] != "" {
-		return "", false
-	}
 	loc := t.Vars["GOOGLE_VERTEX_LOCATION"]
-	if loc == "" {
-		return "", false
-	}
-	got, err := url.Parse(t.BaseURL)
-	if err != nil {
-		return "", false
-	}
-	derived, err := url.Parse(vertexHost(loc))
-	if err != nil {
-		return "", false
-	}
-	if got.Scheme != derived.Scheme || got.Host != derived.Host {
+	if !hostDerived || loc == "" {
 		return "", false
 	}
 	return loc, true

--- a/llm/registry/hostrules.go
+++ b/llm/registry/hostrules.go
@@ -158,3 +158,35 @@ func vertexHost(location string) string {
 	}
 	return "https://" + location + "-aiplatform.googleapis.com"
 }
+
+// VertexDerivedLocation reports the location whose endpoint the resolved
+// transport's base URL actually addresses, and false when the request is not
+// addressed to a location-derived Vertex endpoint at all.
+//
+// The vertex-location rule derives the host from the location, but a transport
+// can inherit the rule and still point somewhere else: a literal host in the
+// base URL (even one whose path reads {GOOGLE_VERTEX_LOCATION}), or a
+// GOOGLE_VERTEX_HOST supplied directly. Those requests reach the host they
+// name, so only the endpoint the rule itself derived makes the location the
+// endpoint's business.
+func (t Transport) VertexDerivedLocation() (string, bool) {
+	if t.HostRule != HostRuleVertexLocation {
+		return "", false
+	}
+	loc := t.Vars["GOOGLE_VERTEX_LOCATION"]
+	if loc == "" {
+		return "", false
+	}
+	got, err := url.Parse(t.BaseURL)
+	if err != nil {
+		return "", false
+	}
+	derived, err := url.Parse(vertexHost(loc))
+	if err != nil {
+		return "", false
+	}
+	if got.Scheme != derived.Scheme || got.Host != derived.Host {
+		return "", false
+	}
+	return loc, true
+}

--- a/llm/registry/hostrules.go
+++ b/llm/registry/hostrules.go
@@ -166,11 +166,17 @@ func vertexHost(location string) string {
 // The vertex-location rule derives the host from the location, but a transport
 // can inherit the rule and still point somewhere else: a literal host in the
 // base URL (even one whose path reads {GOOGLE_VERTEX_LOCATION}), or a
-// GOOGLE_VERTEX_HOST supplied directly. Those requests reach the host they
-// name, so only the endpoint the rule itself derived makes the location the
-// endpoint's business.
+// GOOGLE_VERTEX_HOST supplied directly (even one naming the location's own
+// host, since a path of its own puts something else on the route). Those
+// requests take the route the user built, so only the endpoint the rule itself
+// derived makes the location the endpoint's business.
 func (t Transport) VertexDerivedLocation() (string, bool) {
 	if t.HostRule != HostRuleVertexLocation {
+		return "", false
+	}
+	// buildTransport exposes a supplied host in Vars; a derived one leaves it
+	// out. A supplied host is the user's authority whichever way it is shaped.
+	if t.Vars["GOOGLE_VERTEX_HOST"] != "" {
 		return "", false
 	}
 	loc := t.Vars["GOOGLE_VERTEX_LOCATION"]

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -729,15 +729,15 @@ func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transpo
 	// A host the vertex-location rule derived from the location used the
 	// location as surely as a path placeholder would have, so it is exposed
 	// too (and the regional warning reads it). A host supplied directly used
-	// no location. Only the base URL template can make the rule the author of
-	// the authority — the request URL is that base plus an endpoint path, so a
-	// {GOOGLE_VERTEX_HOST} read anywhere else derives nothing — and only when
-	// that placeholder resolved from the location rather than a supplied value.
+	// no location. Only a {GOOGLE_VERTEX_HOST} in the base URL's authority —
+	// the part of the request URL that names the endpoint — makes the rule its
+	// author, and only when the rule would accept the location: a location it
+	// refuses leaves the placeholder unresolved and derives no endpoint.
 	var hostDerived bool
-	if t.HostRule == HostRuleVertexLocation && slices.Contains(templatePlaceholders(baseURLTemplate), "GOOGLE_VERTEX_HOST") {
+	if t.HostRule == HostRuleVertexLocation && authorityVars(baseURLTemplate)["GOOGLE_VERTEX_HOST"] {
 		_, supplied := lookup("GOOGLE_VERTEX_HOST")
 		loc, located := lookup("GOOGLE_VERTEX_LOCATION")
-		hostDerived = !supplied && located
+		hostDerived = !supplied && located && validVertexLocation(loc)
 		if hostDerived {
 			resolved["GOOGLE_VERTEX_LOCATION"] = loc
 		}

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -58,11 +58,30 @@ type vertexGlobalOnlyFamily struct {
 // names a family Vertex serves only from the global and us/eu endpoints.
 func vertexGlobalOnlyDetail(wireID string) (string, bool) {
 	for _, family := range vertexGlobalOnly {
-		if slices.ContainsFunc(family.patterns, func(p string) bool { return strings.Contains(wireID, p) }) {
+		if slices.ContainsFunc(family.patterns, func(p string) bool { return familyCovers(p, wireID) }) {
 			return family.detail, true
 		}
 	}
 	return "", false
+}
+
+// familyCovers reports whether an id belongs to the family a pattern names:
+// the pattern appears at a boundary — followed by the end of the id or by a
+// separator — so "gemini-3" covers gemini-3.8-flash and gemini-3-pro-preview
+// while a longer number (gemini-30) is a different family.
+func familyCovers(pattern, wireID string) bool {
+	if pattern == "" {
+		return false
+	}
+	for start := 0; start+len(pattern) <= len(wireID); start++ {
+		if !strings.HasPrefix(wireID[start:], pattern) {
+			continue
+		}
+		if rest := wireID[start+len(pattern):]; rest == "" || strings.ContainsRune(".-:@", rune(rest[0])) {
+			return true
+		}
+	}
+	return false
 }
 
 // IsVertexGlobalOnly reports whether wireID names a model Vertex serves only
@@ -269,7 +288,7 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 		mergeCaps(&caps, layer.provider, layer.tag+"/provider", prov)
 	}
 	seedFields(&caps, rec.head.Protocol)
-	transport, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
+	transport, hostDerived, warnings := r.buildTransport(rec, Model{}, rec.head.Protocol)
 	// rowID/ref "" keep firstPartyEndpoint's canonical resolution row-less
 	// and glob-less, mirroring the row-less buildTransport call above -
 	// correctly so: ListModels and credential probes, this path's only
@@ -297,7 +316,7 @@ func (r *Registry) ResolveInstance(name string) (Resolved, error) {
 	}
 	return Resolved{
 		Instance: rec.name, ProviderID: providerID, Protocol: rec.head.Protocol, Surface: rec.head.Surface,
-		Transport: transport, Caps: caps, Headers: r.buildHeaders(rec.head.Headers, nil),
+		Transport: transport, HostDerivedByRule: hostDerived, Caps: caps, Headers: r.buildHeaders(rec.head.Headers, nil),
 		Credential: cred, CredentialHeaders: credHeaders, Provenance: prov, Warnings: warnings,
 		ShadowedEnvVar: r.shadowedEnvVar(rec, cred),
 		DefaultModel:   rec.head.DefaultModel, CheapModel: rec.head.CheapModel,
@@ -462,7 +481,7 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	}
 	seedFields(&caps, rowProto)
 
-	transport, tw := r.buildTransport(rec, row, rowProto)
+	transport, hostDerived, tw := r.buildTransport(rec, row, rowProto)
 	warnings = append(warnings, tw...)
 	if w := r.gateWebSearch(&caps, prov, rec, transport, rowProto, canonicalRowID, ref.Model, altID); w != "" {
 		warnings = append(warnings, w)
@@ -490,9 +509,9 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	}
 	warnings = append(warnings, rec.notes...)
 	// Only the endpoint the host rule derived from the location is regional
-	// Vertex's to explain: a transport that reads the location into its own
-	// URL is addressed somewhere else, and that location is not its problem.
-	if loc, derived := transport.VertexDerivedLocation(); derived && loc != "global" && loc != "us" && loc != "eu" {
+	// Vertex's to explain: a transport addressed to a route the config built is
+	// somewhere else, and that location is not its problem.
+	if loc, derived := VertexLocationDerived(transport, hostDerived); derived && loc != "global" && loc != "us" && loc != "eu" {
 		if detail, known := vertexGlobalOnlyDetail(hit.wireID); known {
 			warnings = append(warnings, fmt.Sprintf("regional Vertex location %q %s; use global, us, or eu for %s", loc, detail, hit.wireID))
 		}
@@ -503,7 +522,8 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	}
 	return Resolved{
 		Instance: rec.name, ProviderID: providerID, Protocol: rowProto, Surface: row.Surface, Transport: transport,
-		ModelID: ref.Model, WireID: hit.wireID, Model: row, Caps: caps, Headers: headers,
+		HostDerivedByRule: hostDerived,
+		ModelID:           ref.Model, WireID: hit.wireID, Model: row, Caps: caps, Headers: headers,
 		Credential: cred, CredentialHeaders: credHeaders, Provenance: prov, Warnings: warnings,
 		DefaultModel: rec.head.DefaultModel, CheapModel: rec.head.CheapModel, Synthesized: hit.synthesized,
 	}, nil
@@ -666,8 +686,9 @@ func (r *Registry) transportShape(rec *record, row Model, proto string) Transpor
 }
 
 // buildTransport applies the cross-protocol rule, the row transport, the
-// protocol defaults, and variable substitution (spec §9.1).
-func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transport, []string) {
+// protocol defaults, and variable substitution (spec §9.1). It also reports
+// whether a host rule derived the base URL's authority (Resolved.HostDerivedByRule).
+func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transport, bool, []string) {
 	t := r.transportShape(rec, row, proto)
 	// The templates the URL is built from, captured before substitution, are
 	// the authoritative list of variables Resolved may expose (URL parts such
@@ -675,7 +696,8 @@ func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transpo
 	// the row's own when it has one, else the provider's — and the endpoint
 	// templates. Resolved is serialized by `evener models inspect`, so no
 	// vars_env value that the URL does not use is ever exposed.
-	templates := []string{t.BaseURL, t.Endpoint, t.StreamEndpoint, t.ModelsEndpoint, t.CountTokensEndpoint}
+	baseURLTemplate := t.BaseURL
+	templates := []string{baseURLTemplate, t.Endpoint, t.StreamEndpoint, t.ModelsEndpoint, t.CountTokensEndpoint}
 
 	var warnings, varWarnings []string
 	// One lookup serves the base URL, the endpoint templates, and the Vars
@@ -697,28 +719,41 @@ func (r *Registry) buildTransport(rec *record, row Model, proto string) (Transpo
 	slices.Sort(varWarnings)
 	warnings = append(warnings, slices.Compact(varWarnings)...)
 	resolved := map[string]string{}
-	referenced := map[string]bool{}
 	for _, tpl := range templates {
-		for _, m := range placeholderRe.FindAllStringSubmatch(tpl, -1) {
-			referenced[m[1]] = true
-			if v, ok := lookup(m[1]); ok {
-				resolved[m[1]] = v
+		for _, name := range templatePlaceholders(tpl) {
+			if v, ok := lookup(name); ok {
+				resolved[name] = v
 			}
 		}
 	}
 	// A host the vertex-location rule derived from the location used the
 	// location as surely as a path placeholder would have, so it is exposed
 	// too (and the regional warning reads it). A host supplied directly used
-	// no location.
-	if t.HostRule == HostRuleVertexLocation && referenced["GOOGLE_VERTEX_HOST"] {
-		if _, direct := lookup("GOOGLE_VERTEX_HOST"); !direct {
-			if loc, ok := lookup("GOOGLE_VERTEX_LOCATION"); ok {
-				resolved["GOOGLE_VERTEX_LOCATION"] = loc
-			}
+	// no location. Only the base URL template can make the rule the author of
+	// the authority — the request URL is that base plus an endpoint path, so a
+	// {GOOGLE_VERTEX_HOST} read anywhere else derives nothing — and only when
+	// that placeholder resolved from the location rather than a supplied value.
+	var hostDerived bool
+	if t.HostRule == HostRuleVertexLocation && slices.Contains(templatePlaceholders(baseURLTemplate), "GOOGLE_VERTEX_HOST") {
+		_, supplied := lookup("GOOGLE_VERTEX_HOST")
+		loc, located := lookup("GOOGLE_VERTEX_LOCATION")
+		hostDerived = !supplied && located
+		if hostDerived {
+			resolved["GOOGLE_VERTEX_LOCATION"] = loc
 		}
 	}
 	t.Vars = resolved
-	return t, warnings
+	return t, hostDerived, warnings
+}
+
+// templatePlaceholders names the {VARIABLE} placeholders a URL template reads.
+func templatePlaceholders(tpl string) []string {
+	matches := placeholderRe.FindAllStringSubmatch(tpl, -1)
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, m[1])
+	}
+	return out
 }
 
 // buildHeaders merges header layers and applies spec §10: an unset $VAR

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -491,8 +491,12 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 	warnings = append(warnings, rec.notes...)
 	if transport.HostRule == HostRuleVertexLocation {
 		// The location the URL was actually built with (buildTransport's
-		// Vars), whichever mapping supplied it.
-		if loc, ok := transport.Vars["GOOGLE_VERTEX_LOCATION"]; ok && loc != "global" && loc != "us" && loc != "eu" {
+		// Vars), whichever mapping supplied it — but only when the host is
+		// the one the rule derived from that location: a directly supplied
+		// GOOGLE_VERTEX_HOST (buildTransport exposes it in Vars) sends the
+		// request elsewhere even when the path still reads the location, and
+		// the location is not that endpoint's problem.
+		if loc, ok := transport.Vars["GOOGLE_VERTEX_LOCATION"]; ok && transport.Vars["GOOGLE_VERTEX_HOST"] == "" && loc != "global" && loc != "us" && loc != "eu" {
 			if detail, ok := vertexGlobalOnlyDetail(hit.wireID); ok {
 				warnings = append(warnings, fmt.Sprintf("regional Vertex location %q %s; use global, us, or eu for %s", loc, detail, hit.wireID))
 			}

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -54,6 +54,26 @@ type vertexGlobalOnlyFamily struct {
 	patterns []string
 }
 
+// vertexGlobalOnlyDetail returns the regional limitation for wireID when it
+// names a family Vertex serves only from the global and us/eu endpoints.
+func vertexGlobalOnlyDetail(wireID string) (string, bool) {
+	for _, family := range vertexGlobalOnly {
+		if slices.ContainsFunc(family.patterns, func(p string) bool { return strings.Contains(wireID, p) }) {
+			return family.detail, true
+		}
+	}
+	return "", false
+}
+
+// IsVertexGlobalOnly reports whether wireID names a model Vertex serves only
+// from its global and us/eu endpoints — the same knowledge resolve uses for
+// its regional warning, exported for callers that must tell a regional
+// "not served here" apart from a genuine access failure.
+func IsVertexGlobalOnly(wireID string) bool {
+	_, ok := vertexGlobalOnlyDetail(wireID)
+	return ok
+}
+
 var datedSuffixRe = regexp.MustCompile(`(-\d{8}(-v\d+(:\d+)?)?|@\d{8})$`)
 
 // StripDatedSuffix removes a provider's dated-snapshot suffix from a model id
@@ -473,11 +493,8 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 		// The location the URL was actually built with (buildTransport's
 		// Vars), whichever mapping supplied it.
 		if loc, ok := transport.Vars["GOOGLE_VERTEX_LOCATION"]; ok && loc != "global" && loc != "us" && loc != "eu" {
-			for _, family := range vertexGlobalOnly {
-				if slices.ContainsFunc(family.patterns, func(p string) bool { return strings.Contains(hit.wireID, p) }) {
-					warnings = append(warnings, fmt.Sprintf("regional Vertex location %q %s; use global, us, or eu for %s", loc, family.detail, hit.wireID))
-					break
-				}
+			if detail, ok := vertexGlobalOnlyDetail(hit.wireID); ok {
+				warnings = append(warnings, fmt.Sprintf("regional Vertex location %q %s; use global, us, or eu for %s", loc, detail, hit.wireID))
 			}
 		}
 	}

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -36,10 +36,23 @@ func IsChatModelID(id string) bool {
 	return true
 }
 
-// vertexGlobalOnly lists Claude ids Anthropic serves only from the global
-// and us/eu endpoints (spec §9.4: "regional endpoints support Sonnet 4.6
-// and earlier").
-var vertexGlobalOnly = []string{"claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-mythos"}
+// vertexGlobalOnly names the model families Vertex serves only from the
+// global and us/eu endpoints, each with the regional limitation its warning
+// states. Anthropic's regional endpoints stop at Sonnet 4.6 (spec §9.4);
+// Gemini 3 and later are global-only today.
+var vertexGlobalOnly = []vertexGlobalOnlyFamily{
+	{detail: "supports Claude Sonnet 4.6 and earlier", patterns: []string{
+		"claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-mythos",
+	}},
+	{detail: "does not serve Gemini 3 or later", patterns: []string{"gemini-3"}},
+}
+
+// vertexGlobalOnlyFamily is one such family: the id substrings it covers and
+// the regional limitation the warning spells out.
+type vertexGlobalOnlyFamily struct {
+	detail   string
+	patterns []string
+}
 
 var datedSuffixRe = regexp.MustCompile(`(-\d{8}(-v\d+(:\d+)?)?|@\d{8})$`)
 
@@ -460,9 +473,9 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 		// The location the URL was actually built with (buildTransport's
 		// Vars), whichever mapping supplied it.
 		if loc, ok := transport.Vars["GOOGLE_VERTEX_LOCATION"]; ok && loc != "global" && loc != "us" && loc != "eu" {
-			for _, p := range vertexGlobalOnly {
-				if strings.Contains(hit.wireID, p) {
-					warnings = append(warnings, fmt.Sprintf("regional Vertex location %q supports Claude Sonnet 4.6 and earlier; use global, us, or eu for %s", loc, hit.wireID))
+			for _, family := range vertexGlobalOnly {
+				if slices.ContainsFunc(family.patterns, func(p string) bool { return strings.Contains(hit.wireID, p) }) {
+					warnings = append(warnings, fmt.Sprintf("regional Vertex location %q %s; use global, us, or eu for %s", loc, family.detail, hit.wireID))
 					break
 				}
 			}

--- a/llm/registry/resolve.go
+++ b/llm/registry/resolve.go
@@ -489,17 +489,12 @@ func (r *Registry) resolveOn(rec *record, ref Ref, warnings []string) (Resolved,
 		warnings = append(warnings, "hidden: provider has no resolvable base URL or protocol")
 	}
 	warnings = append(warnings, rec.notes...)
-	if transport.HostRule == HostRuleVertexLocation {
-		// The location the URL was actually built with (buildTransport's
-		// Vars), whichever mapping supplied it — but only when the host is
-		// the one the rule derived from that location: a directly supplied
-		// GOOGLE_VERTEX_HOST (buildTransport exposes it in Vars) sends the
-		// request elsewhere even when the path still reads the location, and
-		// the location is not that endpoint's problem.
-		if loc, ok := transport.Vars["GOOGLE_VERTEX_LOCATION"]; ok && transport.Vars["GOOGLE_VERTEX_HOST"] == "" && loc != "global" && loc != "us" && loc != "eu" {
-			if detail, ok := vertexGlobalOnlyDetail(hit.wireID); ok {
-				warnings = append(warnings, fmt.Sprintf("regional Vertex location %q %s; use global, us, or eu for %s", loc, detail, hit.wireID))
-			}
+	// Only the endpoint the host rule derived from the location is regional
+	// Vertex's to explain: a transport that reads the location into its own
+	// URL is addressed somewhere else, and that location is not its problem.
+	if loc, derived := transport.VertexDerivedLocation(); derived && loc != "global" && loc != "us" && loc != "eu" {
+		if detail, known := vertexGlobalOnlyDetail(hit.wireID); known {
+			warnings = append(warnings, fmt.Sprintf("regional Vertex location %q %s; use global, us, or eu for %s", loc, detail, hit.wireID))
 		}
 	}
 	providerID := rec.providerID

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -298,6 +298,15 @@ func TestResolve_TransportAssembly(t *testing.T) {
 	if res := mustResolve(t, r, "directhost/claude-opus-5"); hasWarning(res, "regional") || res.Transport.BaseURL != "https://gw.example.test/v1/custom" || res.Transport.Vars["GOOGLE_VERTEX_LOCATION"] != "" {
 		t.Fatalf("a directly supplied host must not expose or warn about the location: %+v", res)
 	}
+	// A host supplied directly is used as-is even when the URL still reads the
+	// location into its path: the request reaches the supplied host, not the
+	// location-derived endpoint, so neither the warning nor a 404 remedy may
+	// claim the location is the problem.
+	r = fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.gateway]\nbase = \"google-vertex-anthropic\"\nbase_url = \"{GOOGLE_VERTEX_HOST}/v1/projects/{GOOGLE_VERTEX_PROJECT}/locations/{GOOGLE_VERTEX_LOCATION}\"\n[providers.gateway.vars]\nGOOGLE_VERTEX_HOST = \"https://gw.example.test\"\n")
+	if res := mustResolve(t, r, "gateway/claude-opus-5"); hasWarning(res, "regional") || res.Transport.BaseURL != "https://gw.example.test/v1/projects/p/locations/europe-west1" || res.Transport.Vars["GOOGLE_VERTEX_LOCATION"] != "europe-west1" || res.Transport.Vars["GOOGLE_VERTEX_HOST"] != "https://gw.example.test" {
+		t.Fatalf("a directly supplied host must keep the path location without the regional warning: %+v", res)
+	}
 }
 
 func TestResolve_HeadersAndCredential(t *testing.T) {

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -325,6 +325,22 @@ func TestResolve_LiteralHostWithLocationPathDoesNotWarn(t *testing.T) {
 	}
 }
 
+// A GOOGLE_VERTEX_HOST supplied directly is the authority the user chose, even
+// when it names the location's own host: a path prefix puts something else in
+// front of the regional endpoint, so the rule's route is not the one taken and
+// the location is not what the request reaches.
+func TestResolve_DirectHostWithPathPrefixDoesNotWarn(t *testing.T) {
+	r := fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.gwproxy]\nbase = \"google-vertex-anthropic\"\nbase_url = \"{GOOGLE_VERTEX_HOST}/v1/projects/{GOOGLE_VERTEX_PROJECT}/locations/{GOOGLE_VERTEX_LOCATION}\"\n[providers.gwproxy.vars]\nGOOGLE_VERTEX_HOST = \"https://europe-west1-aiplatform.googleapis.com/proxy\"\n")
+	res := mustResolve(t, r, "gwproxy/claude-opus-5")
+	if res.Transport.BaseURL != "https://europe-west1-aiplatform.googleapis.com/proxy/v1/projects/p/locations/europe-west1" {
+		t.Fatalf("base URL = %q", res.Transport.BaseURL)
+	}
+	if hasWarning(res, "regional") {
+		t.Fatalf("a supplied host is not the rule's route even when it names the derived host: %+v", res.Warnings)
+	}
+}
+
 func TestResolve_HeadersAndCredential(t *testing.T) {
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "sk", "OPENAI_ORG_ID": "org-1"}, "")
 	res := mustResolve(t, r, "openai/gpt-5.5")

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -381,6 +381,31 @@ func TestVertexGlobalOnlyMatchesAtAnIDBoundary(t *testing.T) {
 	}
 }
 
+// The rule makes the authority, so a {GOOGLE_VERTEX_HOST} the template reads
+// anywhere else — a path or query segment — derives nothing: the request goes
+// where the template's own authority sends it.
+func TestResolve_HostPlaceholderOutsideTheAuthorityDoesNotWarn(t *testing.T) {
+	r := fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.pathhost]\nbase = \"google-vertex-anthropic\"\nbase_url = \"https://gateway.example/{GOOGLE_VERTEX_HOST}/v1\"\n")
+	res := mustResolve(t, r, "pathhost/claude-opus-5")
+	if hasWarning(res, "regional") || res.HostDerivedByRule {
+		t.Fatalf("a host placeholder in the path is not a derived authority: %+v", res)
+	}
+}
+
+// A location the rule refuses derives nothing: the resolver says what is wrong
+// with the location instead of claiming a regional endpoint was reached.
+func TestResolve_InvalidLocationDoesNotWarnRegionally(t *testing.T) {
+	r := fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe_west1"}, "")
+	res := mustResolve(t, r, "google-vertex-anthropic/claude-opus-5")
+	if !hasWarning(res, "invalid GOOGLE_VERTEX_LOCATION") {
+		t.Fatalf("an invalid location must be reported as such: %+v", res.Warnings)
+	}
+	if hasWarning(res, "regional") || res.HostDerivedByRule {
+		t.Fatalf("a refused location derives no endpoint: %+v", res)
+	}
+}
+
 func TestResolve_HeadersAndCredential(t *testing.T) {
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "sk", "OPENAI_ORG_ID": "org-1"}, "")
 	res := mustResolve(t, r, "openai/gpt-5.5")

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -283,6 +283,9 @@ func TestResolve_TransportAssembly(t *testing.T) {
 	if res := mustResolve(t, r, "hostonly/claude-opus-5"); !hasWarning(res, "regional") || res.Transport.BaseURL != "https://europe-west1-aiplatform.googleapis.com/v1/custom" || res.Transport.Vars["GOOGLE_VERTEX_LOCATION"] != "europe-west1" {
 		t.Fatalf("host derived from the location must warn and expose the location: %+v", res)
 	}
+	if res := mustResolve(t, r, "hostonly/claude-opus-5"); !res.HostDerivedByRule {
+		t.Fatal("a base URL that reads {GOOGLE_VERTEX_HOST} the rule derived from is derived provenance")
+	}
 	// A row's own literal base_url replaces the provider template, so the
 	// provider template's location is neither used nor exposed nor warned about.
 	r = fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
@@ -297,6 +300,9 @@ func TestResolve_TransportAssembly(t *testing.T) {
 		"[providers.directhost]\nbase = \"google-vertex-anthropic\"\nbase_url = \"{GOOGLE_VERTEX_HOST}/v1/custom\"\n[providers.directhost.vars]\nGOOGLE_VERTEX_HOST = \"https://gw.example.test\"\n")
 	if res := mustResolve(t, r, "directhost/claude-opus-5"); hasWarning(res, "regional") || res.Transport.BaseURL != "https://gw.example.test/v1/custom" || res.Transport.Vars["GOOGLE_VERTEX_LOCATION"] != "" {
 		t.Fatalf("a directly supplied host must not expose or warn about the location: %+v", res)
+	}
+	if res := mustResolve(t, r, "directhost/claude-opus-5"); res.HostDerivedByRule {
+		t.Fatal("a supplied host is not a derived authority")
 	}
 	// A host supplied directly is used as-is even when the URL still reads the
 	// location into its path: the request reaches the supplied host, not the
@@ -338,6 +344,40 @@ func TestResolve_DirectHostWithPathPrefixDoesNotWarn(t *testing.T) {
 	}
 	if hasWarning(res, "regional") {
 		t.Fatalf("a supplied host is not the rule's route even when it names the derived host: %+v", res.Warnings)
+	}
+	if res.HostDerivedByRule {
+		t.Fatal("a supplied host is not a derived authority")
+	}
+}
+
+// The derivation owns the authority it produces, not every URL that names the
+// host it would produce: a literal base URL on the location's own host, with a
+// path the rule did not build, is still the config's route.
+func TestResolve_LiteralCanonicalHostWithPathPrefixDoesNotWarn(t *testing.T) {
+	r := fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.literalcanon]\nbase = \"google-vertex-anthropic\"\nbase_url = \"https://europe-west1-aiplatform.googleapis.com/proxy/v1/projects/{GOOGLE_VERTEX_PROJECT}/locations/{GOOGLE_VERTEX_LOCATION}\"\n")
+	res := mustResolve(t, r, "literalcanon/claude-opus-5")
+	if res.Transport.BaseURL != "https://europe-west1-aiplatform.googleapis.com/proxy/v1/projects/p/locations/europe-west1" {
+		t.Fatalf("base URL = %q", res.Transport.BaseURL)
+	}
+	if hasWarning(res, "regional") || res.HostDerivedByRule {
+		t.Fatalf("a literal base URL derives nothing, whatever host it names: %+v", res)
+	}
+}
+
+// A family pattern covers the ids in its family, at a boundary: "gemini-3"
+// covers gemini-3.8-flash and gemini-3-pro-preview, but a longer number is a
+// different family, not a longer member of this one.
+func TestVertexGlobalOnlyMatchesAtAnIDBoundary(t *testing.T) {
+	for _, id := range []string{"gemini-3", "gemini-3.8-flash", "gemini-3-pro-preview", "gemini-3-flash-preview", "claude-opus-5", "claude-opus-5@20251101"} {
+		if !IsVertexGlobalOnly(id) {
+			t.Errorf("%q is global-only", id)
+		}
+	}
+	for _, id := range []string{"", "gemini-30", "gemini-31-flash", "gemini-3x", "claude-opus-50", "claude-sonnet-4-6"} {
+		if IsVertexGlobalOnly(id) {
+			t.Errorf("%q is not global-only", id)
+		}
 	}
 }
 

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -261,6 +261,12 @@ func TestResolve_TransportAssembly(t *testing.T) {
 	if res := mustResolve(t, r, "google-vertex-anthropic/claude-sonnet-4-6"); hasWarning(res, "regional") {
 		t.Fatal("Sonnet 4.6 and earlier are fine on regional endpoints")
 	}
+	if res := mustResolve(t, r, "google-vertex/gemini-3.5-flash"); !hasWarning(res, "regional") || !hasWarning(res, "Gemini 3") {
+		t.Fatalf("regional vertex gemini: %+v", res)
+	}
+	if res := mustResolve(t, r, "google-vertex/gemini-2.5-flash"); hasWarning(res, "regional") {
+		t.Fatal("Gemini 2.5 and earlier are fine on regional endpoints")
+	}
 	// The warning is about the location the URL was built with: an instance
 	// whose own base_url carries no location placeholder reaches no regional
 	// endpoint, whatever the environment says.

--- a/llm/registry/resolve_test.go
+++ b/llm/registry/resolve_test.go
@@ -309,6 +309,22 @@ func TestResolve_TransportAssembly(t *testing.T) {
 	}
 }
 
+// A base URL with a literal host reaches that host even when its path reads
+// the location: the vertex-location rule produced nothing here, so the
+// location is not the endpoint's problem and must not be warned about. The
+// rule only owns the authority it derives from the location.
+func TestResolve_LiteralHostWithLocationPathDoesNotWarn(t *testing.T) {
+	r := fixtureLoad(t, map[string]string{"GOOGLE_VERTEX_PROJECT": "p", "GOOGLE_VERTEX_LOCATION": "europe-west1"},
+		"[providers.gwpath]\nbase = \"google-vertex-anthropic\"\nbase_url = \"https://gw.example.test/v1/projects/{GOOGLE_VERTEX_PROJECT}/locations/{GOOGLE_VERTEX_LOCATION}\"\n")
+	res := mustResolve(t, r, "gwpath/claude-opus-5")
+	if res.Transport.BaseURL != "https://gw.example.test/v1/projects/p/locations/europe-west1" {
+		t.Fatalf("base URL = %q", res.Transport.BaseURL)
+	}
+	if hasWarning(res, "regional") {
+		t.Fatalf("a literal host must not be warned about a location it only reads into its path: %+v", res.Warnings)
+	}
+}
+
 func TestResolve_HeadersAndCredential(t *testing.T) {
 	r := fixtureLoad(t, map[string]string{"OPENAI_API_KEY": "sk", "OPENAI_ORG_ID": "org-1"}, "")
 	res := mustResolve(t, r, "openai/gpt-5.5")

--- a/llm/registry/types.go
+++ b/llm/registry/types.go
@@ -184,11 +184,18 @@ type Credential struct {
 // merged across every layer. A prunable field absent from Provenance was
 // never set by a layer; it came from the protocol baseline (spec §8.2).
 type Resolved struct {
-	Instance          string            `json:"instance,omitempty"`
-	ProviderID        string            `json:"provider_id,omitempty"`
-	Protocol          string            `json:"protocol,omitempty"`
-	Surface           string            `json:"surface,omitempty"`
-	Transport         Transport         `json:"transport"`
+	Instance   string    `json:"instance,omitempty"`
+	ProviderID string    `json:"provider_id,omitempty"`
+	Protocol   string    `json:"protocol,omitempty"`
+	Surface    string    `json:"surface,omitempty"`
+	Transport  Transport `json:"transport"`
+	// HostDerivedByRule is true when the transport's host rule produced the
+	// base URL's authority from its input — today only the vertex-location rule
+	// turning GOOGLE_VERTEX_LOCATION into the endpoint host (spec §9.4) — rather
+	// than the config naming that host, literally or through a supplied
+	// variable. Hidden from JSON: it is resolve's own note to the code that
+	// reads the transport afterwards, never part of a wire shape.
+	HostDerivedByRule bool              `json:"-"`
 	ModelID           string            `json:"model_id,omitempty"`
 	WireID            string            `json:"wire_id,omitempty"`
 	Model             Model             `json:"model"`

--- a/mobile-native/src/LaunchModelPicker.tsx
+++ b/mobile-native/src/LaunchModelPicker.tsx
@@ -109,6 +109,12 @@ export function LaunchModelPicker({
               <Copy muted>{item.text}</Copy>
             </View>
           );
+        if (item.kind === "warning")
+          return (
+            <View style={{ paddingLeft: 16, paddingRight: 8, paddingBottom: 4 }}>
+              <Copy muted>{`⚠ ${item.text}`}</Copy>
+            </View>
+          );
         const selected = value === item.option.qualified;
         return (
           <Pressable

--- a/mobile-native/src/ModelPicker.tsx
+++ b/mobile-native/src/ModelPicker.tsx
@@ -167,9 +167,9 @@ export function ModelPicker({
               disabled={disabled}
               onPress={() => setSelected(item.model)}
             />
-            {item.warnings.map((warning) => (
+            {item.warnings.map((warning, warningIndex) => (
               <View
-                key={warning}
+                key={`${warning}-${warningIndex}`}
                 style={{ paddingLeft: 16, paddingRight: 8, paddingBottom: 4 }}
               >
                 <Copy muted>{`⚠ ${warning}`}</Copy>

--- a/mobile-native/src/ModelPicker.tsx
+++ b/mobile-native/src/ModelPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
 import { ActivityIndicator, FlatList, TextInput, View } from "react-native";
 import type { ModelDescriptor } from "../../cmd/evener-hub/frontend/src/protocol/types.gen";
+import { modelPickerEntries } from "./modelPickerEntries";
 import type { SessionControls } from "./sessionControls";
 import { Action, Choice, Copy, ErrorMessage, styles, useColors } from "./ui";
 
@@ -37,6 +38,7 @@ export function ModelPicker({
     );
   }, [state.catalog, search, setting]);
   const disabled = !ready || state.pending !== null || state.loadingModels;
+  const entries = useMemo(() => modelPickerEntries(models), [models]);
   const available =
     selected &&
     state.catalog?.data.some(
@@ -96,9 +98,11 @@ export function ModelPicker({
       ) : null}
       <FlatList
         style={styles.fill}
-        data={models}
+        data={entries}
         keyboardShouldPersistTaps="handled"
-        keyExtractor={(model) => JSON.stringify([model.provider, model.model])}
+        keyExtractor={(entry) =>
+          JSON.stringify([entry.model.provider, entry.model.model])
+        }
         ListHeaderComponent={
           setting === "vision" ? (
             <View style={{ gap: 8, paddingBottom: 12 }}>
@@ -153,15 +157,25 @@ export function ModelPicker({
           ) : null
         }
         renderItem={({ item }) => (
-          <Choice
-            label={`${item.displayName || item.model} · ${item.provider}`}
-            selected={
-              selected?.provider === item.provider &&
-              selected.model === item.model
-            }
-            disabled={disabled}
-            onPress={() => setSelected(item)}
-          />
+          <View>
+            <Choice
+              label={item.label}
+              selected={
+                selected?.provider === item.model.provider &&
+                selected.model === item.model.model
+              }
+              disabled={disabled}
+              onPress={() => setSelected(item.model)}
+            />
+            {item.warnings.map((warning) => (
+              <View
+                key={warning}
+                style={{ paddingLeft: 16, paddingRight: 8, paddingBottom: 4 }}
+              >
+                <Copy muted>{`⚠ ${warning}`}</Copy>
+              </View>
+            ))}
+          </View>
         )}
       />
       <View

--- a/mobile-native/src/modelPickerEntries.test.ts
+++ b/mobile-native/src/modelPickerEntries.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "vitest";
+import { modelPickerEntries } from "./modelPickerEntries";
+
+// A registry warning (a global-only model under a regional Vertex location)
+// has to reach the native session picker's rows: the launch picker, the web
+// picker, and the TUI all show it, so a silently warned model here would read
+// as a safe choice.
+test("a warned model's entry carries the warning for its row", () => {
+	const note =
+		'regional Vertex location "us-central1" does not serve Gemini 3 or later; use global, us, or eu for gemini-3.8-flash';
+	const entries = modelPickerEntries([
+		{
+			provider: "vertex",
+			model: "gemini-3.8-flash",
+			displayName: "Gemini 3.8 Flash",
+			warnings: [note],
+		},
+		{ provider: "openai", model: "gpt-5.5", displayName: "GPT-5.5" },
+	]);
+
+	expect(entries[0]?.warnings).toEqual([note]);
+	expect(entries[0]?.label).toBe("Gemini 3.8 Flash · vertex");
+	expect(entries[1]?.warnings).toEqual([]);
+});
+
+test("a descriptor without a display name labels with its model id", () => {
+	const entries = modelPickerEntries([
+		{ provider: "vertex", model: "gemini-3.8-flash" },
+	]);
+
+	expect(entries[0]?.label).toBe("gemini-3.8-flash · vertex");
+});

--- a/mobile-native/src/modelPickerEntries.ts
+++ b/mobile-native/src/modelPickerEntries.ts
@@ -1,0 +1,21 @@
+import type { ModelDescriptor } from "../../cmd/evener-hub/frontend/src/protocol/types.gen";
+
+// A picker entry is one selectable model and the registry notes that belong
+// under it. The label is built here so the list, its selection, and its
+// warnings cannot drift apart, and so the mapping is testable without a
+// renderer (mobile-native has no component test harness).
+export interface ModelPickerEntry {
+	model: ModelDescriptor;
+	label: string;
+	warnings: string[];
+}
+
+export function modelPickerEntries(
+	models: ModelDescriptor[],
+): ModelPickerEntry[] {
+	return models.map((model) => ({
+		model,
+		label: `${model.displayName || model.model} · ${model.provider}`,
+		warnings: model.warnings ?? [],
+	}));
+}


### PR DESCRIPTION
## Problem

A Google Vertex instance whose `GOOGLE_VERTEX_LOCATION` is a region (e.g. `us-central1`) derives the regional host `{location}-aiplatform.googleapis.com`. Vertex serves its newer publisher models — Gemini 3 and later — only from the global endpoint, so the instance's own default model (`gemini-3.8-flash`) returns `404 Publisher model ... was not found`, while `aiplatform.googleapis.com/locations/global` returns 200. The publisher listing advertises those models from the regional host too, so the model picker offered rows that could never be called, and `providers probe` reported the 404 as `unsupported`.

Verified per model: Gemini 2.5.x works on both hosts; Gemini 3.x 404s on the regional host and works on global (and on the `us`/`eu` rep endpoints).

## Changes

- **Registry (`llm/registry`)**: extend the existing curated `vertexGlobalOnly` list (previously Claude-only) with the Gemini 3 family and generalize the warning text per family, so `evener models list` flags the rows.
- **Provider (`llm/providers/google`)**: reclassify Vertex's publisher-model 404 on a regional location as an actionable `ConfigurationError` naming global/us/eu. A `ConfigurationError` carries no HTTP status, so `providers probe` now reports `error` with the remedy instead of `unsupported`.
- **Wire + picker**: add `warnings` to `appwire.ModelDescriptor`, carry resolved-row warnings through `ModelDescriptorFromResolved` and the launch contract, regenerate `types.gen.ts`, and render them as a dim note under the model row.

The resolver warning is a warn-list, not a hard filter: availability is time-varying and the Vertex listing carries no capability data, so hiding rows would strand users when Google changes a model's regional availability.

## Verification

- `evener models list --provider vertex` under a regional location: `gemini-3.8-flash` carries the regional warning; `gemini-2.5-flash` does not.
- `evener providers probe vertex` regional: `google: error (configuration error: ... use global, us, or eu ...)` (was `unsupported (vertex error (status=404) ...)`).
- `evener launch-check --models --json` (the picker's primary source): `warnings` present for the vertex Gemini 3.x rows, absent for `gemini-2.5-flash`.
- Tests added for the resolver warning, the 404 reclassification, the descriptor mapping, the launch contract, and the picker render.
- Gates: `make vet`, `make lint`, and `make test` (all modules including `web`) green.

## Note

Operators on a regional location still need `GOOGLE_VERTEX_LOCATION = "global"` (or `us`/`eu`) to actually call these models; this change makes evener say so instead of silently offering an uncallable row.


---

## Second fix: MCP tool schemas rejected by Gemini

Testing with the Chrome MCP plugin surfaced a second, independent blocker: a Gemini/Vertex request carrying that tool failed with `400 Invalid JSON payload received. Unknown name "$schema" at 'tools[0].function_declarations[18].parameters'`.

Root cause: an MCP server's `inputSchema` is JSON Schema. The Chrome plugin's `use_browser` (Zod v4 `toJSONSchema`, via the MCP TS SDK) advertises top-level `$schema` and `additionalProperties`. `mcpSchemaToParams` passes the schema through verbatim, and the Gemini sanitizer dropped only `additionalProperties`, so Gemini's restricted `Schema` proto rejected the whole request. Any Gemini target with an MCP tool was affected, not just Vertex.

Fix: strip JSON Schema document metadata (`$schema`, `$id`, `$comment`, `$anchor`, `$dynamicAnchor`, `$vocabulary`) alongside `additionalProperties` in `sanitizeGeminiSchema`.

Verified live against `gemini-3.7-flash`: the real `use_browser` schema as-is → 400 `Unknown name "$schema"`; evener's own sanitized body for that same schema → 200.
