### PR TITLE
fix(web): open a failed tool call's summary line with its body

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -1410,6 +1410,108 @@ test("defaults apply at each level; an explicit summary choice persists across l
   expect(screen.queryByTestId("tool-row-summary")).toBeNull();
 });
 
+// --- failure force-open also opens the summary line (one-line tool call) ---
+// A failed row's body auto-opens at every verbosity level ("only failure earns
+// the eye"). That force-open must carry the summary line with it: otherwise a
+// chat/intent-level failure lands on a state that skips L1 - intent visible,
+// one-line tool call hidden, body open - instead of the complete L2. A clean
+// row is untouched (the level's own default still governs it).
+
+test.each(["chat", "intent"] as const)(
+  "a failed row at the %s level auto-opens its summary line together with the body",
+  (level) => {
+    const config = makeTranscriptDisplayConfig({ kind: "preset", level });
+    renderWithConfig(
+      config,
+      item({
+        id: `summary_fail_${level}`,
+        toolName: "shell",
+        description: "Checking for stray process records",
+        argumentsJSON: JSON.stringify({ command: "git ls-tree -r --name-only HEAD" }),
+        output: "fatal: not a git repository\n[exit 128]",
+      }),
+    );
+    // The failure force-opens the body (unchanged).
+    expect(screen.getByTestId("tool-row-body-trigger").getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByTestId("tool-call-body")).toBeTruthy();
+    // The summary line (the one-line tool call) opens with it, so the row reads
+    // as intent + call + body rather than skipping the call on its way down.
+    expect(screen.getByTestId("tool-row-intent").textContent).toBe("Checking for stray process records");
+    expect(screen.getByTestId("tool-row-summary").textContent).toBe("Ran a shell command");
+    expect(screen.getByTestId("tool-row-trigger").getAttribute("aria-expanded")).toBe("true");
+  },
+);
+
+test("a manual collapse of a failure-opened summary line sticks (the reader's choice wins)", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" });
+  renderWithConfig(
+    config,
+    item({
+      id: "summary_fail_collapse",
+      toolName: "shell",
+      description: "Running a failing command",
+      argumentsJSON: JSON.stringify({ command: "false" }),
+      output: "stdout\n[exit 1]",
+    }),
+  );
+  expect(screen.getByTestId("tool-row-summary")).toBeTruthy();
+
+  // The intent trigger toggles the summary disclosure.
+  fireEvent.click(screen.getByTestId("tool-row-trigger"));
+  expect(screen.queryByTestId("tool-row-summary")).toBeNull();
+  expect(screen.getByTestId("tool-row-trigger").getAttribute("aria-expanded")).toBe("false");
+});
+
+test("a superseded preval-only failure at the chat level leaves the summary line closed", () => {
+  registerToolRenderer({ match: "tci_summary_preval", summary: () => "s", body: () => <div>b</div> });
+  const failedItem = item({
+    id: "summary_preval_bad",
+    toolName: "tci_summary_preval",
+    description: "Retrying a malformed call",
+    error: "missing required field",
+    prevalOnly: true,
+  });
+  const okItem: ItemModel = {
+    id: "summary_preval_ok",
+    turnId: "t1",
+    type: "commandExecution",
+    text: "",
+    toolName: "tci_summary_preval",
+  };
+  threadsStore.setState({ threads: new Map([["ref_a", threadWith([failedItem, okItem])]]) });
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" });
+  render(
+    <TranscriptRenderProvider config={config} surface="readOnly" disclosureScope="test:summary">
+      <ToolCallItem item={failedItem} turn={turn} live={false} sessionRef="ref_a" />
+    </TranscriptRenderProvider>,
+  );
+  // Superseded by the next same-tool success: neither the body nor the summary
+  // is forced open.
+  expect(screen.queryByTestId("tool-call-body")).toBeNull();
+  expect(screen.queryByTestId("tool-row-summary")).toBeNull();
+});
+
+test("a non-failure auto-expand (image read) at the chat level leaves the summary line closed", () => {
+  const config = makeTranscriptDisplayConfig({ kind: "preset", level: "chat" });
+  renderWithConfig(
+    config,
+    item({
+      id: "summary_image_chat",
+      toolName: "read_file",
+      description: "Reading the screenshot",
+      argumentsJSON: JSON.stringify({ file_path: "shot.png" }),
+      output: "[image: PNG, 123 bytes, base64 data follows]",
+      outputImages: [{ src: "shot.png" }],
+    }),
+  );
+  // The picture's own auto-expand still opens the body...
+  expect(screen.getByTestId("tool-row-body-trigger").getAttribute("aria-expanded")).toBe("true");
+  expect(screen.getByTestId("tool-call-body")).toBeTruthy();
+  // ...but the summary-open is scoped to FAILED rows, so an image read keeps
+  // its level's default (chat: L0, only the intent line).
+  expect(screen.queryByTestId("tool-row-summary")).toBeNull();
+});
+
 test("delegate rows from transcripts recorded before the prompt rename still show the brief", () => {
   render(
     <ToolCallItem

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -316,7 +316,13 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
   // no explicit choice.
   const summaryDisclosureKey = scopedDisclosureId(disclosureScope, `summary:${item.id}`);
   const summaryConfigDefault = summaryOpenByDefault(config);
-  const summaryDisclosureOpen = isDisclosureOpen(summaryDisclosureKey, summaryConfigDefault);
+  // The failure force-open above opens the body; it carries the summary line
+  // with it, so a failed row lands on the complete level 2 (intent + one-line
+  // tool call + body) instead of skipping the call on its way down. A
+  // superseded preval-only bounce demotes exactly as the body does (kata hgm1),
+  // and an explicit reader toggle still wins in the store.
+  const summaryFallback = summaryConfigDefault || (failed && !superseded);
+  const summaryDisclosureOpen = isDisclosureOpen(summaryDisclosureKey, summaryFallback);
   const summaryOpen = statedIntent === undefined ? true : summaryDisclosureOpen;
   // A descriptor may suppress its whole row (task_list `action:"view"` and
   // malformed non-mutations - the legacy "no card, no divider, no tool-call
@@ -392,7 +398,7 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
         // autoDefault (the fallback) from here on and survives a remount.
         onToggle={() => toggleDisclosure(disclosureKey, disclosureFallback)}
         summaryOpen={summaryOpen}
-        onToggleSummary={() => toggleDisclosure(summaryDisclosureKey, summaryConfigDefault)}
+        onToggleSummary={() => toggleDisclosure(summaryDisclosureKey, summaryFallback)}
         trailing={trailingControls}
         trailingAfter={trailingAfter}
         title={detail}


### PR DESCRIPTION
## What

A failed tool call force-opens its body at every verbosity level. At chat/intent levels, where the tool-call summary line defaults closed, the row then showed only the intent line plus the body, skipping the one-line tool call. The failure force-open now carries the summary line with it, so a failed row reaches the complete shape: intent + one-line tool call + body.

The summary disclosure's toggle now uses the same fallback, so a reader's manual collapse still wins over the auto-open.

## Scope

- Clean rows are unchanged; the level's own default still governs the summary.
- A non-failure auto-expand (a `read_file` image read whose picture is its output) still opens only the body. Its summary is the noisy "Read <path> · lines 1" header, so it stays out of scope.
- The superseded preval-only bounce carve-out (kata hgm1) demotes the summary exactly as it demotes the body.

## Evidence

- `ToolCallItem.test.tsx`: new tests for chat + intent failure auto-open, manual-collapse persistence, supersession still demoting, and the image-read boundary.
- `npx vitest run src/panes/session/transcript` -> 81 files / 1919 tests passed.
- `make test-web` -> PASS web-typecheck, web-test, web-lint.