### PR TITLE
fix(tokenauth): use a replaced Google credential, and report a refusal as one

### DIFF
--- a/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
+++ b/docs/superpowers/specs/2026-09-04-google-vertex-express-and-discovery-design.md
@@ -318,12 +318,19 @@ already exists in the hub's `credentialLabels.ts`.
 ### 4.3 Authenticator
 
 `tokenauth.GCPADC.tokenSource` caches one token source per instance, rebuilt
-when the credential's identity changes — its source (`adc`, `none`, `store`),
-or the stored JSON's digest; when `res.Credential.Source ==
+when the credential's identity changes — its source (`adc`, `none`, `store`)
+plus a digest of the credential's own bytes: the stored JSON for `store`, and
+for application-default credentials the JSON the library read from the host, so
+a re-login that rewrites the ADC file reaches the next request rather than the
+next process; when `res.Credential.Source ==
 "store"` it builds the token source with `google.CredentialsFromJSON(ctx,
 []byte(value), cloudPlatformScope)` instead of `FindDefaultCredentials`.
 Everything else (`ReuseTokenSource`, the bearer header, §2.2's quota
 header) is shared.
+A token endpoint that refuses the credential itself (`invalid_grant`,
+`invalid_client`) surfaces as `llm.NewAuthenticationError`, so the hub's
+credential test offers "sign in again"; any other token failure keeps its own
+meaning.
 Malformed JSON surfaces as the existing `llm.ConfigurationError` shape,
 naming the instance and "stored credential".
 

--- a/llm/errors.go
+++ b/llm/errors.go
@@ -513,6 +513,25 @@ func NewRequestTimeoutError(provider string, message string, cause error) error 
 	return &requestTimeoutError{base}
 }
 
+// NewAuthenticationError constructs a non-HTTP authentication failure — a
+// credential the provider's token endpoint refused to refresh, say — that
+// matches the unified error hierarchy. HTTP-level 401s arrive through
+// ClassifyHTTPError instead. It is not retryable, and its category is
+// [KindAuthentication].
+//
+// cause is the underlying error (typically the token endpoint's refusal),
+// exposed via Unwrap so callers can inspect it.
+func NewAuthenticationError(provider string, message string, cause error) error {
+	base := httpBaseError{
+		provider:   strings.TrimSpace(provider),
+		statusCode: 0,
+		message:    message,
+		retryable:  false,
+		cause:      cause,
+	}
+	return &authenticationError{base}
+}
+
 func newResponseHeaderTimeoutError(provider string, message string, cause error) error {
 	base := httpBaseError{
 		provider:   strings.TrimSpace(provider),

--- a/llm/errors_provider_copy_test.go
+++ b/llm/errors_provider_copy_test.go
@@ -192,6 +192,7 @@ func TestEveryProviderAttributedErrorCopies(t *testing.T) {
 		NewUnsupportedEndpointError("p", "m", nil),
 		NewUnsupportedToolChoiceError("p", "auto"),
 		NewRequestTimeoutError("p", "m", nil),
+		NewAuthenticationError("p", "m", nil),
 	)
 	for _, err := range cases {
 		if providerOf(err) == "" {

--- a/llm/errors_test.go
+++ b/llm/errors_test.go
@@ -388,6 +388,27 @@ func TestNewRequestTimeoutError_IsRetryable(t *testing.T) {
 	}
 }
 
+func TestNewAuthenticationError_IsNotRetryable(t *testing.T) {
+	refused := errors.New(`oauth2: "invalid_grant" "Token has been expired or revoked."`)
+	err := NewAuthenticationError("vertex", `instance "vertex": application-default credentials were refused (invalid_grant)`, refused)
+	var e Error
+	if !errors.As(err, &e) {
+		t.Fatal("expected Error interface")
+	}
+	if Kind(err) != KindAuthentication {
+		t.Fatalf("Kind() = %v, want KindAuthentication", Kind(err))
+	}
+	if e.Retryable() || retryableError(err) {
+		t.Fatal("a refused credential must not be retried")
+	}
+	if e.StatusCode() != 0 || providerOf(err) != "vertex" {
+		t.Fatalf("StatusCode() = %d, provider = %q, want 0 / vertex", e.StatusCode(), providerOf(err))
+	}
+	if !errors.Is(err, refused) {
+		t.Fatal("the refusal must stay in the chain")
+	}
+}
+
 func TestResponseHeaderTimeoutError_IsRetryable(t *testing.T) {
 	err := newResponseHeaderTimeoutError("openai", "timed out awaiting response headers", context.DeadlineExceeded)
 

--- a/llm/providers/tokenauth/gcpadc.go
+++ b/llm/providers/tokenauth/gcpadc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -105,14 +106,27 @@ func (a *GCPADC) Apply(ctx context.Context, req *http.Request, res registry.Reso
 // (temporarily_unavailable on a 503, server_error), which are not verdicts on
 // the credential and must keep their retryable meaning; so does any failure
 // that carries no code at all (a deadline, an unreachable endpoint).
+//
+// The jwt token source a service account rides builds the same error without
+// filling ErrorCode, leaving the endpoint's words only in the body, so the
+// code is read from there when the field is empty.
 func oauthRefusal(err error) string {
 	refused, ok := errors.AsType[*oauth2.RetrieveError](err)
 	if !ok {
 		return ""
 	}
-	switch refused.ErrorCode {
+	code := refused.ErrorCode
+	if code == "" {
+		var body struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(refused.Body, &body) == nil {
+			code = body.Error
+		}
+	}
+	switch code {
 	case "invalid_grant", "invalid_client":
-		return refused.ErrorCode
+		return code
 	}
 	return ""
 }

--- a/llm/providers/tokenauth/gcpadc.go
+++ b/llm/providers/tokenauth/gcpadc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -21,8 +22,9 @@ const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
 // application-default credentials found on the host, or — when the
 // registry resolved a credentials-store entry for the instance — the
 // service-account / authorized_user JSON stored there (spec 2026-09-04
-// google-vertex-express §4.3). Credentials are looked up at an instance's
-// first request, never at load, and the token source refreshes itself.
+// google-vertex-express §4.3). Credentials are looked up at request time,
+// never at load: the library's answer names the cached token source, so a
+// re-login reaches the next request, and the source refreshes itself.
 type GCPADC struct {
 	// FindCredentials is the ADC lookup seam; nil means google.FindDefaultCredentials.
 	FindCredentials func(ctx context.Context, scopes ...string) (*google.Credentials, error)
@@ -69,6 +71,18 @@ func (a *GCPADC) Apply(ctx context.Context, req *http.Request, res registry.Reso
 	}
 	tok, err := src.ts.Token()
 	if err != nil {
+		// A refresh the token endpoint refused is a verdict on the credential,
+		// not on the endpoint: report it as an authentication failure so the
+		// classes layered on this error (the hub's credential test, the CLI's
+		// probe) offer "sign in again" instead of "check the network". Any
+		// other failure — a deadline, a transport error — keeps its own
+		// meaning.
+		if code := oauthRefusal(err); code != "" {
+			if res.Credential.Source == "store" {
+				return llm.NewAuthenticationError(res.Instance, fmt.Sprintf("instance %q: stored credential JSON was refused (%s)", res.Instance, code), err)
+			}
+			return llm.NewAuthenticationError(res.Instance, fmt.Sprintf("instance %q: application-default credentials were refused (%s) (run `gcloud auth application-default login`, set GOOGLE_APPLICATION_CREDENTIALS, or store a credential JSON for the instance)", res.Instance, code), err)
+		}
 		return fmt.Errorf("instance %q: gcp-adc token: %w", res.Instance, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+tok.AccessToken)
@@ -82,6 +96,18 @@ func (a *GCPADC) Apply(ctx context.Context, req *http.Request, res registry.Reso
 		req.Header.Set("x-goog-user-project", project)
 	}
 	return nil
+}
+
+// oauthRefusal returns the OAuth error code when err is the token endpoint's
+// refusal of the credential itself — invalid_grant for an expired, revoked, or
+// replaced refresh token, invalid_client for a bad secret. Anything else (a
+// deadline, an unreachable endpoint) carries no code: nothing about the
+// credential was decided.
+func oauthRefusal(err error) string {
+	if refused, ok := errors.AsType[*oauth2.RetrieveError](err); ok {
+		return refused.ErrorCode
+	}
+	return ""
 }
 
 // ValidateCredentialJSON reports whether data is a credential JSON the
@@ -99,34 +125,29 @@ func ValidateCredentialJSON(data []byte) error {
 }
 
 // credentialIdentity names the credential a source was built from: the
-// resolution's source alone for application-default credentials or none
-// (so a source that changes — an ADC file removed and the instance
-// re-resolved without a credential — rebuilds rather than reuses), and the
-// source plus a digest of the stored JSON for a stored credential. An ADC
-// file replaced in place keeps the identity "adc": the resolution does not
-// say which file backs it, so a re-login as another account takes effect
-// on the next process, not the next request.
-func credentialIdentity(res registry.Resolved) string {
-	if res.Credential.Source != "store" {
-		return res.Credential.Source
-	}
-	sum := sha256.Sum256([]byte(res.Credential.Value))
-	return res.Credential.Source + "\x00" + hex.EncodeToString(sum[:])
+// credential's own bytes, digested, so a replaced one — a rotated stored
+// value, or an ADC file a re-login rewrote — is noticed on the next request
+// and the source rebuilt rather than kept alongside the new one. The source
+// name keeps an ADC credential and a stored one distinguishable even when
+// their bytes coincide.
+func credentialIdentity(source string, raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return source + "\x00" + hex.EncodeToString(sum[:])
 }
 
 func (a *GCPADC) tokenSource(ctx context.Context, res registry.Resolved) (tokenSource, error) {
-	identity := credentialIdentity(res)
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if c, ok := a.sources[res.Instance]; ok && c.identity == identity {
-		return c.tokenSource, nil
-	}
 	// The source outlives the request that created it, so it must not
 	// inherit that request's cancellation.
 	bg := context.WithoutCancel(ctx)
-	var creds *google.Credentials
-	var err error
 	if res.Credential.Source == "store" {
+		// A stored credential is named by the value resolution handed us, so
+		// the cache answers without parsing anything.
+		identity := credentialIdentity(res.Credential.Source, []byte(res.Credential.Value))
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		if c, ok := a.sources[res.Instance]; ok && c.identity == identity {
+			return c.tokenSource, nil
+		}
 		if err := registry.CheckCredentialJSON([]byte(res.Credential.Value)); err != nil {
 			return tokenSource{}, err
 		}
@@ -134,27 +155,41 @@ func (a *GCPADC) tokenSource(ctx context.Context, res registry.Resolved) (tokenS
 		if fromJSON == nil {
 			fromJSON = google.CredentialsFromJSON //nolint:staticcheck // deprecated upstream in favour of typed parsers; this scheme must accept both authorized_user and service_account JSON (spec §4), and the cloud.google.com/go/auth migration is out of scope
 		}
-		creds, err = fromJSON(bg, []byte(res.Credential.Value), cloudPlatformScope)
-	} else {
-		find := a.FindCredentials
-		if find == nil {
-			find = google.FindDefaultCredentials
+		creds, err := fromJSON(bg, []byte(res.Credential.Value), cloudPlatformScope)
+		if err != nil {
+			return tokenSource{}, err
 		}
-		creds, err = find(bg, cloudPlatformScope)
+		return a.storeSource(res, identity, creds, []byte(res.Credential.Value)), nil
 	}
+	// Application-default credentials carry no value in the resolution: the
+	// library finds them, and the JSON it read is what names them. Reading
+	// them per request is what lets a re-login — which rewrites the ADC file
+	// — reach the next request instead of the next process (spec §4.3).
+	find := a.FindCredentials
+	if find == nil {
+		find = google.FindDefaultCredentials
+	}
+	creds, err := find(bg, cloudPlatformScope)
 	if err != nil {
 		return tokenSource{}, err
 	}
-	// A stored credential is classified from the bytes evener holds; only
-	// ADC has to trust the JSON the library read from the file.
-	credentialJSON := creds.JSON
-	if res.Credential.Source == "store" {
-		credentialJSON = []byte(res.Credential.Value)
+	identity := credentialIdentity(res.Credential.Source, creds.JSON)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if c, ok := a.sources[res.Instance]; ok && c.identity == identity {
+		return c.tokenSource, nil
 	}
+	return a.storeSource(res, identity, creds, creds.JSON), nil
+}
+
+// storeSource caches a freshly built source for the instance and returns it.
+// a.mu is held throughout, so the cache and the map it lives in are written
+// under one lock.
+func (a *GCPADC) storeSource(res registry.Resolved, identity string, creds *google.Credentials, credentialJSON []byte) tokenSource {
 	src := tokenSource{ts: oauth2.ReuseTokenSource(nil, creds.TokenSource), userCredential: isUserCredential(credentialJSON)}
 	if a.sources == nil {
 		a.sources = map[string]cachedSource{}
 	}
 	a.sources[res.Instance] = cachedSource{identity: identity, tokenSource: src}
-	return src, nil
+	return src
 }

--- a/llm/providers/tokenauth/gcpadc.go
+++ b/llm/providers/tokenauth/gcpadc.go
@@ -100,11 +100,18 @@ func (a *GCPADC) Apply(ctx context.Context, req *http.Request, res registry.Reso
 
 // oauthRefusal returns the OAuth error code when err is the token endpoint's
 // refusal of the credential itself — invalid_grant for an expired, revoked, or
-// replaced refresh token, invalid_client for a bad secret. Anything else (a
-// deadline, an unreachable endpoint) carries no code: nothing about the
-// credential was decided.
+// replaced refresh token, invalid_client for a bad secret. The same RFC 6749
+// error field carries the endpoint's own transient conditions
+// (temporarily_unavailable on a 503, server_error), which are not verdicts on
+// the credential and must keep their retryable meaning; so does any failure
+// that carries no code at all (a deadline, an unreachable endpoint).
 func oauthRefusal(err error) string {
-	if refused, ok := errors.AsType[*oauth2.RetrieveError](err); ok {
+	refused, ok := errors.AsType[*oauth2.RetrieveError](err)
+	if !ok {
+		return ""
+	}
+	switch refused.ErrorCode {
+	case "invalid_grant", "invalid_client":
 		return refused.ErrorCode
 	}
 	return ""

--- a/llm/providers/tokenauth/gcpadc_test.go
+++ b/llm/providers/tokenauth/gcpadc_test.go
@@ -130,6 +130,61 @@ func TestGCPADCAFailingTransportIsNotAnAuthFailure(t *testing.T) {
 	}
 }
 
+// The token endpoint reports its own transient conditions through the same
+// RFC 6749 error field (temporarily_unavailable on a 503, server_error): those
+// are not verdicts on the credential, and must keep their retryable meaning
+// rather than telling the reader to sign in again.
+func TestGCPADCATransientTokenFailureKeepsItsRetryableMeaning(t *testing.T) {
+	transient := &oauth2.RetrieveError{ErrorCode: "temporarily_unavailable", ErrorDescription: "The authorization server is currently unable to handle the request."}
+	a := &GCPADC{FindCredentials: func(context.Context, ...string) (*google.Credentials, error) {
+		return &google.Credentials{JSON: []byte(storedUserJSON), TokenSource: failingTokenSource{err: transient}}, nil
+	}}
+	req, _ := http.NewRequest(http.MethodPost, "https://x", nil)
+	err := a.Apply(context.Background(), req, registry.Resolved{Instance: "vertex", Credential: registry.Credential{Source: "adc"}})
+	if err == nil {
+		t.Fatal("Apply accepted a failed token")
+	}
+	if llm.Kind(err) == llm.KindAuthentication {
+		t.Fatalf("Kind = authentication for a transient token failure: %v", err)
+	}
+	if got := llm.Classify(err); got != llm.ErrorClassRetryable {
+		t.Fatalf("Classify = %v, want retryable: a token endpoint that is briefly unavailable is worth retrying", got)
+	}
+	var cfg *llm.ConfigurationError
+	if errors.As(err, &cfg) {
+		t.Fatalf("a transient token failure was reported as configuration: %v", err)
+	}
+}
+
+// A stored credential the token endpoint refuses is reported as a refused
+// credential too, with the stored JSON named as the thing to replace.
+func TestGCPADCReportsAStoredCredentialRefusal(t *testing.T) {
+	refused := &oauth2.RetrieveError{ErrorCode: "invalid_grant", ErrorDescription: "Token has been expired or revoked."}
+	a := &GCPADC{
+		CredentialsFromJSON: func(context.Context, []byte, ...string) (*google.Credentials, error) {
+			return &google.Credentials{JSON: []byte(storedUserJSON), TokenSource: failingTokenSource{err: refused}}, nil
+		},
+		FindCredentials: func(context.Context, ...string) (*google.Credentials, error) {
+			t.Fatal("a stored credential must not fall back to application-default credentials")
+			return nil, errors.New("unreachable")
+		},
+	}
+	req, _ := http.NewRequest(http.MethodPost, "https://x", nil)
+	err := a.Apply(context.Background(), req, storedRes("vertex", storedUserJSON))
+	if err == nil {
+		t.Fatal("Apply accepted a refused stored credential")
+	}
+	if llm.Kind(err) != llm.KindAuthentication {
+		t.Fatalf("Kind = %v, want authentication", llm.Kind(err))
+	}
+	if !strings.Contains(err.Error(), "stored credential JSON") {
+		t.Fatalf("err = %v, want the stored credential named", err)
+	}
+	if !errors.Is(err, refused) {
+		t.Fatalf("err = %v, want the oauth error in the chain", err)
+	}
+}
+
 // A credential replaced under a long-running process (a re-login rewrites the
 // ADC file) must reach the next request: the cached source is dropped when the
 // credential it was built from no longer matches, while an unchanged

--- a/llm/providers/tokenauth/gcpadc_test.go
+++ b/llm/providers/tokenauth/gcpadc_test.go
@@ -10,11 +10,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"golang.org/x/oauth2/jwt"
 
 	"primeradiant.com/evener/llm"
 	"primeradiant.com/evener/llm/registry"
@@ -182,6 +184,58 @@ func TestGCPADCReportsAStoredCredentialRefusal(t *testing.T) {
 	if !errors.Is(err, refused) {
 		t.Fatalf("err = %v, want the oauth error in the chain", err)
 	}
+}
+
+// A service-account token source is golang.org/x/oauth2/jwt, which builds its
+// RetrieveError from the response body and leaves ErrorCode empty: the
+// endpoint's refusal exists only in the body there. Drive the real source
+// against a local token endpoint — the registry refuses a credential naming a
+// foreign token_uri (spec §4), so this is the only offline way to reach that
+// shape — and check both a verdict and a transient condition.
+func TestGCPADCReadsARefusalFromTheJWTStyleError(t *testing.T) {
+	key := testServiceAccountKey(t)
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"refused", http.StatusBadRequest, `{"error":"invalid_grant","error_description":"Invalid JWT Signature."}`, "invalid_grant"},
+		{"transient", http.StatusServiceUnavailable, `{"error":"temporarily_unavailable"}`, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			cfg := jwt.Config{ //nolint:staticcheck // the deprecated fields are this library's only offline entry to the very path a service account takes
+				Email:      "sa@example.iam.gserviceaccount.com",
+				PrivateKey: key,
+				TokenURL:   srv.URL,
+			}
+			ts := cfg.TokenSource(context.Background())
+			_, err := ts.Token()
+			if err == nil {
+				t.Fatal("the token endpoint refused and the source reported success")
+			}
+			if got := oauthRefusal(err); got != tc.want {
+				t.Fatalf("oauthRefusal = %q, want %q (err %v)", got, tc.want, err)
+			}
+		})
+	}
+}
+
+// testServiceAccountKey returns the PEM key testServiceAccountJSON carries.
+func testServiceAccountKey(t *testing.T) []byte {
+	t.Helper()
+	var doc struct {
+		PrivateKey string `json:"private_key"`
+	}
+	if err := json.Unmarshal([]byte(testServiceAccountJSON(t)), &doc); err != nil {
+		t.Fatal(err)
+	}
+	return []byte(doc.PrivateKey)
 }
 
 // A credential replaced under a long-running process (a re-login rewrites the

--- a/llm/providers/tokenauth/gcpadc_test.go
+++ b/llm/providers/tokenauth/gcpadc_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -19,14 +20,24 @@ import (
 	"primeradiant.com/evener/llm/registry"
 )
 
-func TestGCPADCAppliesTokenOncePerInstance(t *testing.T) {
+// The credential is read per request — that is what lets a re-login reach the
+// next request — but an unchanged credential keeps the cached source, so the
+// token it minted is the one every request carries, and each instance has its
+// own source.
+func TestGCPADCCachesPerInstanceWhileTheCredentialStands(t *testing.T) {
 	calls := 0
+	minted := 0
+	credential := `{"type":"authorized_user","client_id":"a","client_secret":"b","refresh_token":"c"}`
 	a := &GCPADC{FindCredentials: func(ctx context.Context, scopes ...string) (*google.Credentials, error) {
 		calls++
 		if len(scopes) != 1 || scopes[0] != cloudPlatformScope {
 			t.Fatalf("scopes = %v", scopes)
 		}
-		return &google.Credentials{TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "adc-token"})}, nil
+		minted++
+		return &google.Credentials{
+			JSON:        []byte(credential),
+			TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: fmt.Sprintf("adc-token-%d", minted)}),
+		}, nil
 	}}
 	res := registry.Resolved{Instance: "vertex", Credential: registry.Credential{Source: "adc"}}
 	for range 2 {
@@ -34,14 +45,19 @@ func TestGCPADCAppliesTokenOncePerInstance(t *testing.T) {
 		if err := a.Apply(context.Background(), req, res); err != nil {
 			t.Fatal(err)
 		}
-		if got := req.Header.Get("Authorization"); got != "Bearer adc-token" {
-			t.Fatalf("Authorization = %q", got)
+		if got := req.Header.Get("Authorization"); got != "Bearer adc-token-1" {
+			t.Fatalf("Authorization = %q, want the cached source's token", got)
 		}
 	}
 	req, _ := http.NewRequest(http.MethodPost, "https://x", nil)
-	_ = a.Apply(context.Background(), req, registry.Resolved{Instance: "google-vertex", Credential: registry.Credential{Source: "adc"}})
-	if calls != 2 {
-		t.Fatalf("FindDefaultCredentials called %d times, want once per instance", calls)
+	if err := a.Apply(context.Background(), req, registry.Resolved{Instance: "google-vertex", Credential: registry.Credential{Source: "adc"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := req.Header.Get("Authorization"); got == "Bearer adc-token-1" {
+		t.Fatalf("Authorization = %q, want the second instance's own source", got)
+	}
+	if calls != 3 {
+		t.Fatalf("FindDefaultCredentials called %d times, want one read per request", calls)
 	}
 }
 
@@ -62,6 +78,93 @@ func TestGCPADCReportsMissingCredentials(t *testing.T) {
 	}
 	if req.Header.Get("Authorization") != "" {
 		t.Fatal("no header on failure")
+	}
+}
+
+// failingTokenSource fails Token() the way a credential refresh does.
+type failingTokenSource struct{ err error }
+
+func (f failingTokenSource) Token() (*oauth2.Token, error) { return nil, f.err }
+
+// A refresh the token endpoint refused is a credential problem, not an
+// unreachable endpoint: the hub's credential test reports the class, and
+// "sign in again" is the remedy it offers for it.
+func TestGCPADCReportsARefusedRefreshAsAuthentication(t *testing.T) {
+	refused := &oauth2.RetrieveError{ErrorCode: "invalid_grant", ErrorDescription: "Token has been expired or revoked."}
+	a := &GCPADC{FindCredentials: func(context.Context, ...string) (*google.Credentials, error) {
+		return &google.Credentials{JSON: []byte(storedUserJSON), TokenSource: failingTokenSource{err: refused}}, nil
+	}}
+	req, _ := http.NewRequest(http.MethodPost, "https://x", nil)
+	err := a.Apply(context.Background(), req, registry.Resolved{Instance: "vertex", Credential: registry.Credential{Source: "adc"}})
+	if err == nil {
+		t.Fatal("Apply accepted a refused refresh")
+	}
+	if llm.Kind(err) != llm.KindAuthentication {
+		t.Fatalf("Kind = %v, want authentication: the hub reports any other class as an unreachable endpoint", llm.Kind(err))
+	}
+	if !errors.Is(err, refused) {
+		t.Fatalf("err = %v, want the oauth error in the chain", err)
+	}
+	if req.Header.Get("Authorization") != "" {
+		t.Fatal("no header on failure")
+	}
+}
+
+// A token that could not be minted because the token endpoint was unreachable
+// keeps its transport meaning: nothing says the credential is bad.
+func TestGCPADCAFailingTransportIsNotAnAuthFailure(t *testing.T) {
+	unreachable := errors.New("dial tcp 169.254.169.254:80: connect: no route to host")
+	a := &GCPADC{FindCredentials: func(context.Context, ...string) (*google.Credentials, error) {
+		return &google.Credentials{TokenSource: failingTokenSource{err: unreachable}}, nil
+	}}
+	req, _ := http.NewRequest(http.MethodPost, "https://x", nil)
+	err := a.Apply(context.Background(), req, registry.Resolved{Instance: "vertex", Credential: registry.Credential{Source: "adc"}})
+	if err == nil {
+		t.Fatal("Apply accepted a failed token")
+	}
+	if llm.Kind(err) == llm.KindAuthentication {
+		t.Fatalf("Kind = authentication for a transport failure: %v", err)
+	}
+	if !errors.Is(err, unreachable) {
+		t.Fatalf("err = %v, want the transport error in the chain", err)
+	}
+}
+
+// A credential replaced under a long-running process (a re-login rewrites the
+// ADC file) must reach the next request: the cached source is dropped when the
+// credential it was built from no longer matches, while an unchanged
+// credential keeps it.
+func TestGCPADCRebuildsADCSourceWhenTheCredentialFileChanges(t *testing.T) {
+	credential := `{"type":"authorized_user","client_id":"c","client_secret":"s","refresh_token":"first"}`
+	token := "token-first"
+	a := &GCPADC{FindCredentials: func(context.Context, ...string) (*google.Credentials, error) {
+		return &google.Credentials{
+			JSON:        []byte(credential),
+			TokenSource: oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+		}, nil
+	}}
+	res := registry.Resolved{Instance: "vertex", Credential: registry.Credential{Source: "adc"}}
+	apply := func() string {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPost, "https://x", nil)
+		if err := a.Apply(context.Background(), req, res); err != nil {
+			t.Fatal(err)
+		}
+		return req.Header.Get("Authorization")
+	}
+	if got := apply(); got != "Bearer token-first" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	// Re-reading the same file must not disturb the cached source.
+	token = "token-reread"
+	if got := apply(); got != "Bearer token-first" {
+		t.Fatalf("Authorization = %q, want the cached source's token", got)
+	}
+	// The re-login: a new credential on disk, which the next request must use.
+	credential = `{"type":"authorized_user","client_id":"c","client_secret":"s","refresh_token":"second"}`
+	token = "token-second"
+	if got := apply(); got != "Bearer token-second" {
+		t.Fatalf("Authorization = %q, want the replaced credential's token", got)
 	}
 }
 
@@ -254,7 +357,7 @@ func TestGCPADCReplacesStoredSourceOnRotation(t *testing.T) {
 		if len(a.sources) != 1 {
 			t.Fatalf("len(a.sources) = %d, want 1", len(a.sources))
 		}
-		if got, want := a.sources["vertex"].identity, credentialIdentity(storedRes("vertex", value)); got != want {
+		if got, want := a.sources["vertex"].identity, credentialIdentity("store", []byte(value)); got != want {
 			t.Fatalf("identity = %q, want %q", got, want)
 		}
 	}

--- a/llm/providers/tokenauth/gcpadc_test.go
+++ b/llm/providers/tokenauth/gcpadc_test.go
@@ -150,8 +150,7 @@ func TestGCPADCATransientTokenFailureKeepsItsRetryableMeaning(t *testing.T) {
 	if got := llm.Classify(err); got != llm.ErrorClassRetryable {
 		t.Fatalf("Classify = %v, want retryable: a token endpoint that is briefly unavailable is worth retrying", got)
 	}
-	var cfg *llm.ConfigurationError
-	if errors.As(err, &cfg) {
+	if _, ok := errors.AsType[*llm.ConfigurationError](err); ok {
 		t.Fatalf("a transient token failure was reported as configuration: %v", err)
 	}
 }


### PR DESCRIPTION
## Problem

A long-lived process could not use a Google credential that had been re-logged-in since it started, and the error it produced read as an unreachable endpoint.

`tokenauth.GCPADC` cached one token source per instance, named by the credential's *source* alone (`adc`). `gcloud auth application-default login` rewrites the ADC file in place, so the cache kept answering with the credential the process read at startup; the failure surfaced only once that access token expired, about an hour in, as `endpoint_failure — The provider endpoint could not be reached` in the hub's credential test. The hub discards the underlying error, and the token failure arrived as a plain error, which its classifier has no HTTP status or error kind for.

Observed on a hub started at 16:43:59 with the ADC file rewritten at 16:52:52: the hub's `auth/test` failed for `vertex` in ~110ms on every attempt, while a fresh process listed the same instance's 49 models in ~150ms.

## Changes

- The cached source is named by the credential's own bytes — the digest of the JSON the library read, alongside the credential's source name — so a re-login reaches the next request. Application-default credentials are therefore read per request (one local file read); an unchanged credential still keeps its cached source.
- A refresh the token endpoint refused (`invalid_grant`, `invalid_client`) is now an `llm.NewAuthenticationError`, so the hub's credential test reports rejected credentials and offers signing in again. A transport failure keeps its own meaning.
- Spec §4.3's identity paragraph and the `GCPADC` type comment follow the new contract.

## Verification

- RED first: a changed ADC JSON rebuilt nothing, and a refused refresh classified as `KindUnknown`.
- Live, with a throwaway credential pointed at by `GOOGLE_APPLICATION_CREDENTIALS` (the real ADC untouched): `providers probe vertex` prints `application-default credentials were refused (invalid_client) (run \`gcloud auth application-default login\`, …)` where the installed binary printed the bare `gcp-adc token: oauth2: "invalid_client"` wrapper.
- The caching test now pins the re-read, the reuse of the cached source while the credential is unchanged, and per-instance sources.
- `make lint && make test` green in a clean lane at this commit.