### PR TITLE
feat(plugins): make the global enable flag "enabled by default"

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ variables:
 |---|---|
 | `--model <provider/model>` | LLM model identifier (required unless resuming an existing session) |
 | `--dir <path>` | Working directory (default: current directory) |
-| `--enabled-plugins <name,...>` | Load exactly these otherwise-loadable plugins for this new session; an empty value loads none |
+| `--enabled-plugins <name,...>` | Load exactly these installed plugins for this new session, including ones whose default is off; an empty value loads none |
 | `--output-schema <json>` | Inline JSON Schema replacing the default `communicate.output` schema |
 | `--verbose` | Emit NDJSON events to stderr (replaces human-readable output) |
 | `--resume <id>` | Resume a previous session by ID |
@@ -274,7 +274,7 @@ variables:
 
 ### Per-session plugin selection
 
-Inspect the effective plugins available to a new direct-CLI session with:
+Inspect the plugins a new direct-CLI session loads by default with:
 
 ```bash
 evener plugin list --effective --json
@@ -288,15 +288,16 @@ evener --enabled-plugins=alpha,beta "task"
 evener --enabled-plugins= "task"
 ```
 
-Omitting `--enabled-plugins` uses the current defaults: every otherwise-loadable
-plugin, including globally enabled installed plugins and explicit plugin
-directories. The flag is new-session-only and cannot replace the plugin set of
-an existing resumed session. It selects manifest names from that otherwise-
-loadable set; globally disabled plugins remain unavailable. The selected set is
-stored with the new session, so resumes, forks, and delegates inherit it.
+Omitting `--enabled-plugins` uses the current defaults: explicit plugin
+directories plus installed plugins marked enabled by default. The flag is
+new-session-only and cannot replace the plugin set of an existing resumed
+session. It selects manifest names from every installed plugin, so naming one
+whose default is off turns it on for that session. The selected set is stored
+with the new session, so resumes, forks, and delegates inherit it.
 
 This does not change persistent plugin state. `evener plugin enable` and
-`evener plugin disable` remain the global controls for future default sessions.
+`evener plugin disable` set whether an installed plugin loads by default in
+future sessions.
 
 ### Structured output
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/InstalledSection.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/InstalledSection.test.tsx
@@ -73,7 +73,7 @@ test("shows broken/disabled/auto-upgrade badges only when applicable", () => {
   });
   render(<InstalledSection onSelect={() => {}} />);
   expect(screen.getByText("broken")).toBeTruthy();
-  expect(screen.getByText("disabled")).toBeTruthy();
+  expect(screen.getByText("off by default")).toBeTruthy();
   expect(screen.getByText("auto-upgrade")).toBeTruthy();
 });
 
@@ -82,7 +82,7 @@ test("no badges render for a healthy, enabled, non-auto-upgrading plugin", () =>
   extensionsStore.setState({ plugins: [LINTER] });
   render(<InstalledSection onSelect={() => {}} />);
   expect(screen.queryByText("broken")).toBeNull();
-  expect(screen.queryByText("disabled")).toBeNull();
+  expect(screen.queryByText("off by default")).toBeNull();
   expect(screen.queryByText("auto-upgrade")).toBeNull();
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/InstalledSection.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/InstalledSection.tsx
@@ -81,7 +81,7 @@ export function InstalledSection({ onSelect }: InstalledSectionProps) {
                     <StatusDot state={pluginStatus(p)} />
                     {p.plugin}
                     {p.broken && <Chip tone="danger">broken</Chip>}
-                    {!p.enabled && <Chip tone="neutral">disabled</Chip>}
+                    {!p.enabled && <Chip tone="neutral">off by default</Chip>}
                     {p.autoUpgrade && <Chip tone="neutral">auto-upgrade</Chip>}
                   </div>
                   <div className={CLASS.rowMeta}>{`@ ${p.marketplace} · v${p.version || "unknown"}`}</div>

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.test.tsx
@@ -62,7 +62,7 @@ test("renders name, state chips, version, marketplace, and source", async () => 
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
   expect(screen.getByRole("dialog", { name: "linter" })).toBeTruthy();
   expect(screen.getByText("broken")).toBeTruthy();
-  expect(screen.getByText("disabled")).toBeTruthy();
+  expect(screen.getByText("off by default")).toBeTruthy();
   expect(screen.getByText("auto-upgrade")).toBeTruthy();
   expect(screen.getByText("v1.2.0")).toBeTruthy();
   expect(screen.getByText("acme-plugins")).toBeTruthy();
@@ -89,7 +89,7 @@ test("the Enabled and Auto-upgrade switches reflect the entry's state", async ()
   extensionsStore.setState({ plugins: [LINTER], marketplaces: [ACME] });
   const browseMarketplace = vi.spyOn(extensionsStore.getState(), "browseMarketplace");
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
-  expect(screen.getByRole("switch", { name: "Enabled" }).getAttribute("aria-checked")).toBe("true");
+  expect(screen.getByRole("switch", { name: "Enabled by default" }).getAttribute("aria-checked")).toBe("true");
   expect(screen.getByRole("switch", { name: "Auto-upgrade" }).getAttribute("aria-checked")).toBe("false");
   const browse = browseMarketplace.mock.results[0];
   if (browse?.type !== "return") throw new Error("Plugin detail sheet did not start its catalog browse");
@@ -105,9 +105,9 @@ test("the Enabled switch calls pluginDisable on an enabled plugin, pluginEnable 
     return { plugins: [{ ...LINTER, enabled: false }] };
   });
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
-  await user.click(screen.getByRole("switch", { name: "Enabled" }));
+  await user.click(screen.getByRole("switch", { name: "Enabled by default" }));
   await waitFor(() =>
-    expect(screen.getByRole("switch", { name: "Enabled" }).getAttribute("aria-checked")).toBe("false"),
+    expect(screen.getByRole("switch", { name: "Enabled by default" }).getAttribute("aria-checked")).toBe("false"),
   );
   expect(getToasts()).toEqual([]);
 });
@@ -121,9 +121,9 @@ test("the Enabled switch calls pluginEnable on a disabled plugin", async () => {
     return { plugins: [{ ...LINTER, enabled: true }] };
   });
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
-  await user.click(screen.getByRole("switch", { name: "Enabled" }));
+  await user.click(screen.getByRole("switch", { name: "Enabled by default" }));
   await waitFor(() =>
-    expect(screen.getByRole("switch", { name: "Enabled" }).getAttribute("aria-checked")).toBe("true"),
+    expect(screen.getByRole("switch", { name: "Enabled by default" }).getAttribute("aria-checked")).toBe("true"),
   );
   expect(getToasts()).toEqual([]);
 });
@@ -136,7 +136,7 @@ test("a failed enable toggle re-enables the switch too", async () => {
     throw new Error("boom");
   });
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
-  const enabledSwitch = screen.getByRole("switch", { name: "Enabled" });
+  const enabledSwitch = screen.getByRole("switch", { name: "Enabled by default" });
   await user.click(enabledSwitch);
   await waitFor(() => expect((enabledSwitch as HTMLButtonElement).disabled).toBe(false));
 });
@@ -149,7 +149,7 @@ test("a failed enable toggle toasts 'Toggle enable failed'", async () => {
     throw new Error("boom");
   });
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
-  await user.click(screen.getByRole("switch", { name: "Enabled" }));
+  await user.click(screen.getByRole("switch", { name: "Enabled by default" }));
   await waitFor(() =>
     expect(getToasts().some((t) => t.kind === "error" && t.text === "Toggle enable failed: boom")).toBe(true),
   );
@@ -168,13 +168,13 @@ test("the Enabled switch is disabled while its RPC is in flight, and re-enables 
       }),
   );
   render(<PluginDetailSheet target={TARGET} onClose={() => {}} />);
-  const enabledSwitch = screen.getByRole("switch", { name: "Enabled" });
+  const enabledSwitch = screen.getByRole("switch", { name: "Enabled by default" });
   await user.click(enabledSwitch);
   expect((enabledSwitch as HTMLButtonElement).disabled).toBe(true);
 
   resolveDisable({ plugins: [{ ...LINTER, enabled: false }] });
   await waitFor(() =>
-    expect((screen.getByRole("switch", { name: "Enabled" }) as HTMLButtonElement).disabled).toBe(false),
+    expect((screen.getByRole("switch", { name: "Enabled by default" }) as HTMLButtonElement).disabled).toBe(false),
   );
 });
 

--- a/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.tsx
+++ b/cmd/evener-hub/frontend/src/panes/settings/sections/marketplacesPlugins/PluginDetailSheet.tsx
@@ -155,7 +155,7 @@ export function PluginDetailSheet({ target, onClose }: PluginDetailSheetProps) {
             {(entry.broken || !entry.enabled || entry.autoUpgrade) && (
               <div className={CLASS.chipRow}>
                 {entry.broken && <Chip tone="danger">broken</Chip>}
-                {!entry.enabled && <Chip tone="neutral">disabled</Chip>}
+                {!entry.enabled && <Chip tone="neutral">off by default</Chip>}
                 {entry.autoUpgrade && <Chip tone="neutral">auto-upgrade</Chip>}
               </div>
             )}
@@ -181,7 +181,7 @@ export function PluginDetailSheet({ target, onClose }: PluginDetailSheetProps) {
                 checked={entry.enabled}
                 onChange={() => void handleToggleEnable(entry.enabled)}
                 disabled={toggleBusy}
-                label="Enabled"
+                label="Enabled by default"
               />
               <Switch
                 checked={entry.autoUpgrade}

--- a/cmd/evener-tui/internal/launchconfig/plugins_panel.go
+++ b/cmd/evener-tui/internal/launchconfig/plugins_panel.go
@@ -521,7 +521,7 @@ func (p PluginsPanel) renderInstalledTab() string {
 			badges = append(badges, tuiprim.StatusBadge(th.StateWarning, "broken"))
 		}
 		if !e.Enabled {
-			badges = append(badges, tuiprim.StatusBadge(th.StateEnded, "disabled"))
+			badges = append(badges, tuiprim.StatusBadge(th.StateEnded, "off by default"))
 		}
 		if e.AutoUpgrade {
 			badges = append(badges, tuiprim.StatusBadge(th.StateIdle, "auto-upgrade"))

--- a/cmd/evener-tui/internal/launchconfig/plugins_panel_covtest_test.go
+++ b/cmd/evener-tui/internal/launchconfig/plugins_panel_covtest_test.go
@@ -632,7 +632,7 @@ func TestCovRenderInstalledTabBadges(t *testing.T) {
 		{Plugin: "gamma", Marketplace: "mp", Enabled: true, AutoUpgrade: true, Version: "2.0"},
 	}}
 	v := p.renderInstalledTab()
-	for _, want := range []string{"alpha", "beta", "gamma", "BROKEN", "DISABLED", "AUTO-UPGRADE", "unknown"} {
+	for _, want := range []string{"alpha", "beta", "gamma", "BROKEN", "OFF BY DEFAULT", "AUTO-UPGRADE", "unknown"} {
 		if !strings.Contains(v, want) {
 			t.Fatalf("installed rows missing %q: %q", want, v)
 		}

--- a/cmd/evener-tui/internal/launchconfig/plugins_panel_test.go
+++ b/cmd/evener-tui/internal/launchconfig/plugins_panel_test.go
@@ -450,7 +450,7 @@ func TestPluginsPanel_InstalledTab_RendersBadges(t *testing.T) {
 	// StatusBadge uppercases its label; check for the badge text distinctly
 	// from the plugin's own (lowercase) name so a name substring can't make
 	// the assertion pass vacuously.
-	for _, want := range []string{"broken-one", "BROKEN", "disabled-one", "DISABLED", "auto-one", "AUTO-UPGRADE", "v1.2.0"} {
+	for _, want := range []string{"broken-one", "BROKEN", "disabled-one", "OFF BY DEFAULT", "auto-one", "AUTO-UPGRADE", "v1.2.0"} {
 		if !strings.Contains(v, want) {
 			t.Errorf("installed view missing %q:\n%s", want, v)
 		}

--- a/cmd/evener/plugin_selection_flag_test.go
+++ b/cmd/evener/plugin_selection_flag_test.go
@@ -108,11 +108,16 @@ func TestPluginSelectionResumeConflicts(t *testing.T) {
 
 func TestRenderEffectivePluginListJSON(t *testing.T) {
 	resolution := plugins.LaunchPluginResolution{
-		Candidates: []plugins.LaunchPluginCandidate{{
-			Name: "alpha", Version: "1.2.3", Description: "Alpha", Source: plugins.LaunchPluginSourceInstalled,
-			Marketplace: "official", Path: "/plugins/alpha", SkillCount: 1, AgentCount: 2,
-			CommandCount: 3, HookCount: 4, MCPCount: 5,
-		}},
+		Candidates: []plugins.LaunchPluginCandidate{
+			{
+				Name: "alpha", Version: "1.2.3", Description: "Alpha", Source: plugins.LaunchPluginSourceInstalled,
+				Marketplace: "official", Path: "/plugins/alpha", Selected: true, SkillCount: 1, AgentCount: 2,
+				CommandCount: 3, HookCount: 4, MCPCount: 5,
+			},
+			// Off by default: present in the inventory, absent from the
+			// default listing.
+			{Name: "beta", Source: plugins.LaunchPluginSourceInstalled, Marketplace: "official", Path: "/plugins/beta"},
+		},
 		Diagnostics: []plugins.LaunchPluginDiagnostic{{Name: "broken", Message: "invalid", Source: plugins.LaunchPluginSourceInstalled}},
 	}
 	var out bytes.Buffer
@@ -124,7 +129,7 @@ func TestRenderEffectivePluginListJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(got.Plugins) != 1 || got.Plugins[0].Name != "alpha" || got.Plugins[0].SkillCount != 1 || got.Plugins[0].MCPCount != 5 {
-		t.Fatalf("plugins = %+v", got.Plugins)
+		t.Fatalf("plugins = %+v, want only the default-selected alpha", got.Plugins)
 	}
 	if len(got.Diagnostics) != 1 || !strings.Contains(got.Diagnostics[0].Message, "invalid") {
 		t.Fatalf("diagnostics = %+v", got.Diagnostics)
@@ -133,7 +138,7 @@ func TestRenderEffectivePluginListJSON(t *testing.T) {
 
 func TestRenderEffectivePluginListHumanIncludesDiagnostics(t *testing.T) {
 	resolution := plugins.LaunchPluginResolution{
-		Candidates:  []plugins.LaunchPluginCandidate{{Name: "alpha", Source: plugins.LaunchPluginSourceDirectory}},
+		Candidates:  []plugins.LaunchPluginCandidate{{Name: "alpha", Source: plugins.LaunchPluginSourceDirectory, Selected: true}},
 		Diagnostics: []plugins.LaunchPluginDiagnostic{{Name: "broken", Path: "/tmp/broken", Message: "invalid manifest"}},
 	}
 	var out bytes.Buffer

--- a/cmd/evener/plugincmd.go
+++ b/cmd/evener/plugincmd.go
@@ -227,8 +227,8 @@ func printPluginUsage(w io.Writer) {
 	_, _ = fmt.Fprintf(w, "  marketplace   Manage plugin marketplaces (add, remove, list, refresh, browse)\n")
 	_, _ = fmt.Fprintf(w, "  install       Install a plugin\n")
 	_, _ = fmt.Fprintf(w, "  remove        Remove an installed plugin\n")
-	_, _ = fmt.Fprintf(w, "  enable        Enable a plugin\n")
-	_, _ = fmt.Fprintf(w, "  disable       Disable a plugin\n")
+	_, _ = fmt.Fprintf(w, "  enable        Enable a plugin by default\n")
+	_, _ = fmt.Fprintf(w, "  disable       Disable a plugin by default\n")
 	_, _ = fmt.Fprintf(w, "  list          List installed plugins\n")
 	_, _ = fmt.Fprintf(w, "  upgrade       Upgrade installed plugins\n")
 	_, _ = fmt.Fprintf(w, "  auto-upgrade  Toggle a plugin's auto-upgrade flag (--off to disable)\n")
@@ -300,7 +300,7 @@ func renderPluginList(w io.Writer, items []plugins.ListItem, asJSON bool) error 
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintf(tw, "PLUGIN@MARKETPLACE\tVERSION\tENABLED\tAUTO-UPGRADE\tBROKEN\n")
+	_, _ = fmt.Fprintf(tw, "PLUGIN@MARKETPLACE\tVERSION\tENABLED-BY-DEFAULT\tAUTO-UPGRADE\tBROKEN\n")
 	for _, item := range items {
 		enabled := "no"
 		if item.Enabled {
@@ -322,12 +322,22 @@ func renderPluginList(w io.Writer, items []plugins.ListItem, asJSON bool) error 
 }
 
 func renderEffectivePluginList(w io.Writer, resolution plugins.LaunchPluginResolution, asJSON bool) error {
+	// The effective listing answers "what would a default launch load", so a
+	// plugin whose registry default is off is omitted here even though a
+	// session allow-list could name it. `plugin list` is the view of the full
+	// installed inventory.
+	candidates := make([]plugins.LaunchPluginCandidate, 0, len(resolution.Candidates))
+	for _, candidate := range resolution.Candidates {
+		if candidate.Selected {
+			candidates = append(candidates, candidate)
+		}
+	}
 	if asJSON {
 		result := effectivePluginListJSON{
-			Plugins:     make([]effectivePluginJSON, 0, len(resolution.Candidates)),
+			Plugins:     make([]effectivePluginJSON, 0, len(candidates)),
 			Diagnostics: resolution.Diagnostics,
 		}
-		for _, candidate := range resolution.Candidates {
+		for _, candidate := range candidates {
 			result.Plugins = append(result.Plugins, effectivePluginJSON{
 				Name: candidate.Name, Version: candidate.Version, Description: candidate.Description,
 				Source: candidate.Source, Marketplace: candidate.Marketplace, Path: candidate.Path,
@@ -338,14 +348,14 @@ func renderEffectivePluginList(w io.Writer, resolution plugins.LaunchPluginResol
 		return json.NewEncoder(w).Encode(result)
 	}
 
-	if len(resolution.Candidates) == 0 {
+	if len(candidates) == 0 {
 		_, _ = fmt.Fprintln(w, "No effective plugins.")
 		renderLaunchPluginDiagnostics(w, resolution.Diagnostics)
 		return nil
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(tw, "PLUGIN\tVERSION\tSOURCE\tSKILLS\tAGENTS\tCOMMANDS\tHOOKS\tMCP")
-	for _, candidate := range resolution.Candidates {
+	for _, candidate := range candidates {
 		source := string(candidate.Source)
 		if candidate.Marketplace != "" {
 			source += ":" + candidate.Marketplace
@@ -459,7 +469,7 @@ func runPluginLifecycle(verb string, args []string, _ io.Reader, stdout, stderr 
 		if err := m.SetEnabled(ctx, plugin, marketplace, true); err != nil {
 			return err
 		}
-		_, _ = fmt.Fprintf(stdout, "Enabled %s@%s\n", plugin, marketplace)
+		_, _ = fmt.Fprintf(stdout, "Enabled %s@%s by default\n", plugin, marketplace)
 		return nil
 
 	case "disable":
@@ -478,7 +488,7 @@ func runPluginLifecycle(verb string, args []string, _ io.Reader, stdout, stderr 
 		if err := m.SetEnabled(ctx, plugin, marketplace, false); err != nil {
 			return err
 		}
-		_, _ = fmt.Fprintf(stdout, "Disabled %s@%s\n", plugin, marketplace)
+		_, _ = fmt.Fprintf(stdout, "Disabled %s@%s by default\n", plugin, marketplace)
 		return nil
 
 	case "upgrade":

--- a/cmd/evener/serve_test.go
+++ b/cmd/evener/serve_test.go
@@ -167,6 +167,11 @@ func TestServePluginRootFlagUsesHubValidatedRegistryAfterDisablement(t *testing.
 	deps := defaultServeDeps()
 	deps.ensureConfigDirs = func() error { return nil }
 	deps.seedMarketplaces = func(context.Context) error { return nil }
+	var got []string
+	deps.provisionSandbox = func(_ *execenv.LocalExecutionEnvironment, cfg *agent.SessionConfig, _ string) error {
+		got = append([]string(nil), cfg.PluginDirs...)
+		return errors.New("stop after config")
+	}
 
 	err := runServeWithDeps([]string{
 		"--model", "openai/gpt-test",
@@ -175,8 +180,14 @@ func TestServePluginRootFlagUsesHubValidatedRegistryAfterDisablement(t *testing.
 		"--plugin-root", hubRoot,
 		"--enabled-plugins=alpha",
 	}, deps)
-	if err == nil || !strings.Contains(err.Error(), "enabled plugin selection is unavailable: alpha: no valid plugin candidate") {
-		t.Fatalf("serve error = %v, want disabled hub-root selection failure", err)
+	if err == nil || !strings.Contains(err.Error(), "stop after config") {
+		t.Fatalf("serve error = %v", err)
+	}
+	// Off by default is not unavailable: the explicit selection loads the
+	// plugin from the hub-validated root, and the ambient registry's same-name
+	// copy stays out.
+	if !reflect.DeepEqual(got, []string{hubInstalledDir}) {
+		t.Fatalf("session plugin dirs = %v, want the hub-root copy %v", got, []string{hubInstalledDir})
 	}
 }
 

--- a/docs/evener-hub.md
+++ b/docs/evener-hub.md
@@ -183,11 +183,13 @@ for the full schema and semantics.
 
 Plugin selection is a new-session control. The default state leaves the
 selection omitted, so the session uses every otherwise-loadable plugin from the
-resolved explicit directories and globally enabled installed plugins. Choosing
-an individual plugin, **All**, or **None** changes the launch to an explicit
-allow-list of manifest names; **None** sends an explicit empty list and loads no
-plugins. Globally disabled plugins are never selectable, and this control does
-not change persistent plugin state.
+resolved explicit directories and installed plugins marked enabled by default.
+Every installed plugin appears in the list, including ones whose default is off.
+Choosing an individual plugin, **All**, or **None** changes the launch to an
+explicit allow-list of manifest names, and an off-by-default plugin named there
+loads for that session; **None** sends an explicit empty list and loads no
+plugins. This control does not change persistent plugin state — the plugin
+detail's **Enabled by default** switch does.
 
 In the desktop new-session pane, the summary appears between the working
 directory/model/effort controls and Advanced options:

--- a/docs/superpowers/specs/2026-08-26-plugin-session-toggle-design.md
+++ b/docs/superpowers/specs/2026-08-26-plugin-session-toggle-design.md
@@ -4,6 +4,13 @@ Date: 2026-08-26
 Status: Approved
 Branch: `main`
 
+> Partially superseded: the global plugin flag is now **Enabled by default**, so
+> an off-by-default installed plugin is listed in the session plugin picker and
+> can be selected for one session. Everything below that says otherwise — the
+> non-goal "Enabling a globally disabled plugin for one session", "Global state
+> remains authoritative", and the matching testing bullets — no longer describes
+> the product.
+
 ## Summary
 
 Evener currently loads every valid plugin supplied through `--plugin-dir`, then

--- a/internal/plugins/resolve.go
+++ b/internal/plugins/resolve.go
@@ -66,9 +66,12 @@ type LaunchPluginResolution struct {
 	SelectionErrors []PluginSelectionError
 }
 
-// ResolveForLaunch enumerates explicit plugin directories followed by globally
-// enabled installed plugins. It loads each candidate with the same loader used
-// by session startup, retaining invalid candidates as structured diagnostics.
+// ResolveForLaunch enumerates explicit plugin directories followed by every
+// installed plugin, whether or not it is enabled by default. It loads each
+// candidate with the same loader used by session startup, retaining invalid
+// candidates as structured diagnostics. An omitted selection selects the
+// candidates that are enabled by default; a present selection selects exactly
+// the named candidates, including ones whose default is off.
 func (m *Manager) ResolveForLaunch(ctx context.Context, explicitDirs []string, enabledNames *[]string) (LaunchPluginResolution, error) {
 	return m.resolveForLaunch(ctx, explicitDirs, enabledNames, func(name string) (bundledCandidate, error) {
 		path, warnings, err := m.materializeBundledPlugin(ctx, name)
@@ -202,7 +205,7 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 		}
 	}
 
-	add := func(loadPath, path string, source LaunchPluginSource, marketplace, registryVersion, registryName string) {
+	add := func(loadPath, path string, source LaunchPluginSource, marketplace, registryVersion, registryName string, defaultSelected bool) {
 		instance, err := enabledLoad(loadPath)
 		if err != nil {
 			name := registryName
@@ -239,7 +242,13 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 		if source == LaunchPluginSourceInstalled && registryVersion != "" {
 			version = registryVersion
 		}
-		selected := enabledNames == nil || requested[name]
+		// The registry's Enabled flag is the plugin's default, not a hard
+		// gate: an omitted selection takes the defaults, while a present
+		// allow-list can turn on a plugin whose default is off for one session.
+		selected := defaultSelected
+		if enabledNames != nil {
+			selected = requested[name]
+		}
 		resolution.Candidates = append(resolution.Candidates, LaunchPluginCandidate{
 			Name: name, Version: version, Description: instance.Manifest.Description,
 			Source: source, Marketplace: marketplace, Path: path, Selected: selected,
@@ -253,7 +262,7 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 	}
 
 	for _, path := range explicitDirs {
-		add(path, path, LaunchPluginSourceDirectory, "", "", "")
+		add(path, path, LaunchPluginSourceDirectory, "", "", "", true)
 	}
 
 	if rootErr == nil {
@@ -269,15 +278,28 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 			}
 			return resolution, err
 		}
-		for _, item := range items {
-			if !item.Enabled {
-				continue
+		// Enumerate on-by-default entries first. Manifest names dedup
+		// first-wins, so a name an on-by-default plugin claims keeps the
+		// winner it had when only enabled entries were candidates; an
+		// off-by-default plugin supplies a name only when no on-by-default
+		// plugin claims it. List's own order (plugin, then marketplace)
+		// still decides within each group.
+		slices.SortStableFunc(items, func(a, b ListItem) int {
+			if a.Enabled == b.Enabled {
+				return 0
 			}
+			if a.Enabled {
+				return -1
+			}
+			return 1
+		})
+		for _, item := range items {
 			// Deliberately do not filter item.Broken. List's validation is a
 			// useful snapshot, but loading here gives Preview a structured
 			// diagnostic and avoids turning a broken candidate into a
-			// registry-level failure.
-			add(item.InstallPath, item.InstallPath, LaunchPluginSourceInstalled, item.Marketplace, item.Version, item.Plugin)
+			// registry-level failure. Every installed plugin is a candidate so
+			// a session can see and select one that is off by default.
+			add(item.InstallPath, item.InstallPath, LaunchPluginSourceInstalled, item.Marketplace, item.Version, item.Plugin, item.Enabled)
 		}
 	}
 
@@ -307,7 +329,7 @@ func (m *Manager) resolveForLaunch(ctx context.Context, explicitDirs []string, e
 				}
 				switch {
 				case err == nil:
-					add(candidate.loadPath, candidate.path, LaunchPluginSourceBundled, "", "", name)
+					add(candidate.loadPath, candidate.path, LaunchPluginSourceBundled, "", "", name, true)
 				case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
 					// The caller left while the store was being readied. That
 					// is the same answer as a caller who had already left when

--- a/internal/plugins/resolve_test.go
+++ b/internal/plugins/resolve_test.go
@@ -95,25 +95,79 @@ func TestResolveForLaunch_Contract(t *testing.T) {
 			},
 		},
 		{
-			name: "disabled and broken registry entries",
+			name: "enabled-by-default, disabled-by-default, and broken registry entries",
 			check: func(t *testing.T, root string, m *Manager) {
 				good := filepath.Join(root, "good")
+				optional := filepath.Join(root, "optional")
 				broken := filepath.Join(root, "broken")
 				writePlugin(t, good, "good", nil)
+				writePlugin(t, optional, "optional", nil)
 				os.MkdirAll(broken, 0o755)
 				saveTestRegistry(t, m, map[string][]InstallEntry{
-					"disabled@m": {{InstallPath: filepath.Join(root, "disabled"), Enabled: false}},
-					"broken@m":   {{InstallPath: broken, Version: "4", Enabled: true}},
 					"good@m":     {{InstallPath: good, Version: "2", Enabled: true}},
+					"optional@m": {{InstallPath: optional, Version: "3", Enabled: false}},
+					"broken@m":   {{InstallPath: broken, Version: "4", Enabled: true}},
+				})
+
+				// Omitted selection takes the defaults: the on-by-default
+				// plugin is selected, the off-by-default one is listed but
+				// unselected, and a broken entry stays a diagnostic.
+				got, err := m.ResolveForLaunch(context.Background(), nil, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				assertCandidateNames(t, got, []string{"good", "optional"})
+				assertStrings(t, got.SelectedDirs, []string{good})
+				if !got.Candidates[0].Selected {
+					t.Errorf("enabled-by-default candidate not selected: %+v", got.Candidates[0])
+				}
+				if got.Candidates[1].Selected {
+					t.Errorf("disabled-by-default candidate selected: %+v", got.Candidates[1])
+				}
+				if len(got.Diagnostics) != 1 || got.Diagnostics[0].Name != "broken" || got.Diagnostics[0].Source != LaunchPluginSourceInstalled {
+					t.Fatalf("broken diagnostic = %+v", got.Diagnostics)
+				}
+
+				// A session allow-list can turn on a plugin whose default is
+				// off, without changing the registry.
+				names := []string{"optional"}
+				on, err := m.ResolveForLaunch(context.Background(), nil, &names)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := on.ValidateSelection(); err != nil {
+					t.Fatalf("disabled-by-default plugin not selectable: %v", err)
+				}
+				assertStrings(t, on.SelectedDirs, []string{optional})
+			},
+		},
+		{
+			name: "an off-by-default plugin cannot shadow an on-by-default one",
+			check: func(t *testing.T, root string, m *Manager) {
+				// The off-by-default entry sorts first by plugin name and
+				// shares the manifest name of the on-by-default one. The
+				// on-by-default copy must stay the winner, the way it was when
+				// only enabled entries were candidates.
+				optional := filepath.Join(root, "aaa-optional")
+				enabled := filepath.Join(root, "zzz-enabled")
+				writePlugin(t, optional, "shared", nil)
+				writePlugin(t, enabled, "shared", nil)
+				saveTestRegistry(t, m, map[string][]InstallEntry{
+					"aaa-optional@m": {{InstallPath: optional, Version: "1", Enabled: false}},
+					"zzz-enabled@m":  {{InstallPath: enabled, Version: "2", Enabled: true}},
 				})
 
 				got, err := m.ResolveForLaunch(context.Background(), nil, nil)
 				if err != nil {
 					t.Fatal(err)
 				}
-				assertCandidateNames(t, got, []string{"good"})
-				if len(got.Diagnostics) != 1 || got.Diagnostics[0].Name != "broken" || got.Diagnostics[0].Source != LaunchPluginSourceInstalled {
-					t.Fatalf("broken diagnostic = %+v", got.Diagnostics)
+				assertCandidateNames(t, got, []string{"shared"})
+				if got.Candidates[0].Path != enabled || !got.Candidates[0].Selected {
+					t.Fatalf("candidate = %+v, want the on-by-default copy %s", got.Candidates[0], enabled)
+				}
+				assertStrings(t, got.SelectedDirs, []string{enabled})
+				if len(got.Diagnostics) != 1 || got.Diagnostics[0].Name != "shared" || !strings.Contains(got.Diagnostics[0].Message, "duplicate") {
+					t.Fatalf("diagnostics = %+v, want one duplicate diagnostic for the off-by-default loser", got.Diagnostics)
 				}
 			},
 		},

--- a/mobile-native/src/PluginsScreen.tsx
+++ b/mobile-native/src/PluginsScreen.tsx
@@ -214,7 +214,7 @@ function Plugins({
           renderItem={({ item }) => (
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel={`${item.plugin}, ${item.marketplace}, ${item.broken ? "broken" : item.enabled ? "enabled" : "disabled"}`}
+              accessibilityLabel={`${item.plugin}, ${item.marketplace}, ${item.broken ? "broken" : item.enabled ? "enabled by default" : "off by default"}`}
               onPress={() => {
                 close();
                 setSelected({
@@ -233,7 +233,7 @@ function Plugins({
               <Copy numberOfLines={2}>{item.plugin}</Copy>
               <Copy muted numberOfLines={2}>
                 {item.marketplace} · {item.version || "Unknown version"}
-                {item.broken ? " · Broken" : !item.enabled ? " · Disabled" : ""}
+                {item.broken ? " · Broken" : !item.enabled ? " · Off by default" : ""}
                 {item.autoUpgrade ? " · Auto-upgrade" : ""}
               </Copy>
             </Pressable>
@@ -274,10 +274,10 @@ function Plugins({
               )}
               <View style={[styles.row, { minHeight: 48, gap: 16 }]}>
                 <View style={styles.fill}>
-                  <Copy>Enabled</Copy>
+                  <Copy>Enabled by default</Copy>
                 </View>
                 <Switch
-                  accessibilityLabel="Plugin enabled"
+                  accessibilityLabel="Plugin enabled by default"
                   value={entry.enabled}
                   disabled={state.busy}
                   onValueChange={(enabled) => {


### PR DESCRIPTION
## What

The installed-plugin **Enabled** setting becomes **Enabled by default**. It no longer gates whether a plugin can load; it sets that plugin's initial state in the per-session plugin picker.

## Behavior

- Launch resolution enumerates **every** installed plugin, not only globally enabled ones, so plugins marked disabled in global settings now appear in the session plugin list.
- The registry `enabled` flag is each plugin's default: on-by-default plugins start selected, off-by-default ones start unselected but listed.
- An omitted session selection still loads only the defaults (explicit plugin dirs plus on-by-default installed plugins). An explicit allow-list can now turn on an off-by-default plugin for one session.
- Manifest-name collisions still prefer the on-by-default copy, so an off-by-default plugin cannot shadow an on-by-default one. The resolver orders on-by-default entries first to preserve the previous winner.
- `evener plugin list --effective` keeps its meaning by listing only default-selected candidates; `evener plugin list` remains the full installed inventory.

## Relabels (label only)

- Web plugin sheet switch -> "Enabled by default", chip -> "off by default".
- Mobile plugins screen label, accessibility text, and row status.
- TUI installed-tab badge -> "off by default".
- CLI `plugin list` column -> `ENABLED-BY-DEFAULT`, enable/disable help and confirmations.
- README and `docs/evener-hub.md` updated; the 2026-08-26 session-plugin spec is marked partially superseded where it documented the old rule.

The registry and wire field stay named `enabled` for Claude Code schema compatibility; no storage migration.

## Testing

- `make vet` pass
- `make test` pass (all Go modules + web gate)
- `make test-native` pass
- `make lint` pass (naming, gofmt, evenerfuzz, eval, internal, golangci, generated, fuzz-registry, secret-scan)
- Focused `go test` over `internal/plugins`, `cmd/evener`, `cmd/evener-tui/internal/launchconfig`, and `cmd/evener-hub` pass
- New/updated coverage: off-by-default candidate listed unselected and excluded from an omitted selection; explicitly requestable for one session; broken entries stay diagnostics; on-by-default wins manifest-name collisions; effective listing filters to defaults.