### PR TITLE
docs(plugins): include explicit-dir candidates in --enabled-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ variables:
 |---|---|
 | `--model <provider/model>` | LLM model identifier (required unless resuming an existing session) |
 | `--dir <path>` | Working directory (default: current directory) |
-| `--enabled-plugins <name,...>` | Load exactly these installed plugins for this new session, including ones whose default is off; an empty value loads none |
+| `--enabled-plugins <name,...>` | Load exactly these plugins for this new session, chosen by manifest name from explicit plugin directories and installed plugins (including ones whose default is off); an empty value loads none |
 | `--output-schema <json>` | Inline JSON Schema replacing the default `communicate.output` schema |
 | `--verbose` | Emit NDJSON events to stderr (replaces human-readable output) |
 | `--resume <id>` | Resume a previous session by ID |
@@ -291,9 +291,10 @@ evener --enabled-plugins= "task"
 Omitting `--enabled-plugins` uses the current defaults: explicit plugin
 directories plus installed plugins marked enabled by default. The flag is
 new-session-only and cannot replace the plugin set of an existing resumed
-session. It selects manifest names from every installed plugin, so naming one
-whose default is off turns it on for that session. The selected set is stored
-with the new session, so resumes, forks, and delegates inherit it.
+session. It selects manifest names from the otherwise-loadable set of explicit
+plugin directories and installed plugins, so naming an off-by-default installed
+plugin turns it on for that session. The selected set is stored with the new
+session, so resumes, forks, and delegates inherit it.
 
 This does not change persistent plugin state. `evener plugin enable` and
 `evener plugin disable` set whether an installed plugin loads by default in


### PR DESCRIPTION
Follow-up to #1175, addressing the roborev finding on that PR.

## Finding

`README.md:267,294` described `--enabled-plugins` as choosing only installed plugins. Launch resolution also accepts manifest names from explicit `--plugin-dir` candidates, so the docs understated the selectable set.

## Fix

- The flag-table row now says the flag chooses by manifest name from explicit plugin directories and installed plugins, including off-by-default installed ones.
- The per-session selection paragraph now says the flag selects from the otherwise-loadable set of explicit plugin directories and installed plugins.

Documentation only; no code changed.

## Verification

- `make lint` pass (naming, gofmt, evenerfuzz, eval, internal, golangci, generated, fuzz-registry, secret-scan)