### PR TITLE
fix(plugins): finish a rename without recording a clone the entry never recorded

### DIFF
--- a/internal/plugins/marketplace_migration.go
+++ b/internal/plugins/marketplace_migration.go
@@ -239,10 +239,17 @@ func (m *Manager) recoverMarkedRename() error {
 	}
 	var undo []func() error
 	if itsOwn {
+		// What the entry recorded before the rename, because the rename clears
+		// it: a location is only followed where the entry recorded one, so an
+		// entry an interrupted fetch left with a clone at the canonical path
+		// but no recorded location stays unfetched, exactly as the normal
+		// rename leaves it — recording that clone would have a later Browse or
+		// Install parse a partial clone instead of clearing and re-cloning.
+		recordedLocation := ref.InstallLocation
 		if ref, reg, undo, err = m.moveMarketplace(marker.From, marker.To, ref, reg, owners); err != nil {
 			return fail(err)
 		}
-		if ref.Source.Kind != SourceDirectory {
+		if ref.Source.Kind != SourceDirectory && recordedLocation != "" {
 			// The rename's own rule, asked of the clone at the name the
 			// rename was taking it to: an entry whose clone made the move
 			// records it, and one with no clone there is unfetched, for the

--- a/internal/plugins/marketplace_migration_test.go
+++ b/internal/plugins/marketplace_migration_test.go
@@ -2780,6 +2780,82 @@ func TestMarketplaceNameMigration_AFailedRestoreKeepsTheMarker(t *testing.T) {
 	mustExist(t, entry.InstallPath)
 }
 
+// An entry an interrupted fetch left has no recorded install location and can
+// still have a clone where the fetch was filling one. Finishing a rename of it
+// must not record that leftover clone: a later Browse or Install would parse a
+// partial clone instead of clearing and re-cloning, which is exactly what the
+// normal rename avoids by following only a location the entry recorded.
+func TestMarketplaceNameMigration_ARecoveryDoesNotRecordACloneTheEntryNeverRecorded(t *testing.T) {
+	m := NewManager(t.TempDir())
+	m.Stderr = io.Discard
+	for _, dir := range []string{m.marketplacesDir(), m.cacheDir()} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The record an interrupted fetch leaves: no install location, and a clone
+	// at the canonical path the fetch was filling.
+	if err := m.saveMarketplaces(Marketplaces{"a": {
+		Source:      Source{Kind: SourceURL, URL: "https://example.invalid/a.git"},
+		LastUpdated: time.Date(2031, 4, 1, 0, 0, 0, 0, time.UTC),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	plantCatalog(t, m.marketplaceDir("a"))
+	plantRenameMarker(t, m, "a", "a-b")
+
+	if err := m.migrateStore(context.Background()); err != nil {
+		t.Fatalf("migrateStore: %v", err)
+	}
+	mk, err := m.loadMarketplaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, ok := mk["a-b"]
+	if !ok || len(mk) != 1 {
+		t.Fatalf("marketplaces = %v, want a-b alone", mk)
+	}
+	if ref.InstallLocation != "" {
+		t.Fatalf("InstallLocation = %q, want the entry left unfetched: nothing recorded that clone", ref.InstallLocation)
+	}
+}
+
+// The other side of it: an entry that did record a location keeps one, at the
+// name the rename took it to, however far the earlier run got.
+func TestMarketplaceNameMigration_ARecoveryKeepsTheLocationTheEntryRecorded(t *testing.T) {
+	m := NewManager(t.TempDir())
+	m.Stderr = io.Discard
+	for _, dir := range []string{m.marketplacesDir(), m.cacheDir()} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := m.saveMarketplaces(Marketplaces{"a": {
+		Source:          Source{Kind: SourceURL, URL: "https://example.invalid/a.git"},
+		InstallLocation: m.marketplaceDir("a"),
+		LastUpdated:     time.Date(2031, 4, 1, 0, 0, 0, 0, time.UTC),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	plantCatalog(t, m.marketplaceDir("a"))
+	plantRenameMarker(t, m, "a", "a-b")
+
+	if err := m.migrateStore(context.Background()); err != nil {
+		t.Fatalf("migrateStore: %v", err)
+	}
+	mk, err := m.loadMarketplaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, ok := mk["a-b"]
+	if !ok || len(mk) != 1 {
+		t.Fatalf("marketplaces = %v, want a-b alone", mk)
+	}
+	if want := m.marketplaceDir("a-b"); ref.InstallLocation != want {
+		t.Fatalf("InstallLocation = %q, want the clone recorded at %q", ref.InstallLocation, want)
+	}
+}
+
 // A never-fetched duplicate has no clone and no cache of its own for an
 // alias's rename to have moved, so finding the derived directories gone says
 // nothing about it. What it does have is a source of its own, which a merge


### PR DESCRIPTION
Follow-up to the Low finding roborev raised on #1065 just before it merged, fixed here rather than there per Jesse's call.

## The defect

`recoverMarkedRename` recomputed `ref.InstallLocation` from whether a clone exists at the name the rename took, while `moveMarketplace` only follows a location the entry had already recorded (`if ref.InstallLocation != ""`).

An entry an interrupted fetch leaves — no recorded location, and a clone at the canonical path the fetch was filling — was therefore recorded as *fetched* by a recovery and left *unfetched* by a normal rename. A later `Browse`, `Install` or `RefreshMarketplace` would then parse that partial clone instead of clearing and re-cloning, failing until an explicit refresh.

## The fix

The recompute happens only where the entry recorded a location. That is why it is there at all: an earlier run may have moved the clone to the new name without recording it, and then the location has to be recovered. So the rule is now the rename's own rule, applied in both paths.

## Tests

- `TestMarketplaceNameMigration_ARecoveryDoesNotRecordACloneTheEntryNeverRecorded` — the interrupted-fetch shape; red without the gate.
- `TestMarketplaceNameMigration_ARecoveryKeepsTheLocationTheEntryRecorded` — an entry that did record one keeps it at the name the rename took, which is what the recompute exists for.

Verified: the full `internal/plugins` package, `go vet` in both tag sets and under `GOOS=windows`, the plugin consumers, and `make lint-golangci`.
