### PR TITLE
test(web): stop a released IndexedDB hold from swallowing in-flight events

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.test.ts
@@ -287,6 +287,46 @@ test("a flush cannot settle while a submit is still in flight", async () => {
   expect(flushResolved).toBe(true);
 });
 
+// The flush above waits inside act(), so durable work with no completion left
+// parks the caller there until vitest abandons the whole test - and an
+// abandoned act() leaves React's act queue open for the rest of the FILE, so
+// every later render produces nothing and one stall becomes dozens of
+// unrelated failures (issue #1187). The per-round tripwire is what turns that
+// back into one named failure, in the test that caused it; without this test a
+// regression that clears the timer or swallows its rejection restores the hang
+// silently, and the only symptom is a file that fails 33 ways again.
+test("a flush that can never settle trips instead of hanging inside act", async () => {
+  let releaseSubmit: () => void = () => undefined;
+  const stalled = new Promise<void>((resolve) => {
+    releaseSubmit = resolve;
+  });
+  const submitted = submitWithPendingTracking(
+    { ref: "ref_a", method: "send", text: "never settles", onFailure: () => undefined },
+    () => stalled,
+  );
+
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  try {
+    // Captured before the clock moves: the rejection lands while the timers
+    // advance, and a handler attached only afterwards is an unhandled
+    // rejection in that window.
+    const flushing = flushPendingTurnsProjectionForTests().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(await flushing).toMatchObject({
+      message: expect.stringMatching(/projection work stalled: 1 operation\(s\) still unsettled after \d+ms/),
+    });
+  } finally {
+    vi.useRealTimers();
+  }
+
+  releaseSubmit();
+  await submitted;
+  await flushPendingTurnsProjectionForTests();
+});
+
 test("recovery action wrappers refresh the durable projection", async () => {
   let mutationId = 0;
   const storage = new MutationOutboxIndexedDB({

--- a/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/queue/pendingTurnsStore.ts
@@ -90,6 +90,38 @@ function trackProjectionWork<T>(work: Promise<T>): Promise<T> {
   });
 }
 
+// A round waits on real durable work, so its wall time scales with machine
+// load - but no amount of load turns work that has no completion left into
+// work that finishes. A test that stalls storage and then flushes without
+// releasing it parks HERE, inside the act() below, until vitest abandons the
+// whole test at its own timeout - and an abandoned act() leaves React's act
+// queue open for the rest of the FILE, so every later render produces nothing
+// and one hang becomes dozens of failures (issue #1187). This bound exists to
+// make that one named failure in the test that caused it, nothing else: it is
+// a tripwire for a stall, never pacing. The slowest round measured across the
+// whole web suite (10373 tests) under 32-way CPU contention was 165ms.
+const SETTLE_STALL_TRIPWIRE_MS = 4_000;
+
+async function awaitOutstandingProjectionWork(outstanding: Promise<unknown>[]): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const tripwire = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `pending-turns projection work stalled: ${outstanding.length} operation(s) still unsettled after ${SETTLE_STALL_TRIPWIRE_MS}ms - release whatever storage or transport this test is holding before flushing`,
+          ),
+        ),
+      SETTLE_STALL_TRIPWIRE_MS,
+    );
+  });
+  try {
+    await Promise.race([Promise.allSettled(outstanding), tripwire]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // Awaits whatever projection work is outstanding right now and reports how
 // much that was. Callers repeat until it reports zero, flushing React in
 // between: the components start this work from effects, so only a flush can
@@ -98,7 +130,7 @@ function trackProjectionWork<T>(work: Promise<T>): Promise<T> {
 // registered itself by the time the caller looks again.
 export async function settlePendingTurnsProjectionForTests(): Promise<number> {
   const outstanding = [...inFlightProjectionWork];
-  await Promise.allSettled(outstanding);
+  await awaitOutstandingProjectionWork(outstanding);
   await new Promise<void>((resolve) => {
     const hop = new MessageChannel();
     hop.port1.onmessage = () => {

--- a/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.test.ts
@@ -46,6 +46,18 @@ test("an event arriving after release still reaches its listener", () => {
   expect(delivered).toBe(1);
 });
 
+// reached is the "the held event arrived" signal, and arriving is not the same
+// question as being held: a caller awaiting it after a release would otherwise
+// wait for a signal that can never come, even though its listener already ran.
+test("an event arriving after release still resolves reached", async () => {
+  const target = new EventTarget();
+  const hold = holdIndexedDBEvent(target, "success");
+  target.addEventListener("success", () => undefined);
+  hold.release();
+  target.dispatchEvent(new Event("success"));
+  await expect(hold.reached).resolves.toBeUndefined();
+});
+
 test("a read released before its success event still settles", async () => {
   const database = await openStore();
   const request = database.transaction("rows", "readonly").objectStore("rows").getAll();

--- a/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.test.ts
+++ b/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.test.ts
@@ -1,0 +1,56 @@
+import { IDBFactory } from "fake-indexeddb";
+import { expect, test } from "vitest";
+import { holdIndexedDBEvent } from "./stalledIndexedDB";
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.addEventListener("success", () => resolve(request.result), { once: true });
+    request.addEventListener("error", () => reject(request.error), { once: true });
+  });
+}
+
+function openStore(): Promise<IDBDatabase> {
+  const open = new IDBFactory().open("stalled-indexeddb-test", 1);
+  open.addEventListener("upgradeneeded", () => open.result.createObjectStore("rows", { keyPath: "id" }));
+  return requestResult(open);
+}
+
+test("release delivers an event the hold already caught", () => {
+  const target = new EventTarget();
+  const hold = holdIndexedDBEvent(target, "success");
+  let delivered = 0;
+  target.addEventListener("success", () => {
+    delivered += 1;
+  });
+  target.dispatchEvent(new Event("success"));
+  expect(delivered).toBe(0);
+  hold.release();
+  expect(delivered).toBe(1);
+});
+
+// Release means "stop holding", not "deliver whatever has arrived so far". The
+// interception outlives mockRestore for every listener already registered
+// through it, so an event still in flight when a test releases is a callback
+// nobody ever calls - and, for an IndexedDB request, a promise that never
+// settles. That is what turned one stalled read in Composer.integration's
+// recovery-projection test into a 5s timeout inside act() (issue #1187).
+test("an event arriving after release still reaches its listener", () => {
+  const target = new EventTarget();
+  const hold = holdIndexedDBEvent(target, "success");
+  let delivered = 0;
+  target.addEventListener("success", () => {
+    delivered += 1;
+  });
+  hold.release();
+  target.dispatchEvent(new Event("success"));
+  expect(delivered).toBe(1);
+});
+
+test("a read released before its success event still settles", async () => {
+  const database = await openStore();
+  const request = database.transaction("rows", "readonly").objectStore("rows").getAll();
+  const hold = holdIndexedDBEvent(request, "success");
+  const rows = requestResult<unknown[]>(request);
+  hold.release();
+  expect(await rows).toEqual([]);
+});

--- a/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.ts
+++ b/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.ts
@@ -4,6 +4,7 @@ import { vi } from "vitest";
 // This distinguishes an unobserved commit from a write that can still abort.
 export function holdIndexedDBEvent(target: EventTarget, type: string) {
   const held: (() => void)[] = [];
+  let released = false;
   let observed: (() => void) | undefined;
   const reached = new Promise<void>((resolve) => {
     observed = resolve;
@@ -14,10 +15,21 @@ export function holdIndexedDBEvent(target: EventTarget, type: string) {
     add(
       eventType,
       (event) => {
-        held.push(() => {
+        const deliver = () => {
           if (typeof listener === "function") listener.call(target, event);
           else listener.handleEvent(event);
-        });
+        };
+        // Release means "stop holding", not "deliver what has already
+        // arrived": restoring the spy stops NEW listeners from being wrapped,
+        // but every listener registered while the hold was up keeps this
+        // wrapper for good. An event still in flight at release time would
+        // otherwise land in a queue nobody drains again, which for an
+        // IndexedDB request is a promise that never settles (issue #1187).
+        if (released) {
+          deliver();
+          return;
+        }
+        held.push(deliver);
         observed?.();
       },
       options,
@@ -26,6 +38,7 @@ export function holdIndexedDBEvent(target: EventTarget, type: string) {
   return {
     reached,
     release() {
+      released = true;
       spy.mockRestore();
       for (const deliver of held.splice(0)) deliver();
     },

--- a/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.ts
+++ b/cmd/evener-hub/frontend/src/stores/testing/stalledIndexedDB.ts
@@ -25,12 +25,14 @@ export function holdIndexedDBEvent(target: EventTarget, type: string) {
         // wrapper for good. An event still in flight at release time would
         // otherwise land in a queue nobody drains again, which for an
         // IndexedDB request is a promise that never settles (issue #1187).
+        // reached answers "has the event arrived", which a release does not
+        // change, so it is signalled on both paths.
+        observed?.();
         if (released) {
           deliver();
           return;
         }
         held.push(deliver);
-        observed?.();
       },
       options,
     );


### PR DESCRIPTION
Closes #1187. Two defects, neither in `Composer.tsx`, found by reproducing the CI cascade locally (48 CPU hogs on 16 cores: 1 failure in 20, then 1 in 26, identical to CI's 33-of-46 with the same first failure).

**Root cause** — `stores/testing/stalledIndexedDB.ts`: `holdIndexedDBEvent` wraps every listener registered while the hold is up. `release()` restored the spy and drained the events queued so far, but the wrapper on already-registered listeners lived forever, so an event still in flight at release time landed in a queue nobody drained again: an IndexedDB request whose promise never settles. In `Composer.integration.test.tsx:635` the swallowed read is a pending-turns projection refresh started by the second submission, and the test's `finally` (`:681`) then waits on `flushPendingTurnsProjectionForTests()` forever. Fixed in `1a62a0987`: `release()` now means "stop holding", so an event arriving after it goes straight to its listener. New `stalledIndexedDB.test.ts` pins it (RED first; its third case reproduces #1187 in one line: a read released before its success event, 5s timeout).

**Cascade** — `panes/session/composer/queue/pendingTurnsStore.ts:139`: that flush waits inside `act()`; when vitest abandons the test at 5s, the open act queue makes every later `render()` in the file produce nothing, which is exactly the `please provide a DOM element` / `reading 'disabled'` shape. Proven with a throwaway probe (an abandoned `act()` poisons later renders; abandoned `waitFor`, `user.type` and plain `await` do not). Fixed in `fb86708c1`: `settlePendingTurnsProjectionForTests` gains a per-round stall tripwire (4s, against a measured slowest round of 165ms across the whole web suite under 32-way contention), so a stalled read fails its own test with `pending-turns projection work stalled: N operation(s) still unsettled after 4000ms` and the rest of the file runs. `Composer.integration.test.tsx` is untouched: no assertion weakened, no timeout widened.

Evidence: before 19/20 and 25/26; after 40/40 under the same contention. Cascade check with a deliberately never-released read: 1 failed / 46 passed instead of 1 timeout plus 33 consequential failures. Gates: `make test-web` (typecheck, tests, biome). `holdIndexedDBEvent` has six consumers; all pass.