### PR TITLE
refactor(mobile): one usage projection for the conversation and the activity store

### DIFF
--- a/mobile/src/conversation/project.ts
+++ b/mobile/src/conversation/project.ts
@@ -771,7 +771,11 @@ export function projectQueue(queue: Thread["evener"]["queue"]): MobileQueue {
   };
 }
 
-function projectUsage(evener: Thread["evener"]): MobileUsage {
+// projectUsage copies EvenerThread's usage aggregate and context fields into
+// MobileUsage. Values are passed straight through: an absent wire field stays
+// undefined rather than becoming a 0 that would read as a real measurement.
+// Shared with the activity service, which adds only durationMs on top.
+export function projectUsage(evener: Thread["evener"]): MobileUsage {
   const usage: EvenerUsage | undefined = evener.usage;
   return {
     inputTokens: usage?.inputTokens,

--- a/mobile/src/services/activity.ts
+++ b/mobile/src/services/activity.ts
@@ -13,11 +13,11 @@ import type {
   EvenerDelegateInfo,
   EvenerDiagnostics,
   EvenerJobInfo,
-  EvenerUsage,
   TaskAggregate,
   Thread,
 } from "../../../cmd/evener-hub/frontend/src/protocol/types.gen";
 import type { MobileCapabilities, MobileUsage } from "../conversation/model";
+import { projectUsage } from "../conversation/project";
 
 // --- view model types --------------------------------------------------------
 
@@ -69,18 +69,10 @@ export interface WorkEntry {
   readonly diagnostics?: RedactedDiagnostic;
 }
 
-export interface UsageSummary {
-  readonly inputTokens?: number;
-  readonly outputTokens?: number;
-  readonly cacheReadTokens?: number;
-  readonly totalTokens?: number;
-  readonly cost?: string;
-  readonly contextUsed?: number;
-  readonly contextWindow?: number;
-  readonly contextRemaining?: number;
-  readonly contextPressure?: number;
-  readonly durationMs?: number;
-}
+// UsageSummary is MobileUsage plus the work duration the activity sheet shows.
+// The token/cost/context fields are the same ones projectUsage produces, so they
+// are inherited rather than restated.
+export type UsageSummary = Readonly<MobileUsage> & { readonly durationMs?: number };
 
 export interface ActivityView {
   readonly tasks: TaskGroup[];
@@ -434,20 +426,8 @@ export function deriveOpenTaskCount(counts: {
 
 // --- usage projection --------------------------------------------------------
 
-function projectUsage(evener: Thread["evener"]): UsageSummary {
-  const usage: EvenerUsage | undefined = evener.usage;
-  return {
-    inputTokens: usage?.inputTokens,
-    outputTokens: usage?.outputTokens,
-    cacheReadTokens: usage?.cacheReadTokens,
-    totalTokens: usage?.totalTokens,
-    cost: evener.cost,
-    contextUsed: evener.contextUsed,
-    contextWindow: evener.contextWindow,
-    contextRemaining: evener.contextRemaining,
-    contextPressure: evener.contextPressure,
-    durationMs: evener.workMillis,
-  };
+function projectUsageSummary(evener: Thread["evener"]): UsageSummary {
+  return { ...projectUsage(evener), durationMs: evener.workMillis };
 }
 
 // --- capabilities projection -------------------------------------------------
@@ -467,7 +447,7 @@ export function createActivityService(): ActivityService {
       return {
         tasks: projectTasks(evener.tasks),
         work: projectWork(evener.diagnostics),
-        usage: projectUsage(evener),
+        usage: projectUsageSummary(evener),
         capabilities: projectCapabilities(evener.capabilities),
         reasoningEffort: evener.reasoningEffort,
         reasoningEffortLevels: evener.reasoningEffortLevels,


### PR DESCRIPTION
SDK migration plan (#1182), the rescoped B3. The row as planned — a shared web/native usage module — was withdrawn after the twin check: the web's `sessionTokens` derives a session figure by summing turns when no cumulative exists, while native forbids exactly that and copies the raw fields through; they share no rule, and native's real analog (`protocol/reducer.ts:797-805`) is already in the package. The question of which behavior is right is recorded as a maintainer decision in the plan.

What native did have was two copies of the same ten-field pass-through: `projectUsage` in `mobile/src/conversation/project.ts:774` and a second one in `mobile/src/services/activity.ts:437-451`. This PR keeps the first as the one implementation (now exported); the activity service's `projectUsageSummary` is a two-line wrapper adding only `durationMs`, and `UsageSummary` becomes `Readonly<MobileUsage> & { readonly durationMs?: number }` so the field list also lives once. The dependency direction already ran `services/ → conversation/`, so no cycle is added.

No test changed: `activity.test.ts:519-525` and `project.test.ts:1445-1455` already pin absence handling on both sides. Gate: `make test-native` (737 native, 777 shared, `tsc --noEmit`). 2 files, +13/−29.