### PR TITLE
feat(protocol): export from the root every error helper the apps import

### DIFF
--- a/cmd/evener-hub/frontend/src/protocol/README.md
+++ b/cmd/evener-hub/frontend/src/protocol/README.md
@@ -2,11 +2,12 @@
 
 The framework independent TypeScript client for Evener's AppWire protocol. It
 has no runtime dependencies and exports the client, the connection seam
-applications program against, the transport contract,
-generated protocol types, wire errors and their session classifiers, the pure
-question formatter, the thread view model and its notification reducer, the
-activity tree parser, merge and disclosure rules, the job log tail parser, the
-send/queue availability table, the stable delegate status rule, and the
+applications program against, the transport contract, generated protocol
+types, wire errors with their session classifiers, the rejection classifier
+and the user-facing message helpers every failure display goes through, the
+pure question formatter, the thread view model and its notification reducer,
+the activity tree parser, merge and disclosure rules, the job log tail parser,
+the send/queue availability table, the stable delegate status rule, and the
 doc-pane URL builders.
 
 Build and qualify from this directory with `npm run qualification`. The runner

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -36,7 +36,23 @@ export type { DocFileContent, DocFileErrorKind } from "./docContent";
 // browser fetch global, so no Node or native consumer of this package can call
 // it. It joins the entry point when it takes a base-URL and fetch port.
 export { DOC_FILE_MAX_BYTES, DocFileError, docFileRawURL, docImageURL } from "./docContent";
-export { ConnectionClosedError, RequestTimeoutError, WireError } from "./errors";
+export {
+  ClientNotReadyError,
+  ConnectionClosedError,
+  errorKind,
+  errorText,
+  friendlyErrorMessage,
+  friendlyLaunchErrorMessage,
+  GENERIC_ERROR_MESSAGE,
+  HUB_UNREACHABLE_MESSAGE,
+  isHubLaunchError,
+  isStaleCursorError,
+  mutationErrorData,
+  RequestTimeoutError,
+  sessionActionError,
+  sessionActionHeadline,
+  WireError,
+} from "./errors";
 export type { ItemFailureSignals } from "./itemFailure";
 export { hasErrorText, hasFailureStatus, hasItemFailure, isInProgressStatus, isNonZeroExit } from "./itemFailure";
 export type { JobLogTail } from "./jobOutput";
@@ -52,6 +68,10 @@ export type {
 } from "./model";
 export { SYSTEM_PRELUDE_TURN_ID } from "./model";
 export type { NotificationRoutingKey } from "./reducer";
+// chunkViewBackingForTests is deliberately absent: it reports the reducer's
+// internal chunk storage so a test can assert the view never copies it, which
+// is a test hook rather than protocol API. It belongs with the package's test
+// support, not the entry point.
 export {
   applyNotification,
   collectAuthoritativeMutationIds,

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -73,6 +73,18 @@ async function qualify() {
     "ConnectionClosedError",
     "RequestTimeoutError",
     "WireError",
+    "ClientNotReadyError",
+    "GENERIC_ERROR_MESSAGE",
+    "HUB_UNREACHABLE_MESSAGE",
+    "errorKind",
+    "errorText",
+    "friendlyErrorMessage",
+    "friendlyLaunchErrorMessage",
+    "isHubLaunchError",
+    "isStaleCursorError",
+    "mutationErrorData",
+    "sessionActionError",
+    "sessionActionHeadline",
     "rpcURLFromLocation",
     "composeAskAnswers",
     "METHOD_NAMES",
@@ -141,6 +153,16 @@ async function qualify() {
 assert.equal(client.rpcURLFromLocation({ protocol: "https:", host: "hub.example:9180" }), "wss://hub.example:9180/rpc");
 assert.equal(client.composeAskAnswers([]), "[answers]");
 assert.equal(new client.WireError("nope", -32000).code, -32000);
+assert.equal(client.errorText(new Error("boom")), "boom");
+assert.equal(client.errorKind(new Error("boom")), "unknown");
+assert.equal(client.friendlyErrorMessage(new Error("boom")), client.GENERIC_ERROR_MESSAGE);
+assert.equal(client.friendlyErrorMessage(new client.ClientNotReadyError("waited")), client.HUB_UNREACHABLE_MESSAGE);
+assert.equal(client.friendlyLaunchErrorMessage(new Error("boom")), client.GENERIC_ERROR_MESSAGE);
+assert.equal(client.isHubLaunchError(new Error("boom")), false);
+assert.equal(client.isStaleCursorError(new Error("boom")), false);
+assert.equal(client.sessionActionHeadline("Couldn't rename", new Error("boom")), "Couldn't rename");
+assert.equal(client.sessionActionError("Couldn't rename", new Error("boom")), "Couldn't rename: boom");
+assert.equal(client.mutationErrorData(new Error("boom")), undefined);
 assert(client.METHOD_NAMES.length > 0);
 const session = {
   kind: "session", sessionId: "thread", ref: "ref", label: "label", aggregate: "idle",


### PR DESCRIPTION
PR A3b of the SDK migration plan (#1182), the plumbing step before the import rewrite (A4).

Measured at `27503c07d` across the web `src`, `mobile/src`, `mobile-native/src` and `mobile-native/scripts/*.mts` (1,161 files): fourteen symbols the apps import from protocol modules are not exported from `index.ts`. Twelve are `errors` declarations — `errorText` (20 sites), `friendlyErrorMessage` (22), `sessionActionError` (17), `ClientNotReadyError`, `isStaleCursorError`, `sessionActionHeadline`, `friendlyLaunchErrorMessage`, `errorKind`, `mutationErrorData`, `GENERIC_ERROR_MESSAGE`, `HUB_UNREACHABLE_MESSAGE`, `isHubLaunchError` — and this PR exports them from the root, adds them to the runner's `runtimeExports` manifest, and smoke-calls the pure ones from the installed tarball. The other two stay off the root on purpose: `reducer`'s `chunkViewBackingForTests` is a test hook that moves with the non-shipped `testing` specifier in A3, and `docContent`'s `readDocFile` is held for the C24 base-URL port; `index.ts` says so beside each. No app file changes; imports stay relative until A4.

One thing for A4's planners: `panes/doc/DocPane.test.tsx:5` does a namespace import of `protocol/docContent` to spy on `readDocFile`, which no root export can satisfy, so that line cannot be rewritten mechanically.

RED: manifest and smoke calls first, `make test-api-package` fails with 24 `tsc` errors (each name, in both the ESM and CJS declaration consumers); GREEN after the exports. Gates: `make test-api-package`, `make test-web`, `make test-native`; biome. 3 files, +49/−6.