### PR TITLE
feat(protocol): publish docContent as a subpath and inject its fetch

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/doc/DocPane.tsx
+++ b/cmd/evener-hub/frontend/src/panes/doc/DocPane.tsx
@@ -11,6 +11,7 @@ import type { PaneProps } from "../../shell/paneRegistry";
 import { Chip, Dialog, EmptyState, PaneScaffold, Skeleton } from "../../widgets";
 import { requireClass } from "../../widgets/internal/requireClass";
 import { Markdown } from "../../widgets/markdown";
+import { browserDocFetch } from "./browserDocFetch";
 import { filenameOf, formatDocBytes, isMarkdownPath } from "./docFile";
 import styles from "./docpane.module.css";
 import type { DocParams } from "./openDoc";
@@ -45,7 +46,7 @@ function DocFileView({ session, path }: { session: string; path: string }) {
   useEffect(() => {
     let cancelled = false;
     setState({ status: "loading" });
-    readDocFile(session, path).then(
+    readDocFile(session, path, browserDocFetch).then(
       (content) => {
         if (!cancelled) setState({ status: "ok", content });
       },

--- a/cmd/evener-hub/frontend/src/panes/doc/browserDocFetch.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/doc/browserDocFetch.test.ts
@@ -1,0 +1,14 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { browserDocFetch } from "./browserDocFetch";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("fetches the given URL with the auth cookie (same-origin credentials)", async () => {
+  const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("x"));
+  await browserDocFetch("/doc/file?format=raw&session=s1&path=notes.txt");
+  expect(spy).toHaveBeenCalledWith("/doc/file?format=raw&session=s1&path=notes.txt", {
+    credentials: "same-origin",
+  });
+});

--- a/cmd/evener-hub/frontend/src/panes/doc/browserDocFetch.ts
+++ b/cmd/evener-hub/frontend/src/panes/doc/browserDocFetch.ts
@@ -1,0 +1,8 @@
+import type { DocFetch } from "../../protocol/docContent";
+
+// The browser's doc transport. same-origin credentials so the hub's auth
+// cookie rides along, exactly as the manifest and every other same-origin
+// fetch in this app do. readDocFile takes this as a port, so the shared
+// package names neither the fetch global nor a credentials policy; the host
+// that has a cookie jar supplies both.
+export const browserDocFetch: DocFetch = (url) => fetch(url, { credentials: "same-origin" });

--- a/cmd/evener-hub/frontend/src/protocol/README.md
+++ b/cmd/evener-hub/frontend/src/protocol/README.md
@@ -8,7 +8,9 @@ and the user-facing message helpers every failure display goes through, the
 pure question formatter, the thread view model and its notification reducer,
 the activity tree parser, merge and disclosure rules, the job log tail parser,
 the send/queue availability table, the stable delegate status rule, and the
-doc-pane URL builders.
+doc-pane URL builders. The doc-pane data layer is published at the
+`./docContent` subpath as well, where `readDocFile` takes the host's fetch:
+the package issues no request of its own and names no credentials policy.
 
 Build and qualify from this directory with `npm run qualification`. The runner
 packs the package, installs that tarball into a temporary consumer, and then,

--- a/cmd/evener-hub/frontend/src/protocol/docContent.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/docContent.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { DOC_FILE_MAX_BYTES, DocFileError, docFileRawURL, docImageURL, readDocFile } from "./docContent";
+import { DOC_FILE_MAX_BYTES, type DocFetch, DocFileError, docFileRawURL, docImageURL, readDocFile } from "./docContent";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -28,20 +28,38 @@ function headers(contentType: string): Record<string, string> {
   return { "Content-Type": contentType };
 }
 
+// A DocFetch that records what it was asked for and answers with a canned
+// response. A real fetch Response satisfies DocResponseLike structurally, so
+// the fake is the real shape the browser adapter hands back.
+function recordingFetch(response: Response): { fetch: DocFetch; urls: string[] } {
+  const urls: string[] = [];
+  return {
+    urls,
+    fetch: async (url) => {
+      urls.push(url);
+      return response;
+    },
+  };
+}
+
+function respondWith(response: Response): DocFetch {
+  return recordingFetch(response).fetch;
+}
+
 describe("readDocFile", () => {
-  test("fetches the raw variant with the auth cookie (same-origin credentials)", async () => {
-    const spy = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response("x", { headers: headers("text/plain; charset=utf-8") }));
-    await readDocFile("s1", "notes.txt");
-    expect(spy).toHaveBeenCalledWith("/doc/file?format=raw&session=s1&path=notes.txt", { credentials: "same-origin" });
+  test("asks the injected fetch for the raw variant and never touches the global fetch", async () => {
+    // The host supplies the fetch, so the package carries no browser global and
+    // no credentials policy; the web's browserDocFetch adapter owns both.
+    const global = vi.spyOn(globalThis, "fetch");
+    const doc = recordingFetch(new Response("x", { headers: headers("text/plain; charset=utf-8") }));
+    await readDocFile("s1", "notes.txt", doc.fetch);
+    expect(doc.urls).toEqual(["/doc/file?format=raw&session=s1&path=notes.txt"]);
+    expect(global).not.toHaveBeenCalled();
   });
 
   test("a text file yields decoded text, not binary, with the charset stripped off the mediaType", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("hello world", { headers: headers("text/plain; charset=utf-8") }),
-    );
-    expect(await readDocFile("s1", "notes.txt")).toEqual({
+    const fetchDoc = respondWith(new Response("hello world", { headers: headers("text/plain; charset=utf-8") }));
+    expect(await readDocFile("s1", "notes.txt", fetchDoc)).toEqual({
       text: "hello world",
       binary: false,
       mediaType: "text/plain",
@@ -51,20 +69,16 @@ describe("readDocFile", () => {
   });
 
   test("markdown source is returned verbatim as text - mode selection is the pane's job, not the data layer's", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response("# Title\n\nBody", { headers: headers("text/plain; charset=utf-8") }),
-    );
-    const doc = await readDocFile("s1", "README.md");
+    const fetchDoc = respondWith(new Response("# Title\n\nBody", { headers: headers("text/plain; charset=utf-8") }));
+    const doc = await readDocFile("s1", "README.md", fetchDoc);
     expect(doc.text).toBe("# Title\n\nBody");
     expect(doc.binary).toBe(false);
   });
 
   test("an octet-stream response is binary with empty text and the octet-stream mediaType", async () => {
     const body = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(body, { headers: headers("application/octet-stream") }),
-    );
-    expect(await readDocFile("s1", "blob.bin")).toEqual({
+    const fetchDoc = respondWith(new Response(body, { headers: headers("application/octet-stream") }));
+    expect(await readDocFile("s1", "blob.bin", fetchDoc)).toEqual({
       text: "",
       binary: true,
       mediaType: "application/octet-stream",
@@ -75,7 +89,7 @@ describe("readDocFile", () => {
 
   test("truncation is read from the X-Doc-Truncated header, with the true total from X-Doc-Total-Size", async () => {
     const body = "a".repeat(DOC_FILE_MAX_BYTES);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    const fetchDoc = respondWith(
       new Response(body, {
         headers: {
           "Content-Type": "text/plain; charset=utf-8",
@@ -84,7 +98,7 @@ describe("readDocFile", () => {
         },
       }),
     );
-    const doc = await readDocFile("s1", "big.log");
+    const doc = await readDocFile("s1", "big.log", fetchDoc);
     expect(doc.truncated).toBe(true);
     expect(doc.sizeBytes).toBe(DOC_FILE_MAX_BYTES); // received (head) bytes
     expect(doc.totalBytes).toBe(2097152); // the file's true size, from the header
@@ -94,32 +108,33 @@ describe("readDocFile", () => {
     // A file of exactly the cap serves its whole self and sends no truncation
     // header; the old body>=cap derivation wrongly flagged this boundary.
     const body = "a".repeat(DOC_FILE_MAX_BYTES);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(body, { headers: headers("text/plain; charset=utf-8") }),
-    );
-    const doc = await readDocFile("s1", "exact.log");
+    const fetchDoc = respondWith(new Response(body, { headers: headers("text/plain; charset=utf-8") }));
+    const doc = await readDocFile("s1", "exact.log", fetchDoc);
     expect(doc.truncated).toBe(false);
     expect(doc.totalBytes).toBeUndefined();
     expect(doc.sizeBytes).toBe(DOC_FILE_MAX_BYTES);
   });
 
   test("a 403 (path escapes the session cwd) rejects with a forbidden DocFileError", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("forbidden", { status: 403 }));
-    await expect(readDocFile("s1", "../etc/passwd")).rejects.toMatchObject({ kind: "forbidden", status: 403 });
+    const fetchDoc = respondWith(new Response("forbidden", { status: 403 }));
+    await expect(readDocFile("s1", "../etc/passwd", fetchDoc)).rejects.toMatchObject({
+      kind: "forbidden",
+      status: 403,
+    });
   });
 
   test("a 404 (missing file / unknown or non-local session) rejects with a not-found DocFileError", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("not found", { status: 404 }));
-    await expect(readDocFile("s1", "gone.txt")).rejects.toMatchObject({ kind: "not-found", status: 404 });
+    const fetchDoc = respondWith(new Response("not found", { status: 404 }));
+    await expect(readDocFile("s1", "gone.txt", fetchDoc)).rejects.toMatchObject({ kind: "not-found", status: 404 });
   });
 
   test("any other non-ok status rejects with a generic error DocFileError carrying the status", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("boom", { status: 500 }));
-    await expect(readDocFile("s1", "x.txt")).rejects.toMatchObject({ kind: "error", status: 500 });
+    const fetchDoc = respondWith(new Response("boom", { status: 500 }));
+    await expect(readDocFile("s1", "x.txt", fetchDoc)).rejects.toMatchObject({ kind: "error", status: 500 });
   });
 
   test("the rejection is a DocFileError instance so the pane can switch on kind", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 404 }));
-    await expect(readDocFile("s1", "gone.txt")).rejects.toBeInstanceOf(DocFileError);
+    const fetchDoc = respondWith(new Response(null, { status: 404 }));
+    await expect(readDocFile("s1", "gone.txt", fetchDoc)).rejects.toBeInstanceOf(DocFileError);
   });
 });

--- a/cmd/evener-hub/frontend/src/protocol/docContent.ts
+++ b/cmd/evener-hub/frontend/src/protocol/docContent.ts
@@ -8,7 +8,9 @@
 //   readDocFile - fetches RAW file bytes from /doc/file?format=raw (the raw
 //   variant of handleDocFile, cmd/evener-hub/doc_serve.go:75), then builds the
 //   client-side DocFileContent the doc pane renders (binary notice / sanitized
-//   markdown / escaped <pre>). It is NOT the legacy /doc/file HTML page.
+//   markdown / escaped <pre>). It is NOT the legacy /doc/file HTML page. The
+//   request itself comes from a DocFetch the host supplies, so this module
+//   names no browser global and no credentials policy of its own.
 export interface DocFileContent {
   text: string;
   binary: boolean;
@@ -46,6 +48,21 @@ export class DocFileError extends Error {
   }
 }
 
+// DocResponseLike is the minimal response surface readDocFile reads. A real
+// fetch Response satisfies it structurally, so a host adapter can hand one
+// straight back while the package itself stays free of the DOM.
+export interface DocResponseLike {
+  ok: boolean;
+  status: number;
+  headers: { get(name: string): string | null };
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+// DocFetch is the host's port for doc requests: it owns transport policy -
+// credentials in the browser, auth headers on native - so the package neither
+// reaches for a global nor decides how the request is authenticated.
+export type DocFetch = (url: string) => Promise<DocResponseLike>;
+
 function errorKindForStatus(status: number): DocFileErrorKind {
   if (status === 403) return "forbidden";
   if (status === 404) return "not-found";
@@ -71,10 +88,8 @@ export function docFileRawURL(session: string, path: string): string {
 // headers (writeDocFileRaw), present only when the file exceeded the cap - so a
 // file of exactly the cap reads as complete, no longer a false positive from
 // the old body>=cap inference (floor cross-cutting #9).
-export async function readDocFile(session: string, path: string): Promise<DocFileContent> {
-  // same-origin credentials so the hub's auth cookie rides along, exactly as
-  // the manifest and every other same-origin fetch in this app do.
-  const res = await fetch(docFileRawURL(session, path), { credentials: "same-origin" });
+export async function readDocFile(session: string, path: string, fetchDoc: DocFetch): Promise<DocFileContent> {
+  const res = await fetchDoc(docFileRawURL(session, path));
   if (!res.ok) {
     throw new DocFileError(errorKindForStatus(res.status), res.status);
   }

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -32,9 +32,9 @@ export type { AnyNotification, AppwireClientOptions, ConnectionState, TerminalRe
 export { APPWIRE_PROTOCOL_VERSION, AppwireClient } from "./client";
 export type { AppwireClientLike } from "./clientLike";
 export type { DocFileContent, DocFileErrorKind } from "./docContent";
-// readDocFile is deliberately absent: it hardcodes a relative URL and the
-// browser fetch global, so no Node or native consumer of this package can call
-// it. It joins the entry point when it takes a base-URL and fetch port.
+// readDocFile is deliberately absent from the root: it needs a fetch from the
+// host, and a consumer that supplies one (or spies on the module) wants the
+// module itself, so it is published at the "./docContent" subpath instead.
 export { DOC_FILE_MAX_BYTES, DocFileError, docFileRawURL, docImageURL } from "./docContent";
 export {
   ClientNotReadyError,

--- a/cmd/evener-hub/frontend/src/protocol/package.json
+++ b/cmd/evener-hub/frontend/src/protocol/package.json
@@ -13,6 +13,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
+    },
+    "./docContent": {
+      "types": "./dist/docContent.d.ts",
+      "import": "./dist/docContent.js",
+      "require": "./dist/docContent.js"
     }
   },
   "scripts": {

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -195,6 +195,28 @@ const version: string = APPWIRE_PROTOCOL_VERSION; void client; void version;`,
       cjsTypeUses: `const app: client.AppwireClient = new client.AppwireClient({ url: "ws://127.0.0.1:1/rpc" }); void app;`,
       smoke: rootSmokeCalls,
     },
+    // The doc-pane data layer, published as its own specifier because
+    // readDocFile is not a root export: it needs a fetch, and a consumer that
+    // wants to substitute one (or spy on the module) needs a real subpath to
+    // import, which a root re-export cannot give it.
+    "./docContent": {
+      values: ["DOC_FILE_MAX_BYTES", "DocFileError", "docFileRawURL", "docImageURL", "readDocFile"],
+      types: ["DocFetch", "DocFileContent", "DocFileErrorKind", "DocResponseLike"],
+      esmTypeUses: `const read: (session: string, path: string, fetchDoc: DocFetch) => Promise<DocFileContent> = readDocFile;
+const cap: number = DOC_FILE_MAX_BYTES; void read; void cap;`,
+      cjsTypeUses: `const read: client.DocFetch = async (url: string) => {
+  void url;
+  throw new client.DocFileError("error", 500);
+}; void read;`,
+      // The URL builders and the size cap are the whole callable surface here:
+      // readDocFile needs a fetch, and qualification makes no requests, so it
+      // is checked for presence and its behavior is covered by unit tests.
+      smoke: `assert.equal(client.docFileRawURL("s", "p"), "/doc/file?format=raw&session=s&path=p");
+assert.equal(client.docImageURL("s", "p"), "/doc/image?session=s&path=p");
+assert.equal(client.DOC_FILE_MAX_BYTES, 512 * 1024);
+assert.equal(typeof client.readDocFile, "function");
+`,
+    },
   };
   const publishedSpecifiers = Object.keys(packageManifest.exports);
   for (const specifier of publishedSpecifiers)


### PR DESCRIPTION
PR A3d of the SDK migration plan (#1182). The package's first real subpath, and the step that lets the coming import rewrite (A4) leave zero exceptions behind.

`package.json` `exports` gains `./docContent`, the qualification manifest gains its entry (per-specifier ESM and CJS declaration consumers, runtime programs and reachability, via #1207), and `readDocFile` no longer calls global `fetch` with `credentials: "same-origin"`: it takes a required `fetchDoc: DocFetch` where `DocFetch = (url) => Promise<DocResponseLike>` and `DocResponseLike` is the minimal `{ ok, status, headers.get, arrayBuffer }` a real `Response` satisfies structurally (a `Promise<Response>` in the `.d.ts` would fail the runner's DOM-free declaration consumers). The web installs `panes/doc/browserDocFetch.ts`, eight lines that make exactly today's call, and `DocPane.tsx` (the only caller) passes it, so behaviour is unchanged. `readDocFile` stays off the root entry point and is reachable only through the subpath; the root keeps the pure helpers and types. No app import is rewritten to the package name yet.

REDs: the manifest entry before the `exports` entry fails the gate with `qualification manifest names ./docContent, which package.json does not export`; `docContent.test.ts` rewritten to inject a recording fake fetch fails ten cases with `Failed to parse URL from /doc/file?...` until `readDocFile` takes `fetchDoc`. The old same-origin case became "never touches the global fetch"; the credentials contract lives in `browserDocFetch.test.ts`. `DocPane.test.tsx` and `docFile.test.ts` are untouched and green. Out of scope for C24: base origin, bearer headers, native image sources, and the injected-fetch URL/auth/status assertions in the runner.

Gates: `make test-api-package`, `make test-web`, `make test-native`; biome on all touched files. 9 files, +125/−43.