### PR TITLE
fix(agent): claim watch-send delivery so two deliverers cannot escalate to exit 1

### DIFF
--- a/agent/job_watch.go
+++ b/agent/job_watch.go
@@ -526,6 +526,46 @@ func (jm *jobManager) watchSendDeliveredLocked(deliveryID string) bool {
 	return ok
 }
 
+// watchSendDelivered reports whether a watch-send with deliveryID has settled
+// delivered, taking jm.mu for callers outside a locked section.
+func (jm *jobManager) watchSendDelivered(deliveryID string) bool {
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
+	return jm.watchSendDeliveredLocked(deliveryID)
+}
+
+// claimWatchSendDelivery takes process-local ownership of one watch-send
+// delivery id. It returns false when another executor already owns it, so the
+// second caller stands down instead of racing the same store write. Mirrors
+// claimStableWatchSettlementRetries. Guarded by jm.mu.
+func (jm *jobManager) claimWatchSendDelivery(deliveryID string) bool {
+	if deliveryID == "" {
+		return true
+	}
+	jm.mu.Lock()
+	defer jm.mu.Unlock()
+	if _, held := jm.deliveringWatchSends[deliveryID]; held {
+		return false
+	}
+	if jm.deliveringWatchSends == nil {
+		jm.deliveringWatchSends = make(map[string]struct{})
+	}
+	jm.deliveringWatchSends[deliveryID] = struct{}{}
+	return true
+}
+
+// releaseWatchSendDeliveryClaim releases a claim taken by
+// claimWatchSendDelivery. It is safe to call on a delivery id that was never
+// claimed.
+func (jm *jobManager) releaseWatchSendDeliveryClaim(deliveryID string) {
+	if deliveryID == "" {
+		return
+	}
+	jm.mu.Lock()
+	delete(jm.deliveringWatchSends, deliveryID)
+	jm.mu.Unlock()
+}
+
 // validateWatchConfig runs the target-independent validation a watch install must
 // pass — condition presence, send target, and config build — and returns the built
 // config. configureWatch routes install validation through it.
@@ -3730,6 +3770,10 @@ func jobFinishedEventData(data events.EventData) (events.JobFinishedData, bool) 
 }
 
 func (jm *jobManager) deliverPendingWatchSend(cfg *watchConfig, state jobstore.WatchSendState, ensurePending bool) (bool, error) {
+	if !jm.claimWatchSendDelivery(state.DeliveryID) {
+		return false, nil
+	}
+	defer jm.releaseWatchSendDeliveryClaim(state.DeliveryID)
 	if !jm.isCurrentPendingWatchSend(cfg, state) {
 		return false, nil
 	}
@@ -3777,6 +3821,7 @@ func (jm *jobManager) deliverStableWatchSend(cfg *watchConfig, state jobstore.Wa
 		return false, errors.New("stable watch controller is unavailable")
 	}
 	receipt := jm.stableWatchReceipt(state.DeliveryID)
+	acquiredReceipt := false
 	if receipt == nil {
 		var err error
 		receipt, err = controller.AcquireWatchDelivery(
@@ -3791,6 +3836,7 @@ func (jm *jobManager) deliverStableWatchSend(cfg *watchConfig, state jobstore.Wa
 			return false, err
 		}
 		jm.rememberStableWatchReceipt(receipt)
+		acquiredReceipt = true
 	}
 	folded, err := jm.store.LoadWatchSends()
 	if err != nil {
@@ -3798,6 +3844,17 @@ func (jm *jobManager) deliverStableWatchSend(cfg *watchConfig, state jobstore.Wa
 	}
 	pending := folded.Pending[state.Key]
 	if pending == nil || pending.DeliveryID != state.DeliveryID || pending.UpdateSeq != state.UpdateSeq {
+		// A concurrent deliverer may have already settled this exact delivery
+		// (its Delivered marker folds the old pending away). Stand down rather
+		// than mistake a completed handoff for stale state, which the drain
+		// path would escalate to exit 1 (#327). Reserve the hard error for
+		// genuine staleness.
+		if jm.watchSendDelivered(state.DeliveryID) {
+			if acquiredReceipt {
+				jm.releaseStableWatchReceipt(state.DeliveryID)
+			}
+			return false, nil
+		}
 		return false, errors.New("stable watch delivery is not the durable pending head")
 	}
 	receiver, err := controller.stableWatchReceiver(state.ReceiverSessionID, state.ReceiverDelegateID)

--- a/agent/job_watch_delivery_claim_test.go
+++ b/agent/job_watch_delivery_claim_test.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"primeradiant.com/evener/agent/events"
+	"primeradiant.com/evener/agent/internal/jobstore"
+)
+
+// TestWatchSendDeliveryConcurrentExecutorsClaimOnce drives two executors of the
+// SAME watch-send delivery id through the exact window issue #327 describes: the
+// ancestor drain and the child turn-boundary flush can both reach
+// deliverPendingWatchSend for one delivery id. Executor A is parked after its
+// durable Delivered event lands but before it removes the in-memory pending and
+// releases its receipt, so executor B enters and observes that same in-memory
+// pending as current. Without a per-delivery executor claim, B re-appends the
+// old pending behind Delivered and raises the "stable watch delivery is not the
+// durable pending head" hard error, which the drain path escalates to exit 1.
+// With the claim, B stands down before it touches the store.
+func TestWatchSendDeliveryConcurrentExecutorsClaimOnce(t *testing.T) {
+	fixture := newStableWatchRuntimeFixture(t, nil)
+	onSessionEventKD(fixture.sourceJM, events.EventCommunicate, events.CommunicateData{Message: "concurrent delivery"})
+	cfg := fixture.onlyWatchConfig(t)
+	state := fixture.requireOnePending(t).state
+
+	deliveredAppended := make(chan struct{}, 1)
+	releaseA := make(chan struct{})
+	var pendingAppends atomic.Int32
+	originalAppend := fixture.sourceJM.appendEvent
+	fixture.sourceJM.appendEvent = func(event jobstore.Event) error {
+		if exactWatchSendEvent(event, jobstore.EventWatchSendPending, state) {
+			pendingAppends.Add(1)
+		}
+		err := originalAppend(event)
+		if err == nil && exactWatchSendEvent(event, jobstore.EventWatchSendDelivered, state) {
+			deliveredAppended <- struct{}{}
+			<-releaseA
+		}
+		return err
+	}
+	released := false
+	defer func() {
+		if !released {
+			close(releaseA)
+		}
+		fixture.sourceJM.appendEvent = originalAppend
+	}()
+
+	aDone := make(chan error, 1)
+	go func() {
+		_, err := fixture.sourceJM.deliverPendingWatchSend(cfg, state, true)
+		aDone <- err
+	}()
+	<-deliveredAppended
+
+	// A's Delivered event is durable but A is still parked before removing the
+	// in-memory pending, so B observes the same current pending. Reset the append
+	// counter so it isolates only what B appends.
+	pendingAppends.Store(0)
+	deliveredB, errB := fixture.sourceJM.deliverPendingWatchSend(cfg, state, true)
+	if errB != nil {
+		close(releaseA)
+		released = true
+		<-aDone
+		t.Fatalf("second deliverer error = %v, want stand-down without error", errB)
+	}
+	if deliveredB {
+		close(releaseA)
+		released = true
+		<-aDone
+		t.Fatal("second deliverer reported a delivery")
+	}
+	if got := pendingAppends.Load(); got != 0 {
+		close(releaseA)
+		released = true
+		<-aDone
+		t.Fatalf("second deliverer appended %d pending events, want 0", got)
+	}
+
+	close(releaseA)
+	released = true
+	if err := <-aDone; err != nil {
+		t.Fatalf("first deliverer: %v", err)
+	}
+
+	eventsLog := loadJobStoreEvents(t, fixture.sourceJM)
+	if got := countExactWatchSendEvents(eventsLog, jobstore.EventWatchSendDelivered, state); got != 1 {
+		t.Fatalf("durable delivered events = %d, want exactly 1", got)
+	}
+	if receipt := fixture.sourceJM.stableWatchReceipt(state.DeliveryID); receipt != nil {
+		t.Fatal("delivery receipt held after the first deliverer settled")
+	}
+}
+
+// TestWatchSendDeliverySettledRerunStandsDown isolates the durable-head belt and
+// braces independently of the executor claim. The claim is free (no executor is
+// running), but the delivery has already settled durably; a rerun that still sees
+// the in-memory pending must consult the delivered set and stand down instead of
+// raising the hard "not the durable pending head" error.
+func TestWatchSendDeliverySettledRerunStandsDown(t *testing.T) {
+	fixture := newStableWatchRuntimeFixture(t, nil)
+	onSessionEventKD(fixture.sourceJM, events.EventCommunicate, events.CommunicateData{Message: "settled rerun"})
+	cfg := fixture.onlyWatchConfig(t)
+	state := fixture.requireOnePending(t).state
+
+	if err := fixture.sourceJM.settleWatchSendDelivered(cfg, state); err != nil {
+		t.Fatalf("settle delivery: %v", err)
+	}
+	// Re-materialize the in-memory pending so the rerun passes the entry read
+	// while the durable pending head is already gone.
+	fixture.sourceJM.rememberUnpersistedTerminalPendingWatchSend(cfg, state)
+
+	delivered, err := fixture.sourceJM.deliverPendingWatchSend(cfg, state, false)
+	if err != nil {
+		t.Fatalf("settled delivery rerun error = %v, want stand-down", err)
+	}
+	if delivered {
+		t.Fatal("settled delivery rerun reported a delivery")
+	}
+	if receipt := fixture.sourceJM.stableWatchReceipt(state.DeliveryID); receipt != nil {
+		t.Fatal("settled delivery rerun leaked a delivery receipt")
+	}
+}

--- a/agent/jobs.go
+++ b/agent/jobs.go
@@ -100,6 +100,13 @@ type jobManager struct {
 	// self-influence depth metric consults so a coalesced-away (never delivered)
 	// predecessor cannot inflate depth. Guarded by jm.mu.
 	deliveredWatchSendIDs map[string]struct{}
+	// deliveringWatchSends is the set of watch-send delivery IDs a process-local
+	// executor currently owns. deliverPendingWatchSend claims the id under jm.mu
+	// before touching the store and releases it on every exit, so two executors
+	// (the ancestor drain and the child turn-boundary flush) cannot both deliver
+	// one send and race a re-appended pending behind its own Delivered marker
+	// (#327). Guarded by jm.mu.
+	deliveringWatchSends map[string]struct{}
 	// watchesLostAtRestore holds the durable records of the watches this restore
 	// ended (clearUnrestoredActiveWatches), owed a callback-cancellation or send
 	// end notice by noticeUnrestoredWatchEnds. Written once at construction, read
@@ -634,6 +641,7 @@ func newJobManagerWithRestore(stateDir, sessionID string, enqueue func(jobNotifi
 		watches:               make(map[watchKey]*watchConfig),
 		lastFedOffset:         make(map[string]int64),
 		deliveredWatchSendIDs: make(map[string]struct{}),
+		deliveringWatchSends:  make(map[string]struct{}),
 		appendEvent:           store.Append,
 		appendEvents:          store.AppendBatch,
 		createOutput:          createOutput,


### PR DESCRIPTION
Fixes #327.

`deliverPendingWatchSend` gated only on the in-memory pending-head read, so the ancestor drain and the child turn-boundary flush could both execute the same delivery id. The second deliverer re-appended the old pending behind `Delivered` and tripped the durable-head invariant, which the drain escalated to a non-zero exit. The delivery id is now claimed under `jm.mu` on entry, released on every exit path, and a deliverer that finds the send already durable stands down instead of re-appending.

## Evidence

- pre-fix: `FAIL primeradiant.com/evener/agent 0.285s: second deliverer error = stable watch delivery is not the durable pending head`
- post-fix: `ok primeradiant.com/evener/agent 1.178s`; both new tests pass under `-race`
- both guards mutation-proven load-bearing

The remaining `agent/sandbox` failures on the authoring host are pre-existing bwrap read-only-`/tmp` environment failures; that package does not import this one.
