### PR TITLE
fix(llm/registry): follow symlinks when writing providers.toml

### DIFF
--- a/cmd/evener-hub/app_rpc_agents_doc.go
+++ b/cmd/evener-hub/app_rpc_agents_doc.go
@@ -65,9 +65,9 @@ func readAgentsDoc(path string) (appwire.AgentsDocResponse, error) {
 
 // writeAgentsDoc replaces the file atomically (temp + rename, mode 0644,
 // parent created), the same way registry.WriteConfigFile lands
-// providers.toml beside it, except that this writer follows a symlinked
-// AGENTS.md first so a dotfiles-managed copy keeps being the source of truth
-// (Jesse's ruling, 2026-09-07; providers.toml follows in its own PR).
+// providers.toml beside it: both follow a symlinked target first so a
+// dotfiles-managed copy keeps being the source of truth (Jesse's ruling,
+// 2026-09-07).
 // Content is written byte for byte: this is the user's own prose, and
 // trimming or appending a newline would make the editor disagree with the
 // file it just saved. The temp file is created exclusively, under a name

--- a/llm/registry/write.go
+++ b/llm/registry/write.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -197,6 +198,19 @@ func ReadConfigFile(path string) (*Layer, bool, error) {
 // unknown keys — refuses the write, wrapped in ErrConfigUnloadable, instead
 // of landing a file whose reload fails and whose author is then locked out of
 // the corrective edit (spec §10, §11.3).
+//
+// A dotfiles-managed providers.toml is a symlink into a managed directory, so
+// the write resolves through the link first and lands the rename on its
+// target: renaming over the link path would replace the link with a regular
+// file and sever the managed copy that is the source of truth (issue #1040,
+// the same follow-the-symlink rule writeAgentsDoc already applies to
+// AGENTS.md; Jesse's ruling, 2026-09-07). Only a path with nothing at the end
+// of it — no file yet, or a link whose target is gone — falls back to the
+// path itself, so a first save creates the file where the config root says it
+// is and a broken link is replaced. A link that is there but unresolvable (a
+// loop, a directory along the way that cannot be searched) is a real target
+// this write cannot reach: renaming over it would sever the very link the rule
+// exists to keep, so it is refused.
 func WriteConfigFile(path string, l *Layer) error {
 	data, err := MarshalConfig(l)
 	if err != nil {
@@ -205,14 +219,22 @@ func WriteConfigFile(path string, l *Layer) error {
 	if _, err := ParseConfig(data); err != nil {
 		return fmt.Errorf("%w: %w", ErrConfigUnloadable, err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+	target := path
+	resolved, err := filepath.EvalSymlinks(path)
+	switch {
+	case err == nil:
+		target = resolved
+	case !errors.Is(err, fs.ErrNotExist):
+		return fmt.Errorf("providers.toml: resolve: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
 		return fmt.Errorf("providers.toml: mkdir: %w", err)
 	}
-	tmp := path + ".tmp"
+	tmp := target + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
 		return fmt.Errorf("providers.toml: write: %w", err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := os.Rename(tmp, target); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("providers.toml: rename: %w", err)
 	}

--- a/llm/registry/write_test.go
+++ b/llm/registry/write_test.go
@@ -115,6 +115,108 @@ func TestReadWriteConfigFile(t *testing.T) {
 	}
 }
 
+func symlinkWriterLayer() *Layer {
+	return &Layer{
+		Tag:     LayerConfig,
+		Default: "local",
+		Providers: map[string]Provider{
+			"local": {ID: "local", Base: "openai-compatible", Transport: Transport{BaseURL: "http://localhost:8080/v1", Auth: AuthNone}},
+		},
+	}
+}
+
+// A dotfiles-managed providers.toml is a symlink into a managed directory.
+// The atomic rename has to land on the link's target: renaming over the link
+// path would replace the link with a regular file and the managed copy would
+// stop being the source of truth (issue #1040). This is the same
+// follow-the-symlink rule writeAgentsDoc already applies to AGENTS.md.
+func TestWriteConfigFileFollowsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "managed", "providers.toml")
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("schema = 2\ndefault = \"old\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "providers.toml")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteConfigFile(link, symlinkWriterLayer()); err != nil {
+		t.Fatalf("WriteConfigFile: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the symlink was replaced with a %v file", info.Mode().Type())
+	}
+	back, exists, err := ReadConfigFile(target)
+	if err != nil || !exists || back.Default != "local" || back.Providers["local"].Base != "openai-compatible" {
+		t.Fatalf("target not updated through the link: %v %v %+v", err, exists, back)
+	}
+}
+
+// A regular providers.toml is written in place: the resolved path is the path
+// itself, so the atomic temp-and-rename behavior is unchanged.
+func TestWriteConfigFileRegularFileUnchanged(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "providers.toml")
+	if err := os.WriteFile(path, []byte("schema = 2\ndefault = \"old\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteConfigFile(path, symlinkWriterLayer()); err != nil {
+		t.Fatalf("WriteConfigFile: %v", err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("a regular file must stay a regular file")
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Fatalf("mode = %v, want 0644", info.Mode().Perm())
+	}
+	back, exists, err := ReadConfigFile(path)
+	if err != nil || !exists || back.Default != "local" {
+		t.Fatalf("read back: %v %v %+v", err, exists, back)
+	}
+}
+
+// A link whose target is gone is not a managed file to write through: there is
+// nothing at the end of it, so the save falls back to the link path and the
+// dangling link is replaced by the file itself. A first save with no file yet
+// takes the same path.
+func TestWriteConfigFileDanglingSymlinkFallsBackToLinkPath(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "providers.toml")
+	if err := os.Symlink(filepath.Join(dir, "gone", "providers.toml"), link); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteConfigFile(link, symlinkWriterLayer()); err != nil {
+		t.Fatalf("WriteConfigFile: %v", err)
+	}
+
+	info, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("a dangling link must be replaced by the file itself")
+	}
+	back, exists, err := ReadConfigFile(link)
+	if err != nil || !exists || back.Default != "local" {
+		t.Fatalf("read back: %v %v %+v", err, exists, back)
+	}
+}
+
 // WriteConfigFile holds the invariant every writer needs: a providers.toml
 // it accepts is one the reader can read back. A layer the parser would refuse
 // never lands on disk, so the write cannot lock its own author out of the


### PR DESCRIPTION
Fixes #1040.

`WriteConfigFile` renamed a temp file straight over the path, so a dotfiles-managed `providers.toml` symlink was replaced by a regular file and the managed copy stopped being the source of truth. The write now resolves the link first and lands the rename on its target, following the rule `writeAgentsDoc` already applies to AGENTS.md: a missing target falls back to the path, an unresolvable one is refused. The second commit drops the now-false caveat from `writeAgentsDoc`'s doc comment.

## Evidence

- pre-fix: `TestWriteConfigFileFollowsSymlink` FAIL (the symlink was replaced with a regular file)
- post-fix: `cd llm && go test ./registry/ -count=1` PASS; `go vet ./registry/` clean
