### PR TITLE
fix(web): mint the browser-guard Chrome profile under a short root

### DIFF
--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -240,8 +240,124 @@ export function chromeProfileIsolationArgs(platform = process.platform) {
 export function chromeProfileEnvironment(profileDir, environment = process.env) {
   return {
     ...environment,
+    // Chrome's process singleton creates its socket directory under the temp
+    // directory, so the launcher's long scratch TMPDIR would push the derived
+    // SingletonSocket path past sun_path (issue #1141). The profile is already
+    // minted under a short root and bounded so this derived path fits; pointing
+    // TMPDIR at it keeps every socket Chrome binds short and reaps them with the
+    // profile.
+    TMPDIR: profileDir,
     BREAKPAD_DUMP_LOCATION: path.join(profileDir, "Crashpad"),
   };
+}
+
+// Chrome's process singleton mints a socket directory under the TEMP DIRECTORY
+// (base::GetTempDir(), i.e. $TMPDIR) named <branding>.<6 random chars> and binds
+// SingletonSocket inside it, and it also puts a SingletonSocket in the profile.
+// AF_UNIX's sun_path is 108 bytes including the terminating NUL, so the usable
+// path is 107 bytes; a longer one makes Chrome abort with "Socket path too long"
+// before DevTools is up (issue #1141). A guard run whose scratch TMPDIR is a
+// nested agent-sandbox path overflows that budget. Both halves of the fix live
+// here: the profile is minted under a short root chosen independently of the
+// ambient TMPDIR, and Chrome is launched with TMPDIR pointed at that short
+// profile (chromeProfileEnvironment) so its temp socket directory lands there
+// too. createChromeProfileDir bounds the profile so the derived socket path
+// always fits.
+export const CHROME_SOCKET_PATH_LIMIT = 107;
+const CHROME_SINGLETON_SUFFIX = "/com.google.Chrome.XXXXXX/SingletonSocket";
+// Node's mkdtemp appends this many random characters to its prefix.
+const CHROME_PROFILE_RANDOM_CHARS = 6;
+
+export function chromeSingletonSocketPath(profileDir) {
+  return `${profileDir}${CHROME_SINGLETON_SUFFIX}`;
+}
+
+// Candidate roots, most preferred first. /private/tmp precedes /tmp so macOS
+// resolves to the canonical short root rather than the long /var/folders/...
+// path os.tmpdir() returns. The ambient TMPDIR is last: it is only used when no
+// short root is usable, and only when the derived socket path still fits.
+export function chromeProfileRootCandidates({ platform = process.platform, ambient = tmpdir() } = {}) {
+  if (platform === "win32") return [ambient];
+  return [...new Set(["/private/tmp", "/tmp", "/var/tmp", ambient])];
+}
+
+function maxProfilePrefixBytes(root, socketLimit) {
+  return (
+    socketLimit -
+    Buffer.byteLength(root) -
+    // path separator between the root and the profile directory
+    1 -
+    CHROME_PROFILE_RANDOM_CHARS -
+    Buffer.byteLength(CHROME_SINGLETON_SUFFIX)
+  );
+}
+
+// The base directory a Chrome profile should be minted under, independent of a
+// long ambient TMPDIR. Pure path selection: the caller may inject `exists`.
+export function chromeProfileRoot({
+  platform = process.platform,
+  ambient = tmpdir(),
+  socketLimit = CHROME_SOCKET_PATH_LIMIT,
+  exists = existsSync,
+} = {}) {
+  const candidates = chromeProfileRootCandidates({ platform, ambient });
+  for (const root of candidates) {
+    if (platform !== "win32" && maxProfilePrefixBytes(root, socketLimit) <= 0) continue;
+    if (platform !== "win32" && !exists(root)) continue;
+    return root;
+  }
+  return ambient;
+}
+
+function trimToByteBudget(text, budget) {
+  if (Buffer.byteLength(text) <= budget) return text;
+  let end = text.length;
+  while (end > 0 && Buffer.byteLength(text.slice(0, end)) > budget) end -= 1;
+  return text.slice(0, end);
+}
+
+// Mint the private profile Chrome is pointed at with --user-data-dir. The
+// caller's prefix stays the directory's leading component (callers and tests use
+// it to identify the run) but is trimmed when it would push the derived socket
+// path past the limit -- the invariant is that the path Chrome binds always
+// fits, whatever the ambient TMPDIR. Each candidate root is tried in order so an
+// unwritable /tmp still falls through; failure to fit any root is fatal.
+export function createChromeProfileDir(
+  profilePrefix,
+  {
+    platform = process.platform,
+    ambient = tmpdir(),
+    socketLimit = CHROME_SOCKET_PATH_LIMIT,
+    makeTempDir = mkdtempSync,
+    exists = existsSync,
+  } = {},
+) {
+  const candidates = chromeProfileRootCandidates({ platform, ambient });
+  let lastError = null;
+  for (const root of candidates) {
+    if (platform !== "win32" && !exists(root)) continue;
+    const prefix = trimToByteBudget(profilePrefix, maxProfilePrefixBytes(root, socketLimit));
+    let dir;
+    try {
+      // Keep a trailing separator when the prefix was trimmed away so mkdtemp
+      // appends its random characters INSIDE the root rather than beside it.
+      const template = `${root.replace(/[\\/]+$/, "")}${path.sep}${prefix}`;
+      dir = makeTempDir(template);
+    } catch (error) {
+      lastError = error;
+      continue;
+    }
+    if (platform === "win32" || Buffer.byteLength(chromeSingletonSocketPath(dir)) <= socketLimit) {
+      return dir;
+    }
+    rmSync(dir, { recursive: true, force: true });
+    lastError = new Error(
+      `profile ${dir} would put Chrome's singleton socket past the ${socketLimit}-byte sun_path limit`,
+    );
+  }
+  throw new Error(
+    `could not mint a Chrome profile whose socket path fits ${socketLimit} bytes (tried ${candidates.join(", ")}): ${lastError?.message ?? "no usable root"}`,
+  );
 }
 
 function childHasExited(child) {
@@ -790,7 +906,7 @@ export async function startBrowserGuard({
   const resolvedChrome = chromeBinary ?? findChrome();
   const vitePort = 0;
   let actualVitePort = vitePort;
-  const profileDir = mkdtempSync(path.join(tmpdir(), profilePrefix));
+  const profileDir = createChromeProfileDir(profilePrefix);
   let vite = null;
   let chrome = null;
   let viteErr = "";

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.mjs
@@ -264,6 +264,10 @@ export function chromeProfileEnvironment(profileDir, environment = process.env) 
 // too. createChromeProfileDir bounds the profile so the derived socket path
 // always fits.
 export const CHROME_SOCKET_PATH_LIMIT = 107;
+// The branding component for a Google Chrome build. A Chromium build names its
+// singleton directory org.chromium.Chromium instead (4 bytes longer), which
+// only bites when a caller's prefix is trimmed to the very last byte under a
+// long ambient TMPDIR.
 const CHROME_SINGLETON_SUFFIX = "/com.google.Chrome.XXXXXX/SingletonSocket";
 // Node's mkdtemp appends this many random characters to its prefix.
 const CHROME_PROFILE_RANDOM_CHARS = 6;
@@ -336,7 +340,13 @@ export function createChromeProfileDir(
   let lastError = null;
   for (const root of candidates) {
     if (platform !== "win32" && !exists(root)) continue;
-    const prefix = trimToByteBudget(profilePrefix, maxProfilePrefixBytes(root, socketLimit));
+    // win32 has no sun_path to fit, so keep the caller's whole identifying
+    // prefix there; this matches the win32 exemptions on the existence check
+    // below and on the fit check after mkdtemp.
+    const prefix =
+      platform === "win32"
+        ? profilePrefix
+        : trimToByteBudget(profilePrefix, maxProfilePrefixBytes(root, socketLimit));
     let dir;
     try {
       // Keep a trailing separator when the prefix was trimmed away so mkdtemp

--- a/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
+++ b/cmd/evener-hub/frontend/scripts/browserGuardProcess.test.mjs
@@ -157,9 +157,15 @@ test("starts concurrent guards on Vite-owned ports and reaps their listeners", a
 
 test("aborts Vite startup and removes its owned profile", async () => {
   const controller = new AbortController();
-  const profilePrefix = `browser-guard-abort-${randomUUID()}-`;
+  // The profile lives under the short guard root (issue #1141), not the ambient
+  // TMPDIR, and a long prefix is trimmed to fit the socket budget -- so the
+  // directory is located by the stable leading marker rather than the full
+  // prefix.
+  const profileMarker = "browser-guard-abort-";
+  const profilePrefix = `${profileMarker}${randomUUID()}-`;
   const children = [];
   let profileDir;
+  const profileRoot = browserGuardProcess.chromeProfileRoot();
   await assert.rejects(
     startBrowserGuard({
       frontend: process.cwd(),
@@ -167,9 +173,9 @@ test("aborts Vite startup and removes its owned profile", async () => {
       chromeBinary: "/fake/chrome",
       signal: controller.signal,
       spawnProcess(command, args, options) {
-        const entry = readdirSync(tmpdir()).find((name) => name.startsWith(profilePrefix));
+        const entry = readdirSync(profileRoot).find((name) => name.startsWith(profileMarker));
         assert.ok(entry, "startup must own a profile before launching its child");
-        profileDir = path.join(tmpdir(), entry);
+        profileDir = path.join(profileRoot, entry);
         const child = new FakeChild(command, args, options);
         child.kill = (signal) => {
           child.signals.push(signal);
@@ -1180,7 +1186,12 @@ for (const scenario of [
       return true;
     };
     const controller = new AbortController();
-    const profilePrefix = `browser-guard-failure-${randomUUID()}-`;
+    // Located by the stable leading marker under the short guard root, since a
+    // long prefix is trimmed and the profile no longer lives under TMPDIR
+    // (issue #1141).
+    const profileMarker = "browser-guard-failure-";
+    const profilePrefix = `${profileMarker}${randomUUID()}-`;
+    const profileRoot = browserGuardProcess.chromeProfileRoot();
     const stderr = "fixture-vite-startup-stderr";
     let profileDir;
     let spawnCount = 0;
@@ -1195,9 +1206,9 @@ for (const scenario of [
       signal: controller.signal,
       spawnProcess() {
         spawnCount++;
-        const entry = readdirSync(tmpdir()).find((name) => name.startsWith(profilePrefix));
+        const entry = readdirSync(profileRoot).find((name) => name.startsWith(profileMarker));
         assert.ok(entry, "startup must create its owned profile");
-        profileDir = path.join(tmpdir(), entry);
+        profileDir = path.join(profileRoot, entry);
         return vite;
       },
     });
@@ -1586,4 +1597,93 @@ test("a Chrome launch failure does not abort the wait for a Vite that is still c
   children[0].exit();
   await cleanup;
   assert.equal(existsSync(guard.profileDir), false);
+});
+
+// Issue #1141: Chrome derives <user-data-dir>/com.google.Chrome.XXXXXX/
+// SingletonSocket and binds it with AF_UNIX. sun_path holds 108 bytes including
+// the NUL, so the usable path is 107 bytes; a longer one makes Chrome abort with
+// "Socket path too long" before DevTools is ready. Minting the profile under a
+// nested agent-sandbox TMPDIR crossed that limit for every guard.
+const LONG_AMBIENT_TMPDIR = `/tmp/evener-sandbox-3905550766/${"nested-scratch/".repeat(8)}`;
+
+test("selects a Chrome profile root that is independent of a long ambient TMPDIR (#1141)", () => {
+  assert.ok(Buffer.byteLength(LONG_AMBIENT_TMPDIR) > 107, "fixture TMPDIR must itself be long");
+
+  const root = browserGuardProcess.chromeProfileRoot({
+    ambient: LONG_AMBIENT_TMPDIR,
+    // A sandbox that exposes its long scratch and a short /tmp.
+    exists: (candidate) => candidate === "/tmp",
+  });
+  assert.equal(root, "/tmp");
+  assert.ok(!root.startsWith(LONG_AMBIENT_TMPDIR), "the profile root must not derive from the ambient TMPDIR");
+
+  const profilePrefix = "transcriptscrollguard-chrome-";
+  const minted = browserGuardProcess.createChromeProfileDir(profilePrefix, {
+    ambient: LONG_AMBIENT_TMPDIR,
+    exists: (candidate) => candidate === "/tmp",
+  });
+  try {
+    assert.ok(minted.startsWith(`${root}${path.sep}`), `profile ${minted} must sit under the short root`);
+    assert.ok(!minted.startsWith(LONG_AMBIENT_TMPDIR), "the profile must not sit under the ambient TMPDIR");
+    assert.ok(minted.includes(profilePrefix), "the caller's prefix must remain the directory's leading component");
+    const socket = browserGuardProcess.chromeSingletonSocketPath(minted);
+    assert.ok(
+      Buffer.byteLength(socket) <= browserGuardProcess.CHROME_SOCKET_PATH_LIMIT,
+      `socket path ${socket} (${Buffer.byteLength(socket)} bytes) must fit ${browserGuardProcess.CHROME_SOCKET_PATH_LIMIT} bytes`,
+    );
+  } finally {
+    rmSync(minted, { recursive: true, force: true });
+  }
+
+  // The pre-fix derivation -- the profile directly under the ambient TMPDIR --
+  // is what overflows, so this pins that the test would catch a regression.
+  const oversized = browserGuardProcess.chromeSingletonSocketPath(
+    path.join(LONG_AMBIENT_TMPDIR, `${profilePrefix}XXXXXX`),
+  );
+  assert.ok(
+    Buffer.byteLength(oversized) > browserGuardProcess.CHROME_SOCKET_PATH_LIMIT,
+    "fixture must reproduce the overflow the fix removes",
+  );
+});
+
+test("points Chrome's temp directory at the short profile so its singleton socket fits (#1141)", () => {
+  const profileDir = "/tmp/transcriptscrollguard-chrome-AbC123";
+  const env = browserGuardProcess.chromeProfileEnvironment(profileDir, {
+    TMPDIR: LONG_AMBIENT_TMPDIR,
+    PATH: "/usr/bin",
+  });
+  // Chrome mints its socket directory under TMPDIR, so inheriting the long
+  // ambient value is exactly the overflow; it must be replaced.
+  assert.equal(env.TMPDIR, profileDir);
+  assert.equal(env.PATH, "/usr/bin");
+  assert.ok(
+    Buffer.byteLength(browserGuardProcess.chromeSingletonSocketPath(env.TMPDIR)) <=
+      browserGuardProcess.CHROME_SOCKET_PATH_LIMIT,
+  );
+});
+
+test("a Chrome launch under a long ambient TMPDIR gets a --user-data-dir whose socket fits (#1141)", async (context) => {
+  const originalTmpdir = process.env.TMPDIR;
+  process.env.TMPDIR = LONG_AMBIENT_TMPDIR;
+  context.after(() => {
+    if (originalTmpdir === undefined) delete process.env.TMPDIR;
+    else process.env.TMPDIR = originalTmpdir;
+  });
+
+  const profilePrefix = "transcriptscrollguard-chrome-";
+  const { guard, children } = await startFakeGuard({ profilePrefix });
+  reapOnTeardown(context, guard, children);
+
+  const userDataDirArg = children[1].args.find((arg) => arg.startsWith("--user-data-dir="));
+  assert.ok(userDataDirArg, "Chrome must be launched with a private profile");
+  const profileDir = userDataDirArg.slice("--user-data-dir=".length);
+  assert.ok(!profileDir.startsWith(LONG_AMBIENT_TMPDIR), `profile ${profileDir} must not sit under the ambient TMPDIR`);
+  // Chrome's singleton socket directory is created under its TMPDIR, not under
+  // --user-data-dir, so the child's environment must carry the short root too.
+  assert.equal(children[1].options.env?.TMPDIR, profileDir);
+  const socket = browserGuardProcess.chromeSingletonSocketPath(profileDir);
+  assert.ok(
+    Buffer.byteLength(socket) <= browserGuardProcess.CHROME_SOCKET_PATH_LIMIT,
+    `Chrome's derived socket path ${socket} (${Buffer.byteLength(socket)} bytes) must fit ${browserGuardProcess.CHROME_SOCKET_PATH_LIMIT} bytes`,
+  );
 });


### PR DESCRIPTION
Fixes #1141.

Chrome mints its process-singleton socket under `$TMPDIR`. The browser guards ran with an agent-sandbox `TMPDIR` long enough that the derived AF_UNIX `sun_path` exceeded the 107-byte usable limit, aborting every guard before DevTools came up. The profile is now minted under a short root chosen independently of the ambient `TMPDIR`, and the Chrome child's `TMPDIR` is pointed at that profile so its temp socket directory lands there too.

## Evidence

- pre-fix: Chrome `FATAL Socket path too long ... SingletonSocket`, exit 2
- post-fix: full browser suite PASS under a 76-byte `TMPDIR`
- `node --test scripts/browserGuardProcess.test.mjs`: the three `#1141` cases pass. The suite's one failure in the authoring checkout is a missing local `node_modules/vite`, which CI installs.
