### PR TITLE
fix(agent): advance the activity resume index past a single oversized entry

### DIFF
--- a/agent/jobs_activity.go
+++ b/agent/jobs_activity.go
@@ -1354,6 +1354,18 @@ func trimActivityTrailingEntry(session *appwire.JobActivitySession, rootID strin
 			return true
 		}
 	}
+	resumeIndex := i
+	if i == 0 {
+		// The dropped entry is the page's only rendered entry, so it cannot
+		// fit even alone. A continuation pointing back at index 0 would
+		// re-render it, re-trim it, and mint this identical token on every
+		// later page, so a client paging the tree would never advance past it.
+		// Advance the resume index past the dropped entry and name it in the
+		// branch error so the skip is reported rather than silent -- and so
+		// the next page resumes after it instead of at it.
+		resumeIndex = i + 1
+		appendActivityBranchError(&session.Branch, fmt.Sprintf("activity entry %s is too large to render and was skipped", activityEntryLabel(*entry, i)))
+	}
 	session.Entries = session.Entries[:i]
 	session.Branch.Truncated = true
 	session.Branch.Continuation = encodeActivityContinuation(activityContinuation{
@@ -1361,12 +1373,29 @@ func trimActivityTrailingEntry(session *appwire.JobActivitySession, rootID strin
 		RootID:         rootID,
 		SessionID:      session.SessionID,
 		Path:           append([]string(nil), path...),
-		ResumeIndex:    i,
+		ResumeIndex:    resumeIndex,
 		JobsEpoch:      jobsEpochs[session.SessionID],
 		DelegatesEpoch: delegatesEpoch,
 		Revision:       revision,
 	})
 	return true
+}
+
+// activityEntryLabel names an activity entry for a branch error, preferring a
+// stable identity (the job or delegate ID) over its page-relative index.
+func activityEntryLabel(entry appwire.JobActivityEntry, index int) string {
+	if entry.Job != nil && entry.Job.JobID != "" {
+		return fmt.Sprintf("job %q", entry.Job.JobID)
+	}
+	if entry.Delegate != nil {
+		if entry.Delegate.DelegateID != "" {
+			return fmt.Sprintf("delegate %q", entry.Delegate.DelegateID)
+		}
+		if entry.Delegate.ChildSessionID != "" {
+			return fmt.Sprintf("delegate for session %q", entry.Delegate.ChildSessionID)
+		}
+	}
+	return fmt.Sprintf("at index %d", index)
 }
 
 func recomputeActivitySession(session *appwire.JobActivitySession) {

--- a/agent/jobs_activity_past_test.go
+++ b/agent/jobs_activity_past_test.go
@@ -1042,3 +1042,50 @@ func TestLoadSessionJobActivityTree_SizeTrimResumesAfterRemovedEntriesWithoutOve
 		}
 	}
 }
+
+// TestLoadSessionJobActivityTree_SingleOversizedEntryResumeAdvances is the
+// single-entry sibling of
+// TestLoadSessionJobActivityTree_SizeTrimResumesAfterRemovedEntriesWithoutOverlap:
+// a session whose ONLY entry's own JSON encoding already exceeds
+// activityMaxEncodedBytes. Dropping that entry leaves an empty page, so a
+// continuation minted at the dropped entry's index (0) would point straight
+// back at the entry that just failed to fit: the next page would re-render it,
+// re-trim it, and mint the identical token forever, and a client paging the
+// activity tree would never advance past it. This walks the pages through the
+// real entry point (LoadSessionJobActivityTree) and asserts the first page's
+// continuation advances past the oversized entry (rather than repeating it)
+// AND names it in the branch error, and that the walk terminates instead of
+// looping with an identical token.
+func TestLoadSessionJobActivityTree_SingleOversizedEntryResumeAdvances(t *testing.T) {
+	stateDir := t.TempDir()
+	rootID := "oversizedroot"
+	started := time.Unix(100, 0).UTC()
+	s1cov_writeJobLog(t, stateDir, rootID, jobstore.Event{
+		Kind: jobstore.EventJobStarted, TS: started, JobID: "job_huge",
+		Type: jobstore.JobShell, OwnerSessionID: rootID, VisibleToSession: rootID,
+		StartedAt: &started, Description: strings.Repeat("d", activityMaxEncodedBytes+64*1024),
+	})
+	savePastActivityMeta(t, stateDir, rootID, "Root")
+
+	first, err := LoadSessionJobActivityTree(context.Background(), stateDir, rootID, appwire.JobsListParams{})
+	if err != nil {
+		t.Fatalf("page 1: %v", err)
+	}
+	if len(first.Root.Entries) != 0 || !first.Root.Branch.Truncated {
+		t.Fatalf("page 1 entries=%d truncated=%v, want entries=0 truncated=true (the only entry cannot fit)", len(first.Root.Entries), first.Root.Branch.Truncated)
+	}
+	if first.Root.Branch.Continuation == "" {
+		t.Fatal("page 1 minted no continuation, want one that advances past the oversized entry")
+	}
+
+	second, err := LoadSessionJobActivityTree(context.Background(), stateDir, rootID, appwire.JobsListParams{Continuation: first.Root.Branch.Continuation})
+	if err != nil {
+		t.Fatalf("page 2: %v", err)
+	}
+	if second.Root.Branch.Continuation != "" {
+		t.Fatalf("page 2 continuation = %q (page 1 minted %q), want empty: the resume token must advance past the skipped entry and terminate pagination instead of re-minting the identical token", second.Root.Branch.Continuation, first.Root.Branch.Continuation)
+	}
+	if !strings.Contains(first.Root.Branch.Error, "job_huge") {
+		t.Fatalf("page 1 Branch.Error = %q, want it to name the skipped entry job_huge", first.Root.Branch.Error)
+	}
+}


### PR DESCRIPTION
Fixes #1172.

When the trailing activity entry dropped by size-trimming was the page's only entry and could not fit on its own, the minted continuation pointed back at that same entry: resuming re-rendered it, re-trimmed it, and minted an identical token forever. The resume index now advances past the dropped entry and the branch error names it, so the skip is reported rather than silent.

## Evidence

- pre-fix: new regression FAIL (identical resume token, page never advances)
- post-fix: `TestLoadSessionJobActivityTree_SingleOversizedEntryResumeAdvances` PASS

This covers the page-1 case. #1177 generalises the minted index to be absolute, so the same shape on page 2+ also advances; both fixes touch `trimActivityTrailingEntry` and are meant to land together.
