### PR TITLE
fix(agent): mint an absolute activity resume index when trimming a page

### DIFF
--- a/agent/jobs_activity.go
+++ b/agent/jobs_activity.go
@@ -715,7 +715,7 @@ func projectBoundedActivityTree(snapshot activitySessionSnapshot, rootID string,
 	// collectActivityJobsEpochs and trimActivityTrailingEntry. revision is
 	// the same value just seeded into budget.revision above, embedded the
 	// same way in whatever continuation trimming mints too.
-	return trimActivityTreeToFit(tree, rootID, snapshot.DelegatesEpoch, collectActivityJobsEpochs(snapshot), revision)
+	return trimActivityTreeToFit(tree, rootID, startDepth, resumeIndex, snapshot.DelegatesEpoch, collectActivityJobsEpochs(snapshot), revision)
 }
 
 // collectActivityJobsEpochs walks snapshot's Children tree and returns
@@ -1311,10 +1311,12 @@ func activityBranchComplete(branch appwire.JobActivityBranchState) bool {
 }
 
 // trimActivityTreeToFit repeatedly drops the tree's trailing entry until it
-// encodes within activityMaxEncodedBytes. delegatesEpoch, jobsEpochs, and
-// revision feed every continuation trimming mints — see
-// trimActivityTrailingEntry.
-func trimActivityTreeToFit(tree appwire.JobActivityTree, rootID string, delegatesEpoch uint64, jobsEpochs map[string]uint64, revision uint64) (appwire.JobActivityTree, error) {
+// encodes within activityMaxEncodedBytes. startDepth/resumeIndex are
+// projectBoundedActivityTree's own projection inputs, threaded through so a
+// minted continuation can name an ABSOLUTE entry index — see
+// trimActivityTrailingEntry. delegatesEpoch, jobsEpochs, and revision feed
+// every continuation trimming mints.
+func trimActivityTreeToFit(tree appwire.JobActivityTree, rootID string, startDepth, resumeIndex int, delegatesEpoch uint64, jobsEpochs map[string]uint64, revision uint64) (appwire.JobActivityTree, error) {
 	for {
 		recomputeActivitySession(&tree.Root)
 		raw, err := json.Marshal(tree)
@@ -1324,7 +1326,7 @@ func trimActivityTreeToFit(tree appwire.JobActivityTree, rootID string, delegate
 		if len(raw) <= activityMaxEncodedBytes {
 			return tree, nil
 		}
-		if !trimActivityTrailingEntry(&tree.Root, rootID, nil, delegatesEpoch, jobsEpochs, revision) {
+		if !trimActivityTrailingEntry(&tree.Root, rootID, nil, startDepth, resumeIndex, delegatesEpoch, jobsEpochs, revision) {
 			return tree, nil
 		}
 	}
@@ -1343,19 +1345,34 @@ func trimActivityTreeToFit(tree appwire.JobActivityTree, rootID string, delegate
 // Carrying all three lets a resumed continuation's staleness check
 // actually detect a rewrite — or, for a live root, a mutation — that raced
 // this trim.
-func trimActivityTrailingEntry(session *appwire.JobActivitySession, rootID string, path []string, delegatesEpoch uint64, jobsEpochs map[string]uint64, revision uint64) bool {
+//
+// depth and resumeIndex are projectActivitySessionAt's own projection inputs,
+// not trimming's: depth is the same counter projection walked the tree with
+// (starting at startDepth, +1 per delegate hop), and resumeIndex is how many
+// of the continuation TARGET's leading entries projection skipped. Only the
+// target sits at depth 0 — projectActivitySessionAt applies resumeIndex there
+// and nowhere else — so the entry this session loses is named absolutely by
+// resumeIndex+i for the target and by i alone for every other visited session.
+func trimActivityTrailingEntry(session *appwire.JobActivitySession, rootID string, path []string, depth, resumeIndex int, delegatesEpoch uint64, jobsEpochs map[string]uint64, revision uint64) bool {
 	if session == nil || len(session.Entries) == 0 {
 		return false
 	}
 	i := len(session.Entries) - 1
 	entry := &session.Entries[i]
 	if entry.Delegate != nil && entry.Delegate.Child != nil {
-		if trimActivityTrailingEntry(entry.Delegate.Child, rootID, appendActivityPath(path, entry.Delegate.DelegateID), delegatesEpoch, jobsEpochs, revision) {
+		if trimActivityTrailingEntry(entry.Delegate.Child, rootID, appendActivityPath(path, entry.Delegate.DelegateID), depth+1, resumeIndex, delegatesEpoch, jobsEpochs, revision) {
 			return true
 		}
 	}
 	session.Entries = session.Entries[:i]
 	session.Branch.Truncated = true
+	// i is a position within the ALREADY-RESUMED page. Add the page's resume
+	// offset back for the one session projection applied it to, or a trim on
+	// page 2+ mints an index pointing back inside the page just returned and
+	// paging repeats it forever.
+	if depth == 0 {
+		i += resumeIndex
+	}
 	session.Branch.Continuation = encodeActivityContinuation(activityContinuation{
 		Version:        activityContinuationV1,
 		RootID:         rootID,

--- a/agent/jobs_activity_branches_test.go
+++ b/agent/jobs_activity_branches_test.go
@@ -435,7 +435,7 @@ func TestTrimActivityTreeToFit(t *testing.T) {
 			Entries: []appwire.JobActivityEntry{{Kind: "shell", Job: new(appwire.JobActivityJob{JobID: "j1"})}},
 		},
 	}
-	got, err := trimActivityTreeToFit(tree, "root", 0, nil, 0)
+	got, err := trimActivityTreeToFit(tree, "root", 0, 0, 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +466,7 @@ func TestTrimActivityTreeToFit_TrimsExcessEntries(t *testing.T) {
 			Entries: entries,
 		},
 	}
-	got, err := trimActivityTreeToFit(tree, "root", 0, nil, 0)
+	got, err := trimActivityTreeToFit(tree, "root", 0, 0, 0, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -484,10 +484,10 @@ func TestTrimActivityTreeToFit_TrimsExcessEntries(t *testing.T) {
 func TestTrimActivityTrailingEntry_EmptyReturnsFalse(t *testing.T) {
 	t.Parallel()
 	session := &appwire.JobActivitySession{SessionID: "root"}
-	if trimActivityTrailingEntry(session, "root", nil, 0, nil, 0) {
+	if trimActivityTrailingEntry(session, "root", nil, 0, 0, 0, nil, 0) {
 		t.Error("empty entries should return false")
 	}
-	if trimActivityTrailingEntry(nil, "root", nil, 0, nil, 0) {
+	if trimActivityTrailingEntry(nil, "root", nil, 0, 0, 0, nil, 0) {
 		t.Error("nil session should return false")
 	}
 }
@@ -506,7 +506,7 @@ func TestTrimActivityTrailingEntry_DelegateChildRecurses(t *testing.T) {
 			{Kind: "delegate", Delegate: &appwire.JobActivityDelegate{DelegateID: "dlg_1", Child: child}},
 		},
 	}
-	if !trimActivityTrailingEntry(session, "root", nil, 0, nil, 0) {
+	if !trimActivityTrailingEntry(session, "root", nil, 0, 0, 0, nil, 0) {
 		t.Fatal("expected trailing entry to be trimmed")
 	}
 	// The recursive call trims the child's entry and returns true; the
@@ -547,7 +547,7 @@ func TestTrimActivityTrailingEntry_EmbedsEpochsInContinuation(t *testing.T) {
 		},
 	}
 	jobsEpochs := map[string]uint64{"root": 7, "child": 42}
-	if !trimActivityTrailingEntry(session, "root", nil, 9, jobsEpochs, 17) {
+	if !trimActivityTrailingEntry(session, "root", nil, 0, 0, 9, jobsEpochs, 17) {
 		t.Fatal("expected trailing entry to be trimmed")
 	}
 	if child.Branch.Continuation == "" {

--- a/agent/jobs_activity_past_test.go
+++ b/agent/jobs_activity_past_test.go
@@ -1042,3 +1042,78 @@ func TestLoadSessionJobActivityTree_SizeTrimResumesAfterRemovedEntriesWithoutOve
 		}
 	}
 }
+
+// TestLoadSessionJobActivityTree_SizeTrimResumeIndexAdvancesAcrossPages is the
+// 60-job form of the walk above: enough ordinary jobs, each large enough that
+// a page size-trims, that page 2 or later must trim BEFORE returning every
+// remaining entry. trimActivityTrailingEntry mints the continuation's
+// ResumeIndex from the trimmed entry's position in the ALREADY-RESUMED page;
+// if that index is page-relative rather than the session's absolute entry
+// index, the minted token points back inside the page just returned and the
+// next page repeats it forever. The 20-job fixture never trims on page 2, so
+// only a strictly advancing token across this longer walk can see it. The
+// observable assertion: every page's minted ResumeIndex is strictly greater
+// than the previous page's, ending at the last job with zero overlap and zero
+// gap.
+func TestLoadSessionJobActivityTree_SizeTrimResumeIndexAdvancesAcrossPages(t *testing.T) {
+	stateDir := t.TempDir()
+	rootID := "advancingtrimroot"
+	const jobCount = 60
+	description := strings.Repeat("d", 250_000)
+	var events []jobstore.Event
+	for i := range jobCount {
+		ts := time.Unix(int64(100+i), 0).UTC()
+		events = append(events, jobstore.Event{
+			Kind: jobstore.EventJobStarted, TS: ts, JobID: fmt.Sprintf("job_%02d", i),
+			Type: jobstore.JobShell, OwnerSessionID: rootID, VisibleToSession: rootID,
+			StartedAt: &ts, Description: description,
+		})
+	}
+	s1cov_writeJobLog(t, stateDir, rootID, events...)
+	savePastActivityMeta(t, stateDir, rootID, "Root")
+
+	var delivered []string
+	continuation := ""
+	lastResumeIndex := -1
+	pages := 0
+	for {
+		pages++
+		if pages > jobCount+1 {
+			t.Fatalf("too many pages (%d) without terminating -- resume is looping instead of advancing", pages)
+		}
+		tree, err := LoadSessionJobActivityTree(context.Background(), stateDir, rootID, appwire.JobsListParams{Continuation: continuation})
+		if err != nil {
+			t.Fatalf("page %d: %v", pages, err)
+		}
+		for _, entry := range tree.Root.Entries {
+			if entry.Job == nil {
+				t.Fatalf("page %d entry without a Job: %+v", pages, entry)
+			}
+			delivered = append(delivered, entry.Job.JobID)
+		}
+		if tree.Root.Branch.Continuation == "" {
+			break
+		}
+		cont, err := decodeActivityContinuation(tree.Root.Branch.Continuation, rootID)
+		if err != nil {
+			t.Fatalf("page %d decode continuation: %v", pages, err)
+		}
+		if cont.ResumeIndex <= lastResumeIndex {
+			t.Fatalf("page %d minted ResumeIndex %d, which did not advance past the previous page's %d -- the minted index points back inside the page just returned, so paging repeats", pages, cont.ResumeIndex, lastResumeIndex)
+		}
+		lastResumeIndex = cont.ResumeIndex
+		continuation = tree.Root.Branch.Continuation
+	}
+	if pages < 2 {
+		t.Fatalf("got %d page(s), want at least 2 -- the fixture must be large enough to force a size trim", pages)
+	}
+	if len(delivered) != jobCount {
+		t.Fatalf("delivered %d entries across %d pages, want exactly %d (zero overlap, zero gap): %v", len(delivered), pages, jobCount, delivered)
+	}
+	for i, id := range delivered {
+		want := fmt.Sprintf("job_%02d", i)
+		if id != want {
+			t.Fatalf("delivered[%d] = %q, want %q -- entries must arrive in order across pages with zero overlap and zero gap: %v", i, id, want, delivered)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1177.

`trimActivityTrailingEntry` minted its resume index from a page-relative position, but the projection had already skipped the page's absolute resume offset. On page 2+ the token therefore pointed back inside the page just returned and paging repeated. The page's absolute offset is now threaded through the trim, and a 60-job walk asserts the token strictly advances.

## Evidence

- pre-fix: page 2 minted `ResumeIndex 16`, which did not advance past the previous page's 16
- post-fix: `TestLoadSessionJobActivityTree_SizeTrimResumeIndexAdvancesAcrossPages` PASS; full agent suite green except the pre-existing `agent/sandbox` bwrap environment failures

Pairs with #1172; both edit `trimActivityTrailingEntry`, and the combined result must mint an absolute index (and, for the single-oversized case at depth 0, one past the dropped entry).
