### PR TITLE
fix(web): omit the line range for binary tool reads

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.test.tsx
@@ -54,6 +54,34 @@ test("read_file: body renders the output text", () => {
   expect(screen.getByText("file contents here")).toBeTruthy();
 });
 
+// --- read_file summary: binary reads have no line range (issue #1174) ------
+// A binary read's output is only the newline-free "[image: ...]" / "[document:
+// ...]" header. readLineRange counts "\n" characters and would report "lines
+// 1" for that empty count, so the summary must omit the range entirely rather
+// than render "Read docs/shot.png · lines 1".
+
+test("read_file: an image read's summary omits the line range - the binary header has no lines", () => {
+  const d = toolRendererFor("read_file");
+  const args = JSON.stringify({ file_path: "docs/shot.png" });
+  const output = "[image: PNG, 123 bytes, base64 data follows]";
+  expect(d.summary(item({ toolName: "read_file", argumentsJSON: args, output }))).toBe("Read docs/shot.png");
+});
+
+test("read_file: a document (PDF) read's summary omits the line range too", () => {
+  const d = toolRendererFor("read_file");
+  const args = JSON.stringify({ file_path: "docs/report.pdf" });
+  const output = "[document: pdf, 90210 bytes, base64 data follows]";
+  expect(d.summary(item({ toolName: "read_file", argumentsJSON: args, output }))).toBe("Read docs/report.pdf");
+});
+
+test("read_file: a text read's summary still shows the derived line range", () => {
+  const d = toolRendererFor("read_file");
+  const args = JSON.stringify({ file_path: "src/app.ts" });
+  expect(d.summary(item({ toolName: "read_file", argumentsJSON: args, output: "a\nb\nc\n" }))).toBe(
+    "Read src/app.ts · lines 1-3",
+  );
+});
+
 // --- read_file body: image/document marker (kata 1nr4) --------------------
 // An image read's body renders nothing: the image displays below via
 // ToolCallItem's ImageGallery at read_file's up-to-600px size, so the

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/fsTools.tsx
@@ -82,7 +82,12 @@ registerToolRenderer({
   autoExpand: isImageRead,
   summary(item: ItemModel) {
     const args = parseArgs(item.argumentsJSON);
-    return `Read ${readFileTarget(item)} · ${readLineRange(args, item.output ?? "")}`;
+    const target = readFileTarget(item);
+    // A binary read's output is only the newline-free "[image|document: ...]"
+    // header, so it has no lines to report. readLineRange counts "\n" chars and
+    // would otherwise report a bogus "lines 1" for that zero count (issue #1174).
+    if (BINARY_PAYLOAD_HEADER.test(item.output ?? "")) return `Read ${target}`;
+    return `Read ${target} · ${readLineRange(args, item.output ?? "")}`;
   },
   body: ReadFileOutputBody,
   // read_file references a single file (floor §3.7): expose it for the "open


### PR DESCRIPTION
Fixes #1174.

A binary `read_file` returns a newline-free payload header, so `readLineRange` counted zero newlines and rendered `lines 1` beside an image or PDF read. The line-range suffix is now omitted when the output is the binary payload header; text reads are unchanged.

## Evidence

- pre-fix: `2 failed | 29 passed` in `fsTools.test.tsx`
- post-fix: `31 passed`; `npm run typecheck` PASS
