### PR TITLE
fix(web): export ActivityNodeLike from the protocol root

### DIFF
--- a/cmd/evener-hub/frontend/src/protocol/activityData.ts
+++ b/cmd/evener-hub/frontend/src/protocol/activityData.ts
@@ -196,7 +196,7 @@ type ActivityIdentity =
   | { kind: "delegate"; delegateId: string }
   | { kind: "shell"; jobId: string };
 
-type ActivityNodeLike = ActivityIdentity | ActivitySessionNode | ActivityShellEntry | ActivityDelegateEntry;
+export type ActivityNodeLike = ActivityIdentity | ActivitySessionNode | ActivityShellEntry | ActivityDelegateEntry;
 
 type TreeIndex = {
   ids: Set<string>;

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -6,6 +6,7 @@ export type {
   ActivityDisclosureState,
   ActivityEntry,
   ActivityJob,
+  ActivityNodeLike,
   ActivitySessionNode,
   ActivityShellEntry,
   ActivityTree,

--- a/cmd/evener-hub/frontend/src/protocol/publicExports.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/publicExports.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { type ActivityNodeLike, activityNodeID } from "./index";
+
+// activityNodeID's parameter type is part of the package's public surface: an
+// installed consumer must be able to name it. Import it from the package root
+// in a type position so a missing re-export fails compilation here.
+describe("protocol package root public exports", () => {
+  it("re-exports the type that activityNodeID's parameter uses", () => {
+    const nodes: ActivityNodeLike[] = [
+      { kind: "session", sessionId: "s1" },
+      { kind: "delegate", delegateId: "d1" },
+      { kind: "shell", jobId: "j1" },
+    ];
+    expect(nodes.map(activityNodeID)).toEqual(["session:s1", "delegate:d1", "job:j1"]);
+  });
+});

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -136,6 +136,7 @@ async function qualify() {
     "AppwireClientLike",
     "WebSocketLike",
     "AskAnswerItem",
+    "ActivityNodeLike",
     "ActivityTree",
     "ActivityState",
     "ItemFailureSignals",


### PR DESCRIPTION
Fixes #1185.

`activityNodeID` is exported and takes `ActivityNodeLike`, but that alias was unexported and absent from the protocol root's type re-exports, so an installed consumer of `@evener/appwire-client` could not name the parameter type even though declaration emit inlined it. The alias is now exported and re-exported, with a root type-position test and a package-qualification assertion.

## Evidence

- pre-fix: `TS2724: '"./index"' has no exported member named 'ActivityNodeLike'`
- post-fix: `npm run typecheck` PASS; `make test-api-package` PASS (qualified `@evener/appwire-client@0.1.0`); negative control confirms the runner bites
