### PR TITLE
fix(evener-dev): write the agent-shards survey cache atomically

### DIFF
--- a/cmd/evener-dev/agentshards.go
+++ b/cmd/evener-dev/agentshards.go
@@ -295,11 +295,18 @@ func runShards(cfg shardsConfig) int {
 	var costs []testCost
 	if !cfg.noSurvey {
 		surveyLog := filepath.Join(logdir, "survey.log")
+		cacheHit := false
 		if !cfg.resurvey && fileHasContent(cachedSurvey) {
-			if data, err := os.ReadFile(cachedSurvey); err == nil {
+			if data, err := os.ReadFile(cachedSurvey); err == nil && cfg.surveyCoversTestSet(data, listOut) {
 				_ = os.WriteFile(surveyLog, data, 0o644)
+				cacheHit = true
 			}
-		} else {
+			// An unreadable cache, or one measuring only part of the current
+			// test set, is no cache at all: survey. The shared cache is
+			// written by concurrent gate runs, so a nonempty file can be a
+			// partial write caught mid-flight.
+		}
+		if !cacheHit {
 			_, _ = fmt.Fprintln(cfg.stdout, "agent-shards: surveying test costs (one-time for this test set)")
 			args := surveyArgs(cfg.surveyParallel, cfg.skip, slices.Contains(cfg.flags, "-short"))
 			if err := cfg.runToLog(in, surveyLog, cfg.agentDir, build, args...); err != nil {
@@ -313,7 +320,7 @@ func runShards(cfg shardsConfig) int {
 			}
 			if cachedSurvey != "" {
 				if data, err := os.ReadFile(surveyLog); err == nil {
-					_ = os.WriteFile(cachedSurvey, data, 0o644)
+					_ = writeFileAtomic(cachedSurvey, data)
 				}
 			}
 		}
@@ -463,6 +470,68 @@ func (cfg shardsConfig) cachedSurveyPath(listOut string) string {
 		return ""
 	}
 	return filepath.Join(cacheDir, "survey-"+testSetKey(listOut)+".log")
+}
+
+// surveyCoversTestSet reports whether a cached survey accounts for every test
+// this run must shard. The cache is keyed by test-set identity and written by
+// concurrent gate runs; a nonempty file can be a partial write caught
+// mid-flight, in which case accepting it would pack shards over the subset it
+// measured and still report green while the rest run in no shard. Tests the
+// survey deliberately skips (the -test.skip regex) are exempt: they draw no
+// cost line by design.
+func (cfg shardsConfig) surveyCoversTestSet(data []byte, listOut string) bool {
+	have := map[string]bool{}
+	for _, tc := range parseSurvey(string(data)) {
+		have[tc.name] = true
+	}
+	var skip *regexp.Regexp
+	if cfg.skip != "" {
+		skip, _ = regexp.Compile(cfg.skip)
+	}
+	for _, tc := range equalWeights(listOut) {
+		if skip != nil && skip.MatchString(tc.name) {
+			continue
+		}
+		if !have[tc.name] {
+			return false
+		}
+	}
+	return true
+}
+
+// writeFileAtomic replaces path with data by writing a uniquely named temp
+// file in the same directory and renaming it into place. A reader sharing the
+// path — the survey cache is shared across concurrent gate runs — therefore
+// only ever observes a complete prior survey or a complete new one, never a
+// truncated in-place write.
+func writeFileAtomic(path string, data []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if tmpName != "" {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	// CreateTemp's files are 0o600; the cache was written 0o644.
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	tmpName = ""
+	return nil
 }
 
 // runToLog runs a child in its own process group with both output streams in

--- a/cmd/evener-dev/agentshards_cache_test.go
+++ b/cmd/evener-dev/agentshards_cache_test.go
@@ -1,0 +1,117 @@
+package dev
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// shardedTestCount sums the "(N tests)" figures the PASS lines report, the
+// number of tests the run actually placed into shards.
+func shardedTestCount(t *testing.T, out string) int {
+	t.Helper()
+	total := 0
+	for line := range strings.SplitSeq(out, "\n") {
+		var shard, n int
+		var seconds float64
+		if _, err := fmt.Sscanf(line, "PASS  agent:%d %fs (%d tests)", &shard, &seconds, &n); err == nil {
+			total += n
+		}
+	}
+	return total
+}
+
+// TestAgentShardsRejectsPartialSurveyCache pins the concurrent gate-run
+// hazard from #1192: the survey cache is shared across runs, and a reader
+// that accepts a nonempty but partial cache packs shards over only the
+// tests it measured, then reports green while the rest run in no shard.
+// A cache that does not cover the current test set must be rejected and
+// the survey re-run.
+func TestAgentShardsRejectsPartialSurveyCache(t *testing.T) {
+	cfg, _, _, _ := e2eConfig(t)
+
+	// First run populates the cache with a complete survey.
+	var firstOut, firstErr bytes.Buffer
+	cfg.stdout, cfg.stderr = &firstOut, &firstErr
+	if rc := runShards(cfg); rc != 0 {
+		t.Fatalf("priming run rc = %d\nstdout:\n%s\nstderr:\n%s", rc, &firstOut, &firstErr)
+	}
+	cached, err := filepath.Glob(filepath.Join(cfg.cacheDir, "survey-*.log"))
+	if err != nil || len(cached) != 1 {
+		t.Fatalf("survey cache not written: %v %v", cached, err)
+	}
+	total := shardedTestCount(t, firstOut.String())
+	if total == 0 {
+		t.Fatalf("priming run sharded no tests:\n%s", &firstOut)
+	}
+
+	// Simulate a second run observing the cache mid-write: nonempty, but
+	// carrying costs for only two of the fixture's tests.
+	partial := "=== RUN   TestFixtureAlpha\n--- PASS: TestFixtureAlpha (0.03s)\n" +
+		"=== RUN   TestFixtureDelta\n--- PASS: TestFixtureDelta (0.00s)\n"
+	if err := os.WriteFile(cached[0], []byte(partial), 0o644); err != nil {
+		t.Fatalf("seeding partial cache: %v", err)
+	}
+
+	cfg2 := cfg
+	var stdout2, stderr2 bytes.Buffer
+	cfg2.stdout, cfg2.stderr = &stdout2, &stderr2
+	if rc := runShards(cfg2); rc != 0 {
+		t.Fatalf("partial-cache rerun rc = %d\nstdout:\n%s\nstderr:\n%s", rc, &stdout2, &stderr2)
+	}
+	if !strings.Contains(stdout2.String(), "surveying test costs") {
+		t.Fatalf("a cache covering only a subset of the test set was accepted; the run did not re-survey:\n%s", &stdout2)
+	}
+	if got := shardedTestCount(t, stdout2.String()); got != total {
+		t.Fatalf("partial-cache rerun sharded %d tests, want %d; the remaining tests ran in no shard:\n%s", got, total, &stdout2)
+	}
+}
+
+// TestWriteFileAtomicReplacesTheDestinationInode pins the atomic-replace
+// mechanism: a replacement must land on a new inode via rename, never by
+// rewriting the shared destination in place, and it must not leave its
+// temporary file behind.
+func TestWriteFileAtomicReplacesTheDestinationInode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "survey.log")
+
+	if err := writeFileAtomic(path, []byte("first\n")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	if err := writeFileAtomic(path, []byte("second\n")); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(data) != "second\n" {
+		t.Fatalf("content = %q, want %q", data, "second\n")
+	}
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if os.SameFile(before, after) {
+		t.Fatalf("replacement reused the destination inode; the write was in place, not an atomic rename")
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading dir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("directory holds %v, want only the destination; a temp file leaked", names)
+	}
+}


### PR DESCRIPTION
Fixes #1192.

The agent-shards survey cache is shared across concurrent gate runs and was written in place. A reader could parse a partially written file, derive costs for a subset of tests, pack shards over that subset, and still report green while the remaining tests ran in no shard. The cache is now written by temp-file-and-rename, and a cache that does not cover the current test set is rejected in favour of a fresh survey.

## Evidence

- pre-fix: `TestAgentShardsRejectsPartialSurveyCache` FAIL (2 shards over 2 of 6 tests, no resurvey)
- post-fix: `go test ./cmd/evener-dev/ -count=1` PASS; `go vet ./cmd/evener-dev/` clean; `gofmt` clean

Follow-up worth noting, deliberately left out of scope here: `writeFileAtomic` duplicates the intent of `internal/plugins.atomicWriteFile`. Consolidating them would mean exporting that helper from a domain package or introducing a shared package, which touches unrelated code.
