### PR TITLE
refactor(protocol): move activityRows into the package (SDK C13)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityRowDetail.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityRowDetail.test.tsx
@@ -2,10 +2,10 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ActivityDelegate, ActivityJob, ActivitySessionNode } from "../../../protocol/activityData";
+import type { ActivityDelegateRow, ActivityJobRow } from "../../../protocol/activityRows";
 import { connectionStore } from "../../../stores/connection";
 import { threadsStore } from "../../../stores/threads";
 import { ActivityRowDetail } from "./ActivityRowDetail";
-import type { ActivityDelegateRow, ActivityJobRow } from "./activityRows";
 
 // Pinned clock: every quiet-age assertion below measures against this instant.
 const NOW = Date.parse("2026-08-05T15:00:12.000Z");

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityRowDetail.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityRowDetail.tsx
@@ -5,6 +5,7 @@
 // except the one output-tail fetch; ActivityTree owns the detailID state and
 // passes the row plus its ticking `now` straight through.
 import { Fragment, type JSX, useEffect, useState } from "react";
+import { type ActivityDelegateRow, type ActivityJobRow, activityDelegateState } from "../../../protocol/activityRows";
 import { connectionStore } from "../../../stores/connection";
 import { threadsStore } from "../../../stores/threads";
 import { parseAnsiLines } from "../../../widgets/codeblock/ansi";
@@ -15,7 +16,6 @@ import { Markdown } from "../../../widgets/markdown";
 import { formatClockTime, splitMandate } from "../transcript/messages/format";
 import { formatQuietAge, quietAnchorMillis } from "./activityFormat";
 import styles from "./activitypanel.module.css";
-import { type ActivityDelegateRow, type ActivityJobRow, activityDelegateState } from "./activityRows";
 
 const CLASS = {
   detailStrip: requireClass(styles.detailStrip, "activitypanel.module.css", "detailStrip"),

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityTree.tsx
@@ -20,12 +20,6 @@ import {
   type ActivityTree as ActivityTreeData,
   activityNodeID,
 } from "../../../protocol/activityData";
-import { Button, Chevron } from "../../../widgets";
-import { requireClass } from "../../../widgets/internal/requireClass";
-import { OpenTranscriptButton } from "../transcript/openTranscript";
-import { ActivityRowDetail } from "./ActivityRowDetail";
-import { formatQuietAge, formatUsagePair, jobStatusDotState, quietAnchorMillis } from "./activityFormat";
-import styles from "./activitypanel.module.css";
 import {
   type ActivityDelegateRow,
   type ActivityFoldRow,
@@ -34,7 +28,13 @@ import {
   activityDelegateState,
   buildActivityRows,
   jobIsFailed,
-} from "./activityRows";
+} from "../../../protocol/activityRows";
+import { Button, Chevron } from "../../../widgets";
+import { requireClass } from "../../../widgets/internal/requireClass";
+import { OpenTranscriptButton } from "../transcript/openTranscript";
+import { ActivityRowDetail } from "./ActivityRowDetail";
+import { formatQuietAge, formatUsagePair, jobStatusDotState, quietAnchorMillis } from "./activityFormat";
+import styles from "./activitypanel.module.css";
 
 export interface ActivityTreeProps {
   tree: ActivityTreeData;

--- a/cmd/evener-hub/frontend/src/protocol/activityRows.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/activityRows.test.ts
@@ -1,10 +1,5 @@
 import { expect, test } from "vitest";
-import type {
-  ActivityJob,
-  ActivitySessionNode,
-  ActivityShellEntry,
-  ActivityTree,
-} from "../../../protocol/activityData";
+import type { ActivityJob, ActivitySessionNode, ActivityShellEntry, ActivityTree } from "./activityData";
 import { activityDelegateState, buildActivityRows, foldRowID } from "./activityRows";
 
 function shell(jobId: string, terminal: boolean, status = terminal ? "completed" : "running") {

--- a/cmd/evener-hub/frontend/src/protocol/activityRows.ts
+++ b/cmd/evener-hub/frontend/src/protocol/activityRows.ts
@@ -17,8 +17,8 @@ import {
   isFailedDelegateOutcome,
   isFailedJobOutcome,
   isTurnContainer,
-} from "../../../protocol/activityData";
-import { stableDelegateDisplayStatus } from "../../../protocol/stableDelegate";
+} from "./activityData";
+import { stableDelegateDisplayStatus } from "./stableDelegate";
 
 export interface ActivityRowBase {
   id: string;

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -26,6 +26,15 @@ export {
 export type { ActivityBranch, ActivityClient, ActivityState } from "./activityList";
 export { ActivityList } from "./activityList";
 export { fenceRootSession, graftContinuationTree } from "./activityMerge";
+export type {
+  ActivityDelegateRow,
+  ActivityDelegateState,
+  ActivityFoldRow,
+  ActivityJobRow,
+  ActivityRow,
+  ActivityRowBase,
+} from "./activityRows";
+export { activityDelegateState, buildActivityRows, foldRowID, jobIsFailed } from "./activityRows";
 export type { AskAnswerItem, AskResolution } from "./askAnswers";
 export { composeAskAnswers } from "./askAnswers";
 export type { AnyNotification, AppwireClientOptions, ConnectionState, TerminalReason } from "./client";

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -42,6 +42,7 @@ async function qualify() {
     "activityData",
     "activityList",
     "activityMerge",
+    "activityRows",
     "itemFailure",
     "jobOutput",
     "model",
@@ -91,6 +92,10 @@ async function qualify() {
     "ActivityList",
     "fenceRootSession",
     "graftContinuationTree",
+    "foldRowID",
+    "jobIsFailed",
+    "activityDelegateState",
+    "buildActivityRows",
     "hasItemFailure",
     "hasErrorText",
     "hasFailureStatus",
@@ -126,6 +131,7 @@ async function qualify() {
     "AskAnswerItem",
     "ActivityTree",
     "ActivityState",
+    "ActivityRow",
     "ItemFailureSignals",
     "JobLogTail",
     "ThreadModel",
@@ -163,6 +169,10 @@ assert(Array.isArray(client.defaultExpandedIDs(tree)));
 assert.equal(client.isActivityFailure("failure", undefined), true);
 assert.equal(client.fenceRootSession(session, session).sessionId, "thread");
 assert.equal(client.graftContinuationTree(tree, "session:thread", tree).revision, 1);
+assert.equal(client.foldRowID("session:thread"), "session:thread:inactive-fold");
+assert.deepEqual(client.buildActivityRows(tree, new Set()), []);
+assert.equal(client.jobIsFailed({ terminal: true, outcome: "failure" }), true);
+assert.equal(client.activityDelegateState({ kind: "delegate", type: "task", child: session }).failed, false);
 assert.equal(client.hasItemFailure({ status: "completed", exitCode: 1 }), true);
 assert.equal(client.hasFailureStatus({ status: "interrupted" }), true);
 assert.equal(client.hasErrorText({ error: "  " }), false);

--- a/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
+++ b/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
@@ -20,6 +20,7 @@
     "types.gen.ts",
     "askAnswers.ts",
     "activityData.ts",
+    "activityRows.ts",
     "activityList.ts",
     "activityMerge.ts",
     "itemFailure.ts",

--- a/mobile-native/src/ActivitySheet.tsx
+++ b/mobile-native/src/ActivitySheet.tsx
@@ -14,11 +14,11 @@ import {
   View,
 } from "react-native";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
+import { ActivityList } from "../../cmd/evener-hub/frontend/src/protocol/activityList";
 import {
   type ActivityRow,
   buildActivityRows,
-} from "../../cmd/evener-hub/frontend/src/panes/session/chrome/activityRows";
-import { ActivityList } from "../../cmd/evener-hub/frontend/src/protocol/activityList";
+} from "../../cmd/evener-hub/frontend/src/protocol/activityRows";
 import { stableDelegateDisplayStatus } from "../../cmd/evener-hub/frontend/src/protocol/stableDelegate";
 import { parseAnsiLines } from "../../cmd/evener-hub/frontend/src/widgets/codeblock/ansi";
 import type { ConversationClientLike } from "../../mobile/src/services/conversation";


### PR DESCRIPTION
Plan row: C13 in `docs/superpowers/plans/2026-09-12-sdk-migration.md`

## What moved

`cmd/evener-hub/frontend/src/panes/session/chrome/activityRows.ts` (208 lines)
→ `cmd/evener-hub/frontend/src/protocol/activityRows.ts`, via `git mv` so
history follows. `activityRows.test.ts` (397 lines) moved alongside and stays
the oracle — no logic changes on either side; the only edits inside the two
files are the intra-package imports collapsing from
`../../../protocol/activityData` to `./activityData` (and `./stableDelegate`).

The module was safe to move without extraction: its only imports were
`protocol/activityData` and `protocol/stableDelegate`, both already shipped.

## The three plumbing sites (phase-C rule)

- `protocol/tsconfig.build.json` `files` gains `activityRows.ts`.
- `protocol/index.ts` re-exports the four runtime symbols
  (`activityDelegateState`, `buildActivityRows`, `foldRowID`, `jobIsFailed`)
  and six types (`ActivityDelegateRow`, `ActivityDelegateState`,
  `ActivityFoldRow`, `ActivityJobRow`, `ActivityRow`, `ActivityRowBase`) in
  alphabetical position.
- `scripts/qualify-package.mjs`: `activityRows` in `shippedModules`, the four
  symbols in `rootValues`, `ActivityRow` in `rootTypes`, and four real calls
  added to the root smoke program — `foldRowID`, `buildActivityRows`,
  `jobIsFailed` and `activityDelegateState` all execute in the bare Node
  consumer.

The runner entry is load-bearing, checked by falsification: with the
`index.ts` re-export removed, `make test-api-package` fails with
`shipped module unreachable from every published specifier: activityRows`.
Worth noting for later C rows: adding the module to `tsconfig.build.json`
alone does **not** turn the gate red — the tarball allowlist admits anything
under `package/dist/`, so the gate stays green while saying nothing about the
module, exactly as the phase-C intro warns. The `shippedModules` entry is what
arms the reachability assertion.

## Importers rewritten

Web (deep relative into `protocol/`, matching neighbouring imports since A4
has not landed):
- `panes/session/chrome/ActivityTree.tsx`
- `panes/session/chrome/ActivityRowDetail.tsx`
- `panes/session/chrome/ActivityRowDetail.test.tsx` (not in the original row
  note, but it imports the two row types)

Native (existing deep path, retargeted):
- `mobile-native/src/ActivitySheet.tsx`

A repo-wide grep for `activityRows` leaves only two hits outside the moved
files: a comment in `protocol/activityMerge.test.ts` naming the test file (its
new sibling) and the historical 2026-08-05 / 2026-08-12 plan documents, which
record where the file was created and are not edited. No test spies on the
module path.

## Gates

- `make test-api-package` — PASS (and demonstrably FAILS without the manifest entry)
- `make test-web` — PASS (typecheck, test, lint)
- `make test-native` — PASS (740 + 777 tests, `tsc --noEmit`)
- `make test-web-browser` — PASS (all five guards), per plan rule 1 for a package-touching PR

Biome `check --write` was run over the touched files under
`cmd/evener-hub/frontend/src` only; `mobile-native/` was deliberately left
alone (no biome config there).