### PR TITLE
refactor(protocol): move the message display formatters into the package (SDK C26)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityRowDetail.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/ActivityRowDetail.tsx
@@ -6,6 +6,7 @@
 // passes the row plus its ticking `now` straight through.
 import { Fragment, type JSX, useEffect, useState } from "react";
 import { type ActivityDelegateRow, type ActivityJobRow, activityDelegateState } from "../../../protocol/activityRows";
+import { formatClockTime, splitMandate } from "../../../protocol/displayFormat";
 import { connectionStore } from "../../../stores/connection";
 import { threadsStore } from "../../../stores/threads";
 import { parseAnsiLines } from "../../../widgets/codeblock/ansi";
@@ -13,7 +14,6 @@ import { AnsiLineContent } from "../../../widgets/codeblock/ansiLine";
 import { Disclosure } from "../../../widgets/disclosure";
 import { requireClass } from "../../../widgets/internal/requireClass";
 import { Markdown } from "../../../widgets/markdown";
-import { formatClockTime, splitMandate } from "../transcript/messages/format";
 import { formatQuietAge, quietAnchorMillis } from "./activityFormat";
 import styles from "./activitypanel.module.css";
 

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/DetailsPanel.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/DetailsPanel.tsx
@@ -30,10 +30,10 @@
 // beside it was. An absent cost (no token data, or an uncataloged model) is an
 // honest unknown and renders no row at all.
 import { forwardRef, useImperativeHandle, useState } from "react";
+import { formatTokenCount } from "../../../protocol/displayFormat";
 import type { ThreadModel } from "../../../protocol/model";
 import { Button, InspectorCard, Meter, Sheet } from "../../../widgets";
 import { requireClass } from "../../../widgets/internal/requireClass";
-import { formatTokenCount } from "../transcript/messages/format";
 import { formatTimestamp, sessionTokens } from "./detailsAccounting";
 import styles from "./detailspanel.module.css";
 import { contextTone, formatWorkDuration, modelLabel, totalWorkMillis } from "./statusFormat";

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/activityFormat.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/activityFormat.ts
@@ -1,8 +1,8 @@
 // Pure formatting helpers for the dense activity tree rows. Kept React-free so
-// each is trivially unit-testable (same contract as transcript/messages/format).
+// each is trivially unit-testable (same contract as protocol/displayFormat).
 
 import { type ActivityUsage, isActivityFailure } from "../../../protocol/activityData";
-import { formatTokenCount } from "../transcript/messages/format";
+import { formatTokenCount } from "../../../protocol/displayFormat";
 
 // formatUsagePair renders a delegate row's token cluster ("↑41k ↓6k"), or null
 // when the daemon sent no usage (old daemon, shell-only work) so the row hides

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/statusFormat.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/statusFormat.test.ts
@@ -10,7 +10,7 @@ import { contextTone, formatWorkDuration, modelLabel, totalWorkMillis } from "./
 // accumulated work time reads "Ns" under a minute, "Nm" under an hour, "Nh Nm"
 // above - the SAME bucketing the rest of the hub's duration displays use, so
 // the status row's work-time clock doesn't invent a new convention. This is
-// deliberately NOT transcript/messages/format.ts's formatDurationMs: that one
+// deliberately NOT protocol/displayFormat.ts's formatDurationMs: that one
 // is scoped to short tool-call durations (sub-second precision, no hour
 // bucket) - work time can span a whole session, hours included.
 test("clamps a zero or negative duration up to the honest minimum of 1 second", () => {

--- a/cmd/evener-hub/frontend/src/panes/session/chrome/statusFormat.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/chrome/statusFormat.ts
@@ -1,6 +1,6 @@
 // Pure formatting helpers for the session chrome's status displays. Kept
 // dependency-free (no React, no ThreadModel) so each is trivially
-// unit-testable - same convention as transcript/messages/format.ts,
+// unit-testable - same convention as protocol/displayFormat.ts,
 // deliberately not shared with it (see formatWorkDuration's own comment for
 // why).
 import type { MeterTone } from "../../../widgets";
@@ -25,7 +25,7 @@ export function contextTone(pressure: number): MeterTone {
 // shows whole seconds (floored, clamped up to a minimum of 1 so a real but
 // sub-second duration never reads "0s"); under an hour shows whole minutes
 // (floored); an hour or more shows "Nh Nm" (minutes modulo 60). This is a
-// SEPARATE convention from transcript/messages/format.ts's formatDurationMs
+// SEPARATE convention from protocol/displayFormat.ts's formatDurationMs
 // (sub-second decimal precision for short tool-call durations, no hour
 // bucket at all) - work time is a session-cumulative clock that can span
 // multiple hours, so it needs the coarser, longer-range bucketing instead.

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.test.tsx
@@ -3,6 +3,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeAll, beforeEach, expect, test } from "vitest";
+import { formatCharCount } from "../../../../protocol/displayFormat";
 import type { ItemModel, TurnModel } from "../../../../protocol/model";
 import { prefsStore, resetPrefsStoreForTests } from "../../../../stores/prefs";
 import { makeTranscriptDisplayConfig } from "../../../../transcriptDisplay/config";
@@ -11,7 +12,6 @@ import { resetDisclosureStoreForTests } from "../../../../widgets/disclosure/dis
 import { TurnBlock } from "../TurnBlock";
 import { SYSTEM_PROMPT_ITEM_ID } from "../transcriptVisibility";
 import { itemRendererFor } from "../types";
-import { formatCharCount } from "./format";
 import { SystemNoticeItem } from "./SystemNoticeItem";
 
 // See TurnSeparator.test.tsx's identical comment: Node 26 shadows jsdom's real

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/SystemNoticeItem.tsx
@@ -23,6 +23,7 @@
 // all, so no disclosure can hold it behind a summary describing a different
 // item.
 
+import { firstLine, formatCharCount, formatDurationMs } from "../../../../protocol/displayFormat";
 import type { ItemModel, TurnModel } from "../../../../protocol/model";
 import type { TranscriptMetadataVisibility } from "../../../../transcriptDisplay/projector";
 import {
@@ -41,7 +42,6 @@ import { requireClass } from "../../../../widgets/internal/requireClass";
 import { SYSTEM_PROMPT_ITEM_ID } from "../transcriptVisibility";
 import { asTurnError } from "../turnFailure";
 import { type ItemRenderProps, registerItemRenderer } from "../types";
-import { firstLine, formatCharCount, formatDurationMs } from "./format";
 import { roundTimingsSummary } from "./roundTimingsView";
 import { isTurnFailureItem, type SystemRun, shouldGroup, systemRunFor } from "./systemGrouping";
 import styles from "./systemnoticeitem.module.css";

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/ThinkBlock.tsx
@@ -45,6 +45,7 @@
 // Expanded-trace anatomy adapted from Beautiful UI's Thinking component (beautifului.dev, MIT © 2026 Shane Levine) — see LICENSES/beautiful-ui.txt.
 
 import { memo } from "react";
+import { formatTokenCount } from "../../../../protocol/displayFormat";
 import type { ItemModel, TurnModel } from "../../../../protocol/model";
 import {
   disclosureScopeForSession,
@@ -60,7 +61,6 @@ import {
 } from "../../../../widgets/disclosure/disclosureStore";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { type ItemRenderProps, ignoringTurn, registerItemRenderer } from "../types";
-import { formatTokenCount } from "./format";
 import {
   formatThoughtDuration,
   joinedReasoningParagraphs,

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/messages/turnMeta.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/messages/turnMeta.ts
@@ -9,9 +9,10 @@
 // "$0.0234"). turnUsageTokens (chrome/detailsAccounting.ts) owns the usage
 // narrowing, shared with the session-details panel's own token derivation so
 // the two surfaces read one turn's tokens by exactly one rule.
+
+import { formatDurationMs, formatTokenCount } from "../../../../protocol/displayFormat";
 import type { TurnModel } from "../../../../protocol/model";
 import { turnUsageTokens } from "../../chrome/detailsAccounting";
-import { formatDurationMs, formatTokenCount } from "./format";
 
 export interface TurnMetaParts {
   duration?: string;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/delegateStatus.tsx
@@ -10,11 +10,11 @@
 // or malformed JSON), it falls back to HeadClippedOutputBody — the previous
 // behavior — so the renderer never regresses for non-delegate targets.
 import type { ReactNode } from "react";
+import { formatClockTime, formatElapsed, splitMandate } from "../../../../protocol/displayFormat";
 import { disclosureScopeForSession, useTranscriptRenderContext } from "../../../../transcriptDisplay/renderContext";
 import { Chip, type ChipTone, CopyButton, Disclosure, Markdown } from "../../../../widgets";
 import { scopedDisclosureId } from "../../../../widgets/disclosure/disclosureStore";
 import { requireClass } from "../../../../widgets/internal/requireClass";
-import { formatClockTime, formatElapsed, splitMandate } from "../messages/format";
 import { OpenTranscriptButton } from "../openTranscript";
 import type { ToolRenderProps } from "../toolRenderers";
 import { HeadClippedOutputBody } from "./bodies";

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/subagentModule.tsx
@@ -3,6 +3,7 @@
 // spawn materializes a frozen pre-hydration row in the shared store; once the
 // owning stable delegate projection exists, it supplies the hydrated state.
 import { useEffect } from "react";
+import { formatElapsed, plainQuoteLine } from "../../../../protocol/displayFormat";
 import { type ItemModel, SYSTEM_PRELUDE_TURN_ID } from "../../../../protocol/model";
 import type { EvenerDelegateInfo } from "../../../../protocol/types.gen";
 import { threadsStore, useThreadsStore } from "../../../../stores/threads";
@@ -12,7 +13,6 @@ import { isDisclosureOpen, toggleDisclosure } from "../../../../widgets/disclosu
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { formatUsagePair } from "../../chrome/activityFormat";
 import { useSessionNow } from "../../liveness";
-import { formatElapsed, plainQuoteLine } from "../messages/format";
 import { statedIntentOf } from "../ToolRow";
 import type { ToolRenderProps } from "../toolRenderers";
 import { registerToolRenderer } from "../toolRenderers";

--- a/cmd/evener-hub/frontend/src/protocol/README.md
+++ b/cmd/evener-hub/frontend/src/protocol/README.md
@@ -8,8 +8,9 @@ and the user-facing message helpers every failure display goes through, the
 pure question formatter, the thread view model and its notification reducer,
 the activity tree parser, merge and disclosure rules, the job log tail parser,
 the send/queue availability table, the send/steer/queue/drain routing
-decisions a composer makes off it, the stable delegate status rule, and the
-doc-pane URL builders, which hang their hrefs off a base origin the host
+decisions a composer makes off it, the stable delegate status rule, the
+display formatters both apps render counts, durations and clock times with,
+and the doc-pane URL builders, which hang their hrefs off a base origin the host
 supplies (empty for a same-origin web page). The doc-pane data layer is
 published at the `./docContent` subpath as well, where `readDocFile` takes the
 host's `DocPort` - that base origin paired with a fetch: the package issues no

--- a/cmd/evener-hub/frontend/src/protocol/displayFormat.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/displayFormat.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { expect, test } from "vitest";
-import { firstLine, formatClockTime, formatDurationMs, formatTokenCount } from "./format";
+import { firstLine, formatClockTime, formatDurationMs, formatTokenCount } from "./displayFormat";
 
 // --- formatTokenCount -----------------------------------------------------
 // Parity: renderer-format.js:582-587. Below 1000 is a plain rounded

--- a/cmd/evener-hub/frontend/src/protocol/displayFormat.ts
+++ b/cmd/evener-hub/frontend/src/protocol/displayFormat.ts
@@ -1,4 +1,4 @@
-// Pure text-formatting helpers shared by transcript renderers.
+// Pure text-formatting helpers shared by the web and native renderers.
 
 // Deliberately never scales past "k" to match the legacy formatter.
 export function formatTokenCount(n: number): string {

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -41,6 +41,17 @@ export { composeAskAnswers } from "./askAnswers";
 export type { AnyNotification, AppwireClientOptions, ConnectionState, TerminalReason } from "./client";
 export { APPWIRE_PROTOCOL_VERSION, AppwireClient } from "./client";
 export type { AppwireClientLike } from "./clientLike";
+export {
+  firstLine,
+  formatCharCount,
+  formatClockTime,
+  formatClockTimeSeconds,
+  formatDurationMs,
+  formatElapsed,
+  formatTokenCount,
+  plainQuoteLine,
+  splitMandate,
+} from "./displayFormat";
 export type { DocFileContent, DocFileErrorKind } from "./docContent";
 // readDocFile is deliberately absent from the root: it needs a DocPort from the
 // host, and a consumer that supplies one (or spies on the module) wants the

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -52,6 +52,7 @@ async function qualify() {
     "stableDelegate",
     "docContent",
     "submitRouting",
+    "displayFormat",
   ];
   // Every runtime export of the package root. The root's generated consumer
   // programs are built from this one list, so an export the entry point stops
@@ -125,6 +126,15 @@ async function qualify() {
     "decideSubmitRoute",
     "decideSteerRoute",
     "isTurnActive",
+    "formatTokenCount",
+    "formatDurationMs",
+    "formatCharCount",
+    "formatClockTime",
+    "formatClockTimeSeconds",
+    "formatElapsed",
+    "firstLine",
+    "splitMandate",
+    "plainQuoteLine",
   ];
   // One exported type per shipped module that declares any, so the declaration
   // check covers each module's packed .d.ts and not just its runtime half.
@@ -197,6 +207,15 @@ assert.equal(client.docFileRawURL("", "s", "p"), "/doc/file?format=raw&session=s
 assert.equal(client.decideSubmitRoute({ hasContent: false, availability: { canSend: true, canQueue: false } }), "none");
 assert.equal(client.decideSteerRoute({ hasText: true, hasAttachments: false, queueDepth: 0 }), "steer");
 assert.equal(client.isTurnActive("active", "turn_1"), true);
+assert.equal(client.formatTokenCount(41200), "41k");
+assert.equal(client.formatDurationMs(1500), "1.5s");
+assert.equal(client.formatCharCount(2500), "2.5k chars");
+assert.equal(client.formatClockTime(undefined), undefined);
+assert.equal(client.formatClockTimeSeconds("not a timestamp"), undefined);
+assert.equal(client.formatElapsed(65000), "1m05s");
+assert.equal(client.firstLine("\\n  hello  \\n", 20), "hello");
+assert.deepEqual(client.splitMandate("first\\n\\nrest"), { first: "first", rest: "rest" });
+assert.equal(client.plainQuoteLine("# Title\\n**bold** line"), "bold line");
 const activity = new client.ActivityList({ request: async () => ({}), onNotification: () => () => {} }, "ref", "thread");
 assert.equal(activity.getSnapshot().tree, null);
 `;

--- a/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
+++ b/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
@@ -31,6 +31,7 @@
     "sessionErrors.ts",
     "stableDelegate.ts",
     "docContent.ts",
-    "submitRouting.ts"
+    "submitRouting.ts",
+    "displayFormat.ts"
   ]
 }

--- a/cmd/evener-hub/frontend/src/widgets/timestamp/index.tsx
+++ b/cmd/evener-hub/frontend/src/widgets/timestamp/index.tsx
@@ -5,7 +5,7 @@
 // party date dependency, matching the project's "prefer standard defaults"
 // stance. The locale is pinned to "en" so output is deterministic across
 // environments (CI and dev alike); the existing transcript formatters
-// (messages/format.ts) are likewise en-style by construction.
+// (protocol/displayFormat.ts) are likewise en-style by construction.
 //
 // Pure render, no internal clock — mirrors Cadence and Loader: the caller
 // owns "now" (the session's shared 3s tick via useSessionNow, or a fixed

--- a/mobile-native/src/ActivityDelegateDetails.tsx
+++ b/mobile-native/src/ActivityDelegateDetails.tsx
@@ -10,7 +10,7 @@ import { absoluteTime } from "../../cmd/evener-hub/frontend/src/panes/session/ch
 import {
   formatElapsed,
   splitMandate,
-} from "../../cmd/evener-hub/frontend/src/panes/session/transcript/messages/format";
+} from "../../cmd/evener-hub/frontend/src/protocol/displayFormat";
 import type { ActivityDelegate } from "../../cmd/evener-hub/frontend/src/protocol/activityData";
 import {
   delegateModel,


### PR DESCRIPTION
`panes/session/transcript/messages/format.ts` (87 lines, no imports) and its
test move into the AppWire package. Both apps already import it — nine web
sites and `mobile-native/src/ActivityDelegateDetails.tsx` — so it is a phase-C
relocation, not a new abstraction. No logic changed; the test file moved with
the module and stays the oracle, only its import specifier changed.

**The rename.** `format` is not a name a package can publish at its root, so
the module lands as `protocol/displayFormat.ts`: it formats counts, durations,
clock times and first lines for display, and says so from the package root.

**Plumbing (the phase-C rule).** A relocation is not done when the file has
moved:
- `protocol/tsconfig.build.json` `files` gains `displayFormat.ts`.
- `protocol/index.ts` re-exports all nine functions, alphabetically between
  `clientLike` and `docContent`. No `rootTypes` entry: the module declares no
  exported type.
- `scripts/qualify-package.mjs` gains `displayFormat` in `shippedModules`, the
  nine names in `rootValues`, and nine real root smoke calls (including
  `formatTokenCount`, `formatDurationMs`, `firstLine` and `splitMandate`).

Falsified per #1224: with the `shippedModules` entry present and the `index.ts`
re-export deleted, `make test-api-package` fails with `shipped module
unreachable from every published specifier: displayFormat`. Restored, green.

**Importers rewritten.** Web: `chrome/{ActivityRowDetail.tsx, DetailsPanel.tsx,
activityFormat.ts}`, `transcript/messages/{SystemNoticeItem.tsx,
SystemNoticeItem.test.tsx, ThinkBlock.tsx, turnMeta.ts}`,
`transcript/tools/{delegateStatus.tsx, subagentModule.tsx}` — deep relative
paths into `protocol/`, matching neighbouring files (A4 has not landed).
Native: `mobile-native/src/ActivityDelegateDetails.tsx`. Four prose citations
of the old path (`chrome/activityFormat.ts`, `chrome/statusFormat.ts` ×2,
`chrome/statusFormat.test.ts`, `widgets/timestamp/index.tsx`) were repointed so
they name a file that exists; the dated `docs/superpowers/plans/` records are
left alone. `protocol/README.md`'s export prose gained the module.

The module's opening comment said "shared by transcript renderers", naming the
directory it no longer lives in and an app half its consumers are not in; it
now reads "shared by the web and native renderers". Nothing else in the file
changed.

**Gates:** `make test-api-package` PASS · `make test-web` PASS
(typecheck/test/lint) · `make test-native` PASS (777 tests + tsc) ·
`make test-web-browser` PASS (5 guards) · `go test -run TestScenarioSource .`
PASS. Biome was run over the touched files under
`cmd/evener-hub/frontend/src` only; it sorted the rewritten import lines and
put a blank line between `turnMeta.ts`'s header comment and its imports.

Plan row: C26 in docs/superpowers/plans/2026-09-12-sdk-migration.md (#1182)
