### PR TITLE
refactor(protocol): move composerInput into the package (SDK C5)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/spawn/startThread.ts
+++ b/cmd/evener-hub/frontend/src/panes/spawn/startThread.ts
@@ -4,8 +4,8 @@
 // prompt + cwd -> real session); T2 fills the rest (branch/access-mode ->
 // launchOverrides, the schema engine, sticky defaults).
 import type { AppwireClientLike } from "../../protocol/clientLike";
+import { buildComposerInput } from "../../protocol/composerInput";
 import type { LaunchConfigLayer, ThreadStartParams } from "../../protocol/types.gen";
-import { buildComposerInput } from "../../stores/composerInput";
 import type { InputAttachment } from "../../stores/threads";
 import { mergeAccessModeSandbox } from "./accessMode";
 

--- a/cmd/evener-hub/frontend/src/protocol/README.md
+++ b/cmd/evener-hub/frontend/src/protocol/README.md
@@ -1,22 +1,23 @@
 # @evener/appwire-client
 
-The framework independent TypeScript client for Evener's AppWire protocol. It
-has no runtime dependencies and exports the client, the connection seam
+The framework independent TypeScript client for Evener's AppWire protocol.
+It has no runtime dependencies and exports the client, the connection seam
 applications program against, the transport contract, generated protocol
 types, wire errors with their session classifiers, the rejection classifier
 and the user-facing message helpers every failure display goes through, the
 pure question formatter, the translation that turns a composer's `[image N]`
-attachment markers into prose at send, the thread view model and its
-notification reducer, the activity tree parser, merge and disclosure rules,
-the job log tail parser, the send/queue availability table, the
-send/steer/queue/drain routing decisions a composer makes off it, the stable
-delegate status rule, the display formatters both apps render counts,
-durations and clock times with, and the doc-pane URL builders, which hang
-their hrefs off a base origin the host supplies (empty for a same-origin web
-page). The doc-pane data layer is published at the `./docContent` subpath as
-well, where `readDocFile` takes the host's `DocPort` - that base origin paired
-with a fetch: the package issues no request of its own and names neither an
-origin nor a credentials policy.
+attachment markers into prose at send and the composer input assembly that
+applies that translation and stages the attached images beside the text, the
+thread view model and its notification reducer, the activity tree parser,
+merge and disclosure rules, the job log tail parser, the send/queue
+availability table, the send/steer/queue/drain routing decisions a composer
+makes off it, the stable delegate status rule, the display formatters both
+apps render counts, durations and clock times with, and the doc-pane URL
+builders, which hang their hrefs off a base origin the host supplies (empty
+for a same-origin web page). The doc-pane data layer is published at the
+`./docContent` subpath as well, where `readDocFile` takes the host's
+`DocPort` - that base origin paired with a fetch: the package issues no
+request of its own and names neither an origin nor a credentials policy.
 
 Build and qualify from this directory with `npm run qualification`. The runner
 packs the package, installs that tarball into a temporary consumer, and then,

--- a/cmd/evener-hub/frontend/src/protocol/composerInput.ts
+++ b/cmd/evener-hub/frontend/src/protocol/composerInput.ts
@@ -1,5 +1,5 @@
-import { translateAttachmentMarkers } from "../protocol/attachmentMarkers";
-import type { InputItem } from "../protocol/types.gen";
+import { translateAttachmentMarkers } from "./attachmentMarkers";
+import type { InputItem } from "./types.gen";
 
 /** Staged image bytes; marker identifies its editing anchor, never a wire field. */
 export interface InputAttachment {

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -43,6 +43,8 @@ export { translateAttachmentMarkers } from "./attachmentMarkers";
 export type { AnyNotification, AppwireClientOptions, ConnectionState, TerminalReason } from "./client";
 export { APPWIRE_PROTOCOL_VERSION, AppwireClient } from "./client";
 export type { AppwireClientLike } from "./clientLike";
+export type { InputAttachment } from "./composerInput";
+export { buildComposerInput, buildInput } from "./composerInput";
 export {
   firstLine,
   formatCharCount,

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -40,6 +40,7 @@ async function qualify() {
     "types.gen",
     "askAnswers",
     "attachmentMarkers",
+    "composerInput",
     "activityData",
     "activityList",
     "activityMerge",
@@ -80,6 +81,8 @@ async function qualify() {
     "rpcURLFromLocation",
     "composeAskAnswers",
     "translateAttachmentMarkers",
+    "buildInput",
+    "buildComposerInput",
     "METHOD_NAMES",
     "NOTIFICATION_NAMES",
     "STEERING_KINDS",
@@ -146,6 +149,7 @@ async function qualify() {
     "WebSocketLike",
     "AskAnswerItem",
     "MarkerAttachment",
+    "InputAttachment",
     "ActivityNodeLike",
     "ActivityTree",
     "ActivityState",
@@ -167,6 +171,11 @@ async function qualify() {
 assert.equal(client.rpcURLFromLocation({ protocol: "https:", host: "hub.example:9180" }), "wss://hub.example:9180/rpc");
 assert.equal(client.composeAskAnswers([]), "[answers]");
 assert.equal(client.translateAttachmentMarkers("[image 1]go", [{ marker: 1, name: "shot.png" }]), "(attached image 1: shot.png)go");
+assert.deepEqual(client.buildInput("hi"), [{ type: "text", text: "hi" }]);
+assert.deepEqual(client.buildComposerInput("[image 1]go", [{ marker: 1, mediaType: "image/png", data: "AA", name: "shot.png" }]), [
+  { type: "text", text: "(attached image 1: shot.png)go" },
+  { type: "image", mediaType: "image/png", data: "AA", name: "shot.png" },
+]);
 assert.equal(new client.WireError("nope", -32000).code, -32000);
 assert.equal(client.errorText(new Error("boom")), "boom");
 assert.equal(client.errorKind(new Error("boom")), "unknown");

--- a/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
+++ b/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
@@ -20,6 +20,7 @@
     "types.gen.ts",
     "askAnswers.ts",
     "attachmentMarkers.ts",
+    "composerInput.ts",
     "activityData.ts",
     "activityRows.ts",
     "activityList.ts",

--- a/cmd/evener-hub/frontend/src/stores/threads.ts
+++ b/cmd/evener-hub/frontend/src/stores/threads.ts
@@ -11,6 +11,7 @@ import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 import { releaseSubagentRows } from "../panes/session/transcript/tools/subagentModuleStore";
 import type { AppwireClientLike } from "../protocol/clientLike";
+import { buildComposerInput, buildInput, type InputAttachment } from "../protocol/composerInput";
 import { ClientNotReadyError, isStaleCursorError, mutationErrorData, WireError } from "../protocol/errors";
 import type { ThreadModel } from "../protocol/model";
 import {
@@ -32,7 +33,6 @@ import type {
 } from "../protocol/types.gen";
 import { resetActivityPanelStoreForTests } from "./activityPanel";
 import { resetActivitySummaryStoreForTests } from "./activitySummary";
-import { buildComposerInput, buildInput, type InputAttachment } from "./composerInput";
 import { connectionStore } from "./connection";
 import { MutationDispatcher } from "./mutationDispatcher";
 import {
@@ -48,7 +48,7 @@ import { MutationOutboxIndexedDB } from "./mutationOutboxIndexedDB";
 import { createSecureUUID } from "./secureUUID";
 import { resetTasksPanelStoreForTests } from "./tasksPanel";
 
-export type { InputAttachment } from "./composerInput";
+export type { InputAttachment } from "../protocol/composerInput";
 
 // InputAttachment is this store's real-attachment shape: base64 bytes, not a
 // hosted URL. The wire's InputItem (appwire/types.go:561-570) supports EITHER

--- a/mobile-native/src/composerCommand.ts
+++ b/mobile-native/src/composerCommand.ts
@@ -8,7 +8,7 @@ import {
   effortLabel,
   effortOptionLevels,
 } from "../../cmd/evener-hub/frontend/src/shell/reasoningEffort";
-import { buildComposerInput } from "../../cmd/evener-hub/frontend/src/stores/composerInput";
+import { buildComposerInput } from "../../cmd/evener-hub/frontend/src/protocol/composerInput";
 import type { MobileConversation } from "../../mobile/src/conversation/model";
 import type {
   ConversationClearActions,

--- a/mobile-native/src/composerInput.test.ts
+++ b/mobile-native/src/composerInput.test.ts
@@ -3,7 +3,7 @@ import { translateAttachmentMarkers } from "../../cmd/evener-hub/frontend/src/pr
 import {
   buildComposerInput,
   buildInput,
-} from "../../cmd/evener-hub/frontend/src/stores/composerInput";
+} from "../../cmd/evener-hub/frontend/src/protocol/composerInput";
 
 describe("shared composer input", () => {
   it("preserves ordinary text and allows image-only input", () => {

--- a/mobile-native/src/draftDocument.ts
+++ b/mobile-native/src/draftDocument.ts
@@ -4,7 +4,7 @@ import {
 	markerText,
 	stripMarker,
 } from "../../cmd/evener-hub/frontend/src/panes/session/composer/attachments/textareaMarkers";
-import type { InputAttachment } from "../../cmd/evener-hub/frontend/src/stores/composerInput";
+import type { InputAttachment } from "../../cmd/evener-hub/frontend/src/protocol/composerInput";
 import type { DraftImage, DraftImageData } from "./draftImages";
 import { restoreUnconfirmedDraft } from "./draftRecovery";
 import type {

--- a/mobile-native/src/draftImages.ts
+++ b/mobile-native/src/draftImages.ts
@@ -1,5 +1,5 @@
 import { MAX_ATTACHMENTS } from "../../cmd/evener-hub/frontend/src/panes/session/composer/attachments/limits";
-import type { InputAttachment } from "../../cmd/evener-hub/frontend/src/stores/composerInput";
+import type { InputAttachment } from "../../cmd/evener-hub/frontend/src/protocol/composerInput";
 
 /** Immutable local image identity plus its composer marker. Bytes live separately. */
 export interface DraftImage {

--- a/mobile-native/src/newSession.ts
+++ b/mobile-native/src/newSession.ts
@@ -17,7 +17,7 @@ import type {
   ModelDescriptor,
   Thread,
 } from "../../cmd/evener-hub/frontend/src/protocol/types.gen";
-import { buildComposerInput } from "../../cmd/evener-hub/frontend/src/stores/composerInput";
+import { buildComposerInput } from "../../cmd/evener-hub/frontend/src/protocol/composerInput";
 import type { NewSessionService } from "../../mobile/src/services/newSession";
 import {
   type CreationDraft,

--- a/mobile-native/src/screens.tsx
+++ b/mobile-native/src/screens.tsx
@@ -36,7 +36,7 @@ import {
 	spliceSlashCommand,
 } from "../../cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion";
 import { humanizeState } from "../../cmd/evener-hub/frontend/src/shell/rail/sessionState";
-import { buildComposerInput } from "../../cmd/evener-hub/frontend/src/stores/composerInput";
+import { buildComposerInput } from "../../cmd/evener-hub/frontend/src/protocol/composerInput";
 import { createConversationService } from "../../mobile/src/services/conversation";
 import { createRosterService } from "../../mobile/src/services/roster";
 import { createActivityStore } from "../../mobile/src/state/activity";


### PR DESCRIPTION
Phase-C relocation: `stores/composerInput.ts` becomes `protocol/composerInput.ts`.

## What moved
`git mv` of the 27-line module (`InputAttachment`, `buildInput`,
`buildComposerInput`). No logic change; the only edits inside the file are its
two now-intra-package imports, `./attachmentMarkers` (shipped by C6) and
`./types.gen`. There is no `composerInput.test.ts` in the web tree — the oracle
is `mobile-native/src/composerInput.test.ts`, a different file that stays put
and only has its specifier repointed.

## The three plumbing sites
- `protocol/tsconfig.build.json` `files`: `composerInput.ts`, beside the
  `attachmentMarkers.ts` it depends on.
- `protocol/index.ts`: `InputAttachment` (type) plus `buildComposerInput` /
  `buildInput`, alphabetically between clientLike and displayFormat.
- `protocol/scripts/qualify-package.mjs`: `shippedModules`, two `rootValues`,
  one `rootTypes`, and two real root smoke calls that assert `buildInput`'s
  text/image item shape and that `buildComposerInput` translates the marker
  before assembling.

Falsified per #1224: with the `shippedModules` entry present and the `index.ts`
re-export (plus its manifest names) removed, `make test-api-package` fails with
`shipped module unreachable from every published specifier: composerInput`.
Restored; green.

## Importers rewritten
Web: `panes/spawn/startThread.ts`, `stores/threads.ts` (both its import and its
`export type { InputAttachment }` re-export, which stays as the store's public
interface). Native: `composerCommand.ts`, `composerInput.test.ts`,
`draftDocument.ts`, `draftImages.ts`, `newSession.ts`, `screens.tsx` — deep
relative paths matching neighbouring files, since A4 has not landed. A repo-wide
grep for `stores/composerInput` and `./composerInput` across web, `mobile/`,
`mobile-native/`, `test/scenarios` and `docs/web-ui` finds nothing else: no
prose citation, no `vi.mock` of the path, no scenario card.

`protocol/README.md`'s export prose gained the module.

## Gates
`make test-api-package` PASS · `make test-web` PASS (typecheck, test, lint) ·
`make test-native` PASS (777 shared tests + tsc) · `make test-web-browser` PASS
(5 guards) · `go test -run TestScenarioSource .` PASS. Biome run only over the
touched files under `cmd/evener-hub/frontend/src`; it sorted the two rewritten
import lines.

Plan row: C5 in docs/superpowers/plans/2026-09-12-sdk-migration.md (#1182)