### PR TITLE
refactor(protocol): move catalogCommands into the package (SDK C15)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion.ts
@@ -9,8 +9,8 @@
 // text/caret state and the plugin slash-command catalog (stores/
 // commandCatalog.ts), the same catalog the modal command palette reads.
 
+import { slashCommandInvocation } from "../../../protocol/catalogCommands";
 import type { CommandDescriptor, EvenerSkillInfo } from "../../../protocol/types.gen";
-import { slashCommandInvocation } from "../../../shell/palette/catalogCommands";
 
 type ScopedCommand = {
   id: string;

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -16,10 +16,10 @@ import {
   useState,
 } from "react";
 import { useStore } from "zustand";
+import { slashCommandInvocation } from "../../protocol/catalogCommands";
 import { friendlyLaunchErrorMessage } from "../../protocol/errors";
 import type { HarnessDescriptor, LaunchConfigLayer, LaunchOption, ModelListResponse } from "../../protocol/types.gen";
 import { useClient } from "../../shell/clientContext";
-import { slashCommandInvocation } from "../../shell/palette/catalogCommands";
 import { splitModelId } from "../../shell/palette/commands";
 import type { PaneProps } from "../../shell/paneRegistry";
 import { effortLabel } from "../../shell/reasoningEffort";

--- a/cmd/evener-hub/frontend/src/protocol/README.md
+++ b/cmd/evener-hub/frontend/src/protocol/README.md
@@ -10,7 +10,8 @@ attachment markers into prose at send, the thread view model and its
 notification reducer, the activity tree parser, merge and disclosure rules,
 the job log tail parser, the send/queue availability table, the
 send/steer/queue/drain routing decisions a composer makes off it, the stable
-delegate status rule, the display formatters both apps render counts,
+delegate status rule, the slash invocation and catalog visibility rules the
+palette and composer share, the display formatters both apps render counts,
 durations and clock times with, and the doc-pane URL builders, which hang
 their hrefs off a base origin the host supplies (empty for a same-origin web
 page). The doc-pane data layer is published at the `./docContent` subpath as

--- a/cmd/evener-hub/frontend/src/protocol/catalogCommands.ts
+++ b/cmd/evener-hub/frontend/src/protocol/catalogCommands.ts
@@ -1,4 +1,4 @@
-import type { CommandDescriptor } from "../../protocol/types.gen";
+import type { CommandDescriptor } from "./types.gen";
 
 // slashCommandInvocation is the one place that decides what a user actually
 // types to invoke a catalog command: a plugin-sourced command with a known
@@ -6,8 +6,8 @@ import type { CommandDescriptor } from "../../protocol/types.gen";
 // only resolves the FIRST plugin registering that name - see app_rpc.go's
 // own dispatch), everything else (user commands, and plugin commands
 // without a pluginName, e.g. a stub catalog entry in a test) is unambiguous
-// as bare "/name". Shared verbatim by catalogCommands below (what the
-// palette's activateCommand inserts, via the stored field on Command) and
+// as bare "/name". Shared verbatim by the palette's catalogCommands (what
+// its activateCommand inserts, via the stored field on Command) and
 // composer/Composer.tsx's commitSlashCompletion (the inline "/" menu's
 // insert) - a single source of truth for the qualification rule, so the two
 // insertion paths can never drift back out of sync the way they did before

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -40,6 +40,7 @@ export type { AskAnswerItem, AskResolution } from "./askAnswers";
 export { composeAskAnswers } from "./askAnswers";
 export type { MarkerAttachment } from "./attachmentMarkers";
 export { translateAttachmentMarkers } from "./attachmentMarkers";
+export { slashCommandInvocation, visibleCatalogCommands } from "./catalogCommands";
 export type { AnyNotification, AppwireClientOptions, ConnectionState, TerminalReason } from "./client";
 export { APPWIRE_PROTOCOL_VERSION, AppwireClient } from "./client";
 export type { AppwireClientLike } from "./clientLike";

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -54,6 +54,7 @@ async function qualify() {
     "docContent",
     "submitRouting",
     "displayFormat",
+    "catalogCommands",
   ];
   // Every runtime export of the package root. The root's generated consumer
   // programs are built from this one list, so an export the entry point stops
@@ -137,6 +138,8 @@ async function qualify() {
     "firstLine",
     "splitMandate",
     "plainQuoteLine",
+    "slashCommandInvocation",
+    "visibleCatalogCommands",
   ];
   // One exported type per shipped module that declares any, so the declaration
   // check covers each module's packed .d.ts and not just its runtime half.
@@ -220,6 +223,8 @@ assert.equal(client.formatElapsed(65000), "1m05s");
 assert.equal(client.firstLine("\\n  hello  \\n", 20), "hello");
 assert.deepEqual(client.splitMandate("first\\n\\nrest"), { first: "first", rest: "rest" });
 assert.equal(client.plainQuoteLine("# Title\\n**bold** line"), "bold line");
+assert.equal(client.slashCommandInvocation({ name: "plan", source: "plugin", pluginName: "acme" }), "/acme:plan");
+assert.deepEqual(client.visibleCatalogCommands([{ name: "plan", source: "plugin", pluginName: "acme" }], new Set()), []);
 const activity = new client.ActivityList({ request: async () => ({}), onNotification: () => () => {} }, "ref", "thread");
 assert.equal(activity.getSnapshot().tree, null);
 `;

--- a/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
+++ b/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
@@ -33,6 +33,7 @@
     "stableDelegate.ts",
     "docContent.ts",
     "submitRouting.ts",
-    "displayFormat.ts"
+    "displayFormat.ts",
+    "catalogCommands.ts"
   ]
 }

--- a/cmd/evener-hub/frontend/src/shell/palette/commands.edge.test.ts
+++ b/cmd/evener-hub/frontend/src/shell/palette/commands.edge.test.ts
@@ -4,8 +4,8 @@
 // - rememberableId for stayOpen and non-stayOpen commands
 
 import { afterEach, expect, test, vi } from "vitest";
+import { slashCommandInvocation, visibleCatalogCommands } from "../../protocol/catalogCommands";
 import type { CommandDescriptor } from "../../protocol/types.gen";
-import { slashCommandInvocation, visibleCatalogCommands } from "./catalogCommands";
 import type { Command } from "./commands";
 import { copyToClipboard, rememberableId, sessionScopedHandoffMatch } from "./commands";
 

--- a/cmd/evener-hub/frontend/src/shell/palette/commands.ts
+++ b/cmd/evener-hub/frontend/src/shell/palette/commands.ts
@@ -9,6 +9,7 @@
 // open) for an idle-guarded action or a Conflict, or as a useToasts() toast
 // for a fire-and-report action - never a silent swallow.
 
+import { slashCommandInvocation, visibleCatalogCommands } from "../../protocol/catalogCommands";
 import type { ThreadModel } from "../../protocol/model";
 import type { CommandDescriptor, ThreadCapabilities } from "../../protocol/types.gen";
 import { useCommandCatalog } from "../../stores/commandCatalog";
@@ -25,7 +26,6 @@ import { effortLabel, effortOptionLevels } from "../reasoningEffort";
 import { navigate } from "../routing";
 import { workspaceStore } from "../workspace";
 import { blocked } from "./blocked";
-import { slashCommandInvocation, visibleCatalogCommands } from "./catalogCommands";
 import { commandScore } from "./commandScore";
 import { focusedModel, hasActiveTurn, type OnPage, type PaletteContext } from "./paletteContext";
 import { readRecentCommandIds } from "./recentCommands";

--- a/mobile-native/src/commandCatalog.ts
+++ b/mobile-native/src/commandCatalog.ts
@@ -2,8 +2,8 @@ import {
   mergeSlashCommands,
   type SlashMenuItem,
 } from "../../cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion";
+import { visibleCatalogCommands } from "../../cmd/evener-hub/frontend/src/protocol/catalogCommands";
 import { sessionActionError } from "../../cmd/evener-hub/frontend/src/protocol/errors";
-import { visibleCatalogCommands } from "../../cmd/evener-hub/frontend/src/shell/palette/catalogCommands";
 import type { ConversationClientLike } from "../../mobile/src/services/conversation";
 
 interface CatalogState {


### PR DESCRIPTION
`shell/palette/catalogCommands.ts` (37 lines) moves to
`protocol/catalogCommands.ts`. No logic changes: the only edit inside the file
is its `types.gen` import becoming `./types.gen`, plus one stale word in the
opening comment ("catalogCommands below" named a function that has always lived
in `shell/palette/commands.ts`, and is now in another directory — it reads "the
palette's catalogCommands"). There is no `catalogCommands.test.ts`; the
behaviour is pinned by `shell/palette/commands.edge.test.ts`, which stays put
with its import repointed.

Plumbing, the three sites every phase-C relocation touches:

- `protocol/tsconfig.build.json` `files` gains `catalogCommands.ts`.
- `protocol/index.ts` re-exports `slashCommandInvocation` and
  `visibleCatalogCommands`, alphabetically between `attachmentMarkers` and
  `client`. No `rootTypes` entry — the module declares no exported type.
- `scripts/qualify-package.mjs`: `shippedModules` entry, both names in
  `rootValues`, and two real root smoke calls (a plugin command qualifying to
  `/acme:plan`, and the same command filtered out against an empty active-plugin
  set).

Falsified per the #1224 runner gap, in two steps: with the `shippedModules`
entry kept, deleting the `index.ts` re-export *and* the two `rootValues` names
fails `make test-api-package` with `shipped module unreachable from every
published specifier: catalogCommands`. Restored; green.

Importers rewritten, deep relative paths matching their neighbours (A4 has not
landed): web `panes/session/composer/slashCompletion.ts`,
`panes/spawn/Spawn.tsx`, `shell/palette/commands.ts`,
`shell/palette/commands.edge.test.ts`; native `mobile-native/src/commandCatalog.ts`.
A repo-wide grep (web, `mobile/`, `mobile-native/`, `test/scenarios`,
`docs/web-ui`) found no other live reference — no `vi.mock` of the path, no
prose citation, no scenario card. `protocol/README.md`'s export prose gained the
module.

Gates: `make test-api-package` PASS · `make test-web` PASS (typecheck, test,
lint) · `make test-native` PASS (777 tests + tsc) · `make test-web-browser` PASS
(5 guards) · `go test -run TestScenarioSource .` PASS. Biome run only over the
touched files under `cmd/evener-hub/frontend/src`; it sorted the rewritten
import lines.

Plan row: C15 in docs/superpowers/plans/2026-09-12-sdk-migration.md (#1182);
lands ahead of C9, which imports it.