### PR TITLE
refactor(protocol): move askShared and deriveAskQuestions into the package (SDK C11b)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskQuestionCard.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskQuestionCard.test.tsx
@@ -5,9 +5,9 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { afterEach, expect, test, vi } from "vitest";
+import type { AskQuestionRef } from "../../../../protocol/deriveAskQuestions";
 import { AskQuestionCard } from "./AskQuestionCard";
 import type { AskAnswerState } from "./askDockStore";
-import type { AskQuestionRef } from "./deriveAskQuestions";
 
 afterEach(cleanup);
 

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskQuestionCard.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskQuestionCard.tsx
@@ -24,10 +24,10 @@
 // them.
 import { useEffect, useId, useRef } from "react";
 import type { AskResolution } from "../../../../protocol/askAnswers";
+import type { AskQuestionRef } from "../../../../protocol/deriveAskQuestions";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import type { AskAnswerState } from "./askDockStore";
 import styles from "./askquestioncard.module.css";
-import type { AskQuestionRef } from "./deriveAskQuestions";
 
 const CLASS = {
   card: requireClass(styles.card, "askquestioncard.module.css", "card"),

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askDockStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askDockStore.ts
@@ -18,10 +18,10 @@
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
 import { type AskResolution, composeAskAnswers } from "../../../../protocol/askAnswers";
+import { liveAskQuestions } from "../../../../protocol/deriveAskQuestions";
 import { sessionActionError } from "../../../../protocol/errors";
 import type { ThreadModel } from "../../../../protocol/model";
 import { threadsStore } from "../../../../stores/threads";
-import { liveAskQuestions } from "./deriveAskQuestions";
 import { type AskBatch, reconcileBatches } from "./reconcileBatches";
 
 export interface AskAnswerState {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/index.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/index.ts
@@ -2,7 +2,7 @@
 // AskDock.tsx's own header for the full mount-expectations note (the
 // useAskDockPending hide/inert seam and what this component deliberately
 // does NOT own). Everything else in this
-// directory (askDockStore, deriveAskQuestions, reconcileBatches)
+// directory (askDockStore, reconcileBatches)
 // is this feature's own implementation detail, not part of
 // its public contract - a sibling stream that needs one of those directly
 // should ask for it to be exported here first.

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/reconcileBatches.test.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/reconcileBatches.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { expect, test, vi } from "vitest";
-import type { AskQuestionRef } from "./deriveAskQuestions";
+import type { AskQuestionRef } from "../../../../protocol/deriveAskQuestions";
 import { type AskBatch, reconcileBatches } from "./reconcileBatches";
 
 function ref(key: string): AskQuestionRef {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/reconcileBatches.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/reconcileBatches.ts
@@ -1,17 +1,16 @@
 // reconcileBatches is the stateful half of the dock's multi-pending-set
 // bookkeeping (wave-5 plan T4: "late-arriving questions never swept into an
-// in-flight settlement"). deriveAskQuestions.ts's liveAskQuestions gives a
-// purely POSITIONAL snapshot of "what the transcript currently says is
-// live" - sufficient for cold attach and the common (nothing in flight)
+// in-flight settlement"). protocol/deriveAskQuestions.ts's liveAskQuestions
+// gives a purely POSITIONAL snapshot of "what the transcript currently says
+// is live" - sufficient for cold attach and the common (nothing in flight)
 // case, but not for the in-flight submission race: while our own composed
 // answer's turn/start round-trip is pending, its eventual echo (a fresh
 // userMessage item) and a SIBLING ask_user call's own ack are both being
-// appended to the SAME transcript by two independent, unordered wire
-// events. Position alone can't tell "my own reply landed, resolving
-// everything before it" apart from "a new question arrived that has
-// nothing to do with my in-flight send" when the two race - see
-// askDockStore.ts's own comment for the concrete interleaving this
-// protects against.
+// appended to the SAME transcript by two independent, unordered wire events.
+// Position alone can't tell "my own reply landed, resolving everything
+// before it" apart from "a new question arrived that has nothing to do with
+// my in-flight send" when the two race - see askDockStore.ts's own comment
+// for the concrete interleaving this protects against.
 //
 // The fix is identity, not position: once a batch is marked `sending`, its
 // own questions are frozen and immune to the live-set signal entirely
@@ -30,7 +29,7 @@
 // include its questions at all (the foreign reply moved the transcript
 // boundary past them) - membership comparisons below use `.key`, but the
 // data itself is never re-derived from a live scan once a batch holds it.
-import type { AskQuestionRef } from "./deriveAskQuestions";
+import type { AskQuestionRef } from "../../../../protocol/deriveAskQuestions";
 
 export interface AskBatch {
   id: string;

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.test.tsx
@@ -72,7 +72,7 @@ test("summary degrades to a bare label for malformed argumentsJSON, never throws
 
 // --- summarySuffix (kata h70z): the collapsed row's "— answered: ..."
 // recap, read back from a later [answers] reply. answeredAskUserSuffix
-// itself is unit-tested exhaustively in ../../askShared.test.ts; these
+// itself is unit-tested exhaustively in protocol/askShared.test.ts; these
 // tests only confirm the descriptor wires it up correctly. -------------
 
 function threadModel(items: ItemModel[]) {

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/tools/askUser.tsx
@@ -15,14 +15,14 @@
 // This transcript card stays read-only: no answer affordance here (the
 // composer's askDock owns that - panes/session/composer/askDock/**). The
 // question/option shape check itself (parseAskUserQuestions and its
-// AskUserOption/AskUserQuestion types) moved to ../../askShared so askDock
-// can reuse the identical parsing without duplicating it or reaching into
-// this directory; this file keeps only what's specific to the read-only
+// AskUserOption/AskUserQuestion types) moved to protocol/askShared.ts so
+// askDock - and the native app - can reuse the identical parsing without
+// duplicating it; this file keeps only what's specific to the read-only
 // card (the malformed-vs-absent fallback wording and the static markup).
 
+import { type AskUserQuestion, answeredAskUserSuffix, parseAskUserQuestions } from "../../../../protocol/askShared";
 import type { ItemModel } from "../../../../protocol/model";
 import { requireClass } from "../../../../widgets/internal/requireClass";
-import { type AskUserQuestion, answeredAskUserSuffix, parseAskUserQuestions } from "../../askShared";
 import type { ToolRenderProps } from "../toolRenderers";
 import { registerToolRenderer } from "../toolRenderers";
 import styles from "./askuser.module.css";

--- a/cmd/evener-hub/frontend/src/protocol/README.md
+++ b/cmd/evener-hub/frontend/src/protocol/README.md
@@ -5,10 +5,12 @@ has no runtime dependencies and exports the client, the connection seam
 applications program against, the transport contract, generated protocol
 types, wire errors with their session classifiers, the rejection classifier
 and the user-facing message helpers every failure display goes through, the
-pure question formatter, the translation that turns a composer's `[image N]`
-attachment markers into prose at send, the thread view model and its
-notification reducer, the activity tree parser, merge and disclosure rules,
-the job log tail parser, the send/queue availability table, the
+pure question formatter, the ask_user question parser and the answered recap
+it reads back out of a transcript, the live-question derivation an answering
+dock renders from a thread, the translation that turns a composer's
+`[image N]` attachment markers into prose at send, the thread view model
+and its notification reducer, the activity tree parser, merge and disclosure
+rules, the job log tail parser, the send/queue availability table, the
 send/steer/queue/drain routing decisions a composer makes off it, the stable
 delegate status rule, the display formatters both apps render counts,
 durations and clock times with, the text and argument helpers a tool call's
@@ -16,8 +18,8 @@ rendering is built from, and the doc-pane URL builders, which hang their hrefs
 off a base origin the host supplies (empty for a same-origin web page). The
 doc-pane data layer is published at the `./docContent` subpath as well, where
 `readDocFile` takes the host's `DocPort` - that base origin paired with a
-fetch: the package issues no request of its own and names neither an origin nor
-a credentials policy.
+fetch: the package issues no request of its own and names neither an origin
+nor a credentials policy.
 
 Build and qualify from this directory with `npm run qualification`. The runner
 packs the package, installs that tarball into a temporary consumer, and then,

--- a/cmd/evener-hub/frontend/src/protocol/askShared.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/askShared.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { expect, test } from "vitest";
-import type { ItemModel, ThreadModel, TurnModel } from "../../protocol/model";
 import { answeredAskUserSuffix, parseAskUserQuestions } from "./askShared";
+import type { ItemModel, ThreadModel, TurnModel } from "./model";
 
 // Direct unit coverage for the shared ask_user parsing helper (extracted
 // from transcript/tools/askUser.tsx per the wave-5 T4 manifest so the

--- a/cmd/evener-hub/frontend/src/protocol/askShared.ts
+++ b/cmd/evener-hub/frontend/src/protocol/askShared.ts
@@ -2,12 +2,12 @@
 // truth: agent/internal/tool/definitions.go's DefAskUser gives the exact
 // argumentsJson shape - {questions:[{header?, question,
 // options:[{label,detail,recommended?}], multi_select?, why?,
-// if_unanswered?}]}, 1-4 questions. This used to live private to
-// transcript/tools/askUser.tsx (the wave-4 read-only tool-call renderer);
-// wave 5's composer/askDock/** needs the identical shape check to build
-// its interactive answering dock, so it moved here - a leaf module outside
-// both transcript/tools/** and composer/** so neither wave's manifest
-// entangles with the other. askUser.tsx imports these back and is
+// if_unanswered?}]}, 1-4 questions. This used to live private to the web
+// transcript's askUser.tsx (the wave-4 read-only tool-call renderer);
+// wave 5's composer/askDock/** needed the identical shape check to build
+// its interactive answering dock, so it became a leaf module the two
+// could share. It is package API now: deriveAskQuestions sits on it and
+// both frontends import that. askUser.tsx imports these back and is
 // otherwise unchanged (its own rendering/tests stay byte-equivalent).
 //
 // Parsing is defensive throughout: a malformed argumentsJSON, a missing
@@ -15,8 +15,8 @@
 // degrade to a fallback rather than throwing, since this is untrusted wire
 // JSON, not a value this file controls the shape of.
 
-import type { ItemModel, ThreadModel } from "../../protocol/model";
-import { parseArgs } from "../../protocol/toolCallText";
+import type { ItemModel, ThreadModel } from "./model";
+import { parseArgs } from "./toolCallText";
 
 export interface AskUserOption {
   label: string;

--- a/cmd/evener-hub/frontend/src/protocol/deriveAskQuestions.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/deriveAskQuestions.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment node
 import { expect, test } from "vitest";
-import type { ItemModel, ThreadModel, TurnModel } from "../../../../protocol/model";
-import type { ThreadCapabilities } from "../../../../protocol/types.gen";
 import { liveAskQuestions } from "./deriveAskQuestions";
+import type { ItemModel, ThreadModel, TurnModel } from "./model";
+import type { ThreadCapabilities } from "./types.gen";
 
 // --- fixtures (mirrors the local item/turn/model builder convention used
 // by transcript/flow/useTranscriptScroll.test.ts, kept local rather than

--- a/cmd/evener-hub/frontend/src/protocol/deriveAskQuestions.ts
+++ b/cmd/evener-hub/frontend/src/protocol/deriveAskQuestions.ts
@@ -10,15 +10,17 @@
 // §6.1).
 //
 // This alone is not sufficient for the live, in-flight-submission case -
-// see reconcileBatches.ts's own comment for why a purely positional signal
-// can't tell "my own reply's echo" apart from "a sibling ask_user call that
-// happened to land first" during the network round-trip of sending an
-// answer. reconcileBatches layers stateful batch-membership on top of the
-// list this function returns; this function's only job is "what does the
-// transcript say is live right now, ignoring any in-flight request."
-import type { ItemModel, ThreadModel } from "../../../../protocol/model";
-import type { AskUserOption } from "../../askShared";
-import { parseAskUserQuestions } from "../../askShared";
+// see askDock/reconcileBatches.ts's own comment for why a purely
+// positional signal can't tell "my own reply's echo" apart from "a
+// sibling ask_user call that happened to land first" during the network
+// round-trip of sending an answer. reconcileBatches layers stateful
+// batch-membership on top of the list this function returns; this
+// function's only job is "what does the transcript say is live right now,
+// ignoring any in-flight request."
+
+import type { AskUserOption } from "./askShared";
+import { parseAskUserQuestions } from "./askShared";
+import type { ItemModel, ThreadModel } from "./model";
 
 // AskQuestionRef is one flattened, individually-addressable question -
 // mirrors legacy's pendingAsk item shape (renderer.js:5832-5844). `key` is

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -38,11 +38,15 @@ export type {
 export { activityDelegateState, buildActivityRows, foldRowID, jobIsFailed } from "./activityRows";
 export type { AskAnswerItem, AskResolution } from "./askAnswers";
 export { composeAskAnswers } from "./askAnswers";
+export type { AskUserOption, AskUserQuestion } from "./askShared";
+export { answeredAskUserSuffix, parseAskUserQuestions } from "./askShared";
 export type { MarkerAttachment } from "./attachmentMarkers";
 export { translateAttachmentMarkers } from "./attachmentMarkers";
 export type { AnyNotification, AppwireClientOptions, ConnectionState, TerminalReason } from "./client";
 export { APPWIRE_PROTOCOL_VERSION, AppwireClient } from "./client";
 export type { AppwireClientLike } from "./clientLike";
+export type { AskQuestionRef } from "./deriveAskQuestions";
+export { liveAskQuestions } from "./deriveAskQuestions";
 export {
   firstLine,
   formatCharCount,

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -39,6 +39,8 @@ async function qualify() {
     "transport",
     "types.gen",
     "askAnswers",
+    "askShared",
+    "deriveAskQuestions",
     "attachmentMarkers",
     "activityData",
     "activityList",
@@ -80,6 +82,9 @@ async function qualify() {
     "sessionActionHeadline",
     "rpcURLFromLocation",
     "composeAskAnswers",
+    "parseAskUserQuestions",
+    "answeredAskUserSuffix",
+    "liveAskQuestions",
     "translateAttachmentMarkers",
     "METHOD_NAMES",
     "NOTIFICATION_NAMES",
@@ -157,6 +162,8 @@ async function qualify() {
     "AppwireClientLike",
     "WebSocketLike",
     "AskAnswerItem",
+    "AskUserQuestion",
+    "AskQuestionRef",
     "MarkerAttachment",
     "ActivityNodeLike",
     "ActivityTree",
@@ -178,6 +185,15 @@ async function qualify() {
   const rootSmokeCalls = `assert.equal(typeof client.AppwireClient, "function");
 assert.equal(client.rpcURLFromLocation({ protocol: "https:", host: "hub.example:9180" }), "wss://hub.example:9180/rpc");
 assert.equal(client.composeAskAnswers([]), "[answers]");
+const askItem = {
+  id: "ask1", turnId: "t1", type: "commandExecution", toolName: "ask_user", status: "completed",
+  argumentsJSON: '{"questions":[{"header":"DB","question":"Which store?","options":[{"label":"SQLite","detail":"one file"}]}]}',
+};
+assert.equal(client.parseAskUserQuestions(askItem)?.[0].question, "Which store?");
+assert.equal(client.parseAskUserQuestions({ argumentsJSON: "not json" }), undefined);
+assert.equal(client.liveAskQuestions({ turns: [{ items: [askItem] }] })[0].key, "ask1:0");
+const askReply = { id: "u1", turnId: "t1", type: "userMessage", text: '[answers]\\n1. [DB] \u2192 "SQLite"' };
+assert.equal(client.answeredAskUserSuffix({ turns: [{ items: [askItem, askReply] }] }, askItem), ' \u2014 answered: "SQLite"');
 assert.equal(client.translateAttachmentMarkers("[image 1]go", [{ marker: 1, name: "shot.png" }]), "(attached image 1: shot.png)go");
 assert.equal(new client.WireError("nope", -32000).code, -32000);
 assert.equal(client.errorText(new Error("boom")), "boom");

--- a/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
+++ b/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
@@ -19,6 +19,8 @@
     "transport.ts",
     "types.gen.ts",
     "askAnswers.ts",
+    "askShared.ts",
+    "deriveAskQuestions.ts",
     "attachmentMarkers.ts",
     "activityData.ts",
     "activityRows.ts",

--- a/mobile-native/src/questionBatches.ts
+++ b/mobile-native/src/questionBatches.ts
@@ -1,8 +1,8 @@
-import type { AskQuestionRef } from "../../cmd/evener-hub/frontend/src/panes/session/composer/askDock/deriveAskQuestions";
 import {
   type AskBatch,
   reconcileBatches,
 } from "../../cmd/evener-hub/frontend/src/panes/session/composer/askDock/reconcileBatches";
+import type { AskQuestionRef } from "../../cmd/evener-hub/frontend/src/protocol/deriveAskQuestions";
 
 /** Own submissions by question identity, using the current web reconciliation. */
 export class QuestionBatches {

--- a/mobile/src/conversation/project.ts
+++ b/mobile/src/conversation/project.ts
@@ -180,7 +180,7 @@ function outputAttachment(
 }
 
 // --- ask_user question parsing ----------------------------------------------
-// Mirrors the Hub's parseAskUserQuestions (askShared.ts): defensive throughout.
+// Mirrors parseAskUserQuestions (protocol/askShared.ts): defensive throughout.
 // Malformed argumentsJson degrades to a fallback (undefined) rather than
 // throwing, since this is untrusted wire JSON.
 

--- a/test/scenarios/ask-two-clients.md
+++ b/test/scenarios/ask-two-clients.md
@@ -165,10 +165,10 @@ and assert what each tab converges to.
   **both** tabs — a successful durable enqueue removes the batch in the sending tab
   (`askDockStore.ts:258`), and the winner's `[answers]` reply lands as a plain
   `userMessage`, which pushes the question behind `liveAskQuestions`' last-user-message
-  boundary in the other (`askDock/deriveAskQuestions.ts:60-90`). `recap` in both tabs
+  boundary in the other (`cmd/evener-hub/frontend/src/protocol/deriveAskQuestions.ts:62-97`). `recap` in both tabs
   reads the identical `Asked: [Deploy] — answered: "<winner's choice>"` — the losing tab
   echoes the *winner's* answer, because the recap is computed from the shared transcript
-  (`panes/session/askShared.ts:118-150`), not from local state.
+  (`cmd/evener-hub/frontend/src/protocol/askShared.ts:118-150`), not from local state.
 - **Step 7 (the loser's own text)**: the rejected intent lands in the durable recovery
   surface — either restored into that tab's composer as an editable draft (`composerDraft`
   starts with `[answers]`; `Composer.tsx:271-297` only does this when the composer is

--- a/test/scenarios/ask-web-answer.md
+++ b/test/scenarios/ask-web-answer.md
@@ -216,7 +216,7 @@ gesture.
   transcript's collapsed `ask_user` row grows its answered recap: the row
   `[data-testid="tool-call-item"][data-tool-name="ask_user"]` reads
   `Asked: [DB choice] — answered: "SQLite"` (`askUser.tsx:113-127` +
-  `panes/session/askShared.ts:118-150`; the note is deliberately stripped from the recap,
+  `cmd/evener-hub/frontend/src/protocol/askShared.ts:118-150`; the note is deliberately stripped from the recap,
   `askShared.ts:88-95`). Falsify: the dock is still up after a successful send, or the row
   still reads a bare `Asked: [DB choice]` long after the reply landed.
 - **Step 8 (exact)**: the outline shows the `ask_user` tool result carrying the ack text


### PR DESCRIPTION
`panes/session/askShared.ts` and `composer/askDock/deriveAskQuestions.ts` move
into the protocol package, with their test files. They travel together because
`deriveAskQuestions.ts` imports `askShared.ts`, which imports `parseArgs` from
`toolCallText.ts` (C11a, #1225) — a package module cannot keep an app-relative
import, so splitting them would leave an intermediate commit that does not
build. No logic changed; the two test files are the oracle and only their
import specifiers moved.

New package surface: `AskUserOption`, `AskUserQuestion`, `parseAskUserQuestions`,
`answeredAskUserSuffix` (askShared); `AskQuestionRef`, `liveAskQuestions`
(deriveAskQuestions).

## Plumbing (the three sites phase C requires)
- `protocol/tsconfig.build.json` `files`: both modules.
- `protocol/index.ts`: all six symbols re-exported, alphabetical by module.
- `scripts/qualify-package.mjs`: `shippedModules`, three `rootValues`, two
  `rootTypes`, and real root smoke calls — a question parsed out of a real
  `argumentsJSON`, the malformed-JSON fallback, `liveAskQuestions` deriving a
  key off an acked call, and `answeredAskUserSuffix` recomposing a recap from
  an `[answers]` reply (its `\n` escaped for the template literal).
- `protocol/README.md` export prose names both.

Falsified per #1224, two steps per module: with the `shippedModules` entry kept
and both the `index.ts` re-export and the module's manifest names removed,
`make test-api-package` fails with `shipped module unreachable from every
published specifier: askShared` (and again for `deriveAskQuestions`). Restored.

## Importers rewritten
Web: `transcript/tools/askUser.tsx`, and `askDock/{AskQuestionCard.tsx,
AskQuestionCard.test.tsx, askDockStore.ts, reconcileBatches.ts,
reconcileBatches.test.ts}` — deep relative paths matching neighbours.
Native: `mobile-native/src/questionBatches.ts` (hand-sorted; biome never runs
over `mobile-native/`).

Also repointed what the move would have left pointing at nothing: the header
comments in `askShared.ts` (it named its old web-tree home), `askUser.tsx`,
`askUser.test.tsx`, `askDock/index.ts` (drops `deriveAskQuestions` from its
list of this directory's files) and `reconcileBatches.ts`, one prose reference
in `mobile/src/conversation/project.ts`, and the three scenario-card citations
in `test/scenarios/ask-{web-answer,two-clients}.md`, whose old paths would have
failed `TestScenarioSourceCitationsResolve`.

## Gates
`make test-api-package` PASS · `make test-web` PASS (typecheck, test, lint) ·
`make test-native` PASS (777 tests + tsc) · `make test-web-browser` PASS
(5 guards) · `go test -run TestScenarioSource .` PASS. Biome run only over the
touched files under `cmd/evener-hub/frontend/src`.

Plan row: C11 (second of two PRs; C11a was #1225) in
`docs/superpowers/plans/2026-09-12-sdk-migration.md` (#1182).
