### PR TITLE
refactor(protocol): move reconcileBatches into the package (SDK C12)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.test.tsx
@@ -1178,9 +1178,9 @@ test("an atomic pending-set replacement with an identical count re-announces the
 
 const SECOND_ASK = [{ header: "Later", question: "q_later", options: [{ label: "later-opt", detail: "d" }] }];
 
-// renderTwoBatches drives the REAL two-batch route (reconcileBatches.ts: a
-// batch mid-send is frozen, so the late ask_user call mints a sibling batch
-// instead of joining the open one). Determinism lives in the ordering, not
+// renderTwoBatches drives the REAL two-batch route
+// (protocol/reconcileBatches.ts: a batch mid-send is frozen, so the late
+// ask_user call mints a sibling batch instead of joining the open one). Determinism lives in the ordering, not
 // in any timing: the click and the ack run in ONE synchronous block (act's
 // callback executes synchronously), and send() can only resolve after its
 // durable outbox write - an IndexedDB round trip that cannot complete inside

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/AskDock.tsx
@@ -71,13 +71,13 @@
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { isIMECompositionKeydown } from "../../../../keybindings/dispatcher";
 import type { AskResolution } from "../../../../protocol/askAnswers";
+import type { AskBatch } from "../../../../protocol/reconcileBatches";
 import { Button, useToasts } from "../../../../widgets";
 import { requireClass } from "../../../../widgets/internal/requireClass";
 import { requestComposerFocus } from "../composerFocus";
 import { AskQuestionCard } from "./AskQuestionCard";
 import { type AskAnswerState, askDockStore, nextUnansweredKey, useAskDockStore } from "./askDockStore";
 import styles from "./askdock.module.css";
-import type { AskBatch } from "./reconcileBatches";
 
 const CLASS = {
   dock: requireClass(styles.dock, "askdock.module.css", "dock"),

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askDockStore.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/askDockStore.ts
@@ -10,8 +10,8 @@
 // component-level useEffect: this is what lets a session's FIRST hydrate
 // (which can complete before any AskDock ever mounts) still populate
 // batches immediately, and it mirrors threads.ts's own connectionStore.
-// subscribe wiring exactly. See reconcileBatches.ts's own header for why a
-// purely positional signal isn't enough on its own, and this file's
+// subscribe wiring exactly. See protocol/reconcileBatches.ts's own header
+// for why a purely positional signal isn't enough on its own, and this file's
 // sendBatch for how the in-flight submission race is actually resolved:
 // freeze the batch until its durable outbox commit, then let the outbox and
 // recovery surfaces own later network outcomes.
@@ -21,8 +21,8 @@ import { type AskResolution, composeAskAnswers } from "../../../../protocol/askA
 import { liveAskQuestions } from "../../../../protocol/deriveAskQuestions";
 import { sessionActionError } from "../../../../protocol/errors";
 import type { ThreadModel } from "../../../../protocol/model";
+import { type AskBatch, reconcileBatches } from "../../../../protocol/reconcileBatches";
 import { threadsStore } from "../../../../stores/threads";
-import { type AskBatch, reconcileBatches } from "./reconcileBatches";
 
 export interface AskAnswerState {
   resolution: AskResolution | null;
@@ -331,10 +331,10 @@ export const askDockStore = createStore<AskDockState>(() => ({
 // reconcileRef folds one ref's current ThreadModel into its ask-dock
 // bookkeeping: recompute the live question set (minus anything this client
 // has permanently excluded - see AskDockRefState's own doc comment),
-// reconcile batches against it (reconcileBatches.ts owns the actual merge/
-// prune/protect rules), and prune any per-question answer draft whose key no
-// longer belongs to any batch (durably submitted or resolved by someone else;
-// there is nothing left for that draft to attach to).
+// reconcile batches against it (protocol/reconcileBatches.ts owns the
+// actual prune/protect rules), and prune any per-question answer draft whose
+// key no longer belongs to any batch (durably submitted or resolved by
+// someone else; there is nothing left for that draft to attach to).
 function reconcileRef(ref: string, model: ThreadModel): void {
   const liveAll = liveAskQuestions(model);
   askDockStore.setState((s) => {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/askDock/index.ts
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/askDock/index.ts
@@ -1,11 +1,10 @@
 // Public surface for the ask_user answering dock (wave-5 plan T4). See
 // AskDock.tsx's own header for the full mount-expectations note (the
 // useAskDockPending hide/inert seam and what this component deliberately
-// does NOT own). Everything else in this
-// directory (askDockStore, reconcileBatches)
-// is this feature's own implementation detail, not part of
-// its public contract - a sibling stream that needs one of those directly
-// should ask for it to be exported here first.
+// does NOT own). Everything else in this directory (askDockStore) is this
+// feature's own implementation detail, not part of its public contract - a
+// sibling stream that needs one of those directly should ask for it to be
+// exported here first.
 // Shared answer formatting is imported directly from protocol/askAnswers;
 // it is not re-exported by this dock's public surface.
 export type { AskDockProps } from "./AskDock";

--- a/cmd/evener-hub/frontend/src/protocol/README.md
+++ b/cmd/evener-hub/frontend/src/protocol/README.md
@@ -7,20 +7,21 @@ types, wire errors with their session classifiers, the rejection classifier
 and the user-facing message helpers every failure display goes through, the
 pure question formatter, the ask_user question parser and the answered recap
 it reads back out of a transcript, the live-question derivation an answering
-dock renders from a thread, the translation that turns a composer's
-`[image N]` attachment markers into prose at send, the thread view model
-and its notification reducer, the activity tree parser, merge and disclosure
-rules, the job log tail parser, the send/queue availability table, the
-send/steer/queue/drain routing decisions a composer makes off it, the stable
-delegate status rule, the slash invocation and catalog visibility rules the
-palette and composer share, the display formatters both apps render counts,
-durations and clock times with, the text and argument helpers a tool call's
-rendering is built from, and the doc-pane URL builders, which hang their hrefs
-off a base origin the host supplies (empty for a same-origin web page). The
-doc-pane data layer is published at the `./docContent` subpath as well, where
-`readDocFile` takes the host's `DocPort` - that base origin paired with a
-fetch: the package issues no request of its own and names neither an origin
-nor a credentials policy.
+dock renders from a thread, the batch reconciliation that keeps an in-flight
+answer's questions frozen while late ones arrive, the translation that turns a
+composer's `[image N]` attachment markers into prose at send, the thread view
+model and its notification reducer, the activity tree parser, merge and
+disclosure rules, the job log tail parser, the send/queue availability table,
+the send/steer/queue/drain routing decisions a composer makes off it, the
+stable delegate status rule, the slash invocation and catalog visibility rules
+the palette and composer share, the display formatters both apps render
+counts, durations and clock times with, the text and argument helpers a tool
+call's rendering is built from, and the doc-pane URL builders, which hang
+their hrefs off a base origin the host supplies (empty for a same-origin web
+page). The doc-pane data layer is published at the `./docContent` subpath as
+well, where `readDocFile` takes the host's `DocPort` - that base origin paired
+with a fetch: the package issues no request of its own and names neither an
+origin nor a credentials policy.
 
 Build and qualify from this directory with `npm run qualification`. The runner
 packs the package, installs that tarball into a temporary consumer, and then,

--- a/cmd/evener-hub/frontend/src/protocol/deriveAskQuestions.ts
+++ b/cmd/evener-hub/frontend/src/protocol/deriveAskQuestions.ts
@@ -10,7 +10,7 @@
 // §6.1).
 //
 // This alone is not sufficient for the live, in-flight-submission case -
-// see askDock/reconcileBatches.ts's own comment for why a purely
+// see protocol/reconcileBatches.ts's own comment for why a purely
 // positional signal can't tell "my own reply's echo" apart from "a
 // sibling ask_user call that happened to land first" during the network
 // round-trip of sending an answer. reconcileBatches layers stateful

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -95,6 +95,8 @@ export type {
   TurnModel,
 } from "./model";
 export { SYSTEM_PRELUDE_TURN_ID } from "./model";
+export type { AskBatch } from "./reconcileBatches";
+export { reconcileBatches } from "./reconcileBatches";
 export type { NotificationRoutingKey } from "./reducer";
 // chunkViewBackingForTests is deliberately absent: it reports the reducer's
 // internal chunk storage so a test can assert the view never copies it, which

--- a/cmd/evener-hub/frontend/src/protocol/reconcileBatches.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reconcileBatches.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { expect, test, vi } from "vitest";
-import type { AskQuestionRef } from "../../../../protocol/deriveAskQuestions";
+import type { AskQuestionRef } from "./deriveAskQuestions";
 import { type AskBatch, reconcileBatches } from "./reconcileBatches";
 
 function ref(key: string): AskQuestionRef {

--- a/cmd/evener-hub/frontend/src/protocol/reconcileBatches.ts
+++ b/cmd/evener-hub/frontend/src/protocol/reconcileBatches.ts
@@ -9,8 +9,9 @@
 // appended to the SAME transcript by two independent, unordered wire events.
 // Position alone can't tell "my own reply landed, resolving everything
 // before it" apart from "a new question arrived that has nothing to do with
-// my in-flight send" when the two race - see askDockStore.ts's own comment
-// for the concrete interleaving this protects against.
+// my in-flight send" when the two race - see the web dock's own
+// askDock/askDockStore.ts comment for the concrete interleaving this
+// protects against.
 //
 // The fix is identity, not position: once a batch is marked `sending`, its
 // own questions are frozen and immune to the live-set signal entirely
@@ -29,7 +30,7 @@
 // include its questions at all (the foreign reply moved the transcript
 // boundary past them) - membership comparisons below use `.key`, but the
 // data itself is never re-derived from a live scan once a batch holds it.
-import type { AskQuestionRef } from "../../../../protocol/deriveAskQuestions";
+import type { AskQuestionRef } from "./deriveAskQuestions";
 
 export interface AskBatch {
   id: string;

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -41,6 +41,7 @@ async function qualify() {
     "askAnswers",
     "askShared",
     "deriveAskQuestions",
+    "reconcileBatches",
     "attachmentMarkers",
     "activityData",
     "activityList",
@@ -86,6 +87,7 @@ async function qualify() {
     "parseAskUserQuestions",
     "answeredAskUserSuffix",
     "liveAskQuestions",
+    "reconcileBatches",
     "translateAttachmentMarkers",
     "METHOD_NAMES",
     "NOTIFICATION_NAMES",
@@ -167,6 +169,7 @@ async function qualify() {
     "AskAnswerItem",
     "AskUserQuestion",
     "AskQuestionRef",
+    "AskBatch",
     "MarkerAttachment",
     "ActivityNodeLike",
     "ActivityTree",
@@ -195,6 +198,9 @@ const askItem = {
 assert.equal(client.parseAskUserQuestions(askItem)?.[0].question, "Which store?");
 assert.equal(client.parseAskUserQuestions({ argumentsJSON: "not json" }), undefined);
 assert.equal(client.liveAskQuestions({ turns: [{ items: [askItem] }] })[0].key, "ask1:0");
+const askBatches = client.reconcileBatches([], client.liveAskQuestions({ turns: [{ items: [askItem] }] }), () => "batch1");
+assert.equal(askBatches[0].id, "batch1");
+assert.equal(askBatches[0].questions[0].key, "ask1:0");
 const askReply = { id: "u1", turnId: "t1", type: "userMessage", text: '[answers]\\n1. [DB] \u2192 "SQLite"' };
 assert.equal(client.answeredAskUserSuffix({ turns: [{ items: [askItem, askReply] }] }, askItem), ' \u2014 answered: "SQLite"');
 assert.equal(client.translateAttachmentMarkers("[image 1]go", [{ marker: 1, name: "shot.png" }]), "(attached image 1: shot.png)go");

--- a/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
+++ b/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
@@ -21,6 +21,7 @@
     "askAnswers.ts",
     "askShared.ts",
     "deriveAskQuestions.ts",
+    "reconcileBatches.ts",
     "attachmentMarkers.ts",
     "activityData.ts",
     "activityRows.ts",

--- a/mobile-native/src/questionBatches.ts
+++ b/mobile-native/src/questionBatches.ts
@@ -1,10 +1,7 @@
-import {
-  type AskBatch,
-  reconcileBatches,
-} from "../../cmd/evener-hub/frontend/src/panes/session/composer/askDock/reconcileBatches";
 import type { AskQuestionRef } from "../../cmd/evener-hub/frontend/src/protocol/deriveAskQuestions";
+import { type AskBatch, reconcileBatches } from "../../cmd/evener-hub/frontend/src/protocol/reconcileBatches";
 
-/** Own submissions by question identity, using the current web reconciliation. */
+/** Own submissions by question identity, using the shared reconciliation. */
 export class QuestionBatches {
   private batches: AskBatch[] = [];
   private excluded = new Set<string>();

--- a/mobile-native/src/screens.tsx
+++ b/mobile-native/src/screens.tsx
@@ -30,11 +30,11 @@ import {
 	View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import type { AskBatch } from "../../cmd/evener-hub/frontend/src/panes/session/composer/askDock/reconcileBatches";
 import {
 	parseSlashToken,
 	spliceSlashCommand,
 } from "../../cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion";
+import type { AskBatch } from "../../cmd/evener-hub/frontend/src/protocol/reconcileBatches";
 import { humanizeState } from "../../cmd/evener-hub/frontend/src/shell/rail/sessionState";
 import { buildComposerInput } from "../../cmd/evener-hub/frontend/src/stores/composerInput";
 import { createConversationService } from "../../mobile/src/services/conversation";


### PR DESCRIPTION
## What moved

`git mv` of `panes/session/composer/askDock/reconcileBatches.{ts,test.ts}` into
`cmd/evener-hub/frontend/src/protocol/`. No logic changes. The module's only
import is `AskQuestionRef`, now `./deriveAskQuestions` (C11b landed it in the
package); the test's is the same plus `./reconcileBatches`.

## Plumbing (the three phase-C sites)

- `protocol/tsconfig.build.json` `files`: `reconcileBatches.ts`, beside
  `deriveAskQuestions.ts`.
- `protocol/index.ts`: `export type { AskBatch }` and
  `export { reconcileBatches }`, alphabetically between `model` and `reducer`.
- `scripts/qualify-package.mjs`: `shippedModules` + `rootValues`
  (`reconcileBatches`) + `rootTypes` (`AskBatch`) + a real root smoke call that
  feeds `liveAskQuestions`' own output through `reconcileBatches` and asserts the
  minted batch id and the question key.

Falsified in two steps per the #1224 runner gap: with the `shippedModules` entry
kept, dropping the `index.ts` re-export and the module's manifest names fails
with `shipped module unreachable from every published specifier:
reconcileBatches`. Restored, green.

## Importers rewritten

- Web: `askDock/askDockStore.ts` and `askDock/AskDock.tsx` on
  `../../../../protocol/reconcileBatches`.
- Native: `mobile-native/src/questionBatches.ts` and
  `mobile-native/src/screens.tsx` (the brief listed only the first) on
  `../../cmd/evener-hub/frontend/src/protocol/reconcileBatches`, hand-sorted —
  biome is never run over `mobile-native/`.
- `askDock/index.ts` drops `reconcileBatches` from its list of this directory's
  files rather than renaming it (C11a/C11b precedent).
- Comments the move falsified, repointed: `deriveAskQuestions.ts` (it named
  `askDock/reconcileBatches.ts`), `askDockStore.ts` x2, `AskDock.test.tsx`, and
  the moved file's own cross-boundary reference to `askDockStore.ts`.
- `protocol/README.md` export prose gained the batch reconciliation.
- Repo-wide grep over web, `mobile/`, `mobile-native/`, `test/scenarios` and
  `docs/web-ui`: no `vi.mock` of the path, no scenario card, no live prose
  citation. The one remaining mention is `docs/superpowers/plans/wave5-report.md`,
  a dated record that is deliberately not swept.

## Gates

`make test-api-package` PASS - `make test-web` PASS (typecheck/test/lint) -
`make test-native` PASS (777 tests + tsc) - `make test-web-browser` PASS
(5 guards) - `go test -run TestScenarioSource .` PASS. Biome over the touched
`cmd/evener-hub/frontend/src` files only.

Plan row: C12 in docs/superpowers/plans/2026-09-12-sdk-migration.md (#1182);
depends on C11 (#1225, #1232).