### PR TITLE
refactor(protocol): move slashCompletion into the package (SDK C9)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/Composer.tsx
@@ -32,6 +32,14 @@ import {
 } from "react";
 import { sessionActionError } from "../../../protocol/errors";
 import { deriveSendQueueAvailability } from "../../../protocol/sendQueueAvailability";
+import {
+  filterSlashMenuItems,
+  mergeSlashCommands,
+  parseSlashToken,
+  type SlashMenuItem,
+  type SlashToken,
+  spliceSlashCommand,
+} from "../../../protocol/slashCompletion";
 import { decideSteerRoute, decideSubmitRoute, isTurnActive } from "../../../protocol/submitRouting";
 import type { PaletteRunContext, ScopedCommand } from "../../../shell/palette/commands";
 import { sessionBuiltinCommands, visibleCatalogCommands } from "../../../shell/palette/commands";
@@ -80,14 +88,6 @@ import {
 import { consumeQuoteInsert, type QuoteInsertPlacement, useQuoteInsertRequest } from "./quoteInsert";
 import { mergeRecoveryComposerDraft, recoveryComposerDraft } from "./recovery/recoveryDraft";
 import { SlashCompletionMenu, optionId as slashOptionId } from "./SlashCompletionMenu";
-import {
-  filterSlashMenuItems,
-  mergeSlashCommands,
-  parseSlashToken,
-  type SlashMenuItem,
-  type SlashToken,
-  spliceSlashCommand,
-} from "./slashCompletion";
 import { recordStoplessComposer } from "./stoplessComposer";
 
 export interface ComposerProps {

--- a/cmd/evener-hub/frontend/src/panes/session/composer/SlashCompletionMenu.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/composer/SlashCompletionMenu.tsx
@@ -11,8 +11,9 @@
 // session-scoped BUILT-INS merged with the plugin catalog, mergeSlashCommands'
 // own doc comment) - this component itself has no notion of which source a
 // row came from beyond rendering its already-resolved label/hint/invocation.
+
+import type { SlashMenuItem } from "../../../protocol/slashCompletion";
 import { requireClass } from "../../../widgets/internal/requireClass";
-import type { SlashMenuItem } from "./slashCompletion";
 import styles from "./slashcompletionmenu.module.css";
 
 const CLASS = {

--- a/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
+++ b/cmd/evener-hub/frontend/src/panes/spawn/Spawn.tsx
@@ -18,6 +18,14 @@ import {
 import { useStore } from "zustand";
 import { slashCommandInvocation } from "../../protocol/catalogCommands";
 import { friendlyLaunchErrorMessage } from "../../protocol/errors";
+import {
+  filterSlashMenuItems,
+  mergeSlashCommands,
+  parseSlashToken,
+  type SlashMenuItem,
+  type SlashToken,
+  spliceSlashCommand,
+} from "../../protocol/slashCompletion";
 import type { HarnessDescriptor, LaunchConfigLayer, LaunchOption, ModelListResponse } from "../../protocol/types.gen";
 import { useClient } from "../../shell/clientContext";
 import { splitModelId } from "../../shell/palette/commands";
@@ -58,14 +66,6 @@ import { imageFilesFromClipboard } from "../session/composer/attachments/clipboa
 import { type TextEditor, useAttachments } from "../session/composer/attachments/useAttachments";
 import { findBuiltinArgument, matchBuiltinInvocation } from "../session/composer/builtinInvocation";
 import { SlashCompletionMenu, optionId as slashOptionId } from "../session/composer/SlashCompletionMenu";
-import {
-  filterSlashMenuItems,
-  mergeSlashCommands,
-  parseSlashToken,
-  type SlashMenuItem,
-  type SlashToken,
-  spliceSlashCommand,
-} from "../session/composer/slashCompletion";
 import { AdvancedOptions } from "./AdvancedOptions";
 import { ACCESS_MODE_OPTIONS, accessModeDefaultLabel } from "./accessMode";
 import { resolveHeadBranch } from "./branch";

--- a/cmd/evener-hub/frontend/src/protocol/LICENSES/beautiful-ui.txt
+++ b/cmd/evener-hub/frontend/src/protocol/LICENSES/beautiful-ui.txt
@@ -1,0 +1,26 @@
+This package's slashCompletion module ports the trailing-token parser and
+menu-filter behaviour of the prompt-bar completion affordance in Beautiful UI
+(https://www.beautifului.dev). Beautiful UI is distributed under the MIT
+License, reproduced below as its terms require.
+
+MIT License
+
+Copyright (c) 2026 Shane Levine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/evener-hub/frontend/src/protocol/README.md
+++ b/cmd/evener-hub/frontend/src/protocol/README.md
@@ -11,14 +11,19 @@ notification reducer, the activity tree parser, merge and disclosure rules,
 the job log tail parser, the send/queue availability table, the
 send/steer/queue/drain routing decisions a composer makes off it, the stable
 delegate status rule, the slash invocation and catalog visibility rules the
-palette and composer share, the display formatters both apps render counts,
-durations and clock times with, the text and argument helpers a tool call's
-rendering is built from, and the doc-pane URL builders, which hang their hrefs
-off a base origin the host supplies (empty for a same-origin web page). The
-doc-pane data layer is published at the `./docContent` subpath as well, where
-`readDocFile` takes the host's `DocPort` - that base origin paired with a
-fetch: the package issues no request of its own and names neither an origin
-nor a credentials policy.
+palette and composer share, the inline slash-completion token parser, menu
+merge, filter and splice the composer's own menu is built from, the display
+formatters both apps render counts, durations and clock times with, the text
+and argument helpers a tool call's rendering is built from, and the doc-pane
+URL builders, which hang their hrefs off a base origin the host supplies
+(empty for a same-origin web page). The doc-pane data layer is published at
+the `./docContent` subpath as well, where `readDocFile` takes the host's
+`DocPort` - that base origin paired with a fetch: the package issues no
+request of its own and names neither an origin nor a credentials policy.
+
+The slash-completion module is ported from Beautiful UI's prompt-bar
+completion affordance and ships its MIT attribution at
+`LICENSES/beautiful-ui.txt`, inside the tarball.
 
 Build and qualify from this directory with `npm run qualification`. The runner
 packs the package, installs that tarball into a temporary consumer, and then,

--- a/cmd/evener-hub/frontend/src/protocol/index.ts
+++ b/cmd/evener-hub/frontend/src/protocol/index.ts
@@ -111,6 +111,20 @@ export {
 export type { SendQueueAvailability, SendQueueAvailabilityInput } from "./sendQueueAvailability";
 export { deriveSendQueueAvailability } from "./sendQueueAvailability";
 export { isActionUnavailable, isThreadNotFound } from "./sessionErrors";
+export type {
+  SlashEmbedding,
+  SlashMatchEvaluation,
+  SlashMenuItem,
+  SlashSpliceResult,
+  SlashToken,
+} from "./slashCompletion";
+export {
+  evaluateSlashLabel,
+  filterSlashMenuItems,
+  mergeSlashCommands,
+  parseSlashToken,
+  spliceSlashCommand,
+} from "./slashCompletion";
 export type { StableDelegateState } from "./stableDelegate";
 export { stableDelegateDisplayStatus } from "./stableDelegate";
 export type { SteerRoute, SubmitRoute } from "./submitRouting";

--- a/cmd/evener-hub/frontend/src/protocol/package.json
+++ b/cmd/evener-hub/frontend/src/protocol/package.json
@@ -6,7 +6,8 @@
   "files": [
     "dist",
     "README.md",
-    "examples"
+    "examples",
+    "LICENSES"
   ],
   "exports": {
     ".": {

--- a/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
+++ b/cmd/evener-hub/frontend/src/protocol/scripts/qualify-package.mjs
@@ -56,6 +56,7 @@ async function qualify() {
     "displayFormat",
     "toolCallText",
     "catalogCommands",
+    "slashCompletion",
   ];
   // Every runtime export of the package root. The root's generated consumer
   // programs are built from this one list, so an export the entry point stops
@@ -152,6 +153,11 @@ async function qualify() {
     "str",
     "slashCommandInvocation",
     "visibleCatalogCommands",
+    "evaluateSlashLabel",
+    "filterSlashMenuItems",
+    "mergeSlashCommands",
+    "parseSlashToken",
+    "spliceSlashCommand",
   ];
   // One exported type per shipped module that declares any, so the declaration
   // check covers each module's packed .d.ts and not just its runtime half.
@@ -174,6 +180,8 @@ async function qualify() {
     "DocFileContent",
     "SubmitRoute",
     "SteerRoute",
+    "SlashToken",
+    "SlashMenuItem",
   ];
   // One call per shipped module, with a trivial input. Importing alone would
   // pass for a module that needs a browser global at load time; calling proves
@@ -250,6 +258,24 @@ assert.deepEqual(client.parseArgs("not json"), {});
 assert.equal(client.parseJSONObject("[]"), undefined);
 assert.equal(client.trailingBracketFooter("done [exit 0]"), "exit 0");
 assert.equal(client.str({ path: "/tmp" }, "path"), "/tmp");
+const slashToken = client.parseSlashToken("say /rev", 8);
+assert.deepEqual(slashToken, { start: 4, end: 8, query: "rev" });
+assert.equal(client.parseSlashToken("say /rev\\nthen", 13), null);
+const slashItems = client.mergeSlashCommands(
+  [{ id: "goal", hint: "sets the session goal" }],
+  [{ name: "review", source: "plugin", pluginName: "acme" }],
+  [{ name: "writing", description: "writing skill" }],
+);
+assert.deepEqual(slashItems.map((item) => item.invocation), ["/goal", "/acme:review", "/writing"]);
+assert.deepEqual(
+  client.filterSlashMenuItems(slashItems, slashToken.query).map((item) => item.label),
+  ["review"],
+);
+assert.equal(client.evaluateSlashLabel("review", "rev").embedding.longestRun, 3);
+assert.deepEqual(client.spliceSlashCommand("say /rev", slashToken, "/acme:review"), {
+  text: "say /acme:review ",
+  caret: 17,
+});
 `;
   // The qualification manifest: every specifier package.json publishes, and the
   // names the package promises at each one. A subpath with no entry here is not
@@ -409,6 +435,10 @@ ${presenceLoop}${surface.smoke ?? ""}`,
     "package/examples/discovery-cli.mjs",
     "package/examples/discovery-logic.mjs",
     "package/examples/private-output.mjs",
+    // The attribution slashCompletion.ts's port requires. It sits outside dist/
+    // and examples/, so it needs its own expectation here and its own clause in
+    // the allowlist below.
+    "package/LICENSES/beautiful-ui.txt",
   ])
     assert(listing.includes(`${expected}\n`), `missing ${expected}`);
   for (const entry of listing.trim().split("\n")) {
@@ -416,7 +446,8 @@ ${presenceLoop}${surface.smoke ?? ""}`,
       entry === "package/package.json" ||
         entry === "package/README.md" ||
         entry.startsWith("package/dist/") ||
-        entry.startsWith("package/examples/"),
+        entry.startsWith("package/examples/") ||
+        entry.startsWith("package/LICENSES/"),
       `unexpected shipped path ${entry}`,
     );
     assert(!entry.endsWith(".ts") || entry.endsWith(".d.ts"), `source leak ${entry}`);

--- a/cmd/evener-hub/frontend/src/protocol/slashCompletion.test.ts
+++ b/cmd/evener-hub/frontend/src/protocol/slashCompletion.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "vitest";
-import type { CommandDescriptor } from "../../../protocol/types.gen";
-import type { ScopedCommand } from "../../../shell/palette/commands";
+import type { ScopedCommand } from "../shell/palette/commands";
 import {
   evaluateSlashLabel,
   filterSlashMenuItems,
@@ -9,6 +8,7 @@ import {
   type SlashMenuItem,
   spliceSlashCommand,
 } from "./slashCompletion";
+import type { CommandDescriptor } from "./types.gen";
 
 // --- parseSlashToken ---------------------------------------------------
 //

--- a/cmd/evener-hub/frontend/src/protocol/slashCompletion.ts
+++ b/cmd/evener-hub/frontend/src/protocol/slashCompletion.ts
@@ -9,8 +9,8 @@
 // text/caret state and the plugin slash-command catalog (stores/
 // commandCatalog.ts), the same catalog the modal command palette reads.
 
-import { slashCommandInvocation } from "../../../protocol/catalogCommands";
-import type { CommandDescriptor, EvenerSkillInfo } from "../../../protocol/types.gen";
+import { slashCommandInvocation } from "./catalogCommands";
+import type { CommandDescriptor, EvenerSkillInfo } from "./types.gen";
 
 type ScopedCommand = {
   id: string;

--- a/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
+++ b/cmd/evener-hub/frontend/src/protocol/tsconfig.build.json
@@ -35,6 +35,7 @@
     "submitRouting.ts",
     "displayFormat.ts",
     "toolCallText.ts",
-    "catalogCommands.ts"
+    "catalogCommands.ts",
+    "slashCompletion.ts"
   ]
 }

--- a/mobile-native/src/CommandCompletion.tsx
+++ b/mobile-native/src/CommandCompletion.tsx
@@ -3,7 +3,7 @@ import { ActivityIndicator, FlatList, Pressable, View } from "react-native";
 import {
   filterSlashMenuItems,
   type SlashMenuItem,
-} from "../../cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion";
+} from "../../cmd/evener-hub/frontend/src/protocol/slashCompletion";
 import type { MobileConversation } from "../../mobile/src/conversation/model";
 import type { ConversationClientLike } from "../../mobile/src/services/conversation";
 import { CommandCatalog } from "./commandCatalog";

--- a/mobile-native/src/commandCatalog.ts
+++ b/mobile-native/src/commandCatalog.ts
@@ -1,9 +1,9 @@
+import { visibleCatalogCommands } from "../../cmd/evener-hub/frontend/src/protocol/catalogCommands";
+import { sessionActionError } from "../../cmd/evener-hub/frontend/src/protocol/errors";
 import {
   mergeSlashCommands,
   type SlashMenuItem,
-} from "../../cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion";
-import { visibleCatalogCommands } from "../../cmd/evener-hub/frontend/src/protocol/catalogCommands";
-import { sessionActionError } from "../../cmd/evener-hub/frontend/src/protocol/errors";
+} from "../../cmd/evener-hub/frontend/src/protocol/slashCompletion";
 import type { ConversationClientLike } from "../../mobile/src/services/conversation";
 
 interface CatalogState {

--- a/mobile-native/src/composerCommand.test.ts
+++ b/mobile-native/src/composerCommand.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from "vitest";
 import {
   parseSlashToken,
   spliceSlashCommand,
-} from "../../cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion";
+} from "../../cmd/evener-hub/frontend/src/protocol/slashCompletion";
 import { builtinComposerItems, composerCommand } from "./composerCommand";
 
 it.each([

--- a/mobile-native/src/composerCommand.ts
+++ b/mobile-native/src/composerCommand.ts
@@ -2,7 +2,7 @@ import {
   findBuiltinArgument,
   matchBuiltinInvocation,
 } from "../../cmd/evener-hub/frontend/src/panes/session/composer/builtinInvocation";
-import { mergeSlashCommands } from "../../cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion";
+import { mergeSlashCommands } from "../../cmd/evener-hub/frontend/src/protocol/slashCompletion";
 import type { ThreadClearResponse } from "../../cmd/evener-hub/frontend/src/protocol/types.gen";
 import {
   effortLabel,

--- a/mobile-native/src/screens.tsx
+++ b/mobile-native/src/screens.tsx
@@ -34,7 +34,7 @@ import type { AskBatch } from "../../cmd/evener-hub/frontend/src/panes/session/c
 import {
 	parseSlashToken,
 	spliceSlashCommand,
-} from "../../cmd/evener-hub/frontend/src/panes/session/composer/slashCompletion";
+} from "../../cmd/evener-hub/frontend/src/protocol/slashCompletion";
 import { humanizeState } from "../../cmd/evener-hub/frontend/src/shell/rail/sessionState";
 import { buildComposerInput } from "../../cmd/evener-hub/frontend/src/stores/composerInput";
 import { createConversationService } from "../../mobile/src/services/conversation";


### PR DESCRIPTION
## What moved

`git mv` of `panes/session/composer/slashCompletion.{ts,test.ts}` into
`protocol/`. No logic changes. Inside the module only its two imports changed
(`./catalogCommands`, `./types.gen`) — it imports nothing outside `protocol/`.
The test file moved with it and stays the oracle; it keeps
`import type { ScopedCommand } from "../shell/palette/commands"` so the web
palette's real type is still what flows into `mergeSlashCommands`
(`protocol/tokenFlood.test.tsx` is the precedent for a package test reaching
into the app tree; no shipped module does).

Published surface: types `SlashEmbedding`, `SlashMatchEvaluation`,
`SlashMenuItem`, `SlashSpliceResult`, `SlashToken`; values
`evaluateSlashLabel`, `filterSlashMenuItems`, `mergeSlashCommands`,
`parseSlashToken`, `spliceSlashCommand`.

## License handling

The module is a port of Beautiful UI's prompt-bar completion affordance,
attributed to `cmd/evener-hub/frontend/LICENSES/beautiful-ui.txt`. That file is
the **web app's** attribution — a dozen widgets and `panes/settings/sections/about.tsx`
cite it, and `about.test.tsx` asserts the embedded license const matches it on
disk — so it stays where it is. Per the C9 row the package gets its own copy at
`protocol/LICENSES/beautiful-ui.txt`, `package.json` `files` gains `LICENSES`,
and the runner's tarball checks gain a `package/LICENSES/beautiful-ui.txt`
expectation plus a `package/LICENSES/` clause in the "unexpected shipped path"
allowlist (without it the gate fails on the new entry — verified).

One deviation from "copy": the MIT text is reproduced **verbatim**, but the
descriptive preamble is rewritten to name what this package actually ports.
The web file's preamble says the evener web UI's "visual design language
(palette, elevation system, type choices, and the chrome patterns applied
across widgets)" is adapted from Beautiful UI, which is not true of a
zero-dependency protocol client that ships one text parser. Publishing that
sentence in the npm tarball would be a false statement; the legally required
half is unchanged.

## Plumbing

- `protocol/tsconfig.build.json` `files`: `slashCompletion.ts`.
- `protocol/index.ts`: both re-export blocks, alphabetical between
  `sessionErrors` and `stableDelegate`.
- `scripts/qualify-package.mjs`: `shippedModules`, 5 `rootValues`, 2
  `rootTypes` (`SlashToken` and `SlashMenuItem` are the parameter types of
  `spliceSlashCommand` and `filterSlashMenuItems`), and real root smoke calls
  that parse a trailing token, reject one across a newline (`\n` escaped as
  `\\n` for the template literal), merge a built-in + plugin + skill, filter by
  the parsed query, score an embedding, and splice the invocation back in.
- `protocol/README.md`: the export prose, plus a sentence on the shipped
  attribution.

## Importers rewritten

Web: `panes/session/composer/Composer.tsx`,
`panes/session/composer/SlashCompletionMenu.tsx`, `panes/spawn/Spawn.tsx` —
deep relative paths matching each file's neighbouring `protocol/` imports.

Native: `mobile-native/src/{commandCatalog,composerCommand,composerCommand.test,CommandCompletion,screens}` —
`commandCatalog.ts`'s block hand-sorted after `protocol/errors` to keep the
file's order (biome never runs over `mobile-native/`).

Repo-wide grep over web, `mobile/`, `mobile-native/`, `test/scenarios` and
`docs/web-ui` found no `vi.mock` of the path, no scenario-card citation and no
prose citing a *path*. The remaining prose hits name the file by bare filename
(`slashCompletion.ts`'s `mergeSlashCommands`), which is still accurate.

## Gates

`make test-api-package` PASS · `make test-web` PASS (typecheck/test/lint) ·
`make test-native` PASS (777 tests + tsc) · `make test-web-browser` PASS
(5 guards) · `go test -run TestScenarioSource .` PASS. Falsified in two steps
per #1224: with `shippedModules` kept, removing the `index.ts` re-export and the
module's `rootValues`/`rootTypes` names gives
`shipped module unreachable from every published specifier: slashCompletion`;
restored and green. Merged `origin/main` `314281cd5` (#1232 C11b) — no
conflicts, both README clauses present — and re-ran test-api-package and
test-web after.

Biome over the six touched files under `cmd/evener-hub/frontend/src` only.

Plan row: C9 in docs/superpowers/plans/2026-09-12-sdk-migration.md (#1182);
depends on C15 (#1230)