### PR TITLE
fix(llm): stop counting thinking the adapter will not replay (#653)

### DIFF
--- a/agent/internal/contextmgr/context_manager_test.go
+++ b/agent/internal/contextmgr/context_manager_test.go
@@ -81,10 +81,27 @@ func TestEstimateTokens_WithThinking(t *testing.T) {
 		}},
 	}
 	got := estimateTokens(turns)
-	totalChars := len("let me think about this carefully") + len("answer")
-	want := totalChars / 4
+	// A thinking part with no replay metadata (no signature, no encrypted
+	// content) is display-only — the adapter never re-sends it — so it must not
+	// be billed to the context estimate (issue #653). Only the answer counts.
+	want := len("answer") / 4
 	if got != want {
 		t.Fatalf("EstimateTokens = %d, want %d", got, want)
+	}
+
+	// Thinking the adapter will replay (provider-scoped signature) is billed.
+	replayable := []schema.Turn{
+		{Kind: schema.TurnAssistant, Message: llm.Message{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentPart{
+				{Kind: llm.ContentThinking, Thinking: &llm.ThinkingData{Text: "let me think about this carefully", Signature: "crypto-sig"}},
+				{Kind: llm.ContentText, Text: "answer"},
+			},
+		}},
+	}
+	totalChars := len("let me think about this carefully") + len("crypto-sig") + len("answer")
+	if got := estimateTokens(replayable); got != totalChars/4 {
+		t.Fatalf("EstimateTokens = %d, want %d", got, totalChars/4)
 	}
 }
 

--- a/llm/token_count.go
+++ b/llm/token_count.go
@@ -249,6 +249,15 @@ func thinkingReplayChars(p ContentPart) int {
 		return len(t.Text)
 	}
 	if t.EncryptedContent != "" {
+		// An OpenAI-compatible encrypted reasoning_details array is replayed by
+		// the chat adapter together with the separately parsed text
+		// (chatcompletions/messages.go), and the Anthropic adapter replays the
+		// text while ignoring the blob. The opaque OpenAI Responses blob is the
+		// other shape: it replays with its summary and id and puts no text on
+		// the wire, so only that shape bills them.
+		if IsOpenAICompatEncryptedReasoning(t.EncryptedContent) {
+			return len(t.EncryptedContent) + len(t.Text)
+		}
 		chars := len(t.EncryptedContent) + len(t.ID)
 		for _, s := range t.Summary {
 			chars += len(s)

--- a/llm/token_count.go
+++ b/llm/token_count.go
@@ -202,10 +202,7 @@ func estimateMessageInputParts(provider, model string, m Message) (int, int) {
 				}
 			}
 		case ContentThinking, ContentRedThinking:
-			if p.Thinking != nil {
-				chars += len(p.Thinking.Text)
-				chars += len(p.Thinking.Signature)
-			}
+			chars += thinkingReplayChars(p)
 		case ContentWebSearch:
 			if p.WebSearch != nil {
 				chars += len(p.WebSearch.Query)
@@ -217,6 +214,30 @@ func estimateMessageInputParts(provider, model string, m Message) (int, int) {
 		}
 	}
 	return chars, tokens
+}
+
+// thinkingReplayChars counts the characters a thinking part contributes to the
+// outgoing request. A part is billed only when the active adapter will actually
+// re-send it, and reasoning reaches the wire solely through provider-scoped
+// replay metadata: an encrypted_content blob (the OpenAI Responses opaque blob,
+// or OpenAI-compat encrypted reasoning_details) or a signature (Anthropic's
+// cryptographic signature, or the OpenAI-compat wire field the part arrived
+// on). A part carrying only raw display text — neither encrypted content nor
+// signature — is never replayed: toResponsesInput emits a reasoning item only
+// when encrypted_content is set, so raw reasoning_text kept for display
+// (gateway-fronted GLM) must not be billed. Redacted thinking replays its
+// payload verbatim and stays billable.
+func thinkingReplayChars(p ContentPart) int {
+	if p.Thinking == nil {
+		return 0
+	}
+	// Redacted thinking replays its payload, which is stored in Thinking.Text,
+	// verbatim. Every other thinking part is billable only when it carries
+	// provider-scoped replay metadata.
+	if p.Kind != ContentRedThinking && p.Thinking.EncryptedContent == "" && p.Thinking.Signature == "" {
+		return 0
+	}
+	return len(p.Thinking.Text) + len(p.Thinking.Signature)
 }
 
 func estimateImageTokens(provider, model string, img *ImageData) int {

--- a/llm/token_count.go
+++ b/llm/token_count.go
@@ -217,16 +217,22 @@ func estimateMessageInputParts(provider, model string, m Message) (int, int) {
 }
 
 // thinkingReplayChars counts the characters a thinking part contributes to the
-// outgoing request. A part is billed only when the active adapter will actually
-// re-send it, and reasoning reaches the wire solely through provider-scoped
-// replay metadata: an encrypted_content blob (the OpenAI Responses opaque blob,
-// or OpenAI-compat encrypted reasoning_details) or a signature (Anthropic's
-// cryptographic signature, or the OpenAI-compat wire field the part arrived
-// on). A part carrying only raw display text — neither encrypted content nor
-// signature — is never replayed: toResponsesInput emits a reasoning item only
-// when encrypted_content is set, so raw reasoning_text kept for display
-// (gateway-fronted GLM) must not be billed. Redacted thinking replays its
-// payload verbatim and stays billable.
+// outgoing request. The estimator is provider-blind — the compaction path calls
+// EstimateMessagesInputTokens, which carries no provider or model — so one rule
+// stands in for every adapter: a thinking part is billed only when it carries
+// provider-scoped replay metadata, an encrypted_content blob (the OpenAI
+// Responses opaque blob, or OpenAI-compat encrypted reasoning_details) or a
+// signature. The Responses adapter is the reference case: toResponsesInput emits
+// a reasoning item only when encrypted_content is set, so raw reasoning_text
+// kept for display (gateway-fronted GLM) is not billed. Redacted thinking
+// replays its payload verbatim and stays billable.
+//
+// Known limitation: an OpenAI-compatible chat adapter replays raw reasoning text
+// through its reasoning field, and also replays an OpenAI-compat
+// encrypted_content array the Responses adapter rejects. This rule therefore
+// under-counts the first and over-counts the second for those adapters. Deciding
+// per adapter needs the provider threaded into the compaction estimate, which it
+// currently is not.
 func thinkingReplayChars(p ContentPart) int {
 	if p.Thinking == nil {
 		return 0

--- a/llm/token_count.go
+++ b/llm/token_count.go
@@ -217,33 +217,51 @@ func estimateMessageInputParts(provider, model string, m Message) (int, int) {
 }
 
 // thinkingReplayChars counts the characters a thinking part contributes to the
-// outgoing request. The estimator is provider-blind — the compaction path calls
-// EstimateMessagesInputTokens, which carries no provider or model — so one rule
-// stands in for every adapter: a thinking part is billed only when it carries
-// provider-scoped replay metadata, an encrypted_content blob (the OpenAI
-// Responses opaque blob, or OpenAI-compat encrypted reasoning_details) or a
-// signature. The Responses adapter is the reference case: toResponsesInput emits
-// a reasoning item only when encrypted_content is set, so raw reasoning_text
-// kept for display (gateway-fronted GLM) is not billed. Redacted thinking
-// replays its payload verbatim and stays billable.
+// outgoing request. The estimator is provider-blind, because the compaction path
+// calls EstimateMessagesInputTokens, which carries no provider or model, so one
+// rule stands in for every adapter: bill the payload each adapter may replay.
 //
-// Known limitation: an OpenAI-compatible chat adapter replays raw reasoning text
-// through its reasoning field, and also replays an OpenAI-compat
-// encrypted_content array the Responses adapter rejects. This rule therefore
-// under-counts the first and over-counts the second for those adapters. Deciding
-// per adapter needs the provider threaded into the compaction estimate, which it
+//   - redacted thinking replays its text payload only (anthropic/request.go
+//     emits "data": Text and never a signature);
+//   - an encrypted blob is replayed verbatim together with its summary and id
+//     by the OpenAI Responses adapter (responses/input.go), and by the
+//     OpenAI-compatible chat adapter for the reasoning_details shape;
+//   - a cryptographic signature (Anthropic) replays its text and signature; an
+//     OpenAI-compatible wire field name in Signature means the text is replayed
+//     in that field, with the name itself not payload.
+//
+// Raw reasoning text that carries no replay metadata is not billed: the
+// Responses adapter keeps it for display only (gateway-fronted GLM), which is
+// the over-count this rule fixes.
+//
+// Known limitation: replay is a property of the adapter, not of the part, so a
+// part with text and no replay metadata is under-counted for adapters that do
+// replay it unsigned: Anthropic's unsigned thinking block, and the
+// ThinkingAsText merge path in the OpenAI-compatible chat adapter. Deciding per
+// adapter needs the provider threaded into the compaction estimate, which it
 // currently is not.
 func thinkingReplayChars(p ContentPart) int {
 	if p.Thinking == nil {
 		return 0
 	}
-	// Redacted thinking replays its payload, which is stored in Thinking.Text,
-	// verbatim. Every other thinking part is billable only when it carries
-	// provider-scoped replay metadata.
-	if p.Kind != ContentRedThinking && p.Thinking.EncryptedContent == "" && p.Thinking.Signature == "" {
-		return 0
+	t := p.Thinking
+	if p.Kind == ContentRedThinking {
+		return len(t.Text)
 	}
-	return len(p.Thinking.Text) + len(p.Thinking.Signature)
+	if t.EncryptedContent != "" {
+		chars := len(t.EncryptedContent) + len(t.ID)
+		for _, s := range t.Summary {
+			chars += len(s)
+		}
+		return chars
+	}
+	if t.Signature != "" {
+		if IsOpenAICompatReasoningField(t.Signature) {
+			return len(t.Text)
+		}
+		return len(t.Text) + len(t.Signature)
+	}
+	return 0
 }
 
 func estimateImageTokens(provider, model string, img *ImageData) int {

--- a/llm/token_count_test.go
+++ b/llm/token_count_test.go
@@ -84,6 +84,29 @@ func TestEstimateMessagesInputTokens_BillsReplayedEncryptedBlob(t *testing.T) {
 
 // Redacted thinking replays only its text payload: anthropic/request.go emits
 // "data": Text and never the signature, so a signature must not be billed.
+// An OpenAI-compatible encrypted reasoning_details array is replayed together
+// with the separately parsed text, so the text must be billed alongside the
+// blob; ID and Summary never ride a compat blob.
+func TestEstimateMessagesInputTokens_CompatEncryptedBlobBillsItsText(t *testing.T) {
+	const blob = `[{"type":"reasoning.text","text":"","signature":"sig-1"}]`
+	plain := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentThinking, Thinking: &ThinkingData{EncryptedContent: blob}},
+	}}}
+	withText := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentThinking, Thinking: &ThinkingData{EncryptedContent: blob, Text: strings.Repeat("t", 400)}},
+	}}}
+	a := EstimateMessagesInputTokens(plain).Tokens
+	if b := EstimateMessagesInputTokens(withText).Tokens; b <= a {
+		t.Fatalf("compat blob with replayed text = %d, want > %d", b, a)
+	}
+	extra := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentThinking, Thinking: &ThinkingData{EncryptedContent: blob, ID: strings.Repeat("i", 400), Summary: []string{strings.Repeat("s", 400)}}},
+	}}}
+	if c := EstimateMessagesInputTokens(extra).Tokens; c != a {
+		t.Fatalf("compat blob ID/Summary changed the estimate: %d vs %d", c, a)
+	}
+}
+
 func TestEstimateMessagesInputTokens_RedactedThinkingBillsTextOnly(t *testing.T) {
 	withSig := []Message{{Role: RoleAssistant, Content: []ContentPart{
 		{Kind: ContentRedThinking, Thinking: &ThinkingData{Text: "redacted", Signature: strings.Repeat("s", 400)}},

--- a/llm/token_count_test.go
+++ b/llm/token_count_test.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"strings"
 	"testing"
 )
 
@@ -35,6 +36,29 @@ func TestEstimateMessagesInputTokensIsAlwaysMarkedInexact(t *testing.T) {
 
 	if empty := EstimateMessagesInputTokens(nil); empty.Exact || empty.Source != TokenCountSourceLocalEstimate {
 		t.Errorf("empty history = %+v, want an inexact local estimate", empty)
+	}
+}
+
+// A thinking part whose raw text the adapter will not replay must not be billed
+// to the context estimate. The OpenAI Responses adapter re-sends a reasoning
+// item only when it carries an encrypted_content blob, so raw reasoning_text
+// kept on the part (gateway-fronted GLM, for example) is display-only. A part
+// that does carry replayable metadata is still counted.
+func TestEstimateMessagesInputTokens_ExcludesNonReplayableThinking(t *testing.T) {
+	rawText := strings.Repeat("r", 400)
+	thinkingOnly := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentThinking, Thinking: &ThinkingData{Text: rawText}},
+	}}}
+	withReplay := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentThinking, Thinking: &ThinkingData{Text: rawText, EncryptedContent: "opaque-blob"}},
+	}}}
+
+	got := EstimateMessagesInputTokens(thinkingOnly).Tokens
+	if got != 0 {
+		t.Fatalf("non-replayable thinking estimate = %d, want 0 (raw reasoning_text is display-only)", got)
+	}
+	if replay := EstimateMessagesInputTokens(withReplay).Tokens; replay <= got {
+		t.Fatalf("replayable thinking estimate = %d, want > %d", replay, got)
 	}
 }
 

--- a/llm/token_count_test.go
+++ b/llm/token_count_test.go
@@ -62,6 +62,40 @@ func TestEstimateMessagesInputTokens_ExcludesNonReplayableThinking(t *testing.T)
 	}
 }
 
+// The replayed payload is the encrypted blob itself, not the part's display
+// text: the Responses adapter sends encrypted_content (plus the summary and id)
+// and ignores Text. A blob-only part must therefore still be billed, and the
+// estimate must grow with the blob.
+func TestEstimateMessagesInputTokens_BillsReplayedEncryptedBlob(t *testing.T) {
+	big := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentThinking, Thinking: &ThinkingData{EncryptedContent: strings.Repeat("b", 400)}},
+	}}}
+	small := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentThinking, Thinking: &ThinkingData{EncryptedContent: "b"}},
+	}}}
+	got := EstimateMessagesInputTokens(big).Tokens
+	if got == 0 {
+		t.Fatalf("blob-only thinking estimate = 0, want the replayed blob billed")
+	}
+	if smallTokens := EstimateMessagesInputTokens(small).Tokens; smallTokens >= got {
+		t.Fatalf("estimate did not grow with the blob: %d vs %d", smallTokens, got)
+	}
+}
+
+// Redacted thinking replays only its text payload: anthropic/request.go emits
+// "data": Text and never the signature, so a signature must not be billed.
+func TestEstimateMessagesInputTokens_RedactedThinkingBillsTextOnly(t *testing.T) {
+	withSig := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentRedThinking, Thinking: &ThinkingData{Text: "redacted", Signature: strings.Repeat("s", 400)}},
+	}}}
+	textOnly := []Message{{Role: RoleAssistant, Content: []ContentPart{
+		{Kind: ContentRedThinking, Thinking: &ThinkingData{Text: "redacted"}},
+	}}}
+	if a, b := EstimateMessagesInputTokens(withSig).Tokens, EstimateMessagesInputTokens(textOnly).Tokens; a != b {
+		t.Fatalf("redacted signature changed the estimate: %d vs %d", a, b)
+	}
+}
+
 type countAdapter struct {
 	name string
 	got  Request


### PR DESCRIPTION
Fixes #653.

The context estimator billed a thinking part's `Text` and `Signature` unconditionally, including raw `reasoning_text` that the Responses adapter keeps for display but never replays.

`thinkingReplayChars` now bills a thinking part only when it carries provider-scoped replay metadata (`EncryptedContent` or `Signature`), or when it is a redacted-thinking part whose payload is replayed verbatim.

Evidence:
- `llm/token_count_test.go` and `agent/internal/contextmgr/context_manager_test.go` fail on the pre-fix tree (100 vs 0 tokens for a non-replayable part; 9 vs 1 through the compaction path) and pass here.
- `go test ./llm/ ./agent/internal/contextmgr/` green.

Known limitation, documented in the code: replay is a property of the adapter, not of the part. `EstimateMessagesInputTokens` carries no provider or model (the compaction path calls it with both empty), so one rule stands in for every adapter. An OpenAI-compatible chat adapter replays plain reasoning text, which this under-counts, and replays an OpenAI-compat encrypted array that the Responses adapter rejects, which this over-counts. Deciding per adapter needs the provider threaded into the compaction estimate; that is a larger change and is not attempted here.
