### PR TITLE
fix(agent): fingerprint repeated tool failures by semantic call signature (#829)

### DIFF
--- a/agent/internal/mcp/breaker_iserror_test.go
+++ b/agent/internal/mcp/breaker_iserror_test.go
@@ -84,7 +84,7 @@ func TestMCPBreaker_IsErrorFailuresParkAtThird(t *testing.T) {
 	if !third.IsError {
 		t.Fatalf("call 3: IsError=false, output=%q", third.Output)
 	}
-	want := "evener did not execute this call: s__probe with these exact arguments has now failed 3 times with the same error; it will not be executed again until you change the arguments or the approach."
+	want := "evener did not execute this call: s__probe with equivalent arguments has now failed 3 times with the same error; it will not be executed again until you change the arguments or the approach."
 	if !strings.HasPrefix(third.Output, want) {
 		t.Errorf("call 3 park text = %q, want prefix %q", third.Output, want)
 	}

--- a/agent/internal/tool/breaker.go
+++ b/agent/internal/tool/breaker.go
@@ -170,19 +170,20 @@ func canonicalNumber(n json.Number) any {
 }
 
 // isNeutralDefaultValue reports whether a canonicalized value means "omitted":
-// null, the empty string, an empty array or object, or numeric zero. Boolean
-// false is deliberately not neutral — a schema's default may be true, so false
-// can be a meaningful instruction.
+// null, the empty string, or an empty array or object. Boolean false and
+// numeric zero are deliberately not neutral, because a value alone cannot say
+// whether a schema treats it as the default. For read_transcript an explicit
+// offset_bytes=0 selects the retained-page operation while omitting it selects
+// the default view (session_tools_transcript.go), so folding zero into
+// "omitted" would hide a meaningful correction and could park a call the model
+// legitimately changed. Erring toward a distinct fingerprint only delays the
+// breaker; erring toward a false match refuses a call the model meant to change.
 func isNeutralDefaultValue(v any) bool {
 	switch x := v.(type) {
 	case nil:
 		return true
 	case string:
 		return x == ""
-	case int64:
-		return x == 0
-	case float64:
-		return x == 0
 	case []any:
 		return len(x) == 0
 	case map[string]any:

--- a/agent/internal/tool/breaker.go
+++ b/agent/internal/tool/breaker.go
@@ -82,11 +82,12 @@ func exactSignature(name string, args []byte) string {
 // failureFingerprint returns the ledger key for a dispatch's repeated-failure
 // run. Unlike exactSignature it hashes a normalized view of the arguments:
 // free-text fields no tool executes on (intent, and the shell tool's
-// presentation-only job description) are dropped, JSON key order and
-// whitespace are canonicalized, and null/empty/zero-valued fields that mean
-// "use the default" are dropped. A call that changes only those fields is the
-// same failing operation, while a change to a meaningful field (target ref,
-// mode, offset, regex) keeps its own fingerprint and bounded history.
+// presentation-only job description) are dropped and JSON key order and
+// whitespace are canonicalized. A call that changes only those is the same
+// failing operation, while any change to a field the tool executes on (target
+// ref, mode, offset, regex, or a presence-sensitive default such as
+// offset_bytes=0 or depends_on: []) keeps its own fingerprint and bounded
+// history: values are never judged to be "defaults" by their content alone.
 //
 // Arguments that are not a single well-formed JSON value fall back to
 // exactSignature, preserving the original byte-exact behavior.
@@ -123,9 +124,20 @@ func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
 	return encoded, true
 }
 
-// canonicalizeValue recursively prunes free-text fields and neutral defaults
-// from a decoded JSON value. Maps are re-encoded by json.Marshal with sorted
-// keys, so key order and whitespace cannot change the fingerprint.
+// canonicalizeValue recursively prunes fields that no tool executes on from a
+// decoded JSON value. Maps are re-encoded by json.Marshal with sorted keys, so
+// key order and whitespace cannot change the fingerprint.
+//
+// Fields are dropped by NAME only. A value that looks like a default is
+// deliberately kept, because whether a value means "omitted" is a property of
+// the field's contract, not of the value: a present read_transcript
+// offset_bytes=0 selects the retained-page operation while omitting it selects
+// the default view, and a present task_list depends_on: [] clears a task's
+// dependencies while omitting it leaves them alone. Pruning by value folded
+// those meaningful calls into the omitted form and could park a call the model
+// legitimately changed. The cost of not pruning is only that a caller which
+// materializes a real default gets its own fingerprint, which delays the
+// breaker rather than refusing a call that was meant to change.
 func canonicalizeValue(v any, dropDescription bool) any {
 	switch x := v.(type) {
 	case map[string]any:
@@ -137,11 +149,7 @@ func canonicalizeValue(v any, dropDescription bool) any {
 			if dropDescription && k == "description" {
 				continue // the shell tool's job label, presentation only
 			}
-			canonical := canonicalizeValue(val, false)
-			if isNeutralDefaultValue(canonical) {
-				continue
-			}
-			out[k] = canonical
+			out[k] = canonicalizeValue(val, false)
 		}
 		return out
 	case []any:
@@ -167,30 +175,6 @@ func canonicalNumber(n json.Number) any {
 		return f
 	}
 	return n
-}
-
-// isNeutralDefaultValue reports whether a canonicalized value means "omitted":
-// null, the empty string, or an empty array or object. Boolean false and
-// numeric zero are deliberately not neutral, because a value alone cannot say
-// whether a schema treats it as the default. For read_transcript an explicit
-// offset_bytes=0 selects the retained-page operation while omitting it selects
-// the default view (session_tools_transcript.go), so folding zero into
-// "omitted" would hide a meaningful correction and could park a call the model
-// legitimately changed. Erring toward a distinct fingerprint only delays the
-// breaker; erring toward a false match refuses a call the model meant to change.
-func isNeutralDefaultValue(v any) bool {
-	switch x := v.(type) {
-	case nil:
-		return true
-	case string:
-		return x == ""
-	case []any:
-		return len(x) == 0
-	case map[string]any:
-		return len(x) == 0
-	default:
-		return false
-	}
 }
 
 // breakerThreshold is how many times a signature may produce the same answer
@@ -227,7 +211,7 @@ func failureParkText(name string, snippets []string) string {
 	var b strings.Builder
 	b.WriteString(parkPrefix)
 	b.WriteString(name)
-	b.WriteString(" with these exact arguments has now failed 3 times with the same error; it will not be executed again until you change the arguments or the approach.")
+	b.WriteString(" with equivalent arguments has now failed 3 times with the same error; it will not be executed again until you change the arguments or the approach.")
 	if len(snippets) > 0 {
 		b.WriteString("\n\nThe failures so far:")
 		for i, snippet := range snippets {

--- a/agent/internal/tool/breaker.go
+++ b/agent/internal/tool/breaker.go
@@ -111,7 +111,7 @@ func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
 	if err := ValidateRawArguments(args); err != nil {
 		return nil, false
 	}
-	if len(bytes.TrimSpace(args)) == 0 {
+	if len(args) == 0 {
 		return []byte("{}"), true
 	}
 	dec := json.NewDecoder(bytes.NewReader(args))
@@ -124,7 +124,7 @@ func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
 	if _, err := dec.Token(); err != io.EOF {
 		return nil, false
 	}
-	encoded, err := json.Marshal(canonicalizeValue(v, name == "shell"))
+	encoded, err := json.Marshal(canonicalizeValue(v, true, name == "shell"))
 	if err != nil {
 		return nil, false
 	}
@@ -135,7 +135,10 @@ func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
 // decoded JSON value. Maps are re-encoded by json.Marshal with sorted keys, so
 // key order and whitespace cannot change the fingerprint.
 //
-// Fields are dropped by NAME only. A value that looks like a default is
+// Fields are dropped by NAME only, and only at the top-level argument object:
+// the registry strips just the top-level `intent`, so a nested `intent` is
+// passed to the handler and must stay part of the fingerprint. A value that
+// looks like a default is
 // deliberately kept, because whether a value means "omitted" is a property of
 // the field's contract, not of the value: a present read_transcript
 // offset_bytes=0 selects the retained-page operation while omitting it selects
@@ -145,24 +148,24 @@ func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
 // legitimately changed. The cost of not pruning is only that a caller which
 // materializes a real default gets its own fingerprint, which delays the
 // breaker rather than refusing a call that was meant to change.
-func canonicalizeValue(v any, dropDescription bool) any {
+func canonicalizeValue(v any, topLevel, dropDescription bool) any {
 	switch x := v.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(x))
 		for k, val := range x {
-			if k == "intent" {
-				continue // free text; the registry strips it before dispatch
+			if topLevel && k == "intent" {
+				continue // free text; the registry strips the top-level one
 			}
-			if dropDescription && k == "description" {
+			if topLevel && dropDescription && k == "description" {
 				continue // the shell tool's job label, presentation only
 			}
-			out[k] = canonicalizeValue(val, false)
+			out[k] = canonicalizeValue(val, false, false)
 		}
 		return out
 	case []any:
 		out := make([]any, 0, len(x))
 		for _, item := range x {
-			out = append(out, canonicalizeValue(item, false))
+			out = append(out, canonicalizeValue(item, false, false))
 		}
 		return out
 	case json.Number:

--- a/agent/internal/tool/breaker.go
+++ b/agent/internal/tool/breaker.go
@@ -104,6 +104,13 @@ func failureFingerprint(name string, args []byte) string {
 // args is not a single well-formed JSON value, in which case the caller must
 // fall back to the exact signature.
 func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
+	// The size and UTF-8 limits are the pre-parse boundary: a body the registry
+	// would reject must not be decoded and re-encoded here first. Falling back
+	// to the exact signature handles it as opaque bytes, which is both cheaper
+	// and what the dispatch path will do with it anyway.
+	if err := ValidateRawArguments(args); err != nil {
+		return nil, false
+	}
 	if len(bytes.TrimSpace(args)) == 0 {
 		return []byte("{}"), true
 	}

--- a/agent/internal/tool/breaker.go
+++ b/agent/internal/tool/breaker.go
@@ -116,7 +116,7 @@ func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
 	if _, err := dec.Token(); err != io.EOF {
 		return nil, false
 	}
-	encoded, err := json.Marshal(canonicalizeValue(v, true, name == "shell"))
+	encoded, err := json.Marshal(canonicalizeValue(v, name == "shell"))
 	if err != nil {
 		return nil, false
 	}
@@ -126,7 +126,7 @@ func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
 // canonicalizeValue recursively prunes free-text fields and neutral defaults
 // from a decoded JSON value. Maps are re-encoded by json.Marshal with sorted
 // keys, so key order and whitespace cannot change the fingerprint.
-func canonicalizeValue(v any, topLevel, dropDescription bool) any {
+func canonicalizeValue(v any, dropDescription bool) any {
 	switch x := v.(type) {
 	case map[string]any:
 		out := make(map[string]any, len(x))
@@ -134,10 +134,10 @@ func canonicalizeValue(v any, topLevel, dropDescription bool) any {
 			if k == "intent" {
 				continue // free text; the registry strips it before dispatch
 			}
-			if topLevel && dropDescription && k == "description" {
+			if dropDescription && k == "description" {
 				continue // the shell tool's job label, presentation only
 			}
-			canonical := canonicalizeValue(val, false, false)
+			canonical := canonicalizeValue(val, false)
 			if isNeutralDefaultValue(canonical) {
 				continue
 			}
@@ -147,7 +147,7 @@ func canonicalizeValue(v any, topLevel, dropDescription bool) any {
 	case []any:
 		out := make([]any, 0, len(x))
 		for _, item := range x {
-			out = append(out, canonicalizeValue(item, false, false))
+			out = append(out, canonicalizeValue(item, false))
 		}
 		return out
 	case json.Number:
@@ -267,13 +267,18 @@ func (l *failureLedger) check(name string, args []byte) (failStreak int, repeatS
 	if l == nil { // a zero-value Registry has no ledger and judges nothing
 		return 0, 0, nil
 	}
+	// Both fingerprints hash the argument body, so compute them before taking
+	// the lock (as record and clearFailures already do): canonicalizing a large
+	// call under l.mu would stall every other dispatch in the batch.
+	exactKey := exactSignature(name, args)
+	semKey := failureFingerprint(name, args)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	if e, ok := l.semantic[failureFingerprint(name, args)]; ok {
+	if e, ok := l.semantic[semKey]; ok {
 		failStreak = e.count
 		snippets = append([]string(nil), e.snippets...)
 	}
-	if e, ok := l.entries[exactSignature(name, args)]; ok {
+	if e, ok := l.entries[exactKey]; ok {
 		repeatStreak = e.bodyCount
 	}
 	return failStreak, repeatStreak, snippets

--- a/agent/internal/tool/breaker.go
+++ b/agent/internal/tool/breaker.go
@@ -1,10 +1,14 @@
 package tool
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
+	"strconv"
 	"strings"
 	"sync"
 	"unicode"
@@ -24,9 +28,10 @@ const maxFailureSnippets = 2
 // maxFailureSnippetRunes truncates each retained failure output, in runes.
 const maxFailureSnippetRunes = 500
 
-// failureEntry tracks, for one dispatch signature (tool name + argument
-// hash), two independent streaks: consecutive failures sharing an error
-// class, and consecutive calls returning a byte-identical result body.
+// failureEntry tracks two independent streaks for the ledger key it is stored
+// under: consecutive failures sharing an error class, and consecutive calls
+// returning a byte-identical result body. The exact-call store uses both; the
+// semantic store uses only the failure streak.
 type failureEntry struct {
 	class    string
 	count    int
@@ -37,27 +42,154 @@ type failureEntry struct {
 }
 
 // failureLedger records consecutive identical-failure streaks per dispatch
-// signature so the breaker can nudge and then park runaway tool calls. It is
+// fingerprint so the breaker can nudge and then park runaway tool calls. It is
 // one-per-session (owned by a *Registry) and safe for concurrent use, since
 // tool batches can dispatch in parallel.
 type failureLedger struct {
-	mu      sync.Mutex
+	mu sync.Mutex
+	// entries is keyed by exactSignature, preserving the original exact-call
+	// fast path: byte-identical calls share an entry, so both the body-hash
+	// repetition streak and the exact failure streak behave as they always did.
 	entries map[string]*failureEntry
-	order   []string // most-recently-used last, for LRU eviction
+	order   []string // entries LRU, most-recently-used last
+
+	// semantic is keyed by failureFingerprint: calls that differ only in
+	// free-text or neutral/default arguments share a failure run here, so a
+	// semantic loop is caught even though its exact bytes keep changing. It
+	// carries its own bounded history so a fingerprint's run never evicts
+	// another's, and it is deliberately separate from entries so the exact-call
+	// repetition fast path is untouched.
+	semantic      map[string]*failureEntry
+	semanticOrder []string // semantic LRU, most-recently-used last
 }
 
 func newFailureLedger() *failureLedger {
 	return &failureLedger{
-		entries: make(map[string]*failureEntry),
+		entries:  make(map[string]*failureEntry),
+		semantic: make(map[string]*failureEntry),
 	}
 }
 
-// signature returns the ledger key for a dispatch: the tool name plus a
-// hash of its raw argument bytes. Two calls with byte-identical arguments
-// share a signature; differing JSON formatting (key order, whitespace) does
-// not, matching the loop detector's existing behavior.
-func signature(name string, args []byte) string {
+// exactSignature returns the ledger key for a dispatch under the exact-call
+// fast path: the tool name plus a hash of its raw argument bytes. Two calls
+// with byte-identical arguments share a signature. It is also the fallback
+// fingerprint for arguments that cannot be canonicalized, so a malformed call
+// still gets exact-call detection.
+func exactSignature(name string, args []byte) string {
 	return name + ":" + shortHash(args)
+}
+
+// failureFingerprint returns the ledger key for a dispatch's repeated-failure
+// run. Unlike exactSignature it hashes a normalized view of the arguments:
+// free-text fields no tool executes on (intent, and the shell tool's
+// presentation-only job description) are dropped, JSON key order and
+// whitespace are canonicalized, and null/empty/zero-valued fields that mean
+// "use the default" are dropped. A call that changes only those fields is the
+// same failing operation, while a change to a meaningful field (target ref,
+// mode, offset, regex) keeps its own fingerprint and bounded history.
+//
+// Arguments that are not a single well-formed JSON value fall back to
+// exactSignature, preserving the original byte-exact behavior.
+func failureFingerprint(name string, args []byte) string {
+	canonical, ok := canonicalArgumentBytes(name, args)
+	if !ok {
+		return exactSignature(name, args)
+	}
+	return name + ":sem:" + shortHash(canonical)
+}
+
+// canonicalArgumentBytes returns the canonical byte view of a tool call's
+// arguments used by the semantic failure fingerprint. The bool is false when
+// args is not a single well-formed JSON value, in which case the caller must
+// fall back to the exact signature.
+func canonicalArgumentBytes(name string, args []byte) ([]byte, bool) {
+	if len(bytes.TrimSpace(args)) == 0 {
+		return []byte("{}"), true
+	}
+	dec := json.NewDecoder(bytes.NewReader(args))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return nil, false
+	}
+	// Reject trailing tokens: only one JSON value is a valid call body.
+	if _, err := dec.Token(); err != io.EOF {
+		return nil, false
+	}
+	encoded, err := json.Marshal(canonicalizeValue(v, true, name == "shell"))
+	if err != nil {
+		return nil, false
+	}
+	return encoded, true
+}
+
+// canonicalizeValue recursively prunes free-text fields and neutral defaults
+// from a decoded JSON value. Maps are re-encoded by json.Marshal with sorted
+// keys, so key order and whitespace cannot change the fingerprint.
+func canonicalizeValue(v any, topLevel, dropDescription bool) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, val := range x {
+			if k == "intent" {
+				continue // free text; the registry strips it before dispatch
+			}
+			if topLevel && dropDescription && k == "description" {
+				continue // the shell tool's job label, presentation only
+			}
+			canonical := canonicalizeValue(val, false, false)
+			if isNeutralDefaultValue(canonical) {
+				continue
+			}
+			out[k] = canonical
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(x))
+		for _, item := range x {
+			out = append(out, canonicalizeValue(item, false, false))
+		}
+		return out
+	case json.Number:
+		return canonicalNumber(x)
+	default:
+		return v
+	}
+}
+
+// canonicalNumber folds a JSON number into a canonical Go representation so
+// equivalent literals (1, 1.0, 1e0) share a fingerprint.
+func canonicalNumber(n json.Number) any {
+	if i, err := strconv.ParseInt(n.String(), 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(n.String(), 64); err == nil {
+		return f
+	}
+	return n
+}
+
+// isNeutralDefaultValue reports whether a canonicalized value means "omitted":
+// null, the empty string, an empty array or object, or numeric zero. Boolean
+// false is deliberately not neutral — a schema's default may be true, so false
+// can be a meaningful instruction.
+func isNeutralDefaultValue(v any) bool {
+	switch x := v.(type) {
+	case nil:
+		return true
+	case string:
+		return x == ""
+	case int64:
+		return x == 0
+	case float64:
+		return x == 0
+	case []any:
+		return len(x) == 0
+	case map[string]any:
+		return len(x) == 0
+	default:
+		return false
+	}
 }
 
 // breakerThreshold is how many times a signature may produce the same answer
@@ -128,44 +260,49 @@ func breakerBypassed(ctx context.Context) bool {
 	return bypass
 }
 
-// check is the pre-dispatch read: the signature's current consecutive-
-// failure streak, consecutive-identical-body streak, and recorded failure
-// snippets, without mutating the ledger.
+// check is the pre-dispatch read: the normalized fingerprint's current
+// consecutive-failure streak and recorded failure snippets, plus the exact
+// call's consecutive-identical-body streak, without mutating the ledger.
 func (l *failureLedger) check(name string, args []byte) (failStreak int, repeatStreak int, snippets []string) {
 	if l == nil { // a zero-value Registry has no ledger and judges nothing
 		return 0, 0, nil
 	}
-	key := signature(name, args)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	e, ok := l.entries[key]
-	if !ok {
-		return 0, 0, nil
+	if e, ok := l.semantic[failureFingerprint(name, args)]; ok {
+		failStreak = e.count
+		snippets = append([]string(nil), e.snippets...)
 	}
-	return e.count, e.bodyCount, append([]string(nil), e.snippets...)
+	if e, ok := l.entries[exactSignature(name, args)]; ok {
+		repeatStreak = e.bodyCount
+	}
+	return failStreak, repeatStreak, snippets
 }
 
 // record is the post-dispatch write for both triggers. The body-hash streak
 // tracks byte-identical result bodies regardless of error status: repetition
 // itself is the signal, since a tool's error flag cannot be trusted (a
 // failing call can report isErr=false with the failure as plain body text).
-// The failure streak keeps its original semantics, except a success no
-// longer deletes the entry — it zeroes the failure streak and clears the
-// class and snippets, but the entry survives so the body hash persists.
+// It is tracked on the exact call, so the repetition nudge is unchanged. The
+// returned failure streak is the semantic fingerprint's run; the exact entry's
+// own failure streak is still maintained so byte-identical calls keep their
+// original history. A success zeroes a failure streak and clears the class and
+// snippets, but the entry survives so the body hash persists.
 func (l *failureLedger) record(name string, args []byte, isErr bool, output string) (failStreak int, repeatStreak int) {
 	if l == nil { // a zero-value Registry has no ledger and judges nothing
 		return 0, 0
 	}
-	key := signature(name, args)
+	exactKey := exactSignature(name, args)
+	semKey := failureFingerprint(name, args)
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	e, ok := l.entries[key]
+	e, ok := l.entries[exactKey]
 	if !ok {
 		e = &failureEntry{}
-		l.entries[key] = e
+		l.entries[exactKey] = e
 	}
-	l.touch(key)
+	l.order = l.touch(l.order, l.entries, exactKey)
 
 	bodyHash := shortHash([]byte(output))
 	if e.bodyHash == bodyHash {
@@ -174,14 +311,31 @@ func (l *failureLedger) record(name string, args []byte, isErr bool, output stri
 		e.bodyHash = bodyHash
 		e.bodyCount = 1
 	}
+	observeFailure(e, isErr, output)
+	repeatStreak = e.bodyCount
 
+	s, ok := l.semantic[semKey]
+	if !ok {
+		s = &failureEntry{}
+		l.semantic[semKey] = s
+	}
+	l.semanticOrder = l.touch(l.semanticOrder, l.semantic, semKey)
+	failStreak = observeFailure(s, isErr, output)
+
+	return failStreak, repeatStreak
+}
+
+// observeFailure advances an entry's consecutive-failure streak for one
+// result, returning the new count (0 for a success). A failure of a different
+// error class restarts the streak at 1 with that failure's snippet; matching
+// failures extend it, keeping only the most recent maxFailureSnippets.
+func observeFailure(e *failureEntry, isErr bool, output string) int {
 	if !isErr {
 		e.class = ""
 		e.count = 0
 		e.snippets = nil
-		return 0, e.bodyCount
+		return 0
 	}
-
 	class := errorClass(output)
 	snippet := TruncateRunes(output, maxFailureSnippetRunes)
 
@@ -189,7 +343,7 @@ func (l *failureLedger) record(name string, args []byte, isErr bool, output stri
 		e.class = class
 		e.count = 1
 		e.snippets = []string{snippet}
-		return 1, e.bodyCount
+		return 1
 	}
 
 	e.count++
@@ -197,13 +351,14 @@ func (l *failureLedger) record(name string, args []byte, isErr bool, output stri
 		e.snippets = e.snippets[1:]
 	}
 	e.snippets = append(e.snippets, snippet)
-	return e.count, e.bodyCount
+	return e.count
 }
 
-// clearFailures retires a signature's failure evidence: the streak, its error
-// class, and the retained snippets. A human who authorizes a dispatch has
+// clearFailures retires a call's failure evidence — both the semantic
+// fingerprint's run and the exact call's own streak: the streaks, their error
+// classes, and the retained snippets. A human who authorizes a dispatch has
 // judged the refusals that preceded it, so they may no longer park a later
-// identical call; if the authorized call fails again, the next ordinary one
+// equivalent call; if the authorized call fails again, the next ordinary one
 // records a fresh streak of 1.
 //
 // The body-hash streak is deliberately left alone. Repetition only ever nudges,
@@ -212,39 +367,44 @@ func (l *failureLedger) clearFailures(name string, args []byte) {
 	if l == nil { // a zero-value Registry has no ledger and judges nothing
 		return
 	}
-	key := signature(name, args)
+	exactKey := exactSignature(name, args)
+	semKey := failureFingerprint(name, args)
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	e, ok := l.entries[key]
-	if !ok {
-		return // nothing recorded, so nothing to retire — and no entry to evict for
+	if e, ok := l.semantic[semKey]; ok {
+		e.class = ""
+		e.count = 0
+		e.snippets = nil
+		l.semanticOrder = l.touch(l.semanticOrder, l.semantic, semKey)
 	}
-	e.class = ""
-	e.count = 0
-	e.snippets = nil
-	l.touch(key)
+	if e, ok := l.entries[exactKey]; ok {
+		e.class = ""
+		e.count = 0
+		e.snippets = nil
+		l.order = l.touch(l.order, l.entries, exactKey)
+	}
 }
 
-// touch moves key to the most-recently-used end of the order and evicts the
-// least-recently-used signature if the ledger has grown past its bound.
-// Recency, not age since first sight, decides what survives: a signature that
-// keeps recurring is exactly the one the breaker must not forget, however
-// much unrelated one-off traffic flows around it. Must be called with l.mu
-// held.
-func (l *failureLedger) touch(key string) {
-	for i, k := range l.order {
+// touch moves key to the most-recently-used end of order and evicts the
+// least-recently-used key from entries if the store has grown past its bound.
+// Recency, not age since first sight, decides what survives: a key that keeps
+// recurring is exactly the one the breaker must not forget, however much
+// unrelated one-off traffic flows around it. Must be called with l.mu held.
+func (l *failureLedger) touch(order []string, entries map[string]*failureEntry, key string) []string {
+	for i, k := range order {
 		if k == key {
-			l.order = append(l.order[:i], l.order[i+1:]...)
+			order = append(order[:i], order[i+1:]...)
 			break
 		}
 	}
-	l.order = append(l.order, key)
-	if len(l.order) <= maxFailureLedgerEntries {
-		return
+	order = append(order, key)
+	if len(order) <= maxFailureLedgerEntries {
+		return order
 	}
-	oldest := l.order[0]
-	l.order = l.order[1:]
-	delete(l.entries, oldest)
+	oldest := order[0]
+	order = order[1:]
+	delete(entries, oldest)
+	return order
 }
 
 // errorClass normalizes a tool error output into a stable 8-character

--- a/agent/internal/tool/breaker_dispatch_test.go
+++ b/agent/internal/tool/breaker_dispatch_test.go
@@ -27,7 +27,7 @@ func wantRepetitionNudge(count int) string {
 const repetitionNudgeMarker = "and received the identical result"
 
 func wantFailurePark(toolName string) string {
-	return "evener did not execute this call: " + toolName + " with these exact arguments has now failed 3 times with the same error; it will not be executed again until you change the arguments or the approach."
+	return "evener did not execute this call: " + toolName + " with equivalent arguments has now failed 3 times with the same error; it will not be executed again until you change the arguments or the approach."
 }
 
 // breakerFake is a registered tool whose executor is supplied by the test and

--- a/agent/internal/tool/breaker_semantic_test.go
+++ b/agent/internal/tool/breaker_semantic_test.go
@@ -9,9 +9,11 @@ import (
 )
 
 // The tests here cover the semantic repeated-failure fingerprint: a call that
-// changes only free-text or neutral/default fields is the same failing
-// operation, while a meaningful change (target, mode, offset) is a fresh
-// attempt that must not erase the old fingerprint's run.
+// changes only free-text fields (intent, the shell job description) or JSON
+// formatting is the same failing operation, while any change to a field the
+// tool executes on (target, mode, offset) is a fresh attempt that must not
+// erase the old fingerprint's run. A value that merely looks like a default is
+// not normalized away: presence is meaningful per the field's contract.
 
 const semanticBoom = "invalid_request: context_lines requires output_match"
 
@@ -56,22 +58,20 @@ func TestBreakerDispatch_IntentOnlyChangeStillParks(t *testing.T) {
 	}
 }
 
-func TestBreakerDispatch_NeutralDefaultsAndFormattingStillPark(t *testing.T) {
+func TestBreakerDispatch_IntentAndFormattingStillPark(t *testing.T) {
 	r := NewRegistry()
 	fake := semanticRefTool(t, r, func(int) (any, error) { return nil, errors.New(semanticBoom) })
 	env := breakerEnv(t)
 	ctx := context.Background()
 
 	// Same effective call every time: differing JSON key order, whitespace, and
-	// provider-materialized default-equivalent values (empty strings and nulls,
-	// which the tool schemas call omitted) must all fingerprint the same.
-	// Explicit numeric zeros are deliberately absent here; see
-	// TestFailureFingerprint_ExplicitZeroIsDistinct.
+	// free-text intent must all fingerprint the same. A value that merely looks
+	// like a default is deliberately absent here, because it is no longer
+	// normalized away (see TestFailureFingerprint_MeaningfulDefaultsArePreserved).
 	calls := []llmCallArgs{
 		{id: "n1", args: `{"transcript_ref":"job:job_1","intent":"look"}`},
 		{id: "n2", args: `{ "intent" : "look again" , "transcript_ref" : "job:job_1" }`},
-		{id: "n3", args: `{"range":"","transcript_ref":"job:job_1"}`},
-		{id: "n4", args: `{"output_match":"","format":null,"transcript_ref":"job:job_1"}`},
+		{id: "n3", args: `{"transcript_ref":"job:job_1"}`},
 	}
 	results := make([]ExecResult, 0, len(calls))
 	for _, c := range calls {
@@ -79,13 +79,10 @@ func TestBreakerDispatch_NeutralDefaultsAndFormattingStillPark(t *testing.T) {
 	}
 
 	if fake.calls != 2 {
-		t.Fatalf("neutral defaults reset the failure streak: invocations = %d, want 2", fake.calls)
+		t.Fatalf("intent-only changes reset the failure streak: invocations = %d, want 2", fake.calls)
 	}
 	if !strings.HasPrefix(results[2].Output, wantFailurePark("read_transcript")) {
-		t.Fatalf("third neutral-default variant was not parked: %q", results[2].Output)
-	}
-	if !strings.HasPrefix(results[3].Output, wantFailurePark("read_transcript")) {
-		t.Fatalf("fourth neutral-default variant was not parked: %q", results[3].Output)
+		t.Fatalf("third intent-only variant was not parked: %q", results[2].Output)
 	}
 }
 
@@ -249,34 +246,20 @@ func TestFailureFingerprint_KeyOrderWhitespaceAndIntentAreEquivalent(t *testing.
 	}
 }
 
-func TestFailureFingerprint_NeutralDefaultsAreEquivalent(t *testing.T) {
-	want := fp("read_transcript", `{"transcript_ref":"job:j1"}`)
-	for _, args := range []string{
-		`{"transcript_ref":"job:j1","range":"","output_match":""}`,
-		`{"transcript_ref":"job:j1","format":null,"extra":{},"list":[]}`,
-	} {
-		if got := fp("read_transcript", args); got != want {
-			t.Errorf("fingerprint(%s) = %q, want %q", args, got, want)
-		}
-	}
-	// Empty and absent arguments are the same call.
-	if fp("read_transcript", ``) != fp("read_transcript", `{}`) {
-		t.Errorf("empty and {} must fingerprint the same")
-	}
-}
-
-// Explicit numeric zero is presence, not omission. read_transcript treats a
-// present offset_bytes as the retained-page operation even when it is zero (see
-// TestNormalizeRetainedReadArgsPreservesExplicitZeroOffset), so folding zero
-// into the omitted form would hide a meaningful correction and could park a
-// call the model legitimately changed. A value-based rule cannot know a
-// schema's numeric defaults, so it errs toward a distinct fingerprint.
-func TestFailureFingerprint_ExplicitZeroIsDistinct(t *testing.T) {
+// A value that looks like a default is presence, not omission. Fields are
+// dropped by name only, so each of these keeps its own fingerprint rather than
+// folding into the omitted form. read_transcript's offset_bytes=0 selects the
+// retained-page operation and task_list's depends_on: [] clears dependencies; a
+// provider-materialized default is a real argument too.
+func TestFailureFingerprint_MeaningfulDefaultsArePreserved(t *testing.T) {
 	base := fp("read_transcript", `{"transcript_ref":"job:j1"}`)
 	for _, args := range []string{
 		`{"transcript_ref":"job:j1","offset_bytes":0}`,
+		`{"transcript_ref":"job:j1","range":""}`,
+		`{"transcript_ref":"job:j1","format":null}`,
 		`{"transcript_ref":"job:j1","context_lines":0}`,
-		`{"transcript_ref":"job:j1","expand_turn":0}`,
+		`{"transcript_ref":"job:j1","extra":{}}`,
+		`{"transcript_ref":"job:j1","list":[]}`,
 	} {
 		if got := fp("read_transcript", args); got == base {
 			t.Errorf("fingerprint(%s) = %q, must differ from the omitted form", args, got)
@@ -284,6 +267,10 @@ func TestFailureFingerprint_ExplicitZeroIsDistinct(t *testing.T) {
 	}
 	if fp("read_file", `{"offset_bytes":0}`) == fp("read_file", `{}`) {
 		t.Error("explicit offset_bytes=0 must not fingerprint as omitted")
+	}
+	// Empty and absent arguments are the same call.
+	if fp("read_transcript", ``) != fp("read_transcript", `{}`) {
+		t.Errorf("empty and {} must fingerprint the same")
 	}
 }
 
@@ -344,12 +331,10 @@ func TestFailureFingerprint_IsBoundedAndSecretFree(t *testing.T) {
 }
 
 // The repetition nudge is an exact-call signal and must stay byte-keyed: two
-// calls whose raw arguments differ only by neutral defaults are the same
+// calls whose raw arguments differ only by a free-text intent are the same
 // semantic operation but not a byte-identical repeat, so a caller comparing
-// their bodies must see the unmodified result. This is the shape
-// TestRegistryExecuteCallNormalizesMaterializedRetainedDefaults exercises one
-// layer up.
-func TestBreakerDispatch_NeutralDefaultsDoNotTriggerRepetitionNudge(t *testing.T) {
+// their bodies must see the unmodified result.
+func TestBreakerDispatch_IntentChangeDoesNotTriggerRepetitionNudge(t *testing.T) {
 	const body = "ready\n"
 	r := NewRegistry()
 	fake := registerBreakerFake(t, r, "read_transcript", func(int) (any, error) { return body, nil })
@@ -360,14 +345,14 @@ func TestBreakerDispatch_NeutralDefaultsDoNotTriggerRepetitionNudge(t *testing.T
 	if omitted.Output != body {
 		t.Fatalf("omitted output = %q, want %q", omitted.Output, body)
 	}
-	materialized := r.ExecuteCall(ctx, env, breakerCall("m1", "read_transcript", `{"transcript_ref":"job:job_1","range":"","output_match":""}`))
+	materialized := r.ExecuteCall(ctx, env, breakerCall("m1", "read_transcript", `{"transcript_ref":"job:job_1","intent":"again"}`))
 	if fake.calls != 2 {
-		t.Fatalf("materialized defaults must dispatch: invocations = %d, want 2", fake.calls)
+		t.Fatalf("an intent-only change must dispatch: invocations = %d, want 2", fake.calls)
 	}
 	if strings.Contains(materialized.Output, repetitionNudgeMarker) {
-		t.Fatalf("neutral defaults triggered the exact-call repetition nudge: %q", materialized.Output)
+		t.Fatalf("an intent-only change triggered the exact-call repetition nudge: %q", materialized.Output)
 	}
 	if materialized.Output != body {
-		t.Fatalf("materialized output = %q, want the unmodified %q", materialized.Output, body)
+		t.Fatalf("intent-only output = %q, want the unmodified %q", materialized.Output, body)
 	}
 }

--- a/agent/internal/tool/breaker_semantic_test.go
+++ b/agent/internal/tool/breaker_semantic_test.go
@@ -1,0 +1,351 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The tests here cover the semantic repeated-failure fingerprint: a call that
+// changes only free-text or neutral/default fields is the same failing
+// operation, while a meaningful change (target, mode, offset) is a fresh
+// attempt that must not erase the old fingerprint's run.
+
+const semanticBoom = "invalid_request: context_lines requires output_match"
+
+// semanticRefTool registers a failing fake whose only meaningful argument is a
+// transcript ref, mirroring the read_transcript loop from issue #829.
+func semanticRefTool(t *testing.T, r *Registry, fn func(calls int) (any, error)) *breakerFake {
+	t.Helper()
+	return registerBreakerFake(t, r, "read_transcript", fn)
+}
+
+func semanticRefCall(id, ref, intent string) llmCallArgs {
+	return llmCallArgs{id: id, args: fmt.Sprintf(`{"transcript_ref":%q,"intent":%q}`, ref, intent)}
+}
+
+// llmCallArgs is a tiny carrier so table-driven tests read clearly.
+type llmCallArgs struct {
+	id   string
+	args string
+}
+
+func TestBreakerDispatch_IntentOnlyChangeStillParks(t *testing.T) {
+	r := NewRegistry()
+	fake := semanticRefTool(t, r, func(int) (any, error) { return nil, errors.New(semanticBoom) })
+	env := breakerEnv(t)
+	ctx := context.Background()
+
+	calls := []llmCallArgs{
+		semanticRefCall("c1", "job:job_1", "first look at the job output"),
+		semanticRefCall("c2", "job:job_1", "try reading the job again"),
+		semanticRefCall("c3", "job:job_1", "one more attempt at the job"),
+	}
+	results := make([]ExecResult, 0, len(calls))
+	for _, c := range calls {
+		results = append(results, r.ExecuteCall(ctx, env, breakerCall(c.id, "read_transcript", c.args)))
+	}
+
+	if fake.calls != 2 {
+		t.Fatalf("intent-only changes reset the failure streak: invocations = %d, want 2", fake.calls)
+	}
+	if !strings.HasPrefix(results[2].Output, wantFailurePark("read_transcript")) {
+		t.Fatalf("third intent-only variant was not parked: %q", results[2].Output)
+	}
+}
+
+func TestBreakerDispatch_NeutralDefaultsAndFormattingStillPark(t *testing.T) {
+	r := NewRegistry()
+	fake := semanticRefTool(t, r, func(int) (any, error) { return nil, errors.New(semanticBoom) })
+	env := breakerEnv(t)
+	ctx := context.Background()
+
+	// Same effective call every time: differing JSON key order, whitespace, and
+	// provider-materialized neutral defaults (range "", expand_turn 0,
+	// context_lines 0, output_match "") must all fingerprint the same.
+	calls := []llmCallArgs{
+		{id: "n1", args: `{"transcript_ref":"job:job_1","intent":"look"}`},
+		{id: "n2", args: `{ "intent" : "look again" , "transcript_ref" : "job:job_1" }`},
+		{id: "n3", args: `{"context_lines":0,"range":"","transcript_ref":"job:job_1"}`},
+		{id: "n4", args: `{"output_match":"","expand_turn":0,"transcript_ref":"job:job_1"}`},
+	}
+	results := make([]ExecResult, 0, len(calls))
+	for _, c := range calls {
+		results = append(results, r.ExecuteCall(ctx, env, breakerCall(c.id, "read_transcript", c.args)))
+	}
+
+	if fake.calls != 2 {
+		t.Fatalf("neutral defaults reset the failure streak: invocations = %d, want 2", fake.calls)
+	}
+	if !strings.HasPrefix(results[2].Output, wantFailurePark("read_transcript")) {
+		t.Fatalf("third neutral-default variant was not parked: %q", results[2].Output)
+	}
+	if !strings.HasPrefix(results[3].Output, wantFailurePark("read_transcript")) {
+		t.Fatalf("fourth neutral-default variant was not parked: %q", results[3].Output)
+	}
+}
+
+func TestBreakerDispatch_MeaningfulChangeGetsFreshAttempt(t *testing.T) {
+	r := NewRegistry()
+	fake := semanticRefTool(t, r, func(int) (any, error) { return nil, errors.New(semanticBoom) })
+	env := breakerEnv(t)
+	ctx := context.Background()
+
+	r.ExecuteCall(ctx, env, breakerCall("m1", "read_transcript", semanticRefCall("", "job:job_a", "x").args))
+	r.ExecuteCall(ctx, env, breakerCall("m2", "read_transcript", semanticRefCall("", "job:job_a", "y").args))
+
+	changed := r.ExecuteCall(ctx, env, breakerCall("m3", "read_transcript", semanticRefCall("", "job:job_b", "z").args))
+	if fake.calls != 3 {
+		t.Fatalf("a meaningful ref change must dispatch: invocations = %d, want 3", fake.calls)
+	}
+	if strings.HasPrefix(changed.Output, "evener did not execute this call:") {
+		t.Fatalf("a meaningful ref change was parked: %q", changed.Output)
+	}
+}
+
+func TestBreakerDispatch_AlternatingFingerprintsKeepBothRuns(t *testing.T) {
+	r := NewRegistry()
+	fake := semanticRefTool(t, r, func(int) (any, error) { return nil, errors.New(semanticBoom) })
+	env := breakerEnv(t)
+	ctx := context.Background()
+
+	calls := []llmCallArgs{
+		semanticRefCall("a1", "job:job_a", "a one"),
+		semanticRefCall("b1", "job:job_b", "b one"),
+		semanticRefCall("a2", "job:job_a", "a two"),
+		semanticRefCall("b2", "job:job_b", "b two"),
+	}
+	for _, c := range calls {
+		r.ExecuteCall(ctx, env, breakerCall(c.id, "read_transcript", c.args))
+	}
+	if fake.calls != 4 {
+		t.Fatalf("setup invocations = %d, want 4", fake.calls)
+	}
+
+	// Both runs reached the threshold independently; neither was erased by the
+	// other's interleaved calls, so the next call of each parks.
+	a3 := r.ExecuteCall(ctx, env, breakerCall("a3", "read_transcript", semanticRefCall("", "job:job_a", "a three").args))
+	b3 := r.ExecuteCall(ctx, env, breakerCall("b3", "read_transcript", semanticRefCall("", "job:job_b", "b three").args))
+	if fake.calls != 4 {
+		t.Fatalf("interleaved runs erased each other: invocations = %d, want 4", fake.calls)
+	}
+	if !strings.HasPrefix(a3.Output, wantFailurePark("read_transcript")) {
+		t.Fatalf("fingerprint A was not parked: %q", a3.Output)
+	}
+	if !strings.HasPrefix(b3.Output, wantFailurePark("read_transcript")) {
+		t.Fatalf("fingerprint B was not parked: %q", b3.Output)
+	}
+}
+
+func TestBreakerDispatch_SuccessClearsOnlyMatchingRun(t *testing.T) {
+	r := NewRegistry()
+	type step struct {
+		ref     string
+		success bool
+	}
+	seq := []step{
+		{ref: "job:job_a"},
+		{ref: "job:job_b"},
+		{ref: "job:job_b"},
+		{ref: "job:job_a", success: true},
+		{ref: "job:job_a"},
+	}
+	fake := semanticRefTool(t, r, func(n int) (any, error) {
+		if n < 1 || n > len(seq) {
+			return nil, fmt.Errorf("unexpected dispatch %d", n)
+		}
+		if seq[n-1].success {
+			return "ok", nil
+		}
+		return nil, errors.New(semanticBoom)
+	})
+	env := breakerEnv(t)
+	ctx := context.Background()
+
+	send := func(id, ref, intent string) ExecResult {
+		return r.ExecuteCall(ctx, env, breakerCall(id, "read_transcript", semanticRefCall("", ref, intent).args))
+	}
+
+	send("s1", "job:job_a", "one")
+	send("s2", "job:job_b", "one")
+	send("s3", "job:job_b", "two")
+	send("s4", "job:job_a", "cleared") // success
+	send("s5", "job:job_a", "rebuilt")
+	if fake.calls != 5 {
+		t.Fatalf("setup invocations = %d, want 5", fake.calls)
+	}
+
+	if streak, _, _ := r.breaker.check("read_transcript", []byte(`{"transcript_ref":"job:job_a"}`)); streak != 1 {
+		t.Fatalf("A's run after its own success = %d, want 1", streak)
+	}
+	if streak, _, _ := r.breaker.check("read_transcript", []byte(`{"transcript_ref":"job:job_b"}`)); streak != 2 {
+		t.Fatalf("B's run was altered by A's success: streak = %d, want 2", streak)
+	}
+
+	// B has reached the threshold and parks; A still has room for one more.
+	parkedB := send("s6", "job:job_b", "three")
+	if fake.calls != 5 {
+		t.Fatalf("B was not parked: invocations = %d, want 5", fake.calls)
+	}
+	if !strings.HasPrefix(parkedB.Output, wantFailurePark("read_transcript")) {
+		t.Fatalf("B's third failure was not parked: %q", parkedB.Output)
+	}
+	send("s7", "job:job_a", "four")
+	if fake.calls != 6 {
+		t.Fatalf("A should still dispatch after its success reset: invocations = %d, want 6", fake.calls)
+	}
+}
+
+func TestBreakerDispatch_BypassStillExecutesSemanticallyParkedCall(t *testing.T) {
+	r := NewRegistry()
+	fake := semanticRefTool(t, r, func(int) (any, error) { return nil, errors.New(semanticBoom) })
+	env := breakerEnv(t)
+	ctx := context.Background()
+
+	send := func(c context.Context, id, ref, intent string) ExecResult {
+		return r.ExecuteCall(c, env, breakerCall(id, "read_transcript", semanticRefCall("", ref, intent).args))
+	}
+	send(ctx, "y1", "job:job_a", "one")
+	send(ctx, "y2", "job:job_a", "two")
+	if fake.calls != 2 {
+		t.Fatalf("setup invocations = %d, want 2", fake.calls)
+	}
+	parked := send(ctx, "y3", "job:job_a", "three")
+	if !strings.HasPrefix(parked.Output, wantFailurePark("read_transcript")) {
+		t.Fatalf("third call was not parked: %q", parked.Output)
+	}
+	if fake.calls != 2 {
+		t.Fatalf("parked call executed: invocations = %d, want 2", fake.calls)
+	}
+
+	bypassed := send(WithBreakerBypass(ctx), "y4", "job:job_a", "authorized")
+	if fake.calls != 3 {
+		t.Fatalf("a bypassed call must execute: invocations = %d, want 3", fake.calls)
+	}
+	if strings.HasPrefix(bypassed.Output, "evener did not execute this call:") {
+		t.Fatalf("bypassed call was parked: %q", bypassed.Output)
+	}
+}
+
+func fp(name, args string) string {
+	return failureFingerprint(name, []byte(args))
+}
+
+func TestFailureFingerprint_KeyOrderWhitespaceAndIntentAreEquivalent(t *testing.T) {
+	want := fp("read_transcript", `{"transcript_ref":"job:j1","intent":"first"}`)
+	for _, args := range []string{
+		`{"transcript_ref":"job:j1","intent":"second"}`,
+		`{ "intent" : "third" , "transcript_ref" : "job:j1" }`,
+		`{"transcript_ref":"job:j1"}`, // intent omitted entirely
+		`{"transcript_ref":"job:j1","intent":null}`,
+	} {
+		if got := fp("read_transcript", args); got != want {
+			t.Errorf("fingerprint(%s) = %q, want %q", args, got, want)
+		}
+	}
+}
+
+func TestFailureFingerprint_NeutralDefaultsAreEquivalent(t *testing.T) {
+	want := fp("read_transcript", `{"transcript_ref":"job:j1"}`)
+	for _, args := range []string{
+		`{"transcript_ref":"job:j1","range":"","expand_turn":0}`,
+		`{"transcript_ref":"job:j1","context_lines":0,"output_match":""}`,
+		`{"transcript_ref":"job:j1","format":null,"extra":{},"list":[]}`,
+		`{"transcript_ref":"job:j1","offset_bytes":0}`,
+	} {
+		if got := fp("read_transcript", args); got != want {
+			t.Errorf("fingerprint(%s) = %q, want %q", args, got, want)
+		}
+	}
+	// Empty and absent arguments are the same call.
+	if fp("read_transcript", ``) != fp("read_transcript", `{}`) {
+		t.Errorf("empty and {} must fingerprint the same")
+	}
+}
+
+func TestFailureFingerprint_EquivalentNumberLiteralsAreEqual(t *testing.T) {
+	if fp("read_file", `{"offset_bytes":1}`) != fp("read_file", `{"offset_bytes":1.0}`) {
+		t.Errorf("1 and 1.0 must fingerprint the same")
+	}
+	if fp("read_file", `{"offset_bytes":1}`) != fp("read_file", `{"offset_bytes":1e0}`) {
+		t.Errorf("1 and 1e0 must fingerprint the same")
+	}
+}
+
+func TestFailureFingerprint_MeaningfulChangesAreDistinct(t *testing.T) {
+	cases := [][2]string{
+		{`{"transcript_ref":"job:j1"}`, `{"transcript_ref":"job:j2"}`},
+		{`{"offset_bytes":10}`, `{"offset_bytes":20}`},
+		{`{"output_match":"alpha"}`, `{"output_match":"beta"}`},
+		{`{"mode":"foreground"}`, `{"mode":"background"}`},
+	}
+	for _, c := range cases {
+		if fp("read_transcript", c[0]) == fp("read_transcript", c[1]) {
+			t.Errorf("meaningful change %s -> %s collapsed", c[0], c[1])
+		}
+	}
+}
+
+func TestFailureFingerprint_UnparseableArgumentsFallBackToExact(t *testing.T) {
+	for _, args := range []string{
+		`{"transcript_ref":`,
+		`{"a":1}{"b":2}`,
+		`not json`,
+	} {
+		if got, want := failureFingerprint("t", []byte(args)), exactSignature("t", []byte(args)); got != want {
+			t.Errorf("fallback fingerprint(%s) = %q, want exact %q", args, got, want)
+		}
+	}
+}
+
+func TestFailureFingerprint_ShellDescriptionIsPresentationOnly(t *testing.T) {
+	if fp("shell", `{"command":"ls","description":"list files"}`) != fp("shell", `{"command":"ls"}`) {
+		t.Errorf("shell description must not change the fingerprint")
+	}
+	// A task's description is meaningful and must stay distinct.
+	if fp("task_list", `{"update":[{"id":1,"description":"x"}]}`) == fp("task_list", `{"update":[{"id":1}]}`) {
+		t.Errorf("task_list description must remain part of the fingerprint")
+	}
+}
+
+func TestFailureFingerprint_IsBoundedAndSecretFree(t *testing.T) {
+	const secret = "TOP-SECRET-CREDENTIAL"
+	got := fp("shell", fmt.Sprintf(`{"command":"echo %s","intent":"%s"}`, secret, secret))
+	if strings.Contains(got, secret) {
+		t.Fatalf("fingerprint leaked a secret value: %q", got)
+	}
+	if len(got) > 128 {
+		t.Fatalf("fingerprint is not bounded: %d bytes", len(got))
+	}
+}
+
+// The repetition nudge is an exact-call signal and must stay byte-keyed: two
+// calls whose raw arguments differ only by neutral defaults are the same
+// semantic operation but not a byte-identical repeat, so a caller comparing
+// their bodies must see the unmodified result. This is the shape
+// TestRegistryExecuteCallNormalizesMaterializedRetainedDefaults exercises one
+// layer up.
+func TestBreakerDispatch_NeutralDefaultsDoNotTriggerRepetitionNudge(t *testing.T) {
+	const body = "ready\n"
+	r := NewRegistry()
+	fake := registerBreakerFake(t, r, "read_transcript", func(int) (any, error) { return body, nil })
+	env := breakerEnv(t)
+	ctx := context.Background()
+
+	omitted := r.ExecuteCall(ctx, env, breakerCall("o1", "read_transcript", `{"transcript_ref":"job:job_1"}`))
+	if omitted.Output != body {
+		t.Fatalf("omitted output = %q, want %q", omitted.Output, body)
+	}
+	materialized := r.ExecuteCall(ctx, env, breakerCall("m1", "read_transcript", `{"transcript_ref":"job:job_1","range":"","context_lines":0}`))
+	if fake.calls != 2 {
+		t.Fatalf("materialized defaults must dispatch: invocations = %d, want 2", fake.calls)
+	}
+	if strings.Contains(materialized.Output, repetitionNudgeMarker) {
+		t.Fatalf("neutral defaults triggered the exact-call repetition nudge: %q", materialized.Output)
+	}
+	if materialized.Output != body {
+		t.Fatalf("materialized output = %q, want the unmodified %q", materialized.Output, body)
+	}
+}

--- a/agent/internal/tool/breaker_semantic_test.go
+++ b/agent/internal/tool/breaker_semantic_test.go
@@ -1,6 +1,7 @@
 package tool
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -271,6 +272,22 @@ func TestFailureFingerprint_MeaningfulDefaultsArePreserved(t *testing.T) {
 	// Empty and absent arguments are the same call.
 	if fp("read_transcript", ``) != fp("read_transcript", `{}`) {
 		t.Errorf("empty and {} must fingerprint the same")
+	}
+}
+
+// Canonicalization must not parse a body that ValidateRawArguments rejects:
+// the size and UTF-8 limits are the pre-parse boundary, so an oversized or
+// non-UTF-8 body falls back to the byte-exact signature rather than being
+// decoded and re-encoded first.
+func TestFailureFingerprint_RejectedRawArgumentsFallBackToExact(t *testing.T) {
+	oversized := append([]byte(`{"patch":"`), bytes.Repeat([]byte("a"), MaxToolArgumentBytes)...)
+	oversized = append(oversized, []byte(`"}`)...)
+	if got, want := fp("write_file", string(oversized)), exactSignature("write_file", oversized); got != want {
+		t.Errorf("oversized fingerprint = %q, want the exact signature %q", got, want)
+	}
+	invalid := []byte{'{', '"', 'x', '"', ':', '"', 0xff, '"', '}'}
+	if got, want := fp("write_file", string(invalid)), exactSignature("write_file", invalid); got != want {
+		t.Errorf("non-UTF-8 fingerprint = %q, want the exact signature %q", got, want)
 	}
 }
 

--- a/agent/internal/tool/breaker_semantic_test.go
+++ b/agent/internal/tool/breaker_semantic_test.go
@@ -279,6 +279,34 @@ func TestFailureFingerprint_MeaningfulDefaultsArePreserved(t *testing.T) {
 // the size and UTF-8 limits are the pre-parse boundary, so an oversized or
 // non-UTF-8 body falls back to the byte-exact signature rather than being
 // decoded and re-encoded first.
+// Only the top-level intent is free text: the registry strips just that one, so
+// a nested field named intent reaches the handler and must stay meaningful.
+func TestFailureFingerprint_NestedIntentIsMeaningful(t *testing.T) {
+	a := fp("task_list", `{"update":[{"id":1,"intent":"alpha"}]}`)
+	b := fp("task_list", `{"update":[{"id":1,"intent":"beta"}]}`)
+	if a == b {
+		t.Errorf("nested intent was normalized away: %q", a)
+	}
+	rootA := fp("task_list", `{"intent":"alpha","update":[{"id":1}]}`)
+	rootB := fp("task_list", `{"intent":"beta","update":[{"id":1}]}`)
+	if rootA != rootB {
+		t.Errorf("top-level intent must be normalized: %q vs %q", rootA, rootB)
+	}
+}
+
+// Whitespace-only arguments are not an empty object: ExecuteCall rejects them as
+// invalid JSON, so the fingerprint must treat them as opaque bytes rather than
+// folding them into the `{}` call.
+func TestFailureFingerprint_WhitespaceOnlyIsNotAnEmptyObject(t *testing.T) {
+	const spaces = "   "
+	if got, want := fp("read_transcript", spaces), exactSignature("read_transcript", []byte(spaces)); got != want {
+		t.Errorf("whitespace-only fingerprint = %q, want the exact signature %q", got, want)
+	}
+	if fp("read_transcript", `{}`) == fp("read_transcript", spaces) {
+		t.Error("whitespace-only must not fingerprint as an empty object")
+	}
+}
+
 func TestFailureFingerprint_RejectedRawArgumentsFallBackToExact(t *testing.T) {
 	oversized := append([]byte(`{"patch":"`), bytes.Repeat([]byte("a"), MaxToolArgumentBytes)...)
 	oversized = append(oversized, []byte(`"}`)...)

--- a/agent/internal/tool/breaker_semantic_test.go
+++ b/agent/internal/tool/breaker_semantic_test.go
@@ -63,13 +63,15 @@ func TestBreakerDispatch_NeutralDefaultsAndFormattingStillPark(t *testing.T) {
 	ctx := context.Background()
 
 	// Same effective call every time: differing JSON key order, whitespace, and
-	// provider-materialized neutral defaults (range "", expand_turn 0,
-	// context_lines 0, output_match "") must all fingerprint the same.
+	// provider-materialized default-equivalent values (empty strings and nulls,
+	// which the tool schemas call omitted) must all fingerprint the same.
+	// Explicit numeric zeros are deliberately absent here; see
+	// TestFailureFingerprint_ExplicitZeroIsDistinct.
 	calls := []llmCallArgs{
 		{id: "n1", args: `{"transcript_ref":"job:job_1","intent":"look"}`},
 		{id: "n2", args: `{ "intent" : "look again" , "transcript_ref" : "job:job_1" }`},
-		{id: "n3", args: `{"context_lines":0,"range":"","transcript_ref":"job:job_1"}`},
-		{id: "n4", args: `{"output_match":"","expand_turn":0,"transcript_ref":"job:job_1"}`},
+		{id: "n3", args: `{"range":"","transcript_ref":"job:job_1"}`},
+		{id: "n4", args: `{"output_match":"","format":null,"transcript_ref":"job:job_1"}`},
 	}
 	results := make([]ExecResult, 0, len(calls))
 	for _, c := range calls {
@@ -250,10 +252,8 @@ func TestFailureFingerprint_KeyOrderWhitespaceAndIntentAreEquivalent(t *testing.
 func TestFailureFingerprint_NeutralDefaultsAreEquivalent(t *testing.T) {
 	want := fp("read_transcript", `{"transcript_ref":"job:j1"}`)
 	for _, args := range []string{
-		`{"transcript_ref":"job:j1","range":"","expand_turn":0}`,
-		`{"transcript_ref":"job:j1","context_lines":0,"output_match":""}`,
+		`{"transcript_ref":"job:j1","range":"","output_match":""}`,
 		`{"transcript_ref":"job:j1","format":null,"extra":{},"list":[]}`,
-		`{"transcript_ref":"job:j1","offset_bytes":0}`,
 	} {
 		if got := fp("read_transcript", args); got != want {
 			t.Errorf("fingerprint(%s) = %q, want %q", args, got, want)
@@ -262,6 +262,28 @@ func TestFailureFingerprint_NeutralDefaultsAreEquivalent(t *testing.T) {
 	// Empty and absent arguments are the same call.
 	if fp("read_transcript", ``) != fp("read_transcript", `{}`) {
 		t.Errorf("empty and {} must fingerprint the same")
+	}
+}
+
+// Explicit numeric zero is presence, not omission. read_transcript treats a
+// present offset_bytes as the retained-page operation even when it is zero (see
+// TestNormalizeRetainedReadArgsPreservesExplicitZeroOffset), so folding zero
+// into the omitted form would hide a meaningful correction and could park a
+// call the model legitimately changed. A value-based rule cannot know a
+// schema's numeric defaults, so it errs toward a distinct fingerprint.
+func TestFailureFingerprint_ExplicitZeroIsDistinct(t *testing.T) {
+	base := fp("read_transcript", `{"transcript_ref":"job:j1"}`)
+	for _, args := range []string{
+		`{"transcript_ref":"job:j1","offset_bytes":0}`,
+		`{"transcript_ref":"job:j1","context_lines":0}`,
+		`{"transcript_ref":"job:j1","expand_turn":0}`,
+	} {
+		if got := fp("read_transcript", args); got == base {
+			t.Errorf("fingerprint(%s) = %q, must differ from the omitted form", args, got)
+		}
+	}
+	if fp("read_file", `{"offset_bytes":0}`) == fp("read_file", `{}`) {
+		t.Error("explicit offset_bytes=0 must not fingerprint as omitted")
 	}
 }
 
@@ -338,7 +360,7 @@ func TestBreakerDispatch_NeutralDefaultsDoNotTriggerRepetitionNudge(t *testing.T
 	if omitted.Output != body {
 		t.Fatalf("omitted output = %q, want %q", omitted.Output, body)
 	}
-	materialized := r.ExecuteCall(ctx, env, breakerCall("m1", "read_transcript", `{"transcript_ref":"job:job_1","range":"","context_lines":0}`))
+	materialized := r.ExecuteCall(ctx, env, breakerCall("m1", "read_transcript", `{"transcript_ref":"job:job_1","range":"","output_match":""}`))
 	if fake.calls != 2 {
 		t.Fatalf("materialized defaults must dispatch: invocations = %d, want 2", fake.calls)
 	}

--- a/agent/internal/tool/breaker_semantic_test.go
+++ b/agent/internal/tool/breaker_semantic_test.go
@@ -334,7 +334,7 @@ func TestFailureFingerprint_ShellDescriptionIsPresentationOnly(t *testing.T) {
 
 func TestFailureFingerprint_IsBoundedAndSecretFree(t *testing.T) {
 	const secret = "TOP-SECRET-CREDENTIAL"
-	got := fp("shell", fmt.Sprintf(`{"command":"echo %s","intent":"%s"}`, secret, secret))
+	got := fp("shell", fmt.Sprintf(`{"command":%q,"intent":%q}`, secret, secret))
 	if strings.Contains(got, secret) {
 		t.Fatalf("fingerprint leaked a secret value: %q", got)
 	}


### PR DESCRIPTION
Fixes #829.

The repeated-failure ledger keyed on raw argument bytes, so a free-text `intent` or a neutral/default field reset the streak. This adds a semantic failure fingerprint above the exact-call fast path: canonical JSON (key order and whitespace folded), `intent` dropped, and `description` dropped for the shell tool. The exact-call guard and `WithBreakerBypass` are unchanged.

Adversarial review caught a false positive in the first revision: it treated numeric zero as a neutral default, which folded read_transcript's explicit `offset_bytes=0` into the omitted form. Presence is meaningful there, because a present `offset_bytes` selects the retained-page operation while omitting it selects the default view, which `TestNormalizeRetainedReadArgsPreservesExplicitZeroOffset` already pins at the tool layer. That is precisely what the issue's false-positive control forbids ("different offsets must remain distinct when they can change the outcome"), so numeric zero is no longer neutral, matching the existing treatment of boolean false.

Evidence:
- `go test ./agent/internal/tool/` green.
- `TestFailureFingerprint_ExplicitZeroIsDistinct` fails when zero-neutrality is restored (all three explicit-zero cases collapse to the omitted fingerprint) and passes here.
- Intent-only and neutral-default variants still park; a meaningful ref change still gets a fresh attempt; alternating fingerprints keep both runs; the 20-call shape from the issue is covered by the intent-only and neutral-default tests.

Trade-off: a value-based rule cannot know a schema's numeric defaults, so an explicit numeric zero that equals a field's real default no longer collapses. That direction only delays the breaker; the other direction would refuse a call the model meant to change.
