### PR TITLE
fix(web): keep a summary-less failed delegate row single-level (#1173)

### DIFF
--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.test.tsx
@@ -1568,3 +1568,35 @@ test("a summary-only job_watch clear renders a non-expandable row (hasBody predi
   );
   expect(screen.queryByTestId("tool-row-body-trigger")).toBeNull();
 });
+
+// --- #1173: a summary-less intent-bearing row stays single-level on failure ---
+// A delegate row deliberately renders no summary text (subagentModule owns its
+// presentation), so the failure force-open must not carry an empty summary line
+// open. The body disclosure chevron stays on the intent line
+// (data-body-trigger-intent), exactly as it does for a clean delegate row.
+test.each(["chat", "intent"] as const)(
+  "a failed delegate row at the %s level renders no empty summary line (body trigger on the intent line)",
+  (level) => {
+    const config = makeTranscriptDisplayConfig({ kind: "preset", level });
+    const { container } = renderWithConfig(
+      config,
+      item({
+        id: `delegate_fail_${level}`,
+        toolName: "delegate",
+        description: "Delegating the flaky suite",
+        argumentsJSON: JSON.stringify({ prompt: "Run the flaky suite" }),
+        error: "delegate activation failed",
+      }),
+    );
+    // The body force-opens (only failure earns the eye, unchanged).
+    expect(screen.getByTestId("tool-row-body-trigger").getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByTestId("tool-call-body")).toBeTruthy();
+    // No summary text exists for a delegate row, so no summary line (empty or
+    // otherwise) renders and no summary-open region is forced.
+    expect(screen.queryByTestId("tool-row-summary")).toBeNull();
+    expect(container.querySelector('[data-body-trigger="true"]')).toBeNull();
+    // The body trigger rides the intent line instead.
+    expect(screen.getByTestId("tool-row").getAttribute("data-body-trigger-intent")).toBe("true");
+    expect(screen.getByTestId("tool-row-intent").textContent).toBe("Delegating the flaky suite");
+  },
+);

--- a/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
+++ b/cmd/evener-hub/frontend/src/panes/session/transcript/ToolCallItem.tsx
@@ -307,6 +307,16 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
   const expandedSummary = expanded ? descriptor.summaryWhenExpanded : undefined;
   const summary =
     expandedSummary !== undefined ? expandedSummary : useProjectedSummary ? projectedSummary : descriptorSummary;
+  // The summary text the row would actually SHOW once its summary line is
+  // open. A delegate row deliberately renders none (subagentModule owns its
+  // presentation) even though its descriptor's own summary() returns the
+  // description the intent line already carries. A row with no summary text
+  // has no summary line to open, so the failure force-open below must never
+  // carry an EMPTY one open (the regression: a failed, non-superseded delegate
+  // took the two-level path with an empty summary and moved the body chevron
+  // onto a stray empty line).
+  const rowSummaryText = isDelegate ? "" : summary;
+  const hasSummaryText = rowSummaryText.trim() !== "";
 
   // Two-level disclosure: the summary line has its own open/closed state,
   // independent of the body disclosure. At verbosity levels where toolCalls is
@@ -322,8 +332,11 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
   // with it, so a failed row lands on the complete level 2 (intent + one-line
   // tool call + body) instead of skipping the call on its way down. A
   // superseded preval-only bounce demotes exactly as the body does (kata hgm1),
-  // and an explicit reader toggle still wins in the store.
-  const summaryFallback = summaryConfigDefault || (failed && !superseded);
+  // and an explicit reader toggle still wins in the store. Only a row that
+  // actually has summary text is carried open: a summary-less intent-bearing
+  // row (a delegate) stays single-level, keeping the body chevron on the
+  // intent line.
+  const summaryFallback = summaryConfigDefault || (failed && !superseded && hasSummaryText);
   const summaryDisclosureOpen = isDisclosureOpen(summaryDisclosureKey, summaryFallback);
   const summaryOpen = statedIntent === undefined ? true : summaryDisclosureOpen;
   // A descriptor may suppress its whole row (task_list `action:"view"` and
@@ -342,7 +355,7 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
     return (
       <div className={CLASS.call} data-testid="tool-call-item" data-tool-name={item.toolName ?? ""}>
         <ToolRow
-          summary={isDelegate ? "" : summary}
+          summary={rowSummaryText}
           summaryLink={summaryLink}
           intent={intent}
           icon={descriptor.icon}
@@ -386,7 +399,7 @@ function ToolCallItemBody({ item, live, sessionRef, projectedSummary, renderCont
         // serves the remaining no-summary states: delegate rows
         // (subagentModule owns their presentation) and a two-level row whose
         // summary line the reader collapsed (summaryOpen=false).
-        summary={isDelegate || !summaryOpen ? "" : summary}
+        summary={!summaryOpen ? "" : rowSummaryText}
         summaryLink={summaryLink}
         intent={intent}
         icon={descriptor.icon}


### PR DESCRIPTION
Fixes #1173.

A failed delegate row has an intent but no summary text, and `summaryOpen` was forced true at chat/intent level, so `ToolRow` took the two-level path and rendered an empty summary line, pushing the body chevron off the intent line. A summary-less intent-bearing row now stays single-level.

Evidence:
- `ToolCallItem.test.tsx` adds the chat-level failed-delegate case; it fails on the pre-fix tree (2 failed / 88 passed) and passes here (90 passed).
- `npx vitest run src/panes/session/transcript` -> 79 files, 1881 tests passed; `tsc --noEmit` clean; `biome check` clean on both touched files.

Note: the same empty-line class exists at `tools/activity/full`, which predates this regression; left out of scope.
