### PR TITLE
fix(doctor): preserve cache-write usage in API logs and doctor output (#946)

### DIFF
--- a/agent/doctor/apilog.go
+++ b/agent/doctor/apilog.go
@@ -58,6 +58,8 @@ type APICallRow struct {
 	InputTokens        *int                       `json:"input_tokens,omitempty"`
 	OutputTokens       *int                       `json:"output_tokens,omitempty"`
 	CacheRead          *int                       `json:"cache_read_tokens,omitempty"`
+	CacheWrite         *int                       `json:"cache_write_tokens,omitempty"`
+	CacheWrite1h       *int                       `json:"cache_write_1h_tokens,omitempty"`
 	UncachedInput      *int                       `json:"uncached_input_tokens,omitempty"`
 	FinishReason       string                     `json:"finish_reason,omitempty"`
 	TextLength         *int                       `json:"text_length,omitempty"`
@@ -108,6 +110,8 @@ type APILogTotals struct {
 	InputTokens                  *int                                     `json:"input_tokens,omitempty"`
 	OutputTokens                 *int                                     `json:"output_tokens,omitempty"`
 	CacheReadTokens              *int                                     `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens             *int                                     `json:"cache_write_tokens,omitempty"`
+	CacheWrite1hTokens           *int                                     `json:"cache_write_1h_tokens,omitempty"`
 	TotalTokens                  *int                                     `json:"total_tokens,omitempty"`
 	AvgLatencyMs                 int64                                    `json:"avg_latency_ms"`
 	ContinuationByEndpointFamily map[string]ContinuationHistoryModeCounts `json:"continuation_by_endpoint_family,omitempty"`
@@ -172,7 +176,7 @@ func apiLog(stateBase, selector string, opts APILogOpts, mode apilog.DecodeMode)
 	var retainedSettlements apiGroupSettlementRetention
 	partialTail := false
 	var latencySum int64
-	var inputTokens, outputTokens, cacheReadTokens, totalTokens optionalIntSum
+	var inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, cacheWrite1hTokens, totalTokens optionalIntSum
 	for {
 		record, decodeErr := decoder.Next()
 		if errors.Is(decodeErr, io.EOF) {
@@ -192,6 +196,8 @@ func apiLog(stateBase, selector string, opts APILogOpts, mode apilog.DecodeMode)
 			inputTokens.add(row.InputTokens)
 			outputTokens.add(row.OutputTokens)
 			cacheReadTokens.add(row.CacheRead)
+			cacheWriteTokens.add(row.CacheWrite)
+			cacheWrite1hTokens.add(row.CacheWrite1h)
 			if record.Response != nil {
 				totalTokens.add(record.Response.Usage.TotalTokens)
 			}
@@ -219,6 +225,8 @@ func apiLog(stateBase, selector string, opts APILogOpts, mode apilog.DecodeMode)
 	res.Totals.InputTokens = inputTokens.result()
 	res.Totals.OutputTokens = outputTokens.result()
 	res.Totals.CacheReadTokens = cacheReadTokens.result()
+	res.Totals.CacheWriteTokens = cacheWriteTokens.result()
+	res.Totals.CacheWrite1hTokens = cacheWrite1hTokens.result()
 	res.Totals.TotalTokens = totalTokens.result()
 	if res.Totals.Calls > 0 {
 		res.Totals.AvgLatencyMs = latencySum / int64(res.Totals.Calls)
@@ -772,6 +780,8 @@ func rowFromAttempt(attempt apilog.APIAttemptRecord) APICallRow {
 		row.InputTokens = attempt.Response.Usage.InputTokens
 		row.OutputTokens = attempt.Response.Usage.OutputTokens
 		row.CacheRead = attempt.Response.Usage.CacheReadTokens
+		row.CacheWrite = attempt.Response.Usage.CacheWriteTokens
+		row.CacheWrite1h = attempt.Response.Usage.CacheWrite1hTokens
 		row.Empty = attempt.Outcome == apilog.AttemptSuccess &&
 			row.TextLength != nil && *row.TextLength == 0 &&
 			row.ToolCalls != nil && *row.ToolCalls == 0

--- a/agent/doctor/apilog_cache_write_test.go
+++ b/agent/doctor/apilog_cache_write_test.go
@@ -1,0 +1,101 @@
+package doctor
+
+import (
+	"encoding/json"
+	"testing"
+
+	"primeradiant.com/evener/agent/schema"
+	"primeradiant.com/evener/llm/apilog"
+)
+
+// TestAPILogExposesDisjointCacheWriteTiers pins issue #946 on the doctor
+// projection: the canonical record's disjoint 5-minute and 1-hour cache-write
+// usage must reach both the typed call rows and the session totals (the
+// `evener doctor apilog --json` surface), and must not be folded into cache
+// reads or uncached input.
+func TestAPILogExposesDisjointCacheWriteTiers(t *testing.T) {
+	base := t.TempDir()
+	bucket := stateHomeBucket(base, hash1)
+	attempt := doctorAttempt("ag_cache_write", 1, apilog.AttemptSuccess, 10, 100, 20, 30, 5, 0)
+	fiveMinute := 44
+	attempt.Response.Usage.CacheWriteTokens = &fiveMinute
+	oneHour := 17
+	attempt.Response.Usage.CacheWrite1hTokens = &oneHour
+	writeRichSession(t, bucket, sidA, nil, []apilog.APILogRecord{attempt, doctorSettlement(attempt, 1)}, schema.SessionMeta{})
+
+	result, err := APILog(base, sidA, APILogOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Calls) != 1 {
+		t.Fatalf("calls = %d, want 1", len(result.Calls))
+	}
+	row := result.Calls[0]
+	if !hasIntValue(row.CacheWrite, fiveMinute) {
+		t.Errorf("row 5-minute cache write = %v, want %d", row.CacheWrite, fiveMinute)
+	}
+	if !hasIntValue(row.CacheWrite1h, oneHour) {
+		t.Errorf("row 1-hour cache write = %v, want %d", row.CacheWrite1h, oneHour)
+	}
+	if !hasIntValue(result.Totals.CacheWriteTokens, fiveMinute) {
+		t.Errorf("totals 5-minute cache write = %v, want %d", result.Totals.CacheWriteTokens, fiveMinute)
+	}
+	if !hasIntValue(result.Totals.CacheWrite1hTokens, oneHour) {
+		t.Errorf("totals 1-hour cache write = %v, want %d", result.Totals.CacheWrite1hTokens, oneHour)
+	}
+	// Disjointness: cache writes remain separate from cache reads and from
+	// the already-uncached input; neither is subtracted nor double-counted.
+	if !hasIntValue(row.CacheRead, 30) {
+		t.Errorf("row cache read = %v, want 30", row.CacheRead)
+	}
+	if !hasIntValue(row.UncachedInput, 100) {
+		t.Errorf("row uncached input = %v, want 100", row.UncachedInput)
+	}
+	if !hasIntValue(result.Totals.InputTokens, 100) {
+		t.Errorf("totals input = %v, want 100", result.Totals.InputTokens)
+	}
+	if !hasIntValue(result.Totals.CacheReadTokens, 30) {
+		t.Errorf("totals cache read = %v, want 30", result.Totals.CacheReadTokens)
+	}
+
+	// The JSON surface is what downstream accounting consumes; assert the
+	// fields are actually present (not just zero-valued) there.
+	encoded, err := json.Marshal(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		Calls  []map[string]json.RawMessage `json:"calls"`
+		Totals map[string]json.RawMessage   `json:"totals"`
+	}
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		field string
+		want  int
+	}{
+		{"cache_write_tokens", fiveMinute},
+		{"cache_write_1h_tokens", oneHour},
+	} {
+		if raw, ok := document.Calls[0][tc.field]; !ok {
+			t.Errorf("json call omitted %q: %s", tc.field, encoded)
+		} else if got := rawInt(t, raw); got != tc.want {
+			t.Errorf("json call %q = %d, want %d", tc.field, got, tc.want)
+		}
+		if raw, ok := document.Totals[tc.field]; !ok {
+			t.Errorf("json totals omitted %q: %s", tc.field, encoded)
+		} else if got := rawInt(t, raw); got != tc.want {
+			t.Errorf("json totals %q = %d, want %d", tc.field, got, tc.want)
+		}
+	}
+}
+
+func rawInt(t *testing.T, raw json.RawMessage) int {
+	t.Helper()
+	var got int
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal %s: %v", raw, err)
+	}
+	return got
+}

--- a/llm/api_attempt.go
+++ b/llm/api_attempt.go
@@ -549,11 +549,12 @@ func buildAPIAttemptRecord(groupID, attemptID string, index int, meta APIAttempt
 			response.TextLength = optionalAPILogInt(len(result.Response.Text()), true)
 			response.ToolCallCount = optionalAPILogInt(len(result.Response.ToolCalls()), true)
 			response.Usage = apilog.Usage{
-				InputTokens:      optionalAPILogInt(result.Response.Usage.InputTokens, true),
-				OutputTokens:     optionalAPILogInt(result.Response.Usage.OutputTokens, true),
-				TotalTokens:      optionalAPILogInt(result.Response.Usage.TotalTokens, true),
-				CacheReadTokens:  cloneAPILogInt(result.Response.Usage.CacheReadTokens),
-				CacheWriteTokens: cloneAPILogInt(result.Response.Usage.CacheWriteTokens),
+				InputTokens:        optionalAPILogInt(result.Response.Usage.InputTokens, true),
+				OutputTokens:       optionalAPILogInt(result.Response.Usage.OutputTokens, true),
+				TotalTokens:        optionalAPILogInt(result.Response.Usage.TotalTokens, true),
+				CacheReadTokens:    cloneAPILogInt(result.Response.Usage.CacheReadTokens),
+				CacheWriteTokens:   cloneAPILogInt(result.Response.Usage.CacheWriteTokens),
+				CacheWrite1hTokens: cloneAPILogInt(result.Response.Usage.CacheWrite1hTokens),
 			}
 		}
 		record.Response = &response

--- a/llm/api_attempt_cache_write_test.go
+++ b/llm/api_attempt_cache_write_test.go
@@ -1,0 +1,79 @@
+package llm
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"primeradiant.com/evener/identifier"
+	apilog "primeradiant.com/evener/llm/apilog"
+)
+
+// TestBuildAPIAttemptRecordPreservesDisjointCacheWriteTiers pins issue #946:
+// llm.Usage carries two disjoint cache-write tiers (5-minute CacheWriteTokens
+// and 1-hour CacheWrite1hTokens); both must survive canonical normalization
+// into apilog.Usage. They must remain separate fields -- neither folded into
+// the other, into cache reads, nor into uncached input.
+func TestBuildAPIAttemptRecordPreservesDisjointCacheWriteTiers(t *testing.T) {
+	fiveMinute, oneHour := 44, 17
+	startedAt := time.Unix(30, 0).UTC()
+	record := buildAPIAttemptRecord("ag_cache_write_tiers", identifier.MustNewAPIAttemptID(), 1, APIAttemptMeta{
+		ProviderInstance: "anthropic-primary",
+		RequestModel:     "claude-test",
+		Method:           http.MethodPost,
+		Endpoint:         "https://provider.test/v1/messages",
+		RequestBody:      []byte("{}"),
+		StartedAt:        startedAt,
+	}, APIAttemptResult{
+		StatusCode:   http.StatusOK,
+		ResponseBody: []byte("{}"),
+		Response: &Response{
+			Model:  "claude-test",
+			Finish: FinishReason{Reason: FinishReasonStop},
+			Usage: Usage{
+				InputTokens:        100,
+				OutputTokens:       20,
+				TotalTokens:        134,
+				CacheReadTokens:    new(30),
+				CacheWriteTokens:   &fiveMinute,
+				CacheWrite1hTokens: &oneHour,
+			},
+		},
+		Outcome:    apilog.AttemptSuccess,
+		FinishedAt: startedAt.Add(time.Millisecond),
+	})
+
+	encoded, err := apilog.MarshalRecord(record)
+	if err != nil {
+		t.Fatalf("MarshalRecord(): %v", err)
+	}
+	var doc struct {
+		Response struct {
+			Usage map[string]json.RawMessage `json:"usage"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(encoded, &doc); err != nil {
+		t.Fatalf("unmarshal canonical record: %v", err)
+	}
+	for field, want := range map[string]int{
+		"cache_read_tokens":     30,
+		"input_tokens":          100,
+		"cache_write_tokens":    fiveMinute,
+		"cache_write_1h_tokens": oneHour,
+	} {
+		raw, ok := doc.Response.Usage[field]
+		if !ok {
+			t.Errorf("canonical usage omitted %q: %s", field, encoded)
+			continue
+		}
+		var got int
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Errorf("canonical usage field %q: %v", field, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("canonical usage %q = %d, want %d", field, got, want)
+		}
+	}
+}

--- a/llm/apilog/record.go
+++ b/llm/apilog/record.go
@@ -50,11 +50,12 @@ type APIAttemptResponse struct {
 }
 
 type Usage struct {
-	InputTokens      *int `json:"input_tokens,omitempty"`
-	OutputTokens     *int `json:"output_tokens,omitempty"`
-	TotalTokens      *int `json:"total_tokens,omitempty"`
-	CacheReadTokens  *int `json:"cache_read_tokens,omitempty"`
-	CacheWriteTokens *int `json:"cache_write_tokens,omitempty"`
+	InputTokens        *int `json:"input_tokens,omitempty"`
+	OutputTokens       *int `json:"output_tokens,omitempty"`
+	TotalTokens        *int `json:"total_tokens,omitempty"`
+	CacheReadTokens    *int `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens   *int `json:"cache_write_tokens,omitempty"`
+	CacheWrite1hTokens *int `json:"cache_write_1h_tokens,omitempty"`
 }
 
 type APIAttemptRecord struct {
@@ -220,6 +221,9 @@ func (u Usage) validate() error {
 	}
 	if u.CacheWriteTokens != nil && *u.CacheWriteTokens < 0 {
 		return errors.New("cache-write token usage must be non-negative")
+	}
+	if u.CacheWrite1hTokens != nil && *u.CacheWrite1hTokens < 0 {
+		return errors.New("1-hour cache-write token usage must be non-negative")
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #946.

Anthropic 1-hour cache writes were dropped from the canonical API log, so doctor rows and totals understated cache-write usage and could not show the 1h/5m split. The field is now recorded on the response parse path and surfaced in the doctor output.

Evidence:
- Reverting each production file fails the new tests: `llm` reports the canonical usage omitted `cache_write_1h_tokens`; the doctor test fails four assertions and omits the field from JSON; reverting `agent/doctor/apilog.go` does not build.
- `go test ./llm/ ./llm/apilog/ ./agent/doctor/` green; `go vet` clean.

Forward-compatibility note: `llm/apilog/codec.go` decodes with `DisallowUnknownFields`, so an older binary reading a record carrying the new key fails to decode. `omitempty` confines the key to records that actually carry an Anthropic 1h cache write, and old-format records still decode. Flagging the hazard rather than changing the codec.
